### PR TITLE
Fix breaking indexes

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2441,6 +2441,24 @@ namespace GitCommands
             return exitCode == 0;
         }
 
+        public bool IsLockedIndex()
+        {
+            return IsLockedIndex(_workingdir);
+        }
+
+        public static bool IsLockedIndex(string repositoryPath)
+        {
+            var gitDir = WorkingDirGitDir(repositoryPath);
+            var indexLockFile = Path.Combine(gitDir, "index.lock");
+
+            if (File.Exists(indexLockFile))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         #region IGitCommands
 
         public string GitWorkingDir
@@ -2481,6 +2499,5 @@ namespace GitCommands
         }
 
         #endregion
-
     }
 }

--- a/GitUI/ToolStripGitStatus.cs
+++ b/GitUI/ToolStripGitStatus.cs
@@ -203,7 +203,7 @@ namespace GitUI
             {
                 // If the previous status call hasn't exited yet, we'll wait until it is
                 // so we don't queue up a bunch of commands
-                if (commandIsRunning)
+                if (commandIsRunning || GitModule.Current.IsLockedIndex())
                 {
                     statusIsUpToDate = false;//tell that computed status isn't up to date
                     return;


### PR DESCRIPTION
It seems that indexes in working tree break, executing git staus while git rebase, checkout, .. etc.
