### PR TITLE
Fix bad path for RestSharp in the installer config

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -125,7 +125,7 @@
         <File Source="..\bin\PSTaskDialog.dll"/>
       </Component>
       <Component Id="RestSharp.dll" Guid="*">
-        <File Source="..\bin\packages\RestSharp.104.1\lib\net4-client\RestSharp.dll"/>
+        <File Source="..\packages\RestSharp.104.1\lib\net4-client\RestSharp.dll"/>
       </Component>
       <Component Id="Microsoft.WindowsAPICodePack.dll" Guid="*">
         <File Source="..\bin\Microsoft.WindowsAPICodePack.dll"/>


### PR DESCRIPTION
f092d2d108458c9b230ec472702d6c0c0f34834d Introduced the incorrect path as part of the update to support using nuget packages.
