### PR TITLE
[Setup] Add choice to add install dir to PATH

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -8,7 +8,7 @@
         <PropertyRef Id="NETFRAMEWORK40CLIENT" />
         <Condition Message=".NET Framework 4.0 must be installed prior to installation of Git Extensions.">
       Installed OR NETFRAMEWORK40CLIENT
-    </Condition>
+        </Condition>
         <Icon Id="gitextensions.ico" SourceFile="../bin/logo/git-extensions-logo-final-256.ico" />
         <?include AddRemove.wxi?>
         <?include EnableUpgrades.wxi?>
@@ -43,6 +43,9 @@
                 <Directory Id="StartMenuDir" Name="$(var.ProductName)" />
             </Directory>
             <Directory Id="DesktopFolder" />
+            <Component Id="Path" Guid="{DAC97FD8-A869-4458-AABD-C27D2C892643}">
+                <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
+            </Component>
         </Directory>
         <?define VsVersions = 2005;2008;2010;2012;2013?>
         <?foreach VsVersion in $(var.VsVersions)?>
@@ -632,6 +635,9 @@
             <Feature Id="ShellExtension" Title="Windows Explorer integration" Level="1">
                 <ComponentRef Id="GitExtensionsShellEx32.dll" />
                 <ComponentRef Id="GitExtensionsShellEx64.dll" />
+            </Feature>
+            <Feature Id="AddToPath" Title="Add installation directory to PATH" Level="1">
+                <ComponentRef Id="Path" />
             </Feature>
             <?foreach VsVersion in $(var.VsVersions)?>
             <Feature Id="VS$(var.VsVersion)" Title="Visual Studio $(var.VsVersion) integration" Level="1">


### PR DESCRIPTION
Git Extensions' installation directory will be added to the system
environment variable "PATH" if selected. Defaults to yes.
Always add to the _system_ variable and not user variable, since
the install package can't install without administrative privileges
anyway, so the "install for this user only" option is broken anyway.

The directory will be removed from PATH when Git Extensions
is uninstalled.

Solves issue #438 (which is a feature request).
