### PR TITLE
Fixing one test

### DIFF
--- a/GitCommandsTests/CommitInformationTest.cs
+++ b/GitCommandsTests/CommitInformationTest.cs
@@ -32,7 +32,7 @@ namespace GitCommandsTests
                           "Notes (p4notes):\n" +
                           "\tP4@547123";
 
-            var expectedHeader = "Author:\tJohn Doe (Acme Inc) <John.Doe@test.com>\n" +
+            var expectedHeader = "Author:\t\tJohn Doe (Acme Inc) <John.Doe@test.com>\n" +
                                  "Author date:\t3 days ago (" + authorTime.ToLocalTime().ToString("ddd MMM dd HH':'mm':'ss yyyy") + ")\n" +
                                  "Committer:\tJane Doe (Acme Inc) <Jane.Doe@test.com>\n" +
                                  "Commit date:\t2 days ago (" + commitTime.ToLocalTime().ToString("ddd MMM dd HH':'mm':'ss yyyy") + ")\n" +


### PR DESCRIPTION
This is a quick fix because of COMMITHEADER_STRING_LENGTH = 16 it needs another \t in the expectedHeader. Future tests should consider the usage of this COMMIT_HEADER_STRING_LENGTH
