### PR TITLE
Fix search for commit hash or large number in commit messages

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -222,7 +222,7 @@ namespace GitCommands
             CommitData data = new CommitData(revision.Guid, revision.TreeGuid, revision.ParentGuids.ToList().AsReadOnly(),
                 String.Format("{0} <{1}>", revision.Author, revision.AuthorEmail), revision.AuthorDate,
                 String.Format("{0} <{1}>", revision.Committer, revision.CommitterEmail), revision.CommitDate,
-                revision.Body ?? revision.Message);
+                revision.Body ?? revision.Subject);
             return data;
         }
     }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1096,7 +1096,7 @@ namespace GitCommands
             revision.MessageEncoding = lines[9];
             if (shortFormat)
             {
-                revision.Message = ReEncodeCommitMessage(lines[10], revision.MessageEncoding);
+                revision.Subject = ReEncodeCommitMessage(lines[10], revision.MessageEncoding);
             }
             else
             {
@@ -1104,7 +1104,7 @@ namespace GitCommands
 
                 //commit message is not reencoded by git when format is given
                 revision.Body = ReEncodeCommitMessage(message, revision.MessageEncoding);
-                revision.Message = revision.Body.Substring(0, revision.Body.IndexOfAny(new[] { '\r', '\n' }));
+                revision.Subject = revision.Body.Substring(0, revision.Body.IndexOfAny(new[] { '\r', '\n' }));
             }
 
             return revision;

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -27,7 +27,7 @@ namespace GitCommands
         public GitRevision(GitModule aModule, string guid)
         {
             Guid = guid;
-            Message = "";
+            Subject = "";
             _module = aModule;
         }
 
@@ -53,7 +53,7 @@ namespace GitCommands
             }
         }
 
-        public string Message { get; set; }
+        public string Subject { get; set; }
         public string Body { get; set; }
         //UTF-8 when is null or empty
         public string MessageEncoding { get; set; }
@@ -77,7 +77,7 @@ namespace GitCommands
             {
                 sha = sha.Substring(0, 4) + ".." + sha.Substring(sha.Length - 4, 4);
             }
-            return String.Format("{0}:{1}", sha, Message);
+            return String.Format("{0}:{1}", sha, Subject);
         }
 
         public bool MatchesSearchString(string searchString)
@@ -89,7 +89,7 @@ namespace GitCommands
                 return true;
 
             return (Author != null && Author.StartsWith(searchString, StringComparison.CurrentCultureIgnoreCase)) ||
-                    Message.ToLower().Contains(searchString);
+                    Subject.ToLower().Contains(searchString);
         }
 
         public bool IsArtificial()

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -239,7 +239,10 @@ namespace GitCommands
                 incompleteBlock.Append(dataBlocks[lastDataBlockIndex]);
             }
 
-            yield return incompleteBlock.ToString();
+            if (incompleteBlock.Length > 0)
+            {
+                yield return incompleteBlock.ToString();
+            }
         }
 
         private void ProccessGitLogExecuted()

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -365,7 +365,7 @@ namespace GitCommands
                     break;
 
                 case ReadStep.CommitMessage:
-                    _revision.Message = _module.ReEncodeCommitMessage(line, _revision.MessageEncoding);
+                    _revision.Subject = _module.ReEncodeCommitMessage(line, _revision.MessageEncoding);
 
                     break;
 

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -57,8 +58,6 @@ namespace GitCommands
 
         public bool ShaOnly { get; set; }
 
-        private readonly char[] _splitChars = " \t\n".ToCharArray();
-
         private readonly char[] _hexChars = "0123456789ABCDEFabcdef".ToCharArray();
 
         private const string CommitBegin = "<(__BEGIN_COMMIT__)>"; // Something unlikely to show up in a comment
@@ -68,19 +67,9 @@ namespace GitCommands
         private enum ReadStep
         {
             Commit,
-            Hash,
-            Parents,
-            Tree,
-            AuthorName,
-            AuthorEmail,
-            AuthorDate,
-            CommitterName,
-            CommitterEmail,
-            CommitterDate,
-            CommitMessageEncoding,
-            CommitMessage,
+            CommitSubject,
+            CommitBody,
             FileName,
-            Done,
         }
 
         private ReadStep _nextStep = ReadStep.Commit;
