### PR TITLE
Patches/addfolderhistory

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -426,7 +426,7 @@ namespace GitUI
             if (item == null)
                 return;
 
-            if (item.ItemType == "blob")
+            if (item.ItemType == "blob" || item.ItemType == "tree")
                 GitUICommands.Instance.StartFileHistoryDialog(item.FileName);
         }
 
@@ -534,7 +534,6 @@ namespace GitUI
             saveAsToolStripMenuItem.Enabled = enableItems;
             openFileToolStripMenuItem.Enabled = enableItems;
             openFileWithToolStripMenuItem.Enabled = enableItems;
-            fileHistoryToolStripMenuItem.Enabled = enableItems;
             openWithToolStripMenuItem.Enabled = enableItems;
         }
 


### PR DESCRIPTION
This is another feature request we had internally here.  I just enabled file history for "tree" items in the file tree view so people could see the history for all items in a directory recursively (a bit like can be done in perforce).
