### PR TITLE
Fix project lookup REST request format for TeamCity 8.

### DIFF
--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -402,7 +402,7 @@ namespace TeamCityIntegration
 
         private Task<XDocument> GetProjectFromNameXmlResponseAsync(string projectName, CancellationToken cancellationToken)
         {
-            return GetXmlResponseAsync(string.Format("projects/name:{0}", projectName), cancellationToken);
+            return GetXmlResponseAsync(string.Format("projects/{0}", projectName), cancellationToken);
         }
 
         private Task<XDocument> GetFilteredBuildsXmlResponseAsync(string buildTypeId, CancellationToken cancellationToken, DateTime? sinceDate = null, bool? running = null)


### PR DESCRIPTION
The "projects" REST request does not always work in TC8, as it did in TC7. Changing to a different format.
