### PR TITLE
Two encodings: FilesEncoding and AppEncoding 

### DIFF
--- a/GitCommands/Commit.cs
+++ b/GitCommands/Commit.cs
@@ -41,7 +41,7 @@ namespace GitCommands
                 return;
             }
 
-            using (var textWriter = new StreamWriter(GetCommitMessagePath(), false, Settings.Encoding))
+            using (var textWriter = new StreamWriter(GetCommitMessagePath(), false, Settings.CommitEncoding))
             {
                 textWriter.Write(commitMessageText);
             }

--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -176,13 +176,6 @@ namespace GitCommands
 
             var body = message.ToString();
 
-            //We need to recode the commit message because of a bug in Git.
-            //We cannot let git recode the message to Settings.Encoding which is
-            //needed to allow the "git log" to print the filename in Settings.Encoding
-            Encoding logoutputEncoding = Settings.Module.GetLogoutputEncoding();
-            if (logoutputEncoding != Settings.Encoding)
-                body = logoutputEncoding.GetString(Settings.Encoding.GetBytes(body));
-
             var commitInformation = new CommitData(guid, treeGuid, parentGuids, author, authorDate,
                 committer, commitDate, body);
 

--- a/GitCommands/CommitInformation.cs
+++ b/GitCommands/CommitInformation.cs
@@ -46,7 +46,7 @@ namespace GitCommands
                 args = "-r "+args;
             else if (!getLocal)
                 return new string[]{};
-            string info = Settings.Module.RunGitCmd("branch " + args);
+            string info = Settings.Module.RunGitCmd("branch " + args, Settings.SystemEncoding);
             if (info.Trim().StartsWith("fatal") || info.Trim().StartsWith("error:"))
                 return new List<string>();
 
@@ -74,7 +74,7 @@ namespace GitCommands
         /// <returns></returns>
         public static IEnumerable<string> GetAllTagsWhichContainGivenCommit(string sha1)
         {
-            string info = Settings.Module.RunGitCmd("tag --contains " + sha1);
+            string info = Settings.Module.RunGitCmd("tag --contains " + sha1, Settings.SystemEncoding);
 
 
             if (info.Trim().StartsWith("fatal") || info.Trim().StartsWith("error:"))

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -57,7 +57,7 @@ namespace GitCommands.Config
             if (string.IsNullOrEmpty(Path.GetFileName(_fileName)) || !File.Exists(_fileName))
                 return;
 
-            FindSections(File.ReadAllLines(_fileName, Settings.Encoding));
+            FindSections(File.ReadAllLines(_fileName, Settings.AppEncoding));
         }
 
         private void FindSections(IEnumerable<string> fileLines)
@@ -119,7 +119,7 @@ namespace GitCommands.Config
                 FileInfoExtensions
                     .MakeFileTemporaryWritable(_fileName,
                                        x =>
-                                       File.WriteAllText(_fileName, configFileContent.ToString(), Settings.Encoding));
+                                       File.WriteAllText(_fileName, configFileContent.ToString(), Settings.AppEncoding));
             }
             catch (Exception ex)
             {

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -124,9 +124,9 @@ namespace GitCommands
                            RedirectStandardOutput = true,
                            RedirectStandardInput = true,
                            RedirectStandardError = true,
-                           StandardOutputEncoding = Settings.Encoding,
-                           StandardErrorEncoding = Settings.Encoding
-                       };
+                           StandardOutputEncoding = Settings.LogOutputEncoding,
+                           StandardErrorEncoding = Settings.LogOutputEncoding
+                        };
         }
 
         internal static bool UseSsh(string arguments)
@@ -866,7 +866,7 @@ namespace GitCommands
                     process1 = gitCommand.CmdStartProcess(Settings.GitCommand, "update-index --add --stdin");
 
                 //process1.StandardInput.WriteLine("\"" + FixPath(file.Name) + "\"");
-                byte[] bytearr = EncodingHelper.ConvertTo(Settings.Encoding, "\"" + FixPath(file.Name) + "\"" + process1.StandardInput.NewLine);
+                byte[] bytearr = EncodingHelper.ConvertTo(Settings.SystemEncoding, "\"" + FixPath(file.Name) + "\"" + process1.StandardInput.NewLine);
                 process1.StandardInput.BaseStream.Write(bytearr, 0, bytearr.Length);
             }
             if (process1 != null)
@@ -886,7 +886,7 @@ namespace GitCommands
                 if (process2 == null)
                     process2 = gitCommand.CmdStartProcess(Settings.GitCommand, "update-index --remove --stdin");
                 //process2.StandardInput.WriteLine("\"" + FixPath(file.Name) + "\"");
-                byte[] bytearr = EncodingHelper.ConvertTo(Settings.Encoding, "\"" + FixPath(file.Name) + "\"" + process2.StandardInput.NewLine);
+                byte[] bytearr = EncodingHelper.ConvertTo(Settings.SystemEncoding, "\"" + FixPath(file.Name) + "\"" + process2.StandardInput.NewLine);
                 process2.StandardInput.BaseStream.Write(bytearr, 0, bytearr.Length);
             }
             if (process2 != null)
@@ -941,7 +941,7 @@ namespace GitCommands
                 if (process2 == null)
                     process2 = gitCommand.CmdStartProcess(Settings.GitCommand, "update-index --force-remove --stdin");
                 //process2.StandardInput.WriteLine("\"" + FixPath(file.Name) + "\"");
-                byte[] bytearr = EncodingHelper.ConvertTo(Settings.Encoding, "\"" + FixPath(file.Name) + "\"" + process2.StandardInput.NewLine);
+                byte[] bytearr = EncodingHelper.ConvertTo(Settings.SystemEncoding, "\"" + FixPath(file.Name) + "\"" + process2.StandardInput.NewLine);
                 process2.StandardInput.BaseStream.Write(bytearr, 0, bytearr.Length);
             }
             if (process2 != null)
@@ -1146,5 +1146,166 @@ namespace GitCommands
                 return left + sep + right;
 
         }
