### PR TITLE
Bugfix: Fetch all prompts for a default branch

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -547,7 +547,7 @@ namespace GitUI.CommandsDialogs
             }
 
             if (Branches.Text.IsNullOrEmpty() && !curLocalBranch.IsNullOrEmpty()
-                && !remote.Equals(currentBranchRemote.Value))
+                && !remote.Equals(currentBranchRemote.Value) && !IsPullAll())
             {
                 int idx = PSTaskDialog.cTaskDialog.ShowCommandBox(this,
                                                         _noRemoteBranchCaption.Text,
@@ -566,7 +566,7 @@ namespace GitUI.CommandsDialogs
             }
 
             if (Branches.Text.IsNullOrEmpty() && !curLocalBranch.IsNullOrEmpty()
-                && Fetch.Checked)
+                && Fetch.Checked && !IsPullAll())
             {
                 int idx = PSTaskDialog.cTaskDialog.ShowCommandBox(this,
                                                         _noRemoteBranchCaption.Text,


### PR DESCRIPTION
![Fetch all prompt](http://spurgius.com/interwebs/img/20130819133347_fetchallbug.png)
This is the dialog I get on `Fetch all`.

@jbialobr since this fixes your changes you are best to evaluate this PR.
