### PR TITLE
DOS Codepage 852 added into supported encodings

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -997,6 +997,7 @@ namespace GitCommands
             addEncoding(new UnicodeEncoding());
             addEncoding(new UTF7Encoding());
             addEncoding(new UTF8Encoding(false));
+            addEncoding(System.Text.Encoding.GetEncoding("CP852"));
 
             try
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -64,7 +64,7 @@ namespace GitUI.Editor
 
             this.encodingToolStripComboBox.Items.AddRange(new Object[]
                                                     {
-                                                        "Default (" + Encoding.Default.HeaderName + ")", "ASCII",
+                                                        "Default (" + Encoding.Default.HeaderName + ")","DOS852", "ASCII",
                                                         "Unicode", "UTF7", "UTF8", "UTF32"
                                                     });
             _internalFileViewer.MouseMove += TextAreaMouseMove;
@@ -267,6 +267,8 @@ namespace GitUI.Editor
                 this.encodingToolStripComboBox.Text = "UTF32";
             else if (this.Encoding == Encoding.Default)
                 this.encodingToolStripComboBox.Text = "Default (" + Encoding.Default.HeaderName + ")";
+            else if (this.Encoding == Encoding.GetEncoding("CP852"))
+                this.encodingToolStripComboBox.Text = "DOS852";
         }
 
         public event EventHandler<EventArgs> ExtraDiffArgumentsChanged;
@@ -927,6 +929,8 @@ namespace GitUI.Editor
                 encod = Module.FilesEncoding;
             else if (encodingToolStripComboBox.Text.StartsWith("Default", StringComparison.CurrentCultureIgnoreCase))
                 encod = Encoding.Default;
+            else if (encodingToolStripComboBox.Text.Equals("DOS852", StringComparison.CurrentCultureIgnoreCase))
+                encod = Encoding.GetEncoding("CP852");
             else if (encodingToolStripComboBox.Text.Equals("ASCII", StringComparison.CurrentCultureIgnoreCase))
                 encod = new ASCIIEncoding();
             else if (encodingToolStripComboBox.Text.Equals("Unicode", StringComparison.CurrentCultureIgnoreCase))


### PR DESCRIPTION
Hello, because I am working with files in DOS Codepage 852 (Latin 2, Czech) and I missed this in the supported encodings, I have added this possibility. Please, can you pull this into your work? Thanks!

And Thanks for the great work you are doing!