### PR TITLE
Remove ANSI sequence from the captured output lines

### DIFF
--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -226,8 +226,12 @@ namespace GitUI
             DataReceived(sender, e);
         }
 
-        public void AppendOutputLine(string line)
+        public void AppendOutputLine(string rawLine)
         {
+            const string ansiSuffix = "\u001B[K";
+
+            var line = rawLine.Replace(ansiSuffix, "");
+
             AppendToOutputString(line + Environment.NewLine);
 
             AddMessageLine(line);


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/issues/1313

The issue is actually caused by a git core bug which I've already sent patch to. Once that patch will be accepted this pull request will be redundant but who knows when this happens :)

Recreate pull request to target the earliest release 2.46
