### PR TITLE
VS-Plugin: Treat WiX files as regular files

### DIFF
--- a/GitPlugin/Commands/ItemCommandBase.cs
+++ b/GitPlugin/Commands/ItemCommandBase.cs
@@ -93,7 +93,7 @@ namespace GitPlugin.Commands
 
         private static CommandTarget GetProjectItemTarget(ProjectItem projectItem)
         {
-            switch (projectItem.Kind)
+            switch (projectItem.Kind.ToUpper())
             {
                 case Constants.vsProjectItemKindPhysicalFile:
                     return CommandTarget.File;


### PR DESCRIPTION
This allows things like 'commit' and so forth to work.

Fixes issue #843.
