### PR TITLE
Add back the broken click event subscription of Clear Image Cache button in Settings Form

### DIFF
--- a/GitUI/FormSettings.Designer.cs
+++ b/GitUI/FormSettings.Designer.cs
@@ -1500,6 +1500,7 @@ namespace GitUI
             this.ClearImageCache.TabIndex = 1;
             this.ClearImageCache.Text = "Clear image cache";
             this.ClearImageCache.UseVisualStyleBackColor = true;
+			this.ClearImageCache.Click += new System.EventHandler(this.ClearImageCache_Click);
             // 
             // ShowAuthorGravatar
             // 


### PR DESCRIPTION
The Clear Image Cache button pressed has no effect because the click event is not subscribed, although the click event handler is there.
