### PR TITLE
fix crash on resolving merge conflicts

### DIFF
--- a/GitCommands/Git/GitCommandsHelper.cs
+++ b/GitCommands/Git/GitCommandsHelper.cs
@@ -523,7 +523,7 @@ namespace GitCommands
                 if (!Int32.TryParse(fileStage.Trim()[0].ToString(), out stage))
                     continue;
 
-                var tempFile = RunCmd(Settings.GitCommand, "checkout-index --temp --stage=" + stage + " -- " + filename);
+                var tempFile = RunCmd(Settings.GitCommand, "checkout-index --temp --stage=" + stage + " -- " + "\"" + filename + "\"");
                 tempFile = tempFile.Split('\t')[0];
                 tempFile = Path.Combine(Settings.WorkingDir, tempFile);
 


### PR DESCRIPTION
git extensions throws exception when attempting to resolve merge conflict on files, that have spaces in path
