### PR TITLE
Fix slow settings load because of UNC paths.

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -185,6 +185,7 @@
             this.cbDefaultCloneDestination.Name = "cbDefaultCloneDestination";
             this.cbDefaultCloneDestination.Size = new System.Drawing.Size(543, 24);
             this.cbDefaultCloneDestination.TabIndex = 18;
+            this.cbDefaultCloneDestination.DropDown += new System.EventHandler(this.defaultCloneDropDown);
             // 
             // chkShowGitCommandLine
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
@@ -16,9 +16,19 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Translate();
         }
 
+        bool loadedDefaultClone = false;
+        private void defaultCloneDropDown(object sender, EventArgs e)
+        {
+            if (!loadedDefaultClone)
+            {
+                FillDefaultCloneDestinationDropDown();
+                loadedDefaultClone = true;
+            }
+        }
+
         protected override void SettingsToPage()
         {
-            FillDefaultCloneDestinationDropDown();
+
 
             chkCheckForUncommittedChangesInCheckoutBranch.Checked = AppSettings.CheckForUncommittedChangesInCheckoutBranch;
             chkStartWithRecentWorkingDir.Checked = AppSettings.StartWithRecentWorkingDir;
@@ -93,7 +103,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             return x =>
             {
-                if (!Directory.Exists(x.Path))
+                if (x.Path.StartsWith(@"\\") || !Directory.Exists(x.Path))
                 {
                     return string.Empty;
                 }
@@ -114,6 +124,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 if (dialog.ShowDialog(this) == DialogResult.OK)
                     cbDefaultCloneDestination.Text = dialog.SelectedPath;
             }
-        }        
+        }
     }
 }


### PR DESCRIPTION
Make combobox lazy loaded.
Ignore UNC paths when loading list.  This prevents trying to access an UNC path that is not accessible at the time.
