### PR TITLE
Add UTF-8 BOM in NetSpell.SpellChecker/AssemblyInfo.cs

### DIFF
--- a/NetSpell.SpellChecker/AssemblyInfo.cs
+++ b/NetSpell.SpellChecker/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2003, Paul Welter
+﻿// Copyright (c) 2003, Paul Welter
 // All rights reserved.
 
 using System;
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("LoreSoft")]
 [assembly: AssemblyProduct("NetSpell")]
-[assembly: AssemblyCopyright("Copyright � 2003 Paul Welter, modified by Henk Westhuis for Git Extensions.")]
+[assembly: AssemblyCopyright("Copyright © 2003 Paul Welter, modified by Henk Westhuis for Git Extensions.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]		
 


### PR DESCRIPTION
Add UTF-8 BOM in NetSpell.SpellChecker/AssemblyInfo.cs

Fix compilation on zh-TW Windows.
