### PR TITLE
Rethrowing original exception to not loose exception class

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -43,7 +43,8 @@ namespace GitCommands.Config
             }
             catch (Exception ex)
             {
-                throw new Exception("Could not load config file: " + _fileName, ex);
+                ex.Data.Add(GetType().Name + ".Load", "Could not load config file: " + _fileName);
+                throw;
             }
         }
 
@@ -123,7 +124,7 @@ namespace GitCommands.Config
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message);
+                ExceptionUtils.ShowException(ex, false);
             }
         }
 

--- a/GitCommands/ExceptionUtils.cs
+++ b/GitCommands/ExceptionUtils.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+using System.Collections;
+
+namespace GitCommands
+{
+    public static class ExceptionUtils
+    {
+
+        public static void ShowException(Exception e)
+        {
+            ShowException(e, true);      
+        }
+
+        public static void ShowException(Exception e, bool canIgnore)
+        {
+            ShowException(e, string.Empty, canIgnore);
+        }
+
+        public static void ShowException(Exception e, string info)
+        {
+            ShowException(e, info, true);
+        }
+
+        public static void ShowException(Exception e, string info, bool canIgnore)
+        {
+            if (!(canIgnore && IsIgnorable(e)))
+                MessageBox.Show(info.Join(Environment.NewLine + Environment.NewLine, e.ToStringWithData()));            
+        }
+
+        public static bool IsIgnorable(Exception e)
+        {
+            return e is ThreadAbortException;
+        }
+
+        public static string ToStringWithData(this Exception e)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(e.ToString());
+            sb.AppendLine();
+            foreach(DictionaryEntry entry in e.Data)
+                sb.AppendLine(entry.Key + " = " + entry.Value);
+            return sb.ToString();
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <Compile Include="CommitData.cs" />
     <Compile Include="DateTimeUtils.cs" />
+    <Compile Include="ExceptionUtils.cs" />
     <Compile Include="FileHelper.cs" />
     <Compile Include="Git\GitCommand.cs" />
     <Compile Include="Git\EncodingHelper.cs" />

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -197,7 +197,7 @@ namespace GitCommands
             {
                 if (Error != null)
                     Error(this, EventArgs.Empty);
-                MessageBox.Show("Cannot load commit log." + Environment.NewLine + Environment.NewLine + ex);
+                ExceptionUtils.ShowException(ex, "Cannot load commit log.");
                 return;
             }
 


### PR DESCRIPTION
I often get message box with excpetion thrown from ConfigFile constructor, because there is thrown new Exception instead of rethrowing ThreadAbortException, which is silently ignored.
