### PR TITLE
Fix issue with copy_plugin.cmd failing with exit code 4

### DIFF
--- a/GitExtensions/copy_plugins.cmd
+++ b/GitExtensions/copy_plugins.cmd
@@ -4,6 +4,6 @@ md Plugins\
 echo Microsoft.TeamFoundation.WorkItemTracking.Client.DataStoreLoader.dll > exclude.txt
 echo Microsoft.WITDataStore.dll >> exclude.txt
 for /d %%I in (%~p0\..\Plugins\*, %~p0\..\Plugins\Statistics\*, %~p0\..\Plugins\BuildServerIntegration\*) do (
-  xcopy /y %%I\bin\%config%\*.dll Plugins\ /EXCLUDE:exclude.txt
-  xcopy /y %%I\bin\%config%\*.pdb Plugins\
+  xcopy /y /r %%I\bin\%config%\*.dll Plugins\ /EXCLUDE:exclude.txt
+  xcopy /y /r %%I\bin\%config%\*.pdb Plugins\
 )


### PR DESCRIPTION
Add /r switch so xcopy will copy read-only files as well
