### PR TITLE
Draw smoother Bezier curves; Cache points outside loop

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1069,43 +1069,46 @@ namespace GitUI.RevisionGridClasses
                             }
                         }
 
+                        bool singleLane = laneInfo.ConnectLane == lane;
+                        int x0 = mid;
+                        int y0 = top - 1;
+                        int x1 = singleLane ? x0 : mid + (laneInfo.ConnectLane - lane) * _laneWidth;
+                        int y1 = top + _rowHeight + 2;
+
+                        Point p0 = new Point(x0, y0);
+                        Point p1 = new Point(x1, y1);
+                        Point c0 = Point.Empty, c1 = Point.Empty;
+                        if (!singleLane)
+                        {
+                            c0 = new Point(x0, top + _rowHeight/2 + 2);
+                            c1 = new Point(x1, top - 1 + _rowHeight/2);
+                        }
+
                         for (int i = drawBorder ? 0 : 2; i < 3; i++)
                         {
-                            Pen penLine = null;
-                            if (i == 0)
+                            Pen penLine;
+                            switch (i)
                             {
+                              case 0:
                                 penLine = _whiteBorderPen;
-                            }
-                            else if (i == 1)
-                            {
+                                break;
+                              case 1:
                                 penLine = _blackBorderPen;
-                            }
-                            else
-                            {
+                                break;
+                              default:
                                 if (brushLineColorPen == null)
-                                    brushLineColorPen = new Pen(brushLineColor, _laneLineWidth);
+                                  brushLineColorPen = new Pen(brushLineColor, _laneLineWidth);
                                 penLine = brushLineColorPen;
+                                break;
                             }
 
-                            if (laneInfo.ConnectLane == lane)
+                            if (singleLane)
                             {
-                                wa.DrawLine
-                                    (
-                                        penLine,
-                                        new Point(mid, top - 1),
-                                        new Point(mid, top + _rowHeight + 2)
-                                    );
+                                wa.DrawLine(penLine, p0, p1);
                             }
                             else
                             {
-                                wa.DrawBezier
-                                    (
-                                        penLine,
-                                        new Point(mid, top - 1),
-                                        new Point(mid, top + _rowHeight + 2),
-                                        new Point(mid + (laneInfo.ConnectLane - lane) * _laneWidth, top - 1),
-                                        new Point(mid + (laneInfo.ConnectLane - lane) * _laneWidth, top + _rowHeight + 2)
-                                    );
+                                wa.DrawBezier(penLine, p0, c0, c1, p1);
                             }
                         }
                     }

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1069,19 +1069,28 @@ namespace GitUI.RevisionGridClasses
                             }
                         }
 
+                        // Precalculate line endpoints
                         bool singleLane = laneInfo.ConnectLane == lane;
                         int x0 = mid;
                         int y0 = top - 1;
                         int x1 = singleLane ? x0 : mid + (laneInfo.ConnectLane - lane) * _laneWidth;
-                        int y1 = top + _rowHeight + 2;
+                        int y1 = top + _rowHeight;
 
                         Point p0 = new Point(x0, y0);
                         Point p1 = new Point(x1, y1);
-                        Point c0 = Point.Empty, c1 = Point.Empty;
-                        if (!singleLane)
+
+                        // Precalculate curve control points when needed
+                        Point c0, c1;
+                        if (singleLane)
                         {
-                            c0 = new Point(x0, top + _rowHeight/2 + 2);
-                            c1 = new Point(x1, top - 1 + _rowHeight/2);
+                            c0 = c1 = Point.Empty;
+                        }
+                        else
+                        {
+                            // Controls the curvature of cross-lane lines (0 = straight line, 1 = 90 degree turns)
+                            const float severity = 0.5f;
+                            c0 = new Point(x0, (int)(y0 * (1.0f - severity) + y1 * severity));
+                            c1 = new Point(x1, (int)(y1 * (1.0f - severity) + y0 * severity));
                         }
 
                         for (int i = drawBorder ? 0 : 2; i < 3; i++)


### PR DESCRIPTION
Minor enhancements:
1. I didn't like the very curvy lines in the graph.  This commit smoothes them significantly.
2. The inner loop recalculates the end points and control points.  The commit precalculates what's needed for  slightly better performance, and readability.

Before and after:
![image](https://cloud.githubusercontent.com/assets/4988217/6210857/32772912-b5d4-11e4-9259-163d2c1d045e.png) ![image](https://cloud.githubusercontent.com/assets/4988217/6210810/a8e3a27a-b5d3-11e4-8f4c-875a670a5faa.png)
