### PR TITLE
Fix error when current path is not a git repo

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -736,6 +736,10 @@ namespace GitUI
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(Module.WorkingDir)) {
+                    return;
+                }
+
                 RevisionGraphDrawStyle = RevisionGraphDrawStyleEnum.DrawNonRelativesGray;
 
                 ApplyFilterFromRevisionFilterDialog();


### PR DESCRIPTION
Old Pull Request: #1666

Issue is not still not resolved with latest LibGit2Sharp branch code.

Screen shot below demonstrates the error that this pull fixes:
![image](https://f.cloud.github.com/assets/114417/202813/e1cafe70-811f-11e2-85de-c3d33fa573b9.png)
