### PR TITLE
Using different encoding to read/write config file, depend on config is local or global.

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -31,9 +31,12 @@ namespace GitCommands.Config
         private readonly string _fileName;
         private readonly IList<ConfigSection> _sections;
 
-        public ConfigFile(string fileName)
+        public bool Local { get; private set; }
+
+        public ConfigFile(string fileName, bool aLocal)
         {
             _sections = new List<ConfigSection>();
+            Local = aLocal;
 
             _fileName = fileName;
             try
@@ -52,12 +55,17 @@ namespace GitCommands.Config
             return _sections;
         }
 
+        private Encoding GetEncoding()
+        {
+            return Local ? Settings.AppEncoding : Settings.GetAppEncoding(false);
+        }
+
         private void Load()
         {
             if (string.IsNullOrEmpty(Path.GetFileName(_fileName)) || !File.Exists(_fileName))
                 return;
 
-            FindSections(File.ReadAllLines(_fileName, Settings.AppEncoding));
+            FindSections(File.ReadAllLines(_fileName, GetEncoding()));
         }
 
         private void FindSections(IEnumerable<string> fileLines)
@@ -119,7 +127,7 @@ namespace GitCommands.Config
                 FileInfoExtensions
                     .MakeFileTemporaryWritable(_fileName,
                                        x =>
-                                       File.WriteAllText(_fileName, configFileContent.ToString(), Settings.AppEncoding));
+                                       File.WriteAllText(_fileName, configFileContent.ToString(), GetEncoding()));
             }
             catch (Exception ex)
             {

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -661,7 +661,7 @@ namespace GitCommands
 
         public static ConfigFile GetGlobalConfig()
         {
-            return new ConfigFile(GetHomeDir() + Settings.PathSeparator.ToString() + ".gitconfig");
+            return new ConfigFile(GetHomeDir() + Settings.PathSeparator.ToString() + ".gitconfig", false);
         }
 
         public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, bool untrackedFiles)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -105,7 +105,7 @@ namespace GitCommands
         /// </summary>
         public IList<string> GetSubmodulesNames()
         {
-            var configFile = new ConfigFile(_workingdir + ".gitmodules");
+            var configFile = GetSubmoduleConfigFile();
             return configFile.GetConfigSections().Select(configSection => configSection.SubSection).ToList();
         }
 
@@ -890,15 +890,20 @@ namespace GitCommands
             return revisionsTab.Any(ex);
         }
 
+        public ConfigFile GetSubmoduleConfigFile()
+        {
+            return new ConfigFile(_workingdir + ".gitmodules", true);
+        }
+
         public string GetSubmoduleRemotePath(string name)
         {
-            var configFile = new ConfigFile(_workingdir + ".gitmodules");
+            var configFile = GetSubmoduleConfigFile();
             return configFile.GetPathValue(string.Format("submodule.{0}.url", name.Trim())).Trim();
         }
 
         public string GetSubmoduleLocalPath(string name)
         {
-            var configFile = new ConfigFile(_workingdir + ".gitmodules");
+            var configFile = GetSubmoduleConfigFile();
             return configFile.GetPathValue(string.Format("submodule.{0}.path", name.Trim())).Trim();
         }
 
