### PR TITLE
Added PowerShell menu item under Tools.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1041,6 +1041,15 @@ namespace GitCommands
             }
         }
 
+        public Process RunPowerShell(string powerShellCommand = null)
+        {
+            string args = "";
+            if (!string.IsNullOrWhiteSpace(powerShellCommand))
+                args = powerShellCommand.Replace("\"", "\\\"") + "\"";
+
+            return RunRealCmdDetached("powershell.exe", args);
+        }
+
         public string Init(bool bare, bool shared)
         {
             if (bare && shared)

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -223,6 +223,7 @@ namespace GitUI.CommandsDialogs
             this.gitItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.powerShellToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 #if Mono212Released //waiting for mono 2.12
             ((System.ComponentModel.ISupportInitialize)(this.toolPanel)).BeginInit();
 #endif
@@ -1899,6 +1900,7 @@ namespace GitUI.CommandsDialogs
             this.gitBashToolStripMenuItem,
             this.gitGUIToolStripMenuItem,
             this.kGitToolStripMenuItem,
+            this.powerShellToolStripMenuItem,
             this.toolStripSeparator6,
             this.PuTTYToolStripMenuItem,
             this.toolStripSeparator41,
@@ -1924,6 +1926,13 @@ namespace GitUI.CommandsDialogs
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
             this.menuStrip1.Size = new System.Drawing.Size(1154, 28);
             this.menuStrip1.TabIndex = 3;
+            // 
+            // powerShellToolStripMenuItem
+            // 
+            this.powerShellToolStripMenuItem.Name = "powerShellToolStripMenuItem";
+            this.powerShellToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.powerShellToolStripMenuItem.Text = "PowerShell";
+            this.powerShellToolStripMenuItem.Click += new System.EventHandler(this.powerShellToolStripMenuItem_Click);
             // 
             // checkForUpdatesToolStripMenuItem
             // 
@@ -2184,5 +2193,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator45;
         private ToolStripSeparator toolStripSeparator46;
         private ToolStripMenuItem checkForUpdatesToolStripMenuItem;
+        private ToolStripMenuItem powerShellToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1299,6 +1299,11 @@ namespace GitUI.CommandsDialogs
             Module.RunGui();
         }
 
+        private void powerShellToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Module.RunPowerShell();
+        }
+        
         private void FormatPatchToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartFormatPatchDialog(this);


### PR DESCRIPTION
- This will be great for those using PS along with PoshGit.

Added this against the 2.46 menu structure. We use PowerShell and PoshGit here. Thought it would be good to have a menu item for it like the Bash shell menu item.
- Greg
