### PR TITLE
Fixed calls of plink for host key caching with invalid urls

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -181,6 +181,28 @@ namespace GitCommands
                    (arguments.Contains("pull"));
         }
 
+        /// <summary>
+        /// Transforms the given input Url to make it compatible with Plink, if necessary
+        /// </summary>
+        public static string GetPlinkCompatibleUrl(string inputUrl)
+        {
+            // We don't need putty for http:// links and git@... urls are already usable.
+            // But ssh:// urls can cause problems
+            if (!inputUrl.StartsWith("ssh") || !Uri.IsWellFormedUriString(inputUrl, UriKind.Absolute))
+                return inputUrl;
+
+            // Turn ssh://user@host/path into user@host:path, which works better
+            Uri uri = new Uri(inputUrl, UriKind.Absolute);
+            string fixedUrl = "";
+
+            if (!String.IsNullOrEmpty(uri.UserInfo))
+                fixedUrl = uri.UserInfo + "@";
+            fixedUrl += uri.Authority;
+            fixedUrl += uri.IsDefaultPort ? ":" + uri.LocalPath.Substring(1) : uri.LocalPath;
+
+            return fixedUrl;
+        }
+
         private static IEnumerable<string> StartProcessAndReadLines(string arguments, string cmd, string workDir, string stdInput)
         {
             if (string.IsNullOrEmpty(cmd))

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1457,25 +1457,6 @@ namespace GitCommands
             return GetPathSetting(string.Format("remote.{0}.puttykeyfile", remote));
         }
 
-        public string GetPlinkCompatibleUrl(string inputUrl)
-        {
-            // We don't need putty for http:// links and git@... urls are already usable.
-            // But ssh:// urls can cause problems
-            if (!inputUrl.StartsWith("ssh") || !Uri.IsWellFormedUriString(inputUrl, UriKind.Absolute))
-                return inputUrl;
-
-            // Turn ssh://user@host/path into user@host:path, which works better
-            Uri uri = new Uri(inputUrl, UriKind.Absolute);
-            string fixedUrl = "";
-
-            if (!String.IsNullOrEmpty(uri.UserInfo))
-                fixedUrl = uri.UserInfo + "@";
-            fixedUrl += uri.Authority;
-            fixedUrl += uri.IsDefaultPort ? ":" + uri.LocalPath.Substring(1) : uri.LocalPath;
-
-            return fixedUrl;
-        }
-
         public static bool PathIsUrl(string path)
         {
             return path.Contains(Path.DirectorySeparatorChar) || path.Contains(AppSettings.PosixPathSeparator.ToString());

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1457,6 +1457,25 @@ namespace GitCommands
             return GetPathSetting(string.Format("remote.{0}.puttykeyfile", remote));
         }
 
+        public string GetPlinkCompatibleUrl(string inputUrl)
+        {
+            // We don't need putty for http:// links and git@... urls are already usable.
+            // But ssh:// urls can cause problems
+            if (!inputUrl.StartsWith("ssh") || !Uri.IsWellFormedUriString(inputUrl, UriKind.Absolute))
+                return inputUrl;
+
+            // Turn ssh://user@host/path into user@host:path, which works better
+            Uri uri = new Uri(inputUrl, UriKind.Absolute);
+            string fixedUrl = "";
+
+            if (!String.IsNullOrEmpty(uri.UserInfo))
+                fixedUrl = uri.UserInfo + "@";
+            fixedUrl += uri.Authority;
+            fixedUrl += uri.IsDefaultPort ? ":" + uri.LocalPath.Substring(1) : uri.LocalPath;
+
+            return fixedUrl;
+        }
+
         public static bool PathIsUrl(string path)
         {
             return path.Contains(Path.DirectorySeparatorChar) || path.Contains(AppSettings.PosixPathSeparator.ToString());

--- a/GitExtensionsTest/GitCommands/Git/GitCommandHelpersTest.cs
+++ b/GitExtensionsTest/GitCommands/Git/GitCommandHelpersTest.cs
@@ -108,5 +108,103 @@ namespace GitExtensionsTest.Git
             Assert.AreEqual("refs/heads/release/2.48", GitCommandHelpers.GetFullBranchName("refs/heads/release/2.48"));
             Assert.AreEqual("refs/tags/my-tag", GitCommandHelpers.GetFullBranchName("refs/tags/my-tag"));
         }
+
+        [TestMethod]
+        public void TestGetPlinkCompatibleUrl_Incompatible()
+        {
+            // Test urls that are incompatible and need to be changed      
+            string inUrl, expectUrl, outUrl;
+
+            // ssh urls can cause problems
+            inUrl = "ssh://user@example.com/path/to/project.git";
+            expectUrl = "user@example.com:path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(expectUrl, outUrl);
+
+            // ssh, no user
+            inUrl = "ssh://example.com/path/to/project.git";
+            expectUrl = "example.com:path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(expectUrl, outUrl);
+        }
+
+        [TestMethod]
+        public void TestGetPlinkCompatibleUrl_Compatible()
+        {
+            // Test urls that are already compatible, these shouldn't be changed
+            string inUrl, outUrl;
+
+            // ssh in compatible form
+            inUrl = "git@github.com:gitextensions/gitextensions.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // ssh in compatible form, no user
+            inUrl = "example.org:some/path/to/repo.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+        }
+        
+        [TestMethod]
+        public void TestGetPlinkCompatibleUrl_NoPlink()
+        {
+            // Test urls that are no valid uris, these should be ignored    
+            string inUrl, outUrl;
+
+            // git protocol does not have authentication
+            inUrl = "git://server/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // git protocol, different port
+            inUrl = "git://server:123/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+            
+            // we don't need plink for http
+            inUrl = "http://user@server/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // http, different port
+            inUrl = "http://user@server:123/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // http, no user
+            inUrl = "http://server/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // we don't need plink for https
+            inUrl = "https://user@server/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // https, different port
+            inUrl = "https://user@server:123/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            // https, no user
+            inUrl = "https://server/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+        }
+
+        [TestMethod]
+        public void TestGetPlinkCompatibleUrl_Invalid()
+        {
+            // Test urls that are no valid uris, these should be ignored  
+            string inUrl, outUrl;
+
+            inUrl = "foo://server/path/to/project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+
+            inUrl = @"ssh:\\server\path\to\project.git";
+            outUrl = GitCommandHelpers.GetPlinkCompatibleUrl(inUrl);
+            Assert.AreEqual(inUrl, outUrl);
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -257,24 +257,11 @@ namespace GitUI.CommandsDialogs
 
         private void TestConnectionClick(object sender, EventArgs e)
         {
-            System.Uri uri;
-            string sshURL = "";
-            if (System.Uri.TryCreate(Url.Text, UriKind.RelativeOrAbsolute, out uri) &&
-                uri.IsAbsoluteUri && uri.Scheme == "ssh")
-            {
-                if (!string.IsNullOrEmpty(uri.UserInfo))
-                    sshURL = uri.UserInfo + "@";
-                sshURL += uri.Authority;
-                if (uri.IsDefaultPort)
-                    sshURL += ":" + uri.LocalPath.Substring(1);
-                else
-                    sshURL += uri.LocalPath;
-            }
-            else
-                sshURL = Url.Text;
+            string url = Module.GetPlinkCompatibleUrl(Url.Text);
+
             Module.RunExternalCmdDetachedShowConsole(
                 "cmd.exe",
-                string.Format("/k \"\"{0}\" -T \"{1}\"\"", AppSettings.Plink, sshURL));
+                string.Format("/k \"\"{0}\" -T \"{1}\"\"", AppSettings.Plink, url));
         }
 
         private void PruneClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -257,7 +257,7 @@ namespace GitUI.CommandsDialogs
 
         private void TestConnectionClick(object sender, EventArgs e)
         {
-            string url = Module.GetPlinkCompatibleUrl(Url.Text);
+            string url = GitCommandHelpers.GetPlinkCompatibleUrl(Url.Text);
 
             Module.RunExternalCmdDetachedShowConsole(
                 "cmd.exe",

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -140,7 +140,7 @@ namespace GitUI
         {
             if (!remoteUrl.IsNullOrEmpty() && MessageBoxes.CacheHostkey(owner))
             {
-                remoteUrl = module.GetPlinkCompatibleUrl(remoteUrl);
+                remoteUrl = GitCommandHelpers.GetPlinkCompatibleUrl(remoteUrl);
 
                 module.RunExternalCmdShowConsole(
                     "cmd.exe",
@@ -162,7 +162,7 @@ namespace GitUI
                     {
                         string remoteUrl = Module.GetPathSetting(string.Format(SettingKeyString.RemoteUrl, Remote));
                         remoteUrl = string.IsNullOrEmpty(remoteUrl) ? Remote : remoteUrl;
-                        remoteUrl = Module.GetPlinkCompatibleUrl(remoteUrl);
+                        remoteUrl = GitCommandHelpers.GetPlinkCompatibleUrl(remoteUrl);
 
                         Module.RunExternalCmdShowConsole("cmd.exe", string.Format("/k \"\"{0}\" {1}\"", AppSettings.Plink, remoteUrl));
 

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -140,6 +140,8 @@ namespace GitUI
         {
             if (!remoteUrl.IsNullOrEmpty() && MessageBoxes.CacheHostkey(owner))
             {
+                remoteUrl = module.GetPlinkCompatibleUrl(remoteUrl);
+
                 module.RunExternalCmdShowConsole(
                     "cmd.exe",
                     string.Format("/k \"\"{0}\" -T \"{1}\"\"", AppSettings.Plink, remoteUrl));
@@ -159,8 +161,10 @@ namespace GitUI
                     if (MessageBox.Show(this, _fingerprintNotRegistredText.Text, _fingerprintNotRegistredTextCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
                     {
                         string remoteUrl = Module.GetPathSetting(string.Format(SettingKeyString.RemoteUrl, Remote));
+                        remoteUrl = string.IsNullOrEmpty(remoteUrl) ? Remote : remoteUrl;
+                        remoteUrl = Module.GetPlinkCompatibleUrl(remoteUrl);
 
-                        Module.RunExternalCmdShowConsole("cmd.exe", string.Format("/k \"\"{0}\" {1}\"", AppSettings.Plink, string.IsNullOrEmpty(remoteUrl) ? Remote : remoteUrl));
+                        Module.RunExternalCmdShowConsole("cmd.exe", string.Format("/k \"\"{0}\" {1}\"", AppSettings.Plink, remoteUrl));
 
                         restart = true;
                     }


### PR DESCRIPTION
When fetching, etc. from a remote repository via a ``ssh://user@host/path`` url, that is not a known host, plink can cause "Host does not exist" errors. This has already been fixed for the connection test.

This can be reproduced with ssh repository links for sourceforge.

I extracted the url fixing code from FormRemote into it's own method and added calls to it in the FormRemoteProcess.