### PR TITLE
Regex for matching a URL was incorrect.

### DIFF
--- a/Plugins/Stash/Settings.cs
+++ b/Plugins/Stash/Settings.cs
@@ -9,7 +9,7 @@ namespace Stash
     class Settings
     {
         private const string StashHttpRegex =
-            @"https?:\/\/([\w\.]+\@)?(?<url>([\w\.]+):?(\d+)?)\/scm\/(?<project>\w+)\/(?<repo>\w+).git";
+            @"(?<prefix>https?:\/\/)([\w\.]+\@)?(?<url>([a-zA-Z0-9\.\-]+):?(\d+)?)\/scm\/(?<project>\w+)\/(?<repo>\w+).git";
         private const string StashSshRegex =
             @"ssh:\/\/([\w\.]+\@)?(?<url>([\w\.]+):?(\d+)?)\/(?<project>\w+)\/(?<repo>\w+).git";
 
@@ -35,7 +35,7 @@ namespace Stash
                 {
                     result.ProjectKey = match.Groups["project"].Value;
                     result.RepoSlug = match.Groups["repo"].Value;
-                    result.StashUrl = match.Groups["url"].Value;
+                    result.StashUrl = match.Groups["prefix"].Value + match.Groups["url"].Value;
                     return result;
                 }
             }

--- a/Plugins/Stash/StashRequestBase.cs
+++ b/Plugins/Stash/StashRequestBase.cs
@@ -25,7 +25,7 @@ namespace Stash
         public StashResponse<T> Send()
         {
             var client = new RestClient();
-            client.BaseUrl = "http://" + Settings.StashUrl;
+            client.BaseUrl = Settings.StashUrl;
             client.Authenticator = new HttpBasicAuthenticator(Settings.Username, Settings.Password);
 
             var request = new RestRequest(ApiUrl, RequestMethod);


### PR DESCRIPTION
Http prefix was hardcoded in Stash api calls. It will now work with http or https.
