### PR TITLE
forcing dispose of repository on destructor

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3469,7 +3469,7 @@ namespace GitCommands
 
         ~GitModule()
         {
-            Dispose(false);
+            Dispose(true);
         }
     }
 }


### PR DESCRIPTION
The only time we don't control object disposing is when it has a destructor, so here we are forcing repository disposing, see #1429
