### PR TITLE
VS Plugin: Allow some commands on all targets. Closes #2590

### DIFF
--- a/GitPlugin/Commands/Commit.cs
+++ b/GitPlugin/Commands/Commit.cs
@@ -67,7 +67,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
 
         private static string GetSelectedFile(EnvDTE80.DTE2 application)

--- a/GitPlugin/Commands/CreateBranch.cs
+++ b/GitPlugin/Commands/CreateBranch.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/GitIgnore.cs
+++ b/GitPlugin/Commands/GitIgnore.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/Merge.cs
+++ b/GitPlugin/Commands/Merge.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/Pull.cs
+++ b/GitPlugin/Commands/Pull.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/Push.cs
+++ b/GitPlugin/Commands/Push.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/Rebase.cs
+++ b/GitPlugin/Commands/Rebase.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/Remotes.cs
+++ b/GitPlugin/Commands/Remotes.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/Stash.cs
+++ b/GitPlugin/Commands/Stash.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }

--- a/GitPlugin/Commands/SwitchBranch.cs
+++ b/GitPlugin/Commands/SwitchBranch.cs
@@ -11,7 +11,7 @@ namespace GitPlugin.Commands
 
         protected override CommandTarget SupportedTargets
         {
-            get { return CommandTarget.SolutionExplorerFileItem; }
+            get { return CommandTarget.Any; }
         }
     }
 }


### PR DESCRIPTION
By some reason many commands enabled on subset of solution item types.
In this PR I swicth _some_ commands to be enabled always: Commit, Create Branch, Git Ignore, Merge, Pull, Push, Rebase, Remotes, Stash, Checkout Branch.

I am not sure - is it bug or by design. But seems pretty weird to allow create branch when file selected and disable when selected folder.

Some other commands, like Apply Patch need to be reviewed to be sure if it is really valuable to disable them when folder selected or nothing selected.