### PR TITLE
Work for #767

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -16,6 +16,7 @@ namespace GitCommands
         public GitRevision(string guid)
         {
             Guid = guid;
+            Message = "";
         }
 
         public List<GitHead> Heads { get { return heads; } }


### PR DESCRIPTION
Set the message property to an empty string to
guard against a commit created
with  --allow-empty-message
