### PR TITLE
Fix unhandled null reference exception.

### DIFF
--- a/GitUI/DataGridViewCheckBoxColumnHeaderCell.cs
+++ b/GitUI/DataGridViewCheckBoxColumnHeaderCell.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
+using System.ComponentModel;
 
 namespace GitUI
 {
@@ -25,9 +26,20 @@ namespace GitUI
             owningColumn.HeaderCell = this;
             owningColumn.HeaderText = string.Empty;
             DataGridView.CurrentCellDirtyStateChanged += OnCurrentCellDirtyStateChanged;
-            DataGridView.Rows.CollectionChanged += (s, e) => UpdateCheckedState();
+            DataGridView.Rows.CollectionChanged += OnCollectionChanged;
             UpdateCheckedState();
             wasAttached = true;
+        }
+
+        public void Detach()
+        {
+            DataGridView.CurrentCellDirtyStateChanged -= OnCurrentCellDirtyStateChanged;
+            DataGridView.Rows.CollectionChanged -= OnCollectionChanged;
+        }
+
+        private void OnCollectionChanged(object sender, CollectionChangeEventArgs e)
+        {
+            UpdateCheckedState();
         }
 
         private void OnCurrentCellDirtyStateChanged(object sender, EventArgs e)

--- a/GitUI/FormVerify.Designer.cs
+++ b/GitUI/FormVerify.Designer.cs
@@ -13,6 +13,7 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
+            selectedItemsHeader.Detach();
             if (disposing && (components != null))
             {
                 components.Dispose();


### PR DESCRIPTION
Closing FormVerify occurs null reference exception.

Settings -> Git maintenance -> Recover lost objects
