### PR TITLE
Follow only exact renames setting added

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1322,6 +1322,28 @@ namespace GitCommands
             }
         }
 
+        // returns " --find-renames=..." according to app settings 
+        public static string FindRenamesOpt()
+        {
+            string result = " --find-renames";
+            if (AppSettings.FollowRenamesInFileHistoryExactOnly)
+            {
+                result += "=\"100%\"";
+            }
+            return result;
+        }
+
+        // returns " --find-renames=... --find-copies=..." according to app settings 
+        public static string FindRenamesAndCopiesOpts()
+        {
+            string findCopies = " --find-copies";
+            if (AppSettings.FollowRenamesInFileHistoryExactOnly)
+            {
+                findCopies += "=\"100%\"";
+            }
+            return FindRenamesOpt() + findCopies;
+        }
+
 #if !__MonoCS__
         static class NativeMethods
         {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -430,6 +430,12 @@ namespace GitCommands
             set { SetBool("followrenamesinfilehistory", value); }
         }
 
+        public static bool FollowRenamesInFileHistoryExactOnly
+        {
+            get { return GetBool("followrenamesinfilehistoryexactonly", false); }
+            set { SetBool("followrenamesinfilehistoryexactonly", value); }
+        }
+
         public static bool FullHistoryInFileHistory
         {
             get { return GetBool("fullhistoryinfilehistory", false); }

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -45,6 +45,7 @@ namespace GitUI.CommandsDialogs
             this.cherryPickThisCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.followFileHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.followFileHistoryRenamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fullHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.ViewTab = new System.Windows.Forms.TabPage();
@@ -125,6 +126,7 @@ namespace GitUI.CommandsDialogs
             this.manipuleerCommitToolStripMenuItem,
             this.toolStripSeparator1,
             this.followFileHistoryToolStripMenuItem,
+            this.followFileHistoryRenamesToolStripMenuItem,
             this.fullHistoryToolStripMenuItem});
             this.DiffContextMenu.Name = "DiffContextMenu";
             this.DiffContextMenu.Size = new System.Drawing.Size(264, 184);
@@ -197,6 +199,13 @@ namespace GitUI.CommandsDialogs
             this.followFileHistoryToolStripMenuItem.Size = new System.Drawing.Size(263, 24);
             this.followFileHistoryToolStripMenuItem.Text = "Detect and follow renames";
             this.followFileHistoryToolStripMenuItem.Click += new System.EventHandler(this.followFileHistoryToolStripMenuItem_Click);
+            // 
+            // followFileHistoryRenamesToolStripMenuItem
+            // 
+            this.followFileHistoryRenamesToolStripMenuItem.Name = "followFileHistoryRenamesToolStripMenuItem";
+            this.followFileHistoryRenamesToolStripMenuItem.Size = new System.Drawing.Size(262, 22);
+            this.followFileHistoryRenamesToolStripMenuItem.Text = "Detect and follow - exact renames and copies only";
+            this.followFileHistoryRenamesToolStripMenuItem.Click += new System.EventHandler(this.followFileHistoryRenamesToolStripMenuItem_Click);
             // 
             // fullHistoryToolStripMenuItem
             // 
@@ -455,5 +464,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem loadHistoryOnShowToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripMenuItem loadBlameOnShowToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem followFileHistoryRenamesToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -170,10 +170,16 @@ namespace GitUI.CommandsDialogs
                 }
 
             }
-            else
+            else if (AppSettings.FollowRenamesInFileHistory)
             {
+                // history of a directory
                 // --parents doesn't work with --follow enabled, but needed to graph a filtered log
                 res.Filter = " --follow --parents -- \"" + fileName + "\"";
+            }
+            else
+            {
+                // rename following disabled
+                res.Filter = " --parents -- \"" + fileName + "\"";
             }
 
             if (AppSettings.FullHistoryInFileHistory)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -60,7 +60,7 @@ namespace GitUI.CommandsDialogs
             FileChanges.SelectionChanged += FileChangesSelectionChanged;
             FileChanges.DisableContextMenu();
 
-            followFileHistoryToolStripMenuItem.Checked = AppSettings.FollowRenamesInFileHistory;
+            UpdateFollowHistoryMenuItems();
             fullHistoryToolStripMenuItem.Checked = AppSettings.FullHistoryInFileHistory;
             loadHistoryOnShowToolStripMenuItem.Checked = AppSettings.LoadFileHistoryOnShow;
             loadBlameOnShowToolStripMenuItem.Checked = AppSettings.LoadBlameOnShow;
