### PR TITLE
Correction of list of branches display 2 times in branches combobox

### DIFF
--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -135,7 +135,6 @@ namespace GitUI
 
         private void toolStripBranches_DropDown(object sender, EventArgs e)
         {
-            InitToolStripBranchFilter();
             UpdateBranchFilterItems();
         }
 


### PR DESCRIPTION
The list of branch is feed in InitToolStripBranchFilter() and also
in UpdateBranchFilterItems() but filtered if needed.
Remove first call to prevent displaying of branches twice that
happens due to an Async call...
