### PR TITLE
Fixes #2493 StartBrowseDialog failed after clone.

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1460,12 +1460,18 @@ namespace GitUI
         {
             if (!InvokeEvent(owner, PreBrowse))
                 return false;
-
             var form = new FormBrowse(this, filter);
-            Application.Run(form);
+
+            if (Application.MessageLoop)
+            {
+                form.Show();
+            }
+            else
+            {
+                Application.Run(form);
+            }
 
             InvokeEvent(owner, PostBrowse);
-
             return true;
         }
 


### PR DESCRIPTION
Fixes #2493.
Checks whether the current thread has a message loop, then choose Show instead Application.Run.