### PR TITLE
Using Common Item Dialog to select folders

### DIFF
--- a/GitCommands/Utils/EnvUtils.cs
+++ b/GitCommands/Utils/EnvUtils.cs
@@ -18,6 +18,30 @@ namespace GitCommands.Utils
                     return false;
             }
         }
+        
+        public static bool IsWindowsVistaOrGreater()
+        {
+            return Environment.OSVersion.Platform == PlatformID.Win32NT
+                   && Environment.OSVersion.Version.CompareTo(new Version(6, 0)) >= 0;
+        }
+
+        public static bool IsWindows7OrGreater()
+        {
+            return Environment.OSVersion.Platform == PlatformID.Win32NT
+                   && Environment.OSVersion.Version.CompareTo(new Version(6, 1)) >= 0;
+        }
+
+        public static bool IsWindows8OrGreater()
+        {
+            return Environment.OSVersion.Platform == PlatformID.Win32NT
+                   && Environment.OSVersion.Version.CompareTo(new Version(6, 2)) >= 0;
+        }
+
+        public static bool IsWindows8Point1OrGreater()
+        {
+            return Environment.OSVersion.Platform == PlatformID.Win32NT
+                   && Environment.OSVersion.Version.CompareTo(new Version(6, 3)) >= 0;
+        }
 
         public static bool RunningOnUnix()
         {

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -225,13 +225,11 @@ namespace GitUI.CommandsDialogs
 
         private void BrowseDir_Click(object sender, EventArgs e)
         {
-            using (var browseDialog = new FolderBrowserDialog())
-            {
+            var userSelectedPath = OsShellUtil.PickFolder(this);
 
-                if (browseDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    PatchDir.Text = browseDialog.SelectedPath;
-                }
+            if (userSelectedPath != null)
+            {
+                PatchDir.Text = userSelectedPath;
             }
         }
 

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -176,10 +176,11 @@ namespace GitUI.CommandsDialogs
 
         private void FromBrowseClick(object sender, EventArgs e)
         {
-            using (var dialog = new FolderBrowserDialog { SelectedPath = _NO_TRANSLATE_From.Text })
+            var userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_From.Text);
+
+            if (userSelectedPath != null)
             {
-                if (dialog.ShowDialog(this) == DialogResult.OK)
-                    _NO_TRANSLATE_From.Text = dialog.SelectedPath;
+                _NO_TRANSLATE_From.Text = userSelectedPath;
             }
 
             FromTextUpdate(sender, e);
@@ -187,10 +188,11 @@ namespace GitUI.CommandsDialogs
 
         private void ToBrowseClick(object sender, EventArgs e)
         {
-            using (var dialog = new FolderBrowserDialog { SelectedPath = _NO_TRANSLATE_To.Text })
+            var userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_To.Text);
+
+            if (userSelectedPath != null)
             {
-                if (dialog.ShowDialog(this) == DialogResult.OK)
-                    _NO_TRANSLATE_To.Text = dialog.SelectedPath;
+                _NO_TRANSLATE_To.Text = userSelectedPath;
             }
 
             ToTextUpdate(sender, e);

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -50,10 +50,11 @@ namespace GitUI.CommandsDialogs
 
         private void Browse_Click(object sender, EventArgs e)
         {
-            using (var dialog = new FolderBrowserDialog())
+            var userSelectedPath = OsShellUtil.PickFolder(this);
+
+            if (userSelectedPath != null)
             {
-                if (dialog.ShowDialog(this) == DialogResult.OK)
-                    OutputPath.Text = dialog.SelectedPath;
+                OutputPath.Text = userSelectedPath;
             }
         }
 

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -79,11 +79,11 @@ namespace GitUI.CommandsDialogs
 
         private void BrowseClick(object sender, EventArgs e)
         {
-            using (var browseDialog = new FolderBrowserDialog())
-            {
+            var userSelectedPath = OsShellUtil.PickFolder(this);
 
-                if (browseDialog.ShowDialog(this) == DialogResult.OK)
-                    Directory.Text = browseDialog.SelectedPath;
+            if (userSelectedPath != null)
+            {
+                Directory.Text = userSelectedPath;
             }
         }
     }

--- a/GitUI/CommandsDialogs/FormSvnClone.cs
+++ b/GitUI/CommandsDialogs/FormSvnClone.cs
@@ -103,10 +103,11 @@ namespace GitUI.CommandsDialogs
 
         private void browseButton_Click(object sender, EventArgs e)
         {
-            using (var dialog = new FolderBrowserDialog { SelectedPath = this._NO_TRANSLATE_destinationComboBox.Text })
+            var userSelectedPath = OsShellUtil.PickFolder(this, this._NO_TRANSLATE_destinationComboBox.Text);
+
+            if (userSelectedPath != null)
             {
-                if (dialog.ShowDialog(this) == DialogResult.OK)
-                    this._NO_TRANSLATE_destinationComboBox.Text = dialog.SelectedPath;
+                this._NO_TRANSLATE_destinationComboBox.Text = userSelectedPath;
             }
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -217,14 +217,12 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             var initialDir = _destinationTB.Text.Length > 0 ? _destinationTB.Text : "C:\\";
 
-            using (var browseDialog = new FolderBrowserDialog { SelectedPath = initialDir })
-            {
+            var userSelectedPath = OsShellUtil.PickFolder(this, initialDir);
 
-                if (browseDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    _destinationTB.Text = browseDialog.SelectedPath;
-                    _destinationTB_TextChanged(sender, e);
-                }
+            if (userSelectedPath != null)
+            {
+                _destinationTB.Text = userSelectedPath;
+                _destinationTB_TextChanged(sender, e);
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -222,14 +222,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void otherHomeBrowse_Click(object sender, EventArgs e)
         {
-            using (FolderBrowserDialog browseDialog = new FolderBrowserDialog())
-            {
-                browseDialog.SelectedPath = Environment.GetEnvironmentVariable("USERPROFILE");
+            var userSelectedPath = OsShellUtil.PickFolder(this, Environment.GetEnvironmentVariable("USERPROFILE"));
 
-                if (browseDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    otherHomeDir.Text = browseDialog.SelectedPath;
-                }
+            if (userSelectedPath != null)
+            {
+                otherHomeDir.Text = userSelectedPath;
             }
         }
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
@@ -121,10 +121,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void DefaultCloneDestinationBrowseClick(object sender, EventArgs e)
         {
-            using (var dialog = new FolderBrowserDialog { SelectedPath = cbDefaultCloneDestination.Text })
+            var userSelectedPath = OsShellUtil.PickFolder(this, cbDefaultCloneDestination.Text);
+
+            if (userSelectedPath != null)
             {
-                if (dialog.ShowDialog(this) == DialogResult.OK)
-                    cbDefaultCloneDestination.Text = dialog.SelectedPath;
+                cbDefaultCloneDestination.Text = userSelectedPath;
             }
         }
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -70,13 +70,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             CheckSettingsLogic.SolveLinuxToolsDir(GitBinPath.Text.Trim());
 
-            using (var browseDialog = new FolderBrowserDialog { SelectedPath = AppSettings.GitBinDir })
-            {
+            var userSelectedPath = OsShellUtil.PickFolder(this, AppSettings.GitBinDir);
 
-                if (browseDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    GitBinPath.Text = browseDialog.SelectedPath;
-                }
+            if (userSelectedPath != null)
+            {
+                GitBinPath.Text = userSelectedPath;
             }
         }
 

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -22,11 +22,11 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
 
         private void BrowseClick(object sender, EventArgs e)
         {
-            using (var browseDialog = new FolderBrowserDialog { SelectedPath = Directory.Text })
-            {
+            var userSelectedPath = OsShellUtil.PickFolder(this, Directory.Text);
 
-                if (browseDialog.ShowDialog(this) == DialogResult.OK)
-                    Directory.Text = browseDialog.SelectedPath;
+            if (userSelectedPath != null)
+            {
+                Directory.Text = userSelectedPath;
             }
         }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -92,6 +92,9 @@
     <Reference Include="ICSharpCode.TextEditor">
       <HintPath>..\Bin\ICSharpCode.TextEditor.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack">
+      <HintPath>..\Bin\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack.Shell">
       <HintPath>..\Bin\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
     </Reference>

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -1,9 +1,14 @@
-﻿using System.Diagnostics;
-using System.Text.RegularExpressions;
-using Microsoft.Win32;
-
-namespace GitUI
+﻿namespace GitUI
 {
+    using System.Diagnostics;
+    using System.Text.RegularExpressions;
+    using System.Windows.Forms;
+
+    using Microsoft.Win32;
+#if !__MonoCS__
+    using Microsoft.WindowsAPICodePack.Dialogs;
+#endif
+
     public static class OsShellUtil
     {
         public static void OpenAs(string file)
@@ -40,6 +45,53 @@ namespace GitUI
                 var defaultBrowserPath = Regex.Match(browserRegistryString, @"(\"".*?\"")").Captures[0].ToString();
                 Process.Start(defaultBrowserPath, url);
             }
+        }
+
+        /// <summary>
+        /// Prompts the user to select a directory.
+        /// </summary>
+        /// <param name="ownerWindow">The owner window.</param>
+        /// <param name="selectedPath">The initially selected path.</param>
+        /// <returns>The path selected by the user, or null if the user cancels the dialog.</returns>
+        public static string PickFolder(IWin32Window ownerWindow, string selectedPath = null)
+        {
+#if !__MonoCS__
+            if (GitCommands.Utils.EnvUtils.IsWindowsVistaOrGreater())
+            {
+                // use Vista+ dialog
+                using (var dialog = new CommonOpenFileDialog())
+                {
+                    dialog.IsFolderPicker = true;
+
+                    if (selectedPath != null)
+                        dialog.InitialDirectory = selectedPath;
+
+                    var result = dialog.ShowDialog(ownerWindow.Handle);
+
+                    if (result == CommonFileDialogResult.Ok)
+                        return dialog.FileName;
+                }
+            }
+            else
+            {
+#endif
+                // use XP-era dialog
+                using (var dialog = new FolderBrowserDialog())
+                {
+                    if (selectedPath != null)
+                        dialog.SelectedPath = selectedPath;
+
+                    var result = dialog.ShowDialog(ownerWindow);
+
+                    if (result == DialogResult.OK)
+                        return dialog.SelectedPath;
+                }
+#if !__MonoCS__
+            }
+#endif
+
+            // return null if the user cancelled
+            return null;
         }
     }
 }

--- a/GitUI/UserControls/FolderBrowserButton.cs
+++ b/GitUI/UserControls/FolderBrowserButton.cs
@@ -20,8 +20,8 @@ namespace GitUI.UserControls
         public Control PathShowingControl { get; set; }
 
         /// <summary>
-        /// Opens a a FolderBrowserDialog with the path in "getter" preselected and
-        /// if the DialogResult.OK is returned uses "setter" to set the path
+        /// Opens a a folder picker dialog with the path in "getter" preselected and
+        /// if OK is returned uses "setter" to set the path
         /// </summary>
         /// <param name="getter"></param>
         /// <param name="setter"></param>
@@ -37,18 +37,15 @@ namespace GitUI.UserControls
                 // since the DirectoryInfo stuff is for convenience we swallow exceptions
             }
 
-            using (var dialog = new FolderBrowserDialog
+            // if we do not use the DirectoryInfo then a path with slashes instead of backslashes won't work
+            if (directoryInfoPath == null) directoryInfoPath = getter();
+
+            // TODO: do we need ParentForm or is "this" ok?
+            var userSelectedPath = OsShellUtil.PickFolder(ParentForm, directoryInfoPath);
+
+            if (userSelectedPath != null)
             {
-                RootFolder = Environment.SpecialFolder.Desktop,
-                // if we do not use the DirectoryInfo then a path with slashes instead of backslashes won't work
-                SelectedPath = directoryInfoPath ?? getter()
-            })
-            {
-                // TODO: do we need ParentForm or is "this" ok?
-                if (dialog.ShowDialog(ParentForm) == DialogResult.OK)
-                {
-                    setter(dialog.SelectedPath);
-                }
+                setter(userSelectedPath);
             }
         }
 


### PR DESCRIPTION
FolderBrowserDialog in Windows Forms still calls the XP-era dialog instead of the much nicer Common Item Dialog seen in Windows Vista and newer (see #2787).