### PR TITLE
Branch filter throws null reference exception when no repository selected

### DIFF
--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -69,19 +69,24 @@ namespace GitUI
 
             _NO_TRANSLATE_toolStripBranches.Items.Clear();
 
-            AsyncLoader.DoAsync(() => GetBranchAndTagRefs(local, tag, remote),
-                branches =>
-                {
-                    foreach (var branch in branches)
-                        _NO_TRANSLATE_toolStripBranches.Items.Add(branch);
-
-                    var autoCompleteList = _NO_TRANSLATE_toolStripBranches.AutoCompleteCustomSource.Cast<string>();
-                    if (!autoCompleteList.SequenceEqual(branches))
+            if (Module.IsValidGitWorkingDir())
+            {
+                AsyncLoader.DoAsync(() => GetBranchAndTagRefs(local, tag, remote),
+                    branches =>
                     {
-                        _NO_TRANSLATE_toolStripBranches.AutoCompleteCustomSource.Clear();
-                        _NO_TRANSLATE_toolStripBranches.AutoCompleteCustomSource.AddRange(branches.ToArray());
-                    }
-                });
+                        foreach (var branch in branches)
+                            _NO_TRANSLATE_toolStripBranches.Items.Add(branch);
+
+                        var autoCompleteList = _NO_TRANSLATE_toolStripBranches.AutoCompleteCustomSource.Cast<string>();
+                        if (!autoCompleteList.SequenceEqual(branches))
+                        {
+                            _NO_TRANSLATE_toolStripBranches.AutoCompleteCustomSource.Clear();
+                            _NO_TRANSLATE_toolStripBranches.AutoCompleteCustomSource.AddRange(branches.ToArray());
+                        }
+                    });
+            }
+
+            _NO_TRANSLATE_toolStripBranches.Enabled = Module.IsValidGitWorkingDir();
         }
 
         private List<string> GetBranchHeads(bool local, bool remote)

--- a/GitUI/Resources/ChangeLog.md
+++ b/GitUI/Resources/ChangeLog.md
@@ -4,6 +4,7 @@
 * Cherry pick selected file/selected lines.
 * Added an option to remember the ignore-white-spaces preference for all the diff viewers.
 * Fixed an intermittent bug where ObjectDisposedException occurs on launch.
+* Fixed a bug where branch filter throws null reference exception when no repository selected
 ### Version 2.48.05 (16 May 2015)
 * Fixed issue #2493: StartBrowseDialog failed after clone
 * Fixed issue #2783: Fixed crash when right click on blank line in 'File Tree'


### PR DESCRIPTION
Disable the branch filter when no repository selected. 
Fixes #2786
