### PR TITLE
Remove hashes from commit message before committing

### DIFF
--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -922,10 +922,13 @@ namespace GitUI
                 var lineNumber = 0;
                 foreach (var line in commitMessageText.Split('\n'))
                 {
-                    if (lineNumber == 1 && !String.IsNullOrEmpty(line))
-                        textWriter.WriteLine();
+                    if (!line.StartsWith("#"))
+                    {
+                        if (lineNumber == 1 && !String.IsNullOrEmpty(line))
+                            textWriter.WriteLine();
 
-                    textWriter.WriteLine(line);
+                        textWriter.WriteLine(line);
+                    }
                     lineNumber++;
                 }
             }


### PR DESCRIPTION
For some reason when a commit message is passed to git from a separate file it sustains hashes (unlike committing from the command line which ignores hashes). Not removing hashes was mucking up the commit template feature since the template uses hashes to indicate fields/notes/etc. This change removes hashes from the commit message before passing the file to git commit -F.
