### PR TITLE
Renamed DoubleClick event to not collide with existing baseclass event

### DIFF
--- a/GitUI/Blame/BlameControl.cs
+++ b/GitUI/Blame/BlameControl.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.Editor;
-using ICSharpCode.TextEditor.Document;
 
 namespace GitUI.Blame
 {
@@ -24,7 +23,7 @@ namespace GitUI.Blame
             BlameFile.IsReadOnly = true;
             BlameFile.SelectedLineChanged += new SelectedLineChangedHandler(BlameFile_SelectedLineChanged);
 
-            BlameFile.DoubleClick += ActiveTextAreaControlDoubleClick;
+            BlameFile.RequestDiffView += ActiveTextAreaControlDoubleClick;
         }
 
         void BlameFile_SelectedLineChanged(object sender, int selectedLine)
@@ -83,7 +82,6 @@ namespace GitUI.Blame
             var frm = new FormDiffSmall();
             frm.SetRevision(_lastRevision);
             frm.ShowDialog();
-             
         }
     }
 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -3,10 +3,7 @@ using System.Drawing;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
-using GitCommands;
-using ICSharpCode.TextEditor.Document;
 using ICSharpCode.TextEditor.Util;
-using GitUI.Properties;
 
 namespace GitUI.Editor
 {
@@ -53,13 +50,7 @@ namespace GitUI.Editor
             _internalFileViewer.TextChanged += TextEditor_TextChanged;
             _internalFileViewer.ScrollPosChanged += new EventHandler(_internalFileViewer_ScrollPosChanged);
             _internalFileViewer.SelectedLineChanged += new SelectedLineChangedHandler(_internalFileViewer_SelectedLineChanged);
-            _internalFileViewer.DoubleClick += new EventHandler(_internalFileViewer_DoubleClick);
-        }
-
-        void _internalFileViewer_DoubleClick(object sender, EventArgs e)
-        {
-            if (DoubleClick != null)
-                DoubleClick(sender, e);
+            _internalFileViewer.DoubleClick += (sender, args) => OnRequestDiffView(EventArgs.Empty);
         }
 
         void _internalFileViewer_SelectedLineChanged(object sender, int selectedLine)
@@ -71,7 +62,16 @@ namespace GitUI.Editor
         public event SelectedLineChangedHandler SelectedLineChanged;
 
         public event EventHandler ScrollPosChanged;
-        public event EventHandler DoubleClick;
+        public event EventHandler RequestDiffView;
+
+        protected virtual void OnRequestDiffView(EventArgs args)
+        {
+            var handler = RequestDiffView;
+            if (handler != null)
+            {
+                handler(this, args);
+            }
+        }
 
         void _internalFileViewer_ScrollPosChanged(object sender, EventArgs e)
         {

--- a/GitUI/FormDiffSmall.cs
+++ b/GitUI/FormDiffSmall.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
-using PatchApply;
 using GitCommands;
-using System.Text.RegularExpressions;
+using PatchApply;
 
 namespace GitUI
 {
@@ -48,7 +42,7 @@ namespace GitUI
         {
             Revision = new GitRevision();
             Revision.Guid = revision;
-            Revision.ParentGuids = new string[]{revision + "^"};
+            Revision.ParentGuids = new string[] { revision + "^" };
             SetRevision(Revision);
         }
 


### PR DESCRIPTION
...and other clean-up.

I used a lambda for an event handler. This should be verified on Mono before taken as a commit.
