### PR TITLE
Allow git-commit to display $EDITOR to enter commit message instead of specifying it in the commit dialog

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1503,15 +1503,15 @@ namespace GitCommands
 
         public string CommitCmd(bool amend)
         {
-            return CommitCmd(amend, false, "");
+            return CommitCmd(amend, false, "", true);
         }
 
         public string CommitCmd(bool amend, string author)
         {
-            return CommitCmd(amend, false, author);
+            return CommitCmd(amend, false, author, true);
         }
 
-        public string CommitCmd(bool amend, bool signOff, string author)
+        public string CommitCmd(bool amend, bool signOff, string author, bool useExplicitCommitMessage)
         {
             string command = "commit";
             if (amend)
@@ -1523,8 +1523,11 @@ namespace GitCommands
             if (!string.IsNullOrEmpty(author))
                 command += " --author=\"" + author + "\"";
 
-            var path = WorkingDirGitDir() + Settings.PathSeparator.ToString() + "COMMITMESSAGE\"";
-            command += " -F \"" + path;
+            if (useExplicitCommitMessage)
+            {
+                var path = WorkingDirGitDir() + Settings.PathSeparator.ToString() + "COMMITMESSAGE\"";
+                command += " -F \"" + path;
+            }
 
             return command;
         }

--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -1101,6 +1101,13 @@ namespace GitCommands
             set { SafeSet("ShellVisibleMenuItems", value, ref _ShellVisibleMenuItems); }
         }
 
+        private static bool? _UseFormCommitMessage;
+        public static bool UseFormCommitMessage
+        {
+            get { return SafeGet("UseFormCommitMessage", true, ref _UseFormCommitMessage); }
+            set { SafeSet("UseFormCommitMessage", value, ref _UseFormCommitMessage); }
+        }
+
         public static string GetGitExtensionsFullPath()
         {
             return GetGitExtensionsDirectory() + "\\GitExtensions.exe";

--- a/GitUI/FormSettings.Designer.cs
+++ b/GitUI/FormSettings.Designer.cs
@@ -92,6 +92,7 @@ namespace GitUI
             this.Language = new System.Windows.Forms.ComboBox();
             this.helpTranslate = new System.Windows.Forms.LinkLabel();
             this.groupBox12 = new System.Windows.Forms.GroupBox();
+            this.chkWriteCommitMessageInCommitWindow = new System.Windows.Forms.CheckBox();
             this.chkPlaySpecialStartupSound = new System.Windows.Forms.CheckBox();
             this.chkCloseProcessDialog = new System.Windows.Forms.CheckBox();
             this.chkShowGitCommandLine = new System.Windows.Forms.CheckBox();
@@ -1039,6 +1040,7 @@ namespace GitUI
             // 
             this.groupBox12.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox12.Controls.Add(this.chkWriteCommitMessageInCommitWindow);
             this.groupBox12.Controls.Add(this.chkPlaySpecialStartupSound);
             this.groupBox12.Controls.Add(this.chkCloseProcessDialog);
             this.groupBox12.Controls.Add(this.chkShowGitCommandLine);
@@ -1057,6 +1059,16 @@ namespace GitUI
             this.groupBox12.TabIndex = 54;
             this.groupBox12.TabStop = false;
             this.groupBox12.Text = "Behaviour";
+            // 
+            // chkWriteCommitMessageInCommitWindow
+            // 
+            this.chkWriteCommitMessageInCommitWindow.AutoSize = true;
+            this.chkWriteCommitMessageInCommitWindow.Location = new System.Drawing.Point(10, 206);
+            this.chkWriteCommitMessageInCommitWindow.Name = "chkWriteCommitMessageInCommitWindow";
+            this.chkWriteCommitMessageInCommitWindow.Size = new System.Drawing.Size(220, 17);
+            this.chkWriteCommitMessageInCommitWindow.TabIndex = 54;
+            this.chkWriteCommitMessageInCommitWindow.Text = "Write Commit Messages in Commit Dialog";
+            this.chkWriteCommitMessageInCommitWindow.UseVisualStyleBackColor = true;
             // 
             // chkPlaySpecialStartupSound
             // 
@@ -1101,7 +1113,7 @@ namespace GitUI
             // label23
             // 
             this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(7, 245);
+            this.label23.Location = new System.Drawing.Point(7, 262);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(205, 13);
             this.label23.TabIndex = 18;
@@ -1109,7 +1121,7 @@ namespace GitUI
             // 
             // SmtpServer
             // 
-            this.SmtpServer.Location = new System.Drawing.Point(395, 238);
+            this.SmtpServer.Location = new System.Drawing.Point(395, 255);
             this.SmtpServer.Name = "SmtpServer";
             this.SmtpServer.Size = new System.Drawing.Size(242, 21);
             this.SmtpServer.TabIndex = 17;
@@ -1121,7 +1133,7 @@ namespace GitUI
             0,
             0,
             0});
