### PR TITLE
IsBare and ValidWorkingDir now using LibGit2Sharp

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2346,7 +2346,20 @@ namespace GitCommands
 
         public static bool IsBareRepository(string repositoryPath)
         {
-            return !Directory.Exists(GetGitDirectory(repositoryPath));
+            if (string.IsNullOrEmpty(repositoryPath))
+                return false;
+
+            try
+            {
+                using (var repo = new LibGit2Sharp.Repository(repositoryPath))
+                {
+                    return repo.Info.IsBare;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
 


### PR DESCRIPTION
When you pass a path over to the repository that is invalid it will throw an exception.
