### PR TITLE
Fix empty blame and file history dialogs #2822

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -182,7 +182,7 @@ namespace GitCommands
                 branchFilter = "--branches=" + BranchFilter;
 
             string arguments = String.Format(CultureInfo.InvariantCulture,
-                "log -z {2} --pretty=format:\"{1}\" {0} {3} --",
+                "log -z {2} --pretty=format:\"{1}\" {0} {3}",
                 logParam,
                 formatString,
                 branchFilter,

--- a/GitUI/UserControls/RevisionGridClasses/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormRevisionFilter.cs
@@ -81,8 +81,9 @@ namespace GitUI.RevisionGridClasses
                 filter += string.Format(" --until=\"{0}\"", Until.Value.ToString("yyyy-MM-dd hh:mm:ss"));
             if (LimitCheck.Checked && _NO_TRANSLATE_Limit.Value > 0)
                 filter += string.Format(" --max-count=\"{0}\"", (int)_NO_TRANSLATE_Limit.Value);
+            filter += " --";
             if (FileFilterCheck.Checked)
-                filter += string.Format(" -- \"{0}\"", FileFilter.Text.Replace('\\', '/'));
+                filter += string.Format(" \"{0}\"", FileFilter.Text.Replace('\\', '/'));
 
             return filter;
         }


### PR DESCRIPTION
The problem was in double `--` in the command line. The first one was added before file filter
if it's enabled, the second one was always added to the end of command line (#2700).

The problem reproduced only with `--follow` option in the command line
("Detect and follow renames"check box in Git Extensions).

The fix is to always add `--` before file filter (it doesn't matter if it's enabled or not).