### PR TITLE
Add GitExtensions.exe.config to installation

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -92,6 +92,9 @@
           </Extension>
         </ProgId>
       </Component>
+      <Component Id="GitExtensions.exe.config" Guid="*">
+        <File Source="..\GitExtensions\bin\Release\GitExtensions.exe.config"/>
+      </Component>
       <Component Id="TranslationApp.exe" Guid="*">
         <File Source="..\GitExtensions\bin\Release\TranslationApp.exe"/>
       </Component>
@@ -514,6 +517,7 @@
       <ComponentRef Id="gitex.cmd"/>
       <ComponentRef Id="GitExtensionsUserManual.pdf"/>
       <ComponentRef Id="GitExtensions.exe"/>
+      <ComponentRef Id="GitExtensions.exe.config"/>
       <ComponentRef Id="TranslationApp.exe"/>
       <ComponentRef Id="Gravatar.dll"/>
       <ComponentRef Id="GitCommands.dll"/>


### PR DESCRIPTION
Make the installation copy `GitExtensions.exe.config` so that `Newtonsoft.Json.dll` can be loaded.

Fixes #1971
