### PR TITLE
Don't suggest remote branch when pulling

### DIFF
--- a/GitUI/FormPull.cs
+++ b/GitUI/FormPull.cs
@@ -244,7 +244,6 @@ namespace GitUI
             Merge.Checked = Settings.PullMerge == "merge";
             Rebase.Checked = Settings.PullMerge == "rebase";
             Fetch.Checked = Settings.PullMerge == "fetch";
-            SetMergeWithToDefaultIfEmpty();
 
             AutoStash.Checked = Settings.AutoStash;
         }
@@ -320,32 +319,16 @@ namespace GitUI
         private void MergeCheckedChanged(object sender, EventArgs e)
         {
             PullImage.BackgroundImage = Resources.merge;
-            SetMergeWithToDefaultIfEmpty();
         }
 
         private void RebaseCheckedChanged(object sender, EventArgs e)
         {
             PullImage.BackgroundImage = Resources.Rebase;
-            SetMergeWithToDefaultIfEmpty();
-        }
-
-        private void SetMergeWithToDefaultIfEmpty()
-        {
-            if (string.IsNullOrEmpty(Branches.Text) && (Rebase.Checked || Merge.Checked))
-            {
-                var branchHead = new GitHead(null, GitCommands.GitCommands.GetSelectedBranch());
-                Branches.Text = branchHead.MergeWith;
-            }
-            if (Fetch.Checked)
-            {
-                Branches.Text = string.Empty;
-            }
         }
 
         private void FetchCheckedChanged(object sender, EventArgs e)
         {
             PullImage.BackgroundImage = Resources.fetch;
-            SetMergeWithToDefaultIfEmpty();
         }
 
         private void PullSourceValidating(object sender, CancelEventArgs e)


### PR DESCRIPTION
It seems the idea isn't very good after all. It might be of little help to inexperienced users but interfers too much everyone else's work. I'll experiment a bit with a separate label displaying something like: "by default merges with: (branch name)" and post if something comes out right, but for now I believe it would be best to remove this functionality from master branch. I'm sending a corresponding patch.
