### PR TITLE
Removed adding of newline after first line in commit message

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -240,6 +240,12 @@ namespace GitCommands
             set { SetBool("showerrorswhenstagingfiles", value); }
         }
 
+        public static bool AddNewlineToCommitMessageWhenMissing
+        {
+            get { return GetBool ("addnewlinetocommitmessagewhenmissing", true); }
+            set { SetBool ("addnewlinetocommitmessagewhenmissing", value); }
+        }
+
         public static string LastCommitMessage
         {
             get { return GetString("lastCommitMessage", ""); }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1558,6 +1558,8 @@ namespace GitUI.CommandsDialogs
 
             using (var textWriter = new StreamWriter(path, false, encoding))
             {
+                var addNewlineToCommitMessageWhenMissing = AppSettings.AddNewlineToCommitMessageWhenMissing;
+
                 var lineNumber = 0;
                 foreach (var line in commitMessageText.Split('\n'))
                 {
@@ -1566,8 +1568,11 @@ namespace GitUI.CommandsDialogs
                     if (!line.StartsWith("#") ||
                         string.IsNullOrEmpty(_commitTemplate))
                     {
-                        if (lineNumber == 1 && !String.IsNullOrEmpty(line))
-                            textWriter.WriteLine();
+                        if (addNewlineToCommitMessageWhenMissing)
+                        {
+                            if (lineNumber == 1 && !String.IsNullOrEmpty(line))
+                                textWriter.WriteLine();
+                        }
 
                         textWriter.WriteLine(line);
                     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -39,9 +39,11 @@
             this.chkShowCommitAndPush = new System.Windows.Forms.CheckBox();
             this.chkShowResetUnstagedChanges = new System.Windows.Forms.CheckBox();
             this.chkShowResetAllChanges = new System.Windows.Forms.CheckBox();
+            this.chkAddNewlineToCommitMessageWhenMissing = new System.Windows.Forms.CheckBox();
             this.groupBoxBehaviour.SuspendLayout();
             this.tableLayoutPanelBehaviour.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize) (this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages))
+                .BeginInit();
             this.grpAdditionalButtons.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
@@ -53,7 +55,7 @@
             this.groupBoxBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
             this.groupBoxBehaviour.Location = new System.Drawing.Point(0, 0);
             this.groupBoxBehaviour.Name = "groupBoxBehaviour";
-            this.groupBoxBehaviour.Size = new System.Drawing.Size(1146, 201);
+            this.groupBoxBehaviour.Size = new System.Drawing.Size(1302, 244);
             this.groupBoxBehaviour.TabIndex = 56;
             this.groupBoxBehaviour.TabStop = false;
             this.groupBoxBehaviour.Text = "Behaviour";
@@ -64,53 +66,62 @@
             this.tableLayoutPanelBehaviour.ColumnCount = 2;
             this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanelBehaviour.Controls.Add(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages, 1, 2);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.lblCommitDialogNumberOfPreviousMessages, 0, 2);
+            this.tableLayoutPanelBehaviour.Controls.Add(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages, 1, 3);
+            this.tableLayoutPanelBehaviour.Controls.Add(this.lblCommitDialogNumberOfPreviousMessages, 0, 3);
             this.tableLayoutPanelBehaviour.Controls.Add(this.chkShowErrorsWhenStagingFiles, 0, 0);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.chkWriteCommitMessageInCommitWindow, 0, 1);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.grpAdditionalButtons, 0, 4);
+            this.tableLayoutPanelBehaviour.Controls.Add(this.chkWriteCommitMessageInCommitWindow, 0, 2);
+            this.tableLayoutPanelBehaviour.Controls.Add(this.grpAdditionalButtons, 0, 5);
+            this.tableLayoutPanelBehaviour.Controls.Add(this.chkAddNewlineToCommitMessageWhenMissing, 0, 1);
             this.tableLayoutPanelBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tableLayoutPanelBehaviour.Location = new System.Drawing.Point(3, 17);
+            this.tableLayoutPanelBehaviour.Location = new System.Drawing.Point(3, 19);
             this.tableLayoutPanelBehaviour.Name = "tableLayoutPanelBehaviour";
-            this.tableLayoutPanelBehaviour.RowCount = 5;
+            this.tableLayoutPanelBehaviour.RowCount = 7;
             this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanelBehaviour.Size = new System.Drawing.Size(1140, 181);
+            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelBehaviour.Size = new System.Drawing.Size(1296, 222);
             this.tableLayoutPanelBehaviour.TabIndex = 57;
             // 
             // _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages
             // 
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(307, 62);
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Name = "_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages";
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(123, 21);
+            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(356, 93);
+            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Maximum = new decimal(new int[]
+            {
+                10,
+                0,
+                0,
+                0
+            });
+            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Minimum = new decimal(new int[]
+            {
+                1,
+                0,
+                0,
+                0
+            });
+            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Name =
+                "_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages";
+            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(123, 23);
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.TabIndex = 3;
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = new decimal(new int[]
+            {
+                1,
+                0,
+                0,
+                0
+            });
             // 
             // lblCommitDialogNumberOfPreviousMessages
             // 
             this.lblCommitDialogNumberOfPreviousMessages.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblCommitDialogNumberOfPreviousMessages.AutoSize = true;
-            this.lblCommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(3, 66);
+            this.lblCommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(3, 97);
             this.lblCommitDialogNumberOfPreviousMessages.Name = "lblCommitDialogNumberOfPreviousMessages";
-            this.lblCommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(229, 13);
+            this.lblCommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(261, 15);
             this.lblCommitDialogNumberOfPreviousMessages.TabIndex = 2;
             this.lblCommitDialogNumberOfPreviousMessages.Text = "Number of previous messages in commit dialog";
             // 
@@ -119,7 +130,7 @@
             this.chkShowErrorsWhenStagingFiles.AutoSize = true;
             this.chkShowErrorsWhenStagingFiles.Location = new System.Drawing.Point(3, 3);
             this.chkShowErrorsWhenStagingFiles.Name = "chkShowErrorsWhenStagingFiles";
-            this.chkShowErrorsWhenStagingFiles.Size = new System.Drawing.Size(173, 17);
+            this.chkShowErrorsWhenStagingFiles.Size = new System.Drawing.Size(186, 19);
             this.chkShowErrorsWhenStagingFiles.TabIndex = 0;
             this.chkShowErrorsWhenStagingFiles.Text = "Show errors when staging files";
             this.chkShowErrorsWhenStagingFiles.UseVisualStyleBackColor = true;
@@ -127,12 +138,13 @@
             // chkWriteCommitMessageInCommitWindow
             // 
             this.chkWriteCommitMessageInCommitWindow.AutoSize = true;
-            this.chkWriteCommitMessageInCommitWindow.Location = new System.Drawing.Point(3, 26);
+            this.chkWriteCommitMessageInCommitWindow.Location = new System.Drawing.Point(3, 53);
             this.chkWriteCommitMessageInCommitWindow.Name = "chkWriteCommitMessageInCommitWindow";
-            this.chkWriteCommitMessageInCommitWindow.Size = new System.Drawing.Size(298, 30);
+            this.chkWriteCommitMessageInCommitWindow.Size = new System.Drawing.Size(329, 34);
             this.chkWriteCommitMessageInCommitWindow.TabIndex = 1;
-            this.chkWriteCommitMessageInCommitWindow.Text = "Compose commit messages in Commit dialog\r\n(otherwise the message will be requeste" +
-    "d during commit)";
+            this.chkWriteCommitMessageInCommitWindow.Text =
+                "Compose commit messages in Commit dialog\r\n(otherwise the message will be requeste" +
+                "d during commit)";
             this.chkWriteCommitMessageInCommitWindow.UseVisualStyleBackColor = true;
             // 
             // grpAdditionalButtons
@@ -142,9 +154,9 @@
             this.tableLayoutPanelBehaviour.SetColumnSpan(this.grpAdditionalButtons, 2);
             this.grpAdditionalButtons.Controls.Add(this.flowLayoutPanel1);
             this.grpAdditionalButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpAdditionalButtons.Location = new System.Drawing.Point(3, 89);
+            this.grpAdditionalButtons.Location = new System.Drawing.Point(3, 122);
             this.grpAdditionalButtons.Name = "grpAdditionalButtons";
-            this.grpAdditionalButtons.Size = new System.Drawing.Size(1134, 89);
+            this.grpAdditionalButtons.Size = new System.Drawing.Size(1290, 97);
             this.grpAdditionalButtons.TabIndex = 5;
             this.grpAdditionalButtons.TabStop = false;
             this.grpAdditionalButtons.Text = "Show additional buttons in commit button area";
@@ -158,9 +170,9 @@
             this.flowLayoutPanel1.Controls.Add(this.chkShowResetAllChanges);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 17);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 19);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1128, 69);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1284, 75);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // chkShowCommitAndPush
@@ -168,7 +180,7 @@
             this.chkShowCommitAndPush.AutoSize = true;
             this.chkShowCommitAndPush.Location = new System.Drawing.Point(3, 3);
             this.chkShowCommitAndPush.Name = "chkShowCommitAndPush";
-            this.chkShowCommitAndPush.Size = new System.Drawing.Size(97, 17);
+            this.chkShowCommitAndPush.Size = new System.Drawing.Size(112, 19);
             this.chkShowCommitAndPush.TabIndex = 0;
             this.chkShowCommitAndPush.Text = "Commit && Push";
             this.chkShowCommitAndPush.UseVisualStyleBackColor = true;
@@ -176,9 +188,9 @@
             // chkShowResetUnstagedChanges
             // 
             this.chkShowResetUnstagedChanges.AutoSize = true;
-            this.chkShowResetUnstagedChanges.Location = new System.Drawing.Point(3, 26);
+            this.chkShowResetUnstagedChanges.Location = new System.Drawing.Point(3, 28);
             this.chkShowResetUnstagedChanges.Name = "chkShowResetUnstagedChanges";
