### PR TITLE
When FormGotoCommit and clipboard data is used select all text in textbox

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -228,6 +228,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             if (!string.IsNullOrEmpty(guid))
             {
                 textboxCommitExpression.Text = text;
+                textboxCommitExpression.SelectAll();
             }
         }
     }


### PR DESCRIPTION
which otherwise is annoying when you want to start typing (or pasting) right after dialog is opened
