### PR TITLE
Fix duplicate key exception

### DIFF
--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace GitCommands
 {
@@ -75,7 +73,7 @@ namespace GitCommands
             {
                 var values = line.Split(':');
                 if (values.Length == 3)
-                    attributes.Add(values[1].Trim(), values[2].Trim());
+                    attributes[values[1].Trim()] = values[2].Trim();
             }
 
             string val;


### PR DESCRIPTION
When in `Solve merge conflicts` dialog I double-click a file to open it in P4Merge an exception is thrown. Some key (I think it was `diff`) is being added to the dictionary twice.
