### PR TITLE
Added Keyboard Navigation for FormCommit

### DIFF
--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using GitCommands;
 using ResourceManager.Translation;
 using PatchApply;
+using GitUI.Hotkey;
 
 namespace GitUI
 {
@@ -131,7 +132,74 @@ namespace GitUI
             SelectedDiff.AddContextMenuEntry(_resetSelectedLines.Text, ResetSelectedLinesToolStripMenuItemClick);
 
             splitMain.SplitterDistance = Settings.CommitDialogSplitter;
+
+            this.Hotkeys = CreateHotkeys();
+            this.HotkeysEnabled = true;
         }
+
+        #region Hotkey commands
+
+        internal enum Commands : int
+        {
+          FocusStagedFiles,
+          FocusUnstagedFiles,
+          FocusSelectedDiff,
+          FocusCommitMessage
+        }
+
+        private void FocusStagedFiles()
+        {
+          FocusFileList(this.Staged);
+        }
+
+        private void FocusUnstagedFiles()
+        {
+          FocusFileList(this.Unstaged);
+        }
+
+        /// <summary>Helper method that moves the focus to the supplied FileStatusList</summary>
+        private void FocusFileList(FileStatusList fileStatusList)
+        {
+          fileStatusList.Focus();
+          fileStatusList.SelectedItem = fileStatusList.GitItemStatuses.Count > 0 ? fileStatusList.GitItemStatuses[0] : null;
+        }
+
+        private void FocusSelectedDiff()
+        {
+          this.SelectedDiff.Focus();
+        }
+
+        private void FocusCommitMessage()
+        {
+          this.Message.StartEditing();
+        }
+
+        protected override void ExecuteCommand(int cmd)
+        {
+          Commands command = (Commands)cmd;
+          
+          switch (command)
+          {
+            case Commands.FocusStagedFiles: FocusStagedFiles(); break;
+            case Commands.FocusUnstagedFiles: FocusUnstagedFiles(); break;
+            case Commands.FocusSelectedDiff: FocusSelectedDiff(); break;
+            case Commands.FocusCommitMessage: FocusCommitMessage(); break;
+          }
+        }
+
+        private IEnumerable<HotkeyMapping> CreateHotkeys()
+        {
+          return new[]
+          {
+            new HotkeyMapping(Keys.Control | Keys.D1, (int)Commands.FocusUnstagedFiles),
+            new HotkeyMapping(Keys.Control | Keys.D2, (int)Commands.FocusSelectedDiff),
+            new HotkeyMapping(Keys.Control | Keys.D3, (int)Commands.FocusStagedFiles),
+            new HotkeyMapping(Keys.Control | Keys.D4, (int)Commands.FocusCommitMessage)
+          };
+        }
+
+        #endregion
+
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
         {

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -8,6 +8,7 @@ using GitUI.Properties;
 using Microsoft.WindowsAPICodePack.Taskbar;
 using ResourceManager.Translation;
 using Settings = GitCommands.Settings;
+using System.Collections.Generic;
 
 namespace GitUI
 {
@@ -33,6 +34,41 @@ namespace GitUI
             Load += GitExtensionsFormLoad;
             FormClosed += GitExtensionsFormFormClosed;
         }
+
+        #region Hotkeys
+
+        /// <summary>Gets or sets a value that specifies if the hotkeys are used</summary>
+        protected bool HotkeysEnabled { get; set; }
+
+        /// <summary>Gets or sets the hotkeys</summary>
+        protected IEnumerable<Hotkey.HotkeyMapping> Hotkeys { get; set; }
+
+        /// <summary>Overridden: Checks if a hotkey wants to handle the key before letting the message propagate</summary>
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+          if (HotkeysEnabled && this.Hotkeys != null)
+            foreach (var hotkey in this.Hotkeys)
+            {
+              if (hotkey.KeyData == keyData)
+              {
+                ExecuteCommand(hotkey.Command);
+                return true;
+              }
+            }
+
+          return base.ProcessCmdKey(ref msg, keyData);
+        }
+        
+        /// <summary>
+        /// Override this method to handle form specific Hotkey commands
+        /// This base method does nothing
+        /// </summary>
+        /// <param name="command"></param>
+        protected virtual void ExecuteCommand(int command)
+        {
+        }
+        
+        #endregion
 
         private void SetFont()
         {

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -88,6 +88,7 @@
     <Compile Include="AboutBox.Designer.cs">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </Compile>
+    <Compile Include="Hotkey\HotkeyMapping.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Editor\FileViewer.cs">
       <SubType>UserControl</SubType>

--- a/GitUI/Hotkey/HotkeyMapping.cs
+++ b/GitUI/Hotkey/HotkeyMapping.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using System.Xml.Serialization;
+
+namespace GitUI.Hotkey
+{
+  [Serializable]
+  public class HotkeyMapping
+  {
+    [XmlAttribute]
+    public int Command { get; set; }
+
+    [XmlAttribute]
+    public Keys KeyData { get; set; }
+
+    public HotkeyMapping()
+    {
+    }
+    public HotkeyMapping(Keys keyData, int command)
+    {
+      this.KeyData = keyData;
+      this.Command = command;
+    }
+  }
+}

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -436,5 +436,10 @@ namespace GitUI.SpellChecker
         {
             OnKeyDown(e);
         }
+
+        public void StartEditing()
+        {
+          EmptyLabelClick(null, null);
+        }
     }
 }


### PR DESCRIPTION
As I prefer keyboard navigation, I've added a little code that allows to jump between the Staged Files, Differences, Unstaged Files and Commit message using Ctrl-1..5

Take care,
Martin
