### PR TITLE
Ability to run scripts with several selected commits: {sHashes} argument

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -16,6 +16,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _scriptSettingsPageHelpDisplayContent = new TranslationString(@"User Input:
 {UserInput}
 
+Selected Commits:
+{sHashes}
+
 Selected Branch:
 {sTag}
 {sBranch}

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -106,9 +106,9 @@ namespace GitUI.Script
             {
                 if (string.IsNullOrEmpty(argument) || !argument.Contains(option))
                     continue;
-                if (option.StartsWith("{c") || selectedRevision != null)
+                if (option.StartsWith("{c") && currentRevision == null)
                 {
-                    currentRevision = GetCurrentRevision(aModule, revisionGrid, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches, currentRevision, option);
+                    currentRevision = GetCurrentRevision(aModule, revisionGrid, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches, currentRevision);
 
                     if (currentLocalBranches.Count == 1)
                         currentRemote = aModule.GetSetting(string.Format("branch.{0}.remote", currentLocalBranches[0].Name));
@@ -120,7 +120,7 @@ namespace GitUI.Script
                                 askToSpecify(currentLocalBranches, "Current Revision Branch")));
                     }
                 }
-                else if (revisionGrid != null)
+                else if (option.StartsWith("{s") && selectedRevision == null && revisionGrid != null)
                 {
                     allSelectedRevisions = revisionGrid.GetSelectedRevisions();
                     allSelectedRevisions.Reverse(); // Put first clicked revisions first
@@ -359,9 +359,9 @@ namespace GitUI.Script
 
         private static GitRevision GetCurrentRevision(GitModule aModule, RevisionGrid RevisionGrid, List<GitRef> currentTags, List<GitRef> currentLocalBranches,
                                                       List<GitRef> currentRemoteBranches, List<GitRef> currentBranches,
-                                                      GitRevision currentRevision, string option)
+                                                      GitRevision currentRevision)
         {
-            if (option.StartsWith("{c") && currentRevision == null)
+            if (currentRevision == null)
             {
                 IList<GitRef> refs;
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -86,6 +86,8 @@ namespace GitUI.Script
 
             string command = OverrideCommandWhenNecessary(originalCommand);
 
+            var allSelectedRevisions = new List<GitRevision>();
+
             GitRevision selectedRevision = null;
             GitRevision currentRevision = null;
 
@@ -120,6 +122,8 @@ namespace GitUI.Script
                 }
                 else if (revisionGrid != null)
                 {
+                    allSelectedRevisions = revisionGrid.GetSelectedRevisions();
+                    allSelectedRevisions.Reverse(); // Put first clicked revisions first
                     selectedRevision = CalculateSelectedRevision(revisionGrid, selectedRemoteBranches, selectedRemotes, selectedLocalBranches, selectedBranches, selectedTags);
                 }
 
@@ -127,6 +131,10 @@ namespace GitUI.Script
                 string url;
                 switch (option)
                 {
+                    case "{sHashes}":
+                        argument = argument.Replace(option,
+                            string.Join(" ", allSelectedRevisions.Select(revision => revision.Guid).ToArray()));
+                        break;
                     case "{sTag}":
                         if (selectedTags.Count == 1)
                             argument = argument.Replace(option, selectedTags[0].Name);
@@ -391,6 +399,7 @@ namespace GitUI.Script
             {
                 string[] options =
                     {
+                        "{sHashes}",
                         "{sTag}",
                         "{sBranch}",
                         "{sLocalBranch}",


### PR DESCRIPTION
{sHashes} is expanded to hashes of all the selected commits separated by space.
Hashes are ordered in selection order: first selected commit hash goes first.

Plus fix for "Specify 'Current Revision Branch':" window when no "current branch" argument is given. Closes #2302.