### PR TITLE
Display correctly windows end of line in git commit message

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -267,7 +267,7 @@ namespace GitCommands
             if (data == null)
                 throw new ArgumentNullException("data");
 
-            var lines = data.Split('\n');
+            var lines = data.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
 
             var guid = lines[0];
 


### PR DESCRIPTION
It could happens that in the commit message, end of line is windows style "\r\n"...
(Don't ask me why!)
But, here, where the windows eol in well handle by git cli,
it is not well handled by GitExtensions and 2 end of lines are displayed :(

This PR fix that.
