### PR TITLE
Remove the dispose so the dialog keeps open when no updates found.

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -126,7 +126,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 {
                     UpdateLabel.Text = _noUpdatesFound.Text;
                 }
-                Dispose();
             }, this);
         }
 


### PR DESCRIPTION
Leave it for the `GC` to collect since there's no particular reason that the form needs to be disposed manually.

This is an additional pull request to #2858 to fix the problem where the `FormUpdates` closes when no updates found.

See @jbialobr 's comment on #2858.

Fixes #2692