### PR TITLE
More room around the controls in the checkout dialog

### DIFF
--- a/GitUI/FormCheckoutBranch.Designer.cs
+++ b/GitUI/FormCheckoutBranch.Designer.cs
@@ -47,9 +47,10 @@ namespace GitUI
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 45);
+            this.label1.Location = new System.Drawing.Point(8, 30);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(110, 21);
+            this.label1.Size = new System.Drawing.Size(78, 15);
             this.label1.TabIndex = 0;
             this.label1.Text = "Select branch";
             // 
@@ -60,18 +61,20 @@ namespace GitUI
             this.Branches.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.Branches.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Branches.FormattingEnabled = true;
-            this.Branches.Location = new System.Drawing.Point(158, 42);
+            this.Branches.Location = new System.Drawing.Point(105, 28);
+            this.Branches.Margin = new System.Windows.Forms.Padding(2);
             this.Branches.Name = "Branches";
-            this.Branches.Size = new System.Drawing.Size(318, 29);
+            this.Branches.Size = new System.Drawing.Size(324, 23);
             this.Branches.TabIndex = 1;
             // 
             // Ok
             // 
             this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.Ok.Location = new System.Drawing.Point(389, 72);
+            this.Ok.Location = new System.Drawing.Point(346, 123);
+            this.Ok.Margin = new System.Windows.Forms.Padding(2);
             this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(87, 25);
+            this.Ok.Size = new System.Drawing.Size(82, 45);
             this.Ok.TabIndex = 2;
             this.Ok.Text = "Checkout";
             this.Ok.UseVisualStyleBackColor = true;
@@ -81,9 +84,10 @@ namespace GitUI
             // 
             this.LocalBranch.AutoSize = true;
             this.LocalBranch.Checked = true;
-            this.LocalBranch.Location = new System.Drawing.Point(13, 13);
+            this.LocalBranch.Location = new System.Drawing.Point(9, 9);
+            this.LocalBranch.Margin = new System.Windows.Forms.Padding(2);
             this.LocalBranch.Name = "LocalBranch";
-            this.LocalBranch.Size = new System.Drawing.Size(127, 25);
+            this.LocalBranch.Size = new System.Drawing.Size(93, 19);
             this.LocalBranch.TabIndex = 3;
             this.LocalBranch.TabStop = true;
             this.LocalBranch.Text = "Local branch";
@@ -93,9 +97,10 @@ namespace GitUI
             // Remotebranch
             // 
             this.Remotebranch.AutoSize = true;
-            this.Remotebranch.Location = new System.Drawing.Point(168, 13);
+            this.Remotebranch.Location = new System.Drawing.Point(112, 9);
+            this.Remotebranch.Margin = new System.Windows.Forms.Padding(2);
             this.Remotebranch.Name = "Remotebranch";
-            this.Remotebranch.Size = new System.Drawing.Size(147, 25);
+            this.Remotebranch.Size = new System.Drawing.Size(106, 19);
             this.Remotebranch.TabIndex = 4;
             this.Remotebranch.Text = "Remote branch";
             this.Remotebranch.UseVisualStyleBackColor = true;
@@ -108,9 +113,11 @@ namespace GitUI
             this.localChangesGB.Controls.Add(this.rbDontChange);
             this.localChangesGB.Controls.Add(this.rbReset);
             this.localChangesGB.Controls.Add(this.rbMerge);
-            this.localChangesGB.Location = new System.Drawing.Point(12, 54);
+            this.localChangesGB.Location = new System.Drawing.Point(9, 103);
+            this.localChangesGB.Margin = new System.Windows.Forms.Padding(2);
             this.localChangesGB.Name = "localChangesGB";
-            this.localChangesGB.Size = new System.Drawing.Size(369, 43);
+            this.localChangesGB.Padding = new System.Windows.Forms.Padding(2);
+            this.localChangesGB.Size = new System.Drawing.Size(305, 50);
             this.localChangesGB.TabIndex = 17;
             this.localChangesGB.TabStop = false;
             this.localChangesGB.Text = "Local changes";
@@ -119,9 +126,10 @@ namespace GitUI
             // rbStash
             // 
             this.rbStash.AutoSize = true;
-            this.rbStash.Location = new System.Drawing.Point(169, 17);
+            this.rbStash.Location = new System.Drawing.Point(130, 20);
+            this.rbStash.Margin = new System.Windows.Forms.Padding(2);
             this.rbStash.Name = "rbStash";
