### PR TITLE
Impact graph plugin to respect the .mailmap file

### DIFF
--- a/GitCommands/Statistics/ImpactLoader.cs
+++ b/GitCommands/Statistics/ImpactLoader.cs
@@ -12,6 +12,11 @@ namespace GitCommands.Statistics
     {
         public delegate void UpdateEventHandler(Commit commit);
 
+        /// <summary>
+        /// property to enable mailmap respectfulness
+        /// </summary>
+        public bool RespectMailmap { get; set; }
+
         public event EventHandler Exited;
         public event EventHandler Error;
         public event UpdateEventHandler Updated;
@@ -87,7 +92,9 @@ namespace GitCommands.Statistics
         {
             try
             {
-                string command = "log --pretty=tformat:\"--- %ad --- %an\" --numstat --date=iso -C --all --no-merges";
+                string authorName = this.RespectMailmap ? "%aN" : "%an";
+
+                string command = "log --pretty=tformat:\"--- %ad --- " + authorName + "\" --numstat --date=iso -C --all --no-merges";
 
                 git = new GitCommandsInstance();
                 git.StreamOutput = true;

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -46,6 +46,7 @@ namespace GitImpact
         public ImpactControl()
         {
             impact_loader = new ImpactLoader();
+            impact_loader.RespectMailmap = true; // respect the .mailmap file
             impact_loader.Updated += new ImpactLoader.UpdateEventHandler(OnImpactUpdate);
 
             authors = new Dictionary<string, ImpactLoader.DataPoint>();


### PR DESCRIPTION
This is a quick patch to make the Impact graph plugin respect the git .mailmap file, for example if one person commits under two names accidentally, it doesn't mess up the impact graph as much.

It's implemented as a default-off (current behaviour) property of the ImpactLoader class, but the plugin itself enables this option before getting the data.
