### PR TITLE
This issue is most noticeable when using non github repositories...

### DIFF
--- a/GitUI/FormRemotes.cs
+++ b/GitUI/FormRemotes.cs
@@ -231,9 +231,19 @@ namespace GitUI
 
         private void TestConnectionClick(object sender, EventArgs e)
         {
+            System.Uri uri = new System.Uri(Url.Text);
+            string sshURL = "";
+            if (uri.Scheme == "ssh")
+            {
+                if (!string.IsNullOrEmpty(uri.UserInfo))
+                    sshURL = uri.UserInfo + "@";
+                sshURL += uri.Host + ":" + uri.LocalPath.Substring(1);
+            }
+            else
+                sshURL = Url.Text;
             Settings.Module.RunRealCmdDetached(
                 "cmd.exe",
-                string.Format("/k \"\"{0}\" -T \"{1}\"\"", Settings.Plink, Url.Text));
+                string.Format("/k \"\"{0}\" -T \"{1}\"\"", Settings.Plink, sshURL));
         }
 
         private void PruneClick(object sender, EventArgs e)


### PR DESCRIPTION
The Manage Remotes UI accepts a URL.  This is fine and that URL works when used by git.  However the Manage Remotes UI has a Test Connection Button.  This button invokes plink.exe directly, passing it the raw URL.  plink.exe doesn't take a URL as an argument, so if we have an ssh:// format URL we parse it into a form which works with plink.exe.
