### PR TITLE
Fixed the About-box not always splitting names

### DIFF
--- a/GitUI/AboutBox.cs
+++ b/GitUI/AboutBox.cs
@@ -8,7 +8,7 @@ namespace GitUI
     {
         public AboutBox()
         {
-            contributersList = string.Concat(coders, translators, designers, other).Split(',');
+            contributersList = string.Concat(coders, ", ", translators, ", ", designers, ", ", other).Split(new char[]{','}, StringSplitOptions.RemoveEmptyEntries);
 
             InitializeComponent(); 
             Translate();


### PR DESCRIPTION
The last coder/first translator, last translator/first designer name used to be concatted together incorrectly.

If you leave the box open for long enough, you'll encounter names like "mabakoGianni Rosa Gallina" and "ferow2kAndréj Telle", this patch aims to fix this.
