### PR TITLE
Fix for "fatal: Not a valid object name" when displaying a nonexistent blob

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -448,9 +448,21 @@ namespace GitUI.Editor
             }
         }
 
+        private string GetFileTextIfBlobExists(string guid)
+        {
+            if (guid != "")
+            {
+                return Module.GetFileText(guid, Encoding);
+            }
+            else
+            {
+                return "";
+            }
+        }
+
         public void ViewGitItem(string fileName, string guid)
         {
-            ViewItem(fileName, () => GetImage(fileName, guid), () => Module.GetFileText(guid, Encoding),
+            ViewItem(fileName, () => GetImage(fileName, guid), () => GetFileTextIfBlobExists(guid),
                 () => GitCommandHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), guid));
         }
 


### PR DESCRIPTION
When browsing through file history: a click on a commit containing deletion of the file caused the error.
