### PR TITLE
Avoid long wait time (affecting certain configurations) while determining encoding

### DIFF
--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -879,9 +879,17 @@ namespace GitCommands
         private static void SetupSystemEncoding()
         {
             //check whether GitExtensions works with standard msysgit or msysgit-unicode
-            String controlStr = "ą";
+
+            // invoke a git command that returns an invalid argument in its response, and
+            // check if a unicode-only character is reported back. If so assume msysgit-unicode
+
+            // git config --get with a malformed key (no section) returns:
+            // "error: key does not contain a section: <key>"
+            const string controlStr = "ą"; // "a caudata"
+            string arguments = string.Format("config --get {0}", controlStr);
+
             int exitCode;
-            String s = Module.RunGitCmd(controlStr, out exitCode, null, Encoding.UTF8);
+            String s = Module.RunGitCmd(arguments, out exitCode, null, Encoding.UTF8);
             if (s != null && s.IndexOf(controlStr) != -1)
                 SystemEncoding = Encoding.UTF8;
             else


### PR DESCRIPTION
Currently, git is invoked with an invalid command, using a unicode-only character as the command name. Invoking an unknown command seems to cause git to search all command files. This search takes about 2 minutes when these files are not in the file system cache.

This long wait time seems to affect only certain configurations (otherwise it would have been reported before). We have it consistently in our team (windows 7/64 bit machines, 1.7.9.msysgit.0).

Note that I don't have msysgit-unicode, so I can't test if the alternative check based on "git config --get 'unicode_character'" really behaves in an equivalent way to "git 'unicode_character'". 
