### PR TITLE
Don't try highlight node when it is not found. Closes #2597

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1161,9 +1161,12 @@ namespace GitUI
                 }
             }
 
-            if (!Revisions.IsRevisionRelative(filtredCurrentCheckout))
+            if (filtredCurrentCheckout != null)
             {
-                HighlightBranch(filtredCurrentCheckout);
+                if (!Revisions.IsRevisionRelative(filtredCurrentCheckout))
+                {
+                    HighlightBranch(filtredCurrentCheckout);
+                }
             }
         }
 


### PR DESCRIPTION
When node not found - filtredCurrentCheckout == null. This raise NullReferenceException in Revisions.IsRevisionRelative and HighlightBranch.