### PR TITLE
Bug: popup complains about missing .gitextensions on Linux

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -274,5 +274,28 @@ namespace GitCommands.Config
 
             return path.Replace("$QUOTE$", "\\\"");
         }
+
+        public static string GetPath()
+        {
+            String[] paths = {
+                Environment.GetEnvironmentVariable("HOME"),
+                Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User),
+                Environment.GetEnvironmentVariable("HOMEDRIVE") + Environment.GetEnvironmentVariable("HOMEPATH"),
+                Environment.GetEnvironmentVariable("USERPROFILE"),
+                Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+            };
+
+            foreach(string path in paths)
+            {
+                if (! String.IsNullOrEmpty(path))
+                {
+                    string candidate = Path.Combine(path, ".gitconfig");
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+            }
+
+            return Path.Combine(Environment.CurrentDirectory, ".gitconfig");
+        }
     }
 }

--- a/GitCommands/Git/GitCommandsHelper.cs
+++ b/GitCommands/Git/GitCommandsHelper.cs
@@ -1536,7 +1536,7 @@ namespace GitCommands
 
         public static ConfigFile GetGlobalConfig()
         {
-            return new ConfigFile(Environment.GetEnvironmentVariable("HOME") + Settings.PathSeparator + ".gitconfig");
+            return new ConfigFile(ConfigFile.GetPath());
         }
 
         public static ConfigFile GetLocalConfig()


### PR DESCRIPTION
I think this works in all cases. Although I wonder why all this HOME stuff is there at all? Isn't .gitconfig supposed to be in user's profile directory? Which would mean that the only folder to check is in Environment.GetFolderPath(Environment.SpecialFolder.Personal)?
