### PR TITLE
Refresh revisions grid after calling userscript from toolbar

### DIFF
--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -350,9 +350,9 @@ namespace GitUI
                 splitter.SplitRecentRepos(repo, mostRecentRepos, mostRecentRepos);
             }
 
-            if (mostRecentRepos.Count > 0)
-                _NO_TRANSLATE_Workingdir.Text = mostRecentRepos[0].Caption;
-            _NO_TRANSLATE_Workingdir.Text = Settings.WorkingDir;
+            _NO_TRANSLATE_Workingdir.Text = mostRecentRepos.Count > 0 
+                ? mostRecentRepos[0].Caption 
+                : Settings.WorkingDir;
         }
 
         /// <summary>


### PR DESCRIPTION
1. FileSystemWatcher is on.
2. Create user script affecting repository (i.e. “git reset --hard HEAD~1” for test)
3. Add toolbar button to call script
4. Click that button and run script

cur: repository was changed and refresh button displays an exclamation, but revisions graph is still outdated, so user should manually refresh graph
exp: repository graph should automatically be refreshed as well as after calling userscript from context menu
