### PR TITLE
Statistics

### DIFF
--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -265,6 +265,7 @@ namespace GitStatistics
 
         private void FormGitStatistics_FormClosing(object sender, FormClosingEventArgs e)
         {
+            lineCounter.Cancel = true;
             lineCounter.LinesOfCodeUpdated -= lineCounter_LinesOfCodeUpdated;
         }
     }

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -183,7 +183,9 @@ namespace GitStatistics
         private void UpdateUI(LineCounter lineCounter, string linesOfCodePerLanguageText, decimal[] extensionValues,
                               string[] extensionLabels)
         {
-            TotalLinesOfTestCode.Text = lineCounter.NumberTestCodeLines + " Lines of test code";
+            TotalLinesOfTestCode.Text = lineCounter.NumberTestCodeLines +
+                                        (lineCounter.Counting ? "+" : "") +
+                                        " Lines of test code";
 
             TestCodePie.SetValues(new Decimal[]
                 {
@@ -238,7 +240,9 @@ namespace GitStatistics
             LinesOfCodeExtensionPie.SetValues(extensionValues);
             LinesOfCodeExtensionPie.ToolTips = extensionLabels;
 
-            TotalLinesOfCode2.Text = TotalLinesOfCode.Text = lineCounter.NumberCodeLines + " Lines of code";
+            TotalLinesOfCode2.Text = TotalLinesOfCode.Text = lineCounter.NumberCodeLines +
+                                                             (lineCounter.Counting ? "+" : "") +
+                                                             " Lines of code";
         }
 
         private void FormGitStatisticsShown(object sender, EventArgs e)

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -158,26 +158,37 @@ namespace GitStatistics
         {
             LineCounter lineCounter = (LineCounter)sender;
 
-            //Must do this synchronously because lineCounter.LinesOfCodePerExtension might change while we are iterating over it otherwise.
-            var extensionValues = new Decimal[lineCounter.LinesOfCodePerExtension.Count];
-            var extensionLabels = new string[lineCounter.LinesOfCodePerExtension.Count];
+            List<KeyValuePair<string, int>> LinesOfCodePerExtension;
+            lock (lineCounter.LinesOfCodePerExtension)
+            {
+                //Must do this synchronously because lineCounter.LinesOfCodePerExtension might change while we are iterating over it otherwise.
+                LinesOfCodePerExtension = new List<KeyValuePair<string, int>>(lineCounter.LinesOfCodePerExtension);
+            }
 
-            List<KeyValuePair<string, int>> LinesOfCodePerExtension = new List<KeyValuePair<string, int>>(lineCounter.LinesOfCodePerExtension);
+            var extensionValues = new Decimal[LinesOfCodePerExtension.Count];
+            var extensionLabels = new string[LinesOfCodePerExtension.Count];
             LinesOfCodePerExtension.Sort((first, next) => -first.Value.CompareTo(next.Value));
 
             var n = 0;
-            string linesOfCodePerLanguageText = "";
+            var linesOfCodePerLanguageText = new StringBuilder(1024);
             foreach (var keyValuePair in LinesOfCodePerExtension)
             {
                 string percent = ((double)keyValuePair.Value / lineCounter.NumberCodeLines).ToString("P1");
-                linesOfCodePerLanguageText += keyValuePair.Value + " Lines of code in " + keyValuePair.Key + " files (" + percent + ")" + Environment.NewLine;
+                linesOfCodePerLanguageText.Append(keyValuePair.Value);
+                if (lineCounter.Counting)
+                {
+                    linesOfCodePerLanguageText.Append('+');
+                }
+
+                linesOfCodePerLanguageText.Append(" Lines of code in ").Append(keyValuePair.Key);
+                linesOfCodePerLanguageText.Append(" files (").Append(percent).AppendLine(")");
                 extensionValues[n] = keyValuePair.Value;
                 extensionLabels[n] = keyValuePair.Value + " Lines of code in " + keyValuePair.Key + " files (" + percent + ")";
                 n++;
             }
 
             //Sync rest to UI thread
-            syncContext.Post(o => UpdateUI(lineCounter, linesOfCodePerLanguageText, extensionValues, extensionLabels), null);
+            syncContext.Post(o => UpdateUI(lineCounter, linesOfCodePerLanguageText.ToString(), extensionValues, extensionLabels), null);
         }
 
         private void UpdateUI(LineCounter lineCounter, string linesOfCodePerLanguageText, decimal[] extensionValues,

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -14,8 +14,8 @@ namespace GitStatistics
         }
 
         StringSetting CodeFiles = new StringSetting("Code files",
-                                "*.c;*.cpp;*.cc;*.h;*.hpp;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.css;" +
-                                "*.vbs;*.vb;*.sql;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js");
+                                "*.c;*.cpp;*.cc;*.cxx;*.h;*.hpp;*.hxx;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.css;" +
+                                "*.vbs;*.vb;*.sql;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.mk;*.java");
         StringSetting IgnoreDirectories = new StringSetting("Directories to ignore (EndsWith)", "\\Debug;\\Release;\\obj;\\bin;\\lib");
         BoolSetting IgnoreSubmodules = new BoolSetting("Ignore submodules", true);
 

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -14,8 +14,8 @@ namespace GitStatistics
         }
 
         StringSetting CodeFiles = new StringSetting("Code files",
-                                "*.c;*.cpp;*.cc;*.h;*.hpp;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" +
-                                "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js");
+                                "*.c;*.cpp;*.cc;*.h;*.hpp;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.css;" +
+                                "*.vbs;*.vb;*.sql;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js");
         StringSetting IgnoreDirectories = new StringSetting("Directories to ignore (EndsWith)", "\\Debug;\\Release;\\obj;\\bin;\\lib");
         BoolSetting IgnoreSubmodules = new BoolSetting("Ignore submodules", true);
 

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -69,11 +69,13 @@ namespace GitStatistics
 
             var filters = filePattern.Split(';');
             var directoryFilter = directoriesToIgnore.Split(';');
+            string root = _directory.FullName;
             List<string> dirs = new List<string>(1024);
-            dirs.Add(_directory.FullName);
-            foreach (var dir in Directory.EnumerateDirectories(_directory.FullName, "*", SearchOption.AllDirectories))
+            dirs.Add(root);
+            foreach (var dir in Directory.EnumerateDirectories(root, "*", SearchOption.AllDirectories))
             {
-                if (!DirectoryIsFiltered(dir, directoryFilter))
+                if (dir.IndexOf(".git", root.Length, StringComparison.InvariantCultureIgnoreCase) < 0 &&
+                    !DirectoryIsFiltered(dir, directoryFilter))
                 {
                     dirs.Add(dir);
                 }

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -23,6 +23,7 @@ namespace GitStatistics
         public int NumberBlankLines { get; private set; }
         public int NumberCodeLines { get; private set; }
         public bool Counting { get; private set; }
+        public bool Cancel { get; set; }
 
         public Dictionary<string, int> LinesOfCodePerExtension { get; private set; }
 
@@ -95,6 +96,11 @@ namespace GitStatistics
 
                         CalculateSums(codeFile);
 
+                        if (Cancel)
+                        {
+                            return;
+                        }
+
                         if (LinesOfCodeUpdated != null && DateTime.Now - lastUpdate > timer)
                         {
                             LinesOfCodeUpdated(this, EventArgs.Empty);
@@ -108,7 +114,7 @@ namespace GitStatistics
                 Counting = false;
                 
                 //Send 'changed' event when done
-                if (LinesOfCodeUpdated != null)
+                if (LinesOfCodeUpdated != null && !Cancel)
                     LinesOfCodeUpdated(this, EventArgs.Empty);
             }
         }

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -35,7 +35,7 @@ namespace GitStatistics
             return false;
         }
 
-        private IEnumerable<FileInfo> GetFiles(DirectoryInfo startDirectory, string filter)
+        private IEnumerable<FileInfo> GetFiles(DirectoryInfo startDirectory, string filter, string[] directoryFilter)
         {
             Queue<DirectoryInfo> queue = new Queue<DirectoryInfo>();
             queue.Enqueue(startDirectory);
@@ -45,7 +45,8 @@ namespace GitStatistics
                 FileInfo[] files = null;
                 try
                 {
-                    files = directory.GetFiles(filter);
+                    if (!DirectoryIsFiltered(directory, directoryFilter))
+                        files = directory.GetFiles(filter);
                     DirectoryInfo[] directories = directory.GetDirectories();
                     foreach (var dir in directories)
                         queue.Enqueue(dir);
@@ -53,6 +54,7 @@ namespace GitStatistics
                 catch (System.UnauthorizedAccessException)
                 {
                 }
+
                 if (files != null)
                 {
                     foreach (var file in files)
@@ -77,11 +79,8 @@ namespace GitStatistics
 
             foreach (var filter in filters)
             {
-                foreach (var file in GetFiles(_directory, filter.Trim()))
+                foreach (var file in GetFiles(_directory, filter.Trim(), directoryFilter))
                 {
-                    if (DirectoryIsFiltered(file.Directory, directoryFilter))
-                        continue;
-
                     var codeFile = new CodeFile(file.FullName);
                     codeFile.CountLines();
 

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -25,29 +25,29 @@ namespace GitStatistics
 
         public Dictionary<string, int> LinesOfCodePerExtension { get; private set; }
 
-        private static bool DirectoryIsFiltered(FileSystemInfo dir, IEnumerable<string> directoryFilters)
+        private static bool DirectoryIsFiltered(string path, IEnumerable<string> directoryFilters)
         {
             foreach (var directoryFilter in directoryFilters)
             {
-                if (dir.FullName.EndsWith(directoryFilter, StringComparison.InvariantCultureIgnoreCase))
+                if (path.EndsWith(directoryFilter, StringComparison.InvariantCultureIgnoreCase))
                     return true;
             }
             return false;
         }
 
-        private IEnumerable<FileInfo> GetFiles(DirectoryInfo startDirectory, string filter, string[] directoryFilter)
+        private IEnumerable<string> GetFiles(string startDirectory, string filter, string[] directoryFilter)
         {
-            Queue<DirectoryInfo> queue = new Queue<DirectoryInfo>();
+            Queue<string> queue = new Queue<string>();
             queue.Enqueue(startDirectory);
             while(queue.Count != 0)
             {
                 IEnumerable<string> efs = null;
                 try
                 {
-                    DirectoryInfo directory = queue.Dequeue();
-                    foreach (var dir in Directory.EnumerateDirectories(directory.FullName))
+                    string directory = queue.Dequeue();
+                    foreach (var dir in Directory.EnumerateDirectories(directory))
                     {
-                        queue.Enqueue(new DirectoryInfo(dir));
+                        queue.Enqueue(dir);
                     }
 
                     if (DirectoryIsFiltered(directory, directoryFilter))
@@ -55,7 +55,7 @@ namespace GitStatistics
                         continue;
                     }
 
-                    efs = Directory.EnumerateFileSystemEntries(directory.FullName, filter);
+                    efs = Directory.EnumerateFileSystemEntries(directory, filter);
                 }
                 catch (System.Exception)
                 {
@@ -66,7 +66,7 @@ namespace GitStatistics
 
                 foreach (var entry in efs)
                 {
-                    yield return new FileInfo(entry);
+                    yield return entry;
                 }
             }
         }
@@ -87,9 +87,9 @@ namespace GitStatistics
 
             foreach (var filter in filters)
             {
-                foreach (var file in GetFiles(_directory, filter.Trim(), directoryFilter))
+                foreach (var file in GetFiles(_directory.FullName, filter.Trim(), directoryFilter))
                 {
-                    var codeFile = new CodeFile(file.FullName);
+                    var codeFile = new CodeFile(file);
                     codeFile.CountLines();
 
                     CalculateSums(codeFile);

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -141,6 +141,9 @@ namespace GitStatistics
                 codeFile.NumberLinesInDesignerFiles;
 
             var extension = codeFile.File.Extension.ToLower();
+            var isTestFile = codeFile.IsTestFile ||
+                             codeFile.File.Directory.FullName.IndexOf("test",
+                                     StringComparison.OrdinalIgnoreCase) >= 0;
 
             lock (LinesOfCodePerExtension)
             {
@@ -155,7 +158,7 @@ namespace GitStatistics
                 LinesOfCodePerExtension[extension] += codeLines;
                 NumberCodeLines += codeLines;
 
-                if (codeFile.IsTestFile || codeFile.File.Directory.FullName.IndexOf("test", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (isTestFile)
                 {
                     NumberTestCodeLines += codeLines;
                 }


### PR DESCRIPTION
Improvements to Statistics Plugin. Key changes:
- Fixed broken statistics when an exception is thrown while traversing files (most notably 'path not found' for broken hardlinks or drive is unmapped, and 'path too long').
- Removed duplicate file extensions and added a few missing.
- Removed containers while enumerating and reduced passes to once-per-type.
- .git directory is now ignored as it shouldn't be part of the stats.
- Cancel line count analysis when plugin form is closed.
- Parallel line count analysis.

Overall the performance improvement is significant, and the results are more accurate.
