### PR TITLE
FormCommit: Allow commit messages with less than 3 characters

### DIFF
--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -45,7 +45,6 @@ namespace GitUI
         private readonly TranslationString _enterCommitMessageCaption = new TranslationString("Commit message");
 
         private readonly TranslationString _enterCommitMessageHint = new TranslationString("Enter commit message");
-        private readonly GitCommandsInstance _gitGetUnstagedCommand = new GitCommandsInstance();
 
         private readonly TranslationString _mergeConflicts =
             new TranslationString("There are unresolved mergeconflicts, solve mergeconflicts before committing.");
@@ -88,6 +87,7 @@ namespace GitUI
         private readonly TranslationString _resetSelectedLinesConfirmation = new TranslationString("Are you sure you want to reset the changes to the selected lines?");
         #endregion
 
+        private readonly GitCommandsInstance _gitGetUnstagedCommand = new GitCommandsInstance();
         private readonly SynchronizationContext _syncContext;
         public bool NeedRefresh;
         private GitItemStatus _currentItem;


### PR DESCRIPTION
For temporary commits I often use very short commit messages. I don't see any point in forcing the user to use at least 3 characters if git doesn't force it either...
