### PR TITLE
DiffTab: context menu fixes

### DIFF
--- a/GitUI/FormBrowse.Designer.cs
+++ b/GitUI/FormBrowse.Designer.cs
@@ -107,7 +107,6 @@ namespace GitUI
             this.findInDiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetFileToToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetFileToAToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetFileToBaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetFileToRemoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.DiffText = new GitUI.Editor.FileViewer();
             this.TreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -926,31 +925,23 @@ namespace GitUI
             this.resetFileToToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetFileTo;
             this.resetFileToToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.resetFileToAToolStripMenuItem,
-            this.resetFileToBaseToolStripMenuItem,
             this.resetFileToRemoteToolStripMenuItem});
             this.resetFileToToolStripMenuItem.Name = "resetFileToToolStripMenuItem";
             this.resetFileToToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
-            this.resetFileToToolStripMenuItem.Text = "Reset file to";
+            this.resetFileToToolStripMenuItem.Text = "Reset file(s) to";
             // 
             // resetFileToAToolStripMenuItem
             // 
             this.resetFileToAToolStripMenuItem.Name = "resetFileToAToolStripMenuItem";
             this.resetFileToAToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            this.resetFileToAToolStripMenuItem.Text = "A";
+            this.resetFileToAToolStripMenuItem.Text = "A (Base)";
             this.resetFileToAToolStripMenuItem.Click += new System.EventHandler(this.resetFileToAToolStripMenuItem_Click);
-            // 
-            // resetFileToBaseToolStripMenuItem
-            // 
-            this.resetFileToBaseToolStripMenuItem.Name = "resetFileToBaseToolStripMenuItem";
-            this.resetFileToBaseToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            this.resetFileToBaseToolStripMenuItem.Text = "Base (parent of B)";
-            this.resetFileToBaseToolStripMenuItem.Click += new System.EventHandler(this.resetFileToBaseToolStripMenuItem_Click);
             // 
             // resetFileToRemoteToolStripMenuItem
             // 
             this.resetFileToRemoteToolStripMenuItem.Name = "resetFileToRemoteToolStripMenuItem";
             this.resetFileToRemoteToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            this.resetFileToRemoteToolStripMenuItem.Text = "Remote (B)";
+            this.resetFileToRemoteToolStripMenuItem.Text = "B (Remote)";
             this.resetFileToRemoteToolStripMenuItem.Click += new System.EventHandler(this.resetFileToRemoteToolStripMenuItem_Click);
             // 
             // fileHistoryDiffToolstripMenuItem
@@ -2011,7 +2002,6 @@ namespace GitUI
         private ToolStripMenuItem fetchAllToolStripMenuItem;
         private ToolStripMenuItem resetFileToToolStripMenuItem;
         private ToolStripMenuItem resetFileToAToolStripMenuItem;
-        private ToolStripMenuItem resetFileToBaseToolStripMenuItem;
         private ToolStripMenuItem resetFileToRemoteToolStripMenuItem;
         private ToolStripMenuItem resetToolStripMenuItem;        
     }

--- a/GitUI/FormBrowse.cs
+++ b/GitUI/FormBrowse.cs
@@ -922,6 +922,12 @@ namespace GitUI
                     }
                     else
                     {
+                        // TODO: depending on which commit was selected first (how to determine this?)
+                        // show either
+                        // "{0} (A: lower --> B: upper)" or
+                        // "{0} (A: upper --> B: lower)"
+                        // Alternatively: Make A and B somehow visible in the revision grid as soon as the Diff Tab is visible
+                        //
                         DiffFiles.GitItemStatuses = Module.GetDiffFiles(revisions[0].Guid, revisions[1].Guid);
                         DiffTabPage.Text = string.Format("{0} (A: first --> B: second)", DiffTabPageTitleBase);
                     }
@@ -2579,20 +2585,6 @@ namespace GitUI
             {
                 Module.CheckoutFiles(files, revisions[1].Guid, false);
             }
-        }
-
-        private void resetFileToBaseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (!revisions.Any() || !revisions[0].HasParent() || !DiffFiles.SelectedItems.Any())
-            {
-                return;
-            }
-
-            var files = DiffFiles.SelectedItems.Select(item => item.Name);
-
-            Module.CheckoutFiles(files, revisions[0].Guid + "^", false);
         }
 
         private void resetFileToRemoteToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
DiffTab: context menu:
1. Rename "Reset file to" to "Reset file(s) to" because multiselection is possible
2. Remove the "Base (parent of B)" menu item since it is covered by "A (Base)" in case of selection of a single revision.
