### PR TITLE
Flicker

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -2114,6 +2114,11 @@ namespace GitUI
 
         void GitTree_MouseMove(object sender, MouseEventArgs e)
         {
+            TreeView gitTree = (TreeView) sender;
+
+            if (!gitTree.Focused)
+                gitTree.Focus();
+
             //DRAG
             // If the mouse moves outside the rectangle, start the drag.
             if (gitTreeDragBoxFromMouseDown != Rectangle.Empty &&
@@ -2122,9 +2127,9 @@ namespace GitUI
                 StringCollection fileList = new StringCollection();
 
                 //foreach (GitItemStatus item in SelectedItems)
-                if (GitTree.SelectedNode != null)
+                if (gitTree.SelectedNode != null)
                 {
-                    GitItem item = GitTree.SelectedNode.Tag as GitItem;
+                    GitItem item = gitTree.SelectedNode.Tag as GitItem;
                     if (item != null)
                     {
                         string fileName = GitCommands.Settings.WorkingDir + item.FileName;

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -1127,8 +1127,13 @@ namespace GitUI
 
             var pt = Revisions.PointToClient(Cursor.Position);
             var hti = Revisions.HitTest(pt.X, pt.Y);
+
+            if (LastRow == hti.RowIndex)
+                return;
+
             LastRow = hti.RowIndex;
             Revisions.ClearSelection();
+            
             if (LastRow >= 0 && Revisions.Rows.Count > LastRow)
                 Revisions.Rows[LastRow].Selected = true;
         }


### PR DESCRIPTION
fixed: RevisionGrid fires SelectionChanges when right mouse button clicks on already selected row which causes unnecessary redrawing the bottom panels of FormBrowse window.

And FileTree auto focuses now when mouse moves over it.
