### PR TITLE
Fix stash apply and drop error.

### DIFF
--- a/GitUI/FormStash.cs
+++ b/GitUI/FormStash.cs
@@ -194,7 +194,7 @@ namespace GitUI
                                        PSTaskDialog.eSysIcons.Information);
                 if (res == DialogResult.OK)
                 {
-                    FormProcess.ShowDialog(this, string.Format("stash drop {0}", Stashes.Text));
+                    FormProcess.ShowDialog(this, string.Format("stash drop \"{0}\"", Stashes.Text));
                     NeedRefresh = true;
                     Initialize();
                     Cursor.Current = Cursors.Default;
@@ -207,7 +207,7 @@ namespace GitUI
             }
             else
             {
-                FormProcess.ShowDialog(this, string.Format("stash drop {0}", Stashes.Text));
+                FormProcess.ShowDialog(this, string.Format("stash drop \"{0}\"", Stashes.Text));
                 NeedRefresh = true;
                 Initialize();
                 Cursor.Current = Cursors.Default;
@@ -218,7 +218,7 @@ namespace GitUI
 
         private void ApplyClick(object sender, EventArgs e)
         {
-            FormProcess.ShowDialog(this, string.Format("stash apply {0}", Stashes.Text));
+            FormProcess.ShowDialog(this, string.Format("stash apply \"{0}\"", Stashes.Text));
 
             MergeConflictHandler.HandleMergeConflicts(UICommands, this, false);
 


### PR DESCRIPTION
Since stash@{0} is changed into stash@0 on command prompt, it is necessary to quote.

The error message is as follows. 

```
fatal: ambiguous argument 'stash@0': unknown revision or path not in the working tree.↲
Use '--' to separate paths from revisions, like this:↲
'git <command> [<revision>...] -- [<file>...]'↲
```

Environment
- GE 2d245d518c15f003cc873808a0c1f6c37ba0800f
- Cygwin git 1.7.9
