### PR TITLE
Updated with correct 3way merge string for Beyond Compare 3

### DIFF
--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -1267,7 +1267,7 @@ namespace GitUI
                     }
                 }
 
-                MergeToolCmd.Text = "\"" + MergetoolPath.Text + "\" \"$BASE\" \"$LOCAL\" \"$REMOTE\"";
+                MergeToolCmd.Text = "\"" + MergetoolPath.Text + "\" \"$LOCAL\" \"$REMOTE\" \"$BASE\" \"$MERGED\"";
                 return;
             }
 


### PR DESCRIPTION
This is the proper string for doing a three way merge with Beyond Compare 3.
Tested on Git 1.7.6-preview20110708 and Beyond Compare 3.2.4(13298) Pro
Edition for Windows

Here is a link to Beyond Compares command line formatting .
http://www.scootersoftware.com/support.php?zz=kb_vcs#gitwindows
