### PR TITLE
Use the faster log -1 when populating the revision graph.

### DIFF
--- a/GitCommands/CommitInformation.cs
+++ b/GitCommands/CommitInformation.cs
@@ -92,7 +92,7 @@ namespace GitCommands
             string info = GitCommandHelpers.RunCmd(
                 Settings.GitCommand,
                 string.Format(
-                    "show -s --pretty=raw --show-notes=* {0}", sha1));
+                    "log -1 --pretty=raw --show-notes=* {0}", sha1));
 
             if (info.Trim().StartsWith("fatal"))
                 return new CommitInformation("Cannot find commit" + sha1, "");


### PR DESCRIPTION
For some reason, show -s ultimately shows the subject information but also
reads the entire diff from the commit.  For large commits, this makes the
revision graph population very slow.  Using log -1 appears to work around
the problem.

Josh found that with a particularly large merge commit we had it was taking 3-5 seconds to use "log -1" whereas with "show" it was taking over 1 minute yet the display of both was exactly the same.
