### PR TITLE
Refactor and decrease time of adding submodules to dropdown list

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1178,15 +1178,6 @@ namespace GitCommands
             return new ConfigFile(_workingDir + ".gitmodules", true);
         }
 
-        public string GetCurrentSubmoduleLocalPath()
-        {
-            if (SuperprojectModule == null)
-                return null;
-            string submodulePath = WorkingDir.Substring(SuperprojectModule.WorkingDir.Length);
-            submodulePath = PathUtil.GetDirectoryName(submodulePath.ToPosixPath());
-            return submodulePath;
-        }
-
         public string GetSubmoduleNameByPath(string localPath)
         {
             var configFile = GetSubmoduleConfigFile();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3058,16 +3058,6 @@ namespace GitUI.CommandsDialogs
             return "[" + branch + "]";
         }
 
-        private ToolStripMenuItem AddSubmoduleToMenu(string name, object module)
-        {
-            var spmenu = new ToolStripMenuItem(name);
-            spmenu.Click += SubmoduleToolStripButtonClick;
-            spmenu.Width = 200;
-            spmenu.Tag = module;
-            toolStripButtonLevelUp.DropDownItems.Add(spmenu);
-            return spmenu;
-        }
-
         DateTime _previousUpdateTime;
 
         private void LoadSubmodulesIntoDropDownMenu()
@@ -3095,136 +3085,153 @@ namespace GitUI.CommandsDialogs
             return !gitSubmoduleStatus.IsDirty ? Resources.Modified : Resources.IconSubmoduleDirty;
         }
 
-        private Task GetSubmoduleStatusImageAsync(ToolStripMenuItem mi, GitModule module, string submodulePath)
+        private void AddSubmoduleStatusImageAndText(ToolStripItemInfo info, GitModule module, string submodulePath)
         {
             if (String.IsNullOrEmpty(submodulePath))
             {
-                mi.Image = Resources.IconFolderSubmodule;
-                return null;
+                info.Image = Resources.IconFolderSubmodule;
+                return;
             }
-            var token = _submodulesStatusImagesCTS.Token;
-            return Task.Factory.StartNew(() =>
+
+            var submoduleStatus = GitCommandHelpers.GetCurrentSubmoduleChanges(module, submodulePath);
+            if (submoduleStatus != null && submoduleStatus.Commit != submoduleStatus.OldCommit)
             {
-                var submoduleStatus = GitCommandHelpers.GetCurrentSubmoduleChanges(module, submodulePath);
-                if (submoduleStatus != null && submoduleStatus.Commit != submoduleStatus.OldCommit)
-                {
-                    var submodule = submoduleStatus.GetSubmodule(module);
-                    submoduleStatus.CheckSubmoduleStatus(submodule);
-                }
-                return submoduleStatus;
+                var submodule = submoduleStatus.GetSubmodule(module);
+                submoduleStatus.CheckSubmoduleStatus(submodule);
+            }
+
+            info.Image = GetItemImage(submoduleStatus);
+            if (submoduleStatus != null)
+                info.Text += submoduleStatus.AddedAndRemovedString();
+        }
+
+        private void UpdateSubmodulesList()
+        {
+            RemoveSubmoduleButtons();
+
+            _previousUpdateTime = DateTime.Now;
+            _submodulesStatusImagesCTS = new CancellationTokenSource();
+
+            var loadingItem = new ToolStripMenuItem("Loading...");
+            toolStripButtonLevelUp.DropDownItems.Add(loadingItem);
+
+            List<ToolStripItemInfo> infoItems = new List<ToolStripItemInfo>();
+
+            var token = _submodulesStatusImagesCTS.Token;
+            Task.Factory.StartNew(() =>
+            {
+                UpdateSubmodulesStatusForMenu(infoItems);
+                UpdateSuperModuleStatusForMenu(infoItems);
             }, token)
                 .ContinueWith((task) =>
                 {
-                    mi.Image = GetItemImage(task.Result);
-                    if (task.Result != null)
-                        mi.Text += task.Result.AddedAndRemovedString();
+                    var items = infoItems.ConvertAll<ToolStripItem>(i => i.createToolStripItem(200));
+                    items.Add(new ToolStripSeparator());
+
+                    var mi = new ToolStripMenuItem(updateAllSubmodulesToolStripMenuItem.Text);
+                    mi.Click += UpdateAllSubmodulesToolStripMenuItemClick;
+                    items.Add(mi);
+
+                    if (!string.IsNullOrEmpty(Module.SubmodulePath))
+                    {
+                        var usmi = new ToolStripMenuItem(_updateCurrentSubmodule.Text);
+                        usmi.Tag = Module.SubmodulePath;
+                        usmi.Click += UpdateSubmoduleToolStripMenuItemClick;
+                        items.Add(usmi);
+                    }
+
+                    toolStripButtonLevelUp.DropDownItems.Clear();
+                    toolStripButtonLevelUp.DropDownItems.AddRange(items.ToArray());
                 },
                     CancellationToken.None,
                     TaskContinuationOptions.OnlyOnRanToCompletion,
                     TaskScheduler.FromCurrentSynchronizationContext());
         }
 
-        private void UpdateSubmodulesList()
+        private void UpdateSubmodulesStatusForMenu(List<ToolStripItemInfo> infoItems)
         {
-            RemoveSubmoduleButtons();
-            _previousUpdateTime = DateTime.Now;
-            _submodulesStatusImagesCTS = new CancellationTokenSource();
-
-            foreach (var submodule in Module.GetSubmodulesLocalPathes().OrderBy(submoduleName => submoduleName))
+            var submodules = Module.GetSubmodulesLocalPathes();
+            Parallel.ForEach(submodules, submodulePath =>
             {
-                var name = submodule;
-                string path = Module.GetSubmoduleFullPath(submodule);
-                if (Settings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(path))
-                    name = name + " " + GetModuleBranch(path);
+                var module = Module.GetSubmodule(submodulePath);
+                var info = CreateModuleMenuItemInfo(submodulePath, module);
+                infoItems.Add(info);
+            });
 
-                var smi = AddSubmoduleToMenu(name, path);
-                var module = Module.GetSubmodule(submodule);
-                var submoduleName = module.GetCurrentSubmoduleLocalPath();
-                GetSubmoduleStatusImageAsync(smi, module.SuperprojectModule, submoduleName);
+            infoItems.Sort((first, second) => first.Text.CompareTo(second.Text));
+
+            if (infoItems.Count == 0)
+            {
+                var info = new ToolStripItemInfo(_noSubmodulesPresent.Text);
+                infoItems.Add(info);
+            }
+        }
+
+        private void UpdateSuperModuleStatusForMenu(List<ToolStripItemInfo> infoItems)
+        {
+            if (Module.SuperprojectModule == null)
+                return;
+
+            var info = new ToolStripItemInfo();
+            info.IsSeparator = true;
+            infoItems.Add(info);
+
+            GitModule superproject = Module.SuperprojectModule;
+            GitModule supersuperproject = Module.FindTopProjectModule();
+
+            bool hasTopProject = superproject.WorkingDir != supersuperproject.WorkingDir;
+            if (hasTopProject)
+            {
+                var displayName = "Top project: " + Path.GetFileName(Path.GetDirectoryName(supersuperproject.WorkingDir));
+                info = CreateModuleMenuItemInfo(displayName, supersuperproject);
+                infoItems.Add(info);
             }
 
-            bool containSubmodules = toolStripButtonLevelUp.DropDownItems.Count != 0;
-            if (!containSubmodules)
-                toolStripButtonLevelUp.DropDownItems.Add(_noSubmodulesPresent.Text);
+            var superProjectDisplayName = "Superproject: ";
+            if (hasTopProject)
+                superProjectDisplayName += superproject.SubmodulePath;
+            else
+                superProjectDisplayName += Path.GetFileName(Path.GetDirectoryName(supersuperproject.WorkingDir));
 
-            string currentSubmoduleName = null;
-            if (Module.SuperprojectModule != null)
+            info = CreateModuleMenuItemInfo(superProjectDisplayName, superproject);
+            infoItems.Add(info);
+
+            var submodules = supersuperproject.GetSubmodulesLocalPathes();
+            if (submodules.Any())
             {
-                var superprojectSeparator = new ToolStripSeparator();
-                toolStripButtonLevelUp.DropDownItems.Add(superprojectSeparator);
+                string currentModulePath = Module.WorkingDir.Substring(supersuperproject.WorkingDir.Length);
+                currentModulePath = PathUtil.GetDirectoryName(currentModulePath.ToPosixPath());
 
-                GitModule supersuperproject = Module.FindTopProjectModule();
-                if (Module.SuperprojectModule.WorkingDir != supersuperproject.WorkingDir)
+                var supersuperSubmodulesInfo = new List<ToolStripItemInfo>();
+                Parallel.ForEach(submodules, submodulePath =>
                 {
-                    var name = "Top project: " + Path.GetFileName(Path.GetDirectoryName(supersuperproject.WorkingDir));
-                    string path = supersuperproject.WorkingDir;
-                    if (Settings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(path))
-                        name = name + " " + GetModuleBranch(path);
+                    var module = supersuperproject.GetSubmodule(submodulePath);
+                    info = CreateModuleMenuItemInfo(submodulePath, module);
 
-                    var smi = AddSubmoduleToMenu(name, supersuperproject);
-                    smi.Image = Resources.IconFolderSubmodule;
-                }
+                    if (submodulePath == currentModulePath)
+                        info.BoldFont = true;
 
-                {
-                    var name = "Superproject: ";
-                    GitModule parentModule = Module.SuperprojectModule;
-                    string localpath = "";
-                    if (Module.SuperprojectModule.WorkingDir != supersuperproject.WorkingDir)
-                    {
-                        parentModule = supersuperproject;
-                        localpath = Module.SuperprojectModule.WorkingDir.Substring(supersuperproject.WorkingDir.Length);
-                        localpath = PathUtil.GetDirectoryName(localpath.ToPosixPath());
-                        name = name + localpath;
-                    }
-                    else
-                        name = name + Path.GetFileName(Path.GetDirectoryName(supersuperproject.WorkingDir));
-                    string path = Module.SuperprojectModule.WorkingDir;
-                    if (Settings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(path))
-                        name = name + " " + GetModuleBranch(path);
+                    supersuperSubmodulesInfo.Add(info);
+                });
 
-                    var smi = AddSubmoduleToMenu(name, Module.SuperprojectModule);
-                    GetSubmoduleStatusImageAsync(smi, parentModule, localpath);
-                }
-
-                var submodules = supersuperproject.GetSubmodulesLocalPathes().OrderBy(submoduleName => submoduleName);
-                if (submodules.Any())
-                {
-                    string localpath = Module.WorkingDir.Substring(supersuperproject.WorkingDir.Length);
-                    localpath = PathUtil.GetDirectoryName(localpath.ToPosixPath());
-
-                    foreach (var submodule in submodules)
-                    {
-                        var name = submodule;
-                        string path = supersuperproject.GetSubmoduleFullPath(submodule);
-                        if (Settings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(path))
-                            name = name + " " + GetModuleBranch(path);
-                        var submenu = AddSubmoduleToMenu(name, path);
-                        if (submodule == localpath)
-                        {
-                            currentSubmoduleName = Module.GetCurrentSubmoduleLocalPath();
-                            submenu.Font = new Font(submenu.Font, FontStyle.Bold);
-                        }
-                        var module = supersuperproject.GetSubmodule(submodule);
-                        var submoduleName = module.GetCurrentSubmoduleLocalPath();
-                        GetSubmoduleStatusImageAsync(submenu, module.SuperprojectModule, submoduleName);
-                    }
-                }
+                supersuperSubmodulesInfo.Sort((first, second) => first.Text.CompareTo(second.Text));
+                infoItems.AddRange(supersuperSubmodulesInfo);
             }
+        }
 
