### PR TITLE
Translate crash fix

### DIFF
--- a/GitUI/FormTranslate.cs
+++ b/GitUI/FormTranslate.cs
@@ -35,7 +35,16 @@ namespace GitUI
                 set
                 {
                     var pc = PropertyChanged;
-                    if (pc != null) pc(this, new PropertyChangedEventArgs("TranslatedValue"));
+                    if (pc != null)
+                    {
+                        try
+                        {
+                            pc(this, new PropertyChangedEventArgs("TranslatedValue"));
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    }
                     _translatedValue = value;
                 }
             }
@@ -398,6 +407,8 @@ namespace GitUI
                 }
 
                 TranslateItem translateItem = (TranslateItem)translateGrid.SelectedRows[0].DataBoundItem;
+
+                if (translateItem == null) return;
 
                 neutralTekst.Text = translateItem.NeutralValue;
                 translatedText.Text = translateItem.TranslatedValue;


### PR DESCRIPTION
if enter some data into translation grid, then switch to another language exception occurs.
