### PR TITLE
Fix #2582 - Initializing filtredCurrentCheckout to empty string when it's null to pr...

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1158,7 +1158,7 @@ namespace GitUI
 
         private void SelectInitialRevision()
         {
-            string filtredCurrentCheckout = _filtredCurrentCheckout;
+            string filtredCurrentCheckout = _filtredCurrentCheckout ?? string.Empty;
             if (LastSelectedRows != null)
             {
                 Revisions.SelectedIds = LastSelectedRows;


### PR DESCRIPTION
This fixes the crash caused by filtredCurrentCheckout being null. See #2582 for full details.