### PR TITLE
Fixed issue #2301: Fix IME error.

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -983,8 +983,11 @@ namespace GitUI.SpellChecker
 
         private void AutoCompleteTimer_Tick (object sender, EventArgs e)
         {
-            UpdateOrShowAutoComplete(false);
-            AutoCompleteTimer.Stop();
+            if (!_customUnderlines.IsImeStartingComposition)
+            {
+                UpdateOrShowAutoComplete(false);
+                AutoCompleteTimer.Stop();
+            }
         }
 
         public void CancelAutoComplete ()


### PR DESCRIPTION
If IME is starting composition, input is canceled by AutoCompleteTimer_Tick method calls.