### PR TITLE
Fix #230 : Don't spawn git status if the previous one is still running

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3215,15 +3215,14 @@ namespace GitCommands
                 return true;
             }
 
+            if (Settings.RunningOnWindows() && Process.GetProcessesByName("git").Length > 0)
+            {
+                return true;
+            }
+
             // Get processes by "ps" command.
             var cmd = Path.Combine(Settings.GitBinDir, "ps");
             var arguments = "x";
-            if (Settings.RunningOnWindows())
-            {
-                // "x" option is unimplemented by msysgit and cygwin.
-                arguments = "";
-            }
-
             var output = RunCmd(cmd, arguments);
             var lines = output.Split('\n');
             if (lines.Count() >= 2)


### PR DESCRIPTION
Hello
When we are low on cpu (e.g. compiling), while working on big repos, git status may take too long and GitExtensions would spawn lots of git status, increasing the pressure on the cpu.
In the code, ps was used but is unable to detect git.exe processes.
So, in Windows context, I use Process.GetProcessesByName.
I validated my solution : problem disappears with my fix.
ded'
