### PR TITLE
Build and run GitExt without opening Visual Studio

### DIFF
--- a/Build/build.VS2010.debug.run.cmd
+++ b/Build/build.VS2010.debug.run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call %~p0\build.generic.debug.run.cmd VS2010

--- a/Build/build.VS2012.debug.cmd
+++ b/Build/build.VS2012.debug.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+call %~p0\build.generic.cmd VS2012 Debug Build
+

--- a/Build/build.VS2012.debug.run.cmd
+++ b/Build/build.VS2012.debug.run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+call %~p0\build.generic.debug.run.cmd VS2012

--- a/Build/build.generic.cmd
+++ b/Build/build.generic.cmd
@@ -1,0 +1,30 @@
+@echo off
+
+rem
+rem Parameters
+rem   %1: vs_solution_version: VS solution version: VS2010, VS2012
+rem   %2: vs_configuration:    VS configuration:    Debug, Release
+rem   %3: vs_target:           target:              Build or Rebuild
+rem
+
+set vs_solution_version=%1
+set vs_configuration=%2
+set vs_target=%3
+
+rem %~p0 = dir to location of this cmd file
+rem cd /d "%~p0"
+
+set msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set project="%~p0\..\GitExtensions.%vs_solution_version%.sln"
+set SkipShellExtRegistration=1
+
+set msbuildparams=/p:Configuration=%vs_configuration% /t:%vs_target% /nologo /v:m
+
+%msbuild% %project% /p:Platform="Any CPU" %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+
+rem %msbuild% %project% /p:Platform=x86 %msbuildparams%
+rem IF ERRORLEVEL 1 EXIT /B 1
+rem %msbuild% %project% /p:Platform=x64 %msbuildparams%
+rem IF ERRORLEVEL 1 EXIT /B 1
+

--- a/Build/build.generic.debug.run.cmd
+++ b/Build/build.generic.debug.run.cmd
@@ -1,0 +1,12 @@
+@echo off
+
+call %~p0\build.generic.cmd %1 Debug Build
+
+IF %ERRORLEVEL% EQU 0 goto success
+echo BUILD FAILED
+pause
+EXIT /B 1
+
+:success
+echo BUILD SUCCEEDED. Start GitExtensions.exe
+start %~p0\..\GitExtensions\bin\Debug\GitExtensions.exe


### PR DESCRIPTION
Sometimes after retrieving the latest code changes, I just would like to compile and run GitExtensions (without starting VS). With this PR this can be done by doubleclicking Build/build.VS2010.debug.run.cmd or Build/build.VS2012.debug.run.cmd. Build will be done in Debug configuration.
