### PR TITLE
Fix refresh issue with the branches filter textbox

### DIFF
--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -147,9 +147,9 @@ namespace GitUI
 
         private void UpdateBranchFilterItems()
         {
+            var index = _NO_TRANSLATE_toolStripBranches.SelectionStart;
             string filter = _NO_TRANSLATE_toolStripBranches.Text;
             _NO_TRANSLATE_toolStripBranches.Items.Clear();
-            var index = _NO_TRANSLATE_toolStripBranches.Text.Length;
             var branches = GetBranchAndTagRefs(localToolStripMenuItem.Checked, remoteToolStripMenuItem.Checked);
             _NO_TRANSLATE_toolStripBranches.Items.AddRange(branches.Where(branch => branch.Contains(filter)).ToArray());
             _NO_TRANSLATE_toolStripBranches.SelectionStart = index;


### PR DESCRIPTION
This bug has been annoying me for quite a time now.
