### PR TITLE
Show graph when single file history is displayed

### DIFF
--- a/GitUI/FormFileHistory.cs
+++ b/GitUI/FormFileHistory.cs
@@ -43,7 +43,11 @@ namespace GitUI
             if (Settings.FollowRenamesInFileHistory)
                 FileChanges.Filter = " --name-only --follow -- \"" + fileName + "\"";
             else
-                FileChanges.Filter = " -- \"" + fileName + "\"";
+            {
+                // --parents doesn't work with --follow enabled, but needed to graph a filtered log
+                FileChanges.Filter = " --parents -- \"" + fileName + "\"";
+                FileChanges.AllowGraphWithFilter = true;
+            }
         }
 
 

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -56,6 +56,7 @@ namespace GitUI
             BranchFilter = String.Empty;
             SetShowBranches();
             Filter = "";
+            AllowGraphWithFilter = false;
             _quickSearchString = "";
             quickSearchTimer.Tick += QuickSearchTimerTick;
 
@@ -80,6 +81,7 @@ namespace GitUI
         public Font NormalFont { get; set; }
         public string CurrentCheckout { get; set; }
         public int LastRow { get; set; }
+        public bool AllowGraphWithFilter { get; set; }
 
         public void SetInitialRevision(GitRevision initialSelectedRevision)
         {
@@ -352,7 +354,8 @@ namespace GitUI
                 LastScrollPos = Revisions.FirstDisplayedScrollingRowIndex;
 
                 //Hide graph column when there it is disabled OR when a filter is active
-                if (!Settings.ShowRevisionGraph || !string.IsNullOrEmpty(Filter))
+                //allowing for special case when history of a single file is being displayed
+                if (!Settings.ShowRevisionGraph || (!string.IsNullOrEmpty(Filter) && !AllowGraphWithFilter))
                 {
                     Revisions.ShowHideRevisionGraph(false);
                 }


### PR DESCRIPTION
Viewing history of a file edited concurrently in multiple branches
is hard without a graph, so I changed the file history form to show
it with proper parent-child links.
Unfortunatelly this works only when following renames is disabled -
a limitation of git, as I understand from discussion on 
http://permalink.gmane.org/gmane.comp.version-control.git/147089.

For viewing files with "plain" history it seems ok. When a file is created 
independently in different branches the graph looks a bit weird, but 
still manageable I think.

As with my other pull request - if I should add a configuration switch,
please let me know.

Best regards,
Grzegorz
