### PR TITLE
Push dialog behavior changed to correct git push command

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -590,6 +590,8 @@ namespace GitCommands
             // branch name with refs/heads/, except for special cases
             if (fromBranch == GitModule.DetachedBranch)
                 fromBranch = "";
+            else
+                fromBranch = GetFullBranchName(fromBranch);
 
             if (toBranch == GitModule.DetachedBranch)
                 toBranch = "";

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -269,11 +269,7 @@ namespace GitUI.CommandsDialogs
                 if (_NO_TRANSLATE_Branch.Text == AllRefs)
                     pushAllBranches = true;
                 else
-                {
-                    srcRev = GitCommandHelpers.GetFullBranchName(_NO_TRANSLATE_Branch.Text);
-                    if (String.IsNullOrEmpty(Module.RevParse(srcRev)))
-                        srcRev = _NO_TRANSLATE_Branch.Text;
-                }
+                    srcRev = _NO_TRANSLATE_Branch.Text;
 
                 pushCmd = GitCommandHelpers.PushCmd(destination, srcRev, RemoteBranch.Text,
                     pushAllBranches, ForcePushBranches.Checked, track, RecursiveSubmodules.SelectedIndex);


### PR DESCRIPTION
"From" branch is set to HEAD if (no branch)
HEAD ref is not expanded to refs/heads/HEAD
"To" branch is set to empty if (no branch)
