### PR TITLE
Work around bug #2262 - Crash on starting when configuration file is corrupted.

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -23,19 +23,33 @@ namespace GitExtensions
 
             if (!EnvUtils.IsMonoRuntime())
             {
-                NBug.Settings.UIMode = NBug.Enums.UIMode.Full;
+                try
+                {
+                    NBug.Settings.UIMode = NBug.Enums.UIMode.Full;
 
-                // Uncomment the following after testing to see that NBug is working as configured
-                NBug.Settings.ReleaseMode = true;
-                NBug.Settings.ExitApplicationImmediately = false;
-                NBug.Settings.WriteLogToDisk = false;
-                NBug.Settings.MaxQueuedReports = 10;
-                NBug.Settings.StopReportingAfter = 90;
-                NBug.Settings.SleepBeforeSend = 30;
-                NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
-                
-                AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
-                Application.ThreadException += NBug.Handler.ThreadException;
+                    // Uncomment the following after testing to see that NBug is working as configured
+                    NBug.Settings.ReleaseMode = true;
+                    NBug.Settings.ExitApplicationImmediately = false;
+                    NBug.Settings.WriteLogToDisk = false;
+                    NBug.Settings.MaxQueuedReports = 10;
+                    NBug.Settings.StopReportingAfter = 90;
+                    NBug.Settings.SleepBeforeSend = 30;
+                    NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
+
+                    AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
+                    Application.ThreadException += NBug.Handler.ThreadException;
+
+                }
+                catch (TypeInitializationException tie)
+                {
+                    // is this exception caused by the configuration?
+                    if (tie.InnerException != null
+                        && tie.InnerException.GetType()
+                            .IsSubclassOf(typeof(System.Configuration.ConfigurationException)))
+                    {
+                        HandleConfigurationException((System.Configuration.ConfigurationException)tie.InnerException);
+                    }
+                }
             }
 
             string[] args = Environment.GetCommandLineArgs();
@@ -145,5 +159,67 @@ namespace GitExtensions
 
             return workingDir;
         }
+
+        /// <summary>
+        /// Used in the rare event that the configuration file for the application is corrupted
+        /// </summary>
+        /// <param name="ce"></param>
+        private static void HandleConfigurationException(System.Configuration.ConfigurationException ce)
+        {
+            try
+            {
+                // perhaps this should be checked for if it is null
+                var in3 = ce.InnerException.InnerException;
+
+                // saves having to have a reference to System.Xml just to check that we have an XmlException
+                if (in3.GetType().Name.Equals("XmlException"))
+                {
+                    var localSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GitExtensions");
+
+                    //assume that if we are having this error and the installation is not a portable one then the folder will exist.
+                    if (Directory.Exists(localSettingsPath))
+                    {
+                        string messageContent = String.Format("There is a problem with the user.xml configuration file.{0}{0}The error message was: {1}{0}{0}The configuration file is usually found in: {2}{0}{0}Problems with configuration can usually be solved by deleting the configuration file. Would you like to delete the file?", Environment.NewLine, in3.Message, localSettingsPath);
+
+                        if (DialogResult.Yes.Equals(MessageBox.Show(messageContent, "Configuration Error", MessageBoxButtons.YesNo, MessageBoxIcon.Error, MessageBoxDefaultButton.Button2)))
+                        {
+                            try
+                            {
+                                Directory.Delete(localSettingsPath, true); //deletes all application settings not just for this instance - but should work
+                                //Restart GitExtensions with the same arguments after old config is deleted?
+                                if (DialogResult.OK.Equals(MessageBox.Show(String.Format("Files have been deleted.{0}{0}Would you like to attempt to restart GitExtensions?", Environment.NewLine), "Configuration Error", MessageBoxButtons.OKCancel, MessageBoxIcon.Information)))
+                                {
+                                    var args = Environment.GetCommandLineArgs();
+                                    System.Diagnostics.Process p = new System.Diagnostics.Process();
+                                    p.StartInfo.FileName = args[0];
+                                    if (args.Length > 1)
+                                    {
+                                        args[0] = "";
+                                        p.StartInfo.Arguments = String.Join(" ", args);
+                                    }
+                                    p.Start();
+                                }
+                            }
+                            catch (IOException)
+                            {
+                                MessageBox.Show(String.Format("Could not delete all files and folders in {0}!", localSettingsPath), "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            }
+                        }
+                    }
+                    //assuming that there is no localSettingsPath directory in existence we probably have a portable installation.
+                    else
+                    {
+                        string messageContent = String.Format("There is a problem with the application settings XML configuration file.{0}{0}The error message was: {1}{0}{0}Problems with configuration can usually be solved by deleting the configuration file.", Environment.NewLine, in3.Message);
+                        MessageBox.Show(messageContent, "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            }
+            finally // if we fail in this somehow at least this message might get somewhere
+            {
+                System.Console.WriteLine("Configuration Error");
+                System.Environment.Exit(1);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
I felt this problem needed some kind of dialog box to appear in order to alert users to what is happening as when the problem occurred for me i tried all sorts of things to get GitExtensions working again. Knowing at least where to look would have saved me a few hours - so hopefully this will help someone else save some hours.

This exception occurs before NBug is loaded so you wouldn't normally receive the bug reports.

I tried to stick to the style guidlines - this is the first fix I've done so please let me know if I've done it wrong - and how to do it right.
