### PR TITLE
Make CommitForm title refreshable

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -567,6 +567,10 @@ namespace GitUI.CommandsDialogs
         {
             _initialized = true;
 
+            Task.Factory.StartNew(() => string.Format(_formTitle.Text, Module.GetSelectedBranch(),
+                                      Module.WorkingDir))
+                .ContinueWith(task => Text = task.Result, _taskScheduler);
+
             Cursor.Current = Cursors.WaitCursor;
 
             if (loadUnstaged)
@@ -1535,10 +1539,6 @@ namespace GitUI.CommandsDialogs
 
             if (_useFormCommitMessage && !string.IsNullOrEmpty(message))
                 Message.Text = message;
-
-            Task.Factory.StartNew(() => string.Format(_formTitle.Text, Module.GetSelectedBranch(),
-                                      Module.WorkingDir))
-                .ContinueWith(task => Text = task.Result, _taskScheduler);
         }
 
         private void SetCommitMessageFromTextBox(string commitMessageText)


### PR DESCRIPTION
Fixes #2666 

NOTE: This pull request repeats #2668 but targets 2.48 explicitly. #2668 supposed to target 2.46 but there is no a **release/2.46** branch anymore.