### PR TITLE
Statistics plugin improvements

### DIFF
--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
@@ -179,8 +179,8 @@ namespace GitStatistics
             // 
             // CommitCountPie
             // 
-            this.CommitCountPie.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CommitCountPie.InitialAngle = 0F;
+            this.CommitCountPie.Dock = System.Windows.Forms.DockStyle.None;
+            this.CommitCountPie.InitialAngle = -30;
             this.CommitCountPie.Location = new System.Drawing.Point(0, 0);
             this.CommitCountPie.Name = "CommitCountPie";
             this.CommitCountPie.Size = new System.Drawing.Size(447, 400);
@@ -255,8 +255,8 @@ namespace GitStatistics
             // 
             // LinesOfCodeExtensionPie
             // 
-            this.LinesOfCodeExtensionPie.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LinesOfCodeExtensionPie.InitialAngle = 0F;
+            this.LinesOfCodeExtensionPie.Dock = System.Windows.Forms.DockStyle.None;
+            this.LinesOfCodeExtensionPie.InitialAngle = -30;
             this.LinesOfCodeExtensionPie.Location = new System.Drawing.Point(0, 0);
             this.LinesOfCodeExtensionPie.Name = "LinesOfCodeExtensionPie";
             this.LinesOfCodeExtensionPie.Size = new System.Drawing.Size(447, 400);
@@ -331,8 +331,8 @@ namespace GitStatistics
             // 
             // LinesOfCodePie
             // 
-            this.LinesOfCodePie.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LinesOfCodePie.InitialAngle = 0F;
+            this.LinesOfCodePie.Dock = System.Windows.Forms.DockStyle.None;
+            this.LinesOfCodePie.InitialAngle = -30;
             this.LinesOfCodePie.Location = new System.Drawing.Point(0, 0);
             this.LinesOfCodePie.Name = "LinesOfCodePie";
             this.LinesOfCodePie.Size = new System.Drawing.Size(447, 400);
@@ -407,8 +407,8 @@ namespace GitStatistics
             // 
             // TestCodePie
             // 
-            this.TestCodePie.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.TestCodePie.InitialAngle = 0F;
+            this.TestCodePie.Dock = System.Windows.Forms.DockStyle.None;
+            this.TestCodePie.InitialAngle = -30;
             this.TestCodePie.Location = new System.Drawing.Point(0, 0);
             this.TestCodePie.Name = "TestCodePie";
             this.TestCodePie.Size = new System.Drawing.Size(447, 400);

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
@@ -159,6 +159,7 @@ namespace GitStatistics
             // splitContainer4.Panel1
             // 
             this.splitContainer4.Panel1.Controls.Add(this.CommitStatistics);
+            this.splitContainer4.Panel1MinSize = 250;
             // 
             // splitContainer4.Panel2
             // 
@@ -234,6 +235,7 @@ namespace GitStatistics
             // splitContainer1.Panel1
             // 
             this.splitContainer1.Panel1.Controls.Add(this.LinesOfCodePerLanguageText);
+            this.splitContainer1.Panel1MinSize = 250;
             // 
             // splitContainer1.Panel2
             // 
@@ -309,6 +311,7 @@ namespace GitStatistics
             // splitContainer6.Panel1
             // 
             this.splitContainer6.Panel1.Controls.Add(this.LinesOfCodePerTypeText);
+            this.splitContainer6.Panel1MinSize = 250;
             // 
             // splitContainer6.Panel2
             // 
@@ -384,6 +387,7 @@ namespace GitStatistics
             // splitContainer8.Panel1
             // 
             this.splitContainer8.Panel1.Controls.Add(this.TestCodeText);
+            this.splitContainer8.Panel1MinSize = 250;
             // 
             // splitContainer8.Panel2
             // 
@@ -428,6 +432,7 @@ namespace GitStatistics
             this.Controls.Add(this.LoadingLabel);
             this.Controls.Add(this.Tabs);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MinimumSize = new System.Drawing.Size(350, 250);
             this.Name = "FormGitStatistics";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Statistics";

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
@@ -170,7 +170,7 @@ namespace GitStatistics
             // CommitStatistics
             // 
             this.CommitStatistics.AutoSize = true;
-            this.CommitStatistics.Location = new System.Drawing.Point(5, 0);
+            this.CommitStatistics.Location = new System.Drawing.Point(9, 4);
             this.CommitStatistics.Name = "CommitStatistics";
             this.CommitStatistics.Size = new System.Drawing.Size(51, 13);
             this.CommitStatistics.TabIndex = 0;
@@ -213,7 +213,7 @@ namespace GitStatistics
             // 
             this.splitContainer2.Panel2.Controls.Add(this.splitContainer1);
             this.splitContainer2.Size = new System.Drawing.Size(737, 433);
-            this.splitContainer2.SplitterDistance = 25;
+            this.splitContainer2.SplitterDistance = 29;
             this.splitContainer2.TabIndex = 2;
             // 
             // TotalLinesOfCode
@@ -238,14 +238,14 @@ namespace GitStatistics
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.LinesOfCodeExtensionPie);
-            this.splitContainer1.Size = new System.Drawing.Size(737, 404);
-            this.splitContainer1.SplitterDistance = 253;
+            this.splitContainer1.Size = new System.Drawing.Size(737, 400);
+            this.splitContainer1.SplitterDistance = 286;
             this.splitContainer1.TabIndex = 1;
             // 
             // LinesOfCodePerLanguageText
             // 
             this.LinesOfCodePerLanguageText.AutoSize = true;
-            this.LinesOfCodePerLanguageText.Location = new System.Drawing.Point(6, 3);
+            this.LinesOfCodePerLanguageText.Location = new System.Drawing.Point(9, 4);
             this.LinesOfCodePerLanguageText.Name = "LinesOfCodePerLanguageText";
             this.LinesOfCodePerLanguageText.Size = new System.Drawing.Size(54, 13);
             this.LinesOfCodePerLanguageText.TabIndex = 1;
@@ -257,7 +257,7 @@ namespace GitStatistics
             this.LinesOfCodeExtensionPie.InitialAngle = 0F;
             this.LinesOfCodeExtensionPie.Location = new System.Drawing.Point(0, 0);
             this.LinesOfCodeExtensionPie.Name = "LinesOfCodeExtensionPie";
-            this.LinesOfCodeExtensionPie.Size = new System.Drawing.Size(480, 404);
+            this.LinesOfCodeExtensionPie.Size = new System.Drawing.Size(447, 400);
             this.LinesOfCodeExtensionPie.TabIndex = 0;
             this.LinesOfCodeExtensionPie.ToolTips = null;
             // 
@@ -266,6 +266,7 @@ namespace GitStatistics
             this.tabPage3.Controls.Add(this.splitContainer5);
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
             this.tabPage3.Size = new System.Drawing.Size(743, 439);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Lines of code per type";
@@ -275,7 +276,7 @@ namespace GitStatistics
             // 
             this.splitContainer5.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer5.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.splitContainer5.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer5.Location = new System.Drawing.Point(3, 3);
             this.splitContainer5.Name = "splitContainer5";
             this.splitContainer5.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -286,14 +287,14 @@ namespace GitStatistics
             // splitContainer5.Panel2
             // 
             this.splitContainer5.Panel2.Controls.Add(this.splitContainer6);
-            this.splitContainer5.Size = new System.Drawing.Size(743, 439);
-            this.splitContainer5.SplitterDistance = 32;
+            this.splitContainer5.Size = new System.Drawing.Size(737, 433);
+            this.splitContainer5.SplitterDistance = 29;
             this.splitContainer5.TabIndex = 0;
             // 
             // TotalLinesOfCode2
             // 
             this.TotalLinesOfCode2.AutoSize = true;
-            this.TotalLinesOfCode2.Location = new System.Drawing.Point(8, 5);
+            this.TotalLinesOfCode2.Location = new System.Drawing.Point(5, 2);
             this.TotalLinesOfCode2.Name = "TotalLinesOfCode2";
             this.TotalLinesOfCode2.Size = new System.Drawing.Size(94, 13);
             this.TotalLinesOfCode2.TabIndex = 1;
@@ -312,8 +313,8 @@ namespace GitStatistics
             // splitContainer6.Panel2
             // 
             this.splitContainer6.Panel2.Controls.Add(this.LinesOfCodePie);
-            this.splitContainer6.Size = new System.Drawing.Size(743, 403);
-            this.splitContainer6.SplitterDistance = 269;
+            this.splitContainer6.Size = new System.Drawing.Size(737, 400);
+            this.splitContainer6.SplitterDistance = 286;
             this.splitContainer6.TabIndex = 0;
             // 
             // LinesOfCodePerTypeText
@@ -331,7 +332,7 @@ namespace GitStatistics
             this.LinesOfCodePie.InitialAngle = 0F;
             this.LinesOfCodePie.Location = new System.Drawing.Point(0, 0);
             this.LinesOfCodePie.Name = "LinesOfCodePie";
-            this.LinesOfCodePie.Size = new System.Drawing.Size(470, 403);
+            this.LinesOfCodePie.Size = new System.Drawing.Size(447, 400);
             this.LinesOfCodePie.TabIndex = 0;
             this.LinesOfCodePie.ToolTips = null;
             // 
@@ -340,6 +341,7 @@ namespace GitStatistics
             this.tabPage4.Controls.Add(this.splitContainer7);
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
+            this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
             this.tabPage4.Size = new System.Drawing.Size(743, 439);
             this.tabPage4.TabIndex = 0;
             this.tabPage4.Text = "Lines of testcode";
@@ -349,7 +351,7 @@ namespace GitStatistics
             // 
             this.splitContainer7.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer7.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.splitContainer7.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer7.Location = new System.Drawing.Point(3, 3);
             this.splitContainer7.Name = "splitContainer7";
             this.splitContainer7.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -360,14 +362,14 @@ namespace GitStatistics
             // splitContainer7.Panel2
             // 
             this.splitContainer7.Panel2.Controls.Add(this.splitContainer8);
