### PR TITLE
Fast jump in blame

### DIFF
--- a/GitUI/Blame/BlameControl.cs
+++ b/GitUI/Blame/BlameControl.cs
@@ -11,6 +11,7 @@ namespace GitUI.Blame
     {
         private GitBlame _blame;
         private string _lastRevision;
+        private RevisionGrid _revGrid;
 
         public BlameControl()
         {
@@ -99,12 +100,13 @@ namespace GitUI.Blame
             SyncBlameViews();
         }
 
-        public void LoadBlame(string guid, string fileName)
+        public void LoadBlame(string guid, string fileName, RevisionGrid revGrid)
         {
             var scrollpos = BlameFile.ScrollPos;
 
             var blameCommitter = new StringBuilder();
             var blameFile = new StringBuilder();
+			_revGrid = revGrid;
 
             _blame = GitCommandHelpers.Blame(fileName, guid);
 
@@ -136,9 +138,16 @@ namespace GitUI.Blame
 
         private void ActiveTextAreaControlDoubleClick(object sender, EventArgs e)
         {
-            var frm = new FormDiffSmall();
-            frm.SetRevision(_lastRevision);
-            frm.ShowDialog();
+            if (_revGrid != null)
+            {
+                _revGrid.SetSelectedRevision(new GitRevision { Guid = _lastRevision, ParentGuids = new[] { _lastRevision + "^" } });
+            }
+            else
+            {
+                var frm = new FormDiffSmall();
+                frm.SetRevision(_lastRevision);
+                frm.ShowDialog();
+            }
         }
     }
 }

--- a/GitUI/Blame/FormBlame.cs
+++ b/GitUI/Blame/FormBlame.cs
@@ -17,7 +17,7 @@ namespace GitUI.Blame
                 revision = new GitRevision {Guid = "Head"};
 
 
-            blameControl1.LoadBlame(revision.Guid, fileName);
+            blameControl1.LoadBlame(revision.Guid, fileName, null);
         }
 
         public string FileName { get; set; }

--- a/GitUI/FormFileHistory.cs
+++ b/GitUI/FormFileHistory.cs
@@ -178,7 +178,7 @@ namespace GitUI
             Text = string.Format("File History ({0})", fileName);
 
             if (tabControl1.SelectedTab == Blame)
-                blameControl1.LoadBlame(revision.Guid, fileName);
+                blameControl1.LoadBlame(revision.Guid, fileName, FileChanges);
             if (tabControl1.SelectedTab == ViewTab)
             {
                 var scrollpos = View.ScrollPos;

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -449,10 +449,13 @@ namespace GitUI
 
             if (revision != null)
             {
-                foreach (DataGridViewRow row in Revisions.Rows)
+                for (var i = 0; i < Revisions.RowCount; i++)
                 {
-                    if (((GitRevision)row.DataBoundItem).Guid == revision.Guid)
-                        row.Selected = true;
+                    if (((GitRevision)Revisions.GetRowData(i)).Guid == revision.Guid)
+                    {
+                        SetSelectedIndex(i);
+                        break;
+                    }
                 }
             }
             Revisions.Select();


### PR DESCRIPTION
Currenlty doubleclick on line in blame opens a new diff window. After my commit doubleclik will jump on tree to the corresponding commit. This is much fuster then previos solution. You can still see a diff by doubleclick on the tree. 
