### PR TITLE
Adjust Settings window placement of flowLayoutPanel4.

### DIFF
--- a/GitUI/SettingsDialog/FormSettings.Designer.cs
+++ b/GitUI/SettingsDialog/FormSettings.Designer.cs
@@ -114,7 +114,7 @@ namespace GitUI
             this.tableLayoutPanel3.Controls.Add(this.settingsTreeView, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.panelCurrentSettingsPage, 1, 1);
             this.tableLayoutPanel3.Controls.Add(this.panel2, 1, 0);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel4, 2, 2);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel4, 1, 2);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";


### PR DESCRIPTION
flowLayoutPanel4 was placed at location 2,2 in tableLayoutPanel3 which places it beyond the last column of tableLayoutPanel3 (2 columns).  Under Mono, this added a new column which made the Settings window look very bad.
