### PR TITLE
Use Shown event to set focus on branch name textbox in Create Branch form

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
@@ -256,7 +256,7 @@
             this.Padding = new System.Windows.Forms.Padding(3);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Create branch";
-            this.Load += new System.EventHandler(this.FormCreateBranch_Load);
+            this.Shown += new System.EventHandler(this.FormCreateBranch_Shown);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using ResourceManager;
@@ -27,7 +26,7 @@ namespace GitUI.CommandsDialogs
                 commitPickerSmallControl1.SetSelectedCommitHash(revision == null ? Module.GetCurrentCheckout() : revision.Guid);
         }
 
-        private void FormCreateBranch_Load(object sender, EventArgs e)
+        private void FormCreateBranch_Shown(object sender, EventArgs e)
         {
             BranchNameTextBox.Focus();
         }


### PR DESCRIPTION
Use Shown event to set focus on branch name textbox in Create Branch form.

For some reason Load event is fired too early and it's effects are negated so Shown event is used instead.