### PR TITLE
Question: What is the best way to preselect a line in the "Archive revision" revision grid control?

### DIFF
--- a/GitUI/FormArchive.cs
+++ b/GitUI/FormArchive.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 using ResourceManager.Translation;
+using GitCommands;
 
 namespace GitUI
 {
@@ -17,14 +18,40 @@ namespace GitUI
         public FormArchive()
             : base(true)
         {
-            InitializeComponent(); 
+            InitializeComponent();
             Translate();
         }
+
+        /// <summary>
+        /// TODO: does not work yet
+        /// </summary>
+        public GitRevision PreselectRevisionOnLoad { get; set; }
+
+        ////private EventHandler tmpEventHandler;
 
         private void FormArchive_Load(object sender, EventArgs e)
         {
             revisionGrid1.Load();
+
+            // does not work
+            ////if (PreselectRevisionOnLoad != null)
+            ////{
+            ////    revisionGrid1.SetSelectedRevision(PreselectRevisionOnLoad);
+            ////}
+
+            ////tmpEventHandler = new EventHandler(revisionGrid1_SelectionChanged);
+            ////revisionGrid1.SelectionChanged += tmpEventHandler;
         }
+
+        ////void revisionGrid1_SelectionChanged(object sender, EventArgs e)
+        ////{
+        ////    if (PreselectRevisionOnLoad != null)
+        ////    {
+        ////        revisionGrid1.SetSelectedRevision(PreselectRevisionOnLoad);
+        ////    }
+
+        ////    //revisionGrid1.SelectionChanged -= tmpEventHandler;
+        ////}
 
         private void Save_Click(object sender, EventArgs e)
         {
@@ -33,14 +60,14 @@ namespace GitUI
                 MessageBox.Show(this, _noRevisionSelectedMsgBox.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
+
             string revision = revisionGrid1.GetSelectedRevisions()[0].TreeGuid;
 
             using (var saveFileDialog = new SaveFileDialog { Filter = _saveFileDialogFilter.Text + "|*.zip", Title = _saveFileDialogCaption.Text })
             {
-
                 if (saveFileDialog.ShowDialog(this) == DialogResult.OK)
                 {
-                FormProcess.ShowDialog(this, "archive --format=zip " + revision + " --output \"" + saveFileDialog.FileName + "\"");
+                    FormProcess.ShowDialog(this, "archive --format=zip " + revision + " --output \"" + saveFileDialog.FileName + "\"");
                     Close();
                 }
             }

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1334,7 +1334,7 @@ namespace GitUI
 
         private void ArchiveToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (GitUICommands.Instance.StartArchiveDialog(this))
+            if (GitUICommands.Instance.StartArchiveDialog(this, RevisionGrid.GetCurrentRevision()))
                 Initialize();
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -946,6 +946,11 @@ namespace GitUI
 
         public bool StartArchiveDialog(IWin32Window owner)
         {
+            return StartArchiveDialog(owner, null);
+        }
+
+        public bool StartArchiveDialog(IWin32Window owner, GitRevision preselectRevision)
+        {
             if (!RequiresValidWorkingDir(owner))
                 return false;
 
@@ -953,7 +958,10 @@ namespace GitUI
                 return true;
 
             using (var form = new FormArchive())
+            {
+                form.PreselectRevisionOnLoad = preselectRevision;
                 form.ShowDialog(owner);
+            }
 
             InvokeEvent(owner, PostArchive);
 


### PR DESCRIPTION
I tried to preselect the revision in the "Archive revision" revision grid based on the main grid. But without success. A possible reason may be that the grid is filled asynchronously and thus SetSelectedRevision does not work. What is the suggested way of doing this?
