### PR TITLE
Always scroll to selection. Restore scroll position only if there is no selection

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1024,13 +1024,12 @@ namespace GitUI
             }
 
             FirstVisibleRevisionBeforeUpdate = null;
-        }
 
             if (!Revisions.IsRevisionRelative(FiltredCurrentCheckout))
             {
                 HighlightBranch(FiltredCurrentCheckout);
             }
-
+        }
 
         private int SearchRevision(string initRevision, out string graphRevision)
         {


### PR DESCRIPTION
When view is refreshed after some action, selection is restored and grid scrolls to show selected revision. Additional scroll to restore first visible row before refresh seems to be unnecessary and only disturbs.