+
+        public static string ReEncodeFileName(string diffStr, int headerLines)
+        {
+            StringReader r = new StringReader(diffStr);
+            StringWriter w = new StringWriter();
+            string line;
+            while (headerLines > 0 && (line = r.ReadLine()) != null)
+            {
+                headerLines--;
+                line = ReEncodeFileName(line);
+                w.WriteLine(line);
+            }
+            w.Write(r.ReadToEnd());
+
+            return w.ToString();
+        }
+
+        public static string ReEncodeFileName(string header)
+        {
+            char[] chars = header.ToCharArray();
+            int i = 0;
+            StringBuilder sb = new StringBuilder();
+            while (i < chars.Length)
+            {
+                char c = chars[i];
+                if (c == '\\')
+                {
+                    //there should be 3 digits
+                    if (chars.Length >= i + 3)
+                    {
+                        string octNumber = "" + chars[i + 1] + chars[i + 2] + chars[i + 3];
+
+                        try
+                        {
+                            int code = System.Convert.ToInt32(octNumber, 8);
+                            sb.Append(Settings.SystemEncoding.GetString(new byte[] { (byte)code }));
+                            i += 4;
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    }
+                }
+                else
+                {
+                    sb.Append(c);
+                    i++;
+                }
+            }
+            return sb.ToString();
+        }
+
+        public static string ReEncodeString(string s, Encoding fromEncoding, Encoding toEncoding)
+        {
+            if (s == null || fromEncoding.HeaderName.Equals(toEncoding.HeaderName))
+                return s;
+            else
+            {
+                byte[] bytes = fromEncoding.GetBytes(s);
+                s = toEncoding.GetString(bytes);
+                return s;
+            }
+        }
+
+        /// <summary>
+        /// reencodes string from GitCommandHelpers.LosslessEncoding to Settings.LogOutputEncoding
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static string ReEncodeStringFromLossless(string s)
+        {
+            return ReEncodeString(s, Settings.LosslessEncoding, Settings.LogOutputEncoding);
+        }
+
+        public static string ReEncodeStringFromLossless(string s, Encoding toEncoding)
+        {
+            if (toEncoding == null)
+                return s;
+            else
+                return ReEncodeString(s, Settings.LosslessEncoding, toEncoding);
+
+        }
+
+        //there is a bug: git does not recode commit message when format is given
+        //Lossless encoding is used, because LogOutputEncoding might not be lossless and not recoded
+        //characters could be replaced by replacement character while reencoding to LogOutputEncoding
+        public static string ReEncodeCommitMessage(string s, string toEncodingName)
+        {
+
+            bool isABug = true;
+
+            Encoding encoding;
+            try
+            {
+                if (isABug)
+                {
+                    if (toEncodingName.IsNullOrEmpty())
+                        encoding = Encoding.UTF8;
+                    else if (toEncodingName.Equals(Settings.LosslessEncoding.HeaderName, StringComparison.InvariantCultureIgnoreCase))
+                        encoding = null; //no recoding is needed
+                    else
+                        encoding = Encoding.GetEncoding(toEncodingName);
+                }
+                else//if bug will be fixed, git should recode commit message to LogOutputEncoding
+                    encoding = Settings.LogOutputEncoding;
+
+            }
+            catch (Exception)
+            {
+                return "! Unsupported commit message encoding: " + toEncodingName + " !\n\n" + s;
+            }
+            return ReEncodeStringFromLossless(s, encoding);
+        }
+
+        /// <summary>
+        /// header part of show result is encoded in logoutputencoding (including reencoded commit message)
+        /// diff part is raw data in file's original encoding
+        /// s should be encoded in LosslessEncoding
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static string ReEncodeShowString(string s)
+        {
+            if (s.IsNullOrEmpty())
+                return s;
+
+            int p = s.IndexOf("diff --git");
+            string header;
+            string diffHeader;
+            string diffContent;
+            string diff;
+            if (p > 0)
+            {
+                header = s.Substring(0, p);
+                diff = s.Substring(p);
+            }
+            else
+            {
+                header = string.Empty;
+                diff = s;
+            }
+
+            p = diff.IndexOf("@@");
+            if (p > 0)
+            {
+                diffHeader = diff.Substring(0, p);
+                diffContent = diff.Substring(p);
+            }
+            else
+            {
+                diffHeader = string.Empty;
+                diffContent = diff;
+            }
+
+            header = ReEncodeString(header, Settings.LosslessEncoding, Settings.LogOutputEncoding);
+            diffHeader = ReEncodeString(diffHeader, Settings.LosslessEncoding, Settings.LogOutputEncoding);
+            diffHeader = ReEncodeFileName(diffHeader);
+            diffContent = ReEncodeString(diffContent, Settings.LosslessEncoding, Settings.FilesEncoding);
+            return header + diffHeader + diffContent;
+        }
+
     }
 }