@@ -162,11 +162,11 @@ namespace GitUI.CommandsDialogs
                 if (hrw.RewriteNecessary)
                 {
                     res.Rewriter = hrw;
-                    res.Filter = " -M -C --name-only --follow -- \"" + fileName + "\"";
+                    res.Filter = " " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --name-only --follow -- \"" + fileName + "\"";
                 }
                 else
                 {
-                    res.Filter = " -M -C --name-only --parents -- \"" + fileName + "\"";
+                    res.Filter = " " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --name-only --parents -- \"" + fileName + "\"";
                 }
 
             }
@@ -174,7 +174,7 @@ namespace GitUI.CommandsDialogs
             {
                 // history of a directory
                 // --parents doesn't work with --follow enabled, but needed to graph a filtered log
-                res.Filter = " --follow --parents -- \"" + fileName + "\"";
+                res.Filter = " " + GitCommandHelpers.FindRenamesOpt() + " --follow --parents -- \"" + fileName + "\"";
             }
             else
             {
@@ -326,9 +326,16 @@ namespace GitUI.CommandsDialogs
         private void followFileHistoryToolStripMenuItem_Click(object sender, EventArgs e)
         {
             AppSettings.FollowRenamesInFileHistory = !AppSettings.FollowRenamesInFileHistory;
-            followFileHistoryToolStripMenuItem.Checked = AppSettings.FollowRenamesInFileHistory;
+            UpdateFollowHistoryMenuItems();
 
             LoadFileHistory();
+        }
+
+        private void UpdateFollowHistoryMenuItems()
+        {
+            followFileHistoryToolStripMenuItem.Checked = AppSettings.FollowRenamesInFileHistory;
+            followFileHistoryRenamesToolStripMenuItem.Enabled = AppSettings.FollowRenamesInFileHistory;
+            followFileHistoryRenamesToolStripMenuItem.Checked = AppSettings.FollowRenamesInFileHistoryExactOnly;
         }
 
         private void fullHistoryToolStripMenuItem_Click(object sender, EventArgs e)
@@ -420,6 +427,23 @@ namespace GitUI.CommandsDialogs
             {
                 FileChanges.NavigateForward();
             }
+        }
+
+        private void DiffContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+
+        }
+
+        private void ToolStrip_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
+        {
+
+        }
+
+        private void followFileHistoryRenamesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.FollowRenamesInFileHistoryExactOnly = !AppSettings.FollowRenamesInFileHistoryExactOnly;
+            UpdateFollowHistoryMenuItems();
+            LoadFileHistory();
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -30,6 +30,7 @@
         {
             this.groupBoxBehaviour = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanelBehaviour = new System.Windows.Forms.TableLayoutPanel();
+            this.chkFollowRenamesInFileHistoryExact = new System.Windows.Forms.CheckBox();
             this.RevisionGridQuickSearchTimeout = new System.Windows.Forms.NumericUpDown();
             this.btnDefaultDestinationBrowse = new System.Windows.Forms.Button();
             this.label24 = new System.Windows.Forms.Label();
@@ -91,6 +92,7 @@
             this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelBehaviour.Controls.Add(this.chkFollowRenamesInFileHistoryExact, 1, 4);
             this.tableLayoutPanelBehaviour.Controls.Add(this.RevisionGridQuickSearchTimeout, 1, 7);
             this.tableLayoutPanelBehaviour.Controls.Add(this.btnDefaultDestinationBrowse, 2, 6);
             this.tableLayoutPanelBehaviour.Controls.Add(this.label24, 0, 7);
@@ -117,6 +119,16 @@
             this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelBehaviour.Size = new System.Drawing.Size(970, 214);
             this.tableLayoutPanelBehaviour.TabIndex = 61;
+            // 
+            // chkFollowRenamesInFileHistoryExact
+            // 
+            this.chkFollowRenamesInFileHistoryExact.AutoSize = true;
+            this.chkFollowRenamesInFileHistoryExact.Location = new System.Drawing.Point(273, 95);
+            this.chkFollowRenamesInFileHistoryExact.Name = "chkFollowRenamesInFileHistoryExact";
+            this.chkFollowRenamesInFileHistoryExact.Size = new System.Drawing.Size(153, 17);
+            this.chkFollowRenamesInFileHistoryExact.TabIndex = 15;
+            this.chkFollowRenamesInFileHistoryExact.Text = "Follow exact renames and copies only";
+            this.chkFollowRenamesInFileHistoryExact.UseVisualStyleBackColor = true;
             // 
             // RevisionGridQuickSearchTimeout
             // 
@@ -204,7 +216,7 @@
             this.lblDefaultCloneDestination.Location = new System.Drawing.Point(3, 162);
             this.lblDefaultCloneDestination.Name = "lblDefaultCloneDestination";
             this.lblDefaultCloneDestination.Size = new System.Drawing.Size(148, 16);
-            this.lblDefaultCloneDestination.TabIndex = 17;
+            this.lblDefaultCloneDestination.TabIndex = 18;
             this.lblDefaultCloneDestination.Text = "Default clone destination";
             // 
             // chkUsePatienceDiffAlgorithm
@@ -223,7 +235,7 @@
             this.chkPlaySpecialStartupSound.Location = new System.Drawing.Point(322, 133);
             this.chkPlaySpecialStartupSound.Name = "chkPlaySpecialStartupSound";
             this.chkPlaySpecialStartupSound.Size = new System.Drawing.Size(181, 20);
-            this.chkPlaySpecialStartupSound.TabIndex = 16;
+            this.chkPlaySpecialStartupSound.TabIndex = 17;
             this.chkPlaySpecialStartupSound.Text = "Play Special Startup Sound";
             this.chkPlaySpecialStartupSound.UseVisualStyleBackColor = true;
             // 
@@ -243,7 +255,7 @@
             this.chkStartWithRecentWorkingDir.Location = new System.Drawing.Point(3, 133);
             this.chkStartWithRecentWorkingDir.Name = "chkStartWithRecentWorkingDir";
             this.chkStartWithRecentWorkingDir.Size = new System.Drawing.Size(211, 20);
-            this.chkStartWithRecentWorkingDir.TabIndex = 15;
+            this.chkStartWithRecentWorkingDir.TabIndex = 16;
             this.chkStartWithRecentWorkingDir.Text = "Open last working directory on startup";
             this.chkStartWithRecentWorkingDir.UseVisualStyleBackColor = true;
             // 
@@ -561,5 +573,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelBehaviour;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelEmailSettings;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelSmtpServer;
+        private System.Windows.Forms.CheckBox chkFollowRenamesInFileHistoryExact;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
@@ -48,6 +48,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowGitCommandLine.Checked = AppSettings.ShowGitCommandLine;
             chkUseFastChecks.Checked = AppSettings.UseFastChecks;
             cbDefaultCloneDestination.Text = AppSettings.DefaultCloneDestinationPath;
+            chkFollowRenamesInFileHistoryExact.Checked = AppSettings.FollowRenamesInFileHistoryExactOnly;
         }
 
         protected override void PageToSettings()
