### PR TITLE
Fix quick filter and wrong graph in File History

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -112,7 +112,8 @@ namespace GitCommands
         }
 
         public RefsFiltringOptions RefsOptions = RefsFiltringOptions.All | RefsFiltringOptions.Boundary;
-        public string Filter = String.Empty;
+        public string RevisionFilter = String.Empty;
+        public string PathFilter = String.Empty;
         public string BranchFilter = String.Empty;
         public RevisionGraphInMemFilter InMemFilter;
         private string _selectedBranchName;
@@ -187,11 +188,12 @@ namespace GitCommands
                 branchFilter = "--branches=" + BranchFilter;
 
             string arguments = String.Format(CultureInfo.InvariantCulture,
-                "log -z {2} --pretty=format:\"{1}\" {0} {3}",
+                "log -z {2} --pretty=format:\"{1}\" {0} {3} -- {4}",
                 logParam,
                 formatString,
                 branchFilter,
-                Filter);
+                RevisionFilter,
+                PathFilter);
 
             Encoding logOutputEncoding = _module.LogOutputEncoding;
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -101,7 +101,8 @@ namespace GitUI.CommandsDialogs
             {
                 if (filter == null)
                     return;
-                FileChanges.FixedFilter = filter.Filter;
+                FileChanges.FixedRevisionFilter = filter.RevisionFilter;
+                FileChanges.FixedPathFilter = filter.PathFilter;
                 FileChanges.Rewriter = filter.Rewriter;
                 FileChanges.FiltredFileName = FileName;
                 FileChanges.AllowGraphWithFilter = true;
@@ -111,7 +112,8 @@ namespace GitUI.CommandsDialogs
 
         private class FixedFilterTuple
         {
-            public string Filter;
+            public string RevisionFilter;
+            public string PathFilter;
             public FollowParentRewriter Rewriter;
         }
 
@@ -162,30 +164,31 @@ namespace GitUI.CommandsDialogs
                 if (hrw.RewriteNecessary)
                 {
                     res.Rewriter = hrw;
-                    res.Filter = " " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --name-only --follow -- \"" + fileName + "\"";
+                    res.RevisionFilter = " " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --name-only --follow";
                 }
                 else
                 {
-                    res.Filter = " " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --name-only --parents -- \"" + fileName + "\"";
+                    res.RevisionFilter = " " + GitCommandHelpers.FindRenamesAndCopiesOpts() + " --name-only --parents";
                 }
-
             }
             else if (AppSettings.FollowRenamesInFileHistory)
             {
                 // history of a directory
                 // --parents doesn't work with --follow enabled, but needed to graph a filtered log
-                res.Filter = " " + GitCommandHelpers.FindRenamesOpt() + " --follow --parents -- \"" + fileName + "\"";
+                res.RevisionFilter = " " + GitCommandHelpers.FindRenamesOpt() + " --follow --parents";
             }
             else
             {
                 // rename following disabled
-                res.Filter = " --parents -- \"" + fileName + "\"";
+                res.RevisionFilter = " --parents";
             }
 
             if (AppSettings.FullHistoryInFileHistory)
             {
-                res.Filter = string.Concat(" --full-history --simplify-by-decoration ", res.Filter);
+                res.RevisionFilter = string.Concat(" --full-history --simplify-by-decoration ", res.RevisionFilter);
             }
+
+            res.PathFilter = " \"" + fileName + "\"";
 
             return res;
         }

--- a/GitUI/FilterRevisionsHelper.cs
+++ b/GitUI/FilterRevisionsHelper.cs
@@ -114,13 +114,13 @@ namespace GitUI
                 return;
             }
 
-            if ((_NO_TRANSLATE_RevisionGrid.Filter == revListArgs) &&
+            if ((_NO_TRANSLATE_RevisionGrid.QuickRevisionFilter == revListArgs) &&
                 (_NO_TRANSLATE_RevisionGrid.InMemMessageFilter == inMemMessageFilter) &&
                 (_NO_TRANSLATE_RevisionGrid.InMemCommitterFilter == inMemCommitterFilter) &&
                 (_NO_TRANSLATE_RevisionGrid.InMemAuthorFilter == inMemAuthorFilter) &&
                 (_NO_TRANSLATE_RevisionGrid.InMemFilterIgnoreCase))
                 return;
-            _NO_TRANSLATE_RevisionGrid.Filter = revListArgs;
+            _NO_TRANSLATE_RevisionGrid.QuickRevisionFilter = revListArgs;
             _NO_TRANSLATE_RevisionGrid.InMemMessageFilter = inMemMessageFilter;
             _NO_TRANSLATE_RevisionGrid.InMemCommitterFilter = inMemCommitterFilter;
             _NO_TRANSLATE_RevisionGrid.InMemAuthorFilter = inMemAuthorFilter;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -125,8 +125,9 @@ namespace GitUI
             showMergeCommitsToolStripMenuItem.Checked = AppSettings.ShowMergeCommits;
             BranchFilter = String.Empty;
             SetShowBranches();
-            Filter = "";
-            FixedFilter = "";
+            QuickRevisionFilter = "";
+            FixedRevisionFilter = "";
+            FixedPathFilter = "";
             InMemFilterIgnoreCase = true;
             InMemAuthorFilter = "";
             InMemCommitterFilter = "";
@@ -214,10 +215,13 @@ namespace GitUI
 
         [Category("Filter")]
         [DefaultValue("")]
-        public string Filter { get; set; }
+        public string QuickRevisionFilter { get; set; }
         [Category("Filter")]
         [DefaultValue("")]
-        public string FixedFilter { get; set; }
+        public string FixedRevisionFilter { get; set; }
+        [Category("Filter")]
+        [DefaultValue("")]
+        public string FixedPathFilter { get; set; }
         [Category("Filter")]
         [DefaultValue(true)]
         public bool InMemFilterIgnoreCase { get; set; }
@@ -991,8 +995,11 @@ namespace GitUI
                 else
                     revGraphIMF = filterBarIMF;
 
-                _revisionGraphCommand = new RevisionGraph(Module) { BranchFilter = BranchFilter,
-                    RefsOptions = _refsOptions, Filter = _revisionFilter.GetFilter() + Filter + FixedFilter
+                _revisionGraphCommand = new RevisionGraph(Module) {
+                    BranchFilter = BranchFilter,
+                    RefsOptions = _refsOptions,
+                    RevisionFilter = _revisionFilter.GetRevisionFilter() + QuickRevisionFilter + FixedRevisionFilter,
+                    PathFilter = _revisionFilter.GetPathFilter() + FixedPathFilter,
                 };
                 _revisionGraphCommand.Updated += GitGetCommitsCommandUpdated;
                 _revisionGraphCommand.Exited += GitGetCommitsCommandExited;
@@ -1097,7 +1104,7 @@ namespace GitUI
         internal bool FilterIsApplied(bool inclBranchFilter)
         {
             return (inclBranchFilter && !string.IsNullOrEmpty(BranchFilter)) ||
-                   !(string.IsNullOrEmpty(Filter) &&
+                   !(string.IsNullOrEmpty(QuickRevisionFilter) &&
                      !_revisionFilter.FilterEnabled() &&
                      string.IsNullOrEmpty(InMemAuthorFilter) &&
                      string.IsNullOrEmpty(InMemCommitterFilter) &&

--- a/GitUI/UserControls/RevisionGridClasses/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormRevisionFilter.cs
@@ -65,7 +65,7 @@ namespace GitUI.RevisionGridClasses
                     FileFilterCheck.Checked);
         }
 
-        public string GetFilter()
+        public string GetRevisionFilter()
         {
             var filter = "";
             if (AuthorCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Author.Text))
@@ -82,10 +82,14 @@ namespace GitUI.RevisionGridClasses
                 filter += string.Format(" --until=\"{0}\"", Until.Value.ToString("yyyy-MM-dd hh:mm:ss"));
             if (LimitCheck.Checked && _NO_TRANSLATE_Limit.Value > 0)
                 filter += string.Format(" --max-count=\"{0}\"", (int)_NO_TRANSLATE_Limit.Value);
-            filter += " --";
+            return filter;
+        }
+
+        public string GetPathFilter()
+        {
+            var filter = "";
             if (FileFilterCheck.Checked)
                 filter += string.Format(" \"{0}\"", FileFilter.Text.Replace('\\', '/'));
-
             return filter;
         }
 


### PR DESCRIPTION
The problem was in double '--' in the 'git log' command line (again :)

We have three sources for 'git log' command line:
1. FormRevisionFilter that can add '-- filename' filter
2. Quick filter that cannot filter by file name
3. FixedFilter set by FormFileHistory always adds file name

All that sources were simple concatenated in RevisionGrid to get resulting filter for 'git log' command line.
But if the first filter contained '-- filename' options, all the following options were treaded as file names.
After my last fix the first filter always added '--', so other filters didn't work.

In this commit I split one Filter string into two strings: RevisionFilter and PathFilter.
RevisionFilter contains 'git log' arguments that filter commits (--grep, --author, --since, etc.)
PathFilter contains only paths. This enables us to concatenate revision filters and path filters independently.

Closes #2700, #2822, #2854