### PR TITLE
Javascript syntax highlighting

### DIFF
--- a/GitUI/Editor/EditorOptions.cs
+++ b/GitUI/Editor/EditorOptions.cs
@@ -30,6 +30,9 @@
                     case "CPP":
                         syntax = "C#";
                         break;
+                    case "JS":
+                        syntax = "JavaScript";
+                        break;
                     default:
                         break;
                 }


### PR DESCRIPTION
The ICSharpCode.TextEditor DLL has builtin syntax highlighting for Javascript and a few others. I'm not currently able to test the other formats, but Javascript highlighting shows in the Commit dialog with this addition.
