### PR TITLE
Create registry key if not exists

### DIFF
--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -1072,7 +1072,11 @@ namespace GitCommands
             get
             {
                 if (_VersionIndependentRegKey == null)
+                {
                     _VersionIndependentRegKey = Registry.CurrentUser.OpenSubKey("Software\\GitExtensions\\GitExtensions", true);
+                    if (_VersionIndependentRegKey == null)
+                        _VersionIndependentRegKey = Registry.CurrentUser.CreateSubKey("Software\\GitExtensions\\GitExtensions", RegistryKeyPermissionCheck.ReadWriteSubTree);
+                }
                 return _VersionIndependentRegKey;
             }
         }


### PR DESCRIPTION
Create registry key if not exists to avoid null reference exception. On a new PC, compile from source, the registry key does not exist, so create it here