@@ -145,8 +134,9 @@ namespace GitCommands
                     /* Committer Name          */ "%cN%n" +
                     /* Committer Email         */ "%cE%n" +
                     /* Committer Date          */ "%ct%n" +
-                    /* Commit message encoding */ "%e%n" + //there is a bug: git does not recode commit message when format is given
-                    /* Commit Message          */ "%s";
+                    /* Commit message encoding */ "%e%x00" + //there is a bug: git does not recode commit message when format is given
+                    /* Commit Subject          */ "%s%x00" +
+                    /* Commit Body             */ "%B%x00";
             }
 
             // NOTE:
@@ -195,8 +185,6 @@ namespace GitCommands
                 RevisionFilter,
                 PathFilter);
 
-            Encoding logOutputEncoding = _module.LogOutputEncoding;
-
             Process p = _module.RunGitCmdDetached(arguments, GitModule.LosslessEncoding);
 
             if (taskState.IsCancellationRequested)
@@ -206,24 +194,53 @@ namespace GitCommands
             if (BeginUpdate != null)
                 BeginUpdate(this, EventArgs.Empty);
 
-            string line;
-            do
+            _nextStep = ReadStep.Commit;
+            foreach (string data in ReadDataBlocks(p.StandardOutput))
             {
-                line = p.StandardOutput.ReadLine();
-                //commit message is not encoded by git
-                if (_nextStep != ReadStep.CommitMessage)
-                    line = GitModule.ReEncodeString(line, GitModule.LosslessEncoding, logOutputEncoding);
+                if (taskState.IsCancellationRequested)
+                    break;
 
-                if (line != null)
-                {
-                    foreach (string entry in line.Split('\0'))
-                    {
-                        DataReceived(entry);
-                    }
-                }
-            } while (line != null && !taskState.IsCancellationRequested);
+                DataReceived(data);
+            }
         }
 
+        private static IEnumerable<string> ReadDataBlocks(StreamReader reader)
+        {
+            int bufferSize = 4 * 1024;
+            char[] buffer = new char[bufferSize];
+
+            StringBuilder incompleteBlock = new StringBuilder();
+            while (true)
+            {
+                int bytesRead = reader.ReadBlock(buffer, 0, bufferSize);
+                if (bytesRead == 0)
+                    break;
+
+                string bufferString = new string(buffer, 0, bytesRead);
+                string[] dataBlocks = bufferString.Split(new char[] { '\0' });
+
+                if (dataBlocks.Length > 1)
+                {
+                    // There are at least two blocks, so we can return the first one
+                    incompleteBlock.Append(dataBlocks[0]);
+                    yield return incompleteBlock.ToString();
+                    incompleteBlock.Clear();
+                }
+
+                int lastDataBlockIndex = dataBlocks.Length - 1;
+
+                // Return all the blocks until the last one 
+                for (int i = 1; i < lastDataBlockIndex; i++)
+                {
+                    yield return dataBlocks[i];
+                }
+
+                // Append the beginning of the last block
+                incompleteBlock.Append(dataBlocks[lastDataBlockIndex]);
+            }
+
+            yield return incompleteBlock.ToString();
+        }
 
         private void ProccessGitLogExecuted()
         {
@@ -275,102 +292,81 @@ namespace GitCommands
                 if (_revision.Guid.Trim(_hexChars).Length == 0 &&
                     (InMemFilter == null || InMemFilter.PassThru(_revision)))
                 {
+                    // Remove full commit message to reduce memory consumption (28% for a repo with 69K commits)
+                    // Full commit message is used in InMemFilter but later it's not needed
+                    _revision.Body = null;
+
                     RevisionCount++;
                     if (Updated != null)
                         Updated(this, new RevisionGraphUpdatedEventArgs(_revision));
                 }
             }
-            _nextStep = ReadStep.Commit;
         }
 
