### PR TITLE
Fixed diff between "copied from file" vs "copied to file"

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1505,7 +1505,7 @@ namespace GitCommands
             var arguments = string.Format("diff{0} -M -C \"{1}\" \"{2}\" -- {3} {4}", extraDiffArguments, to, from, fileName, oldFileName);
             patchManager.LoadPatch(this.RunCachableCmd(Settings.GitCommand, arguments, encoding), false);
 
-            return patchManager.Patches.Count > 0 ? patchManager.Patches[0] : null;
+            return patchManager.Patches.Count > 0 ? patchManager.Patches[patchManager.Patches.Count-1] : null;
         }
 
         public Patch GetSingleDiff(string @from, string to, string fileName, string extraDiffArguments, Encoding encoding)


### PR DESCRIPTION
First patch for copied files compares "copied from file" vs "copied from file". Second compares "copied from file" vs "copied to file".

To reproduce:
Copy some big file A to B. 
Make changes in both files.
Commit.

When you click on file B inf FileList, you can see diff between file A and file A, instead of A vs B.
