### PR TITLE
GitStatistics: #2476 - Now the default behavior of the line counter will...

### DIFF
--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -35,6 +35,7 @@ namespace GitStatistics
                 };
 
         public string DirectoriesToIgnore;
+        public bool EndsWithCompare;
         public DirectoryInfo WorkingDir;
         private SynchronizationContext syncContext;
         private LineCounter lineCounter;
@@ -147,7 +148,7 @@ namespace GitStatistics
         
         public void LoadLinesOfCode()
         {
-            lineCounter.FindAndAnalyzeCodeFiles(_codeFilePattern, DirectoriesToIgnore);
+            lineCounter.FindAndAnalyzeCodeFiles(_codeFilePattern, DirectoriesToIgnore, EndsWithCompare);
         }
 
         void lineCounter_LinesOfCodeUpdated(object sender, EventArgs e)

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -10,7 +10,9 @@ namespace GitStatistics
         StringSetting CodeFiles = new StringSetting("Code files",
                                 "*.c;*.cpp;*.cc;*.h;*.hpp;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" + 
                                 "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js");
-        StringSetting IgnoreDirectories = new StringSetting("Directories to ignore (EndsWith)", "\\Debug;\\Release;\\obj;\\bin;\\lib");
+
+        StringSetting IgnoreDirectories = new StringSetting("Ignore directories containing the following names", "\\Debug;\\Release;\\obj;\\bin;\\lib");
+        BoolSetting UseEndsWith = new BoolSetting("Use old directory filtering (EndsWith)", false);
         BoolSetting IgnoreSubmodules = new BoolSetting("Ignore submodules", true);
 
         #region IGitPlugin Members
@@ -23,6 +25,7 @@ namespace GitStatistics
         {
             yield return CodeFiles;
             yield return IgnoreDirectories;
+            yield return UseEndsWith;
             yield return IgnoreSubmodules;
         }
 
@@ -34,7 +37,8 @@ namespace GitStatistics
             using (var formGitStatistics =
                 new FormGitStatistics(gitUIEventArgs.GitModule, CodeFiles[Settings])
                     {
-                        DirectoriesToIgnore = IgnoreDirectories[Settings]
+                        DirectoriesToIgnore = IgnoreDirectories[Settings],
+                        EndsWithCompare = UseEndsWith[Settings].GetValueOrDefault()
                     })
             {
 


### PR DESCRIPTION
... match directory names containing the filter strings, not just using EndsWith(), for the sake of accuracy.

An option to use the old EndsWith() filtering was added
