### PR TITLE
FormBrowse: File tree / diff Tab: fix "Open containing folder" behaviour

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1122,7 +1122,7 @@ namespace GitUI.CommandsDialogs
             openFileToolStripMenuItem.Enabled = enableItems;
             openFileWithToolStripMenuItem.Enabled = enableItems;
             openWithToolStripMenuItem.Enabled = enableItems;
-            copyFilenameToClipboardToolStripMenuItem.Enabled = enableItems;
+            copyFilenameToClipboardToolStripMenuItem.Enabled = FormBrowseUtil.IsFileOrDirectory(FormBrowseUtil.GetFullPathFromGitItem(Module, gitItem));
             editCheckedOutFileToolStripMenuItem.Enabled = enableItems;
         }
 
@@ -2354,6 +2354,9 @@ namespace GitUI.CommandsDialogs
             return new Tuple<int, string>(idx, DiffText.GetSelectedPatch(RevisionGrid, DiffFiles.SelectedItem));
         }
 
+        //
+        // diff context menu
+        //
         private void openContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (!DiffFiles.SelectedItems.Any())
@@ -2361,14 +2364,8 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in DiffFiles.SelectedItems)
             {
-                var fileNames = new StringBuilder();
-                fileNames.Append((Path.Combine(Module.WorkingDir, item.Name)).Replace(Settings.PathSeparatorWrong, Settings.PathSeparator));
-
-                string filePath = fileNames.ToString();
-                if (File.Exists(filePath))
-                {
-                    OsShellUtil.SelectPathInFileExplorer(filePath);
-                }
+                string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                FormBrowseUtil.ShowFileOrParentFolderInFileExplorer(filePath);
             }
         }
 
@@ -2457,18 +2454,8 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var filePath = Path.Combine(Module.WorkingDir, gitItem.FileName);
-            // needed?
-            ////    var fileNames = new StringBuilder();
-            ////    fileNames.Append((Module.WorkingDir + item.Name).Replace(Settings.PathSeparatorWrong, Settings.PathSeparator));
-            if (File.Exists(filePath))
-            {
-                OsShellUtil.SelectPathInFileExplorer(filePath);
-            }
-            else if (Directory.Exists(filePath))
-            {
-                OsShellUtil.OpenWithFileExplorer(filePath);
-            }
+            var filePath = FormBrowseUtil.GetFullPathFromGitItem(Module, gitItem);
+            FormBrowseUtil.ShowFileOrFolderInFileExplorer(filePath);
         }
 
         private void DiffContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
@@ -2498,10 +2485,8 @@ namespace GitUI.CommandsDialogs
 
                 foreach (var item in DiffFiles.SelectedItems)
                 {
-                    var fileNames = new StringBuilder();
-                    fileNames.Append((Path.Combine(Module.WorkingDir, item.Name)).Replace(Settings.PathSeparatorWrong, Settings.PathSeparator));
-
-                    if (File.Exists(fileNames.ToString()))
+                    string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                    if (FormBrowseUtil.FileOrParentDirectoryExists(filePath))
                     {
                         openContainingFolderToolStripMenuItem.Enabled = true;
                         break;
@@ -2998,10 +2983,8 @@ namespace GitUI.CommandsDialogs
             //enable *<->Local items only when local file exists
             foreach (var item in DiffFiles.SelectedItems)
             {
-                var fileNames = new StringBuilder();
-                fileNames.Append((Path.Combine(Module.WorkingDir, item.Name)).Replace(Settings.PathSeparatorWrong, Settings.PathSeparator));
-
-                if (File.Exists(fileNames.ToString()))
+                string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                if (File.Exists(filePath))
                 {
                     bLocalToolStripMenuItem.Enabled = !artificialRevSelected;
                     aLocalToolStripMenuItem.Enabled = !artificialRevSelected;

--- a/GitUI/CommandsDialogs/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/FormBrowseUtil.cs
@@ -1,0 +1,73 @@
+﻿using GitCommands;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GitUI.CommandsDialogs
+{
+    internal class FormBrowseUtil
+    {
+        // prepare file path
+        // does file path exist
+        // open file path
+        // etc. (Code vereinheitlichen von "opening" und "click")
+
+        public static string GetFullPathFromGitItem(GitModule gitModule, GitItem gitItem)
+        {
+            return GetFullPathFromFilename(gitModule, gitItem.FileName);
+        }
+
+        public static string GetFullPathFromGitItemStatus(GitModule gitModule, GitItemStatus gitItemStatus)
+        {
+            return GetFullPathFromFilename(gitModule, gitItemStatus.Name);
+        }
+
+        public static string GetFullPathFromFilename(GitModule gitModule, string filename)
+        {
+            var filePath = Path.Combine(gitModule.WorkingDir, filename);
+            // needed?
+            ////    var fileNames = new StringBuilder();
+            ////    fileNames.Append((Module.WorkingDir + item.Name).Replace(Settings.PathSeparatorWrong, Settings.PathSeparator));
+
+            return filePath;
+        }
+
+        public static bool FileOrParentDirectoryExists(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            return fileInfo.Exists || fileInfo.Directory.Exists;
+        }
+
+        public static bool IsFileOrDirectory(string path)
+        {
+            return File.Exists(path) || Directory.Exists(path);
+        }
+
+        public static void ShowFileOrParentFolderInFileExplorer(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Exists)
+            {
+                OsShellUtil.SelectPathInFileExplorer(fileInfo.FullName);
+            }
+            else if (fileInfo.Directory.Exists)
+            {
+                OsShellUtil.OpenWithFileExplorer(fileInfo.Directory.FullName);
+            }
+        }
+
+        public static void ShowFileOrFolderInFileExplorer(string path)
+        {
+            if (File.Exists(path))
+            {
+                OsShellUtil.SelectPathInFileExplorer(path);
+            }
+            else if (Directory.Exists(path))
+            {
+                OsShellUtil.OpenWithFileExplorer(path);
+            }
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -98,6 +98,7 @@
     <Compile Include="CommandsDialogs\BrowseDialog\FormUpdates.Designer.cs">
       <DependentUpon>FormUpdates.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\FormBrowseUtil.cs" />
     <Compile Include="CommandsDialogs\RepoHosting\CreatePullRequestForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
- File tree tab: "Open containing folder" now also works on directory nodes (instead of file nodes only)
- Diff tab: If a file does not exist then "Open containing folder" now opens the parent directory of the non-existing file

plus: factor out the logic from the big FormBrowse.cs into a new file FormBrowseUtil.cs
