### PR TITLE
CommitInfo layout tweak

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -84,6 +84,18 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Returns an array of strings containg titles of fields field returned by GetHeader.
+        /// Used to calculate layout in advance
+        /// </summary>
+        /// <returns></returns>
+        public static string[] GetPossibleHeaders()
+        {
+            return new string[] {Strings.GetAuthorText(), Strings.GetAuthorDateText(), Strings.GetCommitterText(),
+                                 Strings.GetCommitDateText(), Strings.GetCommitHashText(), Strings.GetChildrenText(),
+                                 Strings.GetParentsText()};
+        }
+
+        /// <summary>
         /// Generate header.
         /// </summary>
         /// <returns></returns>

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -136,6 +136,7 @@ namespace GitUI.CommitInfo
 
             if (string.IsNullOrEmpty(_revisionGuid))
                 return;
+            _RevisionHeader.SelectionTabs = GetRevisionHeaderTabStops(); 
             _RevisionHeader.Text = string.Empty;
             _RevisionHeader.Refresh();
 
@@ -159,6 +160,21 @@ namespace GitUI.CommitInfo
 
             if (Settings.CommitInfoShowContainedInTags)
                 ThreadPool.QueueUserWorkItem(_ => loadTagInfo(_revisionGuid));
+        }
+
+        private int[] _revisionHeaderTabStops;
+        private int[] GetRevisionHeaderTabStops()
+        {
+            if (_revisionHeaderTabStops != null)
+                return _revisionHeaderTabStops;
+            int tabStop = 0;
+            foreach (string s in CommitData.GetPossibleHeaders())
+            {
+                tabStop = Math.Max(tabStop, TextRenderer.MeasureText(s + "  ", _RevisionHeader.Font).Width);
+            }
+            // simulate a two column layout even when there's more then one tab used
+            _revisionHeaderTabStops = new int[] { tabStop, tabStop + 1, tabStop + 2, tabStop + 3 };
+            return _revisionHeaderTabStops;
         }
 
         private void loadTagInfo(string revision)


### PR DESCRIPTION
This fixes a small issue with tab widths in CommitInfo header.
![CommitInfoLayout](https://f.cloud.github.com/assets/339002/62296/07a67e9e-5cf9-11e2-8032-1a4dd54e3087.png)
Best regards,
Grzegorz
