### PR TITLE
Call EndInvoke after BeginInvoke for AsyncHelpers

### DIFF
--- a/GitUI/AsyncHelpers.cs
+++ b/GitUI/AsyncHelpers.cs
@@ -34,7 +34,12 @@ namespace GitUI
                 SendOrPostCallback cb = tres => continueWith((T)tres);
                 syncContext.Post(cb, res);
             };
-            a.BeginInvoke(null, null);
+            a.BeginInvoke(EndAsync, a);
+        }
+
+        private static void EndAsync(IAsyncResult result)
+        {
+            (result.AsyncState as Action).EndInvoke(result);
         }
     }
 }


### PR DESCRIPTION
EndInvoke must always be called after a BeginInvoke to avoid resource leaks
See http://msdn.microsoft.com/en-us/library/2e08f6yc.aspx
and http://stackoverflow.com/questions/532722/is-endinvoke-optional-sort-of-optional-or-definitely-not-optional