-            var separator = new ToolStripSeparator();
-            toolStripButtonLevelUp.DropDownItems.Add(separator);
+        private ToolStripItemInfo CreateModuleMenuItemInfo(string namePrefix, GitModule module)
+        {
+            var name = AppendModuleBranchForMenu(module, namePrefix);
+            var info = new ToolStripItemInfo(name, module, SubmoduleToolStripButtonClick);
+            AddSubmoduleStatusImageAndText(info, module.SuperprojectModule, module.SubmodulePath);
+            return info;
+        }
 
-            var mi = new ToolStripMenuItem(updateAllSubmodulesToolStripMenuItem.Text);
-            mi.Click += UpdateAllSubmodulesToolStripMenuItemClick;
-            toolStripButtonLevelUp.DropDownItems.Add(mi);
-
-            if (currentSubmoduleName != null)
-            {
-                var usmi = new ToolStripMenuItem(_updateCurrentSubmodule.Text);
-                usmi.Tag = currentSubmoduleName;
-                usmi.Click += UpdateSubmoduleToolStripMenuItemClick;
-                toolStripButtonLevelUp.DropDownItems.Add(usmi);
-            }
+        private string AppendModuleBranchForMenu(GitModule module, string name)
+        {
+            if (Settings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(module.WorkingDir))
+                name = name + " " + GetModuleBranch(module.WorkingDir);
+            return name;
         }
 
         private void toolStripButtonLevelUp_ButtonClick(object sender, EventArgs e)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Hotkey\KeysExtensions.cs" />
     <Compile Include="RepoHosts.cs" />
     <Compile Include="AutoCompletion\AutoCompleteWord.cs" />
