### PR TITLE
[ru] fixed russian translation: “up” was “down” and vice versa

### DIFF
--- a/GitUI/Translation/Russian.xml
+++ b/GitUI/Translation/Russian.xml
@@ -297,11 +297,11 @@ Do you want to abort and remove it from the recent repositories list?</Source>
         </TranslationItem>
         <TranslationItem Name="_moveCategoryDown" Property="Text">
           <Source>Move down</Source>
-          <Value>Переместить вверх</Value>
+          <Value>Переместить вниз</Value>
         </TranslationItem>
         <TranslationItem Name="_moveCategoryUp" Property="Text">
           <Source>Move up</Source>
-          <Value>Переместить вниз</Value>
+          <Value>Переместить вверх</Value>
         </TranslationItem>
         <TranslationItem Name="_moveToCategory" Property="Text">
           <Source>Move to category</Source>


### PR DESCRIPTION
On the main window (start screen with repositories list) recent repositories can be moved up and down.
In russian these commands were swapped.
