### PR TITLE
Allow click-through behavior for ToolStrips and MenuStrips.

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -42,7 +42,7 @@
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.treatAllFilesAsTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showNonprintableCharactersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileviewerToolbar = new System.Windows.Forms.ToolStrip();
+            this.fileviewerToolbar = new ToolStripEx();
             this.nextChangeButton = new System.Windows.Forms.ToolStripButton();
             this.previousChangeButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
@@ -305,7 +305,7 @@
         private System.Windows.Forms.ToolStripMenuItem treatAllFilesAsTextToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyPatchToolStripMenuItem;
-        private System.Windows.Forms.ToolStrip fileviewerToolbar;
+        private ToolStripEx fileviewerToolbar;
         private System.Windows.Forms.ToolStripButton nextChangeButton;
         private System.Windows.Forms.ToolStripButton previousChangeButton;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;

--- a/GitUI/FormBrowse.Designer.cs
+++ b/GitUI/FormBrowse.Designer.cs
@@ -37,8 +37,8 @@ namespace GitUI
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormBrowse));
             this.toolPanel = new System.Windows.Forms.SplitContainer();
-            this.UserMenuToolStrip = new System.Windows.Forms.ToolStrip();
-            this.ToolStrip = new System.Windows.Forms.ToolStrip();
+            this.UserMenuToolStrip = new ToolStripEx();
+            this.ToolStrip = new ToolStripEx();
             this.RefreshButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
             this._NO_TRANSLATE_Workingdir = new System.Windows.Forms.ToolStripSplitButton();
@@ -148,6 +148,7 @@ namespace GitUI
             this.rebaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.runMergetoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator23 = new System.Windows.Forms.ToolStripSeparator();
+            this.SvnFetchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SvnRebaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.SvnDcommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator24 = new System.Windows.Forms.ToolStripSeparator();
@@ -198,8 +199,7 @@ namespace GitUI
             this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
             this.donateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.SvnFetchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuStrip1 = new MenuStripEx();
             this.toolPanel.Panel1.SuspendLayout();
             this.toolPanel.Panel2.SuspendLayout();
             this.toolPanel.SuspendLayout();
@@ -313,7 +313,7 @@ namespace GitUI
             this._NO_TRANSLATE_Workingdir.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this._NO_TRANSLATE_Workingdir.ImageTransparentColor = System.Drawing.Color.Magenta;
             this._NO_TRANSLATE_Workingdir.Name = "_NO_TRANSLATE_Workingdir";
-            this._NO_TRANSLATE_Workingdir.Size = new System.Drawing.Size(91, 22);
+            this._NO_TRANSLATE_Workingdir.Size = new System.Drawing.Size(99, 22);
             this._NO_TRANSLATE_Workingdir.Text = "WorkingDir";
             this._NO_TRANSLATE_Workingdir.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this._NO_TRANSLATE_Workingdir.ToolTipText = "Change working directory";
@@ -324,7 +324,7 @@ namespace GitUI
             // 
             this.branchSelect.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.branchSelect.Name = "branchSelect";
-            this.branchSelect.Size = new System.Drawing.Size(56, 22);
+            this.branchSelect.Size = new System.Drawing.Size(60, 22);
             this.branchSelect.Text = "Branch";
             this.branchSelect.ToolTipText = "Change current branch";
             this.branchSelect.ButtonClick += new System.EventHandler(this.CurrentBranchClick);
@@ -352,7 +352,7 @@ namespace GitUI
             // stashChangesToolStripMenuItem
             // 
             this.stashChangesToolStripMenuItem.Name = "stashChangesToolStripMenuItem";
-            this.stashChangesToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.stashChangesToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
             this.stashChangesToolStripMenuItem.Text = "Stash";
             this.stashChangesToolStripMenuItem.ToolTipText = "Stash changes";
             this.stashChangesToolStripMenuItem.Click += new System.EventHandler(this.StashChangesToolStripMenuItemClick);
@@ -360,7 +360,7 @@ namespace GitUI
             // stashPopToolStripMenuItem
             // 
             this.stashPopToolStripMenuItem.Name = "stashPopToolStripMenuItem";
-            this.stashPopToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.stashPopToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
             this.stashPopToolStripMenuItem.Text = "Stash pop";
             this.stashPopToolStripMenuItem.ToolTipText = "Apply and drop single stash";
             this.stashPopToolStripMenuItem.Click += new System.EventHandler(this.StashPopToolStripMenuItemClick);
@@ -368,12 +368,12 @@ namespace GitUI
             // toolStripSeparator9
             // 
             this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(133, 6);
+            this.toolStripSeparator9.Size = new System.Drawing.Size(126, 6);
             // 
             // viewStashToolStripMenuItem
             // 
             this.viewStashToolStripMenuItem.Name = "viewStashToolStripMenuItem";
-            this.viewStashToolStripMenuItem.Size = new System.Drawing.Size(136, 22);
+            this.viewStashToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
             this.viewStashToolStripMenuItem.Text = "View stash";
             this.viewStashToolStripMenuItem.ToolTipText = "View stash";
             this.viewStashToolStripMenuItem.Click += new System.EventHandler(this.ViewStashToolStripMenuItemClick);
@@ -383,7 +383,7 @@ namespace GitUI
             this.toolStripButton1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton1.Image")));
             this.toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButton1.Name = "toolStripButton1";
-            this.toolStripButton1.Size = new System.Drawing.Size(62, 22);
+            this.toolStripButton1.Size = new System.Drawing.Size(71, 22);
             this.toolStripButton1.Text = "Commit";
             this.toolStripButton1.Click += new System.EventHandler(this.ToolStripButton1Click);
             // 
@@ -439,7 +439,7 @@ namespace GitUI
             // toolStripLabel1
             // 
             this.toolStripLabel1.Name = "toolStripLabel1";
-            this.toolStripLabel1.Size = new System.Drawing.Size(55, 22);
+            this.toolStripLabel1.Size = new System.Drawing.Size(58, 22);
             this.toolStripLabel1.Text = "Branches:";
             // 
             // toolStripBranches
@@ -470,14 +470,14 @@ namespace GitUI
             this.localToolStripMenuItem.CheckOnClick = true;
             this.localToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.localToolStripMenuItem.Name = "localToolStripMenuItem";
-            this.localToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.localToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.localToolStripMenuItem.Text = "Local";
             // 
             // remoteToolStripMenuItem
             // 
             this.remoteToolStripMenuItem.CheckOnClick = true;
             this.remoteToolStripMenuItem.Name = "remoteToolStripMenuItem";
-            this.remoteToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.remoteToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.remoteToolStripMenuItem.Text = "Remote";
             // 
             // toolStripSeparator19
@@ -488,7 +488,7 @@ namespace GitUI
             // toolStripLabel2
             // 
             this.toolStripLabel2.Name = "toolStripLabel2";
-            this.toolStripLabel2.Size = new System.Drawing.Size(35, 22);
+            this.toolStripLabel2.Size = new System.Drawing.Size(36, 22);
             this.toolStripLabel2.Text = "Filter:";
             this.toolStripLabel2.Click += new System.EventHandler(this.ToolStripLabel2Click);
             // 
@@ -530,28 +530,28 @@ namespace GitUI
             this.commitToolStripMenuItem1.CheckOnClick = true;
             this.commitToolStripMenuItem1.CheckState = System.Windows.Forms.CheckState.Checked;
             this.commitToolStripMenuItem1.Name = "commitToolStripMenuItem1";
-            this.commitToolStripMenuItem1.Size = new System.Drawing.Size(185, 22);
+            this.commitToolStripMenuItem1.Size = new System.Drawing.Size(184, 22);
             this.commitToolStripMenuItem1.Text = "Commit";
             // 
             // committerToolStripMenuItem
             // 
             this.committerToolStripMenuItem.CheckOnClick = true;
             this.committerToolStripMenuItem.Name = "committerToolStripMenuItem";
-            this.committerToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.committerToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.committerToolStripMenuItem.Text = "Committer";
             // 
             // authorToolStripMenuItem
             // 
             this.authorToolStripMenuItem.CheckOnClick = true;
             this.authorToolStripMenuItem.Name = "authorToolStripMenuItem";
-            this.authorToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.authorToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.authorToolStripMenuItem.Text = "Author";
             // 
             // diffContainsToolStripMenuItem
             // 
             this.diffContainsToolStripMenuItem.CheckOnClick = true;
             this.diffContainsToolStripMenuItem.Name = "diffContainsToolStripMenuItem";
-            this.diffContainsToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.diffContainsToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.diffContainsToolStripMenuItem.Text = "Diff contains (SLOW)";
             this.diffContainsToolStripMenuItem.Click += new System.EventHandler(this.diffContainsToolStripMenuItem_Click);
             // 
@@ -613,10 +613,10 @@ namespace GitUI
             // CommitInfo
             // 
             this.CommitInfo.Controls.Add(this.RevisionInfo);
-            this.CommitInfo.Location = new System.Drawing.Point(4, 22);
+            this.CommitInfo.Location = new System.Drawing.Point(4, 24);
             this.CommitInfo.Margin = new System.Windows.Forms.Padding(15);
             this.CommitInfo.Name = "CommitInfo";
-            this.CommitInfo.Size = new System.Drawing.Size(915, 259);
+            this.CommitInfo.Size = new System.Drawing.Size(915, 257);
             this.CommitInfo.TabIndex = 2;
             this.CommitInfo.Text = "Commit";
             this.CommitInfo.UseVisualStyleBackColor = true;
@@ -630,16 +630,16 @@ namespace GitUI
             this.RevisionInfo.Location = new System.Drawing.Point(0, 0);
             this.RevisionInfo.Margin = new System.Windows.Forms.Padding(10);
             this.RevisionInfo.Name = "RevisionInfo";
-            this.RevisionInfo.Size = new System.Drawing.Size(915, 259);
+            this.RevisionInfo.Size = new System.Drawing.Size(915, 257);
             this.RevisionInfo.TabIndex = 1;
             // 
             // Tree
             // 
             this.Tree.Controls.Add(this.FileTreeSplitContainer);
-            this.Tree.Location = new System.Drawing.Point(4, 22);
+            this.Tree.Location = new System.Drawing.Point(4, 24);
             this.Tree.Name = "Tree";
             this.Tree.Padding = new System.Windows.Forms.Padding(3);
-            this.Tree.Size = new System.Drawing.Size(915, 259);
+            this.Tree.Size = new System.Drawing.Size(915, 257);
             this.Tree.TabIndex = 0;
             this.Tree.Text = "File tree";
             this.Tree.UseVisualStyleBackColor = true;
@@ -659,7 +659,7 @@ namespace GitUI
             // FileTreeSplitContainer.Panel2
             // 
             this.FileTreeSplitContainer.Panel2.Controls.Add(this.FileText);
-            this.FileTreeSplitContainer.Size = new System.Drawing.Size(909, 241);
+            this.FileTreeSplitContainer.Size = new System.Drawing.Size(909, 251);
             this.FileTreeSplitContainer.SplitterDistance = global::GitUI.Properties.Settings.Default.FormBrowse_FileTreeSplitContainer_SplitterDistance;
             this.FileTreeSplitContainer.TabIndex = 1;
             // 
@@ -670,7 +670,7 @@ namespace GitUI
             this.GitTree.HideSelection = false;
             this.GitTree.Location = new System.Drawing.Point(0, 0);
             this.GitTree.Name = "GitTree";
-            this.GitTree.Size = new System.Drawing.Size(215, 241);
+            this.GitTree.Size = new System.Drawing.Size(215, 251);
             this.GitTree.TabIndex = 0;
             this.GitTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.GitTreeBeforeExpand);
             this.GitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.GitTree_AfterSelect);
@@ -691,27 +691,27 @@ namespace GitUI
             this.toolStripSeparator18,
             this.findToolStripMenuItem});
             this.FileTreeContextMenu.Name = "FileTreeContextMenu";
-            this.FileTreeContextMenu.Size = new System.Drawing.Size(318, 208);
+            this.FileTreeContextMenu.Size = new System.Drawing.Size(269, 192);
             this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
             // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.saveAsToolStripMenuItem.Text = "Save as";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.SaveAsOnClick);
             // 
             // openFileToolStripMenuItem
             // 
             this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
-            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.openFileToolStripMenuItem.Text = "Open this revision (temp file)";
             this.openFileToolStripMenuItem.Click += new System.EventHandler(this.OpenOnClick);
             // 
             // openFileWithToolStripMenuItem
             // 
             this.openFileWithToolStripMenuItem.Name = "openFileWithToolStripMenuItem";
-            this.openFileWithToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.openFileWithToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.openFileWithToolStripMenuItem.Text = "Open this revision with... (temp file)";
             this.openFileWithToolStripMenuItem.Click += new System.EventHandler(this.OpenWithOnClick);
             // 
@@ -719,47 +719,47 @@ namespace GitUI
             // 
             this.openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
             this.openWithToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openWithToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.openWithToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.openWithToolStripMenuItem.Text = "Open checked out file with...";
             this.openWithToolStripMenuItem.Click += new System.EventHandler(this.openWithToolStripMenuItem_Click);
             // 
             // editCheckedOutFileToolStripMenuItem
             // 
             this.editCheckedOutFileToolStripMenuItem.Name = "editCheckedOutFileToolStripMenuItem";
-            this.editCheckedOutFileToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.editCheckedOutFileToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.editCheckedOutFileToolStripMenuItem.Text = "Edit checked out file";
             this.editCheckedOutFileToolStripMenuItem.Click += new System.EventHandler(this.editCheckedOutFileToolStripMenuItem_Click);
             // 
             // toolStripSeparator20
             // 
             this.toolStripSeparator20.Name = "toolStripSeparator20";
-            this.toolStripSeparator20.Size = new System.Drawing.Size(314, 6);
+            this.toolStripSeparator20.Size = new System.Drawing.Size(265, 6);
             // 
             // copyFilenameToClipboardToolStripMenuItem
             // 
             this.copyFilenameToClipboardToolStripMenuItem.Name = "copyFilenameToClipboardToolStripMenuItem";
             this.copyFilenameToClipboardToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyFilenameToClipboardToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.copyFilenameToClipboardToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.copyFilenameToClipboardToolStripMenuItem.Text = "Copy filename to clipboard";
             this.copyFilenameToClipboardToolStripMenuItem.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem_Click);
             // 
             // fileHistoryToolStripMenuItem
             // 
             this.fileHistoryToolStripMenuItem.Name = "fileHistoryToolStripMenuItem";
-            this.fileHistoryToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.fileHistoryToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.fileHistoryToolStripMenuItem.Text = "File history";
             this.fileHistoryToolStripMenuItem.Click += new System.EventHandler(this.FileHistoryOnClick);
             // 
             // toolStripSeparator18
             // 
             this.toolStripSeparator18.Name = "toolStripSeparator18";
-            this.toolStripSeparator18.Size = new System.Drawing.Size(314, 6);
+            this.toolStripSeparator18.Size = new System.Drawing.Size(265, 6);
             // 
             // findToolStripMenuItem
             // 
             this.findToolStripMenuItem.Name = "findToolStripMenuItem";
             this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.findToolStripMenuItem.Size = new System.Drawing.Size(317, 24);
+            this.findToolStripMenuItem.Size = new System.Drawing.Size(268, 22);
             this.findToolStripMenuItem.Text = "Find";
             this.findToolStripMenuItem.Click += new System.EventHandler(this.FindFileOnClick);
             // 
@@ -778,16 +778,16 @@ namespace GitUI
             this.FileText.ScrollPos = 0;
             this.FileText.ShowEntireFile = false;
             this.FileText.ShowLineNumbers = true;
-            this.FileText.Size = new System.Drawing.Size(690, 241);
+            this.FileText.Size = new System.Drawing.Size(690, 251);
             this.FileText.TabIndex = 0;
             this.FileText.TreatAllFilesAsText = false;
             // 
             // Diff
             // 
             this.Diff.Controls.Add(this.DiffSplitContainer);
-            this.Diff.Location = new System.Drawing.Point(4, 22);
+            this.Diff.Location = new System.Drawing.Point(4, 24);
             this.Diff.Name = "Diff";
-            this.Diff.Size = new System.Drawing.Size(915, 259);
+            this.Diff.Size = new System.Drawing.Size(915, 257);
             this.Diff.TabIndex = 1;
             this.Diff.Text = "Diff";
             this.Diff.UseVisualStyleBackColor = true;
@@ -807,7 +807,7 @@ namespace GitUI
             // DiffSplitContainer.Panel2
             // 
             this.DiffSplitContainer.Panel2.Controls.Add(this.DiffText);
-            this.DiffSplitContainer.Size = new System.Drawing.Size(915, 247);
+            this.DiffSplitContainer.Size = new System.Drawing.Size(915, 257);
             this.DiffSplitContainer.SplitterDistance = global::GitUI.Properties.Settings.Default.FormBrowse_DiffSplitContainer_SplitterDistance;
             this.DiffSplitContainer.TabIndex = 0;
             // 
@@ -823,7 +823,7 @@ namespace GitUI
             this.DiffFiles.Revision = null;
             this.DiffFiles.SelectedIndex = -1;
             this.DiffFiles.SelectedItem = null;
-            this.DiffFiles.Size = new System.Drawing.Size(215, 247);
+            this.DiffFiles.Size = new System.Drawing.Size(215, 257);
             this.DiffFiles.TabIndex = 1;
             this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFilesSelectedIndexChanged);
             this.DiffFiles.DataSourceChanged += new System.EventHandler(this.DiffFiles_DataSourceChanged);
@@ -840,14 +840,14 @@ namespace GitUI
             this.difftoolRemoteLocalToolStripMenuItem,
             this.openContainingFolderToolStripMenuItem});
             this.DiffContextMenu.Name = "DiffContextMenu";
-            this.DiffContextMenu.Size = new System.Drawing.Size(312, 100);
+            this.DiffContextMenu.Size = new System.Drawing.Size(261, 158);
             this.DiffContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.DiffContextMenu_Opening);
             // 
             // openWithDifftoolToolStripMenuItem
             // 
             this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             this.openWithDifftoolToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(311, 24);
+            this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
             this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
             this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
             // 
@@ -855,7 +855,7 @@ namespace GitUI
             // 
             this.copyFilenameToClipboardToolStripMenuItem1.Name = "copyFilenameToClipboardToolStripMenuItem1";
             this.copyFilenameToClipboardToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyFilenameToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(311, 24);
+            this.copyFilenameToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(260, 22);
             this.copyFilenameToClipboardToolStripMenuItem1.Text = "Copy filename to clipboard";
             this.copyFilenameToClipboardToolStripMenuItem1.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem1_Click);
             // 
@@ -863,35 +863,35 @@ namespace GitUI
             // 
             this.saveAsToolStripMenuItem1.Name = "saveAsToolStripMenuItem1";
             this.saveAsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveAsToolStripMenuItem1.Size = new System.Drawing.Size(311, 24);
+            this.saveAsToolStripMenuItem1.Size = new System.Drawing.Size(260, 22);
             this.saveAsToolStripMenuItem1.Text = "Save as";
             this.saveAsToolStripMenuItem1.Click += new System.EventHandler(this.saveAsToolStripMenuItem1_Click);
             // 
             // fileHistoryDiffToolstripMenuItem
             // 
             this.fileHistoryDiffToolstripMenuItem.Name = "fileHistoryDiffToolstripMenuItem";
-            this.fileHistoryDiffToolstripMenuItem.Size = new System.Drawing.Size(311, 24);
+            this.fileHistoryDiffToolstripMenuItem.Size = new System.Drawing.Size(260, 22);
             this.fileHistoryDiffToolstripMenuItem.Text = "File history";
             this.fileHistoryDiffToolstripMenuItem.Click += new System.EventHandler(this.fileHistoryDiffToolstripMenuItem_Click);
             // 
             // diffBaseLocalToolStripMenuItem
             // 
             this.diffBaseLocalToolStripMenuItem.Name = "diffBaseLocalToolStripMenuItem";
-            this.diffBaseLocalToolStripMenuItem.Size = new System.Drawing.Size(251, 22);
+            this.diffBaseLocalToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
             this.diffBaseLocalToolStripMenuItem.Text = "Difftool base < - > local";
             this.diffBaseLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
             // 
             // difftoolRemoteLocalToolStripMenuItem
             // 
             this.difftoolRemoteLocalToolStripMenuItem.Name = "difftoolRemoteLocalToolStripMenuItem";
-            this.difftoolRemoteLocalToolStripMenuItem.Size = new System.Drawing.Size(251, 22);
+            this.difftoolRemoteLocalToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
             this.difftoolRemoteLocalToolStripMenuItem.Text = "Difftool remote < - > local ";
             this.difftoolRemoteLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
             // 
             // openContainingFolderToolStripMenuItem
             // 
             this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
-            this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(236, 22);
+            this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
             this.openContainingFolderToolStripMenuItem.Text = "Open containing folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
             // 
@@ -910,7 +910,7 @@ namespace GitUI
             this.DiffText.ScrollPos = 0;
             this.DiffText.ShowEntireFile = false;
             this.DiffText.ShowLineNumbers = true;
-            this.DiffText.Size = new System.Drawing.Size(696, 247);
+            this.DiffText.Size = new System.Drawing.Size(696, 257);
             this.DiffText.TabIndex = 0;
             this.DiffText.TreatAllFilesAsText = false;
             // 
@@ -919,12 +919,12 @@ namespace GitUI
             this.TreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveToolStripMenuItem});
             this.TreeContextMenu.Name = "TreeContextMenu";
-            this.TreeContextMenu.Size = new System.Drawing.Size(110, 28);
+            this.TreeContextMenu.Size = new System.Drawing.Size(99, 26);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(109, 24);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(98, 22);
             this.saveToolStripMenuItem.Text = "Save";
             // 
             // gitItemBindingSource
@@ -948,7 +948,7 @@ namespace GitUI
             // toolStripStatusLabel1
             // 
             this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(13, 17);
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(14, 17);
             this.toolStripStatusLabel1.Text = "X";
             this.toolStripStatusLabel1.Click += new System.EventHandler(this.toolStripStatusLabel1_Click);
             // 
@@ -964,7 +964,7 @@ namespace GitUI
             this.toolStripMenuItem1,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
             this.fileToolStripMenuItem.DropDownOpening += new System.EventHandler(this.FileToolStripMenuItemDropDownOpening);
             // 
@@ -973,14 +973,14 @@ namespace GitUI
             this.openToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("openToolStripMenuItem.Image")));
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
             // 
             // closeToolStripMenuItem
             // 
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
             this.closeToolStripMenuItem.Text = "Close";
             this.closeToolStripMenuItem.Click += new System.EventHandler(this.CloseToolStripMenuItemClick);
             // 
@@ -989,7 +989,7 @@ namespace GitUI
             this.refreshToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("refreshToolStripMenuItem.Image")));
             this.refreshToolStripMenuItem.Name = "refreshToolStripMenuItem";
             this.refreshToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F5;
-            this.refreshToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            this.refreshToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
             this.refreshToolStripMenuItem.Text = "Refresh";
             this.refreshToolStripMenuItem.Click += new System.EventHandler(this.RefreshToolStripMenuItemClick);
             // 
@@ -998,38 +998,38 @@ namespace GitUI
             this.recentToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem2});
             this.recentToolStripMenuItem.Name = "recentToolStripMenuItem";
-            this.recentToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            this.recentToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
             this.recentToolStripMenuItem.Text = "Recent Repositories";
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(97, 22);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(83, 22);
             this.toolStripMenuItem2.Text = "...";
             // 
             // toolStripSeparator12
             // 
             this.toolStripSeparator12.Name = "toolStripSeparator12";
-            this.toolStripSeparator12.Size = new System.Drawing.Size(178, 6);
+            this.toolStripSeparator12.Size = new System.Drawing.Size(174, 6);
             // 
             // fileExplorerToolStripMenuItem
             // 
             this.fileExplorerToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("fileExplorerToolStripMenuItem.Image")));
             this.fileExplorerToolStripMenuItem.Name = "fileExplorerToolStripMenuItem";
-            this.fileExplorerToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            this.fileExplorerToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
             this.fileExplorerToolStripMenuItem.Text = "File Explorer";
             this.fileExplorerToolStripMenuItem.Click += new System.EventHandler(this.FileExplorerToolStripMenuItemClick);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(178, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(174, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItemClick);
             // 
@@ -1040,7 +1040,7 @@ namespace GitUI
             this.gitGUIToolStripMenuItem,
             this.kGitToolStripMenuItem});
             this.gitToolStripMenuItem.Name = "gitToolStripMenuItem";
-            this.gitToolStripMenuItem.Size = new System.Drawing.Size(32, 20);
+            this.gitToolStripMenuItem.Size = new System.Drawing.Size(34, 20);
             this.gitToolStripMenuItem.Text = "Git";
             // 
             // gitBashToolStripMenuItem
@@ -1048,21 +1048,21 @@ namespace GitUI
             this.gitBashToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("gitBashToolStripMenuItem.Image")));
             this.gitBashToolStripMenuItem.Name = "gitBashToolStripMenuItem";
             this.gitBashToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-            this.gitBashToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
+            this.gitBashToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
             this.gitBashToolStripMenuItem.Text = "Git bash";
             this.gitBashToolStripMenuItem.Click += new System.EventHandler(this.GitBashToolStripMenuItemClick1);
             // 
             // gitGUIToolStripMenuItem
             // 
             this.gitGUIToolStripMenuItem.Name = "gitGUIToolStripMenuItem";
-            this.gitGUIToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
+            this.gitGUIToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
             this.gitGUIToolStripMenuItem.Text = "Git GUI";
             this.gitGUIToolStripMenuItem.Click += new System.EventHandler(this.GitGuiToolStripMenuItemClick);
             // 
             // kGitToolStripMenuItem
             // 
             this.kGitToolStripMenuItem.Name = "kGitToolStripMenuItem";
-            this.kGitToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
+            this.kGitToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
             this.kGitToolStripMenuItem.Text = "GitK";
             this.kGitToolStripMenuItem.Click += new System.EventHandler(this.KGitToolStripMenuItemClick);
             // 
@@ -1103,20 +1103,20 @@ namespace GitUI
             this.cherryPickToolStripMenuItem,
             this.goToToolStripMenuItem});
             this.commandsToolStripMenuItem.Name = "commandsToolStripMenuItem";
-            this.commandsToolStripMenuItem.Size = new System.Drawing.Size(71, 20);
+            this.commandsToolStripMenuItem.Size = new System.Drawing.Size(81, 20);
             this.commandsToolStripMenuItem.Text = "Commands";
             // 
             // archiveToolStripMenuItem
             // 
             this.archiveToolStripMenuItem.Name = "archiveToolStripMenuItem";
-            this.archiveToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.archiveToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.archiveToolStripMenuItem.Text = "Archive revision";
             this.archiveToolStripMenuItem.Click += new System.EventHandler(this.ArchiveToolStripMenuItemClick);
             // 
             // cleanupToolStripMenuItem
             // 
             this.cleanupToolStripMenuItem.Name = "cleanupToolStripMenuItem";
-            this.cleanupToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.cleanupToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.cleanupToolStripMenuItem.Text = "Cleanup repository";
             this.cleanupToolStripMenuItem.Click += new System.EventHandler(this.CleanupToolStripMenuItemClick);
             // 
@@ -1124,7 +1124,7 @@ namespace GitUI
             // 
             this.cloneToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("cloneToolStripMenuItem.Image")));
             this.cloneToolStripMenuItem.Name = "cloneToolStripMenuItem";
-            this.cloneToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.cloneToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.cloneToolStripMenuItem.Text = "Clone repository";
             this.cloneToolStripMenuItem.Click += new System.EventHandler(this.CloneToolStripMenuItemClick);
             // 
@@ -1132,7 +1132,7 @@ namespace GitUI
             // 
             this.cloneSVNToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("cloneSVNToolStripMenuItem.Image")));
             this.cloneSVNToolStripMenuItem.Name = "cloneSVNToolStripMenuItem";
-            this.cloneSVNToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.cloneSVNToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.cloneSVNToolStripMenuItem.Text = "Clone SVN repository";
             this.cloneSVNToolStripMenuItem.Click += new System.EventHandler(this.CloneSvnToolStripMenuItemClick);
             // 
@@ -1140,21 +1140,21 @@ namespace GitUI
             // 
             this.initNewRepositoryToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("initNewRepositoryToolStripMenuItem.Image")));
             this.initNewRepositoryToolStripMenuItem.Name = "initNewRepositoryToolStripMenuItem";
-            this.initNewRepositoryToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.initNewRepositoryToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.initNewRepositoryToolStripMenuItem.Text = "Create new repository";
             this.initNewRepositoryToolStripMenuItem.Click += new System.EventHandler(this.InitNewRepositoryToolStripMenuItemClick);
             // 
             // toolStripSeparator21
             // 
             this.toolStripSeparator21.Name = "toolStripSeparator21";
-            this.toolStripSeparator21.Size = new System.Drawing.Size(213, 6);
+            this.toolStripSeparator21.Size = new System.Drawing.Size(219, 6);
             // 
             // commitToolStripMenuItem
             // 
             this.commitToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("commitToolStripMenuItem.Image")));
             this.commitToolStripMenuItem.Name = "commitToolStripMenuItem";
             this.commitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Space)));
-            this.commitToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.commitToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.commitToolStripMenuItem.Text = "Commit";
             this.commitToolStripMenuItem.Click += new System.EventHandler(this.CommitToolStripMenuItemClick);
             // 
@@ -1163,7 +1163,7 @@ namespace GitUI
             this.pullToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("pullToolStripMenuItem.Image")));
             this.pullToolStripMenuItem.Name = "pullToolStripMenuItem";
             this.pullToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Down)));
-            this.pullToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.pullToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.pullToolStripMenuItem.Text = "Pull";
             this.pullToolStripMenuItem.Click += new System.EventHandler(this.PullToolStripMenuItemClick);
             // 
@@ -1172,7 +1172,7 @@ namespace GitUI
             this.pushToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("pushToolStripMenuItem.Image")));
             this.pushToolStripMenuItem.Name = "pushToolStripMenuItem";
             this.pushToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Up)));
-            this.pushToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.pushToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.pushToolStripMenuItem.Text = "Push";
             this.pushToolStripMenuItem.Click += new System.EventHandler(this.PushToolStripMenuItemClick);
             // 
@@ -1180,47 +1180,47 @@ namespace GitUI
             // 
             this.stashToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("stashToolStripMenuItem.Image")));
             this.stashToolStripMenuItem.Name = "stashToolStripMenuItem";
-            this.stashToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.stashToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.stashToolStripMenuItem.Text = "Stash changes";
             this.stashToolStripMenuItem.Click += new System.EventHandler(this.StashToolStripMenuItemClick);
             // 
             // toolStripSeparator25
             // 
             this.toolStripSeparator25.Name = "toolStripSeparator25";
-            this.toolStripSeparator25.Size = new System.Drawing.Size(213, 6);
+            this.toolStripSeparator25.Size = new System.Drawing.Size(219, 6);
             // 
             // applyPatchToolStripMenuItem
             // 
             this.applyPatchToolStripMenuItem.Name = "applyPatchToolStripMenuItem";
-            this.applyPatchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.applyPatchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.applyPatchToolStripMenuItem.Text = "Apply patch";
             this.applyPatchToolStripMenuItem.Click += new System.EventHandler(this.ApplyPatchToolStripMenuItemClick);
             // 
             // formatPatchToolStripMenuItem
             // 
             this.formatPatchToolStripMenuItem.Name = "formatPatchToolStripMenuItem";
-            this.formatPatchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.formatPatchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.formatPatchToolStripMenuItem.Text = "Format patch";
             this.formatPatchToolStripMenuItem.Click += new System.EventHandler(this.FormatPatchToolStripMenuItemClick);
             // 
             // viewDiffToolStripMenuItem
             // 
             this.viewDiffToolStripMenuItem.Name = "viewDiffToolStripMenuItem";
-            this.viewDiffToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.viewDiffToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.viewDiffToolStripMenuItem.Text = "View changes";
             this.viewDiffToolStripMenuItem.Click += new System.EventHandler(this.ViewDiffToolStripMenuItemClick);
             // 
             // patchToolStripMenuItem
             // 
             this.patchToolStripMenuItem.Name = "patchToolStripMenuItem";
-            this.patchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.patchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.patchToolStripMenuItem.Text = "View patch file";
             this.patchToolStripMenuItem.Click += new System.EventHandler(this.PatchToolStripMenuItemClick);
             // 
             // toolStripSeparator22
             // 
             this.toolStripSeparator22.Name = "toolStripSeparator22";
-            this.toolStripSeparator22.Size = new System.Drawing.Size(213, 6);
+            this.toolStripSeparator22.Size = new System.Drawing.Size(219, 6);
             // 
             // checkoutBranchToolStripMenuItem
             // 
@@ -1228,7 +1228,7 @@ namespace GitUI
             this.checkoutBranchToolStripMenuItem.Name = "checkoutBranchToolStripMenuItem";
             this.checkoutBranchToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+.";
             this.checkoutBranchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.OemPeriod)));
-            this.checkoutBranchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.checkoutBranchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.checkoutBranchToolStripMenuItem.Text = "Checkout branch";
             this.checkoutBranchToolStripMenuItem.Click += new System.EventHandler(this.CheckoutBranchToolStripMenuItemClick);
             // 
@@ -1236,7 +1236,7 @@ namespace GitUI
             // 
             this.branchToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("branchToolStripMenuItem.Image")));
             this.branchToolStripMenuItem.Name = "branchToolStripMenuItem";
-            this.branchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.branchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.branchToolStripMenuItem.Text = "Create branch";
             this.branchToolStripMenuItem.Click += new System.EventHandler(this.BranchToolStripMenuItemClick);
             // 
@@ -1244,21 +1244,21 @@ namespace GitUI
             // 
             this.tagToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("tagToolStripMenuItem.Image")));
             this.tagToolStripMenuItem.Name = "tagToolStripMenuItem";
-            this.tagToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.tagToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.tagToolStripMenuItem.Text = "Create tag";
             this.tagToolStripMenuItem.Click += new System.EventHandler(this.TagToolStripMenuItemClick);
             // 
             // deleteBranchToolStripMenuItem
             // 
             this.deleteBranchToolStripMenuItem.Name = "deleteBranchToolStripMenuItem";
-            this.deleteBranchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.deleteBranchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.deleteBranchToolStripMenuItem.Text = "Delete branch";
             this.deleteBranchToolStripMenuItem.Click += new System.EventHandler(this.DeleteBranchToolStripMenuItemClick);
             // 
             // deleteTagToolStripMenuItem
             // 
             this.deleteTagToolStripMenuItem.Name = "deleteTagToolStripMenuItem";
-            this.deleteTagToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.deleteTagToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.deleteTagToolStripMenuItem.Text = "Delete tag";
             this.deleteTagToolStripMenuItem.Click += new System.EventHandler(this.DeleteTagToolStripMenuItemClick);
             // 
@@ -1266,59 +1266,66 @@ namespace GitUI
             // 
             this.mergeBranchToolStripMenuItem.Name = "mergeBranchToolStripMenuItem";
             this.mergeBranchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.M)));
-            this.mergeBranchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.mergeBranchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.mergeBranchToolStripMenuItem.Text = "Merge branches";
             this.mergeBranchToolStripMenuItem.Click += new System.EventHandler(this.MergeBranchToolStripMenuItemClick);
             // 
             // rebaseToolStripMenuItem
             // 
             this.rebaseToolStripMenuItem.Name = "rebaseToolStripMenuItem";
-            this.rebaseToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.rebaseToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.rebaseToolStripMenuItem.Text = "Rebase";
             this.rebaseToolStripMenuItem.Click += new System.EventHandler(this.RebaseToolStripMenuItemClick);
             // 
             // runMergetoolToolStripMenuItem
             // 
             this.runMergetoolToolStripMenuItem.Name = "runMergetoolToolStripMenuItem";
-            this.runMergetoolToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.runMergetoolToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.runMergetoolToolStripMenuItem.Text = "Solve mergeconflicts";
             this.runMergetoolToolStripMenuItem.Click += new System.EventHandler(this.RunMergetoolToolStripMenuItemClick);
             // 
             // toolStripSeparator23
             // 
             this.toolStripSeparator23.Name = "toolStripSeparator23";
-            this.toolStripSeparator23.Size = new System.Drawing.Size(213, 6);
+            this.toolStripSeparator23.Size = new System.Drawing.Size(219, 6);
+            // 
+            // SvnFetchToolStripMenuItem
+            // 
+            this.SvnFetchToolStripMenuItem.Name = "SvnFetchToolStripMenuItem";
+            this.SvnFetchToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
+            this.SvnFetchToolStripMenuItem.Text = "SVN Fetch";
+            this.SvnFetchToolStripMenuItem.Click += new System.EventHandler(this.SvnFetchToolStripMenuItem_Click);
             // 
             // SvnRebaseToolStripMenuItem
             // 
             this.SvnRebaseToolStripMenuItem.Name = "SvnRebaseToolStripMenuItem";
-            this.SvnRebaseToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.SvnRebaseToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.SvnRebaseToolStripMenuItem.Text = "SVN Rebase";
             this.SvnRebaseToolStripMenuItem.Click += new System.EventHandler(this.SvnRebaseToolStripMenuItem_Click);
             // 
             // SvnDcommitToolStripMenuItem
             // 
             this.SvnDcommitToolStripMenuItem.Name = "SvnDcommitToolStripMenuItem";
