### PR TITLE
fix-2266 Del shortcut key in the commit dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -203,6 +203,7 @@ namespace GitUI.CommandsDialogs
             _resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys((int)Commands.ResetSelectedFiles).ToShortcutKeyDisplayString();
             _resetSelectedLinesToolStripMenuItem.Image = Reset.Image;
             resetChanges.ShortcutKeyDisplayString = _resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString;
+            deleteFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys((int)Commands.DeleteSelectedFiles).ToShortcutKeyDisplayString();
             commitAuthorStatus.ToolTipText = _commitCommitterToolTip.Text;
             toolAuthor.Control.PreviewKeyDown += ToolAuthor_PreviewKeyDown;
         }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -180,7 +180,7 @@ namespace GitUI.Hotkey
                 // FormCommit
                 new HotkeySettings(FormCommit.HotkeySettingsName, 
                     hk(FormCommit.Commands.AddToGitIgnore, Keys.None),
-                    hk(FormCommit.Commands.DeleteSelectedFiles, Keys.None),
+                    hk(FormCommit.Commands.DeleteSelectedFiles, Keys.Delete),
                     hk(FormCommit.Commands.FocusUnstagedFiles, Keys.Control | Keys.D1),
                     hk(FormCommit.Commands.FocusSelectedDiff, Keys.Control | Keys.D2),
                     hk(FormCommit.Commands.FocusStagedFiles, Keys.Control | Keys.D3),


### PR DESCRIPTION
Add default value to shortcut add show DisplayString on commit form (fix #2266)
