### PR TITLE
TabOrder set to be able to go through usual commit path only using keyboard

### DIFF
--- a/GitUI/FileStatusList.cs
+++ b/GitUI/FileStatusList.cs
@@ -49,6 +49,18 @@ namespace GitUI
             }
         }
 
+        public new bool Focus()
+        {
+            if (FileStatusListBox.Items.Count > 0)
+            {
+                if (FileStatusListBox.SelectedItem == null)
+                    FileStatusListBox.SelectedIndex = 0;
+                return FileStatusListBox.Focus();
+            }
+            else
+                return false;
+        }
+
         void FileStatusListBox_MeasureItem(object sender, MeasureItemEventArgs e)
         {
             var gitItemStatus = (GitItemStatus)FileStatusListBox.Items[e.Index];

--- a/GitUI/FormCommit.Designer.cs
+++ b/GitUI/FormCommit.Designer.cs
@@ -283,6 +283,7 @@ namespace GitUI
             this.Cancel.Name = "Cancel";
             this.Cancel.Size = new System.Drawing.Size(129, 23);
             this.Cancel.TabIndex = 15;
+            this.Cancel.TabStop = false;
             this.Cancel.Text = "Cancel";
             this.Cancel.UseVisualStyleBackColor = true;
             // 
@@ -305,6 +306,7 @@ namespace GitUI
             this.splitMain.Size = new System.Drawing.Size(918, 644);
             this.splitMain.SplitterDistance = 397;
             this.splitMain.TabIndex = 0;
+            this.splitMain.TabStop = false;
             // 
             // splitLeft
             // 
@@ -326,6 +328,7 @@ namespace GitUI
             this.splitLeft.Size = new System.Drawing.Size(397, 644);
             this.splitLeft.SplitterDistance = 284;
             this.splitLeft.TabIndex = 3;
+            this.splitLeft.TabStop = false;
             // 
             // toolStripContainer1
             // 
@@ -340,6 +343,7 @@ namespace GitUI
             this.toolStripContainer1.Name = "toolStripContainer1";
             this.toolStripContainer1.Size = new System.Drawing.Size(397, 284);
             this.toolStripContainer1.TabIndex = 13;
+            this.toolStripContainer1.TabStop = false;
             // 
             // toolStripContainer1.TopToolStripPanel
             // 
@@ -370,7 +374,7 @@ namespace GitUI
             this.Unstaged.SelectedIndex = -1;
             this.Unstaged.SelectedItem = null;
             this.Unstaged.Size = new System.Drawing.Size(397, 255);
-            this.Unstaged.TabIndex = 10;
+            this.Unstaged.TabIndex = 1;
             // 
             // toolbarUnstaged
             // 
@@ -561,6 +565,7 @@ namespace GitUI
             this.Staged.SelectedItem = null;
             this.Staged.Size = new System.Drawing.Size(397, 328);
             this.Staged.TabIndex = 16;
+            this.Staged.TabStop = false;
             // 
             // toolbarStaged
             // 
@@ -668,6 +673,7 @@ namespace GitUI
             this.splitRight.Size = new System.Drawing.Size(517, 644);
             this.splitRight.SplitterDistance = 502;
             this.splitRight.TabIndex = 0;
+            this.splitRight.TabStop = false;
             // 
             // llShowPreview
             // 
@@ -690,7 +696,7 @@ namespace GitUI
             this.SolveMergeconflicts.Location = new System.Drawing.Point(14, 12);
             this.SolveMergeconflicts.Name = "SolveMergeconflicts";
             this.SolveMergeconflicts.Size = new System.Drawing.Size(188, 42);
-            this.SolveMergeconflicts.TabIndex = 8;
+            this.SolveMergeconflicts.TabIndex = 0;
             this.SolveMergeconflicts.Text = "There are unresolved mergeconflicts\r\n";
             this.SolveMergeconflicts.UseVisualStyleBackColor = false;
             this.SolveMergeconflicts.Visible = false;
@@ -705,6 +711,7 @@ namespace GitUI
             this.SelectedDiff.Name = "SelectedDiff";
             this.SelectedDiff.Size = new System.Drawing.Size(517, 502);
             this.SelectedDiff.TabIndex = 0;
+            this.SelectedDiff.TabStop = false;
             // 
             // Message
             // 
@@ -715,7 +722,8 @@ namespace GitUI
             this.Message.MistakeFont = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Underline);
             this.Message.Name = "Message";
             this.Message.Size = new System.Drawing.Size(342, 110);
-            this.Message.TabIndex = 4;
+            this.Message.TabIndex = 2;
+            this.Message.WatermarkText = "";
             this.Message.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Message_KeyDown);
             this.Message.KeyUp += new System.Windows.Forms.KeyEventHandler(this.Message_KeyUp);
             // 
@@ -853,6 +861,7 @@ namespace GitUI
             this.Commit.Name = "Commit";
             this.Commit.Size = new System.Drawing.Size(171, 26);
             this.Commit.TabIndex = 3;
+            this.Commit.TabStop = false;
             this.Commit.Text = "&Commit";
             this.Commit.UseVisualStyleBackColor = true;
             this.Commit.Click += new System.EventHandler(this.CommitClick);
@@ -866,6 +875,7 @@ namespace GitUI
             this.CommitAndPush.Name = "CommitAndPush";
             this.CommitAndPush.Size = new System.Drawing.Size(171, 26);
             this.CommitAndPush.TabIndex = 9;
+            this.CommitAndPush.TabStop = false;
             this.CommitAndPush.Text = "C&ommit && push";
             this.CommitAndPush.UseVisualStyleBackColor = true;
             this.CommitAndPush.Click += new System.EventHandler(this.CommitAndPush_Click);
@@ -877,6 +887,7 @@ namespace GitUI
             this.Amend.Name = "Amend";
             this.Amend.Size = new System.Drawing.Size(171, 26);
             this.Amend.TabIndex = 10;
+            this.Amend.TabStop = false;
             this.Amend.Text = "&Amend last commit";
             this.Amend.UseVisualStyleBackColor = true;
             this.Amend.Click += new System.EventHandler(this.AmendClick);
@@ -888,6 +899,7 @@ namespace GitUI
             this.Reset.Name = "Reset";
             this.Reset.Size = new System.Drawing.Size(171, 26);
             this.Reset.TabIndex = 11;
+            this.Reset.TabStop = false;
             this.Reset.Text = "Reset changes";
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.ResetClick);

--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -34,7 +34,6 @@ namespace GitUI.SpellChecker
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.SpellCheckTimer = new System.Windows.Forms.Timer(this.components);
             this.TextBox = new System.Windows.Forms.RichTextBox();
-            this.EmptyLabel = new System.Windows.Forms.Label();
             this.SpellCheckContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -69,27 +68,15 @@ namespace GitUI.SpellChecker
             this.TextBox.Text = "";
             this.TextBox.SizeChanged += new System.EventHandler(this.TextBoxSizeChanged);
             this.TextBox.TextChanged += new System.EventHandler(this.TextBoxTextChanged);
+            this.TextBox.Enter += new System.EventHandler(this.TextBox_Enter);
             this.TextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyDown);
             this.TextBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyUp);
             this.TextBox.Leave += new System.EventHandler(this.TextBoxLeave);
-            // 
-            // EmptyLabel
-            // 
-            this.EmptyLabel.BackColor = System.Drawing.SystemColors.Window;
-            this.EmptyLabel.Cursor = System.Windows.Forms.Cursors.IBeam;
-            this.EmptyLabel.ForeColor = System.Drawing.SystemColors.InactiveCaption;
-            this.EmptyLabel.Location = new System.Drawing.Point(3, 3);
-            this.EmptyLabel.Name = "EmptyLabel";
-            this.EmptyLabel.Size = new System.Drawing.Size(117, 27);
-            this.EmptyLabel.TabIndex = 2;
-            this.EmptyLabel.Text = "Enter message";
-            this.EmptyLabel.Click += new System.EventHandler(this.EmptyLabelClick);
             // 
             // EditNetSpell
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.EmptyLabel);
             this.Controls.Add(this.TextBox);
             this.Name = "EditNetSpell";
             this.Size = new System.Drawing.Size(386, 336);
@@ -105,6 +92,5 @@ namespace GitUI.SpellChecker
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.Timer SpellCheckTimer;
         private System.Windows.Forms.RichTextBox TextBox;
-        private System.Windows.Forms.Label EmptyLabel;
     }
 }

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -26,29 +26,33 @@ namespace GitUI.SpellChecker
         private readonly SpellCheckEditControl _customUnderlines;
         private Spelling _spelling;
         private static WordDictionary _wordDictionary;
+        private Font TextBoxFont;
 
         public EditNetSpell()
         {
             InitializeComponent();
+            TextBoxFont = TextBox.Font;
             Translate();
-
-            EmptyLabel.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Italic);
 
             _customUnderlines = new SpellCheckEditControl(TextBox);
 
             SpellCheckTimer.Enabled = false;
 
             EnabledChanged += EditNetSpellEnabledChanged;
+            ShowWatermark();
         }
 
         public override string Text
         {
-            get { return TextBox.Text; }
+            get 
+            {
+                return IsWatermarkShowing ? string.Empty : TextBox.Text; 
+            }
             set
             {
+                HideWatermark();
                 TextBox.Text = value;
-
-                UpdateEmptyLabel();
+                ShowWatermark();
             }
         }
 
@@ -61,18 +65,27 @@ namespace GitUI.SpellChecker
             if (Enabled)
             {
                 TextBox.ReadOnly = false;
-                UpdateEmptyLabel();
+                ShowWatermark();
             }
             else
             {
                 TextBox.ReadOnly = true;
-                EmptyLabel.Visible = false;
+                HideWatermark();
             }
         }
 
-        public void SetEmptyMessage(string message)
+        private bool IsWatermarkShowing = false;
+        private string _WatermarkText = "";
+        public string WatermarkText
         {
-            EmptyLabel.Text = message;
+            get { return _WatermarkText; }
+
+            set 
+            {
+                HideWatermark();
+                _WatermarkText = value;
+                ShowWatermark();
+            }      
         }
 
         private void EditNetSpellLoad(object sender, EventArgs e)
@@ -409,25 +422,12 @@ namespace GitUI.SpellChecker
 
         private void TextBoxSizeChanged(object sender, EventArgs e)
         {
-            EmptyLabel.Location = new Point(3, 3);
-            EmptyLabel.Size = new Size(Size.Width - 6, Size.Height - 6);
             SpellCheckTimer.Enabled = true;
-        }
-
-        private void UpdateEmptyLabel()
-        {
-            EmptyLabel.Visible = TextBox.TextLength == 0;
-        }
-
-        private void EmptyLabelClick(object sender, EventArgs e)
-        {
-            EmptyLabel.Visible = false;
-            TextBox.Focus();
         }
 
         private void TextBoxLeave(object sender, EventArgs e)
         {
-            UpdateEmptyLabel();
+            ShowWatermark();
         }
 
         private void TextBox_KeyUp(object sender, KeyEventArgs e)
@@ -451,9 +451,32 @@ namespace GitUI.SpellChecker
             OnKeyDown(e);
         }
 
-        public void StartEditing()
+        private void TextBox_Enter(object sender, EventArgs e)
         {
-            EmptyLabelClick(null, null);
+            HideWatermark();
         }
+
+        private void ShowWatermark()
+        {
+            if (!Focused && string.IsNullOrEmpty(TextBox.Text))
+            {
+                TextBox.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Italic);
+                TextBox.ForeColor = SystemColors.InactiveCaption;
+                TextBox.Text = WatermarkText;
+                IsWatermarkShowing = true;
+            }
+        }
+
+        private void HideWatermark()
+        {
+            if (IsWatermarkShowing)
+            {
+                TextBox.Font = TextBoxFont;
+                TextBox.Text = string.Empty;
+                TextBox.ForeColor = SystemColors.WindowText;
+            }
+            IsWatermarkShowing = false;
+        }
+
     }
 }


### PR DESCRIPTION
I know that hotkey can be set to go to commit message box, but using tab is more convenient and intuitive.
