### PR TITLE
Right-click on branches button will open branches selection context menu

### DIFF
--- a/GitUI/FormBrowse.Designer.cs
+++ b/GitUI/FormBrowse.Designer.cs
@@ -338,6 +338,7 @@ namespace GitUI
             this.branchSelect.ToolTipText = "Change current branch";
             this.branchSelect.ButtonClick += new System.EventHandler(this.CurrentBranchClick);
             this.branchSelect.DropDownOpening += new System.EventHandler(this.CurrentBranchDropDownOpening);
+            this.branchSelect.MouseUp += new System.Windows.Forms.MouseEventHandler(this.CurrentBranchMouseUp);
             // 
             // toolStripSeparator1
             // 

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1891,6 +1891,15 @@ namespace GitUI
             }
         }
 
+        private void CurrentBranchMouseUp(object sender, MouseEventArgs e)
+        {
+            if (e.Button == System.Windows.Forms.MouseButtons.Right)
+            {
+                CurrentBranchDropDownOpening(sender, e);
+                branchSelect.DropDown.Show(Point.Empty);
+            }
+        }
+
         void BranchSelectToolStripItem_Click(object sender, EventArgs e)
         {
             bool needRefresh;


### PR DESCRIPTION
Toolbar in the FormBrowse form has branches button which if clicked will open "Checkout branch" dialog and if clicked on a small triangle on its right will show available branches to switch to.

This triangle is very small and hard to aim at especially with laptop touchpad. Since this button has no action for right-click we can use right-click to perform same action as clicking a small triangle. This gives a lot larger pixel area to invoke available brances context menu.

If you like this idea I could do the same for known repositories, saved stashes and pull buttons.
