### PR TITLE
PluginRootIntroductionPage: remove "IsInstantSavePage: true"

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginRootIntroductionPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginRootIntroductionPage.cs
@@ -8,13 +8,5 @@
             Text = "Plugins Settings";
             Translate();
         }
-
-        public override bool IsInstantSavePage
-        {
-            get
-            {
-                return true;
-            }
-        }
     }
 }


### PR DESCRIPTION
Since PluginRootIntroductionPage does not have any settings, IsInstantSavePage property should be false. This hides the hint text that "Discard" and "Cancel" button do not work
