### PR TITLE
Initialize remote branch name when pulling

### DIFF
--- a/GitUI/FormPull.cs
+++ b/GitUI/FormPull.cs
@@ -228,6 +228,9 @@ namespace GitUI
             var branch = GitCommands.GitCommands.GetSelectedBranch();
             Remotes.Text = GitCommands.GitCommands.GetSetting(string.Format("branch.{0}.remote", branch));
 
+            var branchHead = new GitHead(null, branch);
+            Branches.Text = branchHead.MergeWith;
+
             Text = string.Format("Pull ({0})", Settings.WorkingDir);
             EnableLoadSshButton();
 


### PR DESCRIPTION
When you pull onto a branch configured for tracking a remote one,
the pull dialog initalizes 'remote', but doesn't initialize 'remote branch'.
This patch causes that form to initialize remote branch name as well.

I'm wondering if I'm missing some frequent use-case here, so if that 
behaviour should remain unchanged, I can add a configuration entry 
to control this feature. Let me know if that's the case.

Best regards,
Grzegorz
