### PR TITLE
Fix revision preselection in RevisionGrid

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -194,7 +194,8 @@ namespace GitCommands
             {
                 if (revision == null || revision.Guid.Trim(hexChars).Length == 0)
                 {
-                    revisions.Add(revision);
+                    if (revision != null)
+                        revisions.Add(revision);
                     Updated(this, new RevisionGraphUpdatedEvent(revision));
                 }
                 nextStep = ReadStep.Commit;

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -302,6 +302,7 @@ namespace GitUI
             Revisions.ClearSelection();
 
             Revisions.Rows[index].Selected = true;
+            Revisions.CurrentCell = Revisions.Rows[index].Cells[1];
 
             Revisions.Select();
         }
@@ -441,8 +442,7 @@ namespace GitUI
         {
             _isLoading = false;
 
-            if (_revisionGraphCommand.Revisions.Count == 1 &&
-                _revisionGraphCommand.Revisions[0] == null && 
+            if (_revisionGraphCommand.Revisions.Count == 0 && 
                 !FilterIsApplied())
             {
                 // This has to happen on the UI thread
@@ -471,8 +471,7 @@ namespace GitUI
             if (Revisions.SelectedRows.Count != 0 || _initialSelectedRevision == null) return;
             for (var i = 0; i < _revisionGraphCommand.Revisions.Count; i++)
             {
-                if (_revisionGraphCommand.Revisions[i] != null && //A null reference occurred here (? should not be possible)
-                    _revisionGraphCommand.Revisions[i].Guid == _initialSelectedRevision.Guid)
+                if (_revisionGraphCommand.Revisions[i].Guid == _initialSelectedRevision.Guid)
                     SetSelectedIndex(i);
             }
         }
@@ -502,7 +501,7 @@ namespace GitUI
                 Revisions.SelectedIds = LastSelectedRows;
                 LastSelectedRows = null;
             }
-            else
+            else if (_initialSelectedRevision == null)
             {
                 Revisions.SelectedIds = new IComparable[] { CurrentCheckout };
             }


### PR DESCRIPTION
Hi,
this patch fixes an issue with RevisionGrid. When it is launched from 
FileStatusList it is supposed to set focus on a specific revision. 
It selected the next revision instead, leading to index out of bounds 
errors.
