### PR TITLE
Add default configuration for meld diff tool.

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -127,6 +127,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "bcomp.exe";
                 case "kdiff3":
                     return "kdiff3.exe";
+                case "meld":
+                    return "meld.exe";
                 case "tmerge":
                     return "TortoiseMerge.exe";
                 case "winmerge":
@@ -156,6 +158,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
                     return FindFileInFolders(exeName, kdiff3path, @"KDiff3\",
                                                           regkdiff3path);
+                case "meld":
+                    string difftoolMeldPath = UnquoteString(GetGlobalSetting("difftool.meld.path"));
+                    string programFilesMeldPath = @"Meld\meld\";
+                    exeName = "meld.exe";
+                    return FindFileInFolders(exeName, difftoolMeldPath, programFilesMeldPath);
+
                 case "tmerge":
                     exeName = "TortoiseGitMerge.exe"; // TortoiseGit 1.8 use new names
                     string difftoolPath = FindFileInFolders(exeName, @"TortoiseGit\bin\");
@@ -186,6 +194,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 case "beyondcompare3":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
                 case "kdiff3":
+                    return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
+                case "meld":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
                 case "tmerge":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";


### PR DESCRIPTION
This adds the command line and typical location for the meld.exe diff tool.

An all-in-one package for meld on windows can be found here : https://code.google.com/p/meld-installer/
(Unfortunately meld for Windows has a bug related to relative paths, and fails to find some of the files passed by git difftool. A small modification can be applied as underlined in this bug report : https://code.google.com/p/meld-installer/issues/detail?can=1&start=0&num=100&q=&colspec=ID%20Type%20Status%20Priority%20Milestone%20Owner%20Summary&groupby=&sort=&id=11)
