### PR TITLE
Feature: Syntax highlighting for commit/rebase dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommandlineHelp.resx
+++ b/GitUI/CommandsDialogs/FormCommandlineHelp.resx
@@ -135,7 +135,7 @@ clone [path]
 commit [--quiet]
 difftool filename
 filehistory filename
-fileeditor filename
+fileeditor [--syntax syntax_name] filename
 formatpatch
 gitbash
 gitignore

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -16,17 +16,23 @@ namespace GitUI.CommandsDialogs
         private string _fileName;
         private bool _formClosing = false;
 
-        public FormEditor(GitUICommands aCommands, string fileName, bool showWarning)
+        public FormEditor(GitUICommands aCommands, string fileName, bool showWarning, string highlightingSyntax)
             : base(aCommands)
         {
             InitializeComponent();
             Translate();
 
+            // set highlighting syntax
+            if (highlightingSyntax != null)
+                fileViewer.SetHighlighting(highlightingSyntax);
+
             // for translation form
             if (fileName != null)
                 OpenFile(fileName);
+
             fileViewer.TextChanged += (s, e) => HasChanges = true;
             fileViewer.TextLoaded += (s, e) => HasChanges = false;
+
             panelMessage.Visible = showWarning;
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             string editor = CommonLogic.GetGlobalEditor();
             if (string.IsNullOrEmpty(editor))
             {
-                GlobalConfigFileSettings.SetPathValue("core.editor", "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor");
+                GlobalConfigFileSettings.SetPathValue("core.editor", "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor --syntax GitCommit");
             }
 
             return true;

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -11,7 +11,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             return new Object[]
             {
-                "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor",
+                "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor --syntax GitCommit",
                 "vi",
                 "notepad",
                 GetNotepadPP(),

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -10,7 +10,6 @@ using System.Windows.Forms;
 using GitCommands;
 using GitUI.CommandsDialogs;
 using GitUI.Hotkey;
-using ICSharpCode.TextEditor.Util;
 using PatchApply;
 using GitCommands.Settings;
 using ResourceManager;
@@ -24,6 +23,7 @@ namespace GitUI.Editor
         private int _currentScrollPos = -1;
         private bool _currentViewIsPatch;
         private readonly IFileViewer _internalFileViewer;
+        private string _highlightingSyntax;
 
         public FileViewer()
         {
@@ -421,6 +421,12 @@ namespace GitUI.Editor
             _async.Load(loadPatchText, ViewPatch);
         }
 
+        public void SetHighlighting(string highlightingSyntax)
+        {
+            _highlightingSyntax = highlightingSyntax;
+            _internalFileViewer.SetHighlighting(highlightingSyntax);
+        }
+
         public void ViewText(string fileName, string text)
         {
             ResetForText(fileName);
@@ -616,7 +622,9 @@ namespace GitUI.Editor
         {
             Reset(false, true);
 
-            if (fileName == null)
+            if (_highlightingSyntax != null)
+                _internalFileViewer.SetHighlighting(_highlightingSyntax);
+            else if (fileName == null)
                 _internalFileViewer.SetHighlighting("Default");
             else
                 _internalFileViewer.SetHighlightingForFile(fileName);

--- a/GitUI/Editor/FileViewerWindows.cs
+++ b/GitUI/Editor/FileViewerWindows.cs
@@ -13,6 +13,12 @@ namespace GitUI.Editor
     {
         private readonly FindAndReplaceForm _findAndReplaceForm = new FindAndReplaceForm();
 
+        static FileViewerWindows()
+        {
+            // init custom syntax highlightings
+            HighlightingManager.Manager.AddSyntaxModeFileProvider(new GitExtensionsResourceSyntaxModeProvider());
+        }
+
         public FileViewerWindows()
         {
             InitializeComponent();

--- a/GitUI/Editor/GitExtensionsResourceSyntaxModeProvider.cs
+++ b/GitUI/Editor/GitExtensionsResourceSyntaxModeProvider.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor
+{
+    class GitExtensionsResourceSyntaxModeProvider : ISyntaxModeFileProvider
+    {
+        readonly ICollection<SyntaxMode> _syntaxModes;
+
+        public GitExtensionsResourceSyntaxModeProvider()
+        {
+            // read syntax modes
+            _syntaxModes = typeof(GitExtensionsResourceSyntaxModeProvider).Assembly
+                .GetManifestResourceNames()
+                .Where(n => n.ToUpperInvariant().EndsWith("-SYNTAXMODE.XSHD"))
+                .Select(path => new { Path = path, Name = Regex.Replace(path, ".*?([^.]+)-syntaxmode.xshd$", "$1", RegexOptions.IgnoreCase) })
+                .Select(a => new SyntaxMode(a.Path, a.Name, String.Empty))
+                .ToArray();
+        }
+
+        public XmlTextReader GetSyntaxModeFile(SyntaxMode syntaxMode)
+        {
+            return new XmlTextReader(typeof(GitExtensionsResourceSyntaxModeProvider).Assembly.GetManifestResourceStream(syntaxMode.FileName));
+        }
+
+        public ICollection<SyntaxMode> SyntaxModes
+        {
+            get { return _syntaxModes; }
+        }
+
+        public void UpdateSyntaxModeList()
+        {
+            // resources don't change during runtime
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -168,6 +168,7 @@
       <DependentUpon>CommitDialogSettingsPage.cs</DependentUpon>
     </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\EditorHelper.cs" />
+    <Compile Include="Editor\GitExtensionsResourceSyntaxModeProvider.cs" />
     <Compile Include="HelperDialogs\FormBuildServerCredentials.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1503,6 +1504,7 @@
     <None Include="Properties\DataSources\GitCommands.GitItemStatus.datasource" />
     <None Include="Properties\DataSources\GitCommands.GitRevision.datasource" />
     <None Include="Resources\Icons\User.PNG" />
+    <EmbeddedResource Include="Resources\SyntaxHighlightings\GitCommit-SyntaxMode.xshd" />
     <None Include="Translation\Czech.Plugins.xlf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1779,7 +1779,7 @@ namespace GitUI
 
         public void RunCommand(string[] args)
         {
-            var arguments = InitializeArguments(args);
+            var arguments = InitializeArguments(ref args);
 
             if (args.Length <= 1)
                 return;
@@ -2103,17 +2103,38 @@ namespace GitUI
                 StartResolveConflictsDialog();
         }
 
-        private static Dictionary<string, string> InitializeArguments(string[] args)
+        private static Dictionary<string, string> InitializeArguments(ref string[] args)
         {
             Dictionary<string, string> arguments = new Dictionary<string, string>();
 
-            for (int i = 2; i < args.Length; i++)
+            List<string> argsList = args.ToList();
+
+            for (int i = 2; i < argsList.Count; i++)
             {
-                if (args[i].StartsWith("--") && i + 1 < args.Length && !args[i + 1].StartsWith("--"))
-                    arguments.Add(args[i].TrimStart('-'), args[++i]);
-                else if (args[i].StartsWith("--"))
-                    arguments.Add(args[i].TrimStart('-'), null);
+                if (!argsList[i].StartsWith("--"))
+                    continue;
+
+                // we found argument: either flag or with value
+
+                if (i + 1 < argsList.Count && !argsList[i + 1].StartsWith("--"))
+                {
+                    arguments.Add(argsList[i].TrimStart('-'), argsList[i + 1]);
+                    argsList.RemoveRange(i, 2);
+                }
+                else
+                {
+                    arguments.Add(argsList[i].TrimStart('-'), null);
+                    argsList.RemoveAt(i);
+                }
+
+                // decrement i, so we examine Ith element again because of shift
+                i--;
             }
+
+            // return updated arguemnts list
+            if (argsList.Count != args.Length)
+                args = argsList.ToArray();
+
             return arguments;
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1869,8 +1869,10 @@ namespace GitUI
                         Module = Module.SuperprojectModule;
                     RunFileHistoryCommand(args);
                     return;
-                case "fileeditor":  // filename
-                    if (!StartFileEditorDialog(args[2]))
+                case "fileeditor":  // filename [--syntax syntax_name]
+                    string syntax;
+                    arguments.TryGetValue("syntax", out syntax);
+                    if (!StartFileEditorDialog(args[2], highlightingSyntax: syntax))
                         System.Environment.ExitCode = -1;
                     return;
                 case "formatpatch":
@@ -2057,9 +2059,9 @@ namespace GitUI
             StartRebaseDialog(branch);
         }
 
-        public bool StartFileEditorDialog(string filename, bool showWarning = false)
+        public bool StartFileEditorDialog(string filename, bool showWarning = false, string highlightingSyntax = null)
         {
-            using (var formEditor = new FormEditor(this, filename, showWarning))
+            using (var formEditor = new FormEditor(this, filename, showWarning, highlightingSyntax))
                 return formEditor.ShowDialog() != DialogResult.Cancel;
         }
 

--- a/GitUI/Resources/SyntaxHighlightings/GitCommit-SyntaxMode.xshd
+++ b/GitUI/Resources/SyntaxHighlightings/GitCommit-SyntaxMode.xshd
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<SyntaxDefinition name="GitCommit" extensions="">
+    <RuleSets>
+        <RuleSet>
+
+            <Span name="LineComment" color="Green" stopateol="true">
+                <Begin>#</Begin>
+            </Span>
+
+        </RuleSet>
+    </RuleSets>
+</SyntaxDefinition>


### PR DESCRIPTION
1. Add ability for specify syntax highlighting for GitExtensions editor via command line:
 `GitExtensions.exe fileeditor --syntax Python <path>`

2. Add simple coloring scheme `GitCommit` which has only definition for comment after #

3. Make default GitExtensions editor command line with syntax 'GitCommit'

Rebase example:

![image](https://cloud.githubusercontent.com/assets/703544/8850500/39dc7948-3151-11e5-9067-4d8464948d26.png)
