### PR TITLE
Include JavaScript files as 'code' files.

### DIFF
--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -9,7 +9,7 @@ namespace GitStatistics
     {
         StringSetting CodeFiles = new StringSetting("Code files",
                                 "*.c;*.cpp;*.cc;*.h;*.hpp;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" + 
-                                "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb");
+                                "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js");
         StringSetting IgnoreDirectories = new StringSetting("Directories to ignore (EndsWith)", "\\Debug;\\Release;\\obj;\\bin;\\lib");
         BoolSetting IgnoreSubmodules = new BoolSetting("Ignore submodules", true);
 


### PR DESCRIPTION
When counting code files, JavaScript (*.js) files are not included, yet other web-types such as CSS and HTML are.
