### PR TITLE
Fixed short name creation for repositories located in root directories

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -240,6 +240,22 @@ namespace GitUI
             Cursor.Current = Cursors.Default;
         }
 
+        /// <summary>
+        /// Returns a short name for repository. 
+        /// If the repository contains a description it is returned,
+        /// otherwise the last part of path is returned.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        /// <returns>Short name for repository</returns>
+        private static String GetRepositoryShortName(string repositoryDir)
+        {
+            DirectoryInfo dirInfo = new DirectoryInfo(repositoryDir);
+            if (dirInfo.Exists)
+                return ReadRepositoryDescription(repositoryDir) ?? dirInfo.Name;
+            else
+                return dirInfo.Name;
+        }
+
         private void UpdateJumplist(bool validWorkingDir)
         {
             if (Settings.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
@@ -249,7 +265,7 @@ namespace GitUI
             
                 if(validWorkingDir)
                 {
-                    string repositoryDescription = ReadRepositoryDescription(Settings.WorkingDir) ?? Directory.GetParent(Settings.WorkingDir).Name;
+                    string repositoryDescription = GetRepositoryShortName(Settings.WorkingDir);
                     string baseFolder = Path.Combine(Settings.ApplicationDataPath, "Recent");
                     if(!Directory.Exists(baseFolder))
                     {
@@ -451,7 +467,7 @@ namespace GitUI
 
             if (!isWorkingDirValid)
                 return defaultTitle;
-            string repositoryDescription = ReadRepositoryDescription(workingDir) ?? Directory.GetParent(workingDir).Name;
+            string repositoryDescription = GetRepositoryShortName(workingDir);
             return string.Format(repositoryTitleFormat, repositoryDescription);
         }
 


### PR DESCRIPTION
Hi! GenerateWindowTitle failed with null reference exception when browsing repositories located in root directories. This patch fixes the issue.
Best regards, Grzegorz.
