### PR TITLE
Building GitCommandTests fails on VS2008

### DIFF
--- a/GitCommandsTests/GitCommandsTests.csproj
+++ b/GitCommandsTests/GitCommandsTests.csproj
@@ -51,7 +51,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>


### PR DESCRIPTION
Building GitCommandTests failed on my system. My version of Microsoft.VisualStudio.QualityTools.UnitTestFrameWork is 9.0.0.0 intead of 10.0.0.1 as required.
Simply removing specific version for this requeriment seems to work perfectly for me.