-            this.RevisionGridQuickSearchTimeout.Location = new System.Drawing.Point(395, 207);
+            this.RevisionGridQuickSearchTimeout.Location = new System.Drawing.Point(395, 224);
             this.RevisionGridQuickSearchTimeout.Maximum = new decimal(new int[] {
             1000000,
             0,
@@ -1154,7 +1166,7 @@ namespace GitUI
             // label24
             // 
             this.label24.AutoSize = true;
-            this.label24.Location = new System.Drawing.Point(7, 214);
+            this.label24.Location = new System.Drawing.Point(7, 231);
             this.label24.Name = "label24";
             this.label24.Size = new System.Drawing.Size(193, 13);
             this.label24.TabIndex = 32;
@@ -3589,6 +3601,7 @@ namespace GitUI
         private CheckedListBox chlMenuEntries;
         private CheckBox chkCascadedContextMenu;
         private CheckBox chkEnableAutoScale;
+        private CheckBox chkWriteCommitMessageInCommitWindow;
 
     }
 }

--- a/GitUI/FormSettings.cs
+++ b/GitUI/FormSettings.cs
@@ -342,6 +342,7 @@ namespace GitUI
 
                 chkStartWithRecentWorkingDir.Checked = Settings.StartWithRecentWorkingDir;
                 chkPlaySpecialStartupSound.Checked = Settings.PlaySpecialStartupSound;
+                chkWriteCommitMessageInCommitWindow.Checked = Settings.UseFormCommitMessage;
                 chkUsePatienceDiffAlgorithm.Checked = Settings.UsePatienceDiffAlgorithm;
                 chkShowCurrentBranchInVisualStudio.Checked = Settings.ShowCurrentBranchInVisualStudio;
                 RevisionGridQuickSearchTimeout.Value = Settings.RevisionGridQuickSearchTimeout;
@@ -556,6 +557,7 @@ namespace GitUI
 
             Settings.StartWithRecentWorkingDir = chkStartWithRecentWorkingDir.Checked;
             Settings.PlaySpecialStartupSound = chkPlaySpecialStartupSound.Checked;
+            Settings.UseFormCommitMessage = chkWriteCommitMessageInCommitWindow.Checked;
             Settings.UsePatienceDiffAlgorithm = chkUsePatienceDiffAlgorithm.Checked;
             Settings.TruncatePathMethod = _NO_TRANSLATE_truncatePathMethod.Text;
             Settings.ShowCurrentBranchInVisualStudio = chkShowCurrentBranchInVisualStudio.Checked;


### PR DESCRIPTION
To better support git workflows which use standard git commit templates or
prepare-commit-msg hooks, the "Write Commit Messages in Commit Dialog" option
has been added to the gitextensions tab of the settings window.

When it is unchecked, the commit dialog won't specify a commit message to the
git-commit, allowing git-commit to do it's behaviour of launching $EDITOR giving
the user the ability to edit the auto-generated commit message, just like on the
command line.

By default the original behaviour is used. (Require the message to be entered
in the commit dialog)