-            this.SvnDcommitToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.SvnDcommitToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.SvnDcommitToolStripMenuItem.Text = "SVN DCommit";
             this.SvnDcommitToolStripMenuItem.Click += new System.EventHandler(this.SvnDcommitToolStripMenuItem_Click);
             // 
             // toolStripSeparator24
             // 
             this.toolStripSeparator24.Name = "toolStripSeparator24";
-            this.toolStripSeparator24.Size = new System.Drawing.Size(213, 6);
+            this.toolStripSeparator24.Size = new System.Drawing.Size(219, 6);
             // 
             // bisectToolStripMenuItem
             // 
             this.bisectToolStripMenuItem.Name = "bisectToolStripMenuItem";
-            this.bisectToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.bisectToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.bisectToolStripMenuItem.Text = "Bisect";
             this.bisectToolStripMenuItem.Click += new System.EventHandler(this.BisectClick);
             // 
             // checkoutToolStripMenuItem
             // 
             this.checkoutToolStripMenuItem.Name = "checkoutToolStripMenuItem";
-            this.checkoutToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.checkoutToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.checkoutToolStripMenuItem.Text = "Checkout revision";
             this.checkoutToolStripMenuItem.Click += new System.EventHandler(this.CheckoutToolStripMenuItemClick);
             // 
@@ -1326,7 +1333,7 @@ namespace GitUI
             // 
             this.cherryPickToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("cherryPickToolStripMenuItem.Image")));
             this.cherryPickToolStripMenuItem.Name = "cherryPickToolStripMenuItem";
-            this.cherryPickToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.cherryPickToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.cherryPickToolStripMenuItem.Text = "Cherry pick";
             this.cherryPickToolStripMenuItem.Click += new System.EventHandler(this.CherryPickToolStripMenuItemClick);
             // 
@@ -1334,9 +1341,9 @@ namespace GitUI
             // 
             this.goToToolStripMenuItem.Image = global::GitUI.Properties.Resources._75;
             this.goToToolStripMenuItem.Name = "goToToolStripMenuItem";
-            this.goToToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
-            | System.Windows.Forms.Keys.G)));
-            this.goToToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.goToToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift)
+                        | System.Windows.Forms.Keys.G)));
+            this.goToToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.goToToolStripMenuItem.Text = "Go to commit";
             this.goToToolStripMenuItem.Click += new System.EventHandler(this.goToToolStripMenuItem_Click);
             // 
@@ -1347,20 +1354,20 @@ namespace GitUI
             this.toolStripSeparator6,
             this.PuTTYToolStripMenuItem});
             this.remotesToolStripMenuItem.Name = "remotesToolStripMenuItem";
-            this.remotesToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
+            this.remotesToolStripMenuItem.Size = new System.Drawing.Size(65, 20);
             this.remotesToolStripMenuItem.Text = "Remotes";
             // 
             // manageRemoteRepositoriesToolStripMenuItem1
             // 
             this.manageRemoteRepositoriesToolStripMenuItem1.Name = "manageRemoteRepositoriesToolStripMenuItem1";
-            this.manageRemoteRepositoriesToolStripMenuItem1.Size = new System.Drawing.Size(219, 22);
+            this.manageRemoteRepositoriesToolStripMenuItem1.Size = new System.Drawing.Size(222, 22);
             this.manageRemoteRepositoriesToolStripMenuItem1.Text = "Manage remote repositories";
             this.manageRemoteRepositoriesToolStripMenuItem1.Click += new System.EventHandler(this.ManageRemoteRepositoriesToolStripMenuItemClick);
             // 
             // toolStripSeparator6
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(216, 6);
+            this.toolStripSeparator6.Size = new System.Drawing.Size(219, 6);
             // 
             // PuTTYToolStripMenuItem
             // 
@@ -1369,14 +1376,14 @@ namespace GitUI
             this.generateOrImportKeyToolStripMenuItem});
             this.PuTTYToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("PuTTYToolStripMenuItem.Image")));
             this.PuTTYToolStripMenuItem.Name = "PuTTYToolStripMenuItem";
-            this.PuTTYToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.PuTTYToolStripMenuItem.Size = new System.Drawing.Size(222, 22);
             this.PuTTYToolStripMenuItem.Text = "PuTTY";
             // 
             // startAuthenticationAgentToolStripMenuItem
             // 
             this.startAuthenticationAgentToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("startAuthenticationAgentToolStripMenuItem.Image")));
             this.startAuthenticationAgentToolStripMenuItem.Name = "startAuthenticationAgentToolStripMenuItem";
-            this.startAuthenticationAgentToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
+            this.startAuthenticationAgentToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.startAuthenticationAgentToolStripMenuItem.Text = "Start authentication agent";
             this.startAuthenticationAgentToolStripMenuItem.Click += new System.EventHandler(this.StartAuthenticationAgentToolStripMenuItemClick);
             // 
@@ -1384,7 +1391,7 @@ namespace GitUI
             // 
             this.generateOrImportKeyToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("generateOrImportKeyToolStripMenuItem.Image")));
             this.generateOrImportKeyToolStripMenuItem.Name = "generateOrImportKeyToolStripMenuItem";
-            this.generateOrImportKeyToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
+            this.generateOrImportKeyToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.generateOrImportKeyToolStripMenuItem.Text = "Generate or import key";
             this.generateOrImportKeyToolStripMenuItem.Click += new System.EventHandler(this.GenerateOrImportKeyToolStripMenuItemClick);
             // 
@@ -1395,7 +1402,7 @@ namespace GitUI
             this._viewPullRequestsToolStripMenuItem,
             this._createPullRequestsToolStripMenuItem});
             this._repositoryHostsToolStripMenuItem.Name = "_repositoryHostsToolStripMenuItem";
-            this._repositoryHostsToolStripMenuItem.Size = new System.Drawing.Size(100, 20);
+            this._repositoryHostsToolStripMenuItem.Size = new System.Drawing.Size(106, 20);
             this._repositoryHostsToolStripMenuItem.Text = "Repository hosts";
             // 
             // _forkCloneRepositoryToolStripMenuItem
@@ -1429,46 +1436,46 @@ namespace GitUI
             this.toolStripSeparator10,
             this.openSubmoduleToolStripMenuItem});
             this.submodulesToolStripMenuItem.Name = "submodulesToolStripMenuItem";
-            this.submodulesToolStripMenuItem.Size = new System.Drawing.Size(76, 20);
+            this.submodulesToolStripMenuItem.Size = new System.Drawing.Size(85, 20);
             this.submodulesToolStripMenuItem.Text = "Submodules";
             // 
             // manageSubmodulesToolStripMenuItem
             // 
             this.manageSubmodulesToolStripMenuItem.Name = "manageSubmodulesToolStripMenuItem";
-            this.manageSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(262, 22);
+            this.manageSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.manageSubmodulesToolStripMenuItem.Text = "Manage submodules";
             this.manageSubmodulesToolStripMenuItem.Click += new System.EventHandler(this.ManageSubmodulesToolStripMenuItemClick);
             // 
             // toolStripSeparator8
             // 
             this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(259, 6);
+            this.toolStripSeparator8.Size = new System.Drawing.Size(218, 6);
             // 
             // updateAllSubmodulesToolStripMenuItem
             // 
             this.updateAllSubmodulesToolStripMenuItem.Name = "updateAllSubmodulesToolStripMenuItem";
-            this.updateAllSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(262, 22);
+            this.updateAllSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.updateAllSubmodulesToolStripMenuItem.Text = "Update all submodules";
             this.updateAllSubmodulesToolStripMenuItem.Click += new System.EventHandler(this.UpdateAllSubmodulesToolStripMenuItemClick);
             // 
             // synchronizeAllSubmodulesToolStripMenuItem
             // 
-            this.synchronizeAllSubmodulesToolStripMenuItem.Name = "syncronizeAllSubmodulesToolStripMenuItem";
-            this.synchronizeAllSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(262, 22);
+            this.synchronizeAllSubmodulesToolStripMenuItem.Name = "synchronizeAllSubmodulesToolStripMenuItem";
+            this.synchronizeAllSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.synchronizeAllSubmodulesToolStripMenuItem.Text = "Synchronize all submodules";
             this.synchronizeAllSubmodulesToolStripMenuItem.Click += new System.EventHandler(this.SynchronizeAllSubmodulesToolStripMenuItemClick);
             // 
             // toolStripSeparator10
             // 
             this.toolStripSeparator10.Name = "toolStripSeparator10";
-            this.toolStripSeparator10.Size = new System.Drawing.Size(259, 6);
+            this.toolStripSeparator10.Size = new System.Drawing.Size(218, 6);
             // 
             // openSubmoduleToolStripMenuItem
             // 
             this.openSubmoduleToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripSeparator11});
             this.openSubmoduleToolStripMenuItem.Name = "openSubmoduleToolStripMenuItem";
-            this.openSubmoduleToolStripMenuItem.Size = new System.Drawing.Size(262, 22);
+            this.openSubmoduleToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.openSubmoduleToolStripMenuItem.Text = "Browse submodule";
             this.openSubmoduleToolStripMenuItem.DropDownOpening += new System.EventHandler(this.OpenSubmoduleToolStripMenuItemDropDownOpening);
             // 
@@ -1483,21 +1490,21 @@ namespace GitUI
             this.settingsToolStripMenuItem,
             this.toolStripSeparator15});
             this.pluginsToolStripMenuItem.Name = "pluginsToolStripMenuItem";
-            this.pluginsToolStripMenuItem.Size = new System.Drawing.Size(52, 20);
+            this.pluginsToolStripMenuItem.Size = new System.Drawing.Size(58, 20);
             this.pluginsToolStripMenuItem.Text = "Plugins";
             this.pluginsToolStripMenuItem.DropDownOpening += new System.EventHandler(this.pluginsToolStripMenuItem_DropDownOpening);
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(124, 22);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
             this.settingsToolStripMenuItem.Text = "Settings";
             this.settingsToolStripMenuItem.Click += new System.EventHandler(this.SettingsToolStripMenuItemClick);
             // 
             // toolStripSeparator15
             // 
             this.toolStripSeparator15.Name = "toolStripSeparator15";
-            this.toolStripSeparator15.Size = new System.Drawing.Size(121, 6);
+            this.toolStripSeparator15.Size = new System.Drawing.Size(113, 6);
             // 
             // settingsToolStripMenuItem1
             // 
@@ -1510,7 +1517,7 @@ namespace GitUI
             this.toolStripSeparator13,
             this.settingsToolStripMenuItem2});
             this.settingsToolStripMenuItem1.Name = "settingsToolStripMenuItem1";
-            this.settingsToolStripMenuItem1.Size = new System.Drawing.Size(58, 20);
+            this.settingsToolStripMenuItem1.Size = new System.Drawing.Size(61, 20);
             this.settingsToolStripMenuItem1.Text = "Settings";
             // 
             // gitMaintenanceToolStripMenuItem
@@ -1521,66 +1528,66 @@ namespace GitUI
             this.deleteIndexlockToolStripMenuItem});
             this.gitMaintenanceToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("gitMaintenanceToolStripMenuItem.Image")));
             this.gitMaintenanceToolStripMenuItem.Name = "gitMaintenanceToolStripMenuItem";
-            this.gitMaintenanceToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.gitMaintenanceToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.gitMaintenanceToolStripMenuItem.Text = "Git maintenance";
             // 
             // compressGitDatabaseToolStripMenuItem
             // 
             this.compressGitDatabaseToolStripMenuItem.Name = "compressGitDatabaseToolStripMenuItem";
-            this.compressGitDatabaseToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.compressGitDatabaseToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.compressGitDatabaseToolStripMenuItem.Text = "Compress git database";
             this.compressGitDatabaseToolStripMenuItem.Click += new System.EventHandler(this.CompressGitDatabaseToolStripMenuItemClick);
             // 
             // verifyGitDatabaseToolStripMenuItem
             // 
             this.verifyGitDatabaseToolStripMenuItem.Name = "verifyGitDatabaseToolStripMenuItem";
-            this.verifyGitDatabaseToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.verifyGitDatabaseToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.verifyGitDatabaseToolStripMenuItem.Text = "Recover lost objects";
             this.verifyGitDatabaseToolStripMenuItem.Click += new System.EventHandler(this.VerifyGitDatabaseToolStripMenuItemClick);
             // 
             // deleteIndexlockToolStripMenuItem
             // 
             this.deleteIndexlockToolStripMenuItem.Name = "deleteIndexlockToolStripMenuItem";
-            this.deleteIndexlockToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.deleteIndexlockToolStripMenuItem.Size = new System.Drawing.Size(194, 22);
             this.deleteIndexlockToolStripMenuItem.Text = "Delete index.lock";
             this.deleteIndexlockToolStripMenuItem.Click += new System.EventHandler(this.deleteIndexlockToolStripMenuItem_Click);
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(166, 6);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(161, 6);
             // 
             // editgitignoreToolStripMenuItem1
             // 
             this.editgitignoreToolStripMenuItem1.Name = "editgitignoreToolStripMenuItem1";
-            this.editgitignoreToolStripMenuItem1.Size = new System.Drawing.Size(169, 22);
+            this.editgitignoreToolStripMenuItem1.Size = new System.Drawing.Size(164, 22);
             this.editgitignoreToolStripMenuItem1.Text = "Edit .gitignore";
             this.editgitignoreToolStripMenuItem1.Click += new System.EventHandler(this.EditGitignoreToolStripMenuItem1Click);
             // 
             // editgitattributesToolStripMenuItem
             // 
             this.editgitattributesToolStripMenuItem.Name = "editgitattributesToolStripMenuItem";
-            this.editgitattributesToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.editgitattributesToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.editgitattributesToolStripMenuItem.Text = "Edit .gitattributes";
             this.editgitattributesToolStripMenuItem.Click += new System.EventHandler(this.editgitattributesToolStripMenuItem_Click);
             // 
             // editmailmapToolStripMenuItem
             // 
             this.editmailmapToolStripMenuItem.Name = "editmailmapToolStripMenuItem";
-            this.editmailmapToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.editmailmapToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.editmailmapToolStripMenuItem.Text = "Edit .mailmap";
             this.editmailmapToolStripMenuItem.Click += new System.EventHandler(this.EditMailMapToolStripMenuItemClick);
             // 
             // toolStripSeparator13
             // 
             this.toolStripSeparator13.Name = "toolStripSeparator13";
-            this.toolStripSeparator13.Size = new System.Drawing.Size(166, 6);
+            this.toolStripSeparator13.Size = new System.Drawing.Size(161, 6);
             // 
             // settingsToolStripMenuItem2
             // 
             this.settingsToolStripMenuItem2.Image = ((System.Drawing.Image)(resources.GetObject("settingsToolStripMenuItem2.Image")));
             this.settingsToolStripMenuItem2.Name = "settingsToolStripMenuItem2";
-            this.settingsToolStripMenuItem2.Size = new System.Drawing.Size(169, 22);
+            this.settingsToolStripMenuItem2.Size = new System.Drawing.Size(164, 22);
             this.settingsToolStripMenuItem2.Text = "Settings";
             this.settingsToolStripMenuItem2.Click += new System.EventHandler(this.SettingsToolStripMenuItem2Click);
             // 
