### PR TITLE
Fixed create tag dialog closing by enter after an error

### DIFF
--- a/GitUI/FormVerify.cs
+++ b/GitUI/FormVerify.cs
@@ -61,7 +61,7 @@ namespace GitUI
 
         private void RemoveClick(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, 
+            if (MessageBox.Show(this,
                 _removeDanglingObjectsQuestion.Text,
                 _removeDanglingObjectsCaption.Text,
                 MessageBoxButtons.YesNo) != DialogResult.Yes)
@@ -78,7 +78,7 @@ namespace GitUI
 
         private void mnuLostObjectsCreateTag_Click(object sender, EventArgs e)
         {
-            using (var frm = new FormTagSmall { Revision = GetCurrentGitRevision() })
+            using (var frm = new FormTagSmall(GetCurrentGitRevision()))
             {
                 var dialogResult = frm.ShowDialog(this);
                 if (dialogResult == DialogResult.OK)

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -439,7 +439,7 @@ namespace GitUI
 
         public bool SetAndApplyBranchFilter(string filter)
         {
-            if (filter.Equals(_revisionFilter.GetBranchFilter())) 
+            if (filter.Equals(_revisionFilter.GetBranchFilter()))
                 return false;
             if (filter.Equals(""))
             {
@@ -456,7 +456,7 @@ namespace GitUI
             return true;
         }
 
-        public void SetLimit(int limit)         
+        public void SetLimit(int limit)
         {
             _revisionFilter.SetLimit(limit);
         }
@@ -1384,8 +1384,11 @@ namespace GitUI
             if (Revisions.RowCount <= LastRow || LastRow < 0)
                 return;
 
-            var frm = new FormTagSmall { Revision = GetRevision(LastRow) };
-            frm.ShowDialog(this);
+            using (var frm = new FormTagSmall(GetRevision(LastRow)))
+            {
+                frm.ShowDialog(this);    
+            }
+            
             RefreshRevisions();
         }
 
@@ -1607,7 +1610,7 @@ namespace GitUI
                 toolStripItem.Click += ToolStripItemClickMergeBranch;
                 mergeBranchDropDown.Items.Add(toolStripItem);
             }
-            
+
 
             foreach (var head in allBranches)
             {
@@ -2317,7 +2320,7 @@ namespace GitUI
             this.remoteToolStripMenuItem.Name = "remoteToolStripMenuItem";
             this.remoteToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.remoteToolStripMenuItem.Text = "Remote";
-        
+
         }
 
         public FilterBranchHelper(ToolStripComboBox toolStripBranches, ToolStripDropDownButton toolStripDropDownButton2, RevisionGrid RevisionGrid)
@@ -2458,7 +2461,7 @@ namespace GitUI
     }
 
 
-    public class FilterRevisionsHelper 
+    public class FilterRevisionsHelper
     {
 
         private ToolStripTextBox _NO_TRANSLATE_toolStripTextBoxFilter;
@@ -2515,7 +2518,7 @@ namespace GitUI
             this.hashToolStripMenuItem.CheckOnClick = true;
             this.hashToolStripMenuItem.Name = "hashToolStripMenuItem";
             this.hashToolStripMenuItem.Size = new System.Drawing.Size(216, 24);
-            this.hashToolStripMenuItem.Text = "Hash";        
+            this.hashToolStripMenuItem.Text = "Hash";
         }
 
         public FilterRevisionsHelper(ToolStripTextBox toolStripTextBoxFilter, ToolStripDropDownButton toolStripDropDownButton1, RevisionGrid RevisionGrid, ToolStripLabel toolStripLabel2, Form form)
@@ -2537,7 +2540,7 @@ namespace GitUI
             this._NO_TRANSLATE_toolStripTextBoxFilter.Leave += this.ToolStripTextBoxFilterLeave;
             this._NO_TRANSLATE_toolStripTextBoxFilter.KeyPress += this.ToolStripTextBoxFilterKeyPress;
 
-        
+
         }
 
         public void SetFilter(string filter)
@@ -2617,9 +2620,10 @@ namespace GitUI
             else
                 commitToolStripMenuItem1.Checked = true;
         }
-        
 
-        public void SetLimit(int limit) {
+
+        public void SetLimit(int limit)
+        {
             _NO_TRANSLATE_RevisionGrid.SetLimit(limit);
         }
 

--- a/GitUI/Tag/FormTagSmall.Designer.cs
+++ b/GitUI/Tag/FormTagSmall.Designer.cs
@@ -69,7 +69,6 @@ namespace GitUI.Tag
             this.TName.Name = "TName";
             this.TName.Size = new System.Drawing.Size(227, 23);
             this.TName.TabIndex = 6;
-            this.TName.KeyUp += new System.Windows.Forms.KeyEventHandler(this.NameKeyUp);
             // 
             // annotate
             // 
@@ -114,6 +113,7 @@ namespace GitUI.Tag
             // 
             // FormTagSmall
             // 
+            this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(459, 167);

--- a/GitUI/Tag/FormTagSmall.cs
+++ b/GitUI/Tag/FormTagSmall.cs
@@ -8,7 +8,7 @@ using GitUI.Script;
 
 namespace GitUI.Tag
 {
-    public partial class FormTagSmall : GitExtensionsForm
+    public sealed partial class FormTagSmall : GitExtensionsForm
     {
         private readonly TranslationString _messageCaption = new TranslationString("Tag");
 
@@ -18,22 +18,22 @@ namespace GitUI.Tag
         private readonly TranslationString _noTagMassage = new TranslationString("Please enter a tag message");
 
         private readonly TranslationString _pushToCaption = new TranslationString("Push tag to {0}");
+        private readonly GitRevision revision;
 
-        public FormTagSmall()
+        public FormTagSmall(GitRevision revision)
         {
             InitializeComponent();
             Translate();
 
             tagMessage.MistakeFont = new Font(SystemFonts.MessageBoxFont, FontStyle.Underline);
+            this.revision = revision;
         }
-
-        public GitRevision Revision { get; set; }
 
         private void OkClick(object sender, EventArgs e)
         {
             try
             {
-                var tagName = CreateTag(sender, e);
+                var tagName = CreateTag();
 
                 if (pushTag.Checked && !string.IsNullOrEmpty(tagName))
                     PushTag(tagName);
@@ -44,9 +44,9 @@ namespace GitUI.Tag
             }
         }
 
-        private string CreateTag(object sender, EventArgs e)
+        private string CreateTag()
         {
-            if (Revision == null)
+            if (revision == null)
             {
                 MessageBox.Show(this, _noRevisionSelected.Text, _messageCaption.Text);
                 return string.Empty;
@@ -63,7 +63,7 @@ namespace GitUI.Tag
             }
 
 
-            var s = Settings.Module.Tag(TName.Text, Revision.Guid, annotate.Checked);
+            var s = Settings.Module.Tag(TName.Text, revision.Guid, annotate.Checked);
 
             if (!string.IsNullOrEmpty(s))
                 MessageBox.Show(this, s, _messageCaption.Text);
@@ -95,12 +95,6 @@ namespace GitUI.Tag
             {
                 ScriptManager.RunEventScripts(ScriptEvent.AfterPush);
             }
-        }
-
-        private void NameKeyUp(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter)
-                OkClick(null, null);
         }
 
         private void AnnotateCheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
1. Open repo browser
2. Create tag named i.e. “foo” with Ctrl-T or “Create new tag” context menu item
3. Try create another one tag with the same name “foo”
4. Tag already exists error message will be shown, press enter to close error message window

cur: error message closes and appears again
exp: error message only closes
