### PR TITLE
Don't update status, if git process is running.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2715,6 +2715,42 @@ namespace GitCommands
             return false;
         }
 
+        public bool IsRunningGitProcess()
+        {
+            if (IsLockedIndex())
+            {
+                return true;
+            }
+
+            // Get processes by "ps" command.
+            var cmd = Path.Combine(Settings.GitBinDir, "ps");
+            var arguments = "x";
+            if (Settings.RunningOnWindows())
+            {
+                // "x" option is unimplemented by msysgit and cygwin.
+                arguments = "";
+            }
+
+            var output = RunCmd(cmd, arguments);
+            var lines = output.Split('\n');
+            var headers = lines[0].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            var commandIndex = Array.IndexOf(headers, "COMMAND");
+            for (int i = 1; i < lines.Count(); i++)
+            {
+                var columns = lines[i].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (commandIndex < columns.Count())
+                {
+                    var command = columns[commandIndex];
+                    if (command.EndsWith("/git"))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         public static string ReEncodeFileName(string diffStr, int headerLines)
         {
             StringReader r = new StringReader(diffStr);

--- a/GitUI/ToolStripGitStatus.cs
+++ b/GitUI/ToolStripGitStatus.cs
@@ -29,7 +29,6 @@ namespace GitUI
         /// </summary>
         private const int MaxUpdatePeriod = 5 * 60 * 1000;
 
-        private bool commandIsRunning = false;
         private bool statusIsUpToDate = true;
         private readonly SynchronizationContext syncContext;
         private readonly FileSystemWatcher workTreeWatcher = new FileSystemWatcher();
@@ -253,13 +252,12 @@ namespace GitUI
             {
                 // If the previous status call hasn't exited yet, we'll wait until it is
                 // so we don't queue up a bunch of commands
-                if (commandIsRunning || Module.IsLockedIndex())
+                if (Module.IsRunningGitProcess())
                 {
                     statusIsUpToDate = false;//tell that computed status isn't up to date
                     return;
                 }
 
-                commandIsRunning = true;
                 statusIsUpToDate = true;
                 AsyncLoader.DoAsync(RunStatusCommand, UpdatedStatusReceived, (e) => { CurrentStatus = WorkingStatus.Stopped; });
                 // Always update every 5 min, even if we don't know anything changed
@@ -275,8 +273,6 @@ namespace GitUI
 
         private void UpdatedStatusReceived(string updatedStatus)
         {
-            commandIsRunning = false;
-
             if (CurrentStatus != WorkingStatus.Started)
                 return;
 


### PR DESCRIPTION
Working tree and index is broken by executing git status while git process is running(ex. rebase, checkout).
Checking index.lock is not sufficient.(refs #1246)
