### PR TITLE
Owner windows fixed for GitUICommands plus other changes

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1580,6 +1580,15 @@ namespace GitCommands
             return GetSelectedBranch(_workingdir);
         }
 
+        public string GetRemoteBranch(string branch)
+        {
+            string remote = GetSetting(string.Format("branch.{0}.remote", branch));
+            string merge = GetSetting(string.Format("branch.{0}.merge", branch));
+            if (String.IsNullOrEmpty(remote) || String.IsNullOrEmpty(merge))
+                return "";
+            return remote + "/" + (merge.StartsWith("refs/heads/") ? merge.Substring(11) : merge);
+        }
+
         public List<GitHead> GetRemoteHeads(string remote, bool tags, bool branches)
         {
             remote = FixPath(remote);

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -2120,15 +2120,17 @@ namespace GitUI
         private void goToToolStripMenuItem_Click(object sender, EventArgs e)
         {
             FormGoToCommit formGoToCommit = new FormGoToCommit();
-            formGoToCommit.ShowDialog(this);
-            string revisionGuid = formGoToCommit.GetRevision();
-            if (!string.IsNullOrEmpty(revisionGuid))
+            if (formGoToCommit.ShowDialog(this) == DialogResult.OK)
             {
-                RevisionGrid.SetSelectedRevision(new GitRevision(revisionGuid));
-            }
-            else
-            {
-                MessageBox.Show(this, _noRevisionFoundError.Text);
+                string revisionGuid = formGoToCommit.GetRevision();
+                if (!string.IsNullOrEmpty(revisionGuid))
+                {
+                    RevisionGrid.SetSelectedRevision(new GitRevision(revisionGuid));
+                }
+                else
+                {
+                    MessageBox.Show(this, _noRevisionFoundError.Text);
+                }
             }
         }
 

--- a/GitUI/FormGoToCommit.Designer.cs
+++ b/GitUI/FormGoToCommit.Designer.cs
@@ -36,9 +36,10 @@
             // 
             // goButton
             // 
+            this.goButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.goButton.Location = new System.Drawing.Point(437, 22);
             this.goButton.Name = "goButton";
-            this.goButton.Size = new System.Drawing.Size(75, 23);
+            this.goButton.Size = new System.Drawing.Size(75, 28);
             this.goButton.TabIndex = 1;
             this.goButton.Text = "Go";
             this.goButton.UseVisualStyleBackColor = true;
@@ -46,9 +47,9 @@
             // 
             // commitExpression
             // 
-            this.commitExpression.Location = new System.Drawing.Point(139, 23);
+            this.commitExpression.Location = new System.Drawing.Point(157, 23);
             this.commitExpression.Name = "commitExpression";
-            this.commitExpression.Size = new System.Drawing.Size(292, 21);
+            this.commitExpression.Size = new System.Drawing.Size(274, 27);
             this.commitExpression.TabIndex = 0;
             // 
             // label1
@@ -56,14 +57,14 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(12, 27);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(101, 13);
+            this.label1.Size = new System.Drawing.Size(139, 20);
             this.label1.TabIndex = 2;
             this.label1.Text = "Commit expression:";
             // 
             // FormGoToCommit
             // 
             this.AcceptButton = this.goButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(524, 69);
             this.Controls.Add(this.label1);

--- a/GitUI/FormMergeBranch.cs
+++ b/GitUI/FormMergeBranch.cs
@@ -28,6 +28,12 @@ namespace GitUI
 
             if (_defaultBranch != null)
                 Branches.Text = _defaultBranch;
+            else
+            {
+                string merge = Settings.Module.GetRemoteBranch(selectedHead);
+                if (!String.IsNullOrEmpty(merge))
+                    Branches.Text = merge;
+            }
 
             Branches.Select();
         }


### PR DESCRIPTION
Owner windows fixed for GitUICommands 
Removed InMemHashFilter because of duplication functionality GoToCommit window
Merge branch window by default now select correct remote branch
GoToCommit cancel button handling fixed

Localization issue with ResetChanges and FormRemoteProcess fixed
Localization of some message boxes fixed
String "Message" moved to class Strings
