### PR TITLE
Allow a plugin to get the exit code from RunGit()

### DIFF
--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -110,6 +110,11 @@ namespace GitCommands
             return Settings.Module.RunGitCmd(arguments);
         }
 
+        public string RunGit(string arguments, out int exitCode)
+        {
+            return Settings.Module.RunGitCmd(arguments, out exitCode);
+        }
+
         public string RunBatchFile(string batchFile)
         {
             return Settings.Module.RunBatchFile(batchFile);

--- a/Plugins/GitUIPluginInterfaces/IGitCommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitCommands.cs
@@ -8,6 +8,8 @@ namespace GitUIPluginInterfaces
 
         string RunGit(string arguments);
 
+        string RunGit(string arguments, out int exitCode);
+
         string RunBatchFile(string batchFile);
     }
 }


### PR DESCRIPTION
RunGit() override in IGitCommands to add an "out int exitCode".
Previously there was no way a plugin could
get the exit code of an arbitrary git command.