@@ -72,6 +73,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RevisionGraphShowWorkingDirChanges = chkShowCurrentChangesInRevisionGraph.Checked;
             AppSettings.ShowStashCount = chkShowStashCountInBrowseWindow.Checked;
             AppSettings.DefaultCloneDestinationPath = cbDefaultCloneDestination.Text;
+            AppSettings.FollowRenamesInFileHistoryExactOnly = chkFollowRenamesInFileHistoryExact.Checked;
         }
 
         private void chkUseSSL_CheckedChanged(object sender, System.EventArgs e)

--- a/GitUI/UserControls/RevisionGridClasses/FollowParentRewriter.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FollowParentRewriter.cs
@@ -122,7 +122,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         // Fetches previous names of _fileName, stores in _previousNames
         private void LoadPreviousNames()
         {
-            string arg = "log -M -C --follow --name-only --format=\"%n\"";
+            string arg = "log " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --follow --name-only --format=\"%n\"";
             if (AppSettings.FullHistoryInFileHistory)
             {
                 arg += " --full-history";
@@ -169,7 +169,7 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         private void LoadParents()
         {
-            string arg = "log -M -C --simplify-merges --parents --boundary --not --glob=notes --not --all --format=\"%H %P\"";
+            string arg = "log " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --simplify-merges --parents --boundary --not --glob=notes --not --all --format=\"%H %P\"";
             if (AppSettings.OrderRevisionByDate)
             {
                 arg += " --date-order";


### PR DESCRIPTION
This contains a new setting to follow only exact renames, which should satisfy use cases in #2329 and #2589.
I also noticed that with "follow renames" disabled "--follow" was still being passed to git, and fixed that.