### PR TITLE
fixed: FormClone remove all '.git' substring from targer dir name if orig

### DIFF
--- a/GitUI/FormClone.cs
+++ b/GitUI/FormClone.cs
@@ -171,8 +171,10 @@ namespace GitUI
             var path = _NO_TRANSLATE_From.Text;
             path = path.TrimEnd(new[] { '\\', '/' });
 
-            if (path.EndsWith(".git"))
-                path = path.Replace(".git", "");
+            const string standardRepositorySuffix = ".git";
+
+            if (path.EndsWith(standardRepositorySuffix))
+                path = path.Substring(0, path.Length - standardRepositorySuffix.Length);
 
             if (path.Contains("\\") || path.Contains("/"))
                 _NO_TRANSLATE_NewDirectory.Text = path.Substring(path.LastIndexOfAny(new[] { '\\', '/' }) + 1);


### PR DESCRIPTION
fixed: FormClone remove all '.git' substring from targer dir name if original repository dir ends with '.git'
