### PR TITLE
Deleting "index.lock", if a git process has been aborted.(ref #1307)

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2725,13 +2725,7 @@ namespace GitCommands
 
         public bool IsLockedIndex()
         {
-            return IsLockedIndex(_workingdir);
-        }
-
-        public static bool IsLockedIndex(string repositoryPath)
-        {
-            var gitDir = WorkingDirGitDir(repositoryPath);
-            var indexLockFile = Path.Combine(gitDir, "index.lock");
+            var indexLockFile = GetIndexLockFile();
 
             if (File.Exists(indexLockFile))
             {
@@ -2741,13 +2735,23 @@ namespace GitCommands
             return false;
         }
 
-        public bool IsRunningGitProcess()
+        public string GetIndexLockFile()
+        {
+            var gitDir = WorkingDirGitDir(_workingdir);
+            return Path.Combine(gitDir, "index.lock");
+        }
+
+        public void DeleteIndexLockFile()
         {
             if (IsLockedIndex())
             {
-                return true;
+                var indexLockFile = GetIndexLockFile();
+                File.Delete(indexLockFile);
             }
+        }
 
+        public bool IsRunningGitProcess()
+        {
             // Get processes by "ps" command.
             var cmd = Path.Combine(Settings.GitBinDir, "ps");
             var arguments = "x";

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -1837,15 +1837,13 @@ namespace GitUI
 
         private void deleteIndexlockToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            string fileName = Path.Combine(Module.WorkingDirGitDir(), "index.lock");
-
-            if (File.Exists(fileName))
+            if (Module.IsLockedIndex())
             {
-                File.Delete(fileName);
+                Module.DeleteIndexLockFile();
                 MessageBox.Show(this, _indexLockDeleted.Text);
             }
             else
-                MessageBox.Show(this, _indexLockNotFound.Text + " " + fileName);
+                MessageBox.Show(this, _indexLockNotFound.Text + " " + Module.GetIndexLockFile());
         }
 
         private void saveAsToolStripMenuItem1_Click(object sender, EventArgs e)

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -138,6 +138,9 @@ namespace GitUI
             if (Process != null)
             {
                 Process.Kill();
+
+                var module = new GitModule(gitCommand.WorkingDirectory);
+                module.DeleteIndexLockFile();
             }
         }
 


### PR DESCRIPTION
If a process of checkout  has been aborted, ".git/index.lock" has remained.
