### PR TITLE
FormChooseCommit: double click behaves like OK button instead of opening the CommitInfo dialog

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -135,6 +135,7 @@
     <Compile Include="UserControls\ExListView.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="UserControls\RevisionGridClasses\DoubleClickRevisionEventArgs.cs" />
     <Compile Include="UserControls\RevisionGridClasses\DvcsGraph.Graph.cs">
       <DependentUpon>DvcsGraph.cs</DependentUpon>
       <SubType>Component</SubType>

--- a/GitUI/HelperDialogs/FormChooseCommit.Designer.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.Designer.cs
@@ -39,22 +39,22 @@
             this.revisionGrid.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.revisionGrid.Location = new System.Drawing.Point(4, 4);
-            this.revisionGrid.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.revisionGrid.MinimumSize = new System.Drawing.Size(250, 125);
+            this.revisionGrid.DoubleClickDoesNotOpenCommitInfo = true;
+            this.revisionGrid.Location = new System.Drawing.Point(3, 3);
+            this.revisionGrid.MinimumSize = new System.Drawing.Size(200, 100);
             this.revisionGrid.Name = "revisionGrid";
             this.revisionGrid.RevisionGraphDrawStyle = GitUI.RevisionGraphDrawStyleEnum.DrawNonRelativesGray;
-            this.revisionGrid.Size = new System.Drawing.Size(1097, 466);
+            this.revisionGrid.Size = new System.Drawing.Size(878, 373);
             this.revisionGrid.TabIndex = 0;
+            this.revisionGrid.DoubleClickRevision += new System.EventHandler<GitUI.UserControls.RevisionGridClasses.DoubleClickRevisionEventArgs>(this.revisionGrid_DoubleClickRevision);
             // 
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(963, 480);
-            this.btnOK.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnOK.Location = new System.Drawing.Point(771, 384);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(138, 31);
+            this.btnOK.Size = new System.Drawing.Size(110, 25);
             this.btnOK.TabIndex = 1;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -68,21 +68,19 @@
             this.tableLayoutPanel1.Controls.Add(this.revisionGrid, 0, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 41F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1105, 515);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(884, 412);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
             // FormChooseCommit
             // 
             this.AcceptButton = this.btnOK;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
-            this.ClientSize = new System.Drawing.Size(1105, 515);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.ClientSize = new System.Drawing.Size(884, 412);
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "FormChooseCommit";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Choose Commit";

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -33,10 +33,7 @@ namespace GitUI.HelperDialogs
 
         }
 
-        
         public GitCommands.GitRevision SelectedRevision { get; private set; }
-
-        
 
         protected override void OnLoad(EventArgs e)
         {
@@ -52,6 +49,16 @@ namespace GitUI.HelperDialogs
                 SelectedRevision = revisions[0];
                 DialogResult = DialogResult.OK;
 
+                Close();
+            }
+        }
+
+        private void revisionGrid_DoubleClickRevision(object sender, UserControls.RevisionGridClasses.DoubleClickRevisionEventArgs e)
+        {
+            if (e.Revision != null)
+            {
+                SelectedRevision = e.Revision;
+                DialogResult = DialogResult.OK;
                 Close();
             }
         }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -18,6 +18,7 @@ using GitUI.RevisionGridClasses;
 using GitUI.Script;
 using Gravatar;
 using ResourceManager.Translation;
+using GitUI.UserControls.RevisionGridClasses;
 
 namespace GitUI
 {
@@ -67,6 +68,7 @@ namespace GitUI
         private RevisionGridLayout layout;
         private int rowHeigth;
         public event GitModuleChangedEventHandler GitModuleChanged;
+        public event EventHandler<DoubleClickRevisionEventArgs> DoubleClickRevision;
 
         public RevisionGrid()
         {
@@ -214,6 +216,15 @@ namespace GitUI
         public bool ShowUncommitedChangesIfPossible
         {
             get; set;
+        }
+
+        [Description("Do not open the commit info dialog on double click. This is used if the double click event is handled elseswhere.")]
+        [Category("Behavior")]
+        [DefaultValue(false)]
+        public bool DoubleClickDoesNotOpenCommitInfo
+        {
+            get;
+            set;
         }
 
         private IndexWatcher _IndexWatcher;
@@ -1481,7 +1492,16 @@ namespace GitUI
 
         private void RevisionsDoubleClick(object sender, EventArgs e)
         {
-            ViewSelectedRevisions();
+            if (DoubleClickRevision != null)
+            {
+                var selectedRevisions = GetSelectedRevisions();
+                DoubleClickRevision(this, new DoubleClickRevisionEventArgs(selectedRevisions.FirstOrDefault()));
+            }
+
+            if (!DoubleClickDoesNotOpenCommitInfo)
+            {
+                ViewSelectedRevisions();
+            }
         }
 
         public void ViewSelectedRevisions()

--- a/GitUI/UserControls/RevisionGridClasses/DoubleClickRevisionEventArgs.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DoubleClickRevisionEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GitCommands;
+
+namespace GitUI.UserControls.RevisionGridClasses
+{
+    public class DoubleClickRevisionEventArgs : EventArgs
+    {
+        GitRevision _revision;
+
+        public DoubleClickRevisionEventArgs(GitRevision revision)
+        {
+            _revision = revision;
+        }
+
+        public GitRevision Revision { get { return _revision; } }
+    }
+}


### PR DESCRIPTION
I find this more intuitive when using the Choose Commit dialog. To achieve it some modifications to RevisionGrid were necessary:
- add option not to show the CommitInfo dialog.
- Add event handler for double click a revision
