### PR TITLE
Improved commits loading performance

### DIFF
--- a/GitCommands/DateTimeUtils.cs
+++ b/GitCommands/DateTimeUtils.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace GitCommands
+{
+    public static class DateTimeUtils
+    {
+        /// <summary>
+        /// Midnight 1 January 1970.
+        /// </summary>
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0);
+
+        public static bool TryParseUnixTime(string unixTime, out DateTime result)
+        {
+            long seconds;
+            if (long.TryParse(unixTime, out seconds))
+            {
+                result = UnixEpoch.AddSeconds(seconds);
+                return true;
+            }
+
+            result = default(DateTime);
+            return false;
+        }
+
+        public static DateTime ParseUnixTime(string unixTime)
+        {
+            return UnixEpoch.AddSeconds(long.Parse(unixTime));
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommitData.cs" />
+    <Compile Include="DateTimeUtils.cs" />
     <Compile Include="FileHelper.cs" />
     <Compile Include="Git\GitCommand.cs" />
     <Compile Include="Git\EncodingHelper.cs" />

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -131,9 +131,9 @@ namespace GitCommands
                         /* Tree                    */ "%T%n" +
                         /* Author Name             */ "%aN%n" +
                         /* Author Email            */ "%aE%n" +
-                        /* Author Date             */ "%ai%n" +
+                        /* Author Date             */ "%at%n" +
                         /* Committer Name          */ "%cN%n" +
-                        /* Committer Date          */ "%ci%n" +
+                        /* Committer Date          */ "%ct%n" +
                         /* Commit message encoding */ "%e%n" + //there is a bug: git does not recode commit message when format is given
                         /* Commit Message          */ "%s";
                 }
@@ -305,8 +305,8 @@ namespace GitCommands
                 case ReadStep.AuthorDate:
                     {
                         DateTime dateTime;
-                        DateTime.TryParse(line, out dateTime);
-                        revision.AuthorDate = dateTime;
+                        if (DateTimeUtils.TryParseUnixTime(line, out dateTime))
+                            revision.AuthorDate = dateTime;
                     }
                     break;
 
@@ -317,8 +317,8 @@ namespace GitCommands
                 case ReadStep.CommitterDate:
                     {
                         DateTime dateTime;
-                        DateTime.TryParse(line, out dateTime);
-                        revision.CommitDate = dateTime;
+                        if (DateTimeUtils.TryParseUnixTime(line, out dateTime))
+                            revision.CommitDate = dateTime;
                     }
                     break;
 

--- a/GitUI/FormVerify.LostObject.cs
+++ b/GitUI/FormVerify.LostObject.cs
@@ -32,7 +32,6 @@ namespace GitUI
             private static readonly Regex RawDataRegex = new Regex(RawDataPattern, RegexOptions.Compiled);
             private static readonly Regex LogRegex = new Regex(LogPattern, RegexOptions.Compiled | RegexOptions.Singleline);
 
-            private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0);
             private readonly LostObjectType objectType;
             private readonly string rawType;
             private readonly string hash;
@@ -95,7 +94,7 @@ namespace GitUI
                         result.Author = GitCommandHelpers.ReEncodeStringFromLossless(logPatternMatch.Groups[1].Value);
                         string encodingName = logPatternMatch.Groups[2].Value;
                         result.Subject = GitCommandHelpers.ReEncodeCommitMessage(logPatternMatch.Groups[3].Value, encodingName);
-                        result.Date = UnixEpoch.AddSeconds(long.Parse(logPatternMatch.Groups[4].Value));
+                        result.Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups[4].Value);
                     }
                 }
 


### PR DESCRIPTION
Performance profiling showed that ~17% of commits loading time is dates parsing.
Changed log format to print unix time instead of human readable dates and replaced dates parsing with numbers parsing (that is faster more than 10 times).