-            this.rbStash.Size = new System.Drawing.Size(75, 24);
+            this.rbStash.Size = new System.Drawing.Size(53, 19);
             this.rbStash.TabIndex = 3;
             this.rbStash.Text = "Stash";
             this.rbStash.UseVisualStyleBackColor = true;
@@ -129,9 +137,10 @@ namespace GitUI
             // rbDontChange
             // 
             this.rbDontChange.AutoSize = true;
-            this.rbDontChange.Location = new System.Drawing.Point(240, 17);
+            this.rbDontChange.Location = new System.Drawing.Point(186, 20);
+            this.rbDontChange.Margin = new System.Windows.Forms.Padding(2);
             this.rbDontChange.Name = "rbDontChange";
-            this.rbDontChange.Size = new System.Drawing.Size(128, 24);
+            this.rbDontChange.Size = new System.Drawing.Size(96, 19);
             this.rbDontChange.TabIndex = 2;
             this.rbDontChange.Text = "Don\'t change";
             this.rbDontChange.UseVisualStyleBackColor = true;
@@ -139,9 +148,10 @@ namespace GitUI
             // rbReset
             // 
             this.rbReset.AutoSize = true;
-            this.rbReset.Location = new System.Drawing.Point(97, 17);
+            this.rbReset.Location = new System.Drawing.Point(73, 20);
+            this.rbReset.Margin = new System.Windows.Forms.Padding(2);
             this.rbReset.Name = "rbReset";
-            this.rbReset.Size = new System.Drawing.Size(76, 24);
+            this.rbReset.Size = new System.Drawing.Size(53, 19);
             this.rbReset.TabIndex = 1;
             this.rbReset.Text = "Reset";
             this.rbReset.UseVisualStyleBackColor = true;
@@ -149,9 +159,10 @@ namespace GitUI
             // rbMerge
             // 
             this.rbMerge.AutoSize = true;
-            this.rbMerge.Location = new System.Drawing.Point(13, 17);
+            this.rbMerge.Location = new System.Drawing.Point(10, 20);
+            this.rbMerge.Margin = new System.Windows.Forms.Padding(2);
             this.rbMerge.Name = "rbMerge";
-            this.rbMerge.Size = new System.Drawing.Size(78, 24);
+            this.rbMerge.Size = new System.Drawing.Size(59, 19);
             this.rbMerge.TabIndex = 0;
             this.rbMerge.Text = "Merge";
             this.rbMerge.UseVisualStyleBackColor = true;
@@ -160,9 +171,10 @@ namespace GitUI
             // 
             this.lnkSettings.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lnkSettings.AutoSize = true;
-            this.lnkSettings.Location = new System.Drawing.Point(13, 78);
+            this.lnkSettings.Location = new System.Drawing.Point(9, 155);
+            this.lnkSettings.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lnkSettings.Name = "lnkSettings";
-            this.lnkSettings.Size = new System.Drawing.Size(115, 21);
+            this.lnkSettings.Size = new System.Drawing.Size(81, 15);
             this.lnkSettings.TabIndex = 19;
             this.lnkSettings.TabStop = true;
             this.lnkSettings.Text = "Show Settings";
@@ -171,8 +183,8 @@ namespace GitUI
             // FormCheckoutBranch
             // 
             this.AcceptButton = this.Ok;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
-            this.ClientSize = new System.Drawing.Size(488, 109);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.ClientSize = new System.Drawing.Size(436, 176);
             this.Controls.Add(this.lnkSettings);
             this.Controls.Add(this.Remotebranch);
             this.Controls.Add(this.LocalBranch);
@@ -181,7 +193,6 @@ namespace GitUI
             this.Controls.Add(this.label1);
             this.Controls.Add(this.localChangesGB);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormCheckoutBranch";

--- a/GitUI/FormCheckoutRemoteBranch.Designer.cs
+++ b/GitUI/FormCheckoutRemoteBranch.Designer.cs
@@ -49,9 +49,10 @@ namespace GitUI
             // 
             this.btOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btOk.Location = new System.Drawing.Point(394, 122);
+            this.btOk.Location = new System.Drawing.Point(345, 127);
+            this.btOk.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.btOk.Name = "btOk";
-            this.btOk.Size = new System.Drawing.Size(87, 25);
+            this.btOk.Size = new System.Drawing.Size(83, 40);
             this.btOk.TabIndex = 2;
             this.btOk.Text = "Checkout";
             this.btOk.UseVisualStyleBackColor = true;
