### PR TITLE
Fix fetch all tool bar option.

### DIFF
--- a/GitUI/FormPull.cs
+++ b/GitUI/FormPull.cs
@@ -516,8 +516,12 @@ namespace GitUI
             _NO_TRANSLATE_Remotes.Enabled = true;
             AddRemote.Enabled = true;
 
-            Merge.Enabled = !IsPullAll();
-            Rebase.Enabled = !IsPullAll();
+            if (IsPullAll())
+            {
+                // Do not merge or rebase when fetching all remotes.
+                Merge.Enabled = false;
+                Rebase.Enabled = false;
+            }
         }
 
         private bool IsPullAll()
@@ -619,10 +623,11 @@ namespace GitUI
             label3.Visible = !string.IsNullOrEmpty(labelRemoteUrl.Text);
 
             // update merge options radio buttons
-            Merge.Enabled = !IsPullAll();
-            Rebase.Enabled = !IsPullAll();
             if (IsPullAll())
             {
+                // Do not merge or rebase when fetching all. 
+                Merge.Enabled = false;
+                Rebase.Enabled = false;
                 Fetch.Checked = true;
             }
         }


### PR DESCRIPTION
Set Text to "[ ALL ]" instead of trying to set SelectedIndex. SelectedIndex = 0 will point to the first remote repository in most cases.  IsPullAll() also explicitly check the Text.

When selecting the fetch all option from the dropdown on the browse toolbar GitExtensions was only fetching origin. 
