### PR TITLE
Hide bisect skip context menu item when repo isn't in the middle of bisect

### DIFF
--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -1543,6 +1543,7 @@ namespace GitUI
             var inTheMiddleOfBisect = Settings.Module.InTheMiddleOfBisect();
             markRevisionAsBadToolStripMenuItem.Visible = inTheMiddleOfBisect;
             markRevisionAsGoodToolStripMenuItem.Visible = inTheMiddleOfBisect;
+            bisectSkipRevisionToolStripMenuItem.Visible = inTheMiddleOfBisect;
             stopBisectToolStripMenuItem.Visible = inTheMiddleOfBisect;
             bisectSeparator.Visible = inTheMiddleOfBisect;
 


### PR DESCRIPTION
Currently “Skip revision” menu item is always shown in context menu, but it will work only in bisect mode.
