### PR TITLE
Application crashes when an empty string is pasted as a commit message

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -663,12 +663,12 @@ namespace GitUI.SpellChecker
                 }
                 // remove image data from clipboard
                 var text = Clipboard.GetText();
-				// Clipboard.SetText throws exception when text is null or empty. See https://msdn.microsoft.com/en-us/library/ydby206k.aspx
-				if (!string.IsNullOrEmpty(text))
-				{
-					Clipboard.SetText(text);
-				}
-			}
+                // Clipboard.SetText throws exception when text is null or empty. See https://msdn.microsoft.com/en-us/library/ydby206k.aspx
+                if (!string.IsNullOrEmpty(text))
+                {
+                    Clipboard.SetText(text);
+                }
+            }
             else if (e.Control && !e.Alt && e.KeyCode == Keys.Z)
             {
                 UndoHighlighting();

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -662,9 +662,13 @@ namespace GitUI.SpellChecker
                     return;
                 }
                 // remove image data from clipboard
-                string text = Clipboard.GetText();
-                Clipboard.SetText(text);
-            }
+                var text = Clipboard.GetText();
+				// Clipboard.SetText throws exception when text is null or empty. See https://msdn.microsoft.com/en-us/library/ydby206k.aspx
+				if (!string.IsNullOrEmpty(text))
+				{
+					Clipboard.SetText(text);
+				}
+			}
             else if (e.Control && !e.Alt && e.KeyCode == Keys.Z)
             {
                 UndoHighlighting();


### PR DESCRIPTION
Clipboard.SetText throws exception when the text is null or empty. See https://msdn.microsoft.com/en-us/library/ydby206k.aspx