### PR TITLE
Use utf8 without BOM and \n as a new line to save config file.

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -110,7 +110,8 @@ namespace GitCommands.Config
                 if (section.Keys.Count == 0)
                     continue;
 
-                configFileContent.AppendLine(section.ToString());
+                configFileContent.Append(section.ToString());
+                configFileContent.Append("\n");
 
                 foreach (var key in section.Keys)
                 {

--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -371,7 +371,7 @@ namespace GitCommands
                     int exitCode;
                     String s = GitModule.Current.RunGitCmd(arguments, out exitCode, null, Encoding.UTF8);
                     if (s != null && s.IndexOf(controlStr) != -1)
-                        _SystemEncoding = Encoding.UTF8;
+                        _SystemEncoding = new UTF8Encoding(false);
                     else
                         _SystemEncoding = Encoding.Default;
                     Debug.WriteLine("System encoding: " + _SystemEncoding.EncodingName);


### PR DESCRIPTION
Reported in #1215.
