### PR TITLE
Make CommitForm title refreshable

### DIFF
--- a/GitUI/FormCommit.cs
+++ b/GitUI/FormCommit.cs
@@ -530,6 +530,15 @@ namespace GitUI
         {
             initialized = true;
 
+            ThreadPool.QueueUserWorkItem(
+                o =>
+                {
+                    var text =
+                        string.Format(_formTitle.Text, Module.GetSelectedBranch(),
+                            Module.WorkingDir);
+
+                    _syncContext.Post(state1 => Text = text, null);
+                });
 
             Cursor.Current = Cursors.WaitCursor;
 
@@ -1306,16 +1315,6 @@ namespace GitUI
 
             if (_useFormCommitMessage && !string.IsNullOrEmpty(message))
                 Message.Text = message;
-
-            ThreadPool.QueueUserWorkItem(
-                o =>
-                {
-                    var text =
-                        string.Format(_formTitle.Text, Module.GetSelectedBranch(),
-                                      Module.WorkingDir);
-
-                    _syncContext.Post(state1 => Text = text, null);
-                });
         }
 
         private void SetCommitMessageFromTextBox(string commitMessageText)


### PR DESCRIPTION
Fixes #2666 

PS: I followed the https://github.com/gitextensions/gitextensions/wiki/Project-Workflow and according to it I had to create a bugfix starting from release 2.46, but there is no a **release/2.46** branch anymore and **2.46** tag only, but we cannot send a pull request for tags, so I had to to target **release/2.48** instead