### PR TITLE
Fixed issue #2657: Build script handling of whitespace characters

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -224,7 +224,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(ProjectDir)copy_plugins.cmd $(ConfigurationName)</PostBuildEvent>
+    <PostBuildEvent>"$(ProjectDir)copy_plugins.cmd" $(ConfigurationName)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GitExtensions/copy_plugins.cmd
+++ b/GitExtensions/copy_plugins.cmd
@@ -3,7 +3,7 @@ set config=%1
 md Plugins\
 echo Microsoft.TeamFoundation.WorkItemTracking.Client.DataStoreLoader.dll > exclude.txt
 echo Microsoft.WITDataStore.dll >> exclude.txt
-for /d %%I in (%~p0\..\Plugins\*, %~p0\..\Plugins\Statistics\*, %~p0\..\Plugins\BuildServerIntegration\*) do (
-  xcopy /y /r %%I\bin\%config%\*.dll Plugins\ /EXCLUDE:exclude.txt
-  xcopy /y /r %%I\bin\%config%\*.pdb Plugins\
+for /d %%I in ("%~p0\..\Plugins\*", "%~p0\..\Plugins\Statistics\*", "%~p0\..\Plugins\BuildServerIntegration\*") do (
+  xcopy /y /r "%%I\bin\%config%\*.dll" Plugins\ /EXCLUDE:exclude.txt
+  xcopy /y /r "%%I\bin\%config%\*.pdb" Plugins\
 )


### PR DESCRIPTION
This PR fixes handling of whitespaces in the *copy_plugins.cmd* build script (issue #2657).

When the Git Extensions repo is cloned (on Windows) to a local path containing whitespaces (e.g. C:\Temporary Files\Git Extensions) the build script copy_plugins.cmd fails because the path ends up malformed (e.g. as C:\Temporary). 