### PR TITLE
States of checkboxes in the Cherry-pick dialog are persisted to settings

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1141,6 +1141,18 @@ namespace GitCommands
             set { SetBool("UseFormCommitMessage", value); }
         }
 
+        public static bool CommitAutomaticallyAfterCherryPick
+        {
+            get { return GetBool("CommitAutomaticallyAfterCherryPick", false); }
+            set { SetBool("CommitAutomaticallyAfterCherryPick", value); }
+        }
+
+        public static bool AddCommitReferenceToCherryPick
+        {
+            get { return GetBool("AddCommitReferenceToCherryPick", false); }
+            set { SetBool("AddCommitReferenceToCherryPick", value); }
+        }
+
         public static DateTime LastUpdateCheck
         {
             get { return GetDate("LastUpdateCheck", default(DateTime)); }

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs
 {
     partial class FormCherryPick
     {
@@ -286,7 +288,8 @@
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Cherry pick commit";
-            this.Load += new System.EventHandler(this.FormCherryPickCommitSmall_Load);
+            this.Load += new System.EventHandler(this.Form_Load);
+            this.FormClosing += new FormClosingEventHandler(this.Form_Closing);
             this.mainTableLayoutPanel.ResumeLayout(false);
             this.mainTableLayoutPanel.PerformLayout();
             this.commitInformationPanel.ResumeLayout(false);


### PR DESCRIPTION
States of the checkboxes are persisted before the form closes.
Fixes #2846.