### PR TITLE
Check for later version updates only

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -84,7 +84,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                         int cver=int.Parse(CurrentVersion);
 
                             
-                        if (ver<cver)
+                        if (ver<=cver)
                             continue;
                         
                         UpdateFound = true;


### PR DESCRIPTION
Right now, we are at 246.  When it checks for updates, the user is told there is an update to version 244. Changed to check the version found against the version we are running and ignore earlier versions.
