### PR TITLE
Rough version of a GUI for request-pull functionality

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1033,6 +1033,10 @@ namespace GitCommands
             return result;
         }
 
+        public string FormatPullRequest(string start, string url)
+        {
+            return RunCmd(Settings.GitCommand, "request-pull " + start + " " + url);
+        }
 
         public string Tag(string tagName, string revision, bool annotation)
         {

--- a/GitUI/FormBrowse.Designer.cs
+++ b/GitUI/FormBrowse.Designer.cs
@@ -135,6 +135,7 @@ namespace GitUI
             this.toolStripSeparator25 = new System.Windows.Forms.ToolStripSeparator();
             this.applyPatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.formatPatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.formatPullRequestToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewDiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.patchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator22 = new System.Windows.Forms.ToolStripSeparator();
@@ -1076,6 +1077,7 @@ namespace GitUI
             this.toolStripSeparator25,
             this.applyPatchToolStripMenuItem,
             this.formatPatchToolStripMenuItem,
+            this.formatPullRequestToolStripMenuItem,
             this.viewDiffToolStripMenuItem,
             this.patchToolStripMenuItem,
             this.toolStripSeparator22,
@@ -1184,6 +1186,13 @@ namespace GitUI
             this.formatPatchToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
             this.formatPatchToolStripMenuItem.Text = "Format patch";
             this.formatPatchToolStripMenuItem.Click += new System.EventHandler(this.FormatPatchToolStripMenuItemClick);
+            // 
+            // formatPullRequestToolStripMenuItem
+            // 
+            this.formatPullRequestToolStripMenuItem.Name = "formatPullRequestToolStripMenuItem";
+            this.formatPullRequestToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.formatPullRequestToolStripMenuItem.Text = "Format pull request";
+            this.formatPullRequestToolStripMenuItem.Click += new System.EventHandler(this.FormatPullRequestToolStripMenuItemClick);
             // 
             // viewDiffToolStripMenuItem
             // 
@@ -1897,5 +1906,6 @@ namespace GitUI
         private ToolStripSeparator toolStripSeparator25;
         private ToolStripSeparator toolStripSeparator22;
         private ToolStripSeparator toolStripSeparator23;        
+        private ToolStripMenuItem formatPullRequestToolStripMenuItem;        
     }
 }

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1136,6 +1136,11 @@ namespace GitUI
                 Initialize();
         }
 
