### PR TITLE
Disabling OnPageShown method for mono

### DIFF
--- a/GitUI/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -24,6 +24,7 @@ namespace GitUI.SettingsDialog.Pages
 
         public override void OnPageShown()
         {
+#if !__MonoCS__
             System.Resources.ResourceManager rm =
                 new System.Resources.ResourceManager("GitUI.Properties.Resources",
                             System.Reflection.Assembly.GetExecutingAssembly());
@@ -50,7 +51,8 @@ namespace GitUI.SettingsDialog.Pages
             }
 
             resourceSet.Close();
-            rm.ReleaseAllResources();            
+            rm.ReleaseAllResources();     
+#endif
         }
 
         protected override void OnLoadSettings()


### PR DESCRIPTION
This fixes #1563. I'm completely disabling this feature on mono since even in .NET windows it requires a "dummy" call to resourceManager so I assume it's not safe. Also on mono implementation it has another behaviour - it returns null thus giving the nullReferenceException.

Debugging this method on my monodevelop crashes requiring me to kill -9
