### PR TITLE
Browse form - clear diff box when showing an empty commit

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -811,7 +811,10 @@ namespace GitUI
         private void ShowSelectedFileDiff()
         {
             if (DiffFiles.SelectedItem == null)
+            {
+                DiffText.ViewPatch("");
                 return;
+            }
 
             var selectedItem = (DiffFiles.SelectedItem).Name;
             var revisions = RevisionGrid.GetRevisions();


### PR DESCRIPTION
When you change focus from a non-empty commit to 
an empty one (these happen sometimes when merging),
the diff control isn't updated.
The submitted patch fixes this.

Best regards,
Grzegorz
