### PR TITLE
I fixed a bug with SaveAs

### DIFF
--- a/GitCommands/Git/GitCommandsHelper.cs
+++ b/GitCommands/Git/GitCommandsHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -518,7 +518,7 @@ namespace GitCommands
             {
                 using (FileStream fileOut = File.Create(saveAs))
                 {
-                    byte[] buf = ms.GetBuffer();
+                    byte[] buf = ms.ToArray();
                     fileOut.Write(buf, 0, buf.Length);
                 }
             }


### PR DESCRIPTION
Hy,

When I use "Save As" in the "File tree tab", gitExtention add more space at the end of file.
I fixed it.

best regards,
