### PR TITLE
Remove old Github settings

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -197,6 +197,10 @@
       <!--Remove unused dll, installed in versions <= 2.31-->
       <Component Id="Github.dll" Guid="0DA13691-140A-4490-8B4C-8AF537DAEB67">
         <RemoveFile Name="Github.dll" Id="Github.dll" On="both"/>
+        <RemoveRegistryValue Id="GithubAPIToken" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubapitoken"/>
+        <RemoveRegistryValue Id="GithubUsername" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubusername"/>
+        <RemoveRegistryValue Id="GithubPassword" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubpassword"/>
+        <RemoveRegistryValue Id="GithubAccess" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubpreferred access method"/>
       </Component>
 
       <Component Id="FindLargeFiles.dll" Guid="*">


### PR DESCRIPTION
Removes the registry settings existant in previous versions, which does contain the username, password, api token and access method if set.

This is particularly interesting for the password, since you wouldn't want it to stay around.