--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -7,9 +7,13 @@ using GitUIPluginInterfaces;
 
 namespace GitCommands
 {
+    public delegate void SetupStartInfo(ProcessStartInfo startInfo);
+    
     public sealed class GitCommandsInstance : IGitCommands, IDisposable
     {
         private readonly object processLock = new object();
+        public SetupStartInfo SetupStartInfoCallback { get; set; }
+
 
         [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
         public Process CmdStartProcess(string cmd, string arguments)
@@ -32,6 +36,8 @@ namespace GitCommands
                 process.StartInfo.WorkingDirectory = Settings.WorkingDir;
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
                 process.StartInfo.LoadUserProfile = true;
+                if (SetupStartInfoCallback != null)
+                    SetupStartInfoCallback(process.StartInfo);
                 process.EnableRaisingEvents = true;
 
                 if (!StreamOutput)

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -30,6 +30,8 @@ namespace GitCommands
         public DateTime CommitDate { get; set; }
 
         public string Message { get; set; }
+        //UTF-8 when is null or empty
+        public string MessageEncoding { get; set; }
 
         #region IGitItem Members
 

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -44,8 +44,6 @@ namespace GitCommands
 
         private GitCommandsInstance gitGetGraphCommand;
 
-        private Encoding logoutputEncoding = null;
-
         private Thread backgroundThread = null;
 
         private enum ReadStep
@@ -59,6 +57,7 @@ namespace GitCommands
             AuthorDate,
             CommitterName,
             CommitterDate,
+            CommitMessageEncoding,
             CommitMessage,
             FileName,
             Done,
@@ -129,13 +128,14 @@ namespace GitCommands
                 if (!ShaOnly)
                 {
                     formatString +=
-                        /* Tree           */ "%T%n" +
-                        /* Author Name    */ "%aN%n" +
-                        /* Author Email    */ "%aE%n" +
-                        /* Author Date    */ "%ai%n" +
-                        /* Committer Name */ "%cN%n" +
-                        /* Committer Date */ "%ci%n" +
-                        /* Commit Message */ "%s";
+                        /* Tree                    */ "%T%n" +
+                        /* Author Name             */ "%aN%n" +
+                        /* Author Email            */ "%aE%n" +
+                        /* Author Date             */ "%ai%n" +
+                        /* Committer Name          */ "%cN%n" +
+                        /* Committer Date          */ "%ci%n" +
+                        /* Commit message encoding */ "%e%n" + //there is a bug: git does not recode commit message when format is given
+                        /* Commit Message          */ "%s";
                 }
 
                 // NOTE:
@@ -159,7 +159,14 @@ namespace GitCommands
 
                 gitGetGraphCommand = new GitCommandsInstance();
                 gitGetGraphCommand.StreamOutput = true;
-                gitGetGraphCommand.CollectOutput = false;
+                gitGetGraphCommand.CollectOutput = false;                
+                Encoding LogOutputEncoding = Settings.LogOutputEncoding;
+                gitGetGraphCommand.SetupStartInfoCallback = (ProcessStartInfo startInfo) =>
+                {
+                    startInfo.StandardOutputEncoding = Settings.LosslessEncoding;
+                    startInfo.StandardErrorEncoding = Settings.LosslessEncoding;
+                }; 
+
                 Process p = gitGetGraphCommand.CmdStartProcess(Settings.GitCommand, arguments);
 
                 if (BeginUpdate != null)
@@ -169,6 +176,9 @@ namespace GitCommands
                 do
                 {
                     line = p.StandardOutput.ReadLine();
+                    //commit message is not encoded by git
+                    if (nextStep != ReadStep.CommitMessage)
+                        line = GitCommandHelpers.ReEncodeString(line, Settings.LosslessEncoding, LogOutputEncoding);
 
                     if (line != null)
                     {
@@ -312,14 +322,13 @@ namespace GitCommands
                     }
                     break;
 
+                case ReadStep.CommitMessageEncoding:
+                    revision.MessageEncoding = line;
+                    break;
+                
                 case ReadStep.CommitMessage:
-                    //We need to recode the commit message because of a bug in Git.
-                    //We cannot let git recode the message to Settings.Encoding which is
-                    //needed to allow the "git log" to print the filename in Settings.Encoding
-                    if (logoutputEncoding == null)
-                        logoutputEncoding = Settings.Module.GetLogoutputEncoding();
+                    revision.Message = GitCommandHelpers.ReEncodeCommitMessage(line, revision.MessageEncoding);
 
-                    revision.Message = logoutputEncoding.Equals(Settings.Encoding) ? line : logoutputEncoding.GetString(Settings.Encoding.GetBytes(line));
                     break;
 
                 case ReadStep.FileName:

--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -5,7 +5,9 @@ using System.Text;
 using System.Windows.Forms;
 using GitCommands.Logging;
 using GitCommands.Repository;
+using GitCommands.Config;
 using Microsoft.Win32;
+using System.Collections.Generic;
 
 namespace GitCommands
 {
@@ -19,6 +21,7 @@ namespace GitCommands
         public static readonly char PathSeparator = '\\';
         public static readonly char PathSeparatorWrong = '/';
 
+        private static Dictionary<String, object> byNameMap = new Dictionary<String, object>();
         static Settings()
         {
             if (!RunningOnWindows())
@@ -263,54 +266,165 @@ namespace GitCommands
             set { SafeSet("revisiongraphdrawnonrelativestextgray", value, ref _revisionGraphDrawNonRelativesTextGray); }
         }
 
-        private static Encoding _encoding;
-        public static Encoding Encoding
+        public static Dictionary<string, Encoding> availableEncodings = new Dictionary<string, Encoding>();
+           
+        private static Encoding GetEncoding(bool local, string settingName, bool fromSettings)
+        {
+            Encoding result;
+            string lname = local ? "_local" + '_' + WorkingDir : "_global";
+            lname = settingName + lname;
+            object o;
+            if (byNameMap.TryGetValue(lname, out o))
+                result = o as Encoding;
+            else
+            {
+                string encodingName;
+                if (fromSettings)
+                    encodingName = GetString("n_" + lname, null);
+                else
+                {
+                    ConfigFile cfg;
+                    if (local)
+                        cfg = Module.GetLocalConfig();
+                    else
+                        cfg = GitCommandHelpers.GetGlobalConfig();
+
+                    encodingName = cfg.GetValue(settingName);
+                }
+
+                if (encodingName.IsNullOrEmpty())
+                    result = null;
+                else if (!availableEncodings.TryGetValue(encodingName, out result))
+                {
+                    try
+                    {
+                        result = Encoding.GetEncoding(encodingName);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new Exception(ex.Message + Environment.NewLine + "Unsupported encoding set in git config file: " + encodingName + Environment.NewLine + "Please check the setting i18n.commitencoding in your local and/or global config files. Command aborted.", ex);
+                    }
+                }
+                byNameMap[lname] = result;                
+            }
+
+            return result;
+
+        }
+
+        private static void SetEncoding(bool local, string settingName, Encoding encoding, bool toSettings)
+        {
+            string lname = local ? "_local" + '_' + WorkingDir : "_global";
+            lname = settingName + lname;
+            byNameMap[lname] = encoding;
+            //storing to config file is handled by FormSettings
+            if (toSettings)
+                SetString("n_" + lname, encoding == null ? null : encoding.HeaderName);
+        }
+
+        //encoding for files paths
+        public static readonly Encoding SystemEncoding = Encoding.Default;
+        //Encoding that let us read all bytes without replacing any char
+        public static readonly Encoding LosslessEncoding = Encoding.GetEncoding("ISO-8859-1");//is any better?
+        //follow by git i18n CommitEncoding and LogOutputEncoding is a hell
+        //command output may consist of:
+        //1) commit message encoded in CommitEncoding, recoded to LogOutputEncoding or not dependent of 
+        //   pretty parameter (pretty=raw - recoded, pretty=format - not recoded)
+        //2) author name encoded dependently on config file encoding, not recoded to LogOutputEncoding
+        //3) file content encoded in its original encoding, not recoded to LogOutputEncoding
+        //4) file path (file name is encoded in system default encoding), not recoded to LogOutputEncoding,
+        //   every not ASCII character is escaped with \ followed by its code as a three digit octal number
+        //5) branch or tag name encoded in system default encoding, not recoded to LogOutputEncoding
+        //saying that "At the core level, git is character encoding agnostic." is not enough
+        //In my opinion every data not encoded in utf8 should contain information
+        //about its encoding, also git should emit structuralized data
+        //i18n CommitEncoding and LogOutputEncoding properties are stored in config file, because of 2)
+        //it is better to encode this file in utf8 for international projects. To read config file properly
+        //we must know its encoding, let user decide by setting AppEncoding property which encoding has to be used
+        //to read/write config file
+        public static Encoding GetAppEncoding(bool local)
+        {
+            return GetEncoding(local, "AppEncoding", true);
+        }
+        public static void SetAppEncoding(bool local, Encoding encoding)
+        {
+            SetEncoding(local, "AppEncoding", encoding, true);
+        }
+        public static Encoding AppEncoding
         {
             get
             {
-                if (_encoding == null)
-                {
-                    string encoding = GetValue("encoding", "");
-
-                    if (string.IsNullOrEmpty(encoding))
-                        _encoding = new UTF8Encoding(false);
-                    else if (encoding.Equals("Default", StringComparison.CurrentCultureIgnoreCase))
-                        _encoding = Encoding.Default;
-                    else if (encoding.Equals("Unicode", StringComparison.CurrentCultureIgnoreCase))
-                        _encoding = new UnicodeEncoding();
-                    else if (encoding.Equals("ASCII", StringComparison.CurrentCultureIgnoreCase))
-                        _encoding = new ASCIIEncoding();
-                    else if (encoding.Equals("UTF7", StringComparison.CurrentCultureIgnoreCase))
-                        _encoding = new UTF7Encoding();
-                    else if (encoding.Equals("UTF32", StringComparison.CurrentCultureIgnoreCase))
-                        _encoding = new UTF32Encoding(true, false);
-                    else
-                        _encoding = new UTF8Encoding(false);
-                }
-                return _encoding;
+                Encoding result = GetAppEncoding(true);
+                if (result == null)
+                    result = GetAppEncoding(false);
+                if (result == null)
+                    result = new UTF8Encoding(false);
+                return result;
             }
-            set
+        }
+
+        public static Encoding GetFilesEncoding(bool local) 
+        {
+            return GetEncoding(local, "i18n.filesEncoding", false);                 
+        }
+        public static void SetFilesEncoding(bool local, Encoding encoding)
+        {
+            SetEncoding(local, "i18n.filesEncoding", encoding, false);
+        }
+        public static Encoding FilesEncoding
+        {
+            get
             {
-                _encoding = value;
+                Encoding result = GetFilesEncoding(true);
+                if (result == null)
+                    result = GetFilesEncoding(false);
+                if (result == null)
+                    result = new UTF8Encoding(false);
+                return result;
+            }
+        }
 
-                if (VersionIndependentRegKey == null)
-                    return;
+        public static Encoding GetCommitEncoding(bool local)
+        {
+            return GetEncoding(local, "i18n.commitEncoding", false);
+        }
+        public static void SetCommitEncoding(bool local, Encoding encoding)
+        {
+            SetEncoding(local, "i18n.commitEncoding", encoding, false);
+        }
+        public static Encoding CommitEncoding
+        {
+            get
+            {
+                Encoding result = GetCommitEncoding(true);
+                if (result == null)
+                    result = GetCommitEncoding(false);
+                if (result == null)
+                    result = new UTF8Encoding(false);
+                return result;
+            }
+        }
 
-                string encoding = "";
-                if (_encoding.EncodingName == Encoding.ASCII.EncodingName)
-                    encoding = "ASCII";
-                else if (_encoding.EncodingName == Encoding.Unicode.EncodingName)
-                    encoding = "Unicode";
-                else if (_encoding.EncodingName == Encoding.UTF7.EncodingName)
-                    encoding = "UTF7";
-                else if (_encoding.EncodingName == Encoding.UTF8.EncodingName)
-                    encoding = "UTF8";
-                else if (_encoding.EncodingName == Encoding.UTF32.EncodingName)
-                    encoding = "UTF32";
-                else if (_encoding.EncodingName == Encoding.Default.EncodingName)
-                    encoding = "Default";
-
-                SetValue("encoding", encoding);
+        public static Encoding GetLogOutputEncoding(bool local)
+        {
+            return GetEncoding(local, "i18n.logoutputencoding", false);
+        }
+        public static void SetLogOutputEncoding(bool local, Encoding encoding)
+        {
+            SetEncoding(local, "i18n.logoutputencoding", encoding, false);
+        }
+        public static Encoding LogOutputEncoding
+        {
+            get
+            {
+                Encoding result = GetLogOutputEncoding(true);
+                if (result == null)
+                    result = GetLogOutputEncoding(false);
+                if (result == null)
+                    result = CommitEncoding;
+                if (result == null)
+                    result = new UTF8Encoding(false);
+                return result;
             }
         }
 
@@ -739,8 +853,49 @@ namespace GitCommands
             { }
         }
 
+        private static void TransferEncodings()
+        {
+            string encoding = GetValue("encoding", "");
+            if (!encoding.IsNullOrEmpty())
+            {
+                Encoding _encoding;
+
+                if (encoding.Equals("Default", StringComparison.CurrentCultureIgnoreCase))
+                    _encoding = Encoding.Default;
+                else if (encoding.Equals("Unicode", StringComparison.CurrentCultureIgnoreCase))
+                    _encoding = new UnicodeEncoding();
+                else if (encoding.Equals("ASCII", StringComparison.CurrentCultureIgnoreCase))
+                    _encoding = new ASCIIEncoding();
+                else if (encoding.Equals("UTF7", StringComparison.CurrentCultureIgnoreCase))
+                    _encoding = new UTF7Encoding();
+                else if (encoding.Equals("UTF32", StringComparison.CurrentCultureIgnoreCase))
+                    _encoding = new UTF32Encoding(true, false);
+                else
+                    _encoding = new UTF8Encoding(false);
+
+                SetFilesEncoding(false, _encoding);
+                SetAppEncoding(false, _encoding);
+                SetValue("encoding", null as string);
+            }
+        }
+
         public static void LoadSettings()
         {
+            Action<Encoding> addEncoding = delegate(Encoding e) { availableEncodings[e.HeaderName] = e; };
+            addEncoding(Encoding.Default);
+            addEncoding(new ASCIIEncoding());
+            addEncoding(new UnicodeEncoding());
+            addEncoding(new UTF7Encoding());
+            addEncoding(new UTF8Encoding());
+
+            try
+            {
+                TransferEncodings();
+                TransferVerDependentReg();
+            }
+            catch
+            { }
+
             try
             {
                 GitCommandHelpers.SetSsh(GetValue<string>("gitssh", null));
@@ -890,49 +1045,127 @@ namespace GitCommands
             SetValue(key, field.AsString());
         }
 
-        private static string VersionIndependentRegKey
+        private static RegistryKey _VersionIndependentRegKey;
+
+        private static RegistryKey VersionIndependentRegKey
         {
             get
             {
-                return string.Concat(Registry.CurrentUser, "\\Software\\GitExtensions\\GitExtensions");
-                //return Application.UserAppDataRegistry.Name.Replace("\\" + Application.ProductVersion, string.Empty);
+                if (_VersionIndependentRegKey == null)
+                    _VersionIndependentRegKey = Registry.CurrentUser.OpenSubKey("Software\\GitExtensions\\GitExtensions", true);
+                return _VersionIndependentRegKey;
             }
         }
 
         public static T GetValue<T>(string name, T defaultValue)
         {
-            T value = (T)Registry.GetValue(VersionIndependentRegKey, name, null);
+            T value = (T)VersionIndependentRegKey.GetValue(name, null);
 
             if (value != null)
                 return value;
-
-            /////////////////////////////////////////////////////////////////////////////////////
-            ///// BEGIN TEMPORARY CODE TO CONVERT OLD VERSION DEPENDENT REGISTRY TO NEW 
-            ///// VERSION INDEPENDENT REGISTRY KEY!
-            /////////////////////////////////////////////////////////////////////////////////////
-            value = (T)Registry.GetValue(VersionIndependentRegKey + "\\1.0.0.0", name, null);
-
-            if (value != null)
-            {
-                SetValue<T>(name, value);
-                return value;
-            }
-
-            if (defaultValue != null)
-            {
-                SetValue<T>(name, defaultValue);
-            }
-            /////////////////////////////////////////////////////////////////////////////////////
-            ///// END TEMPORARY CODE TO CONVERT OLD VERSION DEPENDENT REGISTRY TO NEW 
-            ///// VERSION INDEPENDENT REGISTRY KEY!
-            /////////////////////////////////////////////////////////////////////////////////////
-
+          
             return defaultValue;
+        }
+
+        //temporary code to transfer version dependent registry caused that there was no way to set value to null
+        //if there was the same named key in version dependent registry
+        private static void TransferVerDependentReg()
+        {
+            bool? transfered = GetBool("TransferedVerDependentReg", false);
+            if (!transfered.Value)
+            {
+                string r = Application.UserAppDataRegistry.Name.Replace(Application.ProductVersion, "1.0.0.0");
+                r = r.Substring(Registry.CurrentUser.Name.Length + 1, r.Length - Registry.CurrentUser.Name.Length - 1);
+                RegistryKey versionDependentRegKey = Registry.CurrentUser.OpenSubKey(r, true);
+                try
+                {
+                    foreach (string key in versionDependentRegKey.GetValueNames())
+                    {
+                        object val = versionDependentRegKey.GetValue(key);
+                        object independentVal = VersionIndependentRegKey.GetValue(key, null);
+                        if (independentVal == null)
+                            SetValue<object>(key, val);
+                    }
+                }
+                finally
+                {
+                    versionDependentRegKey.Close();
+                }
+                SetBool("TransferedVerDependentReg", true);
+            }
+            
         }
 
         public static void SetValue<T>(string name, T value)
         {
-            Registry.SetValue(VersionIndependentRegKey, name, value);
+            if (value == null)
+                VersionIndependentRegKey.DeleteValue(name);
+            else
+                VersionIndependentRegKey.SetValue(name, value);
+        }
+
+        public static T GetByName<T>(string name, T defaultValue, Func<object, T> decode)
+        {
+            object o;
+            if (byNameMap.TryGetValue(name, out o))
+            {
+                if( o == null || o is T)
+                    return (T)o;
+                else
+                    throw new Exception("Incompatible class for settings: " + name + ". Expected: " + typeof(T).FullName + ", found: " + o.GetType().FullName);
+            }
+            else
+            {
+                T result;
+                o = GetValue<object>(name, null);
+                if (o == null)
+                    result = defaultValue;
+                else
+                    result = decode(o);
+
+                byNameMap[name] = result;
+                return result;
+            }
+        }
+
+        public static void SetByName<T>(string name, T value, Func<T, object> encode)
+        {
+            object o;
+            if (byNameMap.TryGetValue(name, out o))
+                if (Object.Equals(o, value))
+                    return;
+            if (value == null)
+                o = null;
+            else
+                o = encode(value);
+            SetValue<object>(name, o);
+            byNameMap[name] = value;
+        }
+
+        public static bool? GetBool(string name, bool? defaultValue)
+        {
+            return GetByName<bool?>(name, defaultValue, x => x.ToString().Equals(bool.TrueString));
+        }
+
+        public static void SetString(string name, string value)
+        {
+            SetByName<string>(name, value, (string s) => s);
+        }
+
+        public static string GetString(string name, string defaultValue)
+        {
+            return GetByName<string>(name, defaultValue, x => x.ToString());
+        }
+
+        public static void SetBool(string name, bool? value)
+        {
+            SetByName<bool?>(name, value, (bool? b) => b.Value ? bool.TrueString : bool.FalseString);
+        }
+
+
+        public static string PrefixedName(string prefix, string name) 
+        {
+            return prefix == null ? name : prefix + '_' + name;
         }
     }
 

--- a/GitCommands/patch/Patch.cs
+++ b/GitCommands/patch/Patch.cs
@@ -93,7 +93,7 @@ namespace PatchApply
         {
             try
             {
-                using (var streamReader = new StreamReader(DirToPatch + fileName, Settings.Encoding))
+                using (var streamReader = new StreamReader(DirToPatch + fileName, Settings.FilesEncoding))
                 {
                     string retval = "";
                     string line;

--- a/GitCommands/patch/PatchManager.cs
+++ b/GitCommands/patch/PatchManager.cs
@@ -294,7 +294,7 @@ namespace PatchApply
 
         public void LoadPatchFile(bool applyPatch)
         {
-            using (var re = new StreamReader(PatchFileName, Settings.Encoding))
+            using (var re = new StreamReader(PatchFileName, Settings.FilesEncoding))
             {
                 LoadPatchStream(re, applyPatch);
             }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -53,24 +53,15 @@ namespace GitUI.Editor
 
             IsReadOnly = true;
 
-            this.Encoding = Settings.Encoding;
+            Settings.WorkingDirChanged += WorkingDirChanged;
+
+            this.Encoding = Settings.FilesEncoding;
+            
             this.encodingToolStripComboBox.Items.AddRange(new Object[]
                                                     {
                                                         "Default (" + Encoding.Default.HeaderName + ")", "ASCII",
                                                         "Unicode", "UTF7", "UTF8", "UTF32"
                                                     });
-            if (this.Encoding.GetType() == typeof(ASCIIEncoding))
-                this.encodingToolStripComboBox.Text = "ASCII";
-            else if (this.Encoding.GetType() == typeof(UnicodeEncoding))
-                this.encodingToolStripComboBox.Text = "Unicode";
-            else if (this.Encoding.GetType() == typeof(UTF7Encoding))
-                this.encodingToolStripComboBox.Text = "UTF7";
-            else if (this.Encoding.GetType() == typeof(UTF8Encoding))
-                this.encodingToolStripComboBox.Text = "UTF8";
-            else if (this.Encoding.GetType() == typeof(UTF32Encoding))
-                this.encodingToolStripComboBox.Text = "UTF32";
-            else if (this.Encoding == Encoding.Default)
-                this.encodingToolStripComboBox.Text = "Default (" + Encoding.Default.HeaderName + ")";
             _internalFileViewer.MouseMove += TextAreaMouseMove;
             _internalFileViewer.MouseLeave += TextAreaMouseLeave;
             _internalFileViewer.TextChanged += TextEditor_TextChanged;
@@ -82,6 +73,12 @@ namespace GitUI.Editor
 
             ContextMenu.Opening += ContextMenu_Opening; 
         }
+
+        private void WorkingDirChanged(string oldDir, string newDir, string newGitDir)
+        {
+            this.Encoding = Settings.FilesEncoding;
+        }
+
 
         protected override void OnLoad(EventArgs e)
         {
@@ -189,7 +186,33 @@ namespace GitUI.Editor
         public bool ShowEntireFile { get; set; }
         public bool TreatAllFilesAsText { get; set; }
         public bool DisableFocusControlOnHover { get; set; }
-        public Encoding Encoding { get; set; }
+        private Encoding _Encoding;
+        public Encoding Encoding 
+        {
+            get
+            {
+                return _Encoding;
+            }
+        
+            set
+            {
+                _Encoding = value;
+
+                if (this.Encoding.GetType() == typeof(ASCIIEncoding))
+                    this.encodingToolStripComboBox.Text = "ASCII";
+                else if (this.Encoding.GetType() == typeof(UnicodeEncoding))
+                    this.encodingToolStripComboBox.Text = "Unicode";
+                else if (this.Encoding.GetType() == typeof(UTF7Encoding))
+                    this.encodingToolStripComboBox.Text = "UTF7";
+                else if (this.Encoding.GetType() == typeof(UTF8Encoding))
+                    this.encodingToolStripComboBox.Text = "UTF8";
+                else if (this.Encoding.GetType() == typeof(UTF32Encoding))
+                    this.encodingToolStripComboBox.Text = "UTF32";
+                else if (this.Encoding == Encoding.Default)
+                    this.encodingToolStripComboBox.Text = "Default (" + Encoding.Default.HeaderName + ")";
+
+            }
+        }
 
         public int ScrollPos
         {
@@ -461,7 +484,7 @@ namespace GitUI.Editor
             else
                 path = GitCommands.Settings.WorkingDir + fileName;
 
-            return !File.Exists(path) ? null : FileReader.ReadFileContent(path, GitCommands.Settings.Encoding);
+            return !File.Exists(path) ? null : FileReader.ReadFileContent(path, GitCommands.Settings.FilesEncoding);
         }
 
         private void ResetForImage()
@@ -768,7 +791,7 @@ namespace GitUI.Editor
         {
             Encoding encod = null;
             if (string.IsNullOrEmpty(encodingToolStripComboBox.Text))
-                encod = Settings.Encoding;
+                encod = Settings.FilesEncoding;
             else if (encodingToolStripComboBox.Text.StartsWith("Default", StringComparison.CurrentCultureIgnoreCase))
                 encod = Encoding.Default;
             else if (encodingToolStripComboBox.Text.Equals("ASCII", StringComparison.CurrentCultureIgnoreCase))
@@ -782,7 +805,7 @@ namespace GitUI.Editor
             else if (encodingToolStripComboBox.Text.Equals("UTF32", StringComparison.CurrentCultureIgnoreCase))
                 encod = new UTF32Encoding(true, false);
             else
-                encod = Settings.Encoding;
+                encod = Settings.FilesEncoding;
             if (encod != this.Encoding)
             {
                 this.Encoding = encod;

--- a/GitUI/FormAddToGitIgnore.cs
+++ b/GitUI/FormAddToGitIgnore.cs
@@ -33,10 +33,10 @@ namespace GitUI
                                            gitIgnoreFileAddition.Append(Environment.NewLine);
 
                                            if (File.Exists(Settings.WorkingDir + ".gitignore"))
-                                               if (!File.ReadAllText(Settings.WorkingDir + ".gitignore", Settings.Encoding).EndsWith(Environment.NewLine))
+                                               if (!File.ReadAllText(Settings.WorkingDir + ".gitignore", Settings.SystemEncoding).EndsWith(Environment.NewLine))
                                                    gitIgnoreFileAddition.Insert(0, Environment.NewLine);
 
-                                           using (TextWriter tw = new StreamWriter(x, true, Settings.Encoding))
+                                           using (TextWriter tw = new StreamWriter(x, true, Settings.SystemEncoding))
                                            {
                                                tw.Write(gitIgnoreFileAddition);
                                            }

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1474,7 +1474,7 @@ namespace GitUI
             {
                 if (file.IsTracked)
                     return Settings.Module.GetCurrentChanges(file.Name, file.OldName, false, DiffText.GetExtraDiffArguments(), DiffText.Encoding);
-                return FileReader.ReadFileContent(Settings.WorkingDir + file.Name, Settings.Encoding);
+                return FileReader.ReadFileContent(Settings.WorkingDir + file.Name, Settings.FilesEncoding);
             }
             if (revisions[0].Guid == GitRevision.IndexGuid) //index
             {

--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -406,7 +406,14 @@ namespace GitUI
 
             if (_gitGetUnstagedCommand == null)
             {
-                _gitGetUnstagedCommand = new GitCommandsInstance();
+                _gitGetUnstagedCommand = new GitCommandsInstance()
+                {
+                    SetupStartInfoCallback = (ProcessStartInfo startInfo) =>
+                    {
+                        startInfo.StandardOutputEncoding = Settings.SystemEncoding;
+                        startInfo.StandardErrorEncoding = Settings.SystemEncoding;
+                    }
+                };
                 _gitGetUnstagedCommand.Exited += GitCommandsExited;
             }
 
@@ -1042,7 +1049,7 @@ namespace GitUI
                     message = Settings.Module.GetMergeMessage();
 
                     if (string.IsNullOrEmpty(message) && File.Exists(GitCommands.Commit.GetCommitMessagePath()))
-                        message = File.ReadAllText(GitCommands.Commit.GetCommitMessagePath(), Settings.Encoding);
+                        message = File.ReadAllText(GitCommands.Commit.GetCommitMessagePath(), Settings.CommitEncoding);
                     break;
             }
 
@@ -1073,27 +1080,7 @@ namespace GitUI
             //  given to it does not look like a valid UTF-8 string, unless you 
             //  explicitly say your project uses a legacy encoding. The way to say 
             //  this is to have i18n.commitencoding in .git/config file, like this:...
-            Encoding encoding;
-            string encodingString = Settings.Module.GetLocalConfig().GetValue("i18n.commitencoding");
-            if (string.IsNullOrEmpty(encodingString))
-                encodingString = GitCommandHelpers.GetGlobalConfig().GetValue("i18n.commitencoding");
-
-            if (!string.IsNullOrEmpty(encodingString))
-            {
-                try
-                {
-                    encoding = Encoding.GetEncoding(encodingString);
-                }
-                catch (ArgumentException ex)
-                {
-                    MessageBox.Show(this, ex.Message + Environment.NewLine + "Unsupported encoding set in git config file: " + encodingString + Environment.NewLine + "Please check the setting i18n.commitencoding in your local and/or global config files. Commit aborted.");
-                    return;
-                }
-            }
-            else
-            {
-                encoding = new UTF8Encoding(false);
-            }
+            Encoding encoding = Settings.CommitEncoding;
 
             using (var textWriter = new StreamWriter(path, false, encoding))
             {

--- a/GitUI/FormEditor.cs
+++ b/GitUI/FormEditor.cs
@@ -126,7 +126,7 @@ namespace GitUI
         {
             if (!string.IsNullOrEmpty(_fileName))
             {
-                File.WriteAllText(_fileName, fileViewer.GetText(), GitCommands.Settings.Encoding);
+                File.WriteAllText(_fileName, fileViewer.GetText(), GitCommands.Settings.FilesEncoding);
                 
                 // we've written the changes out to disk now, nothing to save.
                 _textIsChanged = false;

--- a/GitUI/FormGitAttributes.cs
+++ b/GitUI/FormGitAttributes.cs
@@ -53,7 +53,7 @@ namespace GitUI
                             this.GitAttributesFile = _NO_TRANSLATE_GitAttributesText.GetText();
                             if (!this.GitAttributesFile.EndsWith(Environment.NewLine))
                                 this.GitAttributesFile += Environment.NewLine;
-                            File.WriteAllBytes(x,Settings.Encoding.GetBytes(this.GitAttributesFile));
+                            File.WriteAllBytes(x, Settings.SystemEncoding.GetBytes(this.GitAttributesFile));
                         });
             }
             catch (Exception ex)

--- a/GitUI/FormGitIgnore.cs
+++ b/GitUI/FormGitIgnore.cs
@@ -62,7 +62,7 @@ namespace GitUI
                             this.GitIgnoreFile = _NO_TRANSLATE_GitIgnoreEdit.GetText();
                             if (!this.GitIgnoreFile.EndsWith(Environment.NewLine))
                                 this.GitIgnoreFile += Environment.NewLine;
-                            File.WriteAllBytes(x,Settings.Encoding.GetBytes(this.GitIgnoreFile));
+                            File.WriteAllBytes(x, Settings.SystemEncoding.GetBytes(this.GitIgnoreFile));    
                         });
             }
             catch (Exception ex)

--- a/GitUI/FormMailMap.cs
+++ b/GitUI/FormMailMap.cs
@@ -54,7 +54,7 @@ namespace GitUI
                         if (!this.MailMapFile.EndsWith(Environment.NewLine))
                             this.MailMapFile += Environment.NewLine;
 
-                        File.WriteAllBytes(x, Settings.Encoding.GetBytes(this.MailMapFile));
+                        File.WriteAllBytes(x, Settings.AppEncoding.GetBytes(this.MailMapFile));
                         });
             }
             catch (Exception ex)

--- a/GitUI/FormSettings.Designer.cs
+++ b/GitUI/FormSettings.Designer.cs
@@ -111,8 +111,6 @@ namespace GitUI
             this.Language = new System.Windows.Forms.ComboBox();
             this.label49 = new System.Windows.Forms.Label();
             this.chkFollowRenamesInFileHistory = new System.Windows.Forms.CheckBox();
-            this.EncodingLabel = new System.Windows.Forms.Label();
-            this._NO_TRANSLATE_Encoding = new System.Windows.Forms.ComboBox();
             this.Dictionary = new System.Windows.Forms.ComboBox();
             this.label22 = new System.Windows.Forms.Label();
             this.chkShowRelativeDate = new System.Windows.Forms.CheckBox();
@@ -273,6 +271,14 @@ namespace GitUI
             this.repositoryBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.helpProvider1 = new System.Windows.Forms.HelpProvider();
             this.diffFontDialog = new System.Windows.Forms.FontDialog();
+            this.Global_AppEncoding = new System.Windows.Forms.ComboBox();
+            this.label59 = new System.Windows.Forms.Label();
+            this.label60 = new System.Windows.Forms.Label();
+            this.Global_FilesEncoding = new System.Windows.Forms.ComboBox();
+            this.Local_AppEncoding = new System.Windows.Forms.ComboBox();
+            this.LogEncodingLabel = new System.Windows.Forms.Label();
+            this.label61 = new System.Windows.Forms.Label();
+            this.Local_FilesEncoding = new System.Windows.Forms.ComboBox();
             this.LocalSettings.SuspendLayout();
             this.groupBox10.SuspendLayout();
             this.InvalidGitPathLocal.SuspendLayout();
@@ -316,6 +322,10 @@ namespace GitUI
             // 
             // LocalSettings
             // 
+            this.LocalSettings.Controls.Add(this.Local_AppEncoding);
+            this.LocalSettings.Controls.Add(this.LogEncodingLabel);
+            this.LocalSettings.Controls.Add(this.label61);
+            this.LocalSettings.Controls.Add(this.Local_FilesEncoding);
             this.LocalSettings.Controls.Add(this.groupBox10);
             this.LocalSettings.Controls.Add(this.label30);
             this.LocalSettings.Controls.Add(this.InvalidGitPathLocal);
@@ -1070,8 +1080,6 @@ namespace GitUI
             this.TabPageGitExtensions.Controls.Add(this.Language);
             this.TabPageGitExtensions.Controls.Add(this.label49);
             this.TabPageGitExtensions.Controls.Add(this.chkFollowRenamesInFileHistory);
-            this.TabPageGitExtensions.Controls.Add(this.EncodingLabel);
-            this.TabPageGitExtensions.Controls.Add(this._NO_TRANSLATE_Encoding);
             this.TabPageGitExtensions.Controls.Add(this.label23);
             this.TabPageGitExtensions.Controls.Add(this.SmtpServer);
             this.TabPageGitExtensions.Controls.Add(this.Dictionary);
@@ -1290,23 +1298,6 @@ namespace GitUI
             this.chkFollowRenamesInFileHistory.TabIndex = 26;
             this.chkFollowRenamesInFileHistory.Text = "Follow renames in file history (experimental)";
             this.chkFollowRenamesInFileHistory.UseVisualStyleBackColor = true;
-            // 
-            // EncodingLabel
-            // 
-            this.EncodingLabel.AutoSize = true;
-            this.EncodingLabel.Location = new System.Drawing.Point(8, 448);
-            this.EncodingLabel.Name = "EncodingLabel";
-            this.EncodingLabel.Size = new System.Drawing.Size(57, 15);
-            this.EncodingLabel.TabIndex = 20;
-            this.EncodingLabel.Text = "Encoding";
-            // 
-            // _NO_TRANSLATE_Encoding
-            // 
-            this._NO_TRANSLATE_Encoding.FormattingEnabled = true;
-            this._NO_TRANSLATE_Encoding.Location = new System.Drawing.Point(396, 445);
-            this._NO_TRANSLATE_Encoding.Name = "_NO_TRANSLATE_Encoding";
-            this._NO_TRANSLATE_Encoding.Size = new System.Drawing.Size(242, 23);
-            this._NO_TRANSLATE_Encoding.TabIndex = 19;
             // 
             // Dictionary
             // 
@@ -2035,6 +2026,10 @@ namespace GitUI
             // 
             // GlobalSettingsPage
             // 
+            this.GlobalSettingsPage.Controls.Add(this.Global_AppEncoding);
+            this.GlobalSettingsPage.Controls.Add(this.label59);
+            this.GlobalSettingsPage.Controls.Add(this.label60);
+            this.GlobalSettingsPage.Controls.Add(this.Global_FilesEncoding);
             this.GlobalSettingsPage.Controls.Add(this.BrowseCommitTemplate);
             this.GlobalSettingsPage.Controls.Add(this.label57);
             this.GlobalSettingsPage.Controls.Add(this.CommitTemplatePath);
@@ -3090,6 +3085,76 @@ namespace GitUI
             this.diffFontDialog.AllowVerticalFonts = false;
             this.diffFontDialog.FixedPitchOnly = true;
             // 
+            // Global_AppEncoding
+            // 
+            this.Global_AppEncoding.FormattingEnabled = true;
+            this.Global_AppEncoding.Location = new System.Drawing.Point(549, 431);
+            this.Global_AppEncoding.Name = "Global_AppEncoding";
+            this.helpProvider1.SetShowHelp(this.Global_AppEncoding, true);
+            this.Global_AppEncoding.Size = new System.Drawing.Size(250, 21);
+            this.Global_AppEncoding.TabIndex = 51;
+            // 
+            // label59
+            // 
+            this.label59.AutoSize = true;
+            this.label59.Location = new System.Drawing.Point(425, 434);
+            this.label59.Name = "label59";
+            this.label59.Size = new System.Drawing.Size(118, 13);
+            this.label59.TabIndex = 50;
+            this.label59.Text = "GitExtensions encoding";
+            // 
+            // label60
+            // 
+            this.label60.AutoSize = true;
+            this.label60.Location = new System.Drawing.Point(5, 434);
+            this.label60.Name = "label60";
+            this.label60.Size = new System.Drawing.Size(74, 13);
+            this.label60.TabIndex = 49;
+            this.label60.Text = "Files encoding";
+            // 
+            // Global_FilesEncoding
+            // 
+            this.Global_FilesEncoding.FormattingEnabled = true;
+            this.Global_FilesEncoding.Location = new System.Drawing.Point(85, 431);
+            this.Global_FilesEncoding.Name = "Global_FilesEncoding";
+            this.Global_FilesEncoding.Size = new System.Drawing.Size(250, 21);
+            this.Global_FilesEncoding.TabIndex = 48;
+            // 
+            // Local_AppEncoding
+            // 
+            this.Local_AppEncoding.FormattingEnabled = true;
+            this.Local_AppEncoding.Location = new System.Drawing.Point(547, 258);
+            this.Local_AppEncoding.Name = "Local_AppEncoding";
+            this.helpProvider1.SetShowHelp(this.Local_AppEncoding, true);
+            this.Local_AppEncoding.Size = new System.Drawing.Size(250, 21);
+            this.Local_AppEncoding.TabIndex = 47;
+            // 
+            // LogEncodingLabel
+            // 
+            this.LogEncodingLabel.AutoSize = true;
+            this.LogEncodingLabel.Location = new System.Drawing.Point(418, 261);
+            this.LogEncodingLabel.Name = "LogEncodingLabel";
+            this.LogEncodingLabel.Size = new System.Drawing.Size(118, 13);
+            this.LogEncodingLabel.TabIndex = 46;
+            this.LogEncodingLabel.Text = "GitExtensions encoding";
+            // 
+            // label61
+            // 
+            this.label61.AutoSize = true;
+            this.label61.Location = new System.Drawing.Point(14, 261);
+            this.label61.Name = "label61";
+            this.label61.Size = new System.Drawing.Size(74, 13);
+            this.label61.TabIndex = 45;
+            this.label61.Text = "Files encoding";
+            // 
+            // Local_FilesEncoding
+            // 
+            this.Local_FilesEncoding.FormattingEnabled = true;
+            this.Local_FilesEncoding.Location = new System.Drawing.Point(94, 258);
+            this.Local_FilesEncoding.Name = "Local_FilesEncoding";
+            this.Local_FilesEncoding.Size = new System.Drawing.Size(250, 21);
+            this.Local_FilesEncoding.TabIndex = 44;
+            // 
             // FormSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -3256,8 +3321,6 @@ namespace GitUI
         private System.Windows.Forms.ComboBox Dictionary;
 		private System.Windows.Forms.Label label23;
         private System.Windows.Forms.TextBox SmtpServer;
-        private System.Windows.Forms.Label EncodingLabel;
-        private System.Windows.Forms.ComboBox _NO_TRANSLATE_Encoding;
         private System.Windows.Forms.TabPage AppearancePage;
         private System.Windows.Forms.GroupBox groupBox4;
         private System.Windows.Forms.GroupBox groupBox3;
@@ -3408,6 +3471,14 @@ namespace GitUI
         private DataGridViewCheckBoxColumn addToRevisionGridContextMenuDataGridViewCheckBoxColumn;
         private CheckBox chkWarnBeforeCheckout;
         private CheckBox chkStashUntrackedFiles;
+        private ComboBox Global_AppEncoding;
+        private Label label59;
+        private Label label60;
+        private ComboBox Global_FilesEncoding;
+        private ComboBox Local_AppEncoding;
+        private Label LogEncodingLabel;
+        private Label label61;
+        private ComboBox Local_FilesEncoding;
 
     }
 }

--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -32,11 +32,11 @@ namespace GitUI
 
             noImageService.Items.AddRange(GravatarService.DynamicServices.Cast<object>().ToArray());
 
-            _NO_TRANSLATE_Encoding.Items.AddRange(new Object[]
-                                                      {
-                                                          "Default (" + Encoding.Default.HeaderName + ")", "ASCII",
-                                                          "Unicode", "UTF7", "UTF8", "UTF32"
-                                                      });
+            FillEncodings(Global_FilesEncoding);
+            FillEncodings(Global_AppEncoding);
+            FillEncodings(Local_FilesEncoding);
+            FillEncodings(Local_AppEncoding);
+            
             GlobalEditor.Items.AddRange(new Object[] { "\"" + Settings.GetGitExtensionsFullPath() + "\" fileeditor", "vi", "notepad", "notepad++" });
 
             SetCurrentDiffFont(Settings.DiffFont);
@@ -111,6 +111,28 @@ namespace GitUI
             configFile.SetValue("diff.tool", diffTool);
         }
 
+        private void EncodingToCombo(Encoding encoding, ComboBox combo)
+        {
+            if (encoding == null)
+                combo.Text = "";
+            else
+                combo.Text = encoding.EncodingName;           
+        }
+
+        private Encoding ComboToEncoding(ComboBox combo)
+        {
+            if (combo.SelectedItem == null)
+                return null;
+            else
+                return combo.SelectedItem as Encoding;
+        }
+
+        private void FillEncodings(ComboBox combo)
+        {
+            combo.Items.AddRange(Settings.availableEncodings.Values.ToArray());
+            combo.DisplayMember = "EncodingName";
+        }
+
         public void LoadSettings()
         {
             try
@@ -119,19 +141,10 @@ namespace GitUI
                 homeIsSetToLabel.Text = string.Concat(_homeIsSetToString.Text, " ", GitCommandHelpers.GetHomeDir());
 
                 scriptEvent.DataSource = Enum.GetValues(typeof(ScriptEvent));
-
-                if (Settings.Encoding.GetType() == typeof(ASCIIEncoding))
-                    _NO_TRANSLATE_Encoding.Text = "ASCII";
-                else if (Settings.Encoding.GetType() == typeof(UnicodeEncoding))
-                    _NO_TRANSLATE_Encoding.Text = "Unicode";
-                else if (Settings.Encoding.GetType() == typeof(UTF7Encoding))
-                    _NO_TRANSLATE_Encoding.Text = "UTF7";
-                else if (Settings.Encoding.GetType() == typeof(UTF8Encoding))
-                    _NO_TRANSLATE_Encoding.Text = "UTF8";
-                else if (Settings.Encoding.GetType() == typeof(UTF32Encoding))
-                    _NO_TRANSLATE_Encoding.Text = "UTF32";
-                else if (Settings.Encoding == Encoding.Default)
-                    _NO_TRANSLATE_Encoding.Text = "Default (" + Encoding.Default.HeaderName + ")";
+                EncodingToCombo(Settings.GetFilesEncoding(false), Global_FilesEncoding);
+                EncodingToCombo(Settings.GetAppEncoding(false), Global_AppEncoding);
+                EncodingToCombo(Settings.GetFilesEncoding(true), Local_FilesEncoding);
+                EncodingToCombo(Settings.GetAppEncoding(true), Local_AppEncoding);
 
                 chkFocusControlOnHover.Checked = Settings.FocusControlOnHover;
                 chkWarnBeforeCheckout.Checked = Settings.DirtyDirWarnBeforeCheckoutBranch;
@@ -402,21 +415,10 @@ namespace GitUI
             Settings.Pageant = PageantPath.Text;
             Settings.AutoStartPageant = AutostartPageant.Checked;
 
-            if (string.IsNullOrEmpty(_NO_TRANSLATE_Encoding.Text) ||
-                _NO_TRANSLATE_Encoding.Text.StartsWith("Default", StringComparison.CurrentCultureIgnoreCase))
-                Settings.Encoding = Encoding.Default;
-            else if (_NO_TRANSLATE_Encoding.Text.Equals("ASCII", StringComparison.CurrentCultureIgnoreCase))
-                Settings.Encoding = new ASCIIEncoding();
-            else if (_NO_TRANSLATE_Encoding.Text.Equals("Unicode", StringComparison.CurrentCultureIgnoreCase))
-                Settings.Encoding = new UnicodeEncoding();
-            else if (_NO_TRANSLATE_Encoding.Text.Equals("UTF7", StringComparison.CurrentCultureIgnoreCase))
-                Settings.Encoding = new UTF7Encoding();
-            else if (_NO_TRANSLATE_Encoding.Text.Equals("UTF8", StringComparison.CurrentCultureIgnoreCase))
-                Settings.Encoding = new UTF8Encoding(false);
-            else if (_NO_TRANSLATE_Encoding.Text.Equals("UTF32", StringComparison.CurrentCultureIgnoreCase))
-                Settings.Encoding = new UTF32Encoding(true, false);
-            else
-                Settings.Encoding = Encoding.Default;
+            Settings.SetFilesEncoding(false, ComboToEncoding(Global_FilesEncoding));
+            Settings.SetAppEncoding(false, ComboToEncoding(Global_AppEncoding));
+            Settings.SetFilesEncoding(true, ComboToEncoding(Local_FilesEncoding));
+            Settings.SetAppEncoding(true, ComboToEncoding(Local_AppEncoding));
 
             Settings.RevisionGridQuickSearchTimeout = (int)RevisionGridQuickSearchTimeout.Value;
 
@@ -550,6 +552,22 @@ namespace GitUI
             if (globalAutoCrlfFalse.Checked) globalConfig.SetValue("core.autocrlf", "false");
             if (globalAutoCrlfInput.Checked) globalConfig.SetValue("core.autocrlf", "input");
             if (globalAutoCrlfTrue.Checked) globalConfig.SetValue("core.autocrlf", "true");
+
+            Action<Encoding, bool, string> setEncoding = delegate(Encoding e, bool local, string name) 
+            {
+                string value = e == null ? "" : e.HeaderName;
+                if (local)
+                    localConfig.SetValue(name, value);
+                else
+                    globalConfig.SetValue(name, value);
+            };
+            setEncoding(Settings.GetLogOutputEncoding(false), false, "i18n.logoutputencoding");
+            setEncoding(Settings.GetLogOutputEncoding(true), true, "i18n.logoutputencoding");
+            setEncoding(Settings.GetCommitEncoding(false), false, "i18n.commitEncoding");
+            setEncoding(Settings.GetCommitEncoding(true), true, "i18n.commitEncoding");
+            setEncoding(Settings.GetFilesEncoding(false), false, "i18n.filesEncoding");
+            setEncoding(Settings.GetFilesEncoding(true), true, "i18n.filesEncoding");            
+
 
             globalConfig.Save();
 

--- a/GitUI/GitLogForm.cs
+++ b/GitUI/GitLogForm.cs
@@ -83,7 +83,7 @@ namespace GitUI
             string command = CommandCacheItems.SelectedItem as string;
 
             string output;
-            if (GitCommandCache.TryGet(command, Settings.Encoding, out output))
+            if (GitCommandCache.TryGet(command, Settings.LogOutputEncoding, out output))
             {
                 commandCacheOutput.Text = command + "\n-------------------------------------\n\n";
                 commandCacheOutput.Text += output.Replace("\0", "\\0");


### PR DESCRIPTION
FilesEncoding - for repo files content
AppEncoding - for some git config files

Follow by git i18n CommitEncoding and LogOutputEncoding is a hell. Command output may consist of:
1) commit message encoded in CommitEncoding, recoded to LogOutputEncoding or not dependent of 
    pretty parameter (pretty=raw - recoded, pretty=format - not recoded)
2) author name encoded dependently on config file encoding, not recoded to LogOutputEncoding
3) file content encoded in its original encoding, not recoded to LogOutputEncoding
4) file path (file name is encoded in system default encoding), not recoded to LogOutputEncoding,
    every not ASCII character is escaped with \ followed by its code as a three digit octal number
5) branch or tag name encoded in system default encoding, not recoded to LogOutputEncoding

Saying that "At the core level, git is character encoding agnostic." is not enough
In my opinion every data not encoded in utf8 should contain information
about its encoding, also git should emit structuralized data

This pull request fixes all mojibakes I found but one:
When logoutputencoding is different from commitencoding, then stash save produce commit message with mojibakes. But this bug is probably more git than GitExtensions.
