### PR TITLE
Re-enable BranchGrid after it has finished loading.

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -774,6 +774,7 @@ namespace GitUI.CommandsDialogs
                             }
                         }
                     }
+                    BranchGrid.Enabled = true;
                 });
         }
 


### PR DESCRIPTION
When using the Push dialog to push multiple branches, the branches grid stays disabled (bug introduced in 3783df637f08bd71ff17dee8422ff2af72818dc2).
