### PR TITLE
Fixed issue with statistics plugin.

### DIFF
--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -216,7 +216,7 @@ namespace GitStatistics
                 {
                     lineCounter.NumberBlankLines,
                     lineCounter.NumberCommentsLines,
-                    lineCounter.NumberLines,
+                    lineCounter.NumberCodeLines,
                     lineCounter.NumberLinesInDesignerFiles
                 });
             LinesOfCodePie.ToolTips =


### PR DESCRIPTION
Fixed issue where "Lines of code" was allocated too much space on the statistics plugin pie chart.

Fixes issue #2530.
