### PR TITLE
Fixed incorrect path in Github3 plugin postbuild event.

### DIFF
--- a/Plugins/Github3/Github3.csproj
+++ b/Plugins/Github3/Github3.csproj
@@ -74,9 +74,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetPath)" "..\..\..\..\GitExtensions\bin\Debug"
-copy "$(SolutionDir)\bin\Git.hub.dll" "..\..\..\..\GitExtensions\bin\Debug"
-copy "$(SolutionDir)\bin\RestSharp.dll" "..\..\..\..\GitExtensions\bin\Debug"
+    <PostBuildEvent>copy "$(TargetPath)" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
+copy "$(SolutionDir)\bin\Git.hub.dll" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
+copy "$(SolutionDir)\bin\RestSharp.dll" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
The Github3 plugin was using incorrect paths in it's postbuild event.
