### PR TITLE
Handle negative value of Environment.TickCount

### DIFF
--- a/GitUI/ToolStripGitStatus.cs
+++ b/GitUI/ToolStripGitStatus.cs
@@ -248,7 +248,7 @@ namespace GitUI
 
         private void ScheduleImmediateUpdate()
         {
-            nextUpdateTime = 0;
+            nextUpdateTime = Environment.TickCount;
             Update();
         }
 


### PR DESCRIPTION
Happens when computer is not restarted for long period.
