### PR TITLE
Tools version & target framework version are now consistent.

### DIFF
--- a/GitCommandsTests/GitCommandsTests.Mono.csproj
+++ b/GitCommandsTests/GitCommandsTests.Mono.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Setup/MakeInstallers.bat
+++ b/Setup/MakeInstallers.bat
@@ -9,7 +9,7 @@ set msiversion=%version:.=%
 set normal=GitExtensions%msiversion%Setup.msi
 set complete=GitExtensions%msiversion%SetupComplete.msi
 
-set msbuild="%windir%\Microsoft.NET\Framework\v3.5\MSBuild.exe"
+set msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 set output=bin\Release\GitExtensions.msi
 set project=Setup.wixproj
 


### PR DESCRIPTION
This pull request fixes issue #973 (there were only 2 discrepancies) and standardizes on the following:
- VS Projects are set to Tools version 4.0.
- Mono Projects are set to Tools version 3.5.
- Target .NET Framework is 3.5.
- Build scripts call .NET 4.0 version of msbuild.

The VS2008 solution file (GitCommands.sln) remains. Not sure if this should be removed or not.
