### PR TITLE
Display correctly windows end of line in git commit message

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -277,7 +277,7 @@ namespace GitCommands
             if (data == null)
                 throw new ArgumentNullException("Data");
 
-            var lines = data.Split('\n');
+            var lines = data.Replace("\r\n", "\n").Split('\n');
 
             var guid = lines[0];
 


### PR DESCRIPTION
Currently, when you use GitExtension under windows, and create a commit, end of lines used are windows end of line.
These ends of line are well managed by other git clients (git in command line, tig, ...) but not well managed in GitExtension : each end of line is displayed twice, introducing blank line between each line :(

This Pull request correct the display.
