### PR TITLE
Branch filter wildcards

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -112,6 +112,7 @@ namespace GitCommands
         public string BranchFilter = String.Empty;
         public RevisionGraphInMemFilter InMemFilter;
         private string _selectedBranchName;
+        static char[] ShellGlobCharacters = new[] { '?', '*', '[' };
 
         public void Execute()
         {
@@ -181,7 +182,7 @@ namespace GitCommands
 
             string branchFilter = BranchFilter;
             if ((!string.IsNullOrWhiteSpace(BranchFilter)) && 
-                (BranchFilter.IndexOfAny(new[] {'?', '*', '['}) >= 0))
+                (BranchFilter.IndexOfAny(ShellGlobCharacters) >= 0))
                 branchFilter = "--branches=" + BranchFilter;
 
             string arguments = String.Format(CultureInfo.InvariantCulture,


### PR DESCRIPTION
This should address Issue https://github.com/gitextensions/gitextensions/issues/1285

Added support for shell glob wildcards via the log command's --branches=<pattern> option.
http://git-scm.com/docs/git-log (see --branches)

Works well. The only downside, and this is git behavior, is that if the pattern specified doesn't match anything, you get a single line result for the current branch, which can be a bit visually confusing. Still the functionality is worth that minor caveat. 
- Greg