-            this.splitContainer7.Size = new System.Drawing.Size(743, 439);
-            this.splitContainer7.SplitterDistance = 28;
+            this.splitContainer7.Size = new System.Drawing.Size(737, 433);
+            this.splitContainer7.SplitterDistance = 29;
             this.splitContainer7.TabIndex = 0;
             // 
             // TotalLinesOfTestCode
             // 
             this.TotalLinesOfTestCode.AutoSize = true;
-            this.TotalLinesOfTestCode.Location = new System.Drawing.Point(8, 5);
+            this.TotalLinesOfTestCode.Location = new System.Drawing.Point(5, 2);
             this.TotalLinesOfTestCode.Name = "TotalLinesOfTestCode";
             this.TotalLinesOfTestCode.Size = new System.Drawing.Size(94, 13);
             this.TotalLinesOfTestCode.TabIndex = 2;
@@ -386,14 +388,14 @@ namespace GitStatistics
             // splitContainer8.Panel2
             // 
             this.splitContainer8.Panel2.Controls.Add(this.TestCodePie);
-            this.splitContainer8.Size = new System.Drawing.Size(743, 407);
-            this.splitContainer8.SplitterDistance = 260;
+            this.splitContainer8.Size = new System.Drawing.Size(737, 400);
+            this.splitContainer8.SplitterDistance = 286;
             this.splitContainer8.TabIndex = 0;
             // 
             // TestCodeText
             // 
             this.TestCodeText.AutoSize = true;
-            this.TestCodeText.Location = new System.Drawing.Point(8, 4);
+            this.TestCodeText.Location = new System.Drawing.Point(9, 4);
             this.TestCodeText.Name = "TestCodeText";
             this.TestCodeText.Size = new System.Drawing.Size(54, 13);
             this.TestCodeText.TabIndex = 0;
@@ -405,7 +407,7 @@ namespace GitStatistics
             this.TestCodePie.InitialAngle = 0F;
             this.TestCodePie.Location = new System.Drawing.Point(0, 0);
             this.TestCodePie.Name = "TestCodePie";
-            this.TestCodePie.Size = new System.Drawing.Size(479, 407);
+            this.TestCodePie.Size = new System.Drawing.Size(447, 400);
             this.TestCodePie.TabIndex = 0;
             this.TestCodePie.ToolTips = null;
             // 

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -123,12 +123,17 @@ namespace GitStatistics
             pie.SetColors(DecentColors);
             pie.SetShadowStyle(ShadowStyle.GradualShadow);
             pie.Dock = DockStyle.None;
-            pie.Height = pie.Parent.Height;
-            pie.Width = pie.Parent.Width;
-            if (pie.Width > pie.Height)
-                pie.Width = pie.Height;
+
+            if (pie.Parent.Width > pie.Parent.Height)
+            {
+                pie.Height = pie.Parent.Height;
+                pie.Width = pie.Parent.Height;
+            }
             else
-                pie.Height = pie.Width;
+            {
+                pie.Height = pie.Parent.Width;
+                pie.Width = pie.Parent.Width;
+            }
         }
 
         bool initializeLinesOfCodeDone;

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -118,11 +118,9 @@ namespace GitStatistics
             pie.SetBottomMargin(10);
             pie.SetFitChart(false);
             pie.SetEdgeColorType(EdgeColorType.DarkerThanSurface);
-            pie.InitialAngle = -30;
             pie.SetSliceRelativeHeight(0.20f);
             pie.SetColors(DecentColors);
             pie.SetShadowStyle(ShadowStyle.GradualShadow);
-            pie.Dock = DockStyle.None;
 
             if (pie.Parent.Width > pie.Parent.Height)
             {


### PR DESCRIPTION
Resized split containers to be of equal sizes on all tabs:
> Before:
> ![before1](https://cloud.githubusercontent.com/assets/11020536/6657992/f3ce86ec-cb63-11e4-9808-5f5dd116ef2a.gif)
After:
> ![after1](https://cloud.githubusercontent.com/assets/11020536/6657993/f707bdba-cb63-11e4-832f-b850bdbec6d2.gif)

Reduce pie chart flickering on window resizing:
> Before:
> ![before2](https://cloud.githubusercontent.com/assets/11020536/6658030/591ef094-cb65-11e4-84e1-1b6603e52080.gif)
After:
> ![after2](https://cloud.githubusercontent.com/assets/11020536/6658032/5d2c0eba-cb65-11e4-9f7c-9fc5948dce23.gif)

Set minSize for split container panels and form to prevent pie chart overlapping the text on window resizing:
> Before:
![before3](https://cloud.githubusercontent.com/assets/11020536/6658050/a2c1f9e4-cb65-11e4-88a8-321d1d478b49.png)
After:
![after3](https://cloud.githubusercontent.com/assets/11020536/6658051/a56b2ef4-cb65-11e4-92d7-3c995c1c8b18.png)