@@ -1598,7 +1605,7 @@ namespace GitUI
             this.donateToolStripMenuItem,
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(40, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // commitcountPerUserToolStripMenuItem
@@ -1685,17 +1692,11 @@ namespace GitUI
             this.menuStrip1.Size = new System.Drawing.Size(923, 24);
             this.menuStrip1.TabIndex = 3;
             // 
-            // SvnFetchToolStripMenuItem
-            // 
-            this.SvnFetchToolStripMenuItem.Name = "SvnFetchToolStripMenuItem";
-            this.SvnFetchToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
-            this.SvnFetchToolStripMenuItem.Text = "SVN Fetch";
-            this.SvnFetchToolStripMenuItem.Click += new System.EventHandler(this.SvnFetchToolStripMenuItem_Click);
-            // 
             // FormBrowse
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoValidate = System.Windows.Forms.AutoValidate.EnablePreventFocusChange;
             this.ClientSize = new System.Drawing.Size(923, 573);
             this.Controls.Add(this.toolPanel);
             this.Controls.Add(this.menuStrip1);
@@ -1747,7 +1748,7 @@ namespace GitUI
         private System.Windows.Forms.BindingSource gitItemBindingSource;
         private GitUI.RevisionGrid RevisionGrid;
         private System.Windows.Forms.SplitContainer FileTreeSplitContainer;
-        private System.Windows.Forms.ToolStrip ToolStrip;
+        private ToolStripEx ToolStrip;
         private System.Windows.Forms.ToolStripButton toolStripButton1;
         private System.Windows.Forms.ToolStripSplitButton _NO_TRANSLATE_Workingdir;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
@@ -1807,7 +1808,7 @@ namespace GitUI
         private ToolStripButton toggleSplitViewLayout;
         private ToolStripMenuItem editCheckedOutFileToolStripMenuItem;
         private SplitContainer toolPanel;
-        private ToolStrip UserMenuToolStrip;
+        private ToolStripEx UserMenuToolStrip;
         private ToolStripMenuItem fileToolStripMenuItem;
         private ToolStripMenuItem openToolStripMenuItem;
         private ToolStripMenuItem closeToolStripMenuItem;
@@ -1890,7 +1891,7 @@ namespace GitUI
         private ToolStripSeparator toolStripSeparator16;
         private ToolStripMenuItem donateToolStripMenuItem;
         private ToolStripMenuItem aboutToolStripMenuItem;
-        private MenuStrip menuStrip1;
+        private MenuStripEx menuStrip1;
         private ToolStripMenuItem diffBaseLocalToolStripMenuItem;
         private ToolStripMenuItem difftoolRemoteLocalToolStripMenuItem;
         private ToolStripMenuItem openContainingFolderToolStripMenuItem;

--- a/GitUI/FormBrowse.resx
+++ b/GitUI/FormBrowse.resx
@@ -130,119 +130,114 @@
   <data name="RefreshButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAilJREFUOE+dk91P
-        kmEYh/2LOqg2V5vNrZz5hbpYbTpdpRZOsgOXTW0oIiq+Im+MDwlEMszPpimhAsICpsMv0lxaMVsdeGZ1
-        Vgfalb5nCGuu5/B9fu/1e+5duzMyznCmtyc5+nPEGaLpI/UT9xEDwr8BP34fEPy6gBjTofRUU/ayhBvO
-        AoosOShGb3N3qBzR25sesvczgTUuook0YVzR4Xhnwrlpxnb8zbTaiyHWRVe0DblZhnHWkAz5/usAy3of
-        fTEt7m07/RsGnsWNmNf0iCvdCEsatFEVrW+bKNTnopvsSgb49+ZQhR7xfKsfR9yEfrmTmpFKsjsvcVl1
-        kQuN5ygW88gXclAPq1JHECId6CJtUmNPVEOZTY7JJyYFi9T5NDoa0s9fPVaB3FFIsfm61GQPWlOCphkj
-        h0eHhL8ECSUCLH704f8wx/z7N2T4d+ZZ2Pbi3fTg2Zjh9eqU5Nz3zZMCGo27KXfJpbJcIRuZkJv+VcO7
-        TjqWW5IuXTG7pLJvqfPYSjeNsw95MFCbCpj45EZ7/LM6/JjKCTm3XsgotedRN1mFENFISnVL7dy0ljAU
-        ciUDpj6PoYk2MbLjlJQOblmTlLaHmyWlVe4KlLZa9g/2TwF2x3my2MDgpkVSalk38HSlB2FZizrYjPJV
-        DaXGAuqsCjYS6+nnd63aqZ++h2L8DteELK5oMslsOc/V1iwUlmpcAWdq8+kVOlmcqoHK/9++E41D4cEz
-        Af4CIbWLxz0wWegAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIqSURBVDhPlZPdT9JRGMf5i7qoNlebza2c+a6L1abTVWLh
+        NLtw2dSGIoLiT+UX40UCkQzzBZqm5Lu4gOlAhTSWVs5WF95Z3dWF9kl/6wZhzp67c85zPt/z7LMjO0uN
+        x70c/jnk3/L/q9ZzH3FBOB3w4/c+/q+ziGE9NT4FJS+LuOHMJd+SiXL4NncHShGnulJDdn/uYI2JaIIN
+        GCN6HO9MODfM2I72TKtdGMLttIdakJsLME4aEiHff+1jWe+hJ6zFHbfTGzXwLGbEvNaNGOlAWNagDalo
+        fttAXncWem97ImB+dxrV0iOeb/biiJnoXtFROVROhu4Sl1UXuVB/jkIxmxwhE/WgKnkEIdiGPtgiJXaG
+        NJTY5JjmxITGfHUO9Y661PMrRsqQO/IoNF+Xkux+a1KjacLIweEBgS9+lnYWWPw4x/yHaWbev0E2vzXD
+        bHyKqQ0fvugEr1fHJOdz33xJoOGYm1KXXArLEjIoELJSv2pw20nbSlPCoStsl1T2LOuOrHRQP/mQB31V
+        yQDPJzfao8vqwGPKPXJuvSig2J5NtbcCIaiRlOqXW7lpLWJgyZUIGPs8gibUwNCWU1Lav2lNUNoaaJSU
+        VrjLqLFVsbe/dwKwPcqTxTr6NyySUsu6gaeRToQVLWp/IzWvKik25lJtVRLdWU89v2vVTu34PZSjd7gm
+        pHNFk0Za03muNqejtChwLTiTk0/W8cep6Cs/vem0OtY4EOg/A0Am+wshtYvHVqtdJQAAAABJRU5ErkJg
+        gg==
 </value>
   </data>
   <data name="toolStripSplitStash.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAUlJREFUOE9jfHyq
-        6v+HB8sZkIGAQiSDrFkbI0jsb3bGJoa5c1DkmX/88YMLXF6l+P///4NAvAyIF4ExSAyEUXRBOSAD/3Kw
-        bEI14Pe8///fl/8HuQamGUaDxJANwm7Alwn//z9PA2vG5hqQITCNINuRMQNY09v2/3/vRUMMwOMadEPA
-        LgNrel7//+dVf4gBBFyD1Qt/Hpb9/3TOFWIAFtf8f1sIFC+Ehw9KuIA0/XpQ9f/9WW+IAVhc8/9p/H8Q
-        Rg5kuCFgTa9m/P96swBsADbX/L0d/B+OHySBXQmPZvSow+aaH5c9/sPwzxvhYFeipBNYwOByzYfTNv9h
-        +MtFX7Ar4QagRw1yQoK55u0p5/8w/PFCEDjMEAagJQxQIoF5CxY2X65n/Yfh73fKwWGG1QvISRZbskZP
-        5nD1GIkDWy4iJIYtrRPSA5IHAO3qGrZPzd2AAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEsSURBVDhPY3h8qur/5VWKKBgkxgAFf7MzNv3lYEHBUCkI
+        AGn4//8gEC8D4kVgDDMIqgQFwAyEcqEG/J73///7crDNMM0wjOwaEMBuwJcJ//8/TwNrwOYakCHYvAI2
+        CKzpbfv/v/eiIQbgcQ26IQgXPK////OqP8QAAq7B6oU/D8v+fzrnCtGExTX/3xaCMUgMhFHCBSTw60HV
+        //dnvSGasLjm/9N4MEb2FtwQsMJXM/5/vVkAlsDmmr+3gxH4QRJYHCQPNgA9sLC55sdlDzj+eSMcLA43
+        AARgAQPWhMU1H07bwPGXi75gcbgB6FEDkoBhmGvennKG448XgsDiCAOQNMMwzFsw13y5ngXH3+8AYwUo
+        DjcABDDiFgjQwwYbhirFbgDJAD0siDOQgQEAWHQn45beNZEAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="toolStripButton1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAfxJREFUOE+NkktI
-        G1EYhSdZuKmrogsFETctGAziSm0XChJdFEHxMbqQSjRNSlWoD4gtITEmSAj4gOIrYLMoNDWgiI9F6Tq0
-        FcUEpRKCC0MXEgQFBaXkdM6QjE6i4oVD7v3Pd84Mk6sRMlbrt9Ic7ROtSYCmRdAKVbKdFEKCBsHkRXJh
-        ue3gOjOjnNs3y0ydW+VwR97gS8KDDSzK4p4zemTuLGhb1701/niBwNkkAvDiM+zwwSqLe87okSGrKuFr
-        s/3r6SSW/tkxdzWI2QxxRo8MWWaUkuZV3cD4Xg/8l2OYOe/D9Pm7LBl/vgRFhiwzSkHLii7kO3Zg+nQA
-        nkRvlhhMLzJkmVEKXq0VXPtPXHDFu+WnpOWMd8n724uMP+EGM6oC318HbDFRBWeGP8RaYTsSsRi3Sx/y
-        2YVS0BR8vjsTHcHHqIjBP42qkvSBc4oMWWaUAsOn4jHbry44D43oDzegL2xQlfBM0SNDlpmbvzJPKBC3
-        9Jg6GMJQuAnm7VqYtmvkEv5SnNEjQ1aQMrfvQk6tt8jx+nslvPvvYd0TYfldp3xM7jmjR4asFL65B6mm
-        3Gpn4QTbR0MdcO2Y4YpYMB4xw71jkWf0yEh87l3XWZMy9BXD+b6GueKodO9591E/XxLjTPL1KYbsvYuv
-        9lRSiaTSlLjnLOu1Hyp6lPcftiDAj9m4maMAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAHySURBVDhPlZNPSJNxHMZ/XnbyJHWYELKLgmsSncI8KMTc
+        IYKFc68dpFitLTShqTCLsT9uxBhMBdFwUDsIKoERMw8SdBupGG4UyRgdGh5iCAoKRvD0Pu/7S3lnBT7w
+        sN++38/n3buXTdTGtdRqcq9cHnDnbB/c72zHWnlWZ9xJ7O9RYe+d1StIFB9ivprECua08swZd2Qkbkxv
+        zvrI8/46FvfTWEQKrxBGBkGtPHPGHRmyUtPDW+PVF/bSePkrjNnjAGZqyhl3ZMgavs7tN9ah8e37yB5F
+        MXUwiMmDgTP1fOzQSoYsHakL0bNszWe+RzC5N4Rk9cGZUvwTMmTpSF2Im2/NP7M/4ohX7p18Ehur9Btk
+        hky2mgAdqesXyOxGECorEtNTKz8tuxD6pmCuElYfZPOh1IVwvm75NFUaxbOSgsDXWxI3hnOWDFk6UhfC
+        Pt0UDa33I7bjweOCA4MFu9T08D3LHRmydKSu5oIwK6ttmPgyjOGCE77NLng3OzWZryxn3JEhS0faWkxd
+        qUuRu2vXkPr8BMFtBf6NGycPk2fOuCNDlo6unqa+Pdb4nFcfy/chvuVDvOjHeNGHxJZfm3FHhqyuGFOn
+        lou2qyMXM47ZppL6u+dvH90vLGXOuJMM2X+Gt9ag1qK2VZZnzv7/bzx/hPgN9kTBiuuVW4YAAAAASUVO
+        RK5CYII=
 </value>
   </data>
   <data name="toolStripButtonPull.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAPFJREFUOE9jYKA2
-        MJt3bZr5vOv/0TFInCi7QBov/P//f9tPBAbxQeJEG7D52///fS8QGMQnyYC1n/7/b3+MwCA+SQYsf/P/
-        f91tBAbxSTJg/vP//0uvIDCIT9AA5NDvu/X/f/ZpBAbxYbGCMzZACg5+/P9/IlBx3sn//5MO/4NjEB8k
-        DpLH6RLDySfmgySnARWmHvz1P2LXdzgG8UHiIHmQOlzRya3ZvHUtSNGEq///x+z88t9/80cwDeKDxEHy
-        QM3c+NID3JCuC7//J+76+B9EE6sZZjDckPWPiLcZ3VVwQ4hxNs4wAUqIEfIzUfkDnyIAYx4ny5/q96wA
-        AAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADuSURBVDhPtVE9C0FhGL273X8wWvgZVoOFMimb1WJQBpEy
+        MppkEOVuspDF4KPYGBgsVyKUw+G97+ubK06dns5zznPeulf7OVy5ftadG+CW3IvIazDcAVDdKFJzLyKv
+        wWB5BSRnitSWCooLID5RpLZUUJgD0ZEitaWC/BSIdBWp3xZcfv3kEAi1FalN7+nfoFk3gPQxHG4BgcZe
+        kpp7+syJk2s4M808zewxGKxv4dXXktTc02dOnNzB5ohVigyleoCvtoSnbJwmNff0mTvHH0OWJDo7+HXj
+        ND89NiFLSuPPX76FLPnm2ASP7GL+C5p2AGMeJ8uwwtqhAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="toolStripButtonPush.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAPZJREFUOE9jYKAV
-        MJt3bZr5vOv/QTTJdsA03/z//z/JhsA07/75///8d///g2iiDYFp3vbt//8Jz///b38MoUF8gobANG/8
-        +P9/x/3//+tuIzCIDxLHawhI8vQvoLOBNjYAPV96BYFBfJA4SB6kDmugGk4+MR8kCcJ9t/7/zz6NwCA+
-        TA6kDlescAMllEAKJwI1JB3+B8cgPtRmJaAakDrcAKSwC+j8iF3f4RjEx+l0dKNACpvP/vnvv/kjHIP4
-        JBlQe/L7f7c1r+EYxCfJgIVAP1cc+QrHID7RBuj1HloCC3FkGiRObJ4AxwYQ6yJhwqFPrOno6gBOAydi
-        zjzA+AAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAD1SURBVDhPY6AZMJt3bZr5vOv/QTRUiHgA03zz////JBsC
+        07z75///89/9B9NEGwLTvO3b//8Tnv//3/4YQoP4BA2Bad748f//jvv//9fdRmAQHySO1xCQ5OlfQGcD
+        bWwAer70CgKD+CBxkDxIHVQLKjCcfGI+SBKE+279/599GoFBfJgcSB1UCwbgBmIlkKKJQA1Jh//BMYgP
+        EgfJQ9XhBiCFXUBnR+z6DscgPtQAwgCksPnsn//+mz/CMYhPkgG1J7//d1vzGo5BfJIMWAj0c8WRr3AM
+        4hNtgF7voSUgxegYJA5VQhCAYwOIdZEw4dAnDzAwAABOAydiN98w/QAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="GitBash.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAJJJREFUOE9jNJt3
-        bRojA2MmA4ngP8P/6aeStLIYtmzZ8v/C////t/0kHoPUg/SB7QQxFr/4/7/yGvEYpB7FgDVP/v9vv0g8
-        BqlHMcB83vX/pGIUA4A+AfmHJLx69WpEGIA0g0wkFsPUwwORVNuxGkCs7VC/owbiMHEBqd5ASQekBCCy
-        WnA0btq0yZdcTGIGxq4cAK5E+vvW/wAzAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACDSURBVDhPrY/BDUBAFES3KqpQkAp04OjiuE6bjTq40ICD
+        FpyGkSAbm/gfP3mZy8xLvkmqoUyrEVq4MzzvPToA7SKHfe5OQT0D+SCH/UDQTEDRy2E/EMR+fCIQbKHG
+        Wsu8BEwpRz8QaLkJmFKiAi03AVNKVKDlX8FbdoFzLnvLLvh2xqzAuRs4yZo4cAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="EditSettings.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAASdJREFUOE+9U7FO
-        hEAQVVr/4npt/Ro+YK+28h+MVEdoruG+QUqSayjRihwFBQkVFTZEMDz3ze2eyJGgVzjJ5u3M7Lx9OwPX
-        V9p83984jqOGYfCVUmvGwjDcaFDc84jruuu5mGSDIACNaApIIDEa94b0LPZ/BFQxp2pRQdd1J9ncWN8+
-        a5GARU3ToK5rwWlfZALjJtInq+d5Oyubt5ZlKbfbGPNy+/02Q6Jpn0vAe+tA30ziRuOKBW3bIssyQSN9
-        pXPMHwlePoDHA/Cwfx8TSJ4FlJ6mqeCPt/+WgO9PkkT6cBFBVVWI4xjEiwiKokAURSDOErzyc62B7eFz
-        tgd93yPPcxDPCO6e9js20i769n+YjpPFp/GNDsm49Lo1eBzPty3lJ8f/6H4B83jhpmp12P0AAAAASUVO
-        RK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEGSURBVDhPvZGxjoJQEEVfv39h77b7Y1b+g5FKQmOD37CU
+        JDaUaEWkoCChosKGCJuM717fKImYJW6yJ7m5vJk3F8gY4Pv+JggCgbNgCcNwYyVOrI/VCIYB3JVwmTWA
+        51c18i8BKmVyQNd1dEXPkwNA0zRS1zVduQfoBgBcN+F53g6XILy1LEu61tBnwNc2k8QOr0sR79gJzmwY
+        82E1w+W2bSXLMjrOqLv+LeD7IrI8iSz252EAwQA+PU1Tugt4MCUA/58kCf2tgKqqJI5j+lsBRVFIFEX0
+        0YAD1lKLbE8/owF930ue5/SngM/VfochFc6uRYbrhO7rG8B1Wc2d39bz4Lf+XzDmCkO27MFGNz0HAAAA
+        AElFTkSuQmCC
 </value>
   </data>
   <data name="toolStripDropDownButton2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAk5JREFUOE91kt9L
-        01EYxs+ENiGDoHDRkCEVWm4rf4QO6qb/oBsJAsky2qVJGy6wIij6tViksylLNpl1EVK7KJZZ2NKBIS2h
-        bSzRmyGhkWFrqAlP5zlt4qp94YH3+zyf9+V73vPViCKPJRDbilXdScYa3WpwuuXQz2JsgV/vTe48cPlN
-        2eGHSXSM/1BiTY9Z0SGmB3GruS8eOBL4DHNP7H7b6DeEf0GJNT2VSYbsP4NqumPB3llgZAVwvl9Dp1Rw
-        GUqs6TEjQ7ZggMUzXs7p4SzgWQCGloBhKVfij1jTY0bm6OAMTO6ofmNIlf3ptr3Xwv4L0Sz8i8CtONAg
-        z21oH4hQrOkxI0OWPWpAfmGnXy7i/EQGg/NAnS+BLcfOnZGxkWJNjxkZsvnFipruD/aOyDJ8aeDuDHBl
-        agWVl0KPZGMpbzCnUnrMyJBlD3tF1Z13F9vffkfvHHBdnrdrMot9N8Z8f2+ZHjMyZNnDXiEqG/X8vObQ
-        PGyvl9CTAmrlu7k/UZ8fwpoeMzJk2cNeMlqpPRWOx8O20a/ompLXJs9Z25+AxfvJa+qLe1jTY0aGLHty
-        vUJU2Id2W/0p3JObbhnJwBFdg2t6HZ3yL3TIs7Kmx4wMWfZsPmZJ9c2x0NXJDG5/XMdZueVTLxbk52aU
-        WNNjRoasbC7ZPEBT3uY+bnQ+iTQNpLDL5nnV/CwN50RW6UQorTyrzMiQzd1Owa518s0g9JZGIbYfbPAl
-        0fr8ixJresJQ16QYIcj+9+G989O0osxYvaPV5aaE1rg/tzBmZDae34mu1J3G3CpsAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJFSURBVDhPhZLfS5NhHMUfg5aQQVC4aMiQCq22hT9CB3XT
+        f9CNdBVZVrs0acMFVgRFvxaLcjZlySZaFyG1i2KZhS0dGNIK2saSuhkSGhk2hphw+p7nfcWioi8c+O6c
+        z3n3Ps+m/jWuWHq9sy97guJu2v+fhnBu865zLyr23s2hY/y7Fnd6zEzsz3HcybidvZnYvtgHOLvTt9pG
+        vyLxA1rc6elMGLJmbXV2304P9nwERhYB/+sldIoGF6DFnR4zMmTNmjGu0Hgln54oAaFZYGgeGBYFsoa4
+        02NGZv/ANBzBlNWsK1Xjfbhh+8VE9HSqhOgccDUDNMq5be39SYo7PWZkyLKjyysXdvTpHE5NFDEwA9RH
+        slh74OQxie0Ud3rMyJBduVg5+xtvR3IBkQJwYxo4P7WI6rPxe1IsF5WZKqfHjAxZdthVNddfnWl/+Q09
+        n4BLct6uyRJ2XB6LSOm3oceMDFl22FWqusnK12uJz8DzfB7deaBOPssfqMHsKu70mJEhyw67zC2ibVW+
+        +8Oe0S/ompKfTc5Z15eFK/w+7OjNhLjTY0aGLDtmV6kq79BWdzSPm3LTh0eK8KWWEHi3jE75F/rkrNzp
+        MSNDlh1dNmdN7ZWx+IXJIq69XcZxueUjT2bldYta3OkxI0OWHaNqTFllW/Cg3f8g2dyfxxZP6FnLowL8
+        EyWtQ/GC9tySkSHLjlFdnXUim7K6mpTauKcxkkPr489a3OkpW32zZgz2r8On8tUsqsJeu6k1EKSUxb5T
+        e0b2yzcr9RMhpNP8hwPVZgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="toolStripDropDownButton1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAk5JREFUOE91kt9L
-        01EYxs+ENiGDoHDRkCEVWm4rf4QO6qb/oBsJAsky2qVJGy6wIij6tViksylLNpl1EVK7KJZZ2NKBIS2h
-        bSzRmyGhkWFrqAlP5zlt4qp94YH3+zyf9+V73vPViCKPJRDbilXdScYa3WpwuuXQz2JsgV/vTe48cPlN
-        2eGHSXSM/1BiTY9Z0SGmB3GruS8eOBL4DHNP7H7b6DeEf0GJNT2VSYbsP4NqumPB3llgZAVwvl9Dp1Rw
-        GUqs6TEjQ7ZggMUzXs7p4SzgWQCGloBhKVfij1jTY0bm6OAMTO6ofmNIlf3ptr3Xwv4L0Sz8i8CtONAg
-        z21oH4hQrOkxI0OWPWpAfmGnXy7i/EQGg/NAnS+BLcfOnZGxkWJNjxkZsvnFipruD/aOyDJ8aeDuDHBl
-        agWVl0KPZGMpbzCnUnrMyJBlD3tF1Z13F9vffkfvHHBdnrdrMot9N8Z8f2+ZHjMyZNnDXiEqG/X8vObQ
-        PGyvl9CTAmrlu7k/UZ8fwpoeMzJk2cNeMlqpPRWOx8O20a/ompLXJs9Z25+AxfvJa+qLe1jTY0aGLHty
-        vUJU2Id2W/0p3JObbhnJwBFdg2t6HZ3yL3TIs7Kmx4wMWfZsPmZJ9c2x0NXJDG5/XMdZueVTLxbk52aU
-        WNNjRoasbC7ZPEBT3uY+bnQ+iTQNpLDL5nnV/CwN50RW6UQorTyrzMiQzd1Owa518s0g9JZGIbYfbPAl
-        0fr8ixJresJQ16QYIcj+9+G989O0osxYvaPV5aaE1rg/tzBmZDae34mu1J3G3CpsAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJFSURBVDhPhZLfS5NhHMUfg5aQQVC4aMiQCq22hT9CB3XT
+        f9CNdBVZVrs0acMFVgRFvxaLcjZlySZaFyG1i2KZhS0dGNIK2saSuhkSGhk2hphw+p7nfcWioi8c+O6c
+        z3n3Ps+m/jWuWHq9sy97guJu2v+fhnBu865zLyr23s2hY/y7Fnd6zEzsz3HcybidvZnYvtgHOLvTt9pG
+        vyLxA1rc6elMGLJmbXV2304P9nwERhYB/+sldIoGF6DFnR4zMmTNmjGu0Hgln54oAaFZYGgeGBYFsoa4
+        02NGZv/ANBzBlNWsK1Xjfbhh+8VE9HSqhOgccDUDNMq5be39SYo7PWZkyLKjyysXdvTpHE5NFDEwA9RH
+        slh74OQxie0Ud3rMyJBduVg5+xtvR3IBkQJwYxo4P7WI6rPxe1IsF5WZKqfHjAxZdthVNddfnWl/+Q09
+        n4BLct6uyRJ2XB6LSOm3oceMDFl22FWqusnK12uJz8DzfB7deaBOPssfqMHsKu70mJEhyw67zC2ibVW+
+        +8Oe0S/ompKfTc5Z15eFK/w+7OjNhLjTY0aGLDtmV6kq79BWdzSPm3LTh0eK8KWWEHi3jE75F/rkrNzp
+        MSNDlh1dNmdN7ZWx+IXJIq69XcZxueUjT2bldYta3OkxI0OWHaNqTFllW/Cg3f8g2dyfxxZP6FnLowL8
+        EyWtQ/GC9tySkSHLjlFdnXUim7K6mpTauKcxkkPr489a3OkpW32zZgz2r8On8tUsqsJeu6k1EKSUxb5T
+        e0b2yzcr9RMhpNP8hwPVZgAAAABJRU5ErkJggg==
 </value>
   </data>
   <metadata name="FileTreeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -250,20 +245,22 @@
   </metadata>
   <data name="FileText.Encoding" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
-        AAEAAAD/////AQAAAAAAAAAEAQAAABhTeXN0ZW0uVGV4dC5VVEY4RW5jb2RpbmcLAAAAEmVtaXRVVEY4
-        SWRlbnRpZmllchBpc1Rocm93RXhjZXB0aW9uCm1fY29kZVBhZ2UIZGF0YUl0ZW0PZW5jb2RlckZhbGxi
-        YWNrD2RlY29kZXJGYWxsYmFjaxNFbmNvZGluZyttX2NvZGVQYWdlEUVuY29kaW5nK2RhdGFJdGVtFUVu
-        Y29kaW5nK21faXNSZWFkT25seRhFbmNvZGluZytlbmNvZGVyRmFsbGJhY2sYRW5jb2RpbmcrZGVjb2Rl
-        ckZhbGxiYWNrAAAAAwMDAAMAAwMBAQglU3lzdGVtLkdsb2JhbGl6YXRpb24uQ29kZVBhZ2VEYXRhSXRl
-        bSZTeXN0ZW0uVGV4dC5FbmNvZGVyUmVwbGFjZW1lbnRGYWxsYmFjayZTeXN0ZW0uVGV4dC5EZWNvZGVy
-        UmVwbGFjZW1lbnRGYWxsYmFjawglU3lzdGVtLkdsb2JhbGl6YXRpb24uQ29kZVBhZ2VEYXRhSXRlbQEm
-        U3lzdGVtLlRleHQuRW5jb2RlclJlcGxhY2VtZW50RmFsbGJhY2smU3lzdGVtLlRleHQuRGVjb2RlclJl
-        cGxhY2VtZW50RmFsbGJhY2sAAOn9AAAKCQIAAAAJAwAAAOn9AAAKAQkCAAAACQMAAAAEAgAAACZTeXN0
-        ZW0uVGV4dC5FbmNvZGVyUmVwbGFjZW1lbnRGYWxsYmFjawMAAAAKc3RyRGVmYXVsdBtiSXNNaWNyb3Nv
-        ZnRCZXN0Rml0RmFsbGJhY2srRW5jb2RlckZhbGxiYWNrK2JJc01pY3Jvc29mdEJlc3RGaXRGYWxsYmFj
-        awEAAAEBBgYAAAAD77+9AAAEAwAAACZTeXN0ZW0uVGV4dC5EZWNvZGVyUmVwbGFjZW1lbnRGYWxsYmFj
-        awMAAAAKc3RyRGVmYXVsdBtiSXNNaWNyb3NvZnRCZXN0Rml0RmFsbGJhY2srRGVjb2RlckZhbGxiYWNr
-        K2JJc01pY3Jvc29mdEJlc3RGaXRGYWxsYmFjawEAAAEBCQYAAAAAAAs=
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEttc2NvcmxpYiwgVmVyc2lvbj0yLjAuMC4wLCBDdWx0dXJlPW5l
+        dXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAABhTeXN0ZW0uVGV4dC5VVEY4
+        RW5jb2RpbmcLAAAAEmVtaXRVVEY4SWRlbnRpZmllchBpc1Rocm93RXhjZXB0aW9uCm1fY29kZVBhZ2UI
+        ZGF0YUl0ZW0PZW5jb2RlckZhbGxiYWNrD2RlY29kZXJGYWxsYmFjaxNFbmNvZGluZyttX2NvZGVQYWdl
+        EUVuY29kaW5nK2RhdGFJdGVtFUVuY29kaW5nK21faXNSZWFkT25seRhFbmNvZGluZytlbmNvZGVyRmFs
+        bGJhY2sYRW5jb2RpbmcrZGVjb2RlckZhbGxiYWNrAAAABAQEAAQABAQBAQglU3lzdGVtLkdsb2JhbGl6
+        YXRpb24uQ29kZVBhZ2VEYXRhSXRlbQIAAAAmU3lzdGVtLlRleHQuRW5jb2RlclJlcGxhY2VtZW50RmFs
+        bGJhY2sCAAAAJlN5c3RlbS5UZXh0LkRlY29kZXJSZXBsYWNlbWVudEZhbGxiYWNrAgAAAAglU3lzdGVt
+        Lkdsb2JhbGl6YXRpb24uQ29kZVBhZ2VEYXRhSXRlbQIAAAABJlN5c3RlbS5UZXh0LkVuY29kZXJSZXBs
+        YWNlbWVudEZhbGxiYWNrAgAAACZTeXN0ZW0uVGV4dC5EZWNvZGVyUmVwbGFjZW1lbnRGYWxsYmFjawIA
+        AAACAAAAAADp/QAACgkDAAAACQQAAADp/QAACgEJAwAAAAkEAAAABQMAAAAmU3lzdGVtLlRleHQuRW5j
+        b2RlclJlcGxhY2VtZW50RmFsbGJhY2sDAAAACnN0ckRlZmF1bHQbYklzTWljcm9zb2Z0QmVzdEZpdEZh
+        bGxiYWNrK0VuY29kZXJGYWxsYmFjaytiSXNNaWNyb3NvZnRCZXN0Rml0RmFsbGJhY2sBAAABAQIAAAAG
+        BwAAAAPvv70AAAUEAAAAJlN5c3RlbS5UZXh0LkRlY29kZXJSZXBsYWNlbWVudEZhbGxiYWNrAwAAAApz
+        dHJEZWZhdWx0G2JJc01pY3Jvc29mdEJlc3RGaXRGYWxsYmFjaytEZWNvZGVyRmFsbGJhY2srYklzTWlj
+        cm9zb2Z0QmVzdEZpdEZhbGxiYWNrAQAAAQECAAAACQcAAAAAAAs=
 </value>
   </data>
   <metadata name="DiffContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -271,20 +268,22 @@
   </metadata>
   <data name="DiffText.Encoding" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
-        AAEAAAD/////AQAAAAAAAAAEAQAAABhTeXN0ZW0uVGV4dC5VVEY4RW5jb2RpbmcLAAAAEmVtaXRVVEY4
-        SWRlbnRpZmllchBpc1Rocm93RXhjZXB0aW9uCm1fY29kZVBhZ2UIZGF0YUl0ZW0PZW5jb2RlckZhbGxi
-        YWNrD2RlY29kZXJGYWxsYmFjaxNFbmNvZGluZyttX2NvZGVQYWdlEUVuY29kaW5nK2RhdGFJdGVtFUVu
-        Y29kaW5nK21faXNSZWFkT25seRhFbmNvZGluZytlbmNvZGVyRmFsbGJhY2sYRW5jb2RpbmcrZGVjb2Rl
-        ckZhbGxiYWNrAAAAAwMDAAMAAwMBAQglU3lzdGVtLkdsb2JhbGl6YXRpb24uQ29kZVBhZ2VEYXRhSXRl
-        bSZTeXN0ZW0uVGV4dC5FbmNvZGVyUmVwbGFjZW1lbnRGYWxsYmFjayZTeXN0ZW0uVGV4dC5EZWNvZGVy
-        UmVwbGFjZW1lbnRGYWxsYmFjawglU3lzdGVtLkdsb2JhbGl6YXRpb24uQ29kZVBhZ2VEYXRhSXRlbQEm
-        U3lzdGVtLlRleHQuRW5jb2RlclJlcGxhY2VtZW50RmFsbGJhY2smU3lzdGVtLlRleHQuRGVjb2RlclJl
-        cGxhY2VtZW50RmFsbGJhY2sAAOn9AAAKCQIAAAAJAwAAAOn9AAAKAQkCAAAACQMAAAAEAgAAACZTeXN0
-        ZW0uVGV4dC5FbmNvZGVyUmVwbGFjZW1lbnRGYWxsYmFjawMAAAAKc3RyRGVmYXVsdBtiSXNNaWNyb3Nv
-        ZnRCZXN0Rml0RmFsbGJhY2srRW5jb2RlckZhbGxiYWNrK2JJc01pY3Jvc29mdEJlc3RGaXRGYWxsYmFj
-        awEAAAEBBgYAAAAD77+9AAAEAwAAACZTeXN0ZW0uVGV4dC5EZWNvZGVyUmVwbGFjZW1lbnRGYWxsYmFj
-        awMAAAAKc3RyRGVmYXVsdBtiSXNNaWNyb3NvZnRCZXN0Rml0RmFsbGJhY2srRGVjb2RlckZhbGxiYWNr
-        K2JJc01pY3Jvc29mdEJlc3RGaXRGYWxsYmFjawEAAAEBCQYAAAAAAAs=
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEttc2NvcmxpYiwgVmVyc2lvbj0yLjAuMC4wLCBDdWx0dXJlPW5l
+        dXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAABhTeXN0ZW0uVGV4dC5VVEY4
+        RW5jb2RpbmcLAAAAEmVtaXRVVEY4SWRlbnRpZmllchBpc1Rocm93RXhjZXB0aW9uCm1fY29kZVBhZ2UI
+        ZGF0YUl0ZW0PZW5jb2RlckZhbGxiYWNrD2RlY29kZXJGYWxsYmFjaxNFbmNvZGluZyttX2NvZGVQYWdl
+        EUVuY29kaW5nK2RhdGFJdGVtFUVuY29kaW5nK21faXNSZWFkT25seRhFbmNvZGluZytlbmNvZGVyRmFs
+        bGJhY2sYRW5jb2RpbmcrZGVjb2RlckZhbGxiYWNrAAAABAQEAAQABAQBAQglU3lzdGVtLkdsb2JhbGl6
+        YXRpb24uQ29kZVBhZ2VEYXRhSXRlbQIAAAAmU3lzdGVtLlRleHQuRW5jb2RlclJlcGxhY2VtZW50RmFs
+        bGJhY2sCAAAAJlN5c3RlbS5UZXh0LkRlY29kZXJSZXBsYWNlbWVudEZhbGxiYWNrAgAAAAglU3lzdGVt
+        Lkdsb2JhbGl6YXRpb24uQ29kZVBhZ2VEYXRhSXRlbQIAAAABJlN5c3RlbS5UZXh0LkVuY29kZXJSZXBs
+        YWNlbWVudEZhbGxiYWNrAgAAACZTeXN0ZW0uVGV4dC5EZWNvZGVyUmVwbGFjZW1lbnRGYWxsYmFjawIA
+        AAACAAAAAADp/QAACgkDAAAACQQAAADp/QAACgEJAwAAAAkEAAAABQMAAAAmU3lzdGVtLlRleHQuRW5j
+        b2RlclJlcGxhY2VtZW50RmFsbGJhY2sDAAAACnN0ckRlZmF1bHQbYklzTWljcm9zb2Z0QmVzdEZpdEZh
+        bGxiYWNrK0VuY29kZXJGYWxsYmFjaytiSXNNaWNyb3NvZnRCZXN0Rml0RmFsbGJhY2sBAAABAQIAAAAG
+        BwAAAAPvv70AAAUEAAAAJlN5c3RlbS5UZXh0LkRlY29kZXJSZXBsYWNlbWVudEZhbGxiYWNrAwAAAApz
+        dHJEZWZhdWx0G2JJc01pY3Jvc29mdEJlc3RGaXRGYWxsYmFjaytEZWNvZGVyRmFsbGJhY2srYklzTWlj
+        cm9zb2Z0QmVzdEZpdEZhbGxiYWNrAQAAAQECAAAACQcAAAAAAAs=
 </value>
   </data>
   <metadata name="TreeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -301,284 +300,276 @@
   </metadata>
   <data name="openToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAM9JREFUOE9jYKAGuLRSYdrlVYr/ScEgPXC7sWn8cin6////63Dg02DLUAz4//80kmKI
-        gv8/6rDj/8uxGbDy///fDRD8fz5R3kFzwaL//7+UQfCPxv///00DGgQUw4oPYnHB75n//7/OIg4D1WKG
-        wae+//8fxxCHgWoxDXjd8v/PdX+i8H+gWkwDnlT9/3LekSj8H6gWw4Cfdwv/vz5mRhQGqcV0wasZ/79c
-        zyIK/weqRTFg11TxJaQkY5BakB7kbMQN5CgBsS6RGKQWpGcQAAD9vgJAKfpw/wAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAAAzUlE
+        QVQ4T2OgCri0UmHa5VWK/0nBID1Q7QwM2BR8uRT9////dTjwabAaqHaIASBBdAX/f9Rhx/+XYzNg5f//
+        vxsg+P98uEvwYah2mAGL/v//UgbBPxr///83DSKGFR/EYsDvmf//v84iDgPVYhrwqe///8cxxGGgWkwD
+        Xrf8/3PdnygMUotpwJOq/1/OOxKFQWoxDPh5t/D/62NmRGGQWkwXvJrx/8v1LKIwSC2KAbumii8BCZCC
+        QXqg2sGAG4iVgFiXSAxSC9Iz4ICBAQD9vgJAnRHi4AAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="refreshToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAfhJREFUOE9j+I8bbLiy5u+/v2jyDHg05K1On7CnG7uG9z/e7nu4c8LJzpwtKVHLAoLn
-        eftOc81YkZC0KHrCth5kPSAb7n24M/38hObDlZNOdc65MGXexakzz0+Ycrqn/2R7+5GGkKl+kzb3w/Uw
-        vPv+dtrZvr6TrUuuzJ5xrn/W+UlTz/ROONXRfay59Uhd/cFKn173zjXtCA27722v21+68NKMOeen9B5v
-        S10e59BmaVVnYlym5z/B06vbtXFpHYqTug+3dB5uAJradaQ5ambIlF0T4NK+jV5lc4rRPZ2yMjZkjo//
-        VA+gebP3TUeWnrJp0p+/fw7d37f/zp69N3ftvrZ9x+WtDLuv79h5Zdu2i1u2nNu08fR6YMDverQFWduK
-        80uiF4QATXTvdvDrdkePh6U35rUcr4ZrWHByNjBk+4619Z/sKNucnzs3E0XD6ltLWo9XNx4qj1sdEr7Y
-        L3C2Z/aa5O7DzcDw7TzWFDY9YNH+BQgN62+vbD5Sufz6PGD4zr80HR6+TYeqgOGbvCQ2Z2bms7fPkDTc
-        WFWzt3j+xWnA8J12tn/iqa7u462N+6py1qYGTvLOnp5x7s5ZoFNRnLTg9Oy8DWkZqxJdum3tms3Nq42c
-        620zpqUs2DMPaDbEY+ieBqa25LlxeFIkugZgsC46NB+PBgDTtVMOQl44ggAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAACD0lE
+        QVQ4T2P4jxtsuLLm77+/UA4M4NOQtzp9wp5uKAcGoBre/3i77+HOCSc7c7akRC0LCJ7n7TvNNWNFQtKi
+        6AnbeiBqIACk4d6HO9PPT2g+XDnpVOecC1PmXZw68/yEKad7+k+2tx9pCJnqN2lzP0Q1EDC8+/522tm+
+        vpOtS67MnnGuf9b5SVPP9E441dF9rLn1SF39wUqfXvfONe1Q5UANu+9tr9tfuvDSjDnnp/Qeb0tdHufQ
+        ZmlVZ2Jcpuc/wdOr27VxaR1ULRgwdB9u6TzcADS160hz1MyQKbsmQGX+//dt9CqbUwzlwABDysrYkDk+
+        /lM9gObN3jcdKgwGUzZN+vP3z6H7+/bf2bP35q7d17bvuLyVYff1HTuvbNt2ccuWc5s2nl4PDPhdj7ZA
+        dYDBivNLoheEAE1073bw63ZHj4elN+a1HK+Gcv7/X3ByNjBk+4619Z/sKNucnzs3E0XD6ltLWo9XNx4q
+        j1sdEr7YL3C2Z/aa5O7DzcDw7TzWFDY9YNH+BQgN62+vbD5Sufz6PGD4zr80HR6+TYeqgOGbvCQ2Z2bm
+        s7fPkDTcWFWzt3j+xWnA8J12tn/iqa7u462N+6py1qYGTvLOnp5x7s5ZoDIUJy04PTtvQ1rGqkSXblu7
+        ZnPzaiPnetuMaSkL9swDmg1Rg+5pYGpLnhsH5WAD6BqAwbro0HwoBxP8/w8A07VTDmlIn70AAAAASUVO
+        RK5CYII=
 </value>
   </data>
   <data name="fileExplorerToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAM9JREFUOE9jYKAGuLRSYdrlVYr/ScEgPXC7sWn8cin6////63Dg02DLUAz4//80kmKI
-        gv8/6rDj/8uxGbDy///fDRD8fz5R3kFzwaL//7+UQfCPxv///00DGgQUw4oPYnHB75n//7/OIg4D1WKG
-        wae+//8fxxCHgWoxDXjd8v/PdX+i8H+gWkwDnlT9/3LekSj8H6gWw4Cfdwv/vz5mRhQGqcV0wasZ/79c
-        zyIK/weqRTFg11TxJaQkY5BakB7kbMQN5CgBsS6RGKQWpGcQAAD9vgJAKfpw/wAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAAAzUlE
+        QVQ4T2OgCri0UmHa5VWK/0nBID1Q7QwM2BR8uRT9////dTjwabAaqHaIASBBdAX/f9Rhx/+XYzNg5f//
+        vxsg+P98uEvwYah2mAGL/v//UgbBPxr///83DSKGFR/EYsDvmf//v84iDgPVYhrwqe///8cxxGGgWkwD
+        Xrf8/3PdnygMUotpwJOq/1/OOxKFQWoxDPh5t/D/62NmRGGQWkwXvJrx/8v1LKIwSC2KAbumii8BCZCC
+        QXqg2sGAG4iVgFiXSAxSC9Iz4ICBAQD9vgJAnRHi4AAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="gitBashToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAJJJREFUOE9jNJt3bRojA2MmA4ngP8P/6aeStLIYtmzZ8v/C////t/0kHoPUg/SB7QQx
-        Fr/4/7/yGvEYpB7FgDVP/v9vv0g8BqlHMcB83vX/pGIUA4A+AfmHJLx69WpEGIA0g0wkFsPUwwORVNux
-        GkCs7VC/owbiMHEBqd5ASQekBCCyWnA0btq0yZdcTGIGxq4cAK5E+vvW/wAzAAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAAAg0lE
+        QVQ4T62PwQ1AQBREtyqqUJAKdODo4rhOm406uNCAgxachpEgG5v4Hz95mcvMS75JqqFMqxFauDM87z06
+        AO0ih33uTkE9A/kgh/1A0ExA0cthPxDEfnwiEGyhxlrLvARMKUc/EGi5CZhSogItNwFTSlSg5V/BW3aB
+        cy57yy74dsaswLkbOMmaOHAAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="cloneToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAYpJREFUOE+VkzFIQlEUhm9b4NTS4FbQGERiTSERTVGBULNEFDo6hDVIYFAuhUMWNjho
-        UZBEDQ4RCA4WIRXSEEQiFA0OFmhSQf29/2Tmq1fZg8O5597vfPfdd3kN1tXToFLKqcV/n5XjyQ6X0gQ4
-        egR27gCOf3u4To58hVUi2C4A/tyngHNGMs6RI68TbOaBuav6BOTI6wTRW8B7Ud8RyJHXCcLXgCdTn4Ac
-        eZ0glAXcaWAodiMLX6N5dwQqqaphO3EKI9fGweL5K8YS5R+DzSnEsY4lyax1Av/ZM/o3soa7C6g1rMEH
-        FwYkfxP40mXDa3NeOquv7cUE7OgGc81xgnKE2cOioYBgHFuY0ZoGYUEPWiSz5ryIKJhO3lcFtR/QkXYI
-        5ME4rC9mtD01SmYtzTEVFsFUoqAT9EZyUpdKJdj37AK7MApL0SyZdVOgj7dgEkEo86ATuA/y1bpWsox5
-        ae6MDMMSSL1fY/vCftTo7mvnCMuOlZ1Zs+/j9zVpg1a6/ogubd2mBTN59qk3YwKIK/BfWjsAAAAASUVO
-        RK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABg0lE
+        QVQ4T52QP0hCYRTFvzFoamlwK2h0SawpJKIpKhBqlohAR4ewBgkMyqVwSMIGBy0KkqjBIQLBwRqkQhqC
+        SISiwcECTSqo0zvX559nadKFw3n33nN/Hzxl3b4KasI/FASgCMDFG3D0DFm0K+6ZY17PVgCHBcCfqwPo
+        1e/G4ow55vV9BbCfB1bvOwMwx7y+rwCiT4D3tg5oVdwzx7wBEH4APJnOAMwxbwCEsoA7DUzFHmXRrN7j
+        Gaikqsl26ZS5YvFj4+YLc4lyS/EohTh2sSnO3gDwX39gfC9reLVRPNiBDy5MiP8A+NJlGTSX884pYcqL
+        BdgxLF6daQoKYOW8+CuAoTgOsKwdTcKCEfSJs+dcIDxcSr7UAPSqHGmHhDyYh/XThIH3LnH2chxTYQEs
+        JgoGwGgkJ14qlWA/sUvYhVlYiiZx9j2BMf6DbgGEMq8GgPssX+sbIVtYEx+MTMMSSFV+onn9NMpwOzEs
+        L+ovs+edALTq1tSvyfyHhjTZdGdeu1PqG/lKrG05Es6JAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="cloneSVNToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAALEAAA
-        CxABrSO9dQAAAYpJREFUOE+VkzFIQlEUhm9b4NTS4FbQGERiTSERTVGBULNEFDo6hDVIYFAuhUMWNjho
-        UZBEDQ4RCA4WIRXSEEQiFA0OFmhSQf29/2Tmq1fZg8O5597vfPfdd3kN1tXToFLKqcV/n5XjyQ6X0gQ4
-        egR27gCOf3u4To58hVUi2C4A/tyngHNGMs6RI68TbOaBuav6BOTI6wTRW8B7Ud8RyJHXCcLXgCdTn4Ac
-        eZ0glAXcaWAodiMLX6N5dwQqqaphO3EKI9fGweL5K8YS5R+DzSnEsY4lyax1Av/ZM/o3soa7C6g1rMEH
-        FwYkfxP40mXDa3NeOquv7cUE7OgGc81xgnKE2cOioYBgHFuY0ZoGYUEPWiSz5ryIKJhO3lcFtR/QkXYI
-        5ME4rC9mtD01SmYtzTEVFsFUoqAT9EZyUpdKJdj37AK7MApL0SyZdVOgj7dgEkEo86ATuA/y1bpWsox5
-        ae6MDMMSSL1fY/vCftTo7mvnCMuOlZ1Zs+/j9zVpg1a6/ogubd2mBTN59qk3YwKIK/BfWjsAAAAASUVO
-        RK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsNAAALDQHtB8AsAAABg0lE
+        QVQ4T52QP0hCYRTFvzFoamlwK2h0SawpJKIpKhBqlohAR4ewBgkMyqVwSMIGBy0KkqjBIQLBwRqkQhqC
+        SISiwcECTSqo0zvX559nadKFw3n33nN/Hzxl3b4KasI/FASgCMDFG3D0DFm0K+6ZY17PVgCHBcCfqwPo
+        1e/G4ow55vV9BbCfB1bvOwMwx7y+rwCiT4D3tg5oVdwzx7wBEH4APJnOAMwxbwCEsoA7DUzFHmXRrN7j
+        Gaikqsl26ZS5YvFj4+YLc4lyS/EohTh2sSnO3gDwX39gfC9reLVRPNiBDy5MiP8A+NJlGTSX884pYcqL
+        BdgxLF6daQoKYOW8+CuAoTgOsKwdTcKCEfSJs+dcIDxcSr7UAPSqHGmHhDyYh/XThIH3LnH2chxTYQEs
+        JgoGwGgkJ14qlWA/sUvYhVlYiiZx9j2BMf6DbgGEMq8GgPssX+sbIVtYEx+MTMMSSFV+onn9NMpwOzEs
+        L+ovs+edALTq1tSvyfyHhjTZdGdeu1PqG/lKrG05Es6JAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="initNewRepositoryToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAa1JREFUOE+Vkk8ow2EYxx9NFBeTHExWy2m1pB1krtqF3LhImaQdHFwchFpZTji5abk4
-        OLiQVjtYoSRtC6WppZnGmtXW2p+weDzfnx9h+6321qe+Pd/v87zv+3t/RFVW+JgsoFpG0wscUk/s0sQA
-        uuYhIS+t5ZKLDKBrHnBzRPH34j4D6KoD5J5dgvUb2XEgfm3mj5dtBWjUfmfQowy99JHx7qJN7tr9h1xy
-        nkv5JQXo/z560Es769QeOWvmQtrDJTnuW36T33Jufs3O8Wtm/AvRqMFDBln0oBeH0O1u0JR/h4LpmEPC
-        bi6mRrmQsguDKnalBg8ZZNGDXgyoE5qEfo+LfPFrC+dTTs492YQ+FZtSg4cMsmoPen9Wg6hOefNUNunk
-        zINFMKtYGDV4yAjIlq/TPeqNBjo4m3DIUa2ceRxSgEYNHjKaTxr00nIyMiJNM8Is34eMCtCowUNGc8CV
-        j84ziVV+jk7w7Uk9u6ZpC0CjBg+ZigPkx9CF/SQ7mtizQgfGFhqWYCuARg0eMshqnUK/MEljYhqERvWF
-        8KWhDaqn17yC+q74wpV2QK3M+wRHmWPqTFR0DgAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABq0lE
+        QVQ4T5WSQSiDcRjGX00UFyQHk5Wc1JJ2EK5yITcuUibJwcHFQaiV5YSTm5bLDg4uJLUDhZLEQomSmMaa
+        r7bWty3b4vU+f38yG81Tv/bseZ/3+3/ft9FfutojO9Bf/6eTLWoOnDUwgNdx4fJv04IZnmYAr+PCdblD
+        wdfkBgN4HeeXPGe94PhETuwIXjTx28uqAh7Z945Qr5bPfGS7Pa6WZ23MwgxPciY+o4D/OccOdsm7SDU3
+        h+WciHg4I7ebji9z2nRzKjbBqejAB+KRYYYOutjBLm7CsrZEw7teOo0EnFJ2c9Lo44TRJXRqulSGGTro
+        Yge7uECRUCa0eVzkC17YOW6MsfnULrRq2lWGGTro6h3sfqlEqJPf3IiFxzj6YBeaNHZGhhk6upurg3Vq
+        uTup5VjIKbfq4OhjtwIeGWbo6HquTrdpNnzTK0ujwjjf+20KeGSYoaPruTr30VE0NM/Pd4N8vV/MrhFa
+        AfDIMENH17MlfwzL1S7JiQ3smaNNWwX1SFwF4JFhhg66aimPKqeGqF8+rUKpgLcM4K16Vin8KlwZbzjf
+        CXlmRO9HmWPqMBworgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="commitToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAf9JREFUOE+dk01IG1EUhSebrLLRRUEEUdxZFaEbRRcVRNRFQfybdhGUaExKVagiWCUk
-        mgQRRZNFFTOgWQgGXCj4syhdh1qxmGBpCaGLhi5KEBQqKIXjO8PM0zFd9cLJ3Ln3uyeP4T4bAMVmsylm
-        9B3W2EXuFuoWajDqSfHcEVpPdKRvTZaziv5jhBh2vzqqQzg9jK38Ag4Q08WcNfbI/NOgd7/6tetjIxKX
-        y0hgEZvwQ8OULuassUeGLE3kCXhsum9fLGPjrx9rN+NYfSTW2CNjnMQuDbp2n44FzwYRv55F9GoEkas3
-        BXJ9agJFhixnpEHPXnVS+xlA5GIMC/mhAnHQDDJkOSMNeg9qbuO/QwjlBvR/MTWXc+r5wyATz4fBGYuB
-        9isAX1a1wI+Hp7M98P1QEcv5+SH/SIPOnaov0cwkZjIqxr+9sJiYL6xTZMhyRhq0vi+f9R07MffdhdFU
-        G0ZSrRYTvlPskSHLmftFKlJK1KNarHydwESqE56TZrhPnusmfFKssUeGrCJmHm6ivXmpLND/oR6L528x
-        dabC+7lFfkzmrLFHhqzYo/s9MFbT0Rgsnaf7u+RLhE49CKW9CKY9CJ969Rp7ZATvsGyiYcAbxUbts8kn
-        WlusMiM2lLuPdq0yyxp7BqPfvoLLZBjxNhYLVQhVGWLOGnsypAGT/9Ud2C1E0MYpkTAAAAAASUVORK5C
-        YII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAAB80lE
+        QVQ4T52TT0iTcRzG3y47dalDIEIU3kxF6BLYISHELoGE9upBipVtoQkpghVj022EGKaHCvZC7RAkdCjI
+        PETQTSox3CiKMTo0OsQQEgqM4On3+e3d3J9OfuFhv/f5fp5nLy/v60hyquf8y/aA0ajRG6MdX5zxAj5m
+        x2arCwwwMrTaqWT2ih4X57SilBVnPHYwPl5bMPCi7WrwdZeWfy5oWfN6pKg8TVtxxmMHA1tTwK3R/mRr
+        QQ//RvVgZ0L364THDsa/k0Cl4NyzY+PxzUtK/57R0vaYFrdHGxR8e9IKBpZMpaD/edua9y2mxa1xzRUv
+        N4hgeWBgyZjLUsHASvuf9I+EEoWLlX9Cs4XhmjADky4mRcZc7hZ432OK5F0Llac+fDPfr8hXV6lClAf5
+        y1ilgr6nrR+WclO6lXM18fmshesHH8HAkjF2qaDn3pGZyLthzX4J6lqmV2OZHhsqD9eIHQwsGbMqFTgH
+        nCZ3tUN3P01qMtOn0Hq3RtZP2TC/CI8dDCyZ3QLHCXTfORy78OqE5j9e1/Smq/D705WHyRmPHQwsmeoC
+        Zn9XvPk27TfWBpXYCCmRDSueDSm5EbYeOxhYAvUF+4xYdByfOuT1plpy5m3jjdMZryWPx85nYBsKysMX
+        d9DoqFGrL854//8a9y45/wAdXkvyTvTpugAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="pullToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAPFJREFUOE9jYKA2MJt3bZr5vOv/0TFInCi7QBov/P//f9tPBAbxQeJEG7D52///fS8Q
-        GMQnyYC1n/7/b3+MwCA+SQYsf/P/f91tBAbxSTJg/vP//0uvIDCIT9AA5NDvu/X/f/ZpBAbxYbGCMzZA
-        Cg5+/P9/IlBx3sn//5MO/4NjEB8kDpLH6RLDySfmgySnARWmHvz1P2LXdzgG8UHiIHmQOlzRya3ZvHUt
-        SNGEq///x+z88t9/80cwDeKDxEHyQM3c+NID3JCuC7//J+76+B9EE6sZZjDckPWPiLcZ3VVwQ4hxNs4w
-        AUqIEfIzUfkDnyIAYx4ny5/q96wAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAAA7klE
+        QVQ4T7VRPQtBYRi9u91/MFr4GVaDhTIpm9ViUAaRMjKaZBDlbrKQxeCj2BgYLFcilMPhve/rmytOnZ7O
+        c85z3rpX+zlcuX7WnRvgltyLyGsw3AFQ3ShScy8ir8FgeQUkZ4rUlgqKCyA+UaS2VFCYA9GRIrWlgvwU
+        iHQVqd8WXH795BAItRWpTe/p36BZN4D0MRxuAYHGXpKae/rMiZNrODPNPM3sMRisb+HV15LU3NNnTpzc
+        weaIVYoMpXqAr7aEp2ycJjX39Jk7xx9DliQ6O/h14zQ/PTYhS0rjz1++hSz55tgEj+xi/guadgBjHifL
+        sMLaoQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="pushToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAQ1JREFUOE9j/P//PwNFAGQANkPM512fBsT/QTS6BTA9YH3YDIBpvgmUxGYIXgNgmnf/
-        /P9//rv//0E0uiE4DYBp3vbt//8Jz///b38MoUF8ZEOwGgDTvPHj//8d9///r7uNwCA+SBxmCC4D/p/+
-        BXQ20MYGoOdLryAwiA8SB8mDDMFqgNGUk/OhNvzvu/X/f/ZpBAbxYXIgdbjCgBsYXUoghROBGpIO/4Nj
-        EB8kDpIHYm5CsfC/C+j8iF3f4RjEhxoAThIEDWg+++e//+aPcAzik2RA7cnv/93WvIZjEJ8kAxYC/Vxx
-        5Cscg/hEG6Dfd2gJLMSRaZA4LE8Qygvg2ABiXSQMDn28BiCbSgobALhoK4uduoL3AAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABEklE
+        QVQ4T2P4//8/RRjBQAPm865PA+L/IBoqBAcEDYBpvgmUwGYITA9YH5wBBTDNu3/+/z//3X8wjW4ITgNg
+        mrd9+/9/wvP//9sfQ2gQH9kQrAbANG/8+P9/x/3//+tuIzCIDxKHGYLLgP+nfwGdDbSxAej50isIDOKD
+        xEHyIHUwPSAMZxhNOTkfasP/vlv//2efRmAQHyYHUofVACDgBmIlkKKJQA1Jh//BMYgPEgfJg9ThMgAM
+        QAq7gM6O2PUdjkF8qAFgQNCA5rN//vtv/gjHID5JBtSe/P7fbc1rOAbxSTJgIdDPFUe+wjGIT7QB+n2H
+        loAUo2OQOFQJfgOAABwbQKyLhMGhD8RggNUA8vB/BgDj0lhd0RdHyQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="stashToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAUlJREFUOE9jfHyq6v+HB8sZkIGAQiSDrFkbI0jsX3bGJoa5c1DkmX788YMLXF6l+P//
-        /4NAvAyIF4ExSAyEUXRBOSAD/3GwbEI14Pe8///fl/8HuQamGUaDxJANwm7Alwn//z9PA2vG5hqQITCN
-        INuRMQNY09v2/3/vRUMMwOMadEPALgNrel7//+dVf4gBBFyD1Qt/Hpb9/3TOFWIAFtf8f1sIFC+Ehw9K
-        uIA0/XpQ9f/9WW+IAVhc8/9p/H8QRg5kuCFgTa9m/P96swBsADbX/L0d/B+OHySBXQmPZvSow+aaH5c9
-        /sPwzxvhYFeipBNYwOByzYfTNv9h+MtFX7Ar4QagRw1yQoK55u0p5/8w/PFCEDjMEAagJQxQIoF5CxY2
-        X65n/Yfh73fKwWGG1QvISRZbskZP5nD1GIkDWy4iJIYtrRPSA5IHAC9mGtrPNZ12AAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAABLElE
+        QVQ4T2N4fKrq/+VViigYJMYABf+yMzb942BBwVApCABp+P//IBAvA+JFYAwzCKoEBcAMhHKhBvye9///
+        +3KwzTDNMIzsGhDAbsCXCf//P08Da8DmGpAh2LwCNgis6W37/7/3oiEG4HENuiEIFzyv///zqj/EAAKu
+        weqFPw/L/n865wrRhMU1/98WgjFIDIRRwgUk8OtB1f/3Z70hmrC45v/TeDBG9hbcELDCVzP+f71ZAJbA
+        5pq/t4MR+EESWBwkDzYAPbCwuebHZQ84/nkjHCwONwAEYAED1oTFNR9O28Dxl4u+YHG4AehRA5KAYZhr
+        3p5yhuOPF4LA4ggDkDTDMMxbMNd8uZ4Fx9/vAGMFKA43AAQw4hYI0MMGG4YqxW4AyQA9LIgzkIEBAK1Q
+        KAxDNuovAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="checkoutBranchToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAUVJREFUOE+dkztLA0EUhdc6/8I+P8Mfo5VFNBhFAz5QGx+FYmOlhYU2aZRdJSpiUCwk
-        VoKFwRiyF2wCIgY83jvODPuYCcELZ3e4u+ebc4fdEQDBVvS0EwTBOCtbu5NjxQlHX7XEqy6bYZNv+ZI+
-        S+DOygG0QUxKUoMgTgBvVRQlU/kgPoCKawCfejIXZKgRNh4IsQdiAQuH0UH2IPv8dJvN66w11osDYgGc
-        uDCzXzsykFd+snpPWLkjLDcIS7eERdbj1x/FjJMEyNiF0t7JsYE0v4HqDaF6TZi/Yl0SZusEbllIFpCC
-        yAiND6ByEbO6KEcdlMN3zNVj/OgULkAK0uM3olYfU2dtlE7fUDnvQAJISjk3HyAFEUPtuYfpsI2uNsuo
-        MvIgQC6JpJGdjTn1L/i+9eTBZs3DAlQS1qiWrG3ZEWTxX/0ClcknquUM9tMAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABNElE
+        QVQ4T52Qv0vDQBzFb+9/4e5/Vy1W0YI/UBfFoeDipIODLl2URKmKWBQH6SY4KNbSHrgURCz4fC/NHYlJ
+        U/HBu1ze996HSwwAsx206zRyXDcFUtcB+MhqEoRH0oC44J3IciEcZwHMp2WXSeMgHOUCIrnsI1rzIYyz
+        gKSlrXuLfrTLQhiNlqWDcN8VnIb0Dsub9Ab9NIpTEL7GizGlub3GoYM80+t3Fmu3Fqsti5Ubi2X64TMa
+        ewi3HiCVyrvHRw7S/gJq1xa1K4vFS/rCYr5pwShSfC4FkDxEn9B6B6rnfbqHSthFJXjDQrOP7wKA5CED
+        DsOXIWZOOyifvKJ61oUuoJn+2ziA5CEqNB4HmA066MVlzXSmCCClbiInyzowCSB5yO+y9BeApMJUbF+W
+        POD/hvkBO2I3n8UiVlcAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="branchToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAUVJREFUOE+dkztLA0EUhdc6/8I+P8Mfo5VFNBhFAz5QGx+FYmOlhYU2aZRdJSpiUCwk
-        VoKFwRiyF2wCIgY83jvODPuYCcELZ3e4u+ebc4fdEQDBVvS0EwTBOCtbu5NjxQlHX7XEqy6bYZNv+ZI+
-        S+DOygG0QUxKUoMgTgBvVRQlU/kgPoCKawCfejIXZKgRNh4IsQdiAQuH0UH2IPv8dJvN66w11osDYgGc
-        uDCzXzsykFd+snpPWLkjLDcIS7eERdbj1x/FjJMEyNiF0t7JsYE0v4HqDaF6TZi/Yl0SZusEbllIFpCC
-        yAiND6ByEbO6KEcdlMN3zNVj/OgULkAK0uM3olYfU2dtlE7fUDnvQAJISjk3HyAFEUPtuYfpsI2uNsuo
-        MvIgQC6JpJGdjTn1L/i+9eTBZs3DAlQS1qiWrG3ZEWTxX/0ClcknquUM9tMAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABNElE
+        QVQ4T52Qv0vDQBzFb+9/4e5/Vy1W0YI/UBfFoeDipIODLl2URKmKWBQH6SY4KNbSHrgURCz4fC/NHYlJ
+        U/HBu1ze996HSwwAsx206zRyXDcFUtcB+MhqEoRH0oC44J3IciEcZwHMp2WXSeMgHOUCIrnsI1rzIYyz
+        gKSlrXuLfrTLQhiNlqWDcN8VnIb0Dsub9Ab9NIpTEL7GizGlub3GoYM80+t3Fmu3Fqsti5Ubi2X64TMa
+        ewi3HiCVyrvHRw7S/gJq1xa1K4vFS/rCYr5pwShSfC4FkDxEn9B6B6rnfbqHSthFJXjDQrOP7wKA5CED
+        DsOXIWZOOyifvKJ61oUuoJn+2ziA5CEqNB4HmA066MVlzXSmCCClbiInyzowCSB5yO+y9BeApMJUbF+W
+        POD/hvkBO2I3n8UiVlcAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="tagToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAVJJREFUOE+dkz9Lw1AUxePcb+Hu7ueoWCQVNEJqtC2C1IoIEhFBcVdw6uCgUCcHBycX
-        rR9AEKHUQnMHcajYoRb0eO8jeeRvKd5wkseD83vnvrw3BcDYf6qfGoaxxorXmTt7sp4yr6bEq15ua4s/
-        yZJ5lsBTKwHwDWJSkhoHSQXwUjOicKosSBZAxQ0A3xhkJpmohSOq4RNeKkQDnObyRXwjfzDCMW3jkKo4
-        oAre8ZyAaAAnzlmNhasA8oFXuFTGHjnYpVXsUIll4wUPEUgYIG3niuf56wDSRgs1srDJ2qAlVFllKuIe
-        txoSB0Qg0sIj7uB4JpyeiVK3APutgIq3iF9+/IX80xQ9JjrJEH3cjJpY6czBaufhdE18gZRZ9i0tQYDS
-        EDFc9huwO/P8N3rKLK1Ky+MAkXYkiShsjtyFrLMe3ti4eVKASsKa9iVjXboFGfxXf6hJBM3k/VwgAAAA
-        AElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABS0lE
+        QVQ4T52RvUoDQRSFp89b2PsyEYNsBF1h40ASBImICBKQgL5ACqsUFgqxsrCwstG8gCBCiIHsLcQiooUJ
+        6PHecWfYdXcT8SxnZvbeez72RwFQzd5Om40Mt9UMSdYCeEtrHoRHkoAo4ByrZUK4nQZwfVFsa6I8CLcy
+        AUa2NsG72bMgXE4D4hYdUQOvCM05qjsIl34W3V0/tQGrT0xxTLtoUR2HVMMz7k09DuHbaFGq4HdWzi3k
+        BY9oUhUHpLFPm9ijCjvAA25N30L46ACiQvmkeGEhffTQIB/b7C1aQ51dpTJucGX60VwCIHIQeYU7XEOH
+        HvTIQ2VYQvBUQi1cxRdfeQCRg3xgjMtpFxuDJfj9IvTQwxvIhOW75QFEDiKBs3EHwWCZ/8bIhKUnM7MA
+        osSTiONhGZgHEDnI77DoLwCRBBYiu7DIAf5vqG/DSRIbPQfdFwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="cherryPickToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAASlJREFUOE+dk7FLAzEUxp+zu5OT4Na6CK79NwoWxDGuuujgcHAgOHhTUl0KUgcHh6IU
-        QZxusojiYDcn4cT/wOHg831BT66UXDDwuyTH+768JC8LAMQ5Z0XEKLHNGWN2fDANrLXaxbefeK+tGeR5
-        jia4zFyDsixRFEUjjKsZrJ1NrYJ/wH2LUPiko+uvMObNYGMiYM946vwhcjD4APZew1D8iUdvsj01dYPL
-        dyB5DkPhA849HK+Pu1UGUWdA0Q2OYLGFe/1yrtjqGptugYILHGAfHZyghxe147/oOmDwHU5xjK6H89at
-        DKIrcXey+Zu2ZnKIkeZRZZCm6ZDFESLLMiRJgo5te+EY7s9Ab3NRWVHaEbSW+zKiyeqVDP0WYph5plxw
-        yS8cIw7FfAMstqWCsPVB/gAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="PuTTYToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAJVJREFUOE+lkwsOwCAIQ/XmHM2bsRRHRIIfNhNi4tInLa6W/eLN53rQFo5Wa42JCOAd
-        XNiix9YLIuKPAAIqD+itDjE6SXYAG0U8oyDeATQY2SH0hXOF+SAlMBzeCBViJ2ESH757cL3szdEYJ4Am
-        7m6aLPpH9AJ+JK7p2rRTI/MeT56thfDNpwC2/aiTqx9Hx7XYl3/uA3fvXxjHcEm8AAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABFklE
+        QVQ4T52SMUvDUBSF3+7u5CR0a10Krv0bBYXimLkudXAIBASHZnq2XQpShw4dilIEccpkEaVDu3UqRPwH
+        DoHjPbdaiZbXZw98ufeFe04uSQwAY5fCP7D0ke8AKf76mv8bkCTJRqi1AVmWIU3TjXAuF3DQmVkBW8AU
+        DcCLdLcfboJ5gMOx0cp5+gzFpvsGnE7d0PyOZ60nsyAf0F8A4asbGp9wrbAvj6qrAK93QNMdLmBRw6Nc
+        eRas91eg4QZnaKCCJo4xkTje8/4POPyANi5RVXgu3ptuLsCl+vhITctNzjGUPVYbRFHUY4iLOI4RhiEq
+        tqTGEa5+AkQ7wr5Q8qC41zJDmgsD09MAH36JD9zVum7YH5hPQW3Jdg4h7ZEAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="startAuthenticationAgentToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAQRJREFUWEftlosOQiEIhn10H+28mQWLIg/qD+ramm6s5fTwcZWUzop7oDyvkvxkifIa
-        Qu9vBasBrP/bABDlW0NTaF3XVXLOLK9caIVlqSdYsbUMILdi1LV8Tqy3gKLV4QKo3a6BogDaZVMwKwDq
-        +M0AuXPhppziXEsj83ugIRAz461NB5ALhHWlRLWOi5TkAAoCUQAEgkmnJ7jfitUAkNVf5fgJAWY9eWlF
-        VxSI44HjAbgR6YOdWcFVBVyz+mPy4qG/cp/g1OACQbBiR3s1z8qsUE1OQ4CQ21uXIj3hPfNZr6B3T4cL
-        nRNcAK2hlPYj1lN8phLPSlDU8tUjmfvlG2bnXx54AO7M4DdCkOhQAAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAAAz0lE
+        QVRYR+2T7Q7DIAhFfXQfzTdzuUwWbHCCYrYfnuSkKS1w04902aA2fwIvf4bQakeQi0YeQ1umeYwKSik1
+        50yipngEWqyhBHIj00/lZVqgdo+bboFXGajVtuiGLxqKtsDqNvRYn6LudIn2Wc3BvUZdtOH4teziCYnf
+        caQJEQBHmxxAhGD4XNa+Eh3AzQ1wA/xHAC9KgKUg1CSHeeV+wOcYbIEacdxRLvcEoKYolNcx5dMYIS8/
+        FkAM7kSdr3uWg64xQsx8j7bDTVFeBqT0Au7M4DclbnRnAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="generateOrImportKeyToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAScQAA
-        EnEB89x6jgAAAWZJREFUWEfFVgESgyAM05/zNH/GbLFaSgsFxHnH7YaMpE0I27f1TxQQ+3rIByGGsGXj
-        fCUJLeNTgBOZL0iY4F+QaIJrJECX14YAuAkRhkpAmmX2O4DFmIqCvYTuxZy7bS1iVCUHf4WAVyIAluAN
-        SfAYZjrxH3S4FoEtcK1zXJaCQM0wIjlQXw7OC7Ikk1lQOPUCkfMytW5gqpwt6Aoizam0l/VOAy+OsjeK
-        5TEpKmUty1pOrdc+DeO6st8MpRqg9IELSVkUj+Mwh1YVJzV70Zy6+h/ufsWEQw1A9JHQma38dvxDAIhY
-        ozz3Q+Vq+rcJ5OAhhNYJ6uLGJNCqf6I2pV3A8Vb78U6wO8DBI56SzwmkSlNn/kAgl2QpAU8SKASmvXD9
-        fUrG8g4yI5CeMSRq6g0gvg5ACXyUgKfj1TWzfsDNaxdQ6x2XayQTXARYe2+pYG62egwfr+Gsdcw/XbHL
-        Fw8ZUJh2CPwHFOR+6ftiupQAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAABPUlE
+        QVRYR8WUCxLDIAhEc3SPlptZF4NFhMT6Sd/M5gO4S2faHi8QlV4lhlALtdzaTxPOQi+P7MMMlsJMHl2P
+        GWgJs/lIflgmFfD0TpTiKsEzxm8g7gi6aGrV4RnBC5Lhos40tTLoCTM9QrAO1x7qnaiK3jMGb7gNt4Q5
+        OpmoiqJpDiuoJ8MhPufpmivoBjfdAxclWIQz5awWennki9tIeD0rvJEMvsnwGxeyT88y3BPPKnVhHSRZ
+        QVpifoh4nqcr9LWM8GGSST95fl04gC8bPUoFQ9OIBXD3lC4bwkHHAukiwkMIdE9awsMC6SI+NcJfXAA9
+        Do/0i3h9AVn/wwK1ti7Qg7HA9CJkwKa94jOA32H2K+7f7JNk+OgCZDDD7PehmIyKw7cuIMyLUOPeaDgo
+        BqPCEvDJdmOwwYwGOI4P5K6B5CqFNucAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="PuTTYToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAABJxAAAScQHz3HqOAAAAiklE
+        QVQ4T6WQCw7AIAhDPTpH82aMwohf/GxNXjSsbZhpI16wFc+Uc2YiOirRAA4DIfpaQLjdF5ixhFF2uYGB
+        AEB4VeBDxcM1mHtZXyIG1uFJ0MFc0yIxilUO+9dShG9gFYaaAgsO5p5Gb8GPF3cz8Ne+KvBwBDxmHaXr
+        97oqqNefAY9ZY7kpIlBKD6YYZRDeYkEDAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="gitMaintenanceToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAATJJREFUOE+Vk7FLQlEYxXP2v2gRgvwLGp2aHXNocFBwSKghLAihIGlJMEwapMgheg1C
-        QQ2PEIIaCgp0aGl0EBeHggedzvfUe9+7+eAq/IZz3vkOfJfP2ILx6+aTNVo506c+Waq954M+gP8xFgCD
-        V+CzraEW30xHF/RuAPdQQz1fwccVcF/WUEcWyM7yMQieG0B7R0NtZmTOX8Hf+esReGmO6dC/3QOcLY1o
-        8acZ5v05VfB0CrQK9jAfLnCrQDNrD/Phgocj/NbXrAHz4YK3a+DuYIyzDa+xjp/jtEK0+CrDvCpwM4kL
-        84W9yyJGlVWFaDMjc9NDivPCFsmyIEHPKWG4n1KIntyBn5nk45GX+N3aRH93RSF6vkvsnGF0vqEAtXXB
-        rDeRYfGt/kwMhd4kuPOsgj8UnPS5cM+uKgAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABKklE
+        QVQ4T5WQMUvDYBRFu/dfuDjpL3Ds5Oyog4OL4KCgg6gggoLiohCwxaEodhDjUFDQIUhB0EEHQQcXRwdx
+        6aBQ8Phe+uWlX0wgXjjQ+3pyIalk8zw7GgjkEDjFArhfA1GZjwd4badI17tTLMUDL+cQbadI/9/A0ylc
+        baRILxyQP/68M3cNaK+mSM86QpAMwNsN3Df7dOR+sQ7hUop2vSeO+PFzNnBbh9ZcecT3B6J9aM6UR3x/
+        4HqXn4PJ0qjvDzyeweVWn3CZXmOa770JQ7vezRHfBqKp4WMtg/ROFujujBvas44+Fw9IqsKQMKLEA+EK
+        n5s1Q7veE8f51WTAi4pfrUXe18YM7W7AS+EAnUO6R/OG9tIDed9E0btTLLkDEu+bOOJ3FrwAlV8iiP/h
+        s3ymuAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="settingsToolStripMenuItem2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAATNJREFUOE+9U7tOhEAUXev9i+2NpT8DNZHayo9QKjc028A3SEmyDSVakaWgIKGiwoYI
-        Jsd7Lgyy7iYaNnGSmzP3MWfuY+ZqJcv3/WeBO5Gt4zgugFUYhsbGkK1t224QBEc2y7JcOkkgZwAidRJI
-        sNq4uKf9p41x/0fA2xdl0HXdVAo3Rh/J/lZC0zSo6xrEeV+0B5zAvInU6fA8LzRp89ayLPV2Y6NfCW53
-        GRLZPZWA99aB+tjdteS34YG2bZFlmeI4kY341hPBywfwcADu9+9zAq2PB5h6mqaKZqRm3JrBbwSsP0kS
-        7cMigqqqEMcxiIsIiqJAFEUgniV45XOtgd3h82wP+r5HnucgnhDcPO5D9sEI9emNS6fm4+Rh6sPrGf4M
-        l45L5HrEYTzf68R/RMDgS+QL/31lPnV3vSUAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABD0lE
+        QVQ4T72RsW6DQBBEr89fpI9S5sdS5SMcKks0bvA3hBLJDSVJhUxBgURFRRoUsDTZGd85yHaBKDLSMLe7
+        dw/QOSqO460ZTNYAXJIkWzO81b/ucZ/EwxSTtQeoR3HN/nXPxPY/AYKDFgPGcVQGhXoxgOr7Hl3XKYMu
+        ADukG6CYrDmIomjPTTTf2jSNMvQ4F+BlVyK31XsDRF8jWGvg3IP5kZuHYUBZlkrW7HN+AXz8AG9H4PXw
+        PQdIPMBPL4pC6QHSYgD/P89z5SpA27bIsky5ClDXNdI0Vd4FfNoq6YDd8XQXME0TqqpS3gCeN4c9DwWz
+        ngPm10mz9qMzwKTrMj/5PF/Pn27mZkn7+FhvuF/xSnZirTgm4AAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="commitcountPerUserToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAXVJREFUOE+lk00oBGEYx9fZ2dHFzUEOlJODi4uDg2yuuJADDmoPbOSwcZhNaUNh1WRr
-        47B2Uz5KPi5COdDW7kUoRImyUvLzPNO+a1a7lkz9+/XMvPOb92OeMsDzr0sF39OwkAxJcCVUaJzz8SIC
-        TuXB+hsOVfRnQTwD1i0ofxQ8NnpDElxxpr/6DIErHJYSwI2MOko5VJG+EHkAfxqHpQUH5zAXA6ERLN7A
-        0BkoSwu2jiG4DEIjmLmAviNQqqBuozIkUZo4J+PRF4jtwpjUQiOYkhV17X+gzArYZo0Isw5V9CWwEzAY
-        AKERTMr0OzZfURrB/JvFcKYHZb5gLgrdPtmHaE4wfvJOa/wJpRFYj6P03HlR5guCYWjvlX0I5wQjh680
-        r9yjNAL/9QBt6SaU+YLEjhy67IHQLGFJ1u47eEFpBNOXE/SnOlHmBMn6Ftv9I2lda+3Z7l7QutqusN2n
-        oLVpxHLpxipJTZZa/+pe0WYq1jiF7n8Cii2LLGi4Vf4AAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAABaUlE
+        QVQ4T6WRPUgCcRjG3ZsbW9oaoqGgqaGlpcEhktZqMRqqIXBIKRqkhpMgjhL6giMhajBF6AOicgkLGgpB
+        l6jAokAKUoTo6X3ffMuLo4s6eO53z//+74/78AD4VxwX25ezJgU1MZ32cRwXeeicLlIVCLnrve9xXOSB
+        RAkw7iD8UVDs8JkU1EQef+sZCN9A6CYACrQrkxNy54HYIxDKQ+guSF8C0bhQBSsFYPwCQnfB3ikQWReq
+        YOEKGM5AyL11p8GkMDXyZz4E8UNgijpRBXP0RgPHb8KqAPvYRgyLQu5fAisJjIWFKpilx+/bLQtVsFQx
+        MFHyC+2C6AYwGBCqYPrsFd7Ek1AFRnES/nuf0C6IrAK9Q0IVBE/K6Np8EKogdDuKnnyn0C5IHtBPp29A
+        VMEavXsg/SJUwfz1DEZy/cJPQbat2+IhDfcW48jiIQ33Jqve4iENdxHQUUdppDRXyf1XayLg098Dzzu1
+        l7f+2KsJzgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="gitcommandLogToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAQxJREFUOE+Vk0tug0AQRO2dj5BlJG4TZcklvM6WA8BZWPo8IFjAgq/4/2lPtTKRgwme
-        jFTqAaoedIs5E9EJy7KsqygffLFZmqZ96rp+3nt2AgAyTfMm6u6ybZsg6X2sygCk9yD/AuxBlAGyjW07
-        SoDtYL7nxdknwLIstK4r63EvrwE7BEzTRNA4jr80DAN1XccfcwiAUZoR6Pueg1VVUVmWrwEwt23Lgbqu
-        uWZZRnEcUxRFxwD0iRDelOc5pWnKoTAMWUEQ8Gz+bGGeZyqKgpIkYbPv++S6LnmeR47j8B7tHc4Aw5Nt
-        NE1DUmjrcIiGYXyBrCJ45Xn4+Q/ESbsIvQm9vxA8lyfA3klTuXcHVnH9VeR4oOEAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAAA7UlE
+        QVQ4T52QOQ6DMBBFU3KElLle6rQcgLtQ5jwgKKBgFfvOxH8SEGEXIz3NGL6fZd+IiFEU5Sl4r6Gqqoh8
+        c3PGAUHRVwuCLck4HAkm/boANZecFswRdV4wr192XdB1HfV9z0znYY3aFTRNw9R1/UdVVVQUBSL7AgSH
+        MCjLknuSJBTHMSL7AoTzPOcNaZpyD4KAXNclx3EQ2RbgntiEk8IwJN/3eZNt24xlWfwWm4K2bSmKIvI8
+        j8OmaZKu62QYBmmaxjOutykQnR9suEaWZSNY4ztqVSDL8gs/zoDsQiBKEtwFjwOQkRaCa9DtAxpVIREe
+        COJvAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="aboutToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAK9QAA
-        CvUBbxZRbgAAAgtJREFUOE+dU09Ik2Ec/nb5QOjkIQgvdZBgBynFsqMHPXVI7OIlqMM3EKWo0ESFHFHr
-        IMEU50YkDhGEXZyIdWljFGvD/QEdO0gR/kMdw8gp/sGefo/b+27prRce3ofn9/ye7/2+7/faABi3vGmj
-        YpnCLcF9wZ2SHpU9IPAJjpU37rhhGAxoHE8pWE2+NHojeXz4AQR3iyCnxpp4LeVnrw5o8CQ6W/xZTK0B
-        k1tAfxponV47Azk11uihlyGVASbTp34CbsGrFcAvu1rk1Fijp3QSUwfUj8QePwvtYEyKg1lgIAPMyBPV
-        IqfGGj30skcHNIzGo6OZE7xcAp4ni3BEjvQrkCudHnrZU34FT/LYK0d88u0UXdEiPPI0tciVTo9PvI3S
-        80/ASPYPrPABHoWKcC+f6ABypVuRQ7gzp/yQ+zrg5rsvKVeiAOtzAR0ff59hOHWkA8iVTg+97NEB1wcD
-        zq5P63ga2UN7MIe22RzeLh7oAHJqrNFDL3t0gFF1+cptbxqvY7/wYD6Hu4FNvIkXdAA5NdbooZc95QDD
-        MGt7/EPNE8twft2FtbCDe4EN/RfIqbFGD70yzuU54FTJunS1e9zFdMf8Kl6EttEXzsueR59waqzRQ+/5
-        SWSAjQVBXc1D13v7UHBFTJx92J1z36mxVvLYLgSoC8KjCaoF1wT2EsipmRUXr3wX+DH+F38BZdWPV89n
-        BjUAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAryAAAK8gE9UvcRAAAB+0lE
+        QVQ4T52TP2gTcRzFr8uB4OQgiIsOImQQtBRdHXRyUJxcBB2uIBFFRS1asEE0DiKkxbRFFEMRhCxGirqY
+        EJTaYpuADRmKIlZFG0JFYzGW+vx+7p8anfzC4x7vve+7y90vjiSnZ7jyO1xD0lAytEPA0fDiLLudBd6O
+        0arOlJu6+UoqLAaAo+GRifJ/FHRnp4/sytU1Ni/d/iCdq0q778z7gKPhkSHbWeDSPvZayhguzkk5u0YD
+        R8MjEz6Ja1ZQsG1w8tjJ4oKum9lfl87XpLt2x2jgaHhkyLJjVlDQPTQ1MVRb1oUX0qmZAL3ldvwT4JFO
+        hiw7cUFPdub7iD3i8WcrSk4EyNrdooFHOplRy7Jj1q+CwfoPeaUlHS4GyMwu+8sMPNK98jdlaiu8yK9m
+        BQVbrz2ppKdb8h63dODhZx9XK21/mYFHOhmy7JgVFGzuz6eSj97qRPmL9hca2nevoSvPl/xlBo6GR4Ys
+        O2YFBc6qteu2j1R1afKTDo43tCf/XpenWv4yA0fDI0OWHbPCAsdxN53ODey8NavU00V5Dxa0N/8u/gpw
+        NDwyZNmJCzhVNqs3HB1O0947/kZnix/VV2ratak+42h4ZMh2nkQKujAMW9YfSt9IDBTmTOfEKZG6/xIN
+        L8x0/VUQwcY1rDFsNCRCwNH+/W/8f8j5CSB9pjF5WyTOAAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/GitUI/FormCommit.Designer.cs
+++ b/GitUI/FormCommit.Designer.cs
@@ -64,7 +64,7 @@ namespace GitUI
             this.toolStripContainer1 = new System.Windows.Forms.ToolStripContainer();
             this.Loading = new System.Windows.Forms.PictureBox();
             this.Unstaged = new GitUI.FileStatusList();
-            this.toolbarUnstaged = new System.Windows.Forms.ToolStrip();
+            this.toolbarUnstaged = new ToolStripEx();
             this.toolRefreshItem = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.workingToolStripMenuItem = new System.Windows.Forms.ToolStripDropDownButton();
@@ -80,12 +80,12 @@ namespace GitUI
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.selectionFilterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripProgressBar1 = new System.Windows.Forms.ToolStripProgressBar();
-            this.toolbarSelectionFilter = new System.Windows.Forms.ToolStrip();
+            this.toolbarSelectionFilter = new ToolStripEx();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.selectionFilter = new System.Windows.Forms.ToolStripComboBox();
             this.LoadingStaged = new System.Windows.Forms.PictureBox();
             this.Staged = new GitUI.FileStatusList();
-            this.toolbarStaged = new System.Windows.Forms.ToolStrip();
+            this.toolbarStaged = new ToolStripEx();
             this.toolStageAllItem = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStageItem = new System.Windows.Forms.ToolStripButton();
@@ -98,7 +98,7 @@ namespace GitUI
             this.SolveMergeconflicts = new System.Windows.Forms.Button();
             this.SelectedDiff = new GitUI.Editor.FileViewer();
             this.Message = new GitUI.SpellChecker.EditNetSpell();
-            this.toolbarCommit = new System.Windows.Forms.ToolStrip();
+            this.toolbarCommit = new ToolStripEx();
             this.commitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripDropDownButton();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripDropDownButton();
             this.closeDialogAfterEachCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1044,7 +1044,7 @@ namespace GitUI
         private Button CommitAndPush;
         private Button Amend;
         private Button Reset;
-        private ToolStrip toolbarCommit;
+        private ToolStripEx toolbarCommit;
         private ToolStripDropDownButton commitMessageToolStripMenuItem;
         private ToolStripDropDownButton toolStripMenuItem3;
         private ToolStripMenuItem closeDialogAfterEachCommitToolStripMenuItem;
@@ -1052,7 +1052,7 @@ namespace GitUI
         private ToolStripMenuItem refreshDialogOnFormFocusToolStripMenuItem;
         private PictureBox Loading;
         private FileStatusList Unstaged;
-        private ToolStrip toolbarUnstaged;
+        private ToolStripEx toolbarUnstaged;
         private ToolStripProgressBar toolStripProgressBar1;
         private ToolStripDropDownButton workingToolStripMenuItem;
         private ToolStripMenuItem showIgnoredFilesToolStripMenuItem;
@@ -1064,7 +1064,7 @@ namespace GitUI
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripMenuItem editGitIgnoreToolStripMenuItem;
         private ToolStripMenuItem deleteAllUntrackedFilesToolStripMenuItem;
-        private ToolStrip toolbarStaged;
+        private ToolStripEx toolbarStaged;
         private FileStatusList Staged;
         private Button Cancel;
         private ToolStripButton toolStageItem;
@@ -1084,7 +1084,7 @@ namespace GitUI
         private PictureBox LoadingStaged;
 		private ToolStripSeparator toolStripMenuItem2;
 		private ToolStripContainer toolStripContainer1;
-		private ToolStrip toolbarSelectionFilter;
+		private ToolStripEx toolbarSelectionFilter;
 		private ToolStripLabel toolStripLabel1;
 		private ToolStripComboBox selectionFilter;
 		private ToolStripMenuItem selectionFilterToolStripMenuItem;

--- a/GitUI/FormEditor.Designer.cs
+++ b/GitUI/FormEditor.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             this.fileViewer = new GitUI.Editor.FileViewer();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.toolStrip1 = new ToolStripEx();
             this.toolStripSaveButton = new System.Windows.Forms.ToolStripButton();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.toolStrip1.SuspendLayout();
@@ -110,7 +110,7 @@
         #endregion
 
         private GitUI.Editor.FileViewer fileViewer;
-        private System.Windows.Forms.ToolStrip toolStrip1;
+        private ToolStripEx toolStrip1;
         private System.Windows.Forms.ToolStripButton toolStripSaveButton;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }

--- a/GitUI/FormStash.Designer.cs
+++ b/GitUI/FormStash.Designer.cs
@@ -36,7 +36,7 @@ namespace GitUI
             this.gitStashBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.toolStrip1 = new ToolStripEx();
             this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.Stashes = new System.Windows.Forms.ToolStripComboBox();
@@ -366,7 +366,7 @@ namespace GitUI
         private System.Windows.Forms.BindingSource gitStashBindingSource;
         private System.Windows.Forms.RichTextBox StashMessage;
         private FileViewer View;
-        private System.Windows.Forms.ToolStrip toolStrip1;
+        private ToolStripEx toolStrip1;
         private System.Windows.Forms.ToolStripButton toolStripButton1;
         private System.Windows.Forms.ToolStripLabel toolStripLabel1;
         private System.Windows.Forms.ToolStripComboBox Stashes;

--- a/GitUI/FormTranslate.Designer.cs
+++ b/GitUI/FormTranslate.Designer.cs
@@ -31,7 +31,7 @@ namespace GitUI
         {
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.toolStrip1 = new ToolStripEx();
             this.toolStripButtonNew = new System.Windows.Forms.ToolStripButton();
             this.saveAs = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -454,7 +454,7 @@ namespace GitUI
         #endregion
 
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.ToolStrip toolStrip1;
+        private ToolStripEx toolStrip1;
         private System.Windows.Forms.ToolStripLabel translateProgress;
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.ListBox translateCategories;

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -113,7 +113,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="FormDirtyDirWarn.Designer.cs">
-      <DependentUpon>FormDirtyDirWarn.cs</DependentUpon>          
+      <DependentUpon>FormDirtyDirWarn.cs</DependentUpon>
     </Compile>
     <Compile Include="FormRecentReposSettings.Designer.cs">
       <DependentUpon>FormRecentReposSettings.cs</DependentUpon>
@@ -171,6 +171,9 @@
     <Compile Include="Hotkey\HotkeySettingsManager.cs" />
     <Compile Include="Hotkey\KeysExtensions.cs" />
     <Compile Include="Hotkey\TextboxHotkey.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="MenuStripEx.cs">
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="PathFormatter.cs" />
@@ -689,7 +692,7 @@
     <Compile Include="FormApplyPatch.Designer.cs">
       <DependentUpon>FormApplyPatch.cs</DependentUpon>
     </Compile>
-    <Compile Include="NativeMethods.cs" />
+    <Compile Include="Native.cs" />
     <Compile Include="FormOpenDirectory.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -727,6 +730,9 @@
     </Compile>
     <Compile Include="SpellChecker\SpellCheckEditControl.cs" />
     <Compile Include="SpellChecker\TextBoxHelper.cs" />
+    <Compile Include="ToolStripEx.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="ToolStripGitStatus.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GitUI/MenuStripEx.cs
+++ b/GitUI/MenuStripEx.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace GitUI
+{
+    /// <summary>
+    /// This class adds on to the functionality provided in System.Windows.Forms.ToolStrip.
+    /// </summary>
+    public class MenuStripEx : MenuStrip
+    {
+        private bool clickThrough = true;
+
+        /// <summary>
+        /// Gets or sets whether the ToolStripEx honors item clicks when its containing form does
+        /// not have input focus.
+        /// </summary>
+        /// <remarks>
+        /// Default value is false, which is the same behavior provided by the base ToolStrip class.
+        /// </remarks>
+        public bool ClickThrough
+        {
+            get
+            {
+                return this.clickThrough;
+            }
+
+            set
+            {
+                this.clickThrough = value;
+            }
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+
+            if (this.clickThrough &&
+                m.Msg == NativeConstants.WM_MOUSEACTIVATE &&
+                m.Result == (IntPtr)NativeConstants.MA_ACTIVATEANDEAT)
+            {
+                m.Result = (IntPtr)NativeConstants.MA_ACTIVATE;
+            }
+        }
+    }
+}

--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -69,4 +69,17 @@ namespace GitUI
 
         private NativeMethods() { }
     }
