### PR TITLE
Enhancement: update preview list of ignored files in background

### DIFF
--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -13,6 +13,7 @@ namespace GitUI.CommandsDialogs
     public sealed partial class FormAddToGitIgnore : GitModuleForm
     {
         private readonly TranslationString _matchingFilesString = new TranslationString("{0} file(s) matched");
+        private readonly TranslationString _updateStatusString = new TranslationString("Updating ...");
 
         private readonly ManualResetEvent _notifyThread;
         private volatile bool _stopUpdateThread;
@@ -54,8 +55,8 @@ namespace GitUI.CommandsDialogs
 
                 // switch UI to 'refreshing' state and retrieve patterns
                 GitUIExtensions.UISynchronizationContext.Send(state => {
-                    _NO_TRANSLATE_filesWillBeIgnored.Text = "Updating ...";
-                    _NO_TRANSLATE_Preview.DataSource = new List<string> { "Updating ..." };
+                    _NO_TRANSLATE_filesWillBeIgnored.Text = _updateStatusString.Text;
+                    _NO_TRANSLATE_Preview.DataSource = new List<string> { _updateStatusString.Text };
                     _NO_TRANSLATE_Preview.Enabled = false;
 
                     patterns = GetCurrentPatterns().ToArray();

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 using GitCommands;
 using ResourceManager;
@@ -13,19 +14,79 @@ namespace GitUI.CommandsDialogs
     {
         private readonly TranslationString _matchingFilesString = new TranslationString("{0} file(s) matched");
 
+        private readonly ManualResetEvent _notifyThread;
+        private volatile bool _stopUpdateThread;
+
         public FormAddToGitIgnore(GitUICommands aCommands, params string[] filePatterns)
             : base(aCommands)
         {
             InitializeComponent();
             Translate();
+
+            // closed by thread
+            _notifyThread = new ManualResetEvent(false);
+
+            // when form is closed - notify thread for stop activity, but do not wait for actual stop
+            // waithing can lead to deadlocks, because thread uses SyncContext.Send
+            FormClosed += (sender, args) => {
+                _stopUpdateThread = true;
+                _notifyThread.Set();
+            };
+
+            new Thread(UpdateIgnoreItemsThreadProc).Start();
+
             if (filePatterns != null)
                 FilePattern.Text = string.Join(Environment.NewLine, filePatterns);
+        }
+
+        void UpdateIgnoreItemsThreadProc()
+        {
+            while (true)
+            {
+                _notifyThread.WaitOne();
+                _notifyThread.Reset();
+
+                // check if requested quit
+                if (_stopUpdateThread)
+                    break;
+
+                string[] patterns = null;
+
+                // switch UI to 'refreshing' state and retrieve patterns
+                GitUIExtensions.UISynchronizationContext.Send(state => {
+                    _NO_TRANSLATE_filesWillBeIgnored.Text = "Updating ...";
+                    _NO_TRANSLATE_Preview.DataSource = new List<string> { "Updating ..." };
+                    _NO_TRANSLATE_Preview.Enabled = false;
+
+                    patterns = GetCurrentPatterns().ToArray();
+                }, null);
+
+                // check quit condition after each long work
+                if (_stopUpdateThread)
+                    break;
+
+                var ignoredFiles = Module.GetIgnoredFiles(patterns);
+
+                if (_stopUpdateThread)
+                    break;
+
+                // if client request one more refresh - do not update UI and go one more cycle
+                if (_notifyThread.WaitOne(0))
+                    continue;
+
+                // finally - update UI
+                GitUIExtensions.UISynchronizationContext.Post(state => UpdatePreviewPanel((IList<string>)state), ignoredFiles);
+            }
+
+            _notifyThread.Close();
         }
 
         protected override void OnRuntimeLoad(EventArgs e)
         {
             base.OnRuntimeLoad(e);
-            UpdatePreviewPanel();
+
+            // refresh on start
+            _notifyThread.Set();
         }
 
         private void AddToIngoreClick(object sender, EventArgs e)
@@ -67,10 +128,15 @@ namespace GitUI.CommandsDialogs
             Close();
         }
 
-        private void UpdatePreviewPanel()
+        private void UpdatePreviewPanel(IList<string> ignoredFiles)
         {
-            _NO_TRANSLATE_Preview.DataSource = Module.GetIgnoredFiles(GetCurrentPatterns());
+            // thread can call this method after from closed. prevent access to disposed controls
+            if (_stopUpdateThread)
+                return;
+
+            _NO_TRANSLATE_Preview.DataSource = ignoredFiles;
             _NO_TRANSLATE_filesWillBeIgnored.Text = string.Format(_matchingFilesString.Text, _NO_TRANSLATE_Preview.Items.Count);
+            _NO_TRANSLATE_Preview.Enabled = true;
             noMatchPanel.Visible = _NO_TRANSLATE_Preview.Items.Count == 0;
         }
 
@@ -81,7 +147,7 @@ namespace GitUI.CommandsDialogs
 
         private void FilePattern_TextChanged(object sender, EventArgs e)
         {
-            UpdatePreviewPanel();
+            _notifyThread.Set();
         }
 
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1465,6 +1465,10 @@ You will have push access. {2}</source>
         <source>{0} file(s) matched</source>
         <target />
       </trans-unit>
+      <trans-unit id="_updateStatusString.Text">
+        <source>Updating ...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnCancel.Text">
         <source>Cancel</source>
         <target />

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -1814,6 +1814,11 @@ You will have push access. {2}</source>
         <target>{0} файл(ов) найдено</target>
         
       </trans-unit>
+      <trans-unit id="_updateStatusString.Text">
+        <source>Updating ...</source>
+        <target>Обновление ...</target>
+        
+      </trans-unit>
       <trans-unit id="btnCancel.Text">
         <source>Cancel</source>
         <target>Отмена</target>


### PR DESCRIPTION
In dialog FormAddToGitIgnore exists preview list of ignored files which updated on every edited symbol in pattern edit box.
On big repositories it can take relatively long time for update preview list, so editing pattern become annoing.

Implemented retrieve ignored list in background in separate thread.
Added translations to Russian language.
