### PR TITLE
Highlighting of authored commits

### DIFF
--- a/GitCommands/Config/SettingKeyString.cs
+++ b/GitCommands/Config/SettingKeyString.cs
@@ -16,5 +16,15 @@ namespace GitCommands.Config
         /// "remote.{0}.url"
         /// </summary>
         public const string RemoteUrl = "remote.{0}.url";
+
+        /// <summary>
+        /// user.name
+        /// </summary>
+        public const string UserName = "user.name";
+
+        /// <summary>
+        /// user.email
+        /// </summary>
+        public const string UserEmail = "user.email";
     }
 }

--- a/GitCommands/Git/AuthorEmailEqualityComparer.cs
+++ b/GitCommands/Git/AuthorEmailEqualityComparer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GitCommands.Git
+{
+    public sealed class AuthorEmailEqualityComparer : IEqualityComparer<GitRevision>, IEqualityComparer<string>
+    {
+        private static readonly AuthorEmailEqualityComparer CachedInstance = new AuthorEmailEqualityComparer(); 
+        public static AuthorEmailEqualityComparer Instance
+        {
+            get { return CachedInstance; }
+        }
+
+        public bool Equals(GitRevision x, GitRevision y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            return Equals(x.AuthorEmail, y.AuthorEmail);
+        }
+
+        public int GetHashCode(GitRevision revision)
+        {
+            return GetHashCode(revision.AuthorEmail);
+        } 
+
+        public bool Equals(string firstAuthorEmail, string secondAuthorEmail)
+        {
+            return String.Equals(firstAuthorEmail, secondAuthorEmail, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(string authorEmail)
+        {
+            return authorEmail != null ? authorEmail.GetHashCode() : 0;
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -80,6 +80,7 @@
     <Compile Include="DateTimeUtils.cs" />
     <Compile Include="ExceptionUtils.cs" />
     <Compile Include="FileHelper.cs" />
+    <Compile Include="Git\AuthorEmailEqualityComparer.cs" />
     <Compile Include="Logging\CommandLogEntry.cs" />
     <Compile Include="RemoteActionResult.cs" />
     <Compile Include="Settings\BasicSettingTypes.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -873,6 +873,12 @@ namespace GitCommands
             set { SetColor("diffaddedextracolor", value); }
         }
 
+        public static Color AuthoredRevisionsColor
+        {
+            get { return GetColor("authoredrevisionscolor", Color.LightYellow); }
+            set { SetColor("authoredrevisionscolor", value); }
+        }
+
         public static Font DiffFont
         {
             get { return GetFont("difffont", new Font("Courier New", 10)); }
@@ -909,6 +915,12 @@ namespace GitCommands
         {
             get { return GetBool("branchborders", true); }
             set { SetBool("branchborders", value); }
+        }
+
+        public static bool HighlightAuthoredRevisions
+        {
+            get { return GetBool("highlightauthoredrevisions", true); }
+            set { SetBool("highlightauthoredrevisions", value); }
         }
 
         public static string LastFormatPatchDir

--- a/GitExtensionsTest/GitExtensionsTest.csproj
+++ b/GitExtensionsTest/GitExtensionsTest.csproj
@@ -64,6 +64,7 @@
     <Compile Include="GitCommands\Helpers\PathUtilTest.cs" />
     <Compile Include="GitCommands\Patch\PatchManagerTest.cs" />
     <Compile Include="GitCommands\Patch\PatchTest.cs" />
+    <Compile Include="GitUI\AuthorEmailBasedRevisionHighlightingFixture.cs" />
     <Compile Include="GitUI\FollowParentRewriterFixture.cs" />
     <Compile Include="GitUI\FormUpdateFixture.cs" />
     <Compile Include="GitUI\HotkeySettingsManagerFixture.cs" />

--- a/GitExtensionsTest/GitUI/AuthorEmailBasedRevisionHighlightingFixture.cs
+++ b/GitExtensionsTest/GitUI/AuthorEmailBasedRevisionHighlightingFixture.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Config;
+using GitUI.UserControls;
+using NUnit.Framework;
+
+namespace GitExtensionsTest.GitUI
+{
+    [TestFixture]
+    class AuthorEmailBasedRevisionHighlightingFixture
+    {
+        private const string ExpectedAuthorEmail1 = "doe1@example.org";
+        private const string ExpectedAuthorEmail2 = "doe2@example.org";
+
+        [Test]
+        public void AuthorEmailToHighlight_should_be_null_when_no_revision_change_processed_yet()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting();
+
+            sut.AuthorEmailToHighlight.Should().BeNull();
+        }
+
+        [Test]
+        public void When_multiple_revisions_selected_Then_ProcessSelectionChange_should_return_NoAction()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+
+            var action = sut.ProcessRevisionSelectionChange(currentModule,
+                                               new[]
+                                                   {
+                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1),
+                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)
+                                                   });
+
+            action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.NoAction);
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_multiple_revisions_selected_Then_AuthorEmailToHighlight_should_not_change()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+            sut.ProcessRevisionSelectionChange(currentModule,
+                                               new[] {NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)});
+
+            sut.ProcessRevisionSelectionChange(currentModule,
+                                               new[]
+                                                   {
+                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail2),
+                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)
+                                                   });
+
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1);
+        }
+
+        [Test]
+        public void Given_no_previously_selected_revision_When_single_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            
+            action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
+        } 
+
+        [Test]
+        public void Given_no_previously_selected_revision_When_single_revision_selected_Then_AuthorEmailToHighlight_should_change()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+
+            sut.ProcessRevisionSelectionChange(currentModule, new[] {NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)});
+
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1); 
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_ProcessSelectionChange_should_return_NoAction()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.NoAction);
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_AuthorEmailToHighlight_should_not_change()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1);
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail2) });
+
+            action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_AuthorEmailToHighlight_should_change()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail2) });
+
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail2);
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_no_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule(); 
+            currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new GitRevision[0]);
+
+            action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
+        }
+
+        [Test]
+        public void Given_previously_selected_revision_When_no_revision_selected_Then_AuthorEmailToHighlight_should_be_value_of_current_user_email_setting()
+        {
+            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var currentModule = NewModule();
+            currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+
+            sut.ProcessRevisionSelectionChange(currentModule, new GitRevision[0]);
+
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail2);
+        }
+
+        private static GitModule NewModule()
+        {
+            return new GitModule(Path.GetTempPath());
+        }
+
+        private static GitRevision NewRevisionWithAuthorEmail(GitModule currentModule, string authorEmail)
+        {
+            return new GitRevision(currentModule, Guid.NewGuid().ToString())
+                {
+                    AuthorEmail = authorEmail
+                };
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using GitCommands.Utils;
 using GitUI.AutoCompletion;
 using GitUI.CommandsDialogs.CommitDialog;
@@ -25,9 +26,6 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormCommit : GitModuleForm //, IHotkeyable
     {
-        const string UserNameKey = "user.name";
-        const string UserEmailKey = "user.email";
-
         #region Translation
         private readonly TranslationString _amendCommit =
             new TranslationString("You are about to rewrite history." + Environment.NewLine +
@@ -1852,8 +1850,8 @@ namespace GitUI.CommandsDialogs
 
         private void GetUserSettings()
         {
-            _userName = Module.GetEffectiveSetting(UserNameKey);
-            _userEmail = Module.GetEffectiveSetting(UserEmailKey);
+            _userName = Module.GetEffectiveSetting(SettingKeyString.UserName);
+            _userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
 
 
 

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Mail;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using GitUI.CommandsDialogs.FormatPatchDialog;
 using ResourceManager;
 
@@ -44,7 +45,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             Translate();
             if (aCommands != null)
-                MailFrom.Text = Module.GetEffectiveSetting("user.email");
+                MailFrom.Text = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
         }
 
         private void Browse_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using GitCommands.Utils;
 using Microsoft.Win32;
 using ResourceManager;
@@ -633,8 +634,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private bool CheckGlobalUserSettingsValid()
         {
             UserNameSet.Visible = true;
-            if (string.IsNullOrEmpty(GetGlobalSetting("user.name")) ||
-                string.IsNullOrEmpty(GetGlobalSetting("user.email")))
+            if (string.IsNullOrEmpty(GetGlobalSetting(SettingKeyString.UserName)) ||
+                string.IsNullOrEmpty(GetGlobalSetting(SettingKeyString.UserEmail)))
             {
                 UserNameSet.BackColor = Color.LightSalmon;
                 UserNameSet.Text = _noEmailSet.Text;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -43,6 +43,7 @@
             this.BlueIcon = new System.Windows.Forms.RadioButton();
             this.DefaultIcon = new System.Windows.Forms.RadioButton();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.HighlightAuthoredRevisions = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesTextGray = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesGray = new System.Windows.Forms.CheckBox();
             this._NO_TRANSLATE_ColorGraphLabel = new System.Windows.Forms.Label();
@@ -51,6 +52,8 @@
             this.MulticolorBranches = new System.Windows.Forms.CheckBox();
             this.label33 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_ColorRemoteBranchLabel = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_ColorAuthoredRevisions = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_ColorOtherLabel = new System.Windows.Forms.Label();
             this.label36 = new System.Windows.Forms.Label();
             this.label25 = new System.Windows.Forms.Label();
@@ -102,7 +105,7 @@
             this.label55.AutoSize = true;
             this.label55.Location = new System.Drawing.Point(13, 55);
             this.label55.Name = "label55";
-            this.label55.Size = new System.Drawing.Size(54, 13);
+            this.label55.Size = new System.Drawing.Size(60, 15);
             this.label55.TabIndex = 14;
             this.label55.Text = "Icon color";
             // 
@@ -134,7 +137,7 @@
             "Cow"});
             this.IconStyle.Location = new System.Drawing.Point(111, 23);
             this.IconStyle.Name = "IconStyle";
-            this.IconStyle.Size = new System.Drawing.Size(121, 21);
+            this.IconStyle.Size = new System.Drawing.Size(121, 23);
             this.IconStyle.TabIndex = 11;
             this.IconStyle.SelectedIndexChanged += new System.EventHandler(this.IconStyle_SelectedIndexChanged);
             // 
@@ -143,7 +146,7 @@
             this.label54.AutoSize = true;
             this.label54.Location = new System.Drawing.Point(13, 26);
             this.label54.Name = "label54";
-            this.label54.Size = new System.Drawing.Size(52, 13);
+            this.label54.Size = new System.Drawing.Size(57, 15);
             this.label54.TabIndex = 10;
             this.label54.Text = "Icon style";
             // 
@@ -152,7 +155,7 @@
             this.LightblueIcon.AutoSize = true;
             this.LightblueIcon.Location = new System.Drawing.Point(111, 81);
             this.LightblueIcon.Name = "LightblueIcon";
-            this.LightblueIcon.Size = new System.Drawing.Size(71, 17);
+            this.LightblueIcon.Size = new System.Drawing.Size(78, 19);
             this.LightblueIcon.TabIndex = 7;
             this.LightblueIcon.TabStop = true;
             this.LightblueIcon.Text = "Light blue";
@@ -163,7 +166,7 @@
             this.RandomIcon.AutoSize = true;
             this.RandomIcon.Location = new System.Drawing.Point(111, 250);
             this.RandomIcon.Name = "RandomIcon";
-            this.RandomIcon.Size = new System.Drawing.Size(65, 17);
+            this.RandomIcon.Size = new System.Drawing.Size(70, 19);
             this.RandomIcon.TabIndex = 6;
             this.RandomIcon.TabStop = true;
             this.RandomIcon.Text = "Random";
@@ -174,7 +177,7 @@
             this.YellowIcon.AutoSize = true;
             this.YellowIcon.Location = new System.Drawing.Point(111, 222);
             this.YellowIcon.Name = "YellowIcon";
-            this.YellowIcon.Size = new System.Drawing.Size(56, 17);
+            this.YellowIcon.Size = new System.Drawing.Size(60, 19);
             this.YellowIcon.TabIndex = 5;
             this.YellowIcon.TabStop = true;
             this.YellowIcon.Text = "Yellow";
@@ -186,7 +189,7 @@
             this.RedIcon.AutoSize = true;
             this.RedIcon.Location = new System.Drawing.Point(111, 194);
             this.RedIcon.Name = "RedIcon";
-            this.RedIcon.Size = new System.Drawing.Size(45, 17);
+            this.RedIcon.Size = new System.Drawing.Size(45, 19);
             this.RedIcon.TabIndex = 4;
             this.RedIcon.TabStop = true;
             this.RedIcon.Text = "Red";
@@ -198,7 +201,7 @@
             this.GreenIcon.AutoSize = true;
             this.GreenIcon.Location = new System.Drawing.Point(111, 165);
             this.GreenIcon.Name = "GreenIcon";
-            this.GreenIcon.Size = new System.Drawing.Size(54, 17);
+            this.GreenIcon.Size = new System.Drawing.Size(56, 19);
             this.GreenIcon.TabIndex = 3;
             this.GreenIcon.TabStop = true;
             this.GreenIcon.Text = "Green";
@@ -210,7 +213,7 @@
             this.PurpleIcon.AutoSize = true;
             this.PurpleIcon.Location = new System.Drawing.Point(111, 137);
             this.PurpleIcon.Name = "PurpleIcon";
-            this.PurpleIcon.Size = new System.Drawing.Size(55, 17);
+            this.PurpleIcon.Size = new System.Drawing.Size(59, 19);
             this.PurpleIcon.TabIndex = 2;
             this.PurpleIcon.TabStop = true;
             this.PurpleIcon.Text = "Purple";
@@ -222,7 +225,7 @@
             this.BlueIcon.AutoSize = true;
             this.BlueIcon.Location = new System.Drawing.Point(111, 109);
             this.BlueIcon.Name = "BlueIcon";
-            this.BlueIcon.Size = new System.Drawing.Size(46, 17);
+            this.BlueIcon.Size = new System.Drawing.Size(48, 19);
             this.BlueIcon.TabIndex = 1;
             this.BlueIcon.TabStop = true;
             this.BlueIcon.Text = "Blue";
@@ -234,7 +237,7 @@
             this.DefaultIcon.AutoSize = true;
             this.DefaultIcon.Location = new System.Drawing.Point(111, 53);
             this.DefaultIcon.Name = "DefaultIcon";
-            this.DefaultIcon.Size = new System.Drawing.Size(59, 17);
+            this.DefaultIcon.Size = new System.Drawing.Size(63, 19);
             this.DefaultIcon.TabIndex = 0;
             this.DefaultIcon.TabStop = true;
             this.DefaultIcon.Text = "Default";
@@ -243,6 +246,7 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.HighlightAuthoredRevisions);
             this.groupBox4.Controls.Add(this.DrawNonRelativesTextGray);
             this.groupBox4.Controls.Add(this.DrawNonRelativesGray);
             this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorGraphLabel);
@@ -251,6 +255,8 @@
             this.groupBox4.Controls.Add(this.MulticolorBranches);
             this.groupBox4.Controls.Add(this.label33);
             this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorRemoteBranchLabel);
+            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorAuthoredRevisions);
+            this.groupBox4.Controls.Add(this.label1);
             this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorOtherLabel);
             this.groupBox4.Controls.Add(this.label36);
             this.groupBox4.Controls.Add(this.label25);
@@ -259,17 +265,27 @@
             this.groupBox4.Controls.Add(this.label32);
             this.groupBox4.Location = new System.Drawing.Point(3, 3);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(387, 279);
+            this.groupBox4.Size = new System.Drawing.Size(387, 322);
             this.groupBox4.TabIndex = 14;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Revision graph";
+            // 
+            // HighlightAuthoredRevisions
+            // 
+            this.HighlightAuthoredRevisions.AutoSize = true;
+            this.HighlightAuthoredRevisions.Location = new System.Drawing.Point(9, 145);
+            this.HighlightAuthoredRevisions.Name = "HighlightAuthoredRevisions";
+            this.HighlightAuthoredRevisions.Size = new System.Drawing.Size(176, 19);
+            this.HighlightAuthoredRevisions.TabIndex = 17;
+            this.HighlightAuthoredRevisions.Text = "Highlight authored revisions";
+            this.HighlightAuthoredRevisions.UseVisualStyleBackColor = true;
             // 
             // DrawNonRelativesTextGray
             // 
             this.DrawNonRelativesTextGray.AutoSize = true;
             this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(9, 120);
             this.DrawNonRelativesTextGray.Name = "DrawNonRelativesTextGray";
-            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(157, 17);
+            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(171, 19);
             this.DrawNonRelativesTextGray.TabIndex = 17;
             this.DrawNonRelativesTextGray.Text = "Draw non relatives text gray";
             this.DrawNonRelativesTextGray.UseVisualStyleBackColor = true;
@@ -279,7 +295,7 @@
             this.DrawNonRelativesGray.AutoSize = true;
             this.DrawNonRelativesGray.Location = new System.Drawing.Point(9, 96);
             this.DrawNonRelativesGray.Name = "DrawNonRelativesGray";
-            this.DrawNonRelativesGray.Size = new System.Drawing.Size(167, 17);
+            this.DrawNonRelativesGray.Size = new System.Drawing.Size(183, 19);
             this.DrawNonRelativesGray.TabIndex = 16;
             this.DrawNonRelativesGray.Text = "Draw non relatives graph gray";
             this.DrawNonRelativesGray.UseVisualStyleBackColor = true;
@@ -292,17 +308,17 @@
             this._NO_TRANSLATE_ColorGraphLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorGraphLabel.Location = new System.Drawing.Point(287, 21);
             this._NO_TRANSLATE_ColorGraphLabel.Name = "_NO_TRANSLATE_ColorGraphLabel";
-            this._NO_TRANSLATE_ColorGraphLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorGraphLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorGraphLabel.TabIndex = 15;
             this._NO_TRANSLATE_ColorGraphLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorGraphLabel.Click += new System.EventHandler(this._ColorGraphLabel_Click);
+            this._NO_TRANSLATE_ColorGraphLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // StripedBanchChange
             // 
             this.StripedBanchChange.AutoSize = true;
             this.StripedBanchChange.Location = new System.Drawing.Point(9, 45);
             this.StripedBanchChange.Name = "StripedBanchChange";
-            this.StripedBanchChange.Size = new System.Drawing.Size(134, 17);
+            this.StripedBanchChange.Size = new System.Drawing.Size(145, 19);
             this.StripedBanchChange.TabIndex = 14;
             this.StripedBanchChange.Text = "Striped branch change";
             this.StripedBanchChange.UseVisualStyleBackColor = true;
@@ -312,7 +328,7 @@
             this.BranchBorders.AutoSize = true;
             this.BranchBorders.Location = new System.Drawing.Point(9, 71);
             this.BranchBorders.Name = "BranchBorders";
-            this.BranchBorders.Size = new System.Drawing.Size(125, 17);
+            this.BranchBorders.Size = new System.Drawing.Size(136, 19);
             this.BranchBorders.TabIndex = 13;
             this.BranchBorders.Text = "Draw branch borders";
             this.BranchBorders.UseVisualStyleBackColor = true;
@@ -322,7 +338,7 @@
             this.MulticolorBranches.AutoSize = true;
             this.MulticolorBranches.Location = new System.Drawing.Point(9, 20);
             this.MulticolorBranches.Name = "MulticolorBranches";
-            this.MulticolorBranches.Size = new System.Drawing.Size(118, 17);
+            this.MulticolorBranches.Size = new System.Drawing.Size(132, 19);
             this.MulticolorBranches.TabIndex = 12;
             this.MulticolorBranches.Text = "Multicolor branches";
             this.MulticolorBranches.UseVisualStyleBackColor = true;
@@ -331,9 +347,9 @@
             // label33
             // 
             this.label33.AutoSize = true;
-            this.label33.Location = new System.Drawing.Point(6, 204);
+            this.label33.Location = new System.Drawing.Point(6, 235);
             this.label33.Name = "label33";
-            this.label33.Size = new System.Drawing.Size(102, 13);
+            this.label33.Size = new System.Drawing.Size(117, 15);
             this.label33.TabIndex = 8;
             this.label33.Text = "Color remote branch";
             // 
@@ -343,12 +359,34 @@
             this._NO_TRANSLATE_ColorRemoteBranchLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(287, 204);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(287, 235);
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Name = "_NO_TRANSLATE_ColorRemoteBranchLabel";
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 9;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Click += new System.EventHandler(this.ColorRemoteBranchLabel_Click);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
+            // 
+            // _NO_TRANSLATE_ColorAuthoredRevisions
+            // 
+            this._NO_TRANSLATE_ColorAuthoredRevisions.AutoSize = true;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.BackColor = System.Drawing.Color.Red;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Cursor = System.Windows.Forms.Cursors.Hand;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Location = new System.Drawing.Point(287, 292);
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Name = "_NO_TRANSLATE_ColorAuthoredRevisions";
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Size = new System.Drawing.Size(29, 17);
+            this._NO_TRANSLATE_ColorAuthoredRevisions.TabIndex = 11;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Text = "Red";
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Click += new System.EventHandler(this.ColorLabel_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(6, 292);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(136, 15);
+            this.label1.TabIndex = 10;
+            this.label1.Text = "Color authored revisions";
             // 
             // _NO_TRANSLATE_ColorOtherLabel
             // 
@@ -356,28 +394,28 @@
             this._NO_TRANSLATE_ColorOtherLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorOtherLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorOtherLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(287, 232);
+            this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(287, 263);
             this._NO_TRANSLATE_ColorOtherLabel.Name = "_NO_TRANSLATE_ColorOtherLabel";
-            this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 11;
             this._NO_TRANSLATE_ColorOtherLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorOtherLabel.Click += new System.EventHandler(this.ColorOtherLabel_Click);
+            this._NO_TRANSLATE_ColorOtherLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label36
             // 
             this.label36.AutoSize = true;
-            this.label36.Location = new System.Drawing.Point(6, 232);
+            this.label36.Location = new System.Drawing.Point(6, 263);
             this.label36.Name = "label36";
-            this.label36.Size = new System.Drawing.Size(83, 13);
+            this.label36.Size = new System.Drawing.Size(95, 15);
             this.label36.TabIndex = 10;
             this.label36.Text = "Color other label";
             // 
             // label25
             // 
             this.label25.AutoSize = true;
-            this.label25.Location = new System.Drawing.Point(6, 147);
+            this.label25.Location = new System.Drawing.Point(6, 178);
             this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(49, 13);
+            this.label25.Size = new System.Drawing.Size(56, 15);
             this.label25.TabIndex = 4;
             this.label25.Text = "Color tag";
             // 
@@ -387,12 +425,12 @@
             this._NO_TRANSLATE_ColorTagLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorTagLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorTagLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(287, 147);
+            this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(287, 178);
             this._NO_TRANSLATE_ColorTagLabel.Name = "_NO_TRANSLATE_ColorTagLabel";
-            this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorTagLabel.TabIndex = 5;
             this._NO_TRANSLATE_ColorTagLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorTagLabel.Click += new System.EventHandler(this.ColorTagLabel_Click);
+            this._NO_TRANSLATE_ColorTagLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // _NO_TRANSLATE_ColorBranchLabel
             // 
@@ -400,19 +438,19 @@
             this._NO_TRANSLATE_ColorBranchLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorBranchLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(287, 175);
+            this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(287, 206);
             this._NO_TRANSLATE_ColorBranchLabel.Name = "_NO_TRANSLATE_ColorBranchLabel";
-            this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 7;
             this._NO_TRANSLATE_ColorBranchLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorBranchLabel.Click += new System.EventHandler(this.ColorBranchLabel_Click);
+            this._NO_TRANSLATE_ColorBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label32
             // 
             this.label32.AutoSize = true;
-            this.label32.Location = new System.Drawing.Point(6, 175);
+            this.label32.Location = new System.Drawing.Point(6, 206);
             this.label32.Name = "label32";
-            this.label32.Size = new System.Drawing.Size(67, 13);
+            this.label32.Size = new System.Drawing.Size(76, 15);
             this.label32.TabIndex = 6;
             this.label32.Text = "Color branch";
             // 
@@ -428,9 +466,9 @@
             this.groupBox3.Controls.Add(this.label31);
             this.groupBox3.Controls.Add(this.label29);
             this.groupBox3.Controls.Add(this._NO_TRANSLATE_ColorAddedLineLabel);
-            this.groupBox3.Location = new System.Drawing.Point(3, 288);
+            this.groupBox3.Location = new System.Drawing.Point(3, 331);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(387, 194);
+            this.groupBox3.Size = new System.Drawing.Size(387, 173);
             this.groupBox3.TabIndex = 13;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Difference view";
@@ -440,7 +478,7 @@
             this.label43.AutoSize = true;
             this.label43.Location = new System.Drawing.Point(6, 79);
             this.label43.Name = "label43";
-            this.label43.Size = new System.Drawing.Size(150, 13);
+            this.label43.Size = new System.Drawing.Size(176, 15);
             this.label43.TabIndex = 10;
             this.label43.Text = "Color removed line highlighting";
             // 
@@ -452,17 +490,17 @@
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Location = new System.Drawing.Point(284, 79);
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Name = "_NO_TRANSLATE_ColorRemovedLineDiffLabel";
-            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.TabIndex = 11;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Click += new System.EventHandler(this.ColorRemovedLineDiffLabel_Click);
+            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label45
             // 
             this.label45.AutoSize = true;
             this.label45.Location = new System.Drawing.Point(6, 109);
             this.label45.Name = "label45";
-            this.label45.Size = new System.Drawing.Size(139, 13);
+            this.label45.Size = new System.Drawing.Size(162, 15);
             this.label45.TabIndex = 12;
             this.label45.Text = "Color added line highlighting";
             // 
@@ -474,17 +512,17 @@
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Location = new System.Drawing.Point(284, 109);
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Name = "_NO_TRANSLATE_ColorAddedLineDiffLabel";
-            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.TabIndex = 13;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Click += new System.EventHandler(this.ColorAddedLineDiffLabel_Click);
+            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label27
             // 
             this.label27.AutoSize = true;
             this.label27.Location = new System.Drawing.Point(6, 18);
             this.label27.Name = "label27";
-            this.label27.Size = new System.Drawing.Size(94, 13);
+            this.label27.Size = new System.Drawing.Size(108, 15);
             this.label27.TabIndex = 4;
             this.label27.Text = "Color removed line";
             // 
@@ -496,10 +534,10 @@
             this._NO_TRANSLATE_ColorSectionLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorSectionLabel.Location = new System.Drawing.Point(284, 138);
             this._NO_TRANSLATE_ColorSectionLabel.Name = "_NO_TRANSLATE_ColorSectionLabel";
-            this._NO_TRANSLATE_ColorSectionLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorSectionLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorSectionLabel.TabIndex = 9;
             this._NO_TRANSLATE_ColorSectionLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorSectionLabel.Click += new System.EventHandler(this.ColorSectionLabel_Click);
+            this._NO_TRANSLATE_ColorSectionLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // _NO_TRANSLATE_ColorRemovedLine
             // 
@@ -509,17 +547,17 @@
             this._NO_TRANSLATE_ColorRemovedLine.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemovedLine.Location = new System.Drawing.Point(284, 18);
             this._NO_TRANSLATE_ColorRemovedLine.Name = "_NO_TRANSLATE_ColorRemovedLine";
-            this._NO_TRANSLATE_ColorRemovedLine.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorRemovedLine.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorRemovedLine.TabIndex = 5;
             this._NO_TRANSLATE_ColorRemovedLine.Text = "Red";
-            this._NO_TRANSLATE_ColorRemovedLine.Click += new System.EventHandler(this.ColorRemovedLine_Click);
+            this._NO_TRANSLATE_ColorRemovedLine.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label31
             // 
             this.label31.AutoSize = true;
             this.label31.Location = new System.Drawing.Point(6, 139);
             this.label31.Name = "label31";
-            this.label31.Size = new System.Drawing.Size(68, 13);
+            this.label31.Size = new System.Drawing.Size(77, 15);
             this.label31.TabIndex = 8;
             this.label31.Text = "Color section";
             // 
@@ -528,7 +566,7 @@
             this.label29.AutoSize = true;
             this.label29.Location = new System.Drawing.Point(6, 48);
             this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(83, 13);
+            this.label29.Size = new System.Drawing.Size(94, 15);
             this.label29.TabIndex = 6;
             this.label29.Text = "Color added line";
             // 
@@ -540,10 +578,10 @@
             this._NO_TRANSLATE_ColorAddedLineLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAddedLineLabel.Location = new System.Drawing.Point(284, 48);
             this._NO_TRANSLATE_ColorAddedLineLabel.Name = "_NO_TRANSLATE_ColorAddedLineLabel";
-            this._NO_TRANSLATE_ColorAddedLineLabel.Size = new System.Drawing.Size(29, 15);
+            this._NO_TRANSLATE_ColorAddedLineLabel.Size = new System.Drawing.Size(29, 17);
             this._NO_TRANSLATE_ColorAddedLineLabel.TabIndex = 7;
             this._NO_TRANSLATE_ColorAddedLineLabel.Text = "Red";
-            this._NO_TRANSLATE_ColorAddedLineLabel.Click += new System.EventHandler(this.colorAddedLineLabel_Click);
+            this._NO_TRANSLATE_ColorAddedLineLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // ColorsSettingsPage
             // 
@@ -553,7 +591,7 @@
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
             this.Name = "ColorsSettingsPage";
-            this.Size = new System.Drawing.Size(730, 490);
+            this.Size = new System.Drawing.Size(1796, 920);
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.IconPreviewSmall)).EndInit();
@@ -608,5 +646,8 @@
         private System.Windows.Forms.Label label31;
         private System.Windows.Forms.Label label29;
         private System.Windows.Forms.Label _NO_TRANSLATE_ColorAddedLineLabel;
+        private System.Windows.Forms.CheckBox HighlightAuthoredRevisions;
+        private System.Windows.Forms.Label _NO_TRANSLATE_ColorAuthoredRevisions;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -29,6 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             DrawNonRelativesTextGray.Checked = AppSettings.RevisionGraphDrawNonRelativesTextGray;
             BranchBorders.Checked = AppSettings.BranchBorders;
             StripedBanchChange.Checked = AppSettings.StripedBranchChange;
+            HighlightAuthoredRevisions.Checked = AppSettings.HighlightAuthoredRevisions;
 
             _NO_TRANSLATE_ColorGraphLabel.BackColor = AppSettings.GraphColor;
             _NO_TRANSLATE_ColorGraphLabel.Text = AppSettings.GraphColor.Name;
@@ -73,6 +74,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _NO_TRANSLATE_ColorSectionLabel.ForeColor =
                 ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorSectionLabel.BackColor);
 
+            _NO_TRANSLATE_ColorAuthoredRevisions.BackColor = AppSettings.AuthoredRevisionsColor;
+            _NO_TRANSLATE_ColorAuthoredRevisions.Text = AppSettings.AuthoredRevisionsColor.Name;
+            _NO_TRANSLATE_ColorAuthoredRevisions.ForeColor =
+                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAuthoredRevisions.BackColor);
+
             string iconColor = AppSettings.IconColor.ToLower();
             DefaultIcon.Checked = iconColor == "default";
             BlueIcon.Checked = iconColor == "blue";
@@ -94,11 +100,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RevisionGraphDrawNonRelativesTextGray = DrawNonRelativesTextGray.Checked;
             AppSettings.BranchBorders = BranchBorders.Checked;
             AppSettings.StripedBranchChange = StripedBanchChange.Checked;
+            AppSettings.HighlightAuthoredRevisions = HighlightAuthoredRevisions.Checked;
+
             AppSettings.GraphColor = _NO_TRANSLATE_ColorGraphLabel.BackColor;
             AppSettings.TagColor = _NO_TRANSLATE_ColorTagLabel.BackColor;
             AppSettings.BranchColor = _NO_TRANSLATE_ColorBranchLabel.BackColor;
             AppSettings.RemoteBranchColor = _NO_TRANSLATE_ColorRemoteBranchLabel.BackColor;
             AppSettings.OtherTagColor = _NO_TRANSLATE_ColorOtherLabel.BackColor;
+            AppSettings.AuthoredRevisionsColor = _NO_TRANSLATE_ColorAuthoredRevisions.BackColor;
 
             AppSettings.DiffAddedColor = _NO_TRANSLATE_ColorAddedLineLabel.BackColor;
             AppSettings.DiffRemovedColor = _NO_TRANSLATE_ColorRemovedLine.BackColor;
@@ -185,138 +194,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     IconPreviewSmall.Image = (new Icon(icon, 16, 16)).ToBitmap();
                     break;
             }
+        } 
+
+        private void ColorLabel_Click(object sender, EventArgs e)
+        {
+            PickColor((Label) sender);
         }
 
-        private void ColorAddedLineDiffLabel_Click(object sender, EventArgs e)
+        private void PickColor(Control targetColorControl)
         {
-            using (var colorDialog = new ColorDialog
-            {
-                Color = _NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor
-            })
+            using (var colorDialog = new ColorDialog {Color = targetColorControl.BackColor})
             {
                 colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorAddedLineDiffLabel.Text = colorDialog.Color.Name;
+                targetColorControl.BackColor = colorDialog.Color;
+                targetColorControl.Text = colorDialog.Color.Name;
             }
-            _NO_TRANSLATE_ColorAddedLineDiffLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor);
-        }
 
-        private void _ColorGraphLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog { Color = _NO_TRANSLATE_ColorGraphLabel.BackColor })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorGraphLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorGraphLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorGraphLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor);
-        }
-
-        private void colorAddedLineLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog
-            {
-                Color = _NO_TRANSLATE_ColorAddedLineLabel.BackColor
-            })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorAddedLineLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorAddedLineLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorAddedLineLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineLabel.BackColor);
-        }
-
-        private void ColorRemovedLineDiffLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog
-            {
-                Color = _NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor
-            })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorRemovedLineDiffLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorRemovedLineDiffLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor);
-        }
-
-        private void ColorRemovedLine_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog { Color = _NO_TRANSLATE_ColorRemovedLine.BackColor })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorRemovedLine.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorRemovedLine.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorRemovedLine.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemovedLine.BackColor);
-        }
-
-        private void ColorSectionLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog { Color = _NO_TRANSLATE_ColorSectionLabel.BackColor })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorSectionLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorSectionLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorSectionLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorSectionLabel.BackColor);
-        }
-
-        private void ColorTagLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog { Color = _NO_TRANSLATE_ColorTagLabel.BackColor })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorTagLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorTagLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorTagLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorTagLabel.BackColor);
-        }
-
-        private void ColorBranchLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog { Color = _NO_TRANSLATE_ColorBranchLabel.BackColor })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorBranchLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorBranchLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorBranchLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorBranchLabel.BackColor);
-        }
-
-        private void ColorRemoteBranchLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog
-            {
-                Color = _NO_TRANSLATE_ColorRemoteBranchLabel.BackColor
-            })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorRemoteBranchLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorRemoteBranchLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorRemoteBranchLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemoteBranchLabel.BackColor);
-        }
-
-        private void ColorOtherLabel_Click(object sender, EventArgs e)
-        {
-            using (var colorDialog = new ColorDialog { Color = _NO_TRANSLATE_ColorOtherLabel.BackColor })
-            {
-                colorDialog.ShowDialog(this);
-                _NO_TRANSLATE_ColorOtherLabel.BackColor = colorDialog.Color;
-                _NO_TRANSLATE_ColorOtherLabel.Text = colorDialog.Color.Name;
-            }
-            _NO_TRANSLATE_ColorOtherLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorOtherLabel.BackColor);
+            targetColorControl.ForeColor =
+                ColorHelper.GetForeColorForBackColor(targetColorControl.BackColor);
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
+using GitCommands.Config;
 using GitCommands.Settings;
 using GitCommands.Utils;
 using ResourceManager;
@@ -73,8 +74,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             CommonLogic.EncodingToCombo(CurrentSettings.FilesEncoding, Global_FilesEncoding);
 
-            GlobalUserName.Text = CurrentSettings.GetValue("user.name");
-            GlobalUserEmail.Text = CurrentSettings.GetValue("user.email");
+            GlobalUserName.Text = CurrentSettings.GetValue(SettingKeyString.UserName);
+            GlobalUserEmail.Text = CurrentSettings.GetValue(SettingKeyString.UserEmail);
             GlobalEditor.Text = CurrentSettings.GetValue("core.editor");
             GlobalMergeTool.Text = CurrentSettings.GetValue("merge.tool");
             CommitTemplatePath.Text = CurrentSettings.GetValue("commit.template");
@@ -105,8 +106,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (CheckSettingsLogic.CanFindGitCmd())
             {
-                CurrentSettings.SetValue("user.name", GlobalUserName.Text);
-                CurrentSettings.SetValue("user.email", GlobalUserEmail.Text);
+                CurrentSettings.SetValue(SettingKeyString.UserName, GlobalUserName.Text);
+                CurrentSettings.SetValue(SettingKeyString.UserEmail, GlobalUserEmail.Text);
                 CurrentSettings.SetValue("commit.template", CommitTemplatePath.Text);
                 CurrentSettings.SetPathValue("core.editor", GlobalEditor.Text);
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -246,6 +246,7 @@
     <Compile Include="UserControls\RevisionGridClasses\MenuUtil.cs" />
     <Compile Include="UserControls\RevisionGridClasses\NavigationHistory.cs" />
     <Compile Include="UserControls\RevisionGridClasses\ParentChildNavigationHistory.cs" />
+    <Compile Include="UserControls\AuthorEmailBasedRevisionHighlighting.cs" />
     <Compile Include="UserManual\UserManual.cs" />
     <Compile Include="UserManual\SingleHtmlUserManual.cs" />
     <Compile Include="UserManual\StandardHtmlUserManual.cs" />

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -327,7 +327,7 @@ namespace GitUI.Script
                                                              List<string> selectedRemotes, List<GitRef> selectedLocalBranches,
                                                              List<GitRef> selectedBranches, List<GitRef> selectedTags)
         {
-            GitRevision selectedRevision = revisionGrid.GetRevision(revisionGrid.LastRow);
+            GitRevision selectedRevision = revisionGrid.GetRevision(revisionGrid.LastRowIndex);
             foreach (GitRef head in selectedRevision.Refs)
             {
                 if (head.IsTag)

--- a/GitUI/UserControls/AuthorEmailBasedRevisionHighlighting.cs
+++ b/GitUI/UserControls/AuthorEmailBasedRevisionHighlighting.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GitCommands;
+using GitCommands.Config;
+using GitCommands.Git;
+
+namespace GitUI.UserControls
+{
+    class AuthorEmailBasedRevisionHighlighting
+    {
+        public enum SelectionChangeAction
+        {
+            NoAction,
+            RefreshUserInterface,
+        }
+
+        private GitRevision _currentSelectedRevision;
+
+        public string AuthorEmailToHighlight { get; private set; }
+
+        public SelectionChangeAction ProcessRevisionSelectionChange(GitModule currentModule, ICollection<GitRevision> selectedRevisions)
+        {
+            if (selectedRevisions.Count > 1)
+                return SelectionChangeAction.NoAction;
+
+            var newSelectedRevision = selectedRevisions.FirstOrDefault();
+            bool differentRevisionAuthorSelected =
+                !AuthorEmailEqualityComparer.Instance.Equals(_currentSelectedRevision, newSelectedRevision);
+ 
+            if (differentRevisionAuthorSelected)
+            {
+                AuthorEmailToHighlight = newSelectedRevision != null
+                                             ? newSelectedRevision.AuthorEmail
+                                             : currentModule.GetEffectiveSetting(SettingKeyString.UserEmail);
+            }
+
+            _currentSelectedRevision = newSelectedRevision;
+            return differentRevisionAuthorSelected
+                       ? SelectionChangeAction.RefreshUserInterface
+                       : SelectionChangeAction.NoAction;
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -39,6 +39,12 @@ namespace GitUI
                     _filledItemBrush.Dispose();
                     _filledItemBrush = null;
                 }
+
+                if (_authoredRevisionsBrush != null)
+                {
+                    _authoredRevisionsBrush.Dispose();
+                    _authoredRevisionsBrush = null;
+                }
             }
 
             if (disposing && (components != null))

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -480,14 +480,24 @@ namespace GitUI.RevisionGridClasses
 
             lock (_backgroundThread)
             {
-                if (CurrentCell == null)
+                UpdatingVisibleRows = true;
+
+                try
                 {
-                    RowCount = count;
-                    CurrentCell = null;
+                    if (CurrentCell == null)
+                    {
+                        RowCount = count;
+                        CurrentCell = null;
+                    }
+                    else
+                    {
+                        RowCount = count;
+                    }
+
                 }
-                else
+                finally
                 {
-                    RowCount = count;
+                    UpdatingVisibleRows = false;
                 }
             }
         }
@@ -682,6 +692,8 @@ namespace GitUI.RevisionGridClasses
                 }
             }
         }
+
+        public bool UpdatingVisibleRows { get; private set; }
 
         private void UpdateColumnWidth()
         {


### PR DESCRIPTION
Adds highlighting of user's commits. This feature comes in handy (at least for me) when you are skimming through the commits while looking for something related to your work.

Commits are matched with current user's email address. The feature is enabled by default and can be configured in the 'Settings' dialog on the 'Colors' page. Commits are highlighted with LighYellow color by default.

![revisiongraph](https://cloud.githubusercontent.com/assets/5622086/6319782/2de8872e-baca-11e4-8294-ccfee691d1b0.png)
![settings](https://cloud.githubusercontent.com/assets/5622086/6319817/56690b8c-bacb-11e4-8deb-4b713640403f.png)

