### PR TITLE
Parent rewriter for file history, closes #2452

### DIFF
--- a/GitExtensionsTest/GitExtensionsTest.csproj
+++ b/GitExtensionsTest/GitExtensionsTest.csproj
@@ -63,6 +63,7 @@
     <Compile Include="GitCommands\Helpers\FileInfoExtensionsTest.cs" />
     <Compile Include="GitCommands\Patch\PatchManagerTest.cs" />
     <Compile Include="GitCommands\Patch\PatchTest.cs" />
+    <Compile Include="GitUI\FollowParentRewriterFixture.cs" />
     <Compile Include="GitUI\FormUpdateFixture.cs" />
     <Compile Include="GitUI\HotkeySettingsManagerFixture.cs" />
     <Compile Include="GitUI\SingleHtmlUserManualFixture.cs" />

--- a/GitExtensionsTest/GitUI/FollowParentRewriterFixture.cs
+++ b/GitExtensionsTest/GitUI/FollowParentRewriterFixture.cs
@@ -1,0 +1,236 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using GitUI.CommandsDialogs;
+using FluentAssertions;
+using GitUI.UserControls.RevisionGridClasses;
+using GitCommands;
+
+namespace GitExtensionsTest.GitUI
+{
+    [TestFixture]
+    class FollowParentRewriterFixture
+    {
+        private Func<string,StreamReader> StaticReader(string dataFollow, string dataGraph)
+        {
+            Func<string, StreamReader> rf = delegate(string args)
+            {
+                string streamData;
+                if (args.Contains("--follow")) 
+                {
+                    streamData = dataFollow;
+                }
+                else 
+                {
+                    streamData = dataGraph;
+                }
+                streamData.Should().NotBeNull();
+                return new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(streamData)));
+            };
+            return rf;
+        }
+
+        private static GitRevision MkGitRevision(string commitId, params string[] parentIds)
+        {
+            GitRevision r = new GitRevision(null, commitId);
+            r.ParentGuids = parentIds;
+            return r;
+        }
+
+        private class GitRevisionExpectation
+        {
+            private GitRevision[] expected;
+
+            public GitRevisionExpectation(GitRevision[] args)
+            {
+                expected = args;
+            }
+
+            private int calledTimes = 0;
+
+            public void ProcessRevision(GitRevision rev)
+            {
+                calledTimes.Should().BeLessThan(expected.Count(), "Called too many times");
+                var exp = expected[calledTimes];
+                (rev != null).Should().Be(exp != null, "rev==null inconsistency");
+                if (rev != null)
+                {
+                    rev.Guid.Should().Be(exp.Guid, "Guid");
+                    rev.ParentGuids.ShouldBeEquivalentTo(exp.ParentGuids, "Parents");
+                }
+                calledTimes++;
+            }
+
+            public void CheckCalledEnoughTimes()
+            {
+                calledTimes.Should().Be(expected.Count(), "Called number of times");
+            }
+
+        }
+
+        private void CheckFlush(FollowParentRewriter rw, bool flushAll, GitRevision[] expected)
+        {
+            GitRevisionExpectation x = new GitRevisionExpectation(expected);
+            rw.Flush(flushAll, x.ProcessRevision);
+            x.CheckCalledEnoughTimes();
+        }
+
+        [Test]
+        public void RewriterTest1()
+        {
+            string dataFollow =
+                "dd/aa.txt\n"+
+                "\n"+
+                "dd/aa.txt\n"+
+                "\n"+
+                "dd/aa.txt\n"+
+                "\n"+
+                "aa.txt\n"+
+                "\n"+
+                "aa.txt\n"+
+                "\n"+
+                "aa.txt\n"+
+                "\n"+
+                "aa.txt\n"+
+                "\n"+
+                "aa.txt\n";
+            string dataGraph =
+                "bef6694d0b1a58243d817cc3e915952f53269b40 5632365bb31f2da1aae700f47e1a50951754f9ff\n" +
+                "5632365bb31f2da1aae700f47e1a50951754f9ff 9eea2112f54967a17ae0f02fb096a4bc41200846 5744afa2ee91a44eb4393220b19aa99a66459a3f\n" +
+                "9eea2112f54967a17ae0f02fb096a4bc41200846 2cfff1e08548361ca16c3c05bb4407dc3a190ff7\n" +
+                "2cfff1e08548361ca16c3c05bb4407dc3a190ff7 5744afa2ee91a44eb4393220b19aa99a66459a3f\n" +
+                "5744afa2ee91a44eb4393220b19aa99a66459a3f e12f41482b55a19a8cf27ba243855f382c277cbb\n" +
+                "e12f41482b55a19a8cf27ba243855f382c277cbb 02612100c26a72840edbcd971dd3310b6e3f499e\n" +
+                "02612100c26a72840edbcd971dd3310b6e3f499e\n";
+
+            FollowParentRewriter rw = new FollowParentRewriter("dd/aa.txt", StaticReader(dataFollow, dataGraph));
+            rw.RewriteNecessary.Should().BeTrue();
+            rw.PushRevision(null);
+            CheckFlush(rw, false, new GitRevision[] {null} );
+            //
+            rw.PushRevision(MkGitRevision("bef6694d0b1a58243d817cc3e915952f53269b40", "5632365bb31f2da1aae700f47e1a50951754f9ff"));
+            CheckFlush(rw, false, new GitRevision[] { });
+            // 
+            rw.PushRevision(MkGitRevision("5632365bb31f2da1aae700f47e1a50951754f9ff", "9eea2112f54967a17ae0f02fb096a4bc41200846", "5744afa2ee91a44eb4393220b19aa99a66459a3f"));
+            CheckFlush(rw, false, new GitRevision[] { MkGitRevision("bef6694d0b1a58243d817cc3e915952f53269b40", "5632365bb31f2da1aae700f47e1a50951754f9ff") });
+            //
+            rw.PushRevision(MkGitRevision("9eea2112f54967a17ae0f02fb096a4bc41200846", "2cfff1e08548361ca16c3c05bb4407dc3a190ff7"));
+            CheckFlush(rw, false, new GitRevision[] { });
+            rw.PushRevision(MkGitRevision("2cfff1e08548361ca16c3c05bb4407dc3a190ff7", "5744afa2ee91a44eb4393220b19aa99a66459a3f"));
+            CheckFlush(rw, false, new GitRevision[] { });
+            //
+            rw.PushRevision(MkGitRevision("5744afa2ee91a44eb4393220b19aa99a66459a3f", "e12f41482b55a19a8cf27ba243855f382c277cbb"));
+            CheckFlush(rw, false, new GitRevision[] { 
+                MkGitRevision("5632365bb31f2da1aae700f47e1a50951754f9ff", "9eea2112f54967a17ae0f02fb096a4bc41200846", "5744afa2ee91a44eb4393220b19aa99a66459a3f"),
+                MkGitRevision("9eea2112f54967a17ae0f02fb096a4bc41200846", "2cfff1e08548361ca16c3c05bb4407dc3a190ff7"),
+                MkGitRevision("2cfff1e08548361ca16c3c05bb4407dc3a190ff7", "5744afa2ee91a44eb4393220b19aa99a66459a3f")
+            });
+            //
+            rw.PushRevision(MkGitRevision("e12f41482b55a19a8cf27ba243855f382c277cbb", "02612100c26a72840edbcd971dd3310b6e3f499e"));
+            CheckFlush(rw, false, new GitRevision[] { 
+                MkGitRevision("5744afa2ee91a44eb4393220b19aa99a66459a3f", "e12f41482b55a19a8cf27ba243855f382c277cbb")
+            });
+            //
+            CheckFlush(rw, true, new GitRevision[] { 
+                MkGitRevision("e12f41482b55a19a8cf27ba243855f382c277cbb", "02612100c26a72840edbcd971dd3310b6e3f499e")
+            });
+        }
+
+
+        [Test]
+        public void RewriterTest2()
+        {
+            string dataFollow =
+                "dd/aa.txt\n" +
+                "\n" +
+                "aa.txt\n";
+            string dataGraph =
+                "bef6694d0b1a58243d817cc3e915952f53269b40 5632365bb31f2da1aae700f47e1a50951754f9ff\n" +
+                "5632365bb31f2da1aae700f47e1a50951754f9ff 9eea2112f54967a17ae0f02fb096a4bc41200846 5744afa2ee91a44eb4393220b19aa99a66459a3f\n" +
+                "9eea2112f54967a17ae0f02fb096a4bc41200846 2cfff1e08548361ca16c3c05bb4407dc3a190ff7\n" +
+                "2cfff1e08548361ca16c3c05bb4407dc3a190ff7 5744afa2ee91a44eb4393220b19aa99a66459a3f\n" +
+                "5744afa2ee91a44eb4393220b19aa99a66459a3f e12f41482b55a19a8cf27ba243855f382c277cbb\n" +
+                "e12f41482b55a19a8cf27ba243855f382c277cbb 02612100c26a72840edbcd971dd3310b6e3f499e\n" +
+                "02612100c26a72840edbcd971dd3310b6e3f499e\n";
+
+            FollowParentRewriter rw = new FollowParentRewriter("dd/aa.txt", StaticReader(dataFollow, dataGraph));
+            rw.RewriteNecessary.Should().BeTrue();
+            rw.PushRevision(null);
+            CheckFlush(rw, false, new GitRevision[] { null });
+            //
+            rw.PushRevision(MkGitRevision("bef6694d0b1a58243d817cc3e915952f53269b40", "5632365bb31f2da1aae700f47e1a50951754f9ff"));
+            CheckFlush(rw, false, new GitRevision[] { });
+            // 56..2c skipped
+            rw.PushRevision(MkGitRevision("5744afa2ee91a44eb4393220b19aa99a66459a3f", "e12f41482b55a19a8cf27ba243855f382c277cbb"));
+            CheckFlush(rw, false, new GitRevision[] { 
+                MkGitRevision("bef6694d0b1a58243d817cc3e915952f53269b40", "5744afa2ee91a44eb4393220b19aa99a66459a3f")
+            });
+            //
+            rw.PushRevision(MkGitRevision("e12f41482b55a19a8cf27ba243855f382c277cbb", "02612100c26a72840edbcd971dd3310b6e3f499e"));
+            CheckFlush(rw, false, new GitRevision[] { 
+                MkGitRevision("5744afa2ee91a44eb4393220b19aa99a66459a3f", "e12f41482b55a19a8cf27ba243855f382c277cbb")
+            });
+            //
+            CheckFlush(rw, true, new GitRevision[] { 
+                MkGitRevision("e12f41482b55a19a8cf27ba243855f382c277cbb", "02612100c26a72840edbcd971dd3310b6e3f499e")
+            });
+        }
+
+        [Test]
+        public void RewriterTest3()
+        {
+            string dataFollow =
+                "dd/aa.txt\n" +
+                "\n" +
+                "aa.txt\n";
+            string dataGraph =
+                "bef6694d0b1a58243d817cc3e915952f53269b40 5632365bb31f2da1aae700f47e1a50951754f9ff\n" +
+                "5632365bb31f2da1aae700f47e1a50951754f9ff 9eea2112f54967a17ae0f02fb096a4bc41200846 5744afa2ee91a44eb4393220b19aa99a66459a3f\n" +
+                "9eea2112f54967a17ae0f02fb096a4bc41200846 2cfff1e08548361ca16c3c05bb4407dc3a190ff7\n" +
+                "2cfff1e08548361ca16c3c05bb4407dc3a190ff7 5744afa2ee91a44eb4393220b19aa99a66459a3f\n" +
+                "5744afa2ee91a44eb4393220b19aa99a66459a3f e12f41482b55a19a8cf27ba243855f382c277cbb\n" +
+                "e12f41482b55a19a8cf27ba243855f382c277cbb 02612100c26a72840edbcd971dd3310b6e3f499e\n" +
+                "02612100c26a72840edbcd971dd3310b6e3f499e\n";
+
+            FollowParentRewriter rw = new FollowParentRewriter("dd/aa.txt", StaticReader(dataFollow, dataGraph));
+            rw.RewriteNecessary.Should().BeTrue();
+            rw.PushRevision(null);
+            CheckFlush(rw, false, new GitRevision[] { null });
+            //
+            rw.PushRevision(MkGitRevision("bef6694d0b1a58243d817cc3e915952f53269b40", "5632365bb31f2da1aae700f47e1a50951754f9ff"));
+            CheckFlush(rw, false, new GitRevision[] { });
+            // 
+            rw.PushRevision(MkGitRevision("5632365bb31f2da1aae700f47e1a50951754f9ff", "9eea2112f54967a17ae0f02fb096a4bc41200846", "5744afa2ee91a44eb4393220b19aa99a66459a3f"));
+            CheckFlush(rw, false, new GitRevision[] { MkGitRevision("bef6694d0b1a58243d817cc3e915952f53269b40", "5632365bb31f2da1aae700f47e1a50951754f9ff") });
+            // 9e, 2c skipped
+            rw.PushRevision(MkGitRevision("5744afa2ee91a44eb4393220b19aa99a66459a3f", "e12f41482b55a19a8cf27ba243855f382c277cbb"));
+            CheckFlush(rw, false, new GitRevision[] { 
+                MkGitRevision("5632365bb31f2da1aae700f47e1a50951754f9ff", "5744afa2ee91a44eb4393220b19aa99a66459a3f")
+            });
+            //
+            rw.PushRevision(MkGitRevision("e12f41482b55a19a8cf27ba243855f382c277cbb", "02612100c26a72840edbcd971dd3310b6e3f499e"));
+            CheckFlush(rw, false, new GitRevision[] { 
+                MkGitRevision("5744afa2ee91a44eb4393220b19aa99a66459a3f", "e12f41482b55a19a8cf27ba243855f382c277cbb")
+            });
+            //
+            CheckFlush(rw, true, new GitRevision[] { 
+                MkGitRevision("e12f41482b55a19a8cf27ba243855f382c277cbb", "02612100c26a72840edbcd971dd3310b6e3f499e")
+            });
+        }
+
+        [Test]
+        public void RewriterTest4()
+        {
+            string dataFollow =
+                "dd/aa.txt\n" +
+                "\n";
+            string dataGraph = null;
+
+            FollowParentRewriter rw = new FollowParentRewriter("dd/aa.txt", StaticReader(dataFollow, dataGraph));
+            rw.RewriteNecessary.Should().BeFalse();
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
 using ResourceManager;
+using GitUI.UserControls.RevisionGridClasses;
 
 namespace GitUI.CommandsDialogs
 {
@@ -100,14 +101,21 @@ namespace GitUI.CommandsDialogs
             {
                 if (filter == null)
                     return;
-                FileChanges.FixedFilter = filter;
+                FileChanges.FixedFilter = filter.Filter;
+                FileChanges.Rewriter = filter.Rewriter;
                 FileChanges.FiltredFileName = FileName;
                 FileChanges.AllowGraphWithFilter = true;
                 FileChanges.Load();
             });
         }
 
