### PR TITLE
fixed fix bd0cb39040d2859dd934af49013056373390bee3

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -57,7 +57,7 @@ namespace GitCommands.Config
 
         private Encoding GetEncoding()
         {
-            return Local ? Settings.AppEncoding : Settings.GetAppEncoding(false);
+            return Local ? Settings.AppEncoding : Settings.GetAppEncoding(false, true);
         }
 
         private void Load()

--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -336,9 +336,12 @@ namespace GitCommands
         //it is better to encode this file in utf8 for international projects. To read config file properly
         //we must know its encoding, let user decide by setting AppEncoding property which encoding has to be used
         //to read/write config file
-        public static Encoding GetAppEncoding(bool local)
+        public static Encoding GetAppEncoding(bool local, bool returnDefault)
         {
-            return GetEncoding(local, "AppEncoding", true) ?? new UTF8Encoding(false);
+            Encoding result = GetEncoding(local, "AppEncoding", true);
+            if (result == null && returnDefault)
+                result = new UTF8Encoding(false);
+            return result;
         }
         public static void SetAppEncoding(bool local, Encoding encoding)
         {
@@ -348,11 +351,9 @@ namespace GitCommands
         {
             get
             {
-                Encoding result = GetAppEncoding(true);
+                Encoding result = GetAppEncoding(true, false);
                 if (result == null)
-                    result = GetAppEncoding(false);
-                if (result == null)
-                    result = new UTF8Encoding(false);
+                    result = GetAppEncoding(false, true);
                 return result;
             }
         }

--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -315,9 +315,9 @@ namespace GitUI
 
                 scriptEvent.DataSource = Enum.GetValues(typeof(ScriptEvent));
                 EncodingToCombo(Settings.GetFilesEncoding(false), Global_FilesEncoding);
-                EncodingToCombo(Settings.GetAppEncoding(false), Global_AppEncoding);
+                EncodingToCombo(Settings.GetAppEncoding(false, false), Global_AppEncoding);
                 EncodingToCombo(Settings.GetFilesEncoding(true), Local_FilesEncoding);
-                EncodingToCombo(Settings.GetAppEncoding(true), Local_AppEncoding);
+                EncodingToCombo(Settings.GetAppEncoding(true, false), Local_AppEncoding);
 
                 chkWarnBeforeCheckout.Checked = Settings.DirtyDirWarnBeforeCheckoutBranch;
                 chkStartWithRecentWorkingDir.Checked = Settings.StartWithRecentWorkingDir;


### PR DESCRIPTION
default encoding was returned too early
