### PR TITLE
Fixed file selection after bisect mark revision

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -229,12 +229,17 @@ namespace GitUI.Editor
             _currentScrollPos = ScrollPos;
         }
 
+        public void ResetCurrentScrollPos()
+        {
+            _currentScrollPos = 0;
+        }
+
         private void RestoreCurrentScrollPos()
         {
             if (_currentScrollPos < 0)
                 return;
             ScrollPos = _currentScrollPos;
-            _currentScrollPos = 0;
+            ResetCurrentScrollPos();
         }
 
 

--- a/GitUI/Editor/FileViewerWindows.cs
+++ b/GitUI/Editor/FileViewerWindows.cs
@@ -302,7 +302,9 @@ namespace GitUI.Editor
             set
             {
                 var scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
-                scrollBar.Value = scrollBar.Maximum > value ? value : scrollBar.Maximum;
+                int max = scrollBar.Maximum - scrollBar.LargeChange;
+                max = Math.Max(max, scrollBar.Minimum);
+                scrollBar.Value = max > value ? value : max;
             }
         }
 


### PR DESCRIPTION
When program selects revision returned by git bisect good/bad, file selection and scrollposition is not being restored.