@@ -61,9 +62,10 @@ namespace GitUI
             // 
             this.lnkSettings.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lnkSettings.AutoSize = true;
-            this.lnkSettings.Location = new System.Drawing.Point(12, 129);
+            this.lnkSettings.Location = new System.Drawing.Point(8, 155);
+            this.lnkSettings.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lnkSettings.Name = "lnkSettings";
-            this.lnkSettings.Size = new System.Drawing.Size(115, 21);
+            this.lnkSettings.Size = new System.Drawing.Size(81, 15);
             this.lnkSettings.TabIndex = 20;
             this.lnkSettings.TabStop = true;
             this.lnkSettings.Text = "Show Settings";
@@ -72,9 +74,10 @@ namespace GitUI
             // rbDontCreate
             // 
             this.rbDontCreate.AutoSize = true;
-            this.rbDontCreate.Location = new System.Drawing.Point(12, 87);
+            this.rbDontCreate.Location = new System.Drawing.Point(8, 58);
+            this.rbDontCreate.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbDontCreate.Name = "rbDontCreate";
-            this.rbDontCreate.Size = new System.Drawing.Size(215, 25);
+            this.rbDontCreate.Size = new System.Drawing.Size(157, 19);
             this.rbDontCreate.TabIndex = 9;
             this.rbDontCreate.Text = "Checkout remote branch";
             this.rbDontCreate.UseVisualStyleBackColor = true;
@@ -82,9 +85,10 @@ namespace GitUI
             // rbCreateBranch
             // 
             this.rbCreateBranch.AutoSize = true;
-            this.rbCreateBranch.Location = new System.Drawing.Point(12, 37);
+            this.rbCreateBranch.Location = new System.Drawing.Point(8, 25);
+            this.rbCreateBranch.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbCreateBranch.Name = "rbCreateBranch";
-            this.rbCreateBranch.Size = new System.Drawing.Size(327, 25);
+            this.rbCreateBranch.Size = new System.Drawing.Size(229, 19);
             this.rbCreateBranch.TabIndex = 8;
             this.rbCreateBranch.Text = "Create local branch with the name \'{0}\'";
             this.rbCreateBranch.UseVisualStyleBackColor = true;
@@ -93,9 +97,10 @@ namespace GitUI
             // 
             this.rbResetBranch.AutoSize = true;
             this.rbResetBranch.Checked = true;
-            this.rbResetBranch.Location = new System.Drawing.Point(12, 12);
+            this.rbResetBranch.Location = new System.Drawing.Point(8, 8);
+            this.rbResetBranch.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbResetBranch.Name = "rbResetBranch";
-            this.rbResetBranch.Size = new System.Drawing.Size(321, 25);
+            this.rbResetBranch.Size = new System.Drawing.Size(223, 19);
             this.rbResetBranch.TabIndex = 7;
             this.rbResetBranch.TabStop = true;
             this.rbResetBranch.Text = "Reset local branch with the name \'{0}\'";
@@ -108,9 +113,11 @@ namespace GitUI
             this.localChangesGB.Controls.Add(this.rbDontChange);
             this.localChangesGB.Controls.Add(this.rbReset);
             this.localChangesGB.Controls.Add(this.rbMerge);
-            this.localChangesGB.Location = new System.Drawing.Point(12, 104);
+            this.localChangesGB.Location = new System.Drawing.Point(11, 107);
+            this.localChangesGB.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.localChangesGB.Name = "localChangesGB";
-            this.localChangesGB.Size = new System.Drawing.Size(374, 43);
+            this.localChangesGB.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.localChangesGB.Size = new System.Drawing.Size(303, 46);
             this.localChangesGB.TabIndex = 16;
             this.localChangesGB.TabStop = false;
             this.localChangesGB.Text = "Local changes";
@@ -119,9 +126,10 @@ namespace GitUI
             // rbStash
             // 
             this.rbStash.AutoSize = true;
-            this.rbStash.Location = new System.Drawing.Point(169, 17);
+            this.rbStash.Location = new System.Drawing.Point(124, 20);
+            this.rbStash.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbStash.Name = "rbStash";
-            this.rbStash.Size = new System.Drawing.Size(75, 24);
+            this.rbStash.Size = new System.Drawing.Size(53, 19);
             this.rbStash.TabIndex = 3;
             this.rbStash.TabStop = true;
             this.rbStash.Text = "Stash";
