### PR TITLE
Add support for commit templates.

### DIFF
--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using ResourceManager.Translation;
 using PatchApply;
 using GitUI.Hotkey;
@@ -99,6 +100,7 @@ namespace GitUI
         private GitRevision _editedCommit;
         private readonly ToolStripItem _StageSelectedLinesToolStripMenuItem;
         private readonly ToolStripItem _ResetSelectedLinesToolStripMenuItem;
+        private string commitTemplate;
 
         public FormCommit()
             : this(CommitKind.Normal, null)
@@ -348,6 +350,16 @@ namespace GitUI
                     showUntrackedFilesToolStripMenuItem.Checked);
             _gitGetUnstagedCommand.CmdStartProcess(Settings.GitCommand, allChangedFilesCmd);
 
+            // Check if commit.template is used
+            ConfigFile globalConfig = GitCommandHelpers.GetGlobalConfig();
+            string fileName = globalConfig.GetValue("commit.template");
+            if (!string.IsNullOrEmpty(fileName))
+            {
+                StreamReader commitReader = new StreamReader(fileName);
+                commitTemplate = commitReader.ReadToEnd().Replace("\r","");
+                Message.Text = commitTemplate;
+            }
+
             Loading.Visible = true;
             LoadingStaged.Visible = true;
 
@@ -484,7 +496,7 @@ namespace GitUI
                 MessageBox.Show(_mergeConflicts.Text, _mergeConflictsCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-            if (string.IsNullOrEmpty(Message.Text))
+            if (string.IsNullOrEmpty(Message.Text) || Message.Text == commitTemplate)
             {
                 MessageBox.Show(_enterCommitMessage.Text, _enterCommitMessageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Asterisk);
                 return;

--- a/GitUI/FormSettings.Designer.cs
+++ b/GitUI/FormSettings.Designer.cs
@@ -274,6 +274,9 @@ namespace GitUI
             this.repositoryBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.helpProvider1 = new System.Windows.Forms.HelpProvider();
             this.diffFontDialog = new System.Windows.Forms.FontDialog();
+            this.BrowseCommitTemplate = new System.Windows.Forms.Button();
+            this.label57 = new System.Windows.Forms.Label();
+            this.CommitTemplatePath = new System.Windows.Forms.TextBox();
             this.LocalSettings.SuspendLayout();
             this.groupBox10.SuspendLayout();
             this.InvalidGitPathLocal.SuspendLayout();
@@ -2140,6 +2143,9 @@ namespace GitUI
             // 
             // GlobalSettingsPage
             // 
+            this.GlobalSettingsPage.Controls.Add(this.BrowseCommitTemplate);
+            this.GlobalSettingsPage.Controls.Add(this.label57);
+            this.GlobalSettingsPage.Controls.Add(this.CommitTemplatePath);
             this.GlobalSettingsPage.Controls.Add(this.groupBox9);
             this.GlobalSettingsPage.Controls.Add(this.DiffToolCmdSuggest);
             this.GlobalSettingsPage.Controls.Add(this.DifftoolCmd);
@@ -2181,7 +2187,7 @@ namespace GitUI
             this.groupBox9.Controls.Add(this.globalAutoCrlfFalse);
             this.groupBox9.Controls.Add(this.globalAutoCrlfInput);
             this.groupBox9.Controls.Add(this.globalAutoCrlfTrue);
-            this.groupBox9.Location = new System.Drawing.Point(6, 290);
+            this.groupBox9.Location = new System.Drawing.Point(6, 320);
             this.groupBox9.Name = "groupBox9";
             this.groupBox9.Size = new System.Drawing.Size(799, 105);
             this.groupBox9.TabIndex = 31;
@@ -3109,6 +3115,32 @@ namespace GitUI
             this.diffFontDialog.AllowVerticalFonts = false;
             this.diffFontDialog.FixedPitchOnly = true;
             // 
+            // BrowseCommitTemplate
+            // 
+            this.BrowseCommitTemplate.Location = new System.Drawing.Point(506, 285);
+            this.BrowseCommitTemplate.Name = "BrowseCommitTemplate";
+            this.BrowseCommitTemplate.Size = new System.Drawing.Size(75, 25);
+            this.BrowseCommitTemplate.TabIndex = 34;
+            this.BrowseCommitTemplate.Text = "Browse";
+            this.BrowseCommitTemplate.UseVisualStyleBackColor = true;
+            this.BrowseCommitTemplate.Click += new System.EventHandler(this.BrowseCommitTemplate_Click);
+            // 
+            // label57
+            // 
+            this.label57.AutoSize = true;
+            this.label57.Location = new System.Drawing.Point(9, 290);
+            this.label57.Name = "label57";
+            this.label57.Size = new System.Drawing.Size(140, 15);
+            this.label57.TabIndex = 33;
+            this.label57.Text = "Path to commit template";
+            // 
+            // CommitTemplatePath
+            // 
+            this.CommitTemplatePath.Location = new System.Drawing.Point(153, 286);
+            this.CommitTemplatePath.Name = "CommitTemplatePath";
+            this.CommitTemplatePath.Size = new System.Drawing.Size(347, 23);
+            this.CommitTemplatePath.TabIndex = 32;
+            // 
             // FormSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -3427,6 +3459,9 @@ namespace GitUI
         private Button diffFontChangeButton;
         private Label label56;
         private FontDialog diffFontDialog;
+        private Button BrowseCommitTemplate;
+        private Label label57;
+        private TextBox CommitTemplatePath;
 
     }
 }

