### PR TITLE
Allow rebase on commit if no branch is present

### DIFF
--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -1594,6 +1594,14 @@ namespace GitUI
                 }
             }
 
+            //if there is no branch to rebase on, then allow user to rebase on selected commit 
+            if (rebaseDropDown.Items.Count == 0 && !currentBranchPointsToRevision)
+            {
+                ToolStripItem toolStripItem = new ToolStripMenuItem(revision.Guid);
+                toolStripItem.Click += ToolStripItemClickRebaseBranch;
+                rebaseDropDown.Items.Add(toolStripItem);
+            }
+
             //if there is no branch to merge, then let user to merge selected commit into current branch 
             if (mergeBranchDropDown.Items.Count == 0 && !currentBranchPointsToRevision)
             {


### PR DESCRIPTION
This includes the SHA1 of the selected commit in the "Rebase current branch on"
context menu if no branches are present at that commit.  This is implemented in
the same way as nearly identical functionality that already exists for the "Merge
current branch into" context menu.

Rebase is a common part of my workflow, and I'd like to see it get equal treatment. :)
