### PR TITLE
ArgumentOutOfRangeException in StringBuilder

### DIFF
--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -110,7 +110,7 @@ namespace GitUI
             using (var formProcess = new FormProcess(process, arguments, module.WorkingDir, input, useDialogSettings))
             {
                 formProcess.ShowDialog(owner);
-                return formProcess.OutputString.ToString();
+                return formProcess.GetOutputString();
             }
         }
 
@@ -228,7 +228,7 @@ namespace GitUI
 
         public void AppendOutputLine(string line)
         {
-            OutputString.AppendLine(line);
+            AppendToOutputString(line + Environment.NewLine);
 
             AddMessageLine(line);
         }

--- a/GitUI/FormPush.cs
+++ b/GitUI/FormPush.cs
@@ -322,7 +322,7 @@ namespace GitUI
                 //auto pull only if current branch was rejected
                 Regex IsRejected = new Regex(Regex.Escape("! [rejected] ") + ".*" + Regex.Escape(_currentBranch) + ".*" + Regex.Escape(" (non-fast-forward)"), RegexOptions.Compiled);
 
-                if (Settings.AutoPullOnRejected && IsRejected.IsMatch(form.OutputString.ToString()))
+                if (Settings.AutoPullOnRejected && IsRejected.IsMatch(form.GetOutputString()))
                     
                 {
                     if (Settings.PullMerge == Settings.PullAction.Fetch)

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -91,7 +91,7 @@ namespace GitUI
             {
                 //there might be an other error, this condition is too weak
                 /*
-                if (OutputString.ToString().Contains("successfully authenticated"))
+                if (GetOutputString().Contains("successfully authenticated"))
                 {
                     isError = false;
                     return false;
@@ -99,7 +99,7 @@ namespace GitUI
                 */
 
                 // If the authentication failed because of a missing key, ask the user to supply one. 
-                if (OutputString.ToString().Contains("FATAL ERROR") && OutputString.ToString().Contains("authentication"))
+                if (GetOutputString().Contains("FATAL ERROR") && GetOutputString().Contains("authentication"))
                 {
                     string loadedKey;
                     if (FormPuttyError.AskForKey(this, out loadedKey))
@@ -114,7 +114,7 @@ namespace GitUI
                         return true;
                     }
                 }
-                if (OutputString.ToString().ToLower().Contains("the server's host key is not cached in the registry"))
+                if (GetOutputString().ToLower().Contains("the server's host key is not cached in the registry"))
                 {
                     string remoteUrl;
 

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -42,7 +42,7 @@ namespace GitUI
             AbortCallback = abort;
         }
 
-        public StringBuilder OutputString = new StringBuilder();
+        private readonly StringBuilder _outputString = new StringBuilder();
         public ProcessStart ProcessCallback;
         public ProcessAbort AbortCallback;
         private bool errorOccurred;
@@ -278,11 +278,27 @@ namespace GitUI
             try
             {
                 AbortCallback(this);
-                OutputString.Append(Environment.NewLine + "Aborted");
+                AppendToOutputString(Environment.NewLine + "Aborted");
                 Done(false);
                 DialogResult = DialogResult.Abort;
             }
             catch { }
+        }
+
+        public void AppendToOutputString(string text)
+        {
+            lock (_outputString)
+            {
+                _outputString.Append(text);
+            }
+        }
+
+        public string GetOutputString()
+        {
+            lock (_outputString)
+            {
+                return _outputString.ToString();
+            }
         }
 
         private void KeepDialogOpen_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -2007,13 +2007,13 @@ namespace GitUI
                     form.ShowDialog(OwnerForm as IWin32Window);
 
                     ErrorOccurred = form.ErrorOccurred();
-                    CommandOutput = form.OutputString.ToString();
+                    CommandOutput = form.GetOutputString();
                 }
             }
 
             private bool HandleOnExit(ref bool isError, FormProcess form)
             {
-                CommandOutput = form.OutputString.ToString();
+                CommandOutput = form.GetOutputString();
 
                 var e = new GitRemoteCommandCompletedEventArgs(this, isError, false);
 


### PR DESCRIPTION
The OutputString of FormStatus sometimes throws an ArgumentOutOfRangeException. I've seen this at least two times: once in ToString in GitRemoteCommand.Execute, and AppendLine in FormProcess.AppendOutputLine.

I am not sure why this happens and I cannot reproduce it, but my best guess is that it's a problem due to multi threaded access of the StringBuilder. As a fix, I've synchronized all access to the string builder.
