### PR TITLE
Blank line at the top of .gitignore, .gitattributes, .mailmap not necessary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 #basic visual studio directories
 _UpgradeReport_Files/
 [Dd]ebug*/

--- a/GitUI/FormGitAttributes.cs
+++ b/GitUI/FormGitAttributes.cs
@@ -39,14 +39,17 @@ namespace GitUI
                 .MakeFileTemporaryWritable(
                     Settings.WorkingDir + ".gitattributes",
                     x =>
+                    {
+                        this.GitAttributesFile = _NO_TRANSLATE_GitAttributesText.GetText();
+
+                        using (var file = File.OpenWrite(x))
                         {
-                            // Enter a newline to work around a wierd bug 
-                            // that causes the first line to include 3 extra bytes. (encoding marker??)
-                            GitAttributesFile = Environment.NewLine + _NO_TRANSLATE_GitAttributesText.GetText().Trim();
-                            using (TextWriter tw = new StreamWriter(x, false, Settings.Encoding))
-                                tw.Write(GitAttributesFile);
-                            Close();
-                        });
+                            var contents = Settings.Encoding.GetBytes(this.GitAttributesFile);
+                            file.Write(contents, 0, contents.Length);
+                        }
+
+                        Close();
+                    });
         }
 
         private void FormMailMapFormClosing(object sender, FormClosingEventArgs e)

--- a/GitUI/FormGitIgnore.cs
+++ b/GitUI/FormGitIgnore.cs
@@ -52,13 +52,14 @@ namespace GitUI
                         Settings.WorkingDir + ".gitignore",
                         x =>
                         {
-                            // Enter a newline to work around a wierd bug 
-                            // that causes the first line to include 3 extra bytes. (encoding marker??)
-                            GitIgnoreFile = Environment.NewLine + _NO_TRANSLATE_GitIgnoreEdit.GetText().Trim();
-                            using (var tw = new StreamWriter(x, false, Settings.Encoding))
+                            this.GitIgnoreFile = _NO_TRANSLATE_GitIgnoreEdit.GetText();
+
+                            using (var file = File.OpenWrite(x))
                             {
-                                tw.Write(GitIgnoreFile);
+                                var contents = Settings.Encoding.GetBytes(this.GitIgnoreFile);
+                                file.Write(contents, 0, contents.Length);
                             }
+
                             if (closeAfterSave)
                                 Close();
                         });
@@ -84,7 +85,7 @@ namespace GitUI
 
         private void AddDefaultClick(object sender, EventArgs e)
         {
-            _NO_TRANSLATE_GitIgnoreEdit.ViewText(".gitignore", 
+            _NO_TRANSLATE_GitIgnoreEdit.ViewText(".gitignore",
                 _NO_TRANSLATE_GitIgnoreEdit.GetText() +
                 Environment.NewLine + "#ignore thumbnails created by windows" +
                 Environment.NewLine + "Thumbs.db" +

--- a/GitUI/FormMailMap.cs
+++ b/GitUI/FormMailMap.cs
@@ -35,14 +35,17 @@ namespace GitUI
                 .MakeFileTemporaryWritable(
                     Settings.WorkingDir + ".mailmap",
                     x =>
+                    {
+                        this.MailMapFile = _NO_TRANSLATE_MailMapText.GetText();
+
+                        using (var file = File.OpenWrite(x))
                         {
-                            // Enter a newline to work around a wierd bug 
-                            // that causes the first line to include 3 extra bytes. (encoding marker??)
-                            MailMapFile = Environment.NewLine + _NO_TRANSLATE_MailMapText.GetText().Trim();
-                            using (TextWriter tw = new StreamWriter(x, false, Settings.Encoding))
-                                tw.Write(MailMapFile);
-                            Close();
-                        });
+                            var contents = Settings.Encoding.GetBytes(this.MailMapFile);
+                            file.Write(contents, 0, contents.Length);
+                        }
+
+                        Close();
+                    });
         }
 
         private void FormMailMapFormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
We can generate the bytes for the files directly using `Encoding.GetBytes()` and bypass the `StreamWriter` which was adding the [Byte Order Mark](https://secure.wikimedia.org/wikipedia/en/wiki/Byte_order_mark#UTF-8).