@@ -952,7 +957,7 @@ namespace GitCommands
             if (!string.IsNullOrEmpty(superprojectPath))
             {
                 var localPath = currentPath.Substring(superprojectPath.Length);
-                var configFile = new ConfigFile(superprojectPath + ".gitmodules");
+                var configFile = new ConfigFile(superprojectPath + ".gitmodules", true);
                 foreach (ConfigSection configSection in configFile.GetConfigSections())
                 {
                     if (configSection.GetPathValue("path") == localPath)
@@ -1456,7 +1461,7 @@ namespace GitCommands
 
         public ConfigFile GetLocalConfig()
         {
-            return new ConfigFile(WorkingDirGitDir() + Settings.PathSeparator.ToString() + "config");
+            return new ConfigFile(WorkingDirGitDir() + Settings.PathSeparator.ToString() + "config", true);
         }
 
         public string GetSetting(string setting)

--- a/GitCommandsTests/ConfigFileTest.cs
+++ b/GitCommandsTests/ConfigFileTest.cs
@@ -43,7 +43,7 @@ namespace GitCommandsTests
         {
             { //TESTDATA
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), Settings.AppEncoding);
             }
             ConfigFile configFile = new ConfigFile(GetConfigFileName() + "\\");
             
@@ -55,7 +55,7 @@ namespace GitCommandsTests
         {
             { //TESTDATA
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), Settings.AppEncoding);
 
                 //Make sure it is hidden
                 FileInfo configFile = new FileInfo(GetConfigFileName());
@@ -63,7 +63,7 @@ namespace GitCommandsTests
             }
 
             { //PERFORM TEST
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("value1", configFile.GetValue("section1.key1"));
                 Assert.AreEqual("value2", configFile.GetValue("section2.subsection.key2"));
                 Assert.AreEqual("value3", configFile.GetValue("section3.subsection.key3"));
@@ -74,7 +74,7 @@ namespace GitCommandsTests
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("newvalue1", configFile.GetValue("section1.key1"));
             }
         }
@@ -84,17 +84,17 @@ namespace GitCommandsTests
         {
             { //TESTDATA
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), Settings.AppEncoding);
             }
 
             { //PERFORM TEST
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetPathValue("directory.first", @"c:\program files\gitextensions\gitextensions.exe");
                 configFile.Save();
             }
 
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"c:/program files/gitextensions/gitextensions.exe", configFile.GetPathValue("directory.first"));
             }
         }
@@ -104,13 +104,13 @@ namespace GitCommandsTests
         {
 
             { //PERFORM TEST
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetPathValue("directory.first", @"c:\program files\gitextensions\gitextensions.exe");
                 configFile.Save();
             }
 
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"c:/program files/gitextensions/gitextensions.exe", configFile.GetPathValue("directory.first"));
             }
         }
@@ -125,25 +125,25 @@ namespace GitCommandsTests
                 content.AppendLine("path = test.test");
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("test.test", configFile.GetPathValue("submodule.test.test.path"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetPathValue("submodule.test.test.path", "newvalue");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("newvalue", configFile.GetPathValue("submodule.test.test.path"));
             }
         }
@@ -158,25 +158,25 @@ namespace GitCommandsTests
                 content.AppendLine("path = test.test");
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("test.test", configFile.GetPathValue("submodule.test.test.path"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetPathValue("submodule.test.test.path", "newvalue");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("newvalue", configFile.GetPathValue("submodule.test.test.path"));
             }
         }
@@ -203,25 +203,25 @@ namespace GitCommandsTests
                 content.AppendLine("	path = c:/Program Files (x86)/KDiff3/kdiff3.exe");
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("Sergey Pustovit", configFile.GetValue("user.name"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetValue("user.name", "newvalue");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("newvalue", configFile.GetValue("user.name"));
             }
         }
@@ -259,25 +259,25 @@ namespace GitCommandsTests
 
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("0", configFile.GetValue("core.repositoryformatversion"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetValue("core.repositoryformatversion", "1");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("1", configFile.GetValue("core.repositoryformatversion"));
             }
         }
@@ -297,25 +297,25 @@ namespace GitCommandsTests
                 content.AppendLine("	logregex = \\n([A-Z][A-Z0-9]+-/d+)");
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("\\n([A-Z][A-Z0-9]+-/d+)", configFile.GetValue("bugtraq.logregex"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetValue("bugtraq.logregex", "data\\nnewline");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual("data\\nnewline", configFile.GetValue("bugtraq.logregex"));
             }
         }
