### PR TITLE
Fix bug where unable to restore the window if minimized by win+d.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -861,8 +861,8 @@ namespace GitUI.CommandsDialogs
                     _rebase = new WarningToolStripItem
                     {
                         Text = Module.InTheMiddleOfRebase()
-                                   ? _warningMiddleOfRebase.Text
-                                   : _warningMiddleOfPatchApply.Text
+                            ? _warningMiddleOfRebase.Text
+                            : _warningMiddleOfPatchApply.Text
                     };
                     _rebase.Click += RebaseClick;
                     statusStrip.Items.Add(_rebase);
@@ -878,32 +878,37 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            if (validWorkingDir && Module.InTheMiddleOfConflictedMerge() &&
-                !Directory.Exists(Module.GetGitDirectory() + "rebase-apply\\"))
-            {
-                if (_warning == null)
+            AsyncLoader.DoAsync(
+                () => validWorkingDir && Module.InTheMiddleOfConflictedMerge() &&
+                      !Directory.Exists(Module.GetGitDirectory() + "rebase-apply\\"),
+                (result) =>
                 {
-                    _warning = new WarningToolStripItem { Text = _hintUnresolvedMergeConflicts.Text };
-                    _warning.Click += WarningClick;
-                    statusStrip.Items.Add(_warning);
-                }
-            }
-            else
-            {
-                if (_warning != null)
-                {
-                    _warning.Click -= WarningClick;
-                    statusStrip.Items.Remove(_warning);
-                    _warning = null;
-                }
-            }
+                    if (result)
+                    {
+                        if (_warning == null)
+                        {
+                            _warning = new WarningToolStripItem {Text = _hintUnresolvedMergeConflicts.Text};
+                            _warning.Click += WarningClick;
+                            statusStrip.Items.Add(_warning);
+                        }
+                    }
+                    else
+                    {
+                        if (_warning != null)
+                        {
+                            _warning.Click -= WarningClick;
+                            statusStrip.Items.Remove(_warning);
+                            _warning = null;
+                        }
+                    }
 
-            //Only show status strip when there are status items on it.
-            //There is always a close (x) button, do not count first item.
-            if (statusStrip.Items.Count > 1)
-                statusStrip.Show();
-            else
-                statusStrip.Hide();
+                    //Only show status strip when there are status items on it.
+                    //There is always a close (x) button, do not count first item.
+                    if (statusStrip.Items.Count > 1)
+                        statusStrip.Show();
+                    else
+                        statusStrip.Hide();
+                });
         }
 
         /// <summary>

--- a/GitUI/Resources/ChangeLog.md
+++ b/GitUI/Resources/ChangeLog.md
@@ -5,6 +5,8 @@
 * Added an option to remember the ignore-white-spaces preference for all the diff viewers.
 * Fixed an intermittent bug where ObjectDisposedException occurs on launch.
 * Fixed a bug where branch filter throws null reference exception when no repository selected
+* Fixed a bug where unable to restore the windows after minimized by Win+M or Win+D when multiple instances of GitExtensions are running
+
 ### Version 2.48.05 (16 May 2015)
 * Fixed issue #2493: StartBrowseDialog failed after clone
 * Fixed issue #2783: Fixed crash when right click on blank line in 'File Tree'


### PR DESCRIPTION
It seems the calling of `Process.WaitForExit` on the UI thread blocks the message queue. Moving the `InTheMiddleOfConflictedMerge` (which calls `RunGitCmd` and subsequently `Process.WaitForExit`) to background thread solves the problem.

It works for me perfectly on window7 64 bits and windows8.1 64 bits
- [x] We are still able to close the window after activated, it doesn't break #2397 where the InvokeSync was introduced.
- [x] Able to minimize/restore/maximize the window from the taskbar system menu.
- [x] Able to minimize/restore/maximize the window from the window's toolbar and the menu via right click the window title
- [x] Able to restore the window from the taskbar for either single gitextensions instance and multiple instances.
- [x] Able to restore the window by ALT+TAB
- [x] Able to show the status when in middle of `Merge`, `Rebase`, `Bisect`

Fixes #2797, Fixes #2570

