### PR TITLE
fixed an issue with empty commit templates showing watermark text

### DIFF
--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -1779,7 +1779,8 @@ namespace GitUI
             {
                 ToolStripMenuItem item = (ToolStripMenuItem)sender;
                 CommitTemplateItem templateItem = (CommitTemplateItem)(item.Tag);
-                Message.Text = templateItem.Text;                
+                Message.Text = templateItem.Text;
+                Message.Focus();
             }
             catch
             {

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -478,5 +478,10 @@ namespace GitUI.SpellChecker
             IsWatermarkShowing = false;
         }
 
+        public new bool Focus()
+        {
+            HideWatermark();
+            return base.Focus();
+        }
     }
 }


### PR DESCRIPTION
Prior to the patch, when using a commit template with blank contents for the text, the commit-message-box would change to "Enter commit message" as watermark, yet the box itself already being focused.

Thus you were able to edit the watermark text, and when unfocusing/refocusing the text again the whole commit message would disappear.

![Example](http://puu.sh/utB7)

This patch addresses this, in that the message is explicitly focused and the watermark explicitly hidden.

---

Reproduce:
1. Open commit window
2. Select the message area
3. Select a commit template with empty "Commit Template"
4. Write the watermark'd text
