### PR TITLE
Fix Settings panel crash in Mono - Issue #1587.

### DIFF
--- a/GitUI/SettingsDialog/FormSettings.Designer.cs
+++ b/GitUI/SettingsDialog/FormSettings.Designer.cs
@@ -174,7 +174,6 @@ namespace GitUI
             // flowLayoutPanel4
             // 
             this.flowLayoutPanel4.AutoSize = true;
-            this.tableLayoutPanel3.SetColumnSpan(this.flowLayoutPanel4, 2);
             this.flowLayoutPanel4.Controls.Add(this.buttonApply);
             this.flowLayoutPanel4.Controls.Add(this.buttonDiscard);
             this.flowLayoutPanel4.Controls.Add(this.buttonCancel);


### PR DESCRIPTION
flowLayoutPanel4 exceed the number of columns in tableLayoutPanel3 due to the span of 2. 
