### PR TITLE
Toolbox hide/visible status cannot be changed. Fixed. This also solves issue #1493.

### DIFF
--- a/GitPlugin/Plugin.cs
+++ b/GitPlugin/Plugin.cs
@@ -199,7 +199,7 @@ namespace GitPlugin.Commands
                 {
                     // Create the new CommandBar
                     bar = cmdBars.Add(name, position, Type.Missing, false);
-                    bar.Visible = true;
+                    bar.Visible = false; // make it false so it will hide if user disable toolbar. True is forcing it!
                     bar.Position = MsoBarPosition.msoBarTop;
                 }
             }


### PR DESCRIPTION
Now we are able to hide command bar from toolbar. If user want to show it, they can. If they hide then it will be removed from toolbar.

Tested many times. Seems fine.

Issue: https://github.com/gitextensions/gitextensions/issues/1493

If rejected, now you know where it comes :) You can digg and do some stuff on this. Add an option to setting. If user wants the toolbar they can add it manually. You may do this with a little checkbox :+1:
