### PR TITLE
Fixed issue #2670: Revision header too short if Japanese font is used

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -174,6 +174,7 @@
             this._RevisionHeader.Size = new System.Drawing.Size(780, 93);
             this._RevisionHeader.TabIndex = 0;
             this._RevisionHeader.Text = "";
+            this._RevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this._RevisionHeader_ContentsResized);
             this._RevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
             this._RevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -124,6 +124,7 @@ namespace GitUI.CommitInfo
         private List<string> _branches;
         private string _branchInfo;
         private IList<string> _sortedRefs;
+        private System.Drawing.Rectangle _headerResize; // Cache desired size for commit header
 
         private void ReloadCommitInfo()
         {
@@ -158,7 +159,7 @@ namespace GitUI.CommitInfo
             CommitInformation commitInformation = CommitInformation.GetCommitInfo(data, CommandClick != null);
 
             _RevisionHeader.SetXHTMLText(commitInformation.Header);
-            _RevisionHeader.Height = _RevisionHeader.GetPreferredSize(new System.Drawing.Size(0, 0)).Height;
+            _RevisionHeader.Height = _headerResize.Height;
             _revisionInfo = commitInformation.Body;
             updateText();
             LoadAuthorImage(data.Author ?? data.Committer);
@@ -431,6 +432,12 @@ namespace GitUI.CommitInfo
             {
                 DoCommandClick("navigateforward", null);
             }
+        }
+
+        private void _RevisionHeader_ContentsResized(object sender, ContentsResizedEventArgs e)
+        {
+            // Cache desired size for commit header
+            _headerResize = e.NewRectangle;
         }
     }
 }


### PR DESCRIPTION
Fix proposal for #2670: Revision header too short if Japanese font is used

It seems to be fixed:
![image](https://cloud.githubusercontent.com/assets/2798715/6318413/d158cc26-bad3-11e4-87fe-532c77663922.png)
