### PR TITLE
Hook up the "Get from user" button in the Github Search for repositories dialog

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.Designer.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.Designer.cs
@@ -308,6 +308,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this._getFromUserBtn.TabIndex = 2;
             this._getFromUserBtn.Text = "Get from user";
             this._getFromUserBtn.UseVisualStyleBackColor = true;
+            this._getFromUserBtn.Click += new System.EventHandler(this._getFromUserBtn_Click);
             // 
             // _forkBtn
             // 


### PR DESCRIPTION
A "Get from user" button exists in the UI, and an implementation exists in code, but the two were not properly connected so the button did nothing. This simple change hooks the two together.
