### PR TITLE
'Keep selection on files' option for Stage/Unstage operations on Commit form

### DIFF
--- a/GitCommands/Settings.cs
+++ b/GitCommands/Settings.cs
@@ -1013,6 +1013,14 @@ namespace GitCommands
             set { SafeSet("UseFormCommitMessage", value, ref _UseFormCommitMessage); }
         }
 
+        private static bool? _CommitForm_KeepSelectionOnFilesWhenStageUnstage;
+        public static bool CommitForm_KeepSelectionOnFilesWhenStageUnstage
+        {
+            get { return SafeGet("CommitForm_KeepSelectionOnFilesWhenStageUnstage", false, ref _CommitForm_KeepSelectionOnFilesWhenStageUnstage); }
+            set { SafeSet("CommitForm_KeepSelectionOnFilesWhenStageUnstage", value, ref _CommitForm_KeepSelectionOnFilesWhenStageUnstage); }
+        }
+
+
         public static string GetGitExtensionsFullPath()
         {
             return GetGitExtensionsDirectory() + "\\GitExtensions.exe";

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -63,6 +63,8 @@ namespace GitUI.CommandsDialogs
 
             settingsTreeView.AddSettingsPage(new AppearanceSettingsPage(), gitExtPageRef);
 
+            settingsTreeView.AddSettingsPage(new BehaviourSettingsPage(), gitExtPageRef);
+
             settingsTreeView.AddSettingsPage(new ColorsSettingsPage(), gitExtPageRef);
 
             settingsTreeView.AddSettingsPage(new StartPageSettingsPage(), gitExtPageRef);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BehaviourSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BehaviourSettingsPage.Designer.cs
@@ -1,0 +1,76 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    partial class BehaviourSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.chkCommitKeepSelection = new System.Windows.Forms.CheckBox();
+            this.groupBox1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.chkCommitKeepSelection);
+            this.groupBox1.Location = new System.Drawing.Point(4, 4);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(346, 56);
+            this.groupBox1.TabIndex = 0;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Commit";
+            // 
+            // chkCommitKeepSelection
+            // 
+            this.chkCommitKeepSelection.AutoSize = true;
+            this.chkCommitKeepSelection.Location = new System.Drawing.Point(7, 23);
+            this.chkCommitKeepSelection.Name = "chkCommitKeepSelection";
+            this.chkCommitKeepSelection.Size = new System.Drawing.Size(265, 19);
+            this.chkCommitKeepSelection.TabIndex = 0;
+            this.chkCommitKeepSelection.Text = "Keep selection on files when stage or unstage";
+            this.chkCommitKeepSelection.UseVisualStyleBackColor = true;
+            // 
+            // BehaviourSettingsPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupBox1);
+            this.Name = "BehaviourSettingsPage";
+            this.Size = new System.Drawing.Size(353, 212);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox chkCommitKeepSelection;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BehaviourSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BehaviourSettingsPage.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using GitCommands;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    public partial class BehaviourSettingsPage : SettingsPageBase
+    {
+        public BehaviourSettingsPage()
+        {
+            InitializeComponent();
+            Text = "Behaviour";
+            //NOW Check how Translate() works
+            Translate();    
+        }
+
+        protected override void OnLoadSettings()
+        {
+            chkCommitKeepSelection.Checked = Settings.CommitForm_KeepSelectionOnFilesWhenStageUnstage;
+        }
+
+        public override void SaveSettings()
+        {
+            Settings.CommitForm_KeepSelectionOnFilesWhenStageUnstage = chkCommitKeepSelection.Checked;            
+        }
+
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BehaviourSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BehaviourSettingsPage.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -110,6 +110,12 @@
     <Compile Include="CommandsDialogs\RepoHosting\ViewPullRequestsForm.Designer.cs">
       <DependentUpon>ViewPullRequestsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\Pages\BehaviourSettingsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\Pages\BehaviourSettingsPage.Designer.cs">
+      <DependentUpon>BehaviourSettingsPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\Plugins\PluginRootIntroductionPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -892,6 +898,9 @@
     <EmbeddedResource Include="CommandsDialogs\RepoHosting\ViewPullRequestsForm.resx">
       <DependentUpon>ViewPullRequestsForm.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\BehaviourSettingsPage.resx">
+      <DependentUpon>BehaviourSettingsPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Plugins\PluginRootIntroductionPage.resx">
       <DependentUpon>PluginRootIntroductionPage.cs</DependentUpon>

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -274,6 +274,13 @@ namespace GitUI
                 return FileStatusListView.SelectedItems.Cast<ListViewItem>().
                     Select(i => (GitItemStatus)i.Tag);
             }
+            set
+            {
+                ClearSelected();
+                foreach (ListViewItem item in FileStatusListView.Items)
+                    if (value.Select(s=>s.Name).Contains(((GitItemStatus)item.Tag).Name))
+                        item.Selected = true; ;
+            }
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -293,6 +300,24 @@ namespace GitUI
                     return;
                 foreach (ListViewItem item in FileStatusListView.SelectedItems)
                     if (item.Tag == value)
+                        item.Selected = true;
+            }
+        }
+
+        /// <summary>
+        /// Property can be used to actually select GitItemStatus entry in the list
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
+        public GitItemStatus ActiveSelectedItem
+        {
+            get { return SelectedItem; }
+            set
+            {
+                if (value == null)
+                    return;
+                foreach (ListViewItem item in FileStatusListView.Items)
+                    if (((GitItemStatus)item.Tag).Name == value.Name)
                         item.Selected = true;
             }
         }


### PR DESCRIPTION
When user click Stage or Unstage on Commit form focus remains on the same files moved to another list.

Also there is a new page in Settings form named Behaviour
![GE-Settings](https://f.cloud.github.com/assets/1068398/236442/6eb6fc90-87eb-11e2-9710-4c0031838e38.png)
