### PR TITLE
Use the repository URL from the clipboard if available.

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -70,6 +70,30 @@ namespace GitUI.CommandsDialogs
                     _NO_TRANSLATE_To.Text = Module.WorkingDir;
             }
 
+            if (_NO_TRANSLATE_From.Text == _NO_TRANSLATE_To.Text)
+            {
+                // Try to be more helpful to the user.
+                // Use the cliboard text as a potential source URL.
+                try
+                {
+                    if (Clipboard.ContainsText(TextDataFormat.Text))
+                    {
+                        string text = Clipboard.GetText(TextDataFormat.Text) ?? string.Empty;
+
+                        // See if it's a valid URL.
+                        string lowerText = text.ToLowerInvariant();
+                        if (lowerText.StartsWith("http") ||
+                            lowerText.StartsWith("git@"))
+                        {
+                            _NO_TRANSLATE_From.Text = text;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // We tried.
+                }
+            }
 
             FromTextUpdate(null, null);
         }

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -70,7 +70,8 @@ namespace GitUI.CommandsDialogs
                     _NO_TRANSLATE_To.Text = Module.WorkingDir;
             }
 
-            if (_NO_TRANSLATE_From.Text == _NO_TRANSLATE_To.Text)
+            if (_NO_TRANSLATE_To.Text == _NO_TRANSLATE_From.Text ||
+                _NO_TRANSLATE_To.Text == PathUtil.EnsureTrailingPathSeparator(_NO_TRANSLATE_From.Text))
             {
                 // Try to be more helpful to the user.
                 // Use the cliboard text as a potential source URL.

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -84,7 +84,8 @@ namespace GitUI.CommandsDialogs
                         // See if it's a valid URL.
                         string lowerText = text.ToLowerInvariant();
                         if (lowerText.StartsWith("http") ||
-                            lowerText.StartsWith("git@"))
+                            lowerText.StartsWith("git") ||
+                            lowerText.StartsWith("ssh"))
                         {
                             _NO_TRANSLATE_From.Text = text;
                         }


### PR DESCRIPTION
The more common use-case (one should expect) is to copy the repo URL from a website or an online host (f.e. GitHub) and clone in GitExt. This should be more common than typing in the URL manually.

This PR is to automatically detect if the clipboard holds a Git URL and use that for the "Repository to clone" field in the Clone dialogue. If no URL is detect, the default is left as-is (which is the destination directory).