### PR TITLE
Remembering which tabs were loaded for selected revision(s) to prevent reloads

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -802,6 +802,11 @@ namespace GitUI.CommandsDialogs
             if (CommitInfoTabControl.SelectedTab != TreeTabPage)
                 return;
 
+            if (selectedRevisionUpdatedTargets.HasFlag(UpdateTargets.FileTree))
+                return;
+
+            selectedRevisionUpdatedTargets |= UpdateTargets.FileTree;
+
             try
             {
                 GitTree.SuspendLayout();
@@ -874,6 +879,11 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
+            if (selectedRevisionUpdatedTargets.HasFlag(UpdateTargets.DiffList))
+                return;
+
+            selectedRevisionUpdatedTargets |= UpdateTargets.DiffList;
+
             var revisions = RevisionGrid.GetSelectedRevisions();
 
             DiffText.SaveCurrentScrollPos();
@@ -908,6 +918,11 @@ namespace GitUI.CommandsDialogs
         {
             if (CommitInfoTabControl.SelectedTab != CommitInfoTabPage)
                 return;
+
+            if (selectedRevisionUpdatedTargets.HasFlag(UpdateTargets.CommitInfo))
+                return;
+
+            selectedRevisionUpdatedTargets |= UpdateTargets.CommitInfo;
 
             if (RevisionGrid.GetSelectedRevisions().Count == 0)
                 return;
@@ -1097,10 +1112,22 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        [Flags]
+        internal enum UpdateTargets
+        {
+            None = 1,
+            DiffList = 2,
+            FileTree = 4,
+            CommitInfo = 8
+        }
+
+        private UpdateTargets selectedRevisionUpdatedTargets = UpdateTargets.None;
         private void RevisionGridSelectionChanged(object sender, EventArgs e)
         {
             try
             {
+                selectedRevisionUpdatedTargets = UpdateTargets.None;
+
                 var revisions = RevisionGrid.GetSelectedRevisions();
 
                 if (revisions.Count > 0 && GitRevision.IsArtificial(revisions[0].Guid))


### PR DESCRIPTION
Idea is that if for selected revision(s) Diff, FileTree or Commit Info tabs were already loaded we wouldn't load them again until different revision(s) is selected.

Apart from less flickering added value is that File Tree doesn't reset expanded nodes when switching back and forth between tabs.

What I am not sure about is if there are undesired side effects. If this approach is/seems wrong please let me know how could I improve it.