+
+    internal sealed class NativeConstants
+    {
+        private NativeConstants()
+        {
+        }
+
+        internal const uint WM_MOUSEACTIVATE = 0x21;
+        internal const uint MA_ACTIVATE = 1;
+        internal const uint MA_ACTIVATEANDEAT = 2;
+        internal const uint MA_NOACTIVATE = 3;
+        internal const uint MA_NOACTIVATEANDEAT = 4;
+    }
 }

--- a/GitUI/ToolStripEx.cs
+++ b/GitUI/ToolStripEx.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace GitUI
+{
+    /// <summary>
+    /// This class adds on to the functionality provided in System.Windows.Forms.ToolStrip.
+    /// </summary>
+    public class ToolStripEx : ToolStrip
+    {
+        private bool clickThrough = true;
+
+        /// <summary>
+        /// Gets or sets whether the ToolStripEx honors item clicks when its containing form does
+        /// not have input focus.
+        /// </summary>
+        /// <remarks>
+        /// Default value is false, which is the same behavior provided by the base ToolStrip class.
+        /// </remarks>
+        public bool ClickThrough
+        {
+            get
+            {
+                return this.clickThrough;
+            }
+
+            set
+            {
+                this.clickThrough = value;
+            }
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+
+            if (this.clickThrough &&
+                m.Msg == NativeConstants.WM_MOUSEACTIVATE &&
+                m.Result == (IntPtr)NativeConstants.MA_ACTIVATEANDEAT)
+            {
+                m.Result = (IntPtr)NativeConstants.MA_ACTIVATE;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I use two monitors at work and I often keep Git Extensions open on my second monitor. I will be working on my left monitor and then go over to hit a simple button in git extensions on the right monitor, but when I click it nothing happens except the git extensions form is brought into the foreground. This meant that I had to click twice to hit the button in the ToolStrip or the menu item in the MenuStrip. This was misleading because if you hovered over the toolstrip buttons while the form is in the background they would highlight as if you could click them.

As per this article (http://blogs.msdn.com/b/rickbrew/archive/2006/01/09/511003.aspx) I took the liberty of creating ToolStripEx and MenuStripEx classes that override the WndProc method for the control to enable click-through behavior when window is out of focus. I then swapped those controls to use these classes instead of the native classes.  I know that some of my co-workers have been annoyed by this behavior as well so I'm creating a pull request with my changes.
