### PR TITLE
Fixed 'ArgumentOutOfRangeException when right clicking of the the table header of 'Resolve merge conflicts' dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -831,7 +831,12 @@ namespace GitUI.CommandsDialogs
 
         private void ConflictedFilesContextMenu_Opening(object sender, CancelEventArgs e)
         {
-            var fileName = GetFileName();
+            if (ConflictedFiles.SelectedRows.Count == 0)
+            {
+                e.Cancel = true;
+                return;
+            }
+            string fileName = GetFileName();
             ConflictedFilesContextMenu.Enabled = !string.IsNullOrEmpty(fileName);
 
             if (ConflictedFilesContextMenu.Enabled)


### PR DESCRIPTION
Fixed https://github.com/gitextensions/gitextensions/issues/2761 issue