### PR TITLE
fixed issue #452: "Show repository status" always updates status every second

### DIFF
--- a/GitUI/ToolStripGitStatus.cs
+++ b/GitUI/ToolStripGitStatus.cs
@@ -28,6 +28,11 @@ namespace GitUI
         /// </summary>
         private const int MaxUpdatePeriod = 5 * 60 * 1000;
 
+        /// <summary>
+        /// Paths to be ignored on filesystem changes watching.
+        /// </summary>
+        private static readonly string[] IgnoredPaths = new[] { @"\.git", @"\.git\index.lock" };
+
         private GitCommandsInstance gitGetUnstagedCommand = new GitCommandsInstance();
         private readonly SynchronizationContext syncContext;
         private readonly FileSystemWatcher watcher = new FileSystemWatcher();
@@ -101,11 +106,7 @@ namespace GitUI
 
         private void watcher_Changed(object sender, FileSystemEventArgs e)
         {
-            const string repositoryDirectoryName = ".git";
-            var isGitSelfChange = e.FullPath
-                .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                .Any(directoryName => directoryName == repositoryDirectoryName);
-
+            var isGitSelfChange = IgnoredPaths.Any(path => e.FullPath.EndsWith(path));
             if (isGitSelfChange)
                 return;
 


### PR DESCRIPTION
Fixed issue and refactored the code a little.

What was changed:
- filesystem watcher ignores self-changes by git
- toolstrip updates status only when working dir files change or repo changes + one just in case update every 5 minute. No more dummy updates.
- disabling update timer and filesystem watcher when there is no opened repo or during checkout operation.
- small code readability improvements
