### PR TITLE
Fix infinite loop bug during undo with auto-wrap

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1939,8 +1939,14 @@ namespace GitUI.CommandsDialogs
 
         private void Message_TextChanged(object sender, EventArgs e)
         {
-            //always format from 0 to handle pasted text
-            FormatAllText(0);
+            // Format text, except when doing an undo, because
+            // this would itself introduce more steps that
+            // need to be undone.
+            if( !Message.IsUndoInProgress )
+            {
+                // always format from 0 to handle pasted text
+                FormatAllText(0);
+            }
         }
 
         private void Message_TextAssigned(object sender, EventArgs e)

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -56,6 +56,7 @@ namespace GitUI.SpellChecker
         public Font TextBoxFont { get; set; }
 
         public EventHandler TextAssigned;
+        public bool IsUndoInProgress = false;
 
         public EditNetSpell()
         {
@@ -623,12 +624,14 @@ namespace GitUI.SpellChecker
             if (!skipSelectionUndo)
                 return;
 
+            IsUndoInProgress = true;
             while (TextBox.UndoActionName.Equals("Unknown"))
             {
                 TextBox.Undo();
             }
             TextBox.Undo();
             skipSelectionUndo = false;
+            IsUndoInProgress = false;
         }
 
 


### PR DESCRIPTION
If Undo (Ctrl-Z) was used to undo a line that was created due to
auto-wrapping, the result was an infinite loop.

UndoHighlighting() invokes Undo() repeatedly, but if that undo removes
a line break introduced by auto-wrap, Message_TextChanged() runs
immediately and re-wraps it, causing UndoHighlighting() to continue
trying to undo forever.

This fixed the issue by not performing auto formatting during an undo
operation. This should not affect the resulting functionality  because
those undo operations should only restore text that has already
been auto-formatted anyway.