### PR TITLE
Fix for "Open with difftool" when comparing two or more commits

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1390,7 +1390,7 @@ namespace GitUI
 
 
             var output = GitCommandHelpers.OpenWithDifftool(selectedItem, revisions[0].Guid,
-                                                                  revisions[0].ParentGuids[0]);
+                                                                  revisions[revisions.Count - 1].ParentGuids[0]);
             if (!string.IsNullOrEmpty(output))
                 MessageBox.Show(output);
         }


### PR DESCRIPTION
Just a fix. Small and handy. :)
