### PR TITLE
Reduce string allocation and code cleanup

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2402,7 +2402,7 @@ namespace GitCommands
             {
                 result.AuthenticationFail = true;
             }
-            else if (tree.ToLower().Contains("the server's host key is not cached in the registry"))
+            else if (tree.Contains("the server's host key is not cached in the registry", StringComparison.OrdinalIgnoreCase))
             {
                 result.HostKeyFail = true;
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2508,25 +2508,29 @@ namespace GitCommands
 
         private IList<GitRef> GetTreeRefs(string tree)
         {
-            var itemsStrings = tree.Split('\n');
-
             var gitRefs = new List<GitRef>();
             var defaultHeads = new Dictionary<string, GitRef>(); // remote -> HEAD
             var remotes = GetRemotes(false);
 
-            foreach (var itemsString in itemsStrings)
+            using (TextReader tr = new StringReader(tree))
             {
-                if (itemsString == null || itemsString.Length <= 42 || itemsString.StartsWith("error: "))
-                    continue;
+                string line = tr.ReadLine();
+                while (line != null)
+                {
+                    if (line == null || line.Length <= 42 || line.StartsWith("error: "))
+                        continue;
 
-                var completeName = itemsString.Substring(41).Trim();
-                var guid = itemsString.Substring(0, 40);
-                var remoteName = GitCommandHelpers.GetRemoteName(completeName, remotes);
-                var head = new GitRef(this, guid, completeName, remoteName);
-                if (DefaultHeadPattern.IsMatch(completeName))
-                    defaultHeads[remoteName] = head;
-                else
-                    gitRefs.Add(head);
+                    var completeName = line.Substring(41).Trim();
+                    var guid = line.Substring(0, 40);
+                    var remoteName = GitCommandHelpers.GetRemoteName(completeName, remotes);
+                    var head = new GitRef(this, guid, completeName, remoteName);
+                    if (DefaultHeadPattern.IsMatch(completeName))
+                        defaultHeads[remoteName] = head;
+                    else
+                        gitRefs.Add(head);
+
+                    line = tr.ReadLine();
+                }
             }
 
             // do not show default head if remote has a branch on the same commit

--- a/GitCommands/Patch/Patch.cs
+++ b/GitCommands/Patch/Patch.cs
@@ -182,7 +182,7 @@ namespace PatchApply
                     if (line.Length > 1)
                         insertLine = line.Substring(1);
 
-                    //Is the patch allready applied?
+                    //Is the patch already applied?
                     if (fileLines.Count > lineNumber && fileLines[lineNumber].CompareTo(insertLine) == 0)
                     {
                         Rate -= 20;

--- a/GitCommands/Settings/BasicSettingTypes.cs
+++ b/GitCommands/Settings/BasicSettingTypes.cs
@@ -126,9 +126,8 @@ namespace GitCommands.Settings
         {
             return iss.GetValue<bool?>(name, null, x =>
             {
-                var val = x.ToString().ToLower();
-                if (val == "true") return true;
-                if (val == "false") return false;
+                if ("true".Equals(x, StringComparison.OrdinalIgnoreCase)) return true;
+                if ("false".Equals(x, StringComparison.OrdinalIgnoreCase)) return false;
                 return null;
             });
         }

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -59,7 +59,6 @@ namespace System
             return string.IsNullOrEmpty(s);
         }
 
-
         public static string Combine(this string left, string sep, string right)
         {
             if (left.IsNullOrEmpty())
@@ -68,6 +67,11 @@ namespace System
                 return left;
             else
                 return left + sep + right;
+        }
+
+        public static bool Contains(this string s, string value, StringComparison comparisonType)
+        {
+            return s.IndexOf(value, comparisonType) >= 0;
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1220,9 +1220,7 @@ namespace GitUI.CommandsDialogs
         {
             var candidates = Module.GetFullTree(RevisionGrid.GetSelectedRevisions()[0].TreeGuid);
 
-            string nameAsLower = name.ToLower();
-
-            return candidates.Where(fileName => fileName.ToLower().Contains(nameAsLower)).ToList();
+            return candidates.Where(fileName => fileName.Contains(name, StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
         private string SaveSelectedItemToTempFile()
@@ -2741,18 +2739,14 @@ namespace GitUI.CommandsDialogs
 
         private void findInDiffToolStripMenuItem_Click(object sender, EventArgs e)
         {
-
             var candidates = DiffFiles.GitItemStatuses;
 
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-
-                string nameAsLower = name.ToLower();
-
                 return candidates.Where(item =>
                     {
-                        return item.Name != null && item.Name.ToLower().Contains(nameAsLower)
-                            || item.OldName != null && item.OldName.ToLower().Contains(nameAsLower);
+                        return item.Name != null && item.Name.Contains(name, StringComparison.OrdinalIgnoreCase)
+                            || item.OldName != null && item.OldName.Contains(name, StringComparison.OrdinalIgnoreCase);
                     }
                     ).ToList();
             };

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 FileChanges.FixedFilter = filter.Filter;
                 FileChanges.Rewriter = filter.Rewriter;
-                FileChanges.FiltredFileName = FileName;
+                FileChanges.FilteredFileName = FileName;
                 FileChanges.AllowGraphWithFilter = true;
                 FileChanges.Load();
             });

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString noBaseRevision = new TranslationString("There is no base revision for {0}.\nFall back to 2-way merge?");
         private readonly TranslationString ours = new TranslationString("ours");
         private readonly TranslationString theirs = new TranslationString("theirs");
-        private readonly TranslationString fileBinairyChooseLocalBaseRemote = new TranslationString("File ({0}) appears to be a binary file.\nChoose to keep the local({1}), remote({2}) or base file.");
+        private readonly TranslationString fileBinaryChooseLocalBaseRemote = new TranslationString("File ({0}) appears to be a binary file.\nChoose to keep the local({1}), remote({2}) or base file.");
         private readonly TranslationString fileChangeLocallyAndRemotely = new TranslationString("The file has been changed both locally({0}) and remotely({1}). Merge the changes.");
         private readonly TranslationString fileCreatedLocallyAndRemotely = new TranslationString("A file with the same name has been created locally({0}) and remotely({1}). Choose the file you want to keep or merge the files.");
         private readonly TranslationString fileCreatedLocallyAndRemotelyLong = new TranslationString("File {0} does not have a base revision.\nA file with the same name has been created locally({1}) and remotely({2}) causing this conflict.\n\nChoose the file you want to keep, merge the files or delete the file?");
@@ -630,7 +630,7 @@ namespace GitUI.CommandsDialogs
 
         private void BinairyFilesChooseLocalBaseRemote(ConflictData item)
         {
-            string caption = string.Format(fileBinairyChooseLocalBaseRemote.Text,
+            string caption = string.Format(fileBinaryChooseLocalBaseRemote.Text,
                                             item.Local.Filename,
                                             GetLocalSideString(),
                                             GetRemoteSideString());

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -112,7 +112,7 @@ namespace GitUI
                         return true;
                     }
                 }
-                if (GetOutputString().ToLower().Contains("the server's host key is not cached in the registry"))
+                if (GetOutputString().Contains("the server's host key is not cached in the registry", StringComparison.OrdinalIgnoreCase))
                 {
                     string remoteUrl;
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -2120,9 +2120,7 @@ namespace GitUI
         {
             var candidates = Module.GetFullTree("HEAD");
 
-            string nameAsLower = name.ToLower();
-
-            return candidates.Where(fileName => fileName.ToLower().Contains(nameAsLower)).ToList();
+            return candidates.Where(fileName => fileName.Contains(name, StringComparison.OrdinalIgnoreCase)).ToList();
         }
 
         private void Commit(Dictionary<string, string> arguments)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5891,7 +5891,7 @@ Is the mergeconflict solved?</source>
         <source>deleted</source>
         <target />
       </trans-unit>
-      <trans-unit id="fileBinairyChooseLocalBaseRemote.Text">
+      <trans-unit id="fileBinaryChooseLocalBaseRemote.Text">
         <source>File ({0}) appears to be a binary file.
 Choose to keep the local({1}), remote({2}) or base file.</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -241,7 +241,7 @@ namespace GitUI
         public string CurrentCheckout { get; private set; }
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string FiltredFileName { get; set; }
+        public string FilteredFileName { get; set; }
         [Browsable(false)]
         public Task<SuperProjectInfo> SuperprojectCurrentCheckout { get; private set; }
         [Browsable(false)]
@@ -885,7 +885,7 @@ namespace GitUI
         [Browsable(false)]
         public Task<bool> StagedChanges { get; private set; }
 
-        private string _filtredCurrentCheckout;
+        private string _filteredCurrentCheckout;
 
         public void ForceRefreshRevisions()
         {
@@ -909,7 +909,7 @@ namespace GitUI
                     TaskScheduler.FromCurrentSynchronizationContext());
                 //Only check for tracked files. This usually makes more sense and it performs a lot
                 //better then checking for untracked files.
-                // TODO: Check FiltredFileName
+                // TODO: Check FilteredFileName
                 Task<bool> unstagedChanges =
                     Task.Factory.StartNew(() => Module.GetUnstagedFiles().Any());
                 Task<bool> stagedChanges =
@@ -929,7 +929,7 @@ namespace GitUI
 
                 Revisions.ClearSelection();
                 CurrentCheckout = newCurrentCheckout;
-                _filtredCurrentCheckout = null;
+                _filteredCurrentCheckout = null;
                 _currentCheckoutParents = null;
                 SuperprojectCurrentCheckout = newSuperPrjectInfo;
                 UnstagedChanges = unstagedChanges;
@@ -1168,7 +1168,7 @@ namespace GitUI
 
         private void SelectInitialRevision()
         {
-            string filtredCurrentCheckout = _filtredCurrentCheckout;
+            string filteredCurrentCheckout = _filteredCurrentCheckout;
             if (LastSelectedRows != null)
             {
                 Revisions.SelectedIds = LastSelectedRows;
@@ -1184,16 +1184,16 @@ namespace GitUI
                 }
                 else
                 {
-                    SetSelectedRevision(filtredCurrentCheckout);
+                    SetSelectedRevision(filteredCurrentCheckout);
                 }
             }
 
-            if (string.IsNullOrEmpty(filtredCurrentCheckout))
+            if (string.IsNullOrEmpty(filteredCurrentCheckout))
                 return;
 
-            if (!Revisions.IsRevisionRelative(filtredCurrentCheckout))
+            if (!Revisions.IsRevisionRelative(filteredCurrentCheckout))
             {
-                HighlightBranch(filtredCurrentCheckout);
+                HighlightBranch(filteredCurrentCheckout);
             }
         }
 
@@ -2417,11 +2417,11 @@ namespace GitUI
                 return;
             }
 
-            if (_filtredCurrentCheckout == null)
+            if (_filteredCurrentCheckout == null)
             {
                 if (rev.Guid == CurrentCheckout)
                 {
-                    _filtredCurrentCheckout = CurrentCheckout;
+                    _filteredCurrentCheckout = CurrentCheckout;
                 }
                 else
                 {
@@ -2429,18 +2429,18 @@ namespace GitUI
                     {
                         _currentCheckoutParents = GetAllParents(CurrentCheckout);
                     }
-                    _filtredCurrentCheckout = _currentCheckoutParents.FirstOrDefault(parent => parent == rev.Guid);
+                    _filteredCurrentCheckout = _currentCheckoutParents.FirstOrDefault(parent => parent == rev.Guid);
                 }
             }
-            string filtredCurrentCheckout = _filtredCurrentCheckout;
+            string filteredCurrentCheckout = _filteredCurrentCheckout;
 
-            if (filtredCurrentCheckout == rev.Guid && ShowUncommitedChanges())
+            if (filteredCurrentCheckout == rev.Guid && ShowUncommitedChanges())
             {
-                CheckUncommitedChanged( filtredCurrentCheckout );
+                CheckUncommitedChanged( filteredCurrentCheckout );
             }
 
             var dataType = DvcsGraph.DataType.Normal;
-            if (rev.Guid == filtredCurrentCheckout)
+            if (rev.Guid == filteredCurrentCheckout)
                 dataType = DvcsGraph.DataType.Active;
             else if (rev.Refs.Any())
                 dataType = DvcsGraph.DataType.Special;
@@ -2448,7 +2448,7 @@ namespace GitUI
             Revisions.Add(rev.Guid, rev.ParentGuids, dataType, rev);
         }
 
-        private void CheckUncommitedChanged(string filtredCurrentCheckout)
+        private void CheckUncommitedChanged(string filteredCurrentCheckout)
         {
             if (UnstagedChanges.Result)
             {
@@ -2459,7 +2459,7 @@ namespace GitUI
                     ParentGuids =
                         StagedChanges.Result
                             ? new[] { GitRevision.IndexGuid }
-                            : new[] { filtredCurrentCheckout }
+                            : new[] { filteredCurrentCheckout }
                 };
                 Revisions.Add(workingDir.Guid, workingDir.ParentGuids, DvcsGraph.DataType.Normal, workingDir);
             }
@@ -2470,7 +2470,7 @@ namespace GitUI
                 var index = new GitRevision(Module, GitRevision.IndexGuid)
                 {
                     Message = Strings.GetCurrentIndex(),
-                    ParentGuids = new[] { filtredCurrentCheckout }
+                    ParentGuids = new[] { filteredCurrentCheckout }
                 };
                 Revisions.Add(index.Guid, index.ParentGuids, DvcsGraph.DataType.Normal, index);
             }

--- a/NetSpell.SpellChecker/Spelling.cs
+++ b/NetSpell.SpellChecker/Spelling.cs
@@ -22,12 +22,12 @@ namespace NetSpell.SpellChecker
 
         #region Global Regex
         // Regex are class scope and compiled to improve performance on reuse
-        private Regex _digitRegex = new Regex(@"^\d", RegexOptions.Compiled);
-        private Regex _htmlRegex = new Regex(@"</[c-g\d]+>|</[i-o\d]+>|</[a\d]+>|</[q-z\d]+>|<[cg]+[^>]*>|<[i-o]+[^>]*>|<[q-z]+[^>]*>|<[a]+[^>]*>|<(\[^\]*\|'[^']*'|[^'\>])*>", RegexOptions.IgnoreCase & RegexOptions.Compiled);
+        private static readonly Regex _digitRegex = new Regex(@"^\d", RegexOptions.Compiled);
+        private static readonly Regex _htmlRegex = new Regex(@"</[c-g\d]+>|</[i-o\d]+>|</[a\d]+>|</[q-z\d]+>|<[cg]+[^>]*>|<[i-o]+[^>]*>|<[q-z]+[^>]*>|<[a]+[^>]*>|<(\[^\]*\|'[^']*'|[^'\>])*>", RegexOptions.IgnoreCase & RegexOptions.Compiled);
         private MatchCollection _htmlTags;
-        private Regex _letterRegex = new Regex(@"\D", RegexOptions.Compiled);
-        private Regex _upperRegex = new Regex(@"[^\p{Lu}]", RegexOptions.Compiled); // @"[^A-Z]
-        private Regex _wordEx = new Regex(@"\b[\w']+\b", RegexOptions.Compiled); // @"\b[A-Za-z0-9_'À-ÿ]+\b"
+        private static readonly Regex _letterRegex = new Regex(@"\D", RegexOptions.Compiled);
+        private static readonly Regex _upperRegex = new Regex(@"[^\p{Lu}]", RegexOptions.Compiled); // @"[^A-Z]
+        private static readonly Regex _wordRegex = new Regex(@"\b[\w']+\b", RegexOptions.Compiled); // @"\b[A-Za-z0-9_'À-ÿ]+\b"
         private MatchCollection _words;
         private SuggestionEnum _suggestionMode = SuggestionEnum.PhoneticNearMiss;
         #endregion
@@ -231,7 +231,7 @@ namespace NetSpell.SpellChecker
         private void CalculateWords()
         {
             // splits the text into words
-            _words = _wordEx.Matches(_text.ToString());
+            _words = _wordRegex.Matches(_text.ToString());
             
             // remark html
             MarkHtml();

--- a/Plugins/Statistics/GitStatistics/CodeFile.cs
+++ b/Plugins/Statistics/GitStatistics/CodeFile.cs
@@ -189,7 +189,7 @@ namespace GitStatistics
             if (_inCommentBlock && line.Contains("*/"))
                 _inCommentBlock = false;
 
-            if (File.Extension.ToLower() == ".pas" || File.Extension.ToLower() == ".inc")
+            if (File.Extension.Equals(".pas", StringComparison.OrdinalIgnoreCase) || File.Extension.Equals(".inc", StringComparison.OrdinalIgnoreCase))
             {
                 if (line.Contains("*)") || line.Contains("}"))
                     _inCommentBlock = false;


### PR DESCRIPTION
I also had intentions change the string comparisons where GitRef.Names are compared, however I do not know how comparisons are supposed to be treated (ie. OrdinalIgnoreCase vs CurrentCultureIgnoreCase), so those will be untouched.
