### PR TITLE
Recent changes have made building under .NET 3.5 not possible

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -577,7 +577,12 @@ namespace GitCommands
             return GetAllChangedFilesCmd( excludeIgnoredFiles, untrackedFiles ? UntrackedFilesMode.Default : UntrackedFilesMode.No );
         }
 
-        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = 0)
+        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles)
+        {
+            return GetAllChangedFilesCmd(excludeIgnoredFiles, untrackedFiles, 0);
+        }
+
+        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules)
         {
             if (!VersionInUse.SupportGitStatusPorcelain)
                 throw new Exception("The version of git you are using is not supported for this action. Please upgrade to git 1.7.3 or newer.");

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.21022</ProductVersion>
+    <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F15A69AF-7EBD-4F69-A026-5071FA3EC61B}</ProjectGuid>
     <OutputType>WinExe</OutputType>
@@ -56,6 +56,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />

--- a/GitUI/DvcsGraph.cs
+++ b/GitUI/DvcsGraph.cs
@@ -710,7 +710,11 @@ namespace GitUI
 
         private List<Color> getJunctionColors(IEnumerable<Junction> aJunction)
         {
-            var colors = aJunction.Select(getJunctionColor).ToList();
+            List<Color> colors = new List<Color>();
+            foreach (Junction j in aJunction)
+            {
+                colors.Add( getJunctionColor(j) );
+            }
 
             if (colors.Count == 0)
             {

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -26,13 +26,19 @@ namespace GitUI
 
         private GitCommandsInstance gitCommand;
 
+        protected FormProcess() : this(true)
+        { }
+
         //constructor for VS designer
-        protected FormProcess(bool useDialogSettings = true)
+        protected FormProcess(bool useDialogSettings)
             : base(useDialogSettings)
         {
         }
 
-        public FormProcess(string process, string arguments, bool useDialogSettings = true)
+        public FormProcess(string process, string arguments) : this(process, arguments, true)
+        { }
+
+        public FormProcess(string process, string arguments, bool useDialogSettings)
             : base(useDialogSettings)
         {
             ProcessCallback = new ProcessStart(processStart);
@@ -45,13 +51,18 @@ namespace GitUI
 
         //Input does not work for password inputs. I don't know why, but it turned out not to be really necessary.
         //For other inputs, it is not tested.
-        public FormProcess(string process, string arguments, string input, bool useDialogSettings = true)
+        public FormProcess(string process, string arguments, string input) : this(process, arguments, input, true)
+        { }
+        public FormProcess(string process, string arguments, string input, bool useDialogSettings)
             : this(process, arguments, useDialogSettings)
         {
             ProcessInput = input;
         }
 
-        public FormProcess(string arguments, bool useDialogSettings = true)
+        public FormProcess(string arguments) : this(arguments, true)
+        { }
+
+        public FormProcess(string arguments, bool useDialogSettings)
             : this(null, arguments, useDialogSettings)
         {
         }

--- a/GitUI/FormPull.cs
+++ b/GitUI/FormPull.cs
@@ -88,7 +88,11 @@ namespace GitUI
             _NO_TRANSLATE_Remotes.DataSource = remotes;
         }
 
-        public DialogResult PullAndShowDialogWhenFailed(IWin32Window owner = null)
+        public DialogResult PullAndShowDialogWhenFailed()
+        {
+            return PullAndShowDialogWhenFailed(null);
+        }
+        public DialogResult PullAndShowDialogWhenFailed(IWin32Window owner)
         {
             if (PullChanges())
                 return DialogResult.OK;

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -16,7 +16,10 @@ namespace GitUI
         protected readonly SynchronizationContext syncContext;
         private bool UseDialogSettings = true;
 
-        public FormStatus(bool useDialogSettings = true)
+        public FormStatus(): this(true)
+        { }
+
+        public FormStatus(bool useDialogSettings)
         {
             syncContext = SynchronizationContext.Current;
             UseDialogSettings = useDialogSettings;

--- a/Plugins/Statistics/GitImpact/GitImpact.csproj
+++ b/Plugins/Statistics/GitImpact/GitImpact.csproj
@@ -49,7 +49,6 @@
     </Compile>
     <Compile Include="GitImpactPlugin.cs" />
     <Compile Include="ImpactControl.cs">
-      <SubType>UserControl</SubType>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I don't have VS2010 on all my machines so I'd really like to keep 3.5 support around. There isn't anything all that compelling that we need to rush to 4.0.
