### PR TITLE
Added -M -C to get correct file name.

### DIFF
--- a/GitUI/FormFileHistory.cs
+++ b/GitUI/FormFileHistory.cs
@@ -133,7 +133,7 @@ namespace GitUI
                 } while (line != null);
 
                 // here we need --name-only to get the previous filenames in the revision graph
-                filter = " --name-only --parents -- " + listOfFileNames;
+                filter = " -M -C --name-only --parents -- " + listOfFileNames;
             }
             else
             {


### PR DESCRIPTION
Command 
$ git.exe log -z  --pretty=format:"<(**BEGIN_COMMIT**)>%n%H%n%P%n%T%n%aN%n%aE%n%at%n%cN%n%ct%n%e%n%s"  --date-order HEAD --all --boundary --not --glo
b=notes --not --max-count="100000" --name-only --parents -- "GitUI/Resources/Icons/16.png" "GitUI/Icons/16.png"

returns

...
Removed duplicated resources. Resources location changed.
GitUI/Icons/16.png^@GitUI/Resources/Icons/16.png^@^@

I don't know why but GitUI/Icons/16.png is listed at first position and it is taken by FormFileHistory as fileName insted of GitUI/Resources/Icons/16.png.
