### PR TITLE
RevParse dereferences tag to the corresponding commit

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2321,7 +2321,7 @@ namespace GitCommands
 
         public string RevParse(string revisionExpression)
         {
-            string revparseCommand = string.Format("rev-parse \"{0}\"", revisionExpression);
+            string revparseCommand = string.Format("rev-parse \"{0}~0\"", revisionExpression);
             int exitCode = 0;
             string[] resultStrings = RunCmd(Settings.GitCommand, revparseCommand, out exitCode, "").Split('\n');
             return exitCode == 0 ? resultStrings[0] : "";


### PR DESCRIPTION
Can you, please review the following update:

Now "Go to commit" does not work, if name of the annotated tag object is given. The reason, is that it does not find hash of the corresponding commit, but the hash of annotated tag itself.

Fix is to change RevParse, so it derefercences tag object until corresponding commit object is found, or cannot be dereferenced anymore. Recipe is taken from here: http://stackoverflow.com/a/1863712/102243
