### PR TITLE
Make gitextensions recognize git-credential-wincred

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -9,6 +9,7 @@ namespace GitCommands
         private static readonly GitVersion v1_7_1 = new GitVersion("1.7.1");
         private static readonly GitVersion v1_7_7 = new GitVersion("1.7.7");
         private static readonly GitVersion v1_7_11 = new GitVersion("1.7.11");
+        private static readonly GitVersion v1_8_1 = new GitVersion("1.8.1");
 
         public static readonly GitVersion LastSupportedVersion = v1_7_0;
 
@@ -69,6 +70,11 @@ namespace GitCommands
         public bool SupportPushWithRecursiveSubmodulesOnDemand
         {
             get { return this >= v1_7_11; }
+        }
+
+        public bool HasBuiltinCredentialHelper
+        {
+            get { return this >= v1_8_1; }
         }
 
         public bool IsUnknown

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -62,6 +62,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (!CheckGitCredentialStore())
             {
+                if (GitCommandHelpers.VersionInUse.HasBuiltinCredentialHelper)
+                {
+                    var config = GlobalConfigFileSettings;
+                    config.SetValue("credential.helper", "wincred");
+                    return true;
+                }
+
                 string gcsFileName = Path.Combine(AppSettings.GetInstallDir(), @"GitCredentialWinStore\git-credential-winstore.exe");
                 if (File.Exists(gcsFileName))
                 {


### PR DESCRIPTION
With msysgit 1.8.1, git-credential-wincred is always shipped. So gitextensions should recognize it rather than saying no credential helper detected.
