### PR TITLE
Fix for commit summary with polish letters in author names

### DIFF
--- a/GitUI/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class CommitInfo
     {
@@ -108,6 +109,7 @@
             this._RevisionHeader.ContextMenuStrip = this.commitInfoContextMenuStrip;
             this._RevisionHeader.Dock = System.Windows.Forms.DockStyle.Fill;
             this._RevisionHeader.Font = new System.Drawing.Font("Tahoma", 9.75F);
+            this._RevisionHeader.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this._RevisionHeader.Location = new System.Drawing.Point(0, 0);
             this._RevisionHeader.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this._RevisionHeader.Name = "_RevisionHeader";
@@ -176,6 +178,7 @@
             this.RevisionInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.RevisionInfo.ContextMenuStrip = this.commitInfoContextMenuStrip;
             this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RevisionInfo.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.RevisionInfo.Location = new System.Drawing.Point(0, 0);
             this.RevisionInfo.Margin = new System.Windows.Forms.Padding(4);
             this.RevisionInfo.Name = "RevisionInfo";

--- a/GitUI/FormChangeLog.Designer.cs
+++ b/GitUI/FormChangeLog.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class FormChangeLog
     {
@@ -34,6 +35,7 @@
             // ChangeLog
             // 
             this.ChangeLog.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ChangeLog.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.ChangeLog.Location = new System.Drawing.Point(0, 0);
             this.ChangeLog.Name = "ChangeLog";
             this.ChangeLog.Size = new System.Drawing.Size(849, 411);

--- a/GitUI/FormDonate.Designer.cs
+++ b/GitUI/FormDonate.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class FormDonate
     {
@@ -41,6 +42,7 @@
             // richTextBox1
             // 
             this.richTextBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.richTextBox1.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.richTextBox1.Location = new System.Drawing.Point(0, 0);
             this.richTextBox1.Name = "richTextBox1";
             this.richTextBox1.ReadOnly = true;

--- a/GitUI/FormFormatPatch.Designer.cs
+++ b/GitUI/FormFormatPatch.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class FormFormatPatch
     {
@@ -105,6 +106,7 @@
             // 
             this.MailBody.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
                         | System.Windows.Forms.AnchorStyles.Right)));
+            this.MailBody.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.MailBody.Location = new System.Drawing.Point(254, 93);
             this.MailBody.Name = "MailBody";
             this.MailBody.Size = new System.Drawing.Size(477, 56);

--- a/GitUI/FormSettings.Designer.cs
+++ b/GitUI/FormSettings.Designer.cs
@@ -1,4 +1,5 @@
 using GitCommands.Repository;
+using System.Windows.Forms;
 
 namespace GitUI
 {
@@ -2681,6 +2682,7 @@ namespace GitUI
                         | System.Windows.Forms.AnchorStyles.Right)));
             this.argumentsTextBox.Enabled = false;
             this.helpProvider1.SetHelpString(this.argumentsTextBox, resources.GetString("argumentsTextBox.HelpString"));
+            this.argumentsTextBox.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.argumentsTextBox.Location = new System.Drawing.Point(107, 299);
             this.argumentsTextBox.Name = "argumentsTextBox";
             this.helpProvider1.SetShowHelp(this.argumentsTextBox, true);

--- a/GitUI/FormStash.Designer.cs
+++ b/GitUI/FormStash.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using GitUI.Editor;
+using System.Windows.Forms;
 
 namespace GitUI
 {
@@ -193,6 +194,7 @@ namespace GitUI
             this.StashMessage.BackColor = System.Drawing.SystemColors.Info;
             this.StashMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.StashMessage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.StashMessage.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.StashMessage.Location = new System.Drawing.Point(0, 0);
             this.StashMessage.Name = "StashMessage";
             this.StashMessage.ReadOnly = true;

--- a/GitUI/FormStatus.Designer.cs
+++ b/GitUI/FormStatus.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class FormStatus
     {
@@ -115,6 +116,7 @@
             this.Output.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.Output.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Output.Font = new System.Drawing.Font("Lucida Console", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Output.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.Output.Location = new System.Drawing.Point(0, 0);
             this.Output.Name = "Output";
             this.Output.ReadOnly = true;

--- a/GitUI/FormTranslate.Designer.cs
+++ b/GitUI/FormTranslate.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class FormTranslate
     {
@@ -355,6 +356,7 @@
             // neutralTekst
             // 
             this.neutralTekst.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.neutralTekst.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.neutralTekst.Location = new System.Drawing.Point(0, 0);
             this.neutralTekst.Name = "neutralTekst";
             this.neutralTekst.ReadOnly = true;
@@ -365,6 +367,7 @@
             // translatedText
             // 
             this.translatedText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.translatedText.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.translatedText.Location = new System.Drawing.Point(0, 0);
             this.translatedText.Name = "translatedText";
             this.translatedText.Size = new System.Drawing.Size(388, 77);

--- a/GitUI/GitLogForm.Designer.cs
+++ b/GitUI/GitLogForm.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI
+﻿using System.Windows.Forms;
+namespace GitUI
 {
     partial class GitLogForm
     {
@@ -106,6 +107,7 @@
             this.LogOutput.BackColor = System.Drawing.SystemColors.ControlLight;
             this.LogOutput.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.LogOutput.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.LogOutput.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.LogOutput.Location = new System.Drawing.Point(0, 0);
             this.LogOutput.Margin = new System.Windows.Forms.Padding(0);
             this.LogOutput.Name = "LogOutput";
@@ -158,6 +160,7 @@
             this.commandCacheOutput.BackColor = System.Drawing.SystemColors.ControlLight;
             this.commandCacheOutput.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.commandCacheOutput.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commandCacheOutput.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.commandCacheOutput.Location = new System.Drawing.Point(0, 0);
             this.commandCacheOutput.Margin = new System.Windows.Forms.Padding(0);
             this.commandCacheOutput.Name = "commandCacheOutput";

--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI.SpellChecker
+﻿using System.Windows.Forms;
+namespace GitUI.SpellChecker
 {
     partial class EditNetSpell
     {
@@ -60,6 +61,7 @@
             this.TextBox.AcceptsTab = true;
             this.TextBox.ContextMenuStrip = this.SpellCheckContextMenu;
             this.TextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.TextBox.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.TextBox.Location = new System.Drawing.Point(0, 0);
             this.TextBox.Name = "TextBox";
             this.TextBox.Size = new System.Drawing.Size(386, 336);

--- a/GitUI/Statistics/FormCommitCount.Designer.cs
+++ b/GitUI/Statistics/FormCommitCount.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace GitUI.Statistics
+﻿using System.Windows.Forms;
+namespace GitUI.Statistics
 {
     partial class FormCommitCount
     {
@@ -37,6 +38,7 @@
             // CommitCount
             // 
             this.CommitCount.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.CommitCount.LanguageOption = RichTextBoxLanguageOptions.AutoKeyboard;
             this.CommitCount.Location = new System.Drawing.Point(0, 0);
             this.CommitCount.Name = "CommitCount";
             this.CommitCount.ReadOnly = true;


### PR DESCRIPTION
Workaround for problem with polish "ń" letter in names and surnames (font suddenly changes in RichTextBox and interline doubles). There is still a problem in RevisionInfo RichTextBox but it can't be changed because of links. This one was the most painful because there was and extra scrollbar when polish "ń" appers in text.