--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -243,6 +243,7 @@ namespace GitUI
                 GlobalUserEmail.Text = globalConfig.GetValue("user.email");
                 GlobalEditor.Text = globalConfig.GetValue("core.editor");
                 GlobalMergeTool.Text = globalConfig.GetValue("merge.tool");
+                CommitTemplatePath.Text = globalConfig.GetValue("commit.template");
 
                 SetCheckboxFromString(KeepMergeBackup, localConfig.GetValue("mergetool.keepBackup"));
 
@@ -538,6 +539,9 @@ namespace GitUI
             if (string.IsNullOrEmpty(GlobalUserEmail.Text) ||
                 !GlobalUserEmail.Text.Equals(globalConfig.GetValue("user.email")))
                 globalConfig.SetValue("user.email", GlobalUserEmail.Text);
+            if (string.IsNullOrEmpty(CommitTemplatePath.Text) ||
+                !CommitTemplatePath.Text.Equals(globalConfig.GetValue("commit.template")))
+                globalConfig.SetValue("commit.template", CommitTemplatePath.Text);
             globalConfig.SetValue("core.editor", GlobalEditor.Text);
 
             SetGlobalDiffToolToConfig(globalConfig, GlobalDiffTool.Text);
@@ -911,6 +915,7 @@ namespace GitUI
             GlobalUserName.Enabled = canFindGitCmd;
             GlobalUserEmail.Enabled = canFindGitCmd;
             GlobalEditor.Enabled = canFindGitCmd;
+            CommitTemplatePath.Enabled = canFindGitCmd;
             GlobalMergeTool.Enabled = canFindGitCmd;
             MergetoolPath.Enabled = canFindGitCmd;
             MergeToolCmd.Enabled = canFindGitCmd;
@@ -2307,6 +2312,11 @@ namespace GitUI
             diffFontChangeButton.Text = 
                 string.Format("{0}, {1}", diffFont.FontFamily.Name, (int) diffFont.Size);
 
+        }
+
+        private void BrowseCommitTemplate_Click(object sender, EventArgs e)
+        {
+            CommitTemplatePath.Text = SelectFile(".", "*.txt (*.txt)|*.txt", CommitTemplatePath.Text);
         }
     }
 }


### PR DESCRIPTION
Git has built-in support for commit templates via commit.template. There will now be a commit template path box in the global git settings allowing users to point to their commit template txt file. If that path is set it will auto-populate the commit message box with the template text.
