### PR TITLE
Better color for non relative commit text in the revision grid

### DIFF
--- a/GitUI/RevisionGrid.cs
+++ b/GitUI/RevisionGrid.cs
@@ -1068,7 +1068,7 @@ namespace GitUI
 
             Color foreColor;
 
-            if (!Settings.RevisionGraphDrawNonRelativesGray || !Settings.RevisionGraphDrawNonRelativesTextGray || Revisions.RowIsRelative(e.RowIndex))
+            if (!Settings.RevisionGraphDrawNonRelativesTextGray || Revisions.RowIsRelative(e.RowIndex))
             {
                 foreColor = isRowSelected && IsFilledBranchesLayout()
                     ? SystemColors.HighlightText


### PR DESCRIPTION
When option "Draw non relatives text gray" is selected, the text of commit in the revision grid is too light and not readable.
This commit fix that and also the fact that with the new darker gray, when the line is selected, the text is not readable too.

This is a good option but without this correction, it is not very usable :(
