### PR TITLE
fix multiple submenu bug @ 64-bit environment

### DIFF
--- a/SimpleExt/SimpleShlExt.cpp
+++ b/SimpleExt/SimpleShlExt.cpp
@@ -72,7 +72,17 @@ STDMETHODIMP CSimpleShlExt::QueryContextMenu  (
 
     id = PopulateMenu(popupMenu, uidFirstCmd + id);
 
-    InsertMenu(hmenu, uMenuIndex++, MF_STRING | MF_BYPOSITION | MF_POPUP, (int)popupMenu, "Git Extensions");	
+    //InsertMenu(hmenu, uMenuIndex++, MF_STRING | MF_BYPOSITION | MF_POPUP, (int)popupMenu, "Git Extensions");	
+	MENUITEMINFO info;
+
+	info.cbSize = sizeof( MENUITEMINFO );
+	info.fMask = MIIM_ID | MIIM_TYPE | MIIM_SUBMENU;
+	info.fType = MFT_STRING;
+	info.wID = uidFirstCmd + 1;
+	info.dwTypeData = _T("Git Extensions");
+	info.hSubMenu = popupMenu;
+	InsertMenuItem(hmenu, 0, true, &info);
+
     return MAKE_HRESULT ( SEVERITY_SUCCESS, FACILITY_NULL, id-uidFirstCmd );
 }
 


### PR DESCRIPTION
GitExtensionsShellEx64.dll has bug on 64-bit environment.
It makes multiple submenu when select explorer's "File" menu.

snapshot.
![snapshot](https://gist.github.com/raw/1498198/c12e262b5a5f76185a0a12c691b674ecf51c1da0/gitextensions-bug.png)
