### PR TITLE
Use a MUCH more efficient way to query Tfs builds

### DIFF
--- a/Plugins/BuildServerIntegration/TfsIntegration/ITfsHelper.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/ITfsHelper.cs
@@ -26,10 +26,10 @@ namespace TfsInterop.Interface
         string Url { get; set; }
     }
 
-    public interface ITfsHelper
+    public interface ITfsHelper : IDisposable
     {
         bool IsDependencyOk();
         void ConnectToTfsServer(string hostname, string teamCollection, string projectName, string buildDefinition = null);
-        IList<IBuild> QueryBuilds();
+        IList<IBuild> QueryBuilds(DateTime? sinceDate, bool? running);
     }
 }

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
@@ -130,11 +130,7 @@ namespace TfsIntegration
         {
             try
             {
-                var builds = _tfsHelper.QueryBuilds().AsQueryable();
-                if (sinceDate.HasValue)
-                    builds = builds.Where(b => b.StartDate > sinceDate.Value);
-                if (running.HasValue)
-                    builds = builds.Where(b => b.IsFinished != running.Value);
+                var builds = _tfsHelper.QueryBuilds(sinceDate, running);
 
                 Parallel.ForEach(builds, detail => { observer.OnNext(CreateBuildInfo(detail)); });
             }
@@ -167,6 +163,8 @@ namespace TfsIntegration
 
         public void Dispose()
         {
+            if (_tfsHelper != null)
+                _tfsHelper.Dispose();
             GC.SuppressFinalize(this);
         }
     }


### PR DESCRIPTION
A lot(!) less resource extensive and better memory releasing.

Because this plugin will be released with 2.48 and this PR is an important fix.
I found another way to query build that use very few resources contrary to what I have done before.
I really think that this PR MUST be merged before releasing...