-            this.chkShowResetUnstagedChanges.Size = new System.Drawing.Size(148, 17);
+            this.chkShowResetUnstagedChanges.Size = new System.Drawing.Size(156, 19);
             this.chkShowResetUnstagedChanges.TabIndex = 1;
             this.chkShowResetUnstagedChanges.Text = "Reset Unstaged Changes";
             this.chkShowResetUnstagedChanges.UseVisualStyleBackColor = true;
@@ -186,12 +198,23 @@
             // chkShowResetAllChanges
             // 
             this.chkShowResetAllChanges.AutoSize = true;
-            this.chkShowResetAllChanges.Location = new System.Drawing.Point(3, 49);
+            this.chkShowResetAllChanges.Location = new System.Drawing.Point(3, 53);
             this.chkShowResetAllChanges.Name = "chkShowResetAllChanges";
-            this.chkShowResetAllChanges.Size = new System.Drawing.Size(113, 17);
+            this.chkShowResetAllChanges.Size = new System.Drawing.Size(120, 19);
             this.chkShowResetAllChanges.TabIndex = 2;
             this.chkShowResetAllChanges.Text = "Reset All Changes";
             this.chkShowResetAllChanges.UseVisualStyleBackColor = true;
+            // 
+            // chkAddNewlineToCommitMessageWhenMissing
+            // 
+            this.chkAddNewlineToCommitMessageWhenMissing.AutoSize = true;
+            this.chkAddNewlineToCommitMessageWhenMissing.Location = new System.Drawing.Point(3, 28);
+            this.chkAddNewlineToCommitMessageWhenMissing.Name = "chkAddNewlineToCommitMessageWhenMissing";
+            this.chkAddNewlineToCommitMessageWhenMissing.Size = new System.Drawing.Size(347, 19);
+            this.chkAddNewlineToCommitMessageWhenMissing.TabIndex = 0;
+            this.chkAddNewlineToCommitMessageWhenMissing.Text =
+                "Ensure the second line of commit message is empty";
+            this.chkAddNewlineToCommitMessageWhenMissing.UseVisualStyleBackColor = true;
             // 
             // CommitDialogSettingsPage
             // 
@@ -200,12 +223,13 @@
             this.AutoScroll = true;
             this.Controls.Add(this.groupBoxBehaviour);
             this.Name = "CommitDialogSettingsPage";
-            this.Size = new System.Drawing.Size(1146, 421);
+            this.Size = new System.Drawing.Size(1302, 1039);
             this.groupBoxBehaviour.ResumeLayout(false);
             this.groupBoxBehaviour.PerformLayout();
             this.tableLayoutPanelBehaviour.ResumeLayout(false);
             this.tableLayoutPanelBehaviour.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).EndInit();
+            ((System.ComponentModel.ISupportInitialize) (this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages))
+                .EndInit();
             this.grpAdditionalButtons.ResumeLayout(false);
             this.grpAdditionalButtons.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -228,5 +252,6 @@
         private System.Windows.Forms.CheckBox chkShowCommitAndPush;
         private System.Windows.Forms.CheckBox chkShowResetUnstagedChanges;
         private System.Windows.Forms.CheckBox chkShowResetAllChanges;
+        private System.Windows.Forms.CheckBox chkAddNewlineToCommitMessageWhenMissing;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
@@ -14,6 +14,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void SettingsToPage()
         {
             chkShowErrorsWhenStagingFiles.Checked = AppSettings.ShowErrorsWhenStagingFiles;
+            chkAddNewlineToCommitMessageWhenMissing.Checked = AppSettings.AddNewlineToCommitMessageWhenMissing;
             chkWriteCommitMessageInCommitWindow.Checked = AppSettings.UseFormCommitMessage;
             _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = AppSettings.CommitDialogNumberOfPreviousMessages;
             chkShowCommitAndPush.Checked = AppSettings.ShowCommitAndPush;
@@ -25,6 +26,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             AppSettings.ShowErrorsWhenStagingFiles = chkShowErrorsWhenStagingFiles.Checked;
+            AppSettings.AddNewlineToCommitMessageWhenMissing = chkAddNewlineToCommitMessageWhenMissing.Checked;
             AppSettings.UseFormCommitMessage = chkWriteCommitMessageInCommitWindow.Checked;
             AppSettings.CommitDialogNumberOfPreviousMessages = (int) _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value;
             AppSettings.ShowCommitAndPush = chkShowCommitAndPush.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -586,6 +586,10 @@ Please make sure git (msysgit or cygwin) is installed or set the correct command
         <source>Reset Unstaged Changes</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
+        <source>Ensure the second line of commit message is empty</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkWriteCommitMessageInCommitWindow.Text">
         <source>Compose commit messages in Commit dialog
 (otherwise the message will be requested during commit)</source>


### PR DESCRIPTION
After migrating from svn to git we still use our old commit message guidelines. Therefore the second line is not always blank. I understand that this is convention in git, but it should not be enforced by gitextensions.