### PR TITLE
Use environment new line when copying commit info

### DIFF
--- a/GitUI/CommitInfo.cs
+++ b/GitUI/CommitInfo.cs
@@ -213,7 +213,7 @@ namespace GitUI
 
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Clipboard.SetText(string.Concat(_RevisionHeader.Text, Environment.NewLine, RevisionInfo.Text));
+            Clipboard.SetText(string.Concat(_RevisionHeader.Text, Environment.NewLine, RevisionInfo.Text).Replace("\n",Environment.NewLine));
         }
 
         private void showContainedInBranchesRemoteToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Info is read from XML so according
http://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
"\n" is always used as line ending.
So this commit transforms "\n" to environment line ending
