### PR TITLE
#2294 fixed: Commit dialog hangs for hours on selecting or deselecting many files

### DIFF
--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -17,7 +17,7 @@ namespace GitUI
         public event GitUICommandsSourceSetEventHandler GitUICommandsSourceSet;
         private IGitUICommandsSource _uiCommandsSource;
 
-        
+
         /// <summary>Gets the <see cref="IGitUICommandsSource"/>.</summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
@@ -45,9 +45,9 @@ namespace GitUI
 
         /// <summary>Gets the <see cref="UICommandsSource"/>'s <see cref="GitUICommands"/> reference.</summary>
         [Browsable(false)]
-        public GitUICommands UICommands 
-        { 
-            get 
+        public GitUICommands UICommands
+        {
+            get
             {
                 return UICommandsSource.UICommands;
             }
@@ -73,8 +73,12 @@ namespace GitUI
             if (_uiCommandsSource != null)
                 DisposeUICommandsSource();
 
+            DisposeCustomResources();
+
             base.Dispose(disposing);
         }
+
+        protected virtual void DisposeCustomResources() { }
 
         /// <summary>Occurs when the <see cref="UICommandsSource"/> is disposed.</summary>
         protected virtual void DisposeUICommandsSource()

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -54,7 +54,6 @@ namespace GitUI
             this.FileStatusListView.UseCompatibleStateImageBehavior = false;
             this.FileStatusListView.View = System.Windows.Forms.View.Details;
             this.FileStatusListView.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.FileStatusListView_DrawItem);
-            this.FileStatusListView.SelectedIndexChanged += new System.EventHandler(this.FileStatusListView_SelectedIndexChanged);
             this.FileStatusListView.SizeChanged += new System.EventHandler(this.FileStatusListView_SizeChanged);
             this.FileStatusListView.DoubleClick += new System.EventHandler(this.FileStatusListView_DoubleClick);
             this.FileStatusListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FileStatusListView_KeyDown);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,11 +26,22 @@ namespace GitUI
         private readonly TranslationString _DiffWithParent =
             new TranslationString("Diff with parent");
 
+        private readonly IDisposable selectedIndexChangeSubscription;
+        private static readonly TimeSpan SelectedIndexChangeThrottleDuration = TimeSpan.FromMilliseconds(50);
+
         private const int ImageSize = 16;
 
         public FileStatusList()
         {
             InitializeComponent(); Translate();
+
+            selectedIndexChangeSubscription = Observable.FromEventPattern(
+                h => FileStatusListView.SelectedIndexChanged += h,
+                h => FileStatusListView.SelectedIndexChanged -= h)
+                .Throttle(SelectedIndexChangeThrottleDuration)
+                .ObserveOn(SynchronizationContext.Current)
+                .Subscribe(_ => FileStatusListView_SelectedIndexChanged());
+
             SelectFirstItemOnSetItems = true;
             _noDiffFilesChangesDefaultText = NoFiles.Text;
 #if !__MonoCS__ // TODO Drag'n'Drop doesn't work on Mono/Linux
@@ -60,6 +72,11 @@ namespace GitUI
 
             NoFiles.Visible = false;
             NoFiles.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Italic);
+        }
+
+        protected override void DisposeCustomResources()
+        {
+            selectedIndexChangeSubscription.Dispose();
         }
 
         private static ImageList _images;
@@ -414,10 +431,10 @@ namespace GitUI
                 DoubleClick(sender, e);
         }
 
-        void FileStatusListView_SelectedIndexChanged(object sender, EventArgs e)
+        void FileStatusListView_SelectedIndexChanged()
         {
             if (SelectedIndexChanged != null)
-                SelectedIndexChanged(this, e);
+                SelectedIndexChanged(this, EventArgs.Empty);
         }
 
         private static int GetItemImageIndex(GitItemStatus gitItemStatus)
@@ -529,7 +546,7 @@ namespace GitUI
                     if (!empty)
                     {
                         //bug in the ListView control where supplying an empty list will not trigger a SelectedIndexChanged event, so we force it to trigger
-                        FileStatusListView_SelectedIndexChanged(this, EventArgs.Empty);
+                        FileStatusListView_SelectedIndexChanged();
                     }
                     return;
                 }


### PR DESCRIPTION
Just compare profiler reports.

Handling each index change:

