### PR TITLE
Fixing an issue with the open merge tool command.

### DIFF
--- a/GitUI/FormResolveConflicts.cs
+++ b/GitUI/FormResolveConflicts.cs
@@ -396,8 +396,8 @@ namespace GitUI
             int idx = mergetoolCmd.IndexOf(executablePattern);
             if (idx >= 0)
             {
-                mergetoolPath = mergetoolCmd.Substring(0, idx + executablePattern.Length).Trim(new[] { '\"', ' ' });
-                mergetoolCmd = mergetoolCmd.Substring(idx + executablePattern.Length);
+                mergetoolPath = mergetoolCmd.Substring(0, idx + executablePattern.Length + 1).Trim(new[] { '\"', ' ' });
+                mergetoolCmd = mergetoolCmd.Substring(idx + executablePattern.Length + 1);
             }
             Cursor.Current = Cursors.Default;
         }


### PR DESCRIPTION
An extra quote was being prepended to the arguments string causing the command to fail.
