### PR TITLE
Patches/hidecommandwindows

### DIFF
--- a/GitCommands/Git/GitCommandsHelper.cs
+++ b/GitCommands/Git/GitCommandsHelper.cs
@@ -202,7 +202,7 @@ namespace GitCommands
                 ErrorDialog = false,
                 RedirectStandardOutput = false,
                 RedirectStandardInput = false,
-                CreateNoWindow = false,
+                CreateNoWindow = Settings.ShowGitCommandLine,
                 FileName = cmd,
                 Arguments = arguments,
                 WorkingDirectory = Settings.WorkingDir,
@@ -364,7 +364,7 @@ namespace GitCommands
                 RedirectStandardError = false,
 
                 LoadUserProfile = true,
-                CreateNoWindow = false,
+                CreateNoWindow = Settings.ShowGitCommandLine,
                 FileName = cmd,
                 Arguments = arguments,
                 WorkingDirectory = Settings.WorkingDir,


### PR DESCRIPTION
Hope I'm not bugging you with this flood, we just have a lot of local changes I realized I hadn't offered to you yet.  anyway, I noticed that even when we were selecting to not show a command window for git commands we still got a lot so I found these 2 places where it is always creating a window and not using the user selected setting for command windows.
