### PR TITLE
Do check svn-workindir before svn commands. 

### DIFF
--- a/GitCommands/Git/GitSvnCommandHelpers.cs
+++ b/GitCommands/Git/GitSvnCommandHelpers.cs
@@ -83,13 +83,12 @@ namespace GitCommands
         {
             if (string.IsNullOrEmpty(dir))
                 return false;
+            string gitDirectory = GitModule.GetGitDirectory(dir);
+            if (string.IsNullOrEmpty(gitDirectory))
+                return false;
 
-            string path = dir + AppSettings.PathSeparator.ToString() + ".git" + AppSettings.PathSeparator.ToString() + "svn";
-            if (Directory.Exists(path) || File.Exists(path))
-                return true;
-
-            return !dir.Contains(".git") &&
-                   Directory.Exists(dir + AppSettings.PathSeparator.ToString() + "svn");
+            string path = gitDirectory + AppSettings.PathSeparator.ToString() + "svn";
+            return Directory.Exists(path) || File.Exists(path);
         }
     }
 }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -701,6 +701,8 @@ namespace GitUI
 
         public bool StartSvnDcommitDialog(IWin32Window owner)
         {
+            if (!RequiredValidGitSvnWorikingDir(owner))
+                return false;
             Func<bool> action = () =>
             {
                 return FormProcess.ShowDialog(owner, Module, Settings.GitCommand, GitSvnCommandHelpers.DcommitCmd());
@@ -716,6 +718,8 @@ namespace GitUI
 
         public bool StartSvnRebaseDialog(IWin32Window owner)
         {
+            if (!RequiredValidGitSvnWorikingDir(owner))
+                return false;
             Func<bool> action = () =>
             {
                 FormProcess.ShowDialog(owner, Module, Settings.GitCommand, GitSvnCommandHelpers.RebaseCmd());
@@ -732,6 +736,8 @@ namespace GitUI
 
         public bool StartSvnFetchDialog(IWin32Window owner)
         {
+            if (!RequiredValidGitSvnWorikingDir(owner))
+                return false;
             Func<bool> action = () =>
             {
                 return FormProcess.ShowDialog(owner, Module, Settings.GitCommand, GitSvnCommandHelpers.FetchCmd());


### PR DESCRIPTION
Check ValidSvnWorkindDir before do svn commands. 
Method GitSvnCommandHelpers.ValidSvnWorkindDir work not correct on submodule repo
