### PR TITLE
Handle artificial revisions on FormFileHistory.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2060,17 +2060,46 @@ namespace GitCommands
             return blame;
         }
 
-        public string GetFileRevisionText(string file, string revision)
+        public string GetFileRevisionText(string file, string revision, Encoding encoding)
         {
             return
                 this.RunCachableCmd(
                     Settings.GitCommand,
-                    string.Format("show {0}:\"{1}\"", revision, file.Replace('\\', '/')), Settings.FilesEncoding);
+                    string.Format("show {0}:\"{1}\"", revision, file.Replace('\\', '/')), encoding);
         }
 
-        public string GetFileText(string id)
+        public string GetFileText(string id, Encoding encoding)
         {
-            return RunCachableCmd(Settings.GitCommand, "cat-file blob \"" + id + "\"", Settings.FilesEncoding);
+            return RunCachableCmd(Settings.GitCommand, "cat-file blob \"" + id + "\"", encoding);
+        }
+
+        public string GetFileBlobHash(string fileName, string revision)
+        {
+            if (revision == GitRevision.UncommittedWorkingDirGuid) //working dir changes
+            {
+                return null;
+            }
+            else if (revision == GitRevision.IndexGuid) //index
+            {
+                string blob = RunGitCmd(string.Format("ls-files -s \"{0}\"", fileName));
+                string[] s = blob.Split(new char[] { ' ', '\t' });
+                if (s.Length >= 2)
+                    return s[1];
+                else
+                    return string.Empty;
+
+            }
+            else
+            {
+                string blob = RunGitCmd(string.Format("ls-tree -r {0} \"{1}\"", revision, fileName));
+                string[] s = blob.Split(new char[] { ' ', '\t' });
+                if (s.Length >= 3)
+                    return s[2];
+                else
+                    return string.Empty;
+            }
+
+
         }
 
         public static void StreamCopy(Stream input, Stream output)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -378,12 +378,20 @@ namespace GitUI.Editor
 
         public void ViewGitItemRevision(string fileName, string guid)
         {
-            ViewItem(fileName, () => GetImage(fileName, guid), () => Settings.Module.GetFileRevisionText(fileName, guid));
+            if (guid == GitRevision.UncommittedWorkingDirGuid) //working dir changes
+            {
+                ViewFile(fileName);
+            }
+            else
+            {
+                string blob = Settings.Module.GetFileBlobHash(fileName, guid);
+                ViewGitItem(fileName, blob);
+            }
         }
 
         public void ViewGitItem(string fileName, string guid)
         {
-            ViewItem(fileName, () => GetImage(fileName, guid), () => Settings.Module.GetFileText(guid));
+            ViewItem(fileName, () => GetImage(fileName, guid), () => Settings.Module.GetFileText(guid, Encoding));
         }
 
         private void ViewItem(string fileName, Func<Image> getImage, Func<string> getFileText)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -187,6 +187,7 @@
       <DependentUpon>FormVerify.cs</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="GitUIExtensions.cs" />
     <Compile Include="Hotkey\ControlHotkeys.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GitCommands;
+using System.Windows.Forms;
+using GitUI.Editor;
+using ICSharpCode.TextEditor.Util;
+
+namespace GitUI
+{
+    public static class GitUIExtensions
+    {
+
+        public enum DiffWithRevisionKind
+        {
+            DiffBaseLocal,
+            DiffRemoteLocal,
+            DiffAsSelected
+        }
+
+        public static void OpenWithDifftool(this RevisionGrid grid, string fileName, DiffWithRevisionKind diffKind)
+        {
+            IList<GitRevision> revisions = grid.GetSelectedRevisions();
+
+            if (revisions.Count == 0)
+                return;
+
+            string output;
+            if (diffKind == DiffWithRevisionKind.DiffBaseLocal)
+            {
+                if (revisions[0].ParentGuids.Length == 0)
+                    return;
+                output = Settings.Module.OpenWithDifftool(fileName, revisions[0].ParentGuids[0]);
+
+            }
+            else if (diffKind == DiffWithRevisionKind.DiffRemoteLocal)
+                output = Settings.Module.OpenWithDifftool(fileName, revisions[0].Guid);
+            else
+                if (revisions.Count == 1)   // single item selected
+                {
+                    if (revisions[0].Guid == GitRevision.UncommittedWorkingDirGuid) //working dir changes
+                        output = Settings.Module.OpenWithDifftool(fileName);
+                    else if (revisions[0].Guid == GitRevision.IndexGuid) //staged changes
+                        output = Settings.Module.OpenWithDifftool(fileName, null, null, "--cached");
+                    else
+                        output = Settings.Module.OpenWithDifftool(fileName, revisions[0].Guid,
+                                                                      revisions[0].ParentGuids[0]);
+                }
+                else                        // multiple items selected
+                    output = Settings.Module.OpenWithDifftool(fileName, revisions[0].Guid,
+                                                                  revisions[revisions.Count - 1].Guid);
+
+            if (!string.IsNullOrEmpty(output))
+                MessageBox.Show(grid, output);
+        }
+
+
+        public static string GetSelectedPatch(this FileViewer diffViewer, RevisionGrid grid, GitItemStatus file)
+        {
+            IList<GitRevision> revisions = grid.GetSelectedRevisions();
+
+            if (revisions.Count == 0)
+                return null;
+
+            if (revisions[0].Guid == GitRevision.UncommittedWorkingDirGuid) //working dir changes
+            {
+                if (file.IsTracked)
+                    return Settings.Module.GetCurrentChanges(file.Name, file.OldName, false, diffViewer.GetExtraDiffArguments(), diffViewer.Encoding);
+                return FileReader.ReadFileContent(Settings.WorkingDir + file.Name, diffViewer.Encoding);
+            }
+            if (revisions[0].Guid == GitRevision.IndexGuid) //index
+            {
+                return Settings.Module.GetCurrentChanges(file.Name, file.OldName, true, diffViewer.GetExtraDiffArguments(), diffViewer.Encoding);
+            }
+            var secondRevision = revisions.Count == 2 ? revisions[1].Guid : revisions[0].Guid + "^";
+
+            PatchApply.Patch patch = Settings.Module.GetSingleDiff(revisions[0].Guid, secondRevision, file.Name, file.OldName,
+                                                    diffViewer.GetExtraDiffArguments(), diffViewer.Encoding);
+
+            if (patch == null)
+                return null;
+
+            if (file.IsSubmodule)
+                return GitCommandHelpers.ProcessSubmodulePatch(patch.Text);
+
+            return patch.Text;
+        }
+
+
+        public static void ViewPatch(this FileViewer diffViewer, RevisionGrid grid, GitItemStatus file, string defaultText)
+        {
+            diffViewer.ViewPatch(() =>
+                                   {
+                                       string selectedPatch = diffViewer.GetSelectedPatch(grid, file);
+
+                                       return selectedPatch ?? defaultText;
+                                   });
+        }
+
+        public static void RemoveIfExists(this TabControl tabControl, TabPage page)
+        {
+            if (tabControl.TabPages.Contains(page))
+                tabControl.TabPages.Remove(page);
+        }
+
+        public static void InsertIfNotExists(this TabControl tabControl, int index, TabPage page)
+        {
+            if (!tabControl.TabPages.Contains(page))
+                tabControl.TabPages.Insert(index, page);
+        }
+
+
+    }
+}


### PR DESCRIPTION
Also fixed View for image files (GetImage works with blob hash, not with revision hash).
