### PR TITLE
Fix call to System.IO.Path.Combine. It was combining using the string.Co...

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGridClasses/IndexWatcher.cs
@@ -61,7 +61,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                     GitIndexWatcher.IncludeSubdirectories = false;
                     GitIndexWatcher.EnableRaisingEvents = enabled;
 
-                    RefsWatcher.Path = Path.Combine(Path, "refs");
+                    RefsWatcher.Path = System.IO.Path.Combine(Path, "refs");
                     RefsWatcher.IncludeSubdirectories = true;
                     RefsWatcher.EnableRaisingEvents = enabled;
                 }


### PR DESCRIPTION
Fix call to System.IO.Path.Combine. It was combining using the string.Combine extension method (which was unintended, and threw a NotSupportedException).