@@ -130,9 +138,10 @@ namespace GitUI
             // rbDontChange
             // 
             this.rbDontChange.AutoSize = true;
-            this.rbDontChange.Location = new System.Drawing.Point(240, 17);
+            this.rbDontChange.Location = new System.Drawing.Point(181, 20);
+            this.rbDontChange.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbDontChange.Name = "rbDontChange";
-            this.rbDontChange.Size = new System.Drawing.Size(128, 24);
+            this.rbDontChange.Size = new System.Drawing.Size(96, 19);
             this.rbDontChange.TabIndex = 2;
             this.rbDontChange.TabStop = true;
             this.rbDontChange.Text = "Don\'t change";
@@ -141,9 +150,10 @@ namespace GitUI
             // rbReset
             // 
             this.rbReset.AutoSize = true;
-            this.rbReset.Location = new System.Drawing.Point(97, 17);
+            this.rbReset.Location = new System.Drawing.Point(67, 20);
+            this.rbReset.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbReset.Name = "rbReset";
-            this.rbReset.Size = new System.Drawing.Size(76, 24);
+            this.rbReset.Size = new System.Drawing.Size(53, 19);
             this.rbReset.TabIndex = 1;
             this.rbReset.TabStop = true;
             this.rbReset.Text = "Reset";
@@ -152,9 +162,10 @@ namespace GitUI
             // rbMerge
             // 
             this.rbMerge.AutoSize = true;
-            this.rbMerge.Location = new System.Drawing.Point(13, 17);
+            this.rbMerge.Location = new System.Drawing.Point(4, 20);
+            this.rbMerge.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbMerge.Name = "rbMerge";
-            this.rbMerge.Size = new System.Drawing.Size(78, 24);
+            this.rbMerge.Size = new System.Drawing.Size(59, 19);
             this.rbMerge.TabIndex = 0;
             this.rbMerge.TabStop = true;
             this.rbMerge.Text = "Merge";
@@ -163,9 +174,10 @@ namespace GitUI
             // rbCreateBranchWithCustomName
             // 
             this.rbCreateBranchWithCustomName.AutoSize = true;
-            this.rbCreateBranchWithCustomName.Location = new System.Drawing.Point(12, 62);
+            this.rbCreateBranchWithCustomName.Location = new System.Drawing.Point(8, 41);
+            this.rbCreateBranchWithCustomName.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rbCreateBranchWithCustomName.Name = "rbCreateBranchWithCustomName";
-            this.rbCreateBranchWithCustomName.Size = new System.Drawing.Size(325, 25);
+            this.rbCreateBranchWithCustomName.Size = new System.Drawing.Size(232, 19);
             this.rbCreateBranchWithCustomName.TabIndex = 21;
             this.rbCreateBranchWithCustomName.Text = "Create local branch with custom name:";
             this.rbCreateBranchWithCustomName.UseVisualStyleBackColor = true;
@@ -175,16 +187,17 @@ namespace GitUI
             // 
             this.txtCustomBranchName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.txtCustomBranchName.Enabled = false;
-            this.txtCustomBranchName.Location = new System.Drawing.Point(302, 61);
+            this.txtCustomBranchName.Location = new System.Drawing.Point(249, 40);
+            this.txtCustomBranchName.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.txtCustomBranchName.Name = "txtCustomBranchName";
-            this.txtCustomBranchName.Size = new System.Drawing.Size(179, 28);
+            this.txtCustomBranchName.Size = new System.Drawing.Size(176, 23);
             this.txtCustomBranchName.TabIndex = 22;
             // 
             // FormCheckoutRemoteBranch
             // 
             this.AcceptButton = this.btOk;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
-            this.ClientSize = new System.Drawing.Size(493, 157);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.ClientSize = new System.Drawing.Size(436, 174);
             this.Controls.Add(this.txtCustomBranchName);
             this.Controls.Add(this.rbCreateBranchWithCustomName);
             this.Controls.Add(this.lnkSettings);
@@ -194,7 +207,6 @@ namespace GitUI
             this.Controls.Add(this.btOk);
             this.Controls.Add(this.localChangesGB);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormCheckoutRemoteBranch";


### PR DESCRIPTION
The Checkout Branch and Checkout Remote Branch dialogs were very cramped. Added some space in them.