-        private string BuildFilter(string fileName)
+        private class FixedFilterTuple
+        {
+            public string Filter;
+            public FollowParentRewriter Rewriter;
+        }
+
+        private FixedFilterTuple BuildFilter(string fileName)
         {
             if (string.IsNullOrEmpty(fileName))
                 return null;
@@ -142,55 +150,37 @@ namespace GitUI.CommandsDialogs
 
             FileName = fileName;
 
-            string filter;
+            FixedFilterTuple res = new FixedFilterTuple();
             if (AppSettings.FollowRenamesInFileHistory && !Directory.Exists(fullFilePath))
             {
                 // git log --follow is not working as expected (see  http://kerneltrap.org/mailarchive/git/2009/1/30/4856404/thread)
-                //
-                // But we can take a more complicated path to get reasonable results:
-                //  1. use git log --follow to get all previous filenames of the file we are interested in
-                //  2. use git log "list of files names" to get the history graph 
-                //
-                // note: This implementation is quite a quick hack (by someone who does not speak C# fluently).
-                // 
-
-                string arg = "log --format=\"%n\" --name-only --follow -- \"" + fileName + "\"";
-                Process p = Module.RunGitCmdDetached(arg);
-
-                // the sequence of (quoted) file names - start with the initial filename for the search.
-                var listOfFileNames = new StringBuilder("\"" + fileName + "\"");
-
-                // keep a set of the file names already seen
-                var setOfFileNames = new HashSet<string> { fileName };
-
-                string line;
-                do
+                FollowParentRewriter hrw = new FollowParentRewriter(fileName, delegate(string arg){
+                    Process p = Module.RunGitCmdDetached(arg);
+                    return p.StandardOutput;
+                });
+                if (hrw.RewriteNecessary)
                 {
-                    line = p.StandardOutput.ReadLine();
+                    res.Rewriter = hrw;
+                    res.Filter = " -M -C --follow -- \"" + fileName + "\"";
+                }
+                else
+                {
+                    res.Filter = " -M -C --parents -- \"" + fileName + "\"";
+                }
 
-                    if (!string.IsNullOrEmpty(line) && setOfFileNames.Add(line))
-                    {
-                        listOfFileNames.Append(" \"");
-                        listOfFileNames.Append(line);
-                        listOfFileNames.Append('\"');
-                    }
-                } while (line != null);
-
-                // here we need --name-only to get the previous filenames in the revision graph
-                filter = " -M -C --name-only --parents -- " + listOfFileNames;
             }
             else
             {
                 // --parents doesn't work with --follow enabled, but needed to graph a filtered log
-                filter = " --parents -- \"" + fileName + "\"";
+                res.Filter = " --follow --parents -- \"" + fileName + "\"";
             }
 
             if (AppSettings.FullHistoryInFileHistory)
             {
-                filter = string.Concat(" --full-history --simplify-by-decoration ", filter);
+                res.Filter = string.Concat(" --full-history --simplify-by-decoration ", res.Filter);
             }
 
