### PR TITLE
Performance improvement: select all files in commit form without excess redrawings

### DIFF
--- a/GitUI/FileStatusList.cs
+++ b/GitUI/FileStatusList.cs
@@ -10,25 +10,25 @@ using GitUI.Properties;
 
 namespace GitUI
 {
-    public partial class FileStatusList : GitExtensionsControl
+    public sealed partial class FileStatusList : GitExtensionsControl
     {
         private const int ImageSize = 16;
 
         public FileStatusList()
         {
             InitializeComponent(); Translate();
-            SizeChanged += new EventHandler(FileStatusList_SizeChanged);
+            SizeChanged += FileStatusList_SizeChanged;
             FileStatusListBox.DrawMode = DrawMode.OwnerDrawVariable;
-            FileStatusListBox.MeasureItem += new MeasureItemEventHandler(FileStatusListBox_MeasureItem);
-            FileStatusListBox.DrawItem += new DrawItemEventHandler(FileStatusListBox_DrawItem);
-            FileStatusListBox.SelectedIndexChanged += new EventHandler(FileStatusListBox_SelectedIndexChanged);
-            FileStatusListBox.DataSourceChanged += new EventHandler(FileStatusListBox_DataSourceChanged);
-            FileStatusListBox.DoubleClick += new EventHandler(FileStatusListBox_DoubleClick);
+            FileStatusListBox.MeasureItem += FileStatusListBox_MeasureItem;
+            FileStatusListBox.DrawItem += FileStatusListBox_DrawItem;
+            FileStatusListBox.SelectedIndexChanged += FileStatusListBox_SelectedIndexChanged;
+            FileStatusListBox.DataSourceChanged += FileStatusListBox_DataSourceChanged;
+            FileStatusListBox.DoubleClick += FileStatusListBox_DoubleClick;
             FileStatusListBox.Sorted = true;
             FileStatusListBox.SelectionMode = SelectionMode.MultiExtended;
 #if !__MonoCS__ // TODO Drag'n'Drop doesnt work on Mono/Linux
-            FileStatusListBox.MouseMove += new MouseEventHandler(FileStatusListBox_MouseMove);
-            FileStatusListBox.MouseDown += new MouseEventHandler(FileStatusListBox_MouseDown);
+            FileStatusListBox.MouseMove += FileStatusListBox_MouseMove;
+            FileStatusListBox.MouseDown += FileStatusListBox_MouseDown;
 #endif
             FileStatusListBox.HorizontalScrollbar = true;
 
@@ -76,8 +76,7 @@ namespace GitUI
             //SELECT
             if (e.Button == MouseButtons.Right)
             {
-                Point point = new Point(e.X, e.Y);
-                int hoverIndex = FileStatusListBox.IndexFromPoint(point);
+                var hoverIndex = FileStatusListBox.IndexFromPoint(e.Location);
 
                 if (hoverIndex >= 0)
                 {
@@ -215,13 +214,7 @@ namespace GitUI
         {
             get
             {
-                IList<GitItemStatus> selectedItems = new List<GitItemStatus>();
-                foreach (object selectedItem in FileStatusListBox.SelectedItems)
-                {
-                    selectedItems.Add((GitItemStatus)selectedItem);
-                }
-
-                return selectedItems;
+                return FileStatusListBox.SelectedItems.Cast<GitItemStatus>().ToList();
             }
         }
 
@@ -252,7 +245,8 @@ namespace GitUI
 
         private int nextIndexToSelect = -1;
 
-        public void StoreNextIndexToSelect() {
+        public void StoreNextIndexToSelect()
+        {
             nextIndexToSelect = -1;
             foreach (int idx in FileStatusListBox.SelectedIndices)
                 if (idx > nextIndexToSelect)
@@ -260,7 +254,8 @@ namespace GitUI
             nextIndexToSelect = nextIndexToSelect - FileStatusListBox.SelectedIndices.Count + 1;
         }
 
-        public void SelectStoredNextIndex() {
+        public void SelectStoredNextIndex()
+        {
             nextIndexToSelect = Math.Min(nextIndexToSelect, FileStatusListBox.Items.Count - 1);
             if (nextIndexToSelect > -1)
                 SelectedIndex = nextIndexToSelect;
@@ -275,16 +270,16 @@ namespace GitUI
 
         void FileStatusListBox_DoubleClick(object sender, EventArgs e)
         {
-            if (this.DoubleClick == null)
+            if (DoubleClick == null)
                 GitUICommands.Instance.StartFileHistoryDialog(this, SelectedItem.Name, Revision);
             else
-                this.DoubleClick(sender, e);
+                DoubleClick(sender, e);
         }
 
         void FileStatusListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (SelectedIndexChanged != null)
-                SelectedIndexChanged(sender, e);
+                SelectedIndexChanged(this, e);
         }
 
         void FileStatusListBox_DataSourceChanged(object sender, EventArgs e)
@@ -344,7 +339,6 @@ namespace GitUI
             {
                 return FileStatusListBox.DataSource as IList<GitItemStatus>;
             }
-
             set
             {
                 if (value == null || value.Count == 0)
@@ -358,7 +352,7 @@ namespace GitUI
                 if (value != null && value.Count == 0 && prevSelectedIndex >= 0)
                 {
                     //bug in the ListBox control where supplying an empty list will not trigger a SelectedIndexChanged event, so we force it to trigger
-                    FileStatusListBox_SelectedIndexChanged(this, null);
+                    FileStatusListBox_SelectedIndexChanged(this, EventArgs.Empty);
                 }
             }
         }
@@ -384,29 +378,25 @@ namespace GitUI
                     {
                         if (e.Control)
                         {
+                            FileStatusListBox.BeginUpdate();
                             try
                             {
-                                FileStatusListBox.SuspendLayout();
-                                FileStatusListBox.ClearSelected();
-                                for (int n = FileStatusListBox.Items.Count - 1; n >= 0; n--)
-                                {
-                                    FileStatusListBox.SetSelected(n, true);
-                                }
+                                for (var i = 0; i < FileStatusListBox.Items.Count; i++)
+                                    FileStatusListBox.SetSelected(i, true);
                                 e.Handled = true;
                             }
                             finally
                             {
-                                FileStatusListBox.ResumeLayout();
+                                FileStatusListBox.EndUpdate();
                             }
                         }
                         break;
                     }
                 default:
-                    if (this.KeyDown != null)
-                        this.KeyDown(sender, e);
+                    if (KeyDown != null)
+                        KeyDown(sender, e);
                     break;
             }
-                
         }
 
         public int SetSelectionFilter(string filter)


### PR DESCRIPTION
There was funny issue while selecting all files in commit form using Ctrl-A: selection  jumped down and then rised selecting items one by one. It looked like a special animation, but at the same time it was annoying if you want just to select many items without waiting.

How to reproduce:
1. Run Git Extensions
2. Somehow do many changes/additions/deletions. For example, open large repo and mixed reset your current branch to some old commit, so your unchanged workdir will seem as changed.
3. Open commit form, note that there are few hundred unstaged files.
4. Put focus on unstaged files list and press Ctrl-A

cur: operation takes much time, up to minute or more depending on changes count.
exp: operation should be executed immediately

Technical details:
Algorithm used to call SuspendLayout/ResumeLayout without any effect: items redrawing and selected index changed event (causes diff refresh) occured for each item in the list. I just replaced them with BeginUpdate/EndUpdate methods.
