### PR TITLE
fixed no default encoding being set

### DIFF
--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -338,7 +338,7 @@ namespace GitCommands
         //to read/write config file
         public static Encoding GetAppEncoding(bool local)
         {
-            return GetEncoding(local, "AppEncoding", true);
+            return GetEncoding(local, "AppEncoding", true) ?? new UTF8Encoding(false);
         }
         public static void SetAppEncoding(bool local, Encoding encoding)
         {


### PR DESCRIPTION
this led to an error whenever I opened Git Extension, as encoding can't be null, but it tries to load the settings with encoding = null initially.
