### PR TITLE
Add option to sign-off commits

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1390,14 +1390,22 @@ namespace GitCommands
 
         public string CommitCmd(bool amend)
         {
-            return CommitCmd(amend, "");
+            return CommitCmd(amend, false, "");
         }
 
         public string CommitCmd(bool amend, string author)
         {
+            return CommitCmd(amend, false, author);
+        }
+
+        public string CommitCmd(bool amend, bool signOff, string author)
+        {
             string command = "commit";
             if (amend)
                 command += " --amend";
+
+            if (signOff)
+                command += " --signoff";
 
             if (!string.IsNullOrEmpty(author))
                 command += " --author=\"" + author + "\"";

--- a/GitUI/FormCommit.Designer.cs
+++ b/GitUI/FormCommit.Designer.cs
@@ -104,6 +104,7 @@ namespace GitUI
             this.closeDialogAfterEachCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.closeDialogAfterAllFilesCommittedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.refreshDialogOnFormFocusToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.signOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolAuthorLabelItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolAuthor = new System.Windows.Forms.ToolStripTextBox();
@@ -782,6 +783,7 @@ namespace GitUI
             this.closeDialogAfterAllFilesCommittedToolStripMenuItem,
             this.refreshDialogOnFormFocusToolStripMenuItem,
             this.toolStripSeparator2,
+            this.signOffToolStripMenuItem,
             this.toolAuthorLabelItem,
             this.toolAuthor});
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
@@ -813,6 +815,13 @@ namespace GitUI
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
+            // 
+            // signOffToolStripMenuItem
+            // 
+            this.signOffToolStripMenuItem.Name = "signOffToolStripMenuItem";
+            this.signOffToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
+            this.signOffToolStripMenuItem.Text = "Sign-off commit";
+            this.signOffToolStripMenuItem.Click += new System.EventHandler(this.signOffToolStripMenuItem_Click);
             this.toolStripSeparator2.Size = new System.Drawing.Size(377, 6);
             // 
             // toolAuthorLabelItem
@@ -1166,5 +1175,6 @@ namespace GitUI
         private ToolStripMenuItem generateListOfChangesInSubmodulesChangesToolStripMenuItem;
         private ToolStripDropDownButton commitTemplatesToolStripMenuItem;
         private ToolStripMenuItem openContainingFolderToolStripMenuItem;
+        private ToolStripMenuItem signOffToolStripMenuItem;
     }
 }

--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -711,7 +711,7 @@ namespace GitUI
 
                 ScriptManager.RunEventScripts(ScriptEvent.BeforeCommit);
 
-                var form = new FormProcess(Settings.Module.CommitCmd(amend, toolAuthor.Text));
+                var form = new FormProcess(Settings.Module.CommitCmd(amend, signOffToolStripMenuItem.Checked, toolAuthor.Text));
                 form.ShowDialog(this);
 
                 NeedRefresh = true;
@@ -1548,6 +1548,11 @@ namespace GitUI
                 RescanChanges();
 
             return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void signOffToolStripMenuItem_Click(object snder, EventArgs e)
+        {
+            signOffToolStripMenuItem.Checked = !signOffToolStripMenuItem.Checked;
         }
 
         private void toolAuthor_TextChanged(object sender, EventArgs e)


### PR DESCRIPTION
Option added to Commit->Options menu, next to Author.
From git-commit man page, "Add Signed-off-by line by the committer at the end of the commit log message."