+    <Compile Include="ToolStripItemInfo.cs" />
     <Compile Include="UserControls\BranchComboBox.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GitUI/ToolStripItemInfo.cs
+++ b/GitUI/ToolStripItemInfo.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GitUI
+{
+    /// <summary>
+    /// Data class to populate data for a ToolStripMenuItem on a non-UI thread and then convert to a ToolStripMenuItem on the UI thread.
+    /// This allows more work to be done on a background thread and additionally facilitates use of AddRange() which is MUCH quicker
+    /// than adding individual items.
+    /// </summary>
+    class ToolStripItemInfo
+    {
+        public string Text { get; set; }
+        public Image Image { get; set; }
+        public object Tag { get; set; }
+        public EventHandler ClickHandler { get; set; }
+        public bool BoldFont { get; set; }
+
+        /// <summary>
+        /// Controls whether a ToolStripSeparator is created. If true, all other fields are ignored.
+        /// </summary>
+        public bool IsSeparator { get; set; }
+
+
+        public ToolStripItemInfo() { }
+
+        public ToolStripItemInfo(string text)
+        {
+            Text = text;
+        }
+
+        public ToolStripItemInfo(string text, object tag, EventHandler clickHandler)
+        {
+            Text = text;
+            Tag = tag;
+            ClickHandler = clickHandler;
+        }
+
+        public ToolStripItem createToolStripItem(int width)
+        {
+            if (IsSeparator)
+                return new ToolStripSeparator();
+            else
+            {
+                var menuItem = new ToolStripMenuItem(Text, Image, ClickHandler);
+                menuItem.Tag = Tag;
+                menuItem.Width = width;
+                if (BoldFont)
+                    menuItem.Font = new Font(menuItem.Font, FontStyle.Bold);
+                return menuItem;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Every submodule has a new thread started to get the image for the
submodule dropdown list. This is fine for a small amount of submodules
but is very slow for a large number of submodules.

Benchmarking the time to finish populating all information for the
submodule dropdown list with 150 submodules takes about 10 seconds on
average. In addition, a large amount of the work is done on the UI
thread causing the application to not be responsive.

Refactored the code to not be in one giant function, all information
is retrieved on a background thread, and parallel threads are used to
get submodule status information. This gives about an 80% performance
increase for 150 submodules.

Other changes:
- Show a "Loading..." menu item while submodule information is being
  retrieved.
- Removed the GetCurrentSubmoduleLocalPath() function from the
  GitModule class as it was only used in the submodule dropdown code
  and does the same thing as the SubmodulePath property.
- Created a ToolStripItemInfo class to hold information for a
  ToolStripItem while on a background thread.
