### PR TITLE
Fix Issue #1590 "Show current branch only"

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -797,7 +797,7 @@ namespace GitUI
 
                 IndexWatcher.Reset();
 
-                if (!Settings.ShowGitNotes && !LogParam.Contains(" --not --glob=notes --not"))
+                if (!Settings.ShowGitNotes && LogParam.Contains("--all --boundary") && !LogParam.Contains(" --not --glob=notes --not"))
                     LogParam = LogParam + " --not --glob=notes --not";
 
                 if (Settings.ShowGitNotes && LogParam.Contains(" --not --glob=notes --not"))


### PR DESCRIPTION
Fix issue #1590

The bug happen on next case.
1. Add a git note
2. disable "Show git notes"
3. check "Show current branch only"

> git log --all --not --glob=notes --not
> This command is ok,
> but... 
> git log --not --glob=notes --not
> This command output nothing.
