### PR TITLE
Better filtering by author/committer/message

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -47,6 +47,27 @@ namespace GitCommands
             get { return a == 0 && b == 0 && c == 0 && d == 0; }
         }
 
+        // Returns true if it's possible to pass given string as command line
+        // argument to git for searching.
+        // As of msysgit 1.7.3.1 git-rev-list requires its search arguments
+        // (--author, --committer, --regex) to be encoded with the exact encoding
+        // used at commit time.
+        // This causes problems under Windows, where command line arguments are
+        // passed as WideChars. Git uses argv, which contains strings
+        // recoded into 8-bit system codepage, and that means searching for strings
+        // outside ASCII range gets crippled, unless commit messages in git
+        // are encoded according to system codepage.
+        // For versions of git displaying such behaviour, this function should return
+        // false if its argument isn't command-line safe, i.e. it contains chars
+        // outside ASCII (7bit) range.
+        public bool IsRegExStringCmdPassable(string s)
+        {
+            if (s==null) return true;
+            foreach (char ch in s)
+                if ((uint)ch >= 0x80) return false;
+            return true;
+        }
+
         private static string Fix(string version)
         {
             if (version == null)

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -8,6 +8,11 @@ using System.Windows.Forms;
 
 namespace GitCommands
 {
+    public abstract class RevisionGraphInMemFilter
+    {
+        public abstract bool PassThru(GitRevision rev);
+    }
+
     public sealed class RevisionGraph : IDisposable
     {
         public event EventHandler Exited;
@@ -97,6 +102,7 @@ namespace GitCommands
 
         public string LogParam = "HEAD --all";
         public string BranchFilter = String.Empty;
+        public RevisionGraphInMemFilter InMemFilter = null;
 
         public void Execute()
         {
@@ -199,9 +205,12 @@ namespace GitCommands
             {
                 if (revision == null || revision.Guid.Trim(hexChars).Length == 0)
                 {
-                    if (revision != null)
-                        revisions.Add(revision);
-                    Updated(this, new RevisionGraphUpdatedEventArgs(revision));
+                    if ((revision == null) || (InMemFilter == null) || InMemFilter.PassThru(revision))
+                    {
+                        if (revision != null)
+                            revisions.Add(revision);
+                        Updated(this, new RevisionGraphUpdatedEventArgs(revision));
+                    }
                 }
                 nextStep = ReadStep.Commit;
             }

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -898,12 +898,31 @@ namespace GitUI
 
         private void ApplyFilter()
         {
+            string revListArgs;
+            string inMemMessageFilter;
+            string inMemCommitterFilter;
+            string inMemAuthorFilter;
             bool[] filterParams = new bool[4];
             filterParams[0] = commitToolStripMenuItem1.Checked;
             filterParams[1] = committerToolStripMenuItem.Checked;
             filterParams[2] = authorToolStripMenuItem.Checked;
-            if (RevisionGrid.Filter == RevisionGrid.FormatQuickFilter(toolStripTextBoxFilter.Text, filterParams)) return;
-            RevisionGrid.Filter = RevisionGrid.FormatQuickFilter(toolStripTextBoxFilter.Text, filterParams);
+            RevisionGrid.FormatQuickFilter(toolStripTextBoxFilter.Text,
+                                           filterParams,
+                                           out revListArgs,
+                                           out inMemMessageFilter,
+                                           out inMemCommitterFilter,
+                                           out inMemAuthorFilter);
+            if ((RevisionGrid.Filter == revListArgs) &&
+                (RevisionGrid.InMemMessageFilter == inMemMessageFilter) &&
+                (RevisionGrid.InMemCommitterFilter == inMemCommitterFilter) &&
+                (RevisionGrid.InMemAuthorFilter == inMemAuthorFilter) &&
+                (RevisionGrid.InMemFilterIgnoreCase))
+                return;
+            RevisionGrid.Filter = revListArgs;
+            RevisionGrid.InMemMessageFilter = inMemMessageFilter;
+            RevisionGrid.InMemCommitterFilter = inMemCommitterFilter;
+            RevisionGrid.InMemAuthorFilter = inMemAuthorFilter;
+            RevisionGrid.InMemFilterIgnoreCase = true;
             RevisionGrid.ForceRefreshRevisions();
         }
 

--- a/GitUI/FormRevisionFilter.cs
+++ b/GitUI/FormRevisionFilter.cs
@@ -58,11 +58,11 @@ namespace GitUI
                 filter += string.Format(" --since=\"{0}\"", Since.Value);
             if (CheckUntil.Checked)
                 filter += string.Format(" --until=\"{0}\"", Until.Value);
-            if (AuthorCheck.Checked)
+            if (AuthorCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Author.Text))
                 filter += string.Format(" --author=\"{0}\"", Author.Text);
-            if (CommitterCheck.Checked)
+            if (CommitterCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Committer.Text))
                 filter += string.Format(" --committer=\"{0}\"", Committer.Text);
-            if (MessageCheck.Checked)
+            if (MessageCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Message.Text))
                 filter += string.Format(" --grep=\"{0}\"", Message.Text);
             if (LimitCheck.Checked)
                 filter += string.Format(" --max-count=\"{0}\"", ((int)_NO_TRANSLATE_Limit.Value).ToString());
@@ -72,6 +72,35 @@ namespace GitUI
                 filter += string.Format(" -- \"{0}\"", FileFilter.Text.Replace('\\', '/'));
 
             return filter;
+        }
+
+        public string GetInMemAuthorFilter()
+        {
+            if (AuthorCheck.Checked && !GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Author.Text))
+                return Author.Text;
+            else
+                return string.Empty;
+        }
+
+        public string GetInMemCommitterFilter()
+        {
+            if (CommitterCheck.Checked && !GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Committer.Text))
+                return Committer.Text;
+            else
+                return string.Empty;
+        }
+
+        public string GetInMemMessageFilter()
+        {
+            if (MessageCheck.Checked && !GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Message.Text))
+                return Message.Text;
+            else
+                return string.Empty;
+        }
+
+        public bool GetIgnoreCase()
+        {
+            return IgnoreCase.Checked;
         }
 
         public string GetBranchFilter()


### PR DESCRIPTION
This is a workaround allowing to search for commits using characters outside ASCII range.
It should fix issue 223.
