### PR TITLE
Dashboard splitter bar exception fix

### DIFF
--- a/GitUI/Dashboard.cs
+++ b/GitUI/Dashboard.cs
@@ -263,7 +263,7 @@ namespace GitUI
         bool isValidSplit(SplitContainer splitcontainer, int value)
         {
             bool valid;
-            int limit = (splitContainer7.Orientation == Orientation.Horizontal)
+            int limit = (splitcontainer.Orientation == Orientation.Horizontal)
                 ? splitcontainer.Height
                 : splitcontainer.Width;
             valid = (value > splitcontainer.Panel1MinSize) && (value < limit - splitcontainer.Panel2MinSize);


### PR DESCRIPTION
I've pushed what is hopefully a fix for the splitter exception (in topic branch splitterfix) mentioned in https://github.com/gitextensions/gitextensions/issues/1026 which seems to be caused when the splitter bar is dragged all the way to the bottom of the window.  The value is checked to lie within the valid range before it is used.
