### PR TITLE
Changed the post-build steps to work anytime that the repo's path has a space.

### DIFF
--- a/Plugins/Github/Github.csproj
+++ b/Plugins/Github/Github.csproj
@@ -78,8 +78,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) ..\..\..\..\GitExtensions\bin\Debug
-copy $(SolutionDir)\bin\GithubSharp.Core.Dll ..\..\..\..\GitExtensions\bin\Debug</PostBuildEvent>
+    <PostBuildEvent>copy "$(TargetPath)" "..\..\..\..\GitExtensions\bin\Debug"
+copy "$(SolutionDir)\bin\GithubSharp.Core.Dll" "..\..\..\..\GitExtensions\bin\Debug"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Changed the post-build steps to work anytime that the repo's path has a space.
