### PR TITLE
Fix Nuget.sh

### DIFF
--- a/.nuget/Nuget.sh
+++ b/.nuget/Nuget.sh
@@ -3,7 +3,7 @@
 if [ ! -d 'packages' ]; then
 	mkdir packages
 fi
-if [ $1 = NoMono ] ; then 
+if [ "$1" = "NoMono" ] ; then
 
 	find ./ -name packages.config -exec .nuget/NuGet.exe install {} -o packages \;
 	


### PR DESCRIPTION
Fix `Nuget.sh` when called without arguments. Without the quotes, I get this warning:

``` sh
$ .nuget/Nuget.sh 
.nuget/Nuget.sh: 6: [: =: unexpected operator
```
