### PR TITLE
fixed: RevisionGraph is updated twice after the Settings window closed wh

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1148,7 +1148,6 @@ namespace GitUI
             Initialize();
             RevisionGrid.ReloadHotkeys();
             RevisionGrid.ReloadTranslation();
-            RevisionGrid.ForceRefreshRevisions();
         }
 
         private void ArchiveToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
fixed: RevisionGraph is updated twice after the Settings window closed which some time cause a rather long pause with high CPU usage ending with a ThreadAbortException.
