### PR TITLE
Fix typos in .gitignore template text

### DIFF
--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -31,9 +31,9 @@ namespace GitUI.CommandsDialogs
         private static readonly string DefaultIgnorePatternsFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GitExtensions/DefaultIgnorePatterns.txt");
         private static readonly string[] DefaultIgnorePatterns = new[]
         {
-            "#ignore thumbnails created by windows",
+            "#Ignore thumbnails created by Windows",
             "Thumbs.db",
-            "#Ignore files build by Visual Studio",
+            "#Ignore files built by Visual Studio",
             "*.obj",
             "*.exe",
             "*.pdb",

--- a/GitUI/CommandsDialogs/FormGitIgnore.resx
+++ b/GitUI/CommandsDialogs/FormGitIgnore.resx
@@ -127,9 +127,9 @@
     <value>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -5007,9 +5007,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -4991,9 +4991,9 @@ Controleer bestandstoegang.</target>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch
@@ -5015,9 +5015,9 @@ _ReSharper*/</source>
         <target>Definieer bestandsnaam patroon welke git moet negeren.
 
 Voorbeeld:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.obj
 *.exe
 *.pdb

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4099,9 +4099,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -5056,9 +5056,9 @@ Verifiez s'il est accessible.</target>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -5067,9 +5067,9 @@ Bitte prüfen Sie, ob auf die Datei zugegriffen werden kann.</target>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -4643,9 +4643,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch
@@ -4667,9 +4667,9 @@ _ReSharper*/</source>
         <target>Specifica i pattern per i file/cartelle che si vogliono far ignorare da git.
 
 Esempio:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.obj
 *.exe
 *.pdb

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -5005,9 +5005,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -4918,9 +4918,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -4954,9 +4954,9 @@ Sprawdź, czy plik jest dostępny.</target>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -4769,9 +4769,9 @@ Verifique se este arquivo está acessível.</target>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -4054,9 +4054,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -4154,9 +4154,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -5061,9 +5061,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch
@@ -5085,9 +5085,9 @@ _ReSharper*/</source>
         <target>Укажите шаблоны файлов для игнорирования.
 
 Пример:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.obj
 *.exe
 *.pdb

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -5047,9 +5047,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -5053,9 +5053,9 @@ Compruebe que el archivo esté accesible.
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -4639,9 +4639,9 @@ Check if file is accessible.</source>
         <source>Specify filepatterns you want git to ignore.
 
 Example:
-#ignore thumbnails created by windows
+#Ignore thumbnails created by Windows
 Thumbs.db
-#Ignore files build by Visual Studio
+#Ignore files built by Visual Studio
 *.user
 *.aps
 *.pch


### PR DESCRIPTION
Makes capitalisation consistent, and replaces _build_ with _built_.

This change was applied across translations as well.