### PR TITLE
Fixed the issue with ampersands being interpreted as a prefix character in the revision grid.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,10 @@ SimpleExt_p.c
 #ignore some unwanted files
 *.ncb
 *.suo
-*.csproj.user
 *.orig
 *.msi
 *.user
+*.[Cc]ache
 Thumbs.db
 GitPlugin/bin/*
 Setup/GitExtensions207.zip

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -1147,7 +1147,7 @@ namespace GitUI
 
         private void DrawColumnText(IDeviceContext dc, string text, Font font, Color color, Rectangle bounds)
         {
-            TextRenderer.DrawText(dc, text, font, bounds, color, TextFormatFlags.EndEllipsis);
+            TextRenderer.DrawText(dc, text, font, bounds, color, TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
         }
 
         private static Rectangle AdjustCellBounds(Rectangle cellBounds, float offset)


### PR DESCRIPTION
Fixed the issue with ampersands being interpreted as a prefix character in the revision grid.

This fixes #619.
