### PR TITLE
retry push only when autopull completed with no errors

### DIFF
--- a/GitUI/FormPull.cs
+++ b/GitUI/FormPull.cs
@@ -44,6 +44,7 @@ namespace GitUI
             new TranslationString("Please select a source directory");
 
         private List<GitHead> _heads;
+        public bool ErrorOccurred { get; private set; }
 
         public FormPull()
         {
@@ -62,6 +63,7 @@ namespace GitUI
             Rebase.Checked = Settings.PullMerge == "rebase";
             Fetch.Checked = Settings.PullMerge == "fetch";
             AutoStash.Checked = Settings.AutoStash;
+            ErrorOccurred = false;
         }
 
         public DialogResult PullAndShowDialogWhenFailed()
@@ -218,6 +220,7 @@ namespace GitUI
                 if (!PullAll())
                     process.Remote = source;
                 process.ShowDialog();
+                ErrorOccurred = process.ErrorOccurred();
             }
 
             try

--- a/GitUI/FormPush.cs
+++ b/GitUI/FormPush.cs
@@ -213,10 +213,17 @@ namespace GitUI
                 if (Settings.AutoPullOnRejected && 
                     form.OutputString.ToString().Contains("To prevent you from losing history, non-fast-forward updates were rejected"))
                 {
-                    if (GitUICommands.Instance.StartPullDialog(true))
+                    if (Settings.PullMerge == "fetch")
+                        form.OutputString.Append("\nCan not perform auto pull, when merge option is set to fetch.");
+                    else 
                     {
-                        form.Retry();
-                        return true;
+                        bool pullCompleted;
+                        GitUICommands.Instance.StartPullDialog(true, out pullCompleted);
+                        if (pullCompleted)
+                        {
+                            form.Retry();
+                            return true;
+                        }
                     }
                 }
             }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -379,11 +379,25 @@ namespace GitUI
 
         public bool StartPullDialog(bool pullOnShow)
         {
+            bool errorOccurred;
+            return StartPullDialog(pullOnShow, out errorOccurred);
+        }
+
+        /// <summary>
+        /// Starts pull dialog
+        /// </summary>
+        /// <param name="pullOnShow"></param>
+        /// <param name="pullCompleted">true if pull completed with no errors</param>
+        /// <returns>if revision grid should be refreshed</returns>
+        public bool StartPullDialog(bool pullOnShow, out bool pullCompleted)
+        {
+            pullCompleted = false;
+
             if (!RequiresValidWorkingDir())
                 return false;
 
             if (!InvokeEvent(PrePull))
-                return false;
+                return true;
 
             FormPull formPull = new FormPull();
             DialogResult dlgResult;
@@ -392,13 +406,16 @@ namespace GitUI
             else
                 dlgResult = formPull.ShowDialog();
 
-            bool result = dlgResult == DialogResult.OK;
-            if (result)
-                 InvokeEvent(PostPull);
+            if (dlgResult == DialogResult.OK)
+            {
+                InvokeEvent(PostPull);
+                pullCompleted = !formPull.ErrorOccurred;                
+            }
 
-            return result;
+            return true;//maybe InvokeEvent should have 'needRefresh' out parameter?
         }
-                
+
+        
         public bool StartViewPatchDialog()
         {
             if (!InvokeEvent(PreViewPatch))


### PR DESCRIPTION
This change allow user to check if merge/rebase was done correctly. Also prevents from infinite loop.
