### PR TITLE
Adding keyboard shortcut for File > File Explorer menu item.

### DIFF
--- a/GitUI/FormBrowse.Designer.cs
+++ b/GitUI/FormBrowse.Designer.cs
@@ -1056,6 +1056,8 @@ namespace GitUI
             this.fileExplorerToolStripMenuItem.Image = global::GitUI.Properties.Resources.open;
             this.fileExplorerToolStripMenuItem.Name = "fileExplorerToolStripMenuItem";
             this.fileExplorerToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this.fileExplorerToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            | System.Windows.Forms.Keys.O)));
             this.fileExplorerToolStripMenuItem.Text = "File Explorer";
             this.fileExplorerToolStripMenuItem.Click += new System.EventHandler(this.FileExplorerToolStripMenuItemClick);
             // 


### PR DESCRIPTION
I think that opening repository folder is a common enough action to have a keyboard shortcut (Ctrl+Shift+O). At least I use it in my workflows a lot.
