### PR TITLE
Fixing typo Ammend -> Amend in chkAmmend.Text

### DIFF
--- a/GitUI/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -95,7 +95,7 @@
             this.chkAmmend.Name = "chkAmmend";
             this.chkAmmend.Size = new System.Drawing.Size(145, 18);
             this.chkAmmend.TabIndex = 0;
-            this.chkAmmend.Text = "Ammend last commit";
+            this.chkAmmend.Text = "Amend last commit";
             this.chkAmmend.UseVisualStyleBackColor = true;
             // 
             // chkAutoPopStashAfterPull

--- a/GitUI/Translation/Dutch.xml
+++ b/GitUI/Translation/Dutch.xml
@@ -623,7 +623,7 @@ Value:  {2} = {3}</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value>Laatste commit uitbreiden</Value>
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">

--- a/GitUI/Translation/Francais.xml
+++ b/GitUI/Translation/Francais.xml
@@ -681,7 +681,7 @@ Valeur: {2} = {3}</Value>
           <Value>Ajouter un suivi de référence pour les branches nouvellement poussées</Value>
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value>Modifier le dernier commit</Value>
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text">

--- a/GitUI/Translation/German.xml
+++ b/GitUI/Translation/German.xml
@@ -639,7 +639,7 @@ Wert:  {2} = {3}</Value>
           <Value>Eine Tracking Referenz für einen gerade gepushten Branch anlegen</Value>
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value>Letzten Commit korrigieren (Amend)</Value>
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text">

--- a/GitUI/Translation/Italiano.xml
+++ b/GitUI/Translation/Italiano.xml
@@ -624,7 +624,7 @@ Value:  {2} = {3}</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text" type="unfinished">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">

--- a/GitUI/Translation/Japanese.xml
+++ b/GitUI/Translation/Japanese.xml
@@ -629,7 +629,7 @@ Value:  {2} = {3}</Source>
           <Value>新規ブランチをプッシュする時に追跡先として設定</Value>
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value>コミットやり直し</Value>
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">

--- a/GitUI/Translation/Russian.xml
+++ b/GitUI/Translation/Russian.xml
@@ -621,7 +621,7 @@ Value:  {2} = {3}</Source>
           <Value>Добавить отслеживание ссылки для вновь запушенной ветви</Value>
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value>Присоединить к последнему коммиту</Value>
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">

--- a/GitUI/Translation/Simplified Chinese.xml
+++ b/GitUI/Translation/Simplified Chinese.xml
@@ -625,7 +625,7 @@ Value:  {2} = {3}</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text" type="unfinished">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">

--- a/GitUI/Translation/Spanish.xml
+++ b/GitUI/Translation/Spanish.xml
@@ -623,7 +623,7 @@ Value:  {2} = {3}</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text" type="unfinished">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">

--- a/GitUI/Translation/Traditional Chinese.xml
+++ b/GitUI/Translation/Traditional Chinese.xml
@@ -625,7 +625,7 @@ Value:  {2} = {3}</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAmmend" Property="Text" type="unfinished">
-          <Source>Ammend last commit</Source>
+          <Source>Amend last commit</Source>
           <Value />
         </TranslationItem>
         <TranslationItem Name="chkAutoPopStashAfterPull" Property="Text" type="unfinished">


### PR DESCRIPTION
Fixing typo Ammend -> Amend in chkAmmend.Text in English and updates all other translation files

chkAmmend and Settings.DontConfirmAmmend should also be fixed but then old saved settings in DontConfirmAmmend might get lost and currently I cannot open and fix them in the Designer myself

Suggestion: 
chkAmmend -> chkAmend 
DontConfirmAmmend -> DontConfirmAmend 