```
100,00%   <StartCommitDialog>b__38  •  3 063 859* ms  •  1 call  •  GitUI.GitUICommands+<>c__DisplayClass39.<StartCommitDialog>b__38
  100,00%   ShowDialog  •  3 063 859 ms  •  1 call  •  System.Windows.Forms.Form.ShowDialog(IWin32Window)
    73,97%   WndProc  •  2 266 428 ms  •  659 calls  •  GitUI.UserControls.ExListView.WndProc(Message&)
      73,97%   WndProc  •  2 266 427 ms  •  659 calls  •  System.Windows.Forms.ListView.WndProc(Message&)
        73,95%   WndProc  •  2 265 721 ms  •  38 042 calls  •  GitUI.UserControls.ExListView.WndProc(Message&)
          73,95%   WndProc  •  2 265 575 ms  •  38 041 calls  •  System.Windows.Forms.ListView.WndProc(Message&)
            73,93%   FileStatusListView_SelectedIndexChanged  •  2 265 042 ms  •  12 649 calls  •  GitUI.FileStatusList.FileStatusListView_SelectedIndexChanged(Object, EventArgs)
              73,93%   UnstagedSelectionChanged  •  2 265 036 ms  •  12 649 calls  •  GitUI.CommandsDialogs.FormCommit.UnstagedSelectionChanged(Object, EventArgs)
                >31,24%   ToList  •  957 107 ms  •  12 649 calls  •  System.Linq.Enumerable.ToList(IEnumerable[TSource])
                >29,74%   Any  •  911 170 ms  •  12 649 calls  •  System.Linq.Enumerable.Any(IEnumerable[TSource])
                >12,92%   ShowChanges  •  395 878 ms  •  12 649 calls  •  GitUI.CommandsDialogs.FormCommit.ShowChanges(GitItemStatus, Boolean)
    4,97%   <Load>b__f  •  152 329 ms  •  12 652 calls  •  GitCommands.AsyncLoader+<>c__DisplayClass11`1.<Load>b__f(Task[T])
      4,97%   <ViewItem>b__15  •  152 320 ms  •  12 649 calls  •  GitUI.Editor.FileViewer+<>c__DisplayClass19.<ViewItem>b__15(String)
        4,97%   ViewText  •  152 318 ms  •  12 649 calls  •  GitUI.Editor.FileViewer.ViewText(String, String)
          >4,65%   SetText  •  142 323 ms  •  12 649 calls  •  GitUI.Editor.FileViewerWindows.SetText(String)
          >0,32%   ResetForText  •  9 657 ms  •  12 649 calls  •  GitUI.Editor.FileViewer.ResetForText(String)
```

Ignoring index changes which are followed by next index change within milliseconds:

```
  100,00%   StartCommitDialog  •  7 904* ms  •  1 call  •  GitUI.GitUICommands.StartCommitDialog(IWin32Window)
    100,00%   StartCommitDialog  •  7 904* ms  •  1 call  •  GitUI.GitUICommands.StartCommitDialog(IWin32Window, Boolean)
      100,00%   DoActionOnRepo  •  7 904* ms  •  1 call  •  GitUI.GitUICommands.DoActionOnRepo(IWin32Window, Boolean, Boolean, GitUIEventHandler, GitUIPostActionEventHandler, Func[Boolean])
        100,00%   <StartCommitDialog>b__38  •  7 904* ms  •  1 call  •  GitUI.GitUICommands+<>c__DisplayClass39.<StartCommitDialog>b__38
          100,00%   ShowDialog  •  7 904 ms  •  1 call  •  System.Windows.Forms.Form.ShowDialog(IWin32Window)
            >10,96%   WndProc  •  866 ms  •  41 calls  •  GitUI.UserControls.ExListView.WndProc(Message&)
            4,67%   OnNext  •  369 ms  •  1 call  •  System.Reactive.AnonymousSafeObserver`1.OnNext(T)
              4,67%   ctor>b__2  •  369 ms  •  1 call  •  GitUI.FileStatusList.ctor>b__2(EventPattern[EventArgs])
                4,67%   FileStatusListView_SelectedIndexChanged  •  369 ms  •  1 call  •  GitUI.FileStatusList.FileStatusListView_SelectedIndexChanged
                  4,67%   UnstagedSelectionChanged  •  369 ms  •  1 call  •  GitUI.CommandsDialogs.FormCommit.UnstagedSelectionChanged(Object, EventArgs)
                    >2,27%   Any  •  180 ms  •  1 call  •  System.Linq.Enumerable.Any(IEnumerable[TSource])
                    >2,00%   ToList  •  158 ms  •  1 call  •  System.Linq.Enumerable.ToList(IEnumerable[TSource])
                    >0,39%   ShowChanges  •  31 ms  •  1 call  •  GitUI.CommandsDialogs.FormCommit.ShowChanges(GitItemStatus, Boolean)
                    >0,00%   ClearDiffViewIfNoFilesLeft  •  0 ms  •  1 call  •  GitUI.CommandsDialogs.FormCommit.ClearDiffViewIfNoFilesLeft
```

Now selecting or deselecting unstaged files takes less than second regardless of files count, there is actually single refresh.
