### PR TITLE
Support Windows 7 Jumplist for Recent Repositories

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -253,6 +253,21 @@ namespace GitExtensions
                         Pull(arguments);
                         Push(arguments);
                         return;
+                    case "openrepo":
+                        if (args.Length > 2)
+                        {
+                            if (File.Exists(args[2]))
+                            {
+                                string path = File.ReadAllText(args[2]);
+                                if (Directory.Exists(path))
+                                {
+                                    Settings.WorkingDir = path;
+                                }
+                            }
+                        }
+
+                        GitUICommands.Instance.StartBrowseDialog();
+                        return;
                     default:
                         Application.Run(new FormCommandlineHelp());
                         return;

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -80,6 +80,11 @@
       </Component>
       <Component Id="GitExtensions.exe" Guid="*">
         <File Source="..\GitExtensions\bin\Release\GitExtensions.exe"/>
+        <ProgId Id="GitExtensions" Description="Git Extentions Shortcut" Icon="cow_head.ico" Advertise="yes">
+          <Extension Id="gitext">
+            <Verb Id="open" Command="Open Git Extentions Repository" Argument="openrepo &quot;%1&quot;" />
+          </Extension>
+        </ProgId>
       </Component>
       <Component Id="Gravatar.dll" Guid="*">
         <File Source="..\GitExtensions\bin\Release\Gravatar.dll"/>


### PR DESCRIPTION
This pull request adds support for Windows 7 "Recent" Jumplist to quickly open repositories.  I have created a new file type ".gitext" which is required to get this functionality with Windows.  When the Browser loads a repo it will write out a file with the name of the repo + ".gitext" into Settings.ApplicationDataPath\Recent and notify windows to add this to the recent items list.