-        void DataReceived(string line)
+        void DataReceived(string data)
         {
-            if (line == null)
-                return;
-
-            if (line == CommitBegin)
+            if (data.StartsWith(CommitBegin))
             {
                 // a new commit finalizes the last revision
                 FinishRevision();
-
                 _nextStep = ReadStep.Commit;
             }
 
             switch (_nextStep)
             {
                 case ReadStep.Commit:
-                    // Sanity check
-                    if (line == CommitBegin)
+                    data = GitModule.ReEncodeString(data, GitModule.LosslessEncoding, _module.LogOutputEncoding);
+
+                    string[] lines = data.Split(new char[] { '\n' });
+                    Debug.Assert(lines.Length == 11);
+                    Debug.Assert(lines[0] == CommitBegin);
+
+                    _revision = new GitRevision(_module, null);
+
+                    _revision.Guid = lines[1];
                     {
-                        _revision = new GitRevision(_module, null);
+                        List<GitRef> gitRefs;
+                        if (_refs.TryGetValue(_revision.Guid, out gitRefs))
+                            _revision.Refs.AddRange(gitRefs);
                     }
-                    else
-                    {
-                        // Bail out until we see what we expect
-                        return;
-                    }
-                    break;
 
-                case ReadStep.Hash:
-                    _revision.Guid = line;
+                    _revision.ParentGuids = lines[2].Split(new char[] { ' ' });
+                    _revision.TreeGuid = lines[3];
 
-                    List<GitRef> gitRefs;
-                    if (_refs.TryGetValue(_revision.Guid, out gitRefs))
-                        _revision.Refs.AddRange(gitRefs);
-
-                    break;
-
-                case ReadStep.Parents:
-                    _revision.ParentGuids = line.Split(_splitChars, StringSplitOptions.RemoveEmptyEntries);
-                    break;
-
-                case ReadStep.Tree:
-                    _revision.TreeGuid = line;
-                    break;
-
-                case ReadStep.AuthorName:
-                    _revision.Author = line;
-                    break;
-
-                case ReadStep.AuthorEmail:
-                    _revision.AuthorEmail = line;
-                    break;
-
-                case ReadStep.AuthorDate:
+                    _revision.Author = lines[4];
+                    _revision.AuthorEmail = lines[5];
                     {
                         DateTime dateTime;
-                        if (DateTimeUtils.TryParseUnixTime(line, out dateTime))
+                        if (DateTimeUtils.TryParseUnixTime(lines[6], out dateTime))
                             _revision.AuthorDate = dateTime;
                     }
-                    break;
 
-                case ReadStep.CommitterName:
-                    _revision.Committer = line;
-                    break;
-
-                case ReadStep.CommitterEmail:
-                    _revision.CommitterEmail = line;
-                    break;
-
-                case ReadStep.CommitterDate:
+                    _revision.Committer = lines[7];
+                    _revision.CommitterEmail = lines[8];
                     {
                         DateTime dateTime;
-                        if (DateTimeUtils.TryParseUnixTime(line, out dateTime))
+                        if (DateTimeUtils.TryParseUnixTime(lines[9], out dateTime))
                             _revision.CommitDate = dateTime;
                     }
+
+                    _revision.MessageEncoding = lines[10];
                     break;
 
-                case ReadStep.CommitMessageEncoding:
-                    _revision.MessageEncoding = line;
+                case ReadStep.CommitSubject:
+                    _revision.Subject = _module.ReEncodeCommitMessage(data, _revision.MessageEncoding);
                     break;
 
-                case ReadStep.CommitMessage:
-                    _revision.Subject = _module.ReEncodeCommitMessage(line, _revision.MessageEncoding);
-
+                case ReadStep.CommitBody:
+                    _revision.Body = _module.ReEncodeCommitMessage(data, _revision.MessageEncoding);
                     break;
 
                 case ReadStep.FileName:
-                    _revision.Name = line;
+                    if (!string.IsNullOrEmpty(data))
+                    {
+                        // Git adds \n between the format string (ends with \0 in our case) 
+                        // and the first file name. So, we need to remove it from the file name.
+                        _revision.Name = data.TrimStart(new char[] { '\n' });
+                    }
                     break;
             }
 

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -57,7 +57,7 @@ namespace GitUI.CommandsDialogs
                     labelDateCaption.Text = String.Format("{0}: {1}", Strings.GetCommitDateText(), _diffSelectedRevision.CommitDate);
                     labelAuthor.Text = _diffSelectedRevision.Author;
                     gbDiffRevision.Text = _diffSelectedRevision.Guid.Substring(0, 10);
-                    labelMessage.Text = _diffSelectedRevision.Message;
+                    labelMessage.Text = _diffSelectedRevision.Subject;
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2871,7 +2871,7 @@ namespace GitUI.CommandsDialogs
             {
                 resetFileToSelectedToolStripMenuItem.Visible = true;
                 TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
-                resetFileToSelectedToolStripMenuItem.Text += " (" + revisions[0].Message.ShortenTo(50) + ")";
+                resetFileToSelectedToolStripMenuItem.Text += " (" + revisions[0].Subject.ShortenTo(50) + ")";
 
                 if (revisions[0].HasParent())
                 {
@@ -2880,7 +2880,7 @@ namespace GitUI.CommandsDialogs
                     GitRevision parentRev = RevisionGrid.GetRevision(revisions[0].ParentGuids[0]);
                     if (parentRev != null)
                     {
-                        resetFileToParentToolStripMenuItem.Text += " (" + parentRev.Message.ShortenTo(50) + ")";
+                        resetFileToParentToolStripMenuItem.Text += " (" + parentRev.Subject.ShortenTo(50) + ")";
                     }
                 }
                 else
@@ -2898,11 +2898,11 @@ namespace GitUI.CommandsDialogs
             {
                 resetFileToFirstToolStripMenuItem.Visible = true;
                 TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
-                resetFileToFirstToolStripMenuItem.Text += " (" + revisions[1].Message.ShortenTo(50) + ")";
+                resetFileToFirstToolStripMenuItem.Text += " (" + revisions[1].Subject.ShortenTo(50) + ")";
 
                 resetFileToSecondToolStripMenuItem.Visible = true;
                 TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
-                resetFileToSecondToolStripMenuItem.Text += " (" + revisions[0].Message.ShortenTo(50) + ")";
+                resetFileToSecondToolStripMenuItem.Text += " (" + revisions[0].Subject.ShortenTo(50) + ")";
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs
                 for (int i = 0; i < parents.Length; i++)
                 {
                     var item = new ListViewItem(i + 1 + "");
-                    item.SubItems.Add(parents[i].Message);
+                    item.SubItems.Add(parents[i].Subject);
                     item.SubItems.Add(parents[i].Author);
                     item.SubItems.Add(parents[i].CommitDate.ToShortDateString());
                     ParentsList.Items.Add(item);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1543,10 +1543,10 @@ namespace GitUI.CommandsDialogs
             switch (_commitKind)
             {
                 case CommitKind.Fixup:
-                    message = string.Format("fixup! {0}", _editedCommit.Message);
+                    message = string.Format("fixup! {0}", _editedCommit.Subject);
                     break;
                 case CommitKind.Squash:
-                    message = string.Format("squash! {0}", _editedCommit.Message);
+                    message = string.Format("squash! {0}", _editedCommit.Subject);
                     break;
                 default:
                     message = Module.GetMergeMessage();

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs
                 for (int i = 0; i < parents.Length; i++)
                 {
                     var item = new ListViewItem(i + 1 + "");
-                    item.SubItems.Add(parents[i].Message);
+                    item.SubItems.Add(parents[i].Subject);
                     item.SubItems.Add(parents[i].Author);
                     item.SubItems.Add(parents[i].CommitDate.ToShortDateString());
                     ParentsList.Items.Add(item);

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -213,7 +213,7 @@ namespace GitUI.Script
                         argument = argument.Replace(option, selectedRevision.Guid);
                         break;
                     case "{sMessage}":
-                        argument = argument.Replace(option, selectedRevision.Message);
+                        argument = argument.Replace(option, selectedRevision.Subject);
                         break;
                     case "{sAuthor}":
                         argument = argument.Replace(option, selectedRevision.Author);
@@ -268,7 +268,7 @@ namespace GitUI.Script
                         argument = argument.Replace(option, currentRevision.Guid);
                         break;
                     case "{cMessage}":
-                        argument = argument.Replace(option, currentRevision.Message);
+                        argument = argument.Replace(option, currentRevision.Subject);
                         break;
                     case "{cAuthor}":
                         argument = argument.Replace(option, currentRevision.Author);

--- a/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -56,7 +56,7 @@ namespace GitUI.UserControls
                     groupBox1.Text = Revision.Guid.Substring(0, 10);
                     labelAuthor.Text = string.Format("{0}", Revision.Author);
                     labelDate.Text = string.Format(Strings.GetCommitDateText() + ": {0}", Revision.CommitDate);
-                    labelMessage.Text = string.Format("{0}", Revision.Message);
+                    labelMessage.Text = string.Format("{0}", Revision.Subject);
                     
                     var tagList = Revision.Refs.Where(r => r.IsTag).ToList();
                     string tagListStr = string.Join(", ", tagList.Select(h => h.LocalName).ToArray());

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -829,14 +829,14 @@ namespace GitUI
             private static bool CheckCondition(string filter, Regex regex, string value)
             {
                 return string.IsNullOrEmpty(filter) ||
-                       ((regex != null) && regex.Match(value).Success);
+                       ((regex != null) && (value != null) && regex.Match(value).Success);
             }
 
             public override bool PassThru(GitRevision rev)
             {
                 return CheckCondition(_AuthorFilter, _AuthorFilterRegex, rev.Author) &&
                        CheckCondition(_CommitterFilter, _CommitterFilterRegex, rev.Committer) &&
-                       (CheckCondition(_MessageFilter, _MessageFilterRegex, rev.Subject) ||
+                       (CheckCondition(_MessageFilter, _MessageFilterRegex, rev.Body) ||
                         CheckCondition(_ShaFilter, _ShaFilterRegex, rev.Guid));
             }
 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -836,7 +836,7 @@ namespace GitUI
             {
                 return CheckCondition(_AuthorFilter, _AuthorFilterRegex, rev.Author) &&
                        CheckCondition(_CommitterFilter, _CommitterFilterRegex, rev.Committer) &&
-                       (CheckCondition(_MessageFilter, _MessageFilterRegex, rev.Message) ||
+                       (CheckCondition(_MessageFilter, _MessageFilterRegex, rev.Subject) ||
                         CheckCondition(_ShaFilter, _ShaFilterRegex, rev.Guid));
             }
 
@@ -1647,7 +1647,7 @@ namespace GitUI
             }
             else if (columnIndex == messageColIndex)
             {
-                e.Value = revision.Message;
+                e.Value = revision.Subject;
             }
             else if (columnIndex == authorColIndex)
             {
@@ -2462,7 +2462,7 @@ namespace GitUI
                 //Add working directory as virtual commit
                 var workingDir = new GitRevision(Module, GitRevision.UnstagedGuid)
                 {
-                    Message = Strings.GetCurrentUnstagedChanges(),
+                    Subject = Strings.GetCurrentUnstagedChanges(),
                     ParentGuids =
                         StagedChanges.Result
                             ? new[] { GitRevision.IndexGuid }
@@ -2476,7 +2476,7 @@ namespace GitUI
                 //Add index as virtual commit
                 var index = new GitRevision(Module, GitRevision.IndexGuid)
                 {
-                    Message = Strings.GetCurrentIndex(),
+                    Subject = Strings.GetCurrentIndex(),
                     ParentGuids = new[] { filtredCurrentCheckout }
                 };
                 Revisions.Add(index.Guid, index.ParentGuids, DvcsGraph.DataType.Normal, index);
@@ -2492,7 +2492,7 @@ namespace GitUI
 
         private void MessageToolStripMenuItemClick(object sender, EventArgs e)
         {
-            Clipboard.SetText(GetRevision(LastRowIndex).Message);
+            Clipboard.SetText(GetRevision(LastRowIndex).Subject);
         }
 
         private void AuthorToolStripMenuItemClick(object sender, EventArgs e)
@@ -3008,7 +3008,7 @@ namespace GitUI
         {
             var revision = GetRevision(LastRowIndex);
             CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(hashCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(revision.Guid, 15));
-            CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(messageCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(revision.Message, 30));
+            CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(messageCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(revision.Subject, 30));
             CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(authorCopyToolStripMenuItem, revision.Author);
             CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(dateCopyToolStripMenuItem, revision.CommitDate.ToString());
         }


### PR DESCRIPTION
PR #1477 added ability to find a commit by SHA hash in quick filter.
If the value in quick filter looks like a SHA hash, Git Extensions removes
--grep command line option and adds _MessageFilter and _ShaFilter
to RevisionGridInMemFilter. RevisionGridInMemFilter filters revisions
with the required SHA hash and revisions that contain the SHA hash
in the commit message (GitRevision.Message). So, it should not have
break anything. But the problem is that GitRevision.Message contains
only commit subject, not the full commit message.

In the first commit I renamed GitRevision.Message to
GitRevision.Subject to avoid such mistakes in the future.

In the second commit I added filling of GitRevision.Body (it was null) and using it
for filtering in RevisionGridInMemFilter. It's removed after filtering to
leave memory consumption on the same level.

Closes #2840