### PR TITLE
Fixed issue 761: [Open In customized merge tool] would cause error message for Diff-Script invoking

### DIFF
--- a/GitUI/FormResolveConflicts.cs
+++ b/GitUI/FormResolveConflicts.cs
@@ -187,7 +187,7 @@ namespace GitUI
                 if (!(extensionsSeperator > 0) || extensionsSeperator + 1 >= fileName.Length)
                     return false;
 
-                string[] mergeScripts = Directory.GetFiles(Settings.GetInstallDir() + Settings.PathSeparator + "Diff-Scripts" + Settings.PathSeparator, "merge-" + fileName.Substring(extensionsSeperator + 1) + ".*");
+                string[] mergeScripts = Directory.GetFiles(Path.GetDirectoryName(Application.ExecutablePath) + Settings.PathSeparator + "Diff-Scripts" + Settings.PathSeparator, "merge-" + fileName.Substring(extensionsSeperator + 1) + ".*");
 
                 if (mergeScripts.Length > 0)
                 {


### PR DESCRIPTION
For portable edition/reinstall situation, performing conflict resolving by clicking on [Open In customized merge tool] would cause error message for Diff-Script invoking when the executable file differs to that stored in registry. Therefore, fix it by getting parent folder of executable file instead of by InstallDir entry in registry.
