### PR TITLE
Fix OS detection for Gerrit postbuild

### DIFF
--- a/Plugins/Gerrit/Gerrit.csproj
+++ b/Plugins/Gerrit/Gerrit.csproj
@@ -146,12 +146,12 @@
     <Content Include="Resources\GerritInstallHook.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup Condition="$(Platform) == 'WINDOWS_NT'">
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <PostBuildEvent>copy "$(TargetPath)" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
 copy "$(TargetDir)\Newtonsoft.Json.dll" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
 </PostBuildEvent>
   </PropertyGroup>
-  <PropertyGroup Condition="$(Platform) != 'WINDOWS_NT'">
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
   <PostBuildEvent>cp "$(TargetPath)" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
       cp "$(TargetDir)\Newtonsoft.Json.dll" "..\..\..\..\GitExtensions\bin\$(ConfigurationName)\"
   </PostBuildEvent>


### PR DESCRIPTION
This was preventing me from building on Windows 8.1 with Visual Studio 2013.
