### PR TITLE
RSS feeds should load asynchronously

### DIFF
--- a/GitUI/DashboardCategory.cs
+++ b/GitUI/DashboardCategory.cs
@@ -55,9 +55,17 @@ namespace GitUI
                 m_repositoryCategory = value;
 
                 if (m_repositoryCategory != null && m_repositoryCategory.CategoryType == RepositoryCategoryType.RssFeed)
-                    m_repositoryCategory.DownloadRssFeed();
-
-                InitRepositoryCategory();
+                {
+                    AsyncHelpers.DoAsync(
+                        () => { m_repositoryCategory.DownloadRssFeed(); return this; },
+                        obj => { obj.InitRepositoryCategory(); },
+                        ex => { }
+                    );
+                }
+                else
+                {
+                    InitRepositoryCategory();
+                }
             }
         }
 


### PR DESCRIPTION
As it is now, RSS feeds are loaded along with a list of repositories and so on, delaying the start-up time unnecessarily if you have any. The desired behaviour would be to load them in the background, making the list of repositories available to work at just immediately.
