### PR TITLE
Fix path to CreateLocalBranches plugin.

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -160,7 +160,7 @@
         <File Source="..\Plugins\AutoCompileSubmodules\AutoCompileSubmodules\bin\Release\AutoCompileSubmodules.dll"/>
       </Component>
       <Component Id="CreateLocalBranches.dll" Guid="*">
-        <File Source="..\Plugins\Statistics\CreateLocalBranches\bin\Release\CreateLocalBranches.dll"/>
+        <File Source="..\GitPlugin\CreateLocalBranches\bin\Release\CreateLocalBranches.dll"/>
       </Component>
       <Component Id="GitStatistics.dll" Guid="*">
         <File Source="..\Plugins\Statistics\GitStatistics\bin\Release\GitStatistics.dll"/>


### PR DESCRIPTION
The location of this plugin changed recently.  This change just locates it from the new directory.
