### PR TITLE
Fix for #1313: Set TERM to "dumb"

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -82,8 +82,8 @@ namespace GitCommands
             //Default!
             Environment.SetEnvironmentVariable("HOME", GetDefaultHomeDir());
             // To prevent leaking processes and suppress ANSI sequences, set TERM to "dumb".
-			// Don't use "msys" because that still allows ANSI sequences.
-			// See issues #1092 and #1313.
+            // Don't use "msys" because that still allows ANSI sequences.
+            // See issues #1092 and #1313.
             Environment.SetEnvironmentVariable("TERM", "dumb");
         }
 


### PR DESCRIPTION
Sets the TERM environment variable to "dumb" to suppress ANSI sequences. Tested with the case described in #1313.
