### PR TITLE
Fix error when current path is not a git repo

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -736,6 +736,10 @@ namespace GitUI
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(Module.WorkingDir)) {
+                    return;
+                }
+
                 RevisionGraphDrawStyle = RevisionGraphDrawStyleEnum.DrawNonRelativesGray;
 
                 ApplyFilterFromRevisionFilterDialog();


### PR DESCRIPTION
On the LibGit2Sharp branch, if GitExtensions is started with a path that isn't a valid git repository, it will throw an exception and popup a dialog box.
This commit resolves that issue.
