### PR TITLE
Browsing history in revision grid

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2855,6 +2855,14 @@ namespace GitUI.CommandsDialogs
                 if (commit != null)
                     RevisionGrid.SetSelectedRevision(new GitRevision(Module, commit.Guid));
             }
+            else if (e.Command == "navigatebackward")
+            {
+                RevisionGrid.NavigateBackward();
+            }
+            else if (e.Command == "navigateforward")
+            {
+                RevisionGrid.NavigateForward();
+            }
         }
 
         private void SubmoduleToolStripButtonClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -415,6 +415,14 @@ namespace GitUI.CommandsDialogs
                 if (commit != null)
                     FileChanges.SetSelectedRevision(new GitRevision(Module, commit.Guid));
             }
+            else if (e.Command == "navigatebackward")
+            {
+                FileChanges.NavigateBackward();
+            }
+            else if (e.Command == "navigateforward")
+            {
+                FileChanges.NavigateForward();
+            }
         }
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -175,6 +175,7 @@
             this._RevisionHeader.TabIndex = 0;
             this._RevisionHeader.Text = "";
             this._RevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
+            this._RevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 
             // CommitInfo
             // 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -335,5 +335,25 @@ namespace GitUI.CommitInfo
             Module.EditNotes(_revision.Guid);
             ReloadCommitInfo();
         }
+
+        private void DoCommandClick(string command, string data)
+        {
+            if (CommandClick != null)
+            {
+                CommandClick(this, new CommandEventArgs(command, data));
+            }
+        }
+
+        private void _RevisionHeader_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.XButton1)
+            {
+                DoCommandClick("navigatebackward", null);
+            }
+            else if (e.Button == MouseButtons.XButton2)
+            {
+                DoCommandClick("navigateforward", null);
+            }
+        }
     }
 }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -239,6 +239,7 @@
     <Compile Include="UserControls\RevisionGridClasses\CaptionCustomMenuRenderer.cs" />
     <Compile Include="UserControls\RevisionGridClasses\GitRefListsForRevision.cs" />
     <Compile Include="UserControls\RevisionGridClasses\MenuUtil.cs" />
+    <Compile Include="UserControls\RevisionGridClasses\NavigationHistory.cs" />
     <Compile Include="UserManual\UserManual.cs" />
     <Compile Include="UserManual\SingleHtmlUserManual.cs" />
     <Compile Include="UserManual\StandardHtmlUserManual.cs" />

--- a/GitUI/UserControls/RevisionGridClasses/NavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGridClasses/NavigationHistory.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GitUI.UserControls.RevisionGridClasses
+{
+    class NavigationHistory
+    {
+        // history of selected items (browse history)
+        // head == currently selected item
+        private readonly Stack<string> prevItems = new Stack<string>();
+        // backtracked items
+        // head == item to show when navigating forward
+        private readonly Stack<string> nextItems = new Stack<string>();
+
+        /// <summary>
+        /// Sets curr as current visible item and resets forward history
+        /// </summary>
+        /// <param name="curr"></param>
+        public void Push(string curr)
+        {
+            if ((prevItems.Count == 0) || !prevItems.Peek().Equals(curr))
+            {
+                prevItems.Push(curr);
+                nextItems.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Returns whether CanNavigateBackward is possible
+        /// </summary>
+        public bool CanNavigateBackward
+        {
+            get 
+            {
+                return (prevItems.Count > 1);
+            }
+        }
+
+        /// <summary>
+        /// Navigatees backward in history, returns item which should be selected, null if no previous item is available
+        /// </summary>
+        /// <exception cref="InvalidOperationException">When no previous history is available.</exception>
+        public string NavigateBackward()
+        {
+            if (CanNavigateBackward)
+            {
+                string curr = prevItems.Pop();
+                string prev = prevItems.Peek();
+                nextItems.Push(curr);
+                return prev;
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        /// <summary>
+        /// Returns whether CanNavigateForward is possible
+        /// </summary>
+        public bool CanNavigateForward
+        {
+            get
+            {
+                return (nextItems.Count != 0);
+            }
+        }
+
+        /// <summary>
+        /// Navigatees forward in history, returns item which should be selected, null if no next item is available
+        /// </summary>
+        /// <exception cref="InvalidOperationException">When no forward history is available.</exception>
+        public string NavigateForward()
+        {
+            if (CanNavigateForward)
+            {
+                string next = nextItems.Pop();
+                prevItems.Push(next);
+                return next;
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        /// <summary>
+        /// Clears history and sets current item
+        /// </summary>
+        public void Reset(string curr)
+        {
+            Clear();
+            prevItems.Push(curr);
+        }
+
+        /// <summary>
+        /// Clears both backward and forward history
+        /// </summary>
+        public void Clear()
+        {
+            prevItems.Clear();
+            nextItems.Clear();
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -133,6 +133,26 @@ namespace GitUI.UserControls.RevisionGridClasses
 
             {
                 var menuCommand = new MenuCommand();
+                menuCommand.Name = "NavigateBackward";
+                menuCommand.Text = "Navigate backward";
+                menuCommand.ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.NavigateBackward);
+
+                resultList.Add(menuCommand);
+            }
+
+            {
+                var menuCommand = new MenuCommand();
+                menuCommand.Name = "NavigateForward";
+                menuCommand.Text = "Navigate forward";
+                menuCommand.ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.NavigateForward);
+
+                resultList.Add(menuCommand);
+            }
+
+            resultList.Add(MenuCommand.CreateSeparator());
+
+            {
+                var menuCommand = new MenuCommand();
                 menuCommand.Name = "QuickSearch";
                 menuCommand.Text = "Quick search";
                 menuCommand.ExecuteAction = () => MessageBox.Show(_quickSearchQuickHelp.Text);


### PR DESCRIPTION
Added support for backward/forward navigation mouse and keyboard buttons

closes #1800
