### PR TITLE
remove nuget restore packages for non windows for now

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -4,7 +4,7 @@
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
         
         <!-- Enable the restore command to run before builds -->
-        <RestorePackages Condition="  '$(RestorePackages)' == '' ">false</RestorePackages>
+        <RestorePackages Condition="  '$(RestorePackages)' == '' Or '$(OS)' != 'Windows_NT' ">false</RestorePackages>
 
         <!-- Property that enables building a package from a project -->
         <BuildPackage Condition=" '$(BuildPackage)' == '' ">false</BuildPackage>


### PR DESCRIPTION
Necessary in order to build from command line on linux (xbuild)
