### PR TITLE
Shell Extensions: IsValidGitDir UNC path performance bug fix (resolves #2250)

### DIFF
--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -350,15 +350,22 @@ bool CGitExtensionsShellEx::IsValidGitDir(TCHAR m_szFile[])
 
     std::wstring dir(m_szFile);
 
-    size_t pos;
+    bool continueToParentDirectory;
     do
     {
         if (ValidWorkingDir(dir))
             return true;
-        pos = dir.rfind('\\');
-        if (pos != std::wstring::npos)
-            dir.resize(pos);
-    } while (pos != std::wstring::npos);
+
+        size_t lastBackslashPos = dir.rfind('\\');
+
+        // PathIsRoot returns true for "C:\" and "\\server\share" but false for "C:" and "\\server\share\"
+        // => The right part of the conjunction won't stop the loop for "C:", but the left part will
+        // because "C:".rfind('\\') == wstring::npos
+        continueToParentDirectory = (lastBackslashPos != std::wstring::npos) && !PathIsRoot(dir.c_str());
+
+        if (continueToParentDirectory)
+            dir.resize(lastBackslashPos);
+    } while (continueToParentDirectory);
     return false;
 }
 


### PR DESCRIPTION
At the moment, when executing `IsValidGitDir` on the UNC path `\\server\share\dir`, it tests the following paths: 
- `\\server\share\dir\.git` and `\\server\share\dir\info`
- `\\server\share\.git` and `\\server\share\info`
- `\\server\.git` and `\\server\info`, 
- `\\.git` and `\\info`

The last 2 paths cause the performance issue because the OS tries to reach the servers `.git` and `info`.

This PR fixes #2250.

This PR contains a second bug fix (see first commit): Fixed undetected working directory in root directory (the additional `dir.rfind` in the while condition stopped the loop _before_ e.g. `C:` has been reached).

As I'm not a C++ hacker please review this PR carefully.
