### PR TITLE
Patches/fixhistorycasing

### DIFF
--- a/GitUI/FormFileHistory.cs
+++ b/GitUI/FormFileHistory.cs
@@ -46,11 +46,11 @@ namespace GitUI
 
             // grab the 8.3 file path
             StringBuilder shortPath = new StringBuilder(4096);
-            GetShortPathName(fullFilePath, shortPath, shortPath.Capacity);
+            NativeMethods.GetShortPathName(fullFilePath, shortPath, shortPath.Capacity);
 
             // use 8.3 file path to get properly cased full file path
             StringBuilder longPath = new StringBuilder(4096);
-            GetLongPathName(shortPath.ToString(), longPath, longPath.Capacity);
+            NativeMethods.GetLongPathName(shortPath.ToString(), longPath, longPath.Capacity);
 
             // remove the working dir and now we have a properly cased file name.
             fileName = longPath.ToString().Substring(Settings.WorkingDir.Length);
@@ -67,12 +67,6 @@ namespace GitUI
             }
         }
  
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern int GetLongPathName(string lpszShortPath, StringBuilder lpszLongPath, int cchBuffer);
-
         private void DiffExtraDiffArgumentsChanged(object sender, EventArgs e)
         {
             UpdateSelectedFileViewers();

--- a/GitUI/NativeMethods.cs
+++ b/GitUI/NativeMethods.cs
@@ -60,6 +60,12 @@ namespace GitUI
         [return: MarshalAs(UnmanagedType.Bool)]
         internal extern static bool ShowCaretAPI(
             IntPtr hwnd);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern int GetLongPathName(string lpszShortPath, StringBuilder lpszLongPath, int cchBuffer);
         #endregion
 
         private NativeMethods() { }


### PR DESCRIPTION
We have some vcproj files that contain incorrect case sensitivity for some files in the project where File1.cpp is in the project but the file on disk is file1.cpp.  We found that this causes the "File history" to not populate for these files when activated from a right-click in Visual Studio.  

This fix uses some kernel32 calls to force filename strings to the same case as the file on disk before calling for the history.
