### PR TITLE
Fix #2584 - Escape the last backslash from paths before running GitExtensions to avo...

### DIFF
--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -609,9 +609,16 @@ void CGitExtensionsShellEx::RunGitEx(const TCHAR* command)
     CString szCommandName = command;
     CString args;
 
+    if (szFile.GetLength() > 1 && szFile[szFile.GetLength() - 1] == '\\')
+    {
+        // Escape the final backslash to avoid escaping the quote.
+        // This is a problem for drive roots on Windows, such as "C:\".
+        szFile += '\\';
+    }
+
     args += command;
     args += " \"";
-    args += m_szFile;
+    args += szFile;
     args += "\"";
 
     CString dir = "";

--- a/GitPlugin/Git/GitCommands.cs
+++ b/GitPlugin/Git/GitCommands.cs
@@ -65,7 +65,16 @@ namespace GitPlugin.Git
         public static Process RunGitEx(string command, string filename)
         {
             if (!string.IsNullOrEmpty(filename))
+            {
+                if (filename.EndsWith("\\"))
+                {
+                    // Escape the final backslash to avoid escaping the quote.
+                    // This is a problem for drive roots on Windows, such as "C:\".
+                    filename += "\\";
+                }
+
                 command += " \"" + filename + "\"";
+            }
 
             string path = GetGitExRegValue("InstallDir");
             string workDir = Path.GetDirectoryName(filename);


### PR DESCRIPTION
This fixes the crash due to cloning in the root of drive as described in #2584.

I also fixed the same case when running GitExtensions from GitCommands.