### PR TITLE
Allow pushing a non-branch source rev to a remote branch

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -540,7 +540,8 @@ namespace GitCommands
         {
             path = FixPath(path);
 
-            fromBranch = GitModule.GetFullBranchName(fromBranch);
+            // This method is for pushing to remote branches, so fully qualify the
+            // remote branch name with refs/heads/.
             toBranch = GitModule.GetFullBranchName(toBranch);
 
             if (string.IsNullOrEmpty(fromBranch) && !string.IsNullOrEmpty(toBranch))
@@ -1244,7 +1245,7 @@ namespace GitCommands
 
         /// <summary>
         /// Takes a date/time which and determines a friendly string for time from now to be displayed for the relative time from the date.
-        /// It is important to note that times are compared using the current timezone, so the date that is passed in should be converted 
+        /// It is important to note that times are compared using the current timezone, so the date that is passed in should be converted
         /// to the local timezone before passing it in.
         /// </summary>
         /// <param name="originDate">Current date.</param>

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs
             //known remotes anyway.
             if (TabControlTagBranch.SelectedTab == BranchTab && PushToRemote.Checked)
             {
-                //If the current branch is not the default push, and not known by the remote 
+                //If the current branch is not the default push, and not known by the remote
                 //(as far as we know since we are disconnected....)
                 if (RemoteBranch.Text != GetDefaultPushRemote(_NO_TRANSLATE_Remotes.Text) &&
                     !Module.GetHeads(true, true).Any(x => x.Remote == _NO_TRANSLATE_Remotes.Text && x.LocalName == RemoteBranch.Text) )
@@ -242,7 +242,16 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                pushCmd = GitCommandHelpers.PushCmd(destination, _NO_TRANSLATE_Branch.Text, RemoteBranch.Text,
+                // Try to make source rev into a fully qualified branch name. If that
+                // doesn't exist, then it must be something other than a branch, so
+                // fall back to using the name just as it was passed in.
+                string srcRev = GitModule.GetFullBranchName(_NO_TRANSLATE_Branch.Text);
+                if (String.IsNullOrEmpty(Module.RevParse(srcRev)))
+                {
+                    srcRev = _NO_TRANSLATE_Branch.Text;
+                }
+
+                pushCmd = GitCommandHelpers.PushCmd(destination, srcRev, RemoteBranch.Text,
                     PushAllBranches.Checked, ForcePushBranches.Checked, track, RecursiveSubmodules.SelectedIndex);
             }
             else if (TabControlTagBranch.SelectedTab == TagTab)


### PR DESCRIPTION
This change allows for specifying non-branch source revs when
pushing to remote branches. This is a capability that was broken as
part of PR #1618.

This change allows things like "HEAD", "HEAD~1", a specific SHA1, or a
local tag to be specified as the source revision when pushing to a
remote branch.

If there is an ambiguity, a local branch with the source name
provided will be preferred, so the original intent of PR #1618 will be
retained.