+        private void FormatPullRequestToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            GitUICommands.Instance.StartFormatPullRequestDialog(this);
+        }
+
         private void GitcommandLogToolStripMenuItemClick(object sender, EventArgs e)
         {
             new GitLogForm().Show();

--- a/GitUI/FormFormatPullRequest.Designer.cs
+++ b/GitUI/FormFormatPullRequest.Designer.cs
@@ -1,0 +1,145 @@
+﻿namespace GitUI
+{
+    partial class FormFormatPullRequest
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.buttonFormatPullRequest = new System.Windows.Forms.Button();
+            this.lblURL = new System.Windows.Forms.Label();
+            this.pullURL = new System.Windows.Forms.TextBox();
+            this.requestText = new System.Windows.Forms.TextBox();
+            this.RevisionGrid = new GitUI.RevisionGrid();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.buttonFormatPullRequest);
+            this.splitContainer1.Panel1.Controls.Add(this.lblURL);
+            this.splitContainer1.Panel1.Controls.Add(this.pullURL);
+            this.splitContainer1.Panel1.Controls.Add(this.requestText);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.RevisionGrid);
+            this.splitContainer1.Size = new System.Drawing.Size(814, 522);
+            this.splitContainer1.SplitterDistance = 271;
+            this.splitContainer1.TabIndex = 1;
+            // 
+            // buttonFormatPullRequest
+            // 
+            this.buttonFormatPullRequest.Location = new System.Drawing.Point(666, 236);
+            this.buttonFormatPullRequest.Name = "buttonFormatPullRequest";
+            this.buttonFormatPullRequest.Size = new System.Drawing.Size(136, 23);
+            this.buttonFormatPullRequest.TabIndex = 3;
+            this.buttonFormatPullRequest.Text = "Format Pull Request";
+            this.buttonFormatPullRequest.UseVisualStyleBackColor = true;
+            this.buttonFormatPullRequest.Click += new System.EventHandler(this.buttonFormatPullRequest_Click);
+            // 
+            // lblURL
+            // 
+            this.lblURL.AutoSize = true;
+            this.lblURL.Location = new System.Drawing.Point(7, 36);
+            this.lblURL.Name = "lblURL";
+            this.lblURL.Size = new System.Drawing.Size(26, 13);
+            this.lblURL.TabIndex = 2;
+            this.lblURL.Text = "URL";
+            // 
+            // pullURL
+            // 
+            this.pullURL.Location = new System.Drawing.Point(41, 33);
+            this.pullURL.Name = "pullURL";
+            this.pullURL.Size = new System.Drawing.Size(601, 21);
+            this.pullURL.TabIndex = 1;
+            // 
+            // requestText
+            // 
+            this.requestText.ImeMode = System.Windows.Forms.ImeMode.Off;
+            this.requestText.Location = new System.Drawing.Point(41, 62);
+            this.requestText.Multiline = true;
+            this.requestText.Name = "requestText";
+            this.requestText.Size = new System.Drawing.Size(601, 197);
+            this.requestText.TabIndex = 0;
+            // 
+            // RevisionGrid
+            // 
+            this.RevisionGrid.AllowGraphWithFilter = false;
+            this.RevisionGrid.BranchFilter = "";
+            this.RevisionGrid.CurrentCheckout = null;
+            this.RevisionGrid.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.RevisionGrid.Filter = "";
+            this.RevisionGrid.Font = new System.Drawing.Font("Tahoma", 8.25F);
+            this.RevisionGrid.InMemAuthorFilter = "";
+            this.RevisionGrid.InMemCommitterFilter = "";
+            this.RevisionGrid.InMemFilterIgnoreCase = false;
+            this.RevisionGrid.InMemMessageFilter = "";
+            this.RevisionGrid.LastRow = 0;
+            this.RevisionGrid.Location = new System.Drawing.Point(0, 3);
+            this.RevisionGrid.Name = "RevisionGrid";
+            this.RevisionGrid.NormalFont = new System.Drawing.Font("Tahoma", 8.75F);
+            this.RevisionGrid.Size = new System.Drawing.Size(814, 244);
+            this.RevisionGrid.SuperprojectCurrentCheckout = null;
+            this.RevisionGrid.TabIndex = 1;
+            // 
+            // FormFormatPullRequest
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(814, 522);
+            this.Controls.Add(this.splitContainer1);
+            this.Name = "FormFormatPullRequest";
+            this.Text = "FormFormatPullRequest";
+            this.Load += new System.EventHandler(this.FormFormatPullRequest_Load);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private RevisionGrid RevisionGrid;
+        private System.Windows.Forms.TextBox requestText;
+        private System.Windows.Forms.Label lblURL;
+        private System.Windows.Forms.TextBox pullURL;
+        private System.Windows.Forms.Button buttonFormatPullRequest;
+
+    }
+}

--- a/GitUI/FormFormatPullRequest.cs
+++ b/GitUI/FormFormatPullRequest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using GitCommands;
+
+namespace GitUI
+{
+    public partial class FormFormatPullRequest : GitExtensionsForm
+    {
+        public FormFormatPullRequest()
+        {
+            InitializeComponent();Translate();
+        }
+
+        private void FormFormatPullRequest_Load(object sender, EventArgs e)
+        {
+            RevisionGrid.Load();
+            RevisionGrid.MultiSelect = false;
+        }
+
+        private void buttonFormatPullRequest_Click(object sender, EventArgs e)
+        {
+            List<GitRevision> revs = RevisionGrid.GetSelectedRevisions();
+
+            requestText.Text = Settings.Module.FormatPullRequest(revs[0].Guid, pullURL.Text).Replace("\n","\r\n");
+        }
+
+    }
+}

--- a/GitUI/FormFormatPullRequest.resx
+++ b/GitUI/FormFormatPullRequest.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -106,6 +106,12 @@
       <DependentUpon>DvcsGraph.cs</DependentUpon>
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="FormFormatPullRequest.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="FormFormatPullRequest.Designer.cs">
+      <DependentUpon>FormFormatPullRequest.cs</DependentUpon>
+    </Compile>
     <Compile Include="FormRenameBranch.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -725,6 +731,9 @@
     <EmbeddedResource Include="AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FormFormatPullRequest.resx">
+      <DependentUpon>FormFormatPullRequest.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="FormRenameBranch.resx">
       <DependentUpon>FormRenameBranch.cs</DependentUpon>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -564,6 +564,14 @@ namespace GitUI
             return StartFormatPatchDialog(null);
         }
 
+        public bool StartFormatPullRequestDialog(IWin32Window owner)
+        {
+            var form = new FormFormatPullRequest();
+            form.ShowDialog(owner);
+
+            return true;
+        }
+
         public bool StartStashDialog(IWin32Window owner)
         {
             if (!RequiresValidWorkingDir())


### PR DESCRIPTION
I put together a quick GUI for using the `request-pull` feature of Git - for times that you are not able to use GitHub to manage your pull requests.

I'd like some input on it - it's a proof of concept right now, and I'd like some suggestions on how to make it better. My main concerns is that it's not intuitive enough, you have to select the starting revision from the revision graph, but I don't have a good idea of how to phrase it.
