### PR TITLE
Implement Mergetool/Difftool command suggestions for p4merge (Merge only) and BeyondCompare3 (Merge and Diff).

### DIFF
--- a/GitUI/FormSettings.Designer.cs
+++ b/GitUI/FormSettings.Designer.cs
@@ -2164,6 +2164,7 @@ namespace GitUI
             this.DifftoolPath.Name = "DifftoolPath";
             this.DifftoolPath.Size = new System.Drawing.Size(347, 23);
             this.DifftoolPath.TabIndex = 25;
+            this.DifftoolPath.TextChanged += new System.EventHandler(this.DifftoolPath_TextChanged);
             // 
             // GlobalDiffTool
             // 
@@ -2307,6 +2308,7 @@ namespace GitUI
             this.MergetoolPath.Name = "MergetoolPath";
             this.MergetoolPath.Size = new System.Drawing.Size(347, 23);
             this.MergetoolPath.TabIndex = 10;
+            this.MergetoolPath.TextChanged += new System.EventHandler(this.MergetoolPath_TextChanged);
             // 
             // GlobalKeepMergeBackup
             // 

--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -1123,6 +1123,12 @@ namespace GitUI
             DiffToolCmdSuggest_Click(null, null);
         }
 
+        private void DifftoolPath_TextChanged(object sender, EventArgs e)
+        {
+            Settings.Module.SetGlobalPathSetting(string.Format("difftool.{0}.path", GlobalMergeTool.Text.Trim()), MergetoolPath.Text.Trim());
+            DiffToolCmdSuggest_Click(null, null);
+        }
+
         private void BrowseDiffTool_Click(object sender, EventArgs e)
         {
             if (GlobalDiffTool.Text.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase))
@@ -1151,6 +1157,12 @@ namespace GitUI
             else
                 MergeToolCmd.Enabled = true;
 
+            MergeToolCmdSuggest_Click(null, null);
+        }
+
+        private void MergetoolPath_TextChanged(object sender, EventArgs e)
+        {
+            Settings.Module.SetGlobalPathSetting(string.Format("mergetool.{0}.path", GlobalMergeTool.Text.Trim()), MergetoolPath.Text.Trim());
             MergeToolCmdSuggest_Click(null, null);
         }
 

--- a/GitUI/MergeToolsHelper.cs
+++ b/GitUI/MergeToolsHelper.cs
@@ -177,12 +177,15 @@ namespace GitUI
                     exeName = "winmergeu.exe";
                     return FindFileInFolders(exeName, winmergepath, @"WinMerge\");
                 case "beyondcompare3":
+                    string bcomppath = UnquoteString(GetGlobalSetting("mergetool.beyondcompare3.path"));
+
                     exeName = "bcomp.exe";
-                    return FindFileInFolders(exeName,   @"Beyond Compare 3 (x86)\",
-                                                        @"Beyond Compare 3\");
+                    return FindFileInFolders(exeName, bcomppath, @"Beyond Compare 3 (x86)\",
+                                                                 @"Beyond Compare 3\");
                 case "p4merge":
+                    string p4mergepath = UnquoteString(GetGlobalSetting("mergetool.p4merge.path"));
                     exeName = "p4merge.exe";
-                    return FindFileInFolders(exeName, @"Perforce\");
+                    return FindFileInFolders(exeName, p4mergepath, @"Perforce\");
                 case "araxis":
                     exeName = "Compare.exe";
                     return FindFileInFolders(exeName,   @"Araxis\Araxis Merge\",


### PR DESCRIPTION
Previous implementation did not work because it only checked GlobalPathSetting(mergetool.chosenTool.path) while never actually _setting_ that GlobalPathSetting after a file browse. 

This was corrected by attaching a TextChanged handler to Mergetoolpath and Difftoolpath.
