### PR TITLE
Fulfills feature request #984

### DIFF
--- a/GitUI/FormGitIgnore.cs
+++ b/GitUI/FormGitIgnore.cs
@@ -28,7 +28,7 @@ namespace GitUI
         private string _originalGitIgnoreFileContent = string.Empty;
 
         #region default patterns
-		private static readonly string DefaultIgnorePatternsFile = "./DefaultIgnorePatterns.txt";
+		private static readonly string DefaultIgnorePatternsFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GitExtensions/DefaultIgnorePatterns.txt");
         private static readonly string[] DefaultIgnorePatterns = new[]
         {
             "#ignore thumbnails created by windows",


### PR DESCRIPTION
If you create a DefaultIgnorePatterns.txt file within the same directory as the executable, it will override the hard coded settings within the program.
