### PR TITLE
Do not refresh revisions in grid when Delete Tag dialog is canceled

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -994,7 +994,12 @@ namespace GitUI
                 return true;
 
             using (var form = new FormDeleteTag(this, tag))
-                form.ShowDialog(owner);
+            {
+                if (form.ShowDialog(owner) != DialogResult.OK)
+                {
+                    return false;
+                }
+            }
 
             InvokeEvent(owner, PostDeleteTag);
 

--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -1808,9 +1808,10 @@ namespace GitUI
             if (toolStripItem == null)
                 return;
 
-            UICommands.StartDeleteTagDialog(this, toolStripItem.Text);
-
-            ForceRefreshRevisions();
+            if (UICommands.StartDeleteTagDialog(this, toolStripItem.Text))
+            {
+                ForceRefreshRevisions();
+            }
         }
 
         private void ToolStripItemClickDeleteBranch(object sender, EventArgs e)

--- a/GitUI/Tag/FormDeleteTag.cs
+++ b/GitUI/Tag/FormDeleteTag.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Windows.Forms;
-using GitCommands;
 using GitUI.Script;
 using ResourceManager.Translation;
 
@@ -38,6 +37,7 @@ namespace GitUI.Tag
                 if (deleteTag.Checked && !string.IsNullOrEmpty(Tags.Text))
                     RemoveRemoteTag(Tags.Text);
 
+                DialogResult = DialogResult.OK;
                 Close();
             }
             catch (Exception ex)


### PR DESCRIPTION
As a result "InvokeEvent(owner, PostDeleteTag);" will not be called when Delete Tag dialog is canceled.