@@ -330,25 +330,25 @@ namespace GitCommandsTests
                 content.AppendLine(@"	unc = //test/");
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"//test/", configFile.GetPathValue("path.unc"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetPathValue("path.unc", @"//test/test2/");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"//test/test2/", configFile.GetPathValue("path.unc"));
             }
         }
@@ -363,25 +363,25 @@ namespace GitCommandsTests
                 content.AppendLine(@"	unc = \\\\test\\"); //<- escaped value in config file
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"\\test\", configFile.GetPathValue("path.unc"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetPathValue("path.unc", @"\\test\test2\");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"\\test\test2\", configFile.GetPathValue("path.unc"));
             }
         }
@@ -396,25 +396,25 @@ namespace GitCommandsTests
                 content.AppendLine("	test = test");
 
                 //Write test config
-                File.WriteAllText(GetConfigFileName(), content.ToString(), Encoding.UTF8);
+                File.WriteAllText(GetConfigFileName(), content.ToString(), Settings.AppEncoding);
             }
 
             //CHECK GET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"test", configFile.GetValue("section.sub section.test"));
             }
 
             //CHECK SET CONFIG VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 configFile.SetValue("section.sub section.test", @"test2");
                 configFile.Save();
             }
 
             //CHECK WRITTEN VALUE
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
                 Assert.AreEqual(@"test2", configFile.GetValue("section.sub section.test"));
             }
         }
@@ -424,7 +424,7 @@ namespace GitCommandsTests
         {
             // create test data
             {
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
 
                 configFile.AddValue("remote.origin.fetch", "+mypath");
                 configFile.AddValue("remote.origin.fetch", "+myotherpath");
@@ -435,7 +435,7 @@ namespace GitCommandsTests
             // verify
             {
 
-                ConfigFile configFile = new ConfigFile(GetConfigFileName());
+                ConfigFile configFile = new ConfigFile(GetConfigFileName(), true);
 
                 IList<string> values = configFile.GetValues("remote.origin.fetch");
 

--- a/GitUI/FormResolveConflicts.cs
+++ b/GitUI/FormResolveConflicts.cs
@@ -267,7 +267,7 @@ namespace GitUI
             {
                 if (Directory.Exists(Settings.WorkingDir + filename) && !File.Exists(Settings.WorkingDir + filename))
                 {
-                    var submoduleConfig = new ConfigFile(Settings.WorkingDir + ".gitmodules");
+                    var submoduleConfig = Settings.Module.GetSubmoduleConfigFile();
                     if (submoduleConfig.GetConfigSections().Any(configSection => configSection.GetPathValue("path").Trim().Equals(filename.Trim())))
                     {
                         if (MessageBox.Show(this, mergeConflictIsSubmodule.Text, mergeConflictIsSubmoduleCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)

--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -468,7 +468,7 @@ namespace GitUI
                         //practice this is only used to core.autocrlf. If there are more cases, we might
                         //need to consider a better solution.
                         var configFile =
-                            new ConfigFile(Path.GetDirectoryName(Settings.GitBinDir).Replace("bin", "etc\\gitconfig"));
+                            new ConfigFile(Path.GetDirectoryName(Settings.GitBinDir).Replace("bin", "etc\\gitconfig"), false);
                         globalAutocrlf = configFile.GetValue("core.autocrlf").ToLower();
                     }
                     catch

--- a/GitUI/FormSubmodules.cs
+++ b/GitUI/FormSubmodules.cs
@@ -106,7 +106,7 @@ namespace GitUI
             Cursor.Current = Cursors.WaitCursor;
             Settings.Module.RunGitCmd("rm --cached \"" + SubModuleName.Text + "\"");
 
-            var modules = new ConfigFile(Settings.WorkingDir + ".gitmodules");
+            var modules = Settings.Module.GetSubmoduleConfigFile();
             modules.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
             if (modules.GetConfigSections().Count > 0)
                 modules.Save();


### PR DESCRIPTION
Should fix Issue #357.
I didn't checked if ConfigFileTest compiles.
