### PR TITLE
Support Windows 7 ThumbnailToolBarButton, for commiting, pushing and pulling.

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -272,13 +272,13 @@ namespace GitUI
             {
                 if (!_toolbarButtonsCreated)
                 {
-                    _commitButton = new ThumbnailToolBarButton(MakeIcon(toolStripButton1.Image, 48, true), "Commit");
+                    _commitButton = new ThumbnailToolBarButton(MakeIcon(toolStripButton1.Image, 48, true), toolStripButton1.Text);
                     _commitButton.Click += ToolStripButton1Click;
 
-                    _pushButton = new ThumbnailToolBarButton(MakeIcon(toolStripButtonPush.Image, 48, true), "Push");
+                    _pushButton = new ThumbnailToolBarButton(MakeIcon(toolStripButtonPush.Image, 48, true), toolStripButtonPush.Text);
                     _pushButton.Click += PushToolStripMenuItemClick;
 
-                    _pullButton = new ThumbnailToolBarButton(MakeIcon(toolStripButtonPull.Image, 48, true), "Pull");
+                    _pullButton = new ThumbnailToolBarButton(MakeIcon(toolStripButtonPull.Image, 48, true), toolStripButtonPull.Text);
                     _pullButton.Click += PullToolStripMenuItemClick;
 
                     _toolbarButtonsCreated = true;


### PR DESCRIPTION
This pull request expands on my last pull request to expand support for the Windows 7 taskbar in gitextensions.  This code creates three icons under the Git Extensions thumbnail preview, which allow you to quickly bring up the commit, push, and pull dialogs.  It uses the icons straight from the toolbar items for their icons.  I have uploaded a screenshot of this here: http://twitpic.com/53beot - the screenshot shows two Git Extension windows open with separate repositories. From the thumbnail preview, you can activate the respective dialogs.

I feel like this will be a great time saver!
