### PR TITLE
Handle new descriptions of detached head introduced in git 1.8.3

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -267,6 +267,8 @@ namespace GitCommands
 
         public static readonly string DetachedBranch = "(no branch)";
 
+        private static readonly string[] DetachedPrefixes = { "(no branch", "(detached from " };
+
         public Settings.PullAction LastPullAction
         {
             get { return Settings.GetEnum("LastPullAction_" + WorkingDir, Settings.PullAction.None); }
@@ -2593,7 +2595,12 @@ namespace GitCommands
 
         public bool IsDetachedHead()
         {
-            return GetSelectedBranch().Equals(DetachedBranch, StringComparison.Ordinal);
+            return IsDetachedHead(GetSelectedBranch());
+        }
+
+        public bool IsDetachedHead(string branch)
+        {
+            return DetachedPrefixes.Any(a => branch.StartsWith(branch, StringComparison.Ordinal));
         }
 
         public string GetCurrentRemote()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2787,7 +2787,7 @@ namespace GitUI.CommandsDialogs
         private string GetModuleBranch(string path)
         {
             string branch = GitModule.GetSelectedBranchFast(path);
-            if (branch == GitModule.DetachedBranch)
+            if (Module.IsDetachedHead(branch))
                 return "[no branch]";
             return "[" + branch + "]";
         }

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -338,7 +338,7 @@ namespace GitUI.CommandsDialogs
         private IList<string> GetContainsRevisionBranches()
         {
             return Module.GetAllBranchesWhichContainGivenCommit(_containRevison, LocalBranch.Checked, !LocalBranch.Checked)
-                        .Where(a => !a.Equals(GitModule.DetachedBranch, StringComparison.Ordinal) && 
+                        .Where(a => !Module.IsDetachedHead(a) && 
                             !a.EndsWith("/HEAD")).ToList();
         }
 

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -37,7 +37,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (!branch.StartsWith("* "))
                     mergedBranches.Add(branch.Trim());
-                else if (branch != "* " + GitModule.DetachedBranch)
+                else if (!branch.StartsWith("* ") || (branch.StartsWith("* ") && !Module.IsDetachedHead(branch.Substring(2))))
                     _currentBranch = branch.Trim('*', ' ');
             }
 

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -492,7 +492,7 @@ namespace GitUI.CommandsDialogs
 
         private string CalculateLocalBranch()
         {
-            if (_branch.Equals(GitModule.DetachedBranch, StringComparison.Ordinal) || string.IsNullOrEmpty(Branches.Text))
+            if (Module.IsDetachedHead(_branch) || string.IsNullOrEmpty(Branches.Text))
                 _branch = null;
             return _branch;
         }


### PR DESCRIPTION
Handle new descriptions of detached head introduced in git 1.8.3

see git gc8183cd builtin/branch.c

There are 4 types in total:
(no branch, rebasing %s)
(no branch, bisect started on %s)
(detached from %s)
(no branch)