-            return filter;
+            return res;
         }
 
         private void DiffExtraDiffArgumentsChanged(object sender, EventArgs e)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -241,6 +241,7 @@
     </Compile>
     <Compile Include="UserControls\RevisionGridClasses\CopyToClipboardMenuHelper.cs" />
     <Compile Include="UserControls\RevisionGridClasses\CaptionCustomMenuRenderer.cs" />
+    <Compile Include="UserControls\RevisionGridClasses\FollowParentRewriter.cs" />
     <Compile Include="UserControls\RevisionGridClasses\GitRefListsForRevision.cs" />
     <Compile Include="UserControls\RevisionGridClasses\MenuUtil.cs" />
     <Compile Include="UserControls\RevisionGridClasses\NavigationHistory.cs" />

--- a/GitUI/UserControls/RevisionGridClasses/FollowParentRewriter.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FollowParentRewriter.cs
@@ -1,0 +1,318 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GitCommands;
+using System.IO;
+
+namespace GitUI.UserControls.RevisionGridClasses
+{
+    /// Parent rewriter supplementing similar funcionality in git
+    /// Created as a substitute to rewrite parents while following file renames
+    /// The general idea is as follows:
+    /// * A single _fileName is processed
+    /// * EnsureHistoryLoaded() checkes whether there were any renames in file's history. 
+    ///   If there were no renames, no further processing is needed.
+    /// * If there were renames, LoadParents() creates an in-memory graph of all commits leading up to 
+    ///   interesting commits (i.e. commits modifying any of the current or historical file names)
+    /// * The RevisionGrid fetches revisions while following renames and passes them to PushRevision() 
+    ///   These revisions are called "Seen" revisions. They are a subset of revisions processed during 
+    ///   the LoadParents() phase.
+    /// * Each time a revision is queued, the _historyGraph is passed to reach to its ancestors to find 
+    ///   another descendent Seen revision. That revision's parent is rewritten to point to currently 
+    ///   processed revision (UpdateDescendants()).
+    /// * When all parents of a revision point to a Seen revision, than it is safe to pass it further with
+    ///   rewritten parents Flush(false)
+    /// * A final Flush(true) passes on any pending revisions even if they weren't completely rewritten
+    public class FollowParentRewriter
+    {
+        private class CommitData
+        {
+            // original parents
+            internal List<string> parents = new List<string>();
+            // original children
+            internal List<string> children = new List<string>();
+            // rewritten parents (Empty == no rewriting necessary)
+            internal List<string> rewrittenParents = new List<string>();
+            // null  == mentioned as parent only
+            // !null == received GitRevision data (==seen)
+            internal GitRevision rev = null;
+            // true == all ancestors were seen
+            internal bool allAncectorsSeen = false;
+            
+            internal void AddParent(string parentId)
+            {
+                if (!parents.Contains(parentId))
+                {
+                    parents.Add(parentId);
+                }
+            }
+
+            internal void AddChild(string childId)
+            {
+                if (!children.Contains(childId))
+                {
+                    children.Add(childId);
+                }
+            }
+
+            internal bool WasSeen()
+            {
+                return rev != null;
+            }
+        }
+
+        private Func<string, StreamReader> _gitExecFunc;
+        private string _fileName;
+        public FollowParentRewriter(String fileName, Func<string, StreamReader> gitExecFunc)
+        {
+            _fileName = fileName;
+            _gitExecFunc = gitExecFunc;
+        }
+
+        private CommitData ProvideCommitData(string commitId)
+        {
+            if (!_historyGraph.ContainsKey(commitId))
+            {
+                CommitData dta = new CommitData();
+                _historyGraph.Add(commitId, dta);
+                return dta;
+            }
+            else
+            {
+                return _historyGraph[commitId];
+            }
+        }
+
+        /// <summary>
+        /// Previous names of analysed file
+        /// </summary>
+        private HashSet<string> _previousNames = new HashSet<string>();
+
+        private void AddNameToPreviousNames(string line)
+        {
+            if (!_previousNames.Contains(line))
+            {
+                _previousNames.Add(line);
+            }
+        }
+
+        // Fetches previous names of _fileName, stores in _previousNames
+        private void LoadPreviousNames()
+        {
+            string arg = "log -M -C --follow --name-only --format=\"%n\"";
+            if (AppSettings.FullHistoryInFileHistory)
+            {
+                arg += " --full-history";
+            }
+            arg += " -- \"" + _fileName + "\"";
+            using (StreamReader gitResult = _gitExecFunc(arg))
+            {
+                string line;
+                while ((line = gitResult.ReadLine()) != null)
+                {
+                    if (line.IsNotNullOrWhitespace())
+                    {
+                        AddNameToPreviousNames(line);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Commits and their immediate relatives
+        /// commitId => CommitData
+        /// </summary>
+        private Dictionary<string, CommitData> _historyGraph = new Dictionary<string, CommitData>();
+
+        // line contains commitid followed by one or more parentIds
+        private void AddCommitToParentsGraph(string line)
+        {
+            char[] space = new char[] { ' ' };
+            string[] commitAndParents = line.Split(space, 2);
+            string commitId = commitAndParents[0];
+            CommitData ownData = ProvideCommitData(commitId);
+            if ((commitAndParents.Length > 1) &&
+                commitAndParents[1].IsNotNullOrWhitespace())
+            {
+                string[] parents = commitAndParents[1].Split(space);
+                foreach (string parentId in parents)
+                {
+                    ownData.AddParent(parentId);
+                    CommitData parentData = ProvideCommitData(parentId);
+                    parentData.AddChild(commitId);
+                }
+            }
+        }
+
+        private void LoadParents()
+        {
+            string arg = "log -M -C --parents --full-history --format=\"%H %P\" -- \"" + _previousNames.Join("\" \"") + "\"";
+            using (StreamReader gitResult = _gitExecFunc(arg))
+            {
+                string line;
+                while ((line = gitResult.ReadLine()) != null)
+                {
+                    AddCommitToParentsGraph(line);
+                }
+            }
+        }
+
+        private bool _historyLoaded = false;
+        private void EnsureHistoryLoaded()
+        {
+            if (!_historyLoaded) {
+                LoadPreviousNames();
+                _historyLoaded = true;
+                if (RewriteNecessary)
+                {
+                    LoadParents();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the rewrite process is needed (i.e. the file had more than one name throughout its history)
+        /// </summary>
+        /// <returns></returns>
+        public bool RewriteNecessary {
+            get {
+                EnsureHistoryLoaded();
+                return _previousNames.Count() > 1;
+            }
+        }
+
+        /// <summary>
+        /// Finds nearest seen descendents pending rewrite and changes their parent pointers to rev
+        /// </summary>
+        /// <param name="rev"></param>
+        private void UpdateDescendants(GitRevision rev)
+        {
+            // child, parent
+            Queue<Tuple<string, string>> toCheck = new Queue<Tuple<string, string>>();
+            // pairs (child, child) already passed through toCheck
+            HashSet<Tuple<string, string>> toCheckDuplicates = new HashSet<Tuple<string, string>>();
+            ProvideCommitData(rev.Guid).children.ForEach((g) => {
+                Tuple<string, string> t = new Tuple<string, string>(g, rev.Guid);
+                toCheck.Enqueue(t);
+                toCheckDuplicates.Add(t);
+            });
+            while (toCheck.Count() != 0)
+            {
+                Tuple<string,string> ct = toCheck.Dequeue();
+                string checkChild = ct.Item1;
+                string checkParent = ct.Item2;
+
+                CommitData cdta = ProvideCommitData(checkChild);
+                bool allAncestorsSeen = true;
+                // cdta was seen and was reached from seen revision (rev)
+                // Each of its parents pointing "in the direction" of rev should be replaced with rev
+                foreach (string parentId in cdta.parents)
+                {
+                    if ((parentId == checkParent) && !cdta.rewrittenParents.Contains(rev.Guid))
+                    {
+                        cdta.rewrittenParents.Add(rev.Guid);
+                    }
+                    // At the same time we check whether all other parents of cdta are seen or reachable
+                    else if (allAncestorsSeen)
+                    {
+                        CommitData parentDta = ProvideCommitData(parentId);
+                        if (!parentDta.WasSeen() && !parentDta.allAncectorsSeen)
+                        {
+                            allAncestorsSeen = false;
+                        }
+                    }
+                }
+                if (allAncestorsSeen)
+                {
+                    cdta.allAncectorsSeen = true;
+                }
+                if (!cdta.WasSeen())
+                {
+                    // If cdta is an unseen revision, then we must continue along its descendants to find 
+                    // a seen revision
+                    cdta.children.ForEach((g) =>
+                    {
+                        Tuple<string, string> t = new Tuple<string, string>(g, checkChild);
+                        if (!toCheckDuplicates.Contains(t))
+                        {
+                            toCheck.Enqueue(t);
+                            toCheckDuplicates.Add(t);
+                        }
+                    });
+                }
+            }
+        }
+
+        private void UpdateHistoryGraph(GitRevision rev)
+        {
+            CommitData dta = ProvideCommitData(rev.Guid);
+            dta.rev = rev;
+        }
+
+        private Queue<GitRevision> _revisionQueue = new Queue<GitRevision>();
+
+        /// <summary>
+        /// Receives revision data, stores it for receiving by Flush
+        /// </summary>
+        /// <param name="rev"></param>
+        public void PushRevision(GitRevision rev)
+        {
+            _revisionQueue.Enqueue(rev);
+            if ((rev != null) && RewriteNecessary)
+            {
+                UpdateHistoryGraph(rev);
+                UpdateDescendants(rev);
+            }
+        }
+
+        private void RewriteParents(GitRevision rev)
+        {
+            CommitData cdta = ProvideCommitData(rev.Guid);
+            if (cdta.WasSeen() && (cdta.rewrittenParents.Count() != 0))
+            {
+                rev.ParentGuids = cdta.rewrittenParents.ToArray();
+            }
+        }
+
+        private void DequeueAndProcessRevision(Action<GitRevision> processRevision)
+        {
+            GitRevision rev = _revisionQueue.Dequeue();
+            if ((rev != null) && RewriteNecessary)
+            {
+                RewriteParents(rev);
+            }
+            processRevision(rev);
+        }
+
+        /// <summary>
+        /// Calls supplied function with any revisions ready to be processed
+        /// If flushAll==True then forces processing of all pending revisions without rewriting them
+        /// </summary>
+        public void Flush(bool flushAll, Action<GitRevision> processRevision)
+        {
+            if (!flushAll && RewriteNecessary)
+            {
+                while (_revisionQueue.Count() != 0)
+                {
+                    GitRevision r = _revisionQueue.Peek();
+                    if ((r == null)  || ProvideCommitData(r.Guid).allAncectorsSeen)
+                    {
+                        DequeueAndProcessRevision(processRevision);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                };
+            }
+            else
+            {
+                while (_revisionQueue.Count() != 0)
+                {
+                    DequeueAndProcessRevision(processRevision);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Emulates git's missing --parent rewriting with --follow for files with multiple names in history.
