### PR TITLE
Allow null branch in GitCommandHelpers.GetFullBranchName

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -326,7 +326,7 @@ namespace GitCommands
 
         public static string GetFullBranchName(string branch)
         {
-            if (branch.StartsWith("refs/"))
+            if (string.IsNullOrEmpty(branch) || branch.StartsWith("refs/"))
                 return branch;
             return "refs/heads/" + branch;
         }


### PR DESCRIPTION
Fix NullReferenceException in GitCommandHelpers.PushCmd overload called by Gerrit plugin.
