### PR TITLE
Implement support for --assume-unchanged

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1019,6 +1019,26 @@ namespace GitCommands
             return diffFiles;
         }
 
+        public static List<GitItemStatus> GetAssumeUnchangedFilesFromString(GitModule module, string lsString)
+        {
+            List<GitItemStatus> result = new List<GitItemStatus>();
+            string[] lines = lsString.SplitLines();
+            foreach (string line in lines)
+            {
+                char statusCharacter = line[0];
+                if (char.IsUpper(statusCharacter))
+                    continue;
+
+                string fileName = line.Substring(line.IndexOf(' ') + 1);
+                GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(fileName, statusCharacter);
+                gitItemStatus.IsStaged = false;
+                gitItemStatus.IsAssumeUnchanged = true;
+                result.Add(gitItemStatus);
+            }
+
+            return result;
+        }
+
         private static GitItemStatus GitItemStatusFromCopyRename(bool fromDiff, string nextfile, string fileName, char x, string status)
         {
             var gitItemStatus = new GitItemStatus();

--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -13,6 +13,7 @@ namespace GitCommands
             IsRenamed = false;
             IsCopied = false;
             IsConflict = false;
+            IsAssumeUnchanged = false;
             IsNew = false;
             IsStaged = true;
             IsSubmodule = false;
@@ -33,6 +34,7 @@ namespace GitCommands
                 else if (IsRenamed) return "Renamed";
                 else if (IsConflict) return "Conflict";
                 else if (IsCopied) return "Copied";
+                else if (IsAssumeUnchanged) return "Unchanged";
                 else return "";
             }
         }
@@ -44,6 +46,7 @@ namespace GitCommands
         public bool IsRenamed { get; set; }
         public bool IsCopied { get; set; }
         public bool IsConflict { get; set; }
+        public bool IsAssumeUnchanged { get; set; }
         public bool IsStaged { get; set; }
         public bool IsSubmodule { get; set; }
         public string RenameCopyPercentage { get; set; }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2146,16 +2146,23 @@ namespace GitCommands
             return list;
         }
 
-        public IList<GitItemStatus> GetAllChangedFiles(bool excludeIgnoredFiles = true, UntrackedFilesMode untrackedFiles = UntrackedFilesMode.Default)
+        public IList<GitItemStatus> GetAllChangedFiles(bool excludeIgnoredFiles = true, bool excludeAssumeUnchangedFiles = true, UntrackedFilesMode untrackedFiles = UntrackedFilesMode.Default)
         {
             var status = RunGitCmd(GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles, untrackedFiles));
+            List<GitItemStatus> result = GitCommandHelpers.GetAllChangedFilesFromString(this, status);
 
-            return GitCommandHelpers.GetAllChangedFilesFromString(this, status);
+            if (!excludeAssumeUnchangedFiles)
+            {
+                string lsOutput = RunGitCmd("ls-files -v");
+                result.AddRange(GitCommandHelpers.GetAssumeUnchangedFilesFromString(this, lsOutput));
+            }
+
+            return result;
         }
 
-        public IList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus(bool excludeIgnoredFiles = true, UntrackedFilesMode untrackedFiles = UntrackedFilesMode.Default)
+        public IList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus(bool excludeIgnoredFiles = true, bool excludeAssumeUnchangedFiles = true, UntrackedFilesMode untrackedFiles = UntrackedFilesMode.Default)
         {
-            var status = GetAllChangedFiles(excludeIgnoredFiles, untrackedFiles);
+            var status = GetAllChangedFiles(excludeIgnoredFiles, excludeAssumeUnchangedFiles, untrackedFiles);
             GetCurrentSubmoduleStatus(status);
             return status;
         }

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -179,7 +179,7 @@ namespace System
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
         public static string[] SplitLines(this string value)
         {
-            return value.Split(NewLineSeparator);
+            return value.Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
         }
 
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries; then trim whitespace.</summary>

--- a/GitExtensions.VS2013.sln
+++ b/GitExtensions.VS2013.sln
@@ -197,7 +197,6 @@ Global
 		{92B57383-233E-46AE-8A86-6E98BF349A72}.ReleaseTC|Mixed Platforms.Build.0 = Release|Any CPU
 		{9380C29C-3C7F-47A8-A4C9-A5EE9D7B386A}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{9380C29C-3C7F-47A8-A4C9-A5EE9D7B386A}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{9380C29C-3C7F-47A8-A4C9-A5EE9D7B386A}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{9380C29C-3C7F-47A8-A4C9-A5EE9D7B386A}.Release|Any CPU.ActiveCfg = Release|x86
 		{9380C29C-3C7F-47A8-A4C9-A5EE9D7B386A}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{9380C29C-3C7F-47A8-A4C9-A5EE9D7B386A}.Release|Mixed Platforms.Build.0 = Release|x86

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -79,6 +79,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.workingToolStripMenuItem = new System.Windows.Forms.ToolStripDropDownButton();
             this.showIgnoredFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAssumeUnchangedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showUntrackedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.deleteSelectedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -679,6 +680,7 @@ namespace GitUI.CommandsDialogs
             this.workingToolStripMenuItem.AutoToolTip = false;
             this.workingToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showIgnoredFilesToolStripMenuItem,
+            this.showAssumeUnchangedFilesToolStripMenuItem,
             this.showUntrackedFilesToolStripMenuItem,
             this.toolStripSeparator3,
             this.deleteSelectedFilesToolStripMenuItem,
@@ -701,6 +703,13 @@ namespace GitUI.CommandsDialogs
             this.showIgnoredFilesToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
             this.showIgnoredFilesToolStripMenuItem.Text = "Show ignored files";
             this.showIgnoredFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowIgnoredFilesToolStripMenuItemClick);
+            // 
+            // showAssumeUnchangedFilesToolStripMenuItem
+            // 
+            this.showAssumeUnchangedFilesToolStripMenuItem.Name = "showAssumeUnchangedFilesToolStripMenuItem";
+            this.showAssumeUnchangedFilesToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            this.showAssumeUnchangedFilesToolStripMenuItem.Text = "Show assume unchanged files";
+            this.showAssumeUnchangedFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowAssumeUnchangedFilesToolStripMenuItemClick);
             // 
             // showUntrackedFilesToolStripMenuItem
             // 
@@ -1393,6 +1402,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripProgressBar toolStripProgressBar1;
         private ToolStripDropDownButton workingToolStripMenuItem;
         private ToolStripMenuItem showIgnoredFilesToolStripMenuItem;
+        private ToolStripMenuItem showAssumeUnchangedFilesToolStripMenuItem;
         private ToolStripMenuItem showUntrackedFilesToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem deleteSelectedFilesToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -37,6 +37,8 @@ namespace GitUI.CommandsDialogs
             this.deleteFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.addFileTogitignoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.assumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.doNotAssumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.interactiveAddtoolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileTooltip = new System.Windows.Forms.ToolTip(this.components);
@@ -194,6 +196,8 @@ namespace GitUI.CommandsDialogs
             this.deleteFileToolStripMenuItem,
             this.toolStripSeparator5,
             this.addFileTogitignoreToolStripMenuItem,
+            this.assumeUnchangedToolStripMenuItem,
+            this.doNotAssumeUnchangedToolStripMenuItem,
             this.toolStripSeparator4,
             this.interactiveAddtoolStripMenuItem});
             this.UnstagedFileContext.Name = "UnstagedFileContext";
@@ -308,6 +312,21 @@ namespace GitUI.CommandsDialogs
             this.addFileTogitignoreToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.addFileTogitignoreToolStripMenuItem.Text = "Add file to .gitignore";
             this.addFileTogitignoreToolStripMenuItem.Click += new System.EventHandler(this.AddFileTogitignoreToolStripMenuItemClick);
+            // 
+            // assumeUnchangedToolStripMenuItem
+            // 
+            this.assumeUnchangedToolStripMenuItem.Name = "assumeUnchangedToolStripMenuItem";
+            this.assumeUnchangedToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.assumeUnchangedToolStripMenuItem.Text = "Assume unchanged";
+            this.assumeUnchangedToolStripMenuItem.Click += new System.EventHandler(this.AssumeUnchangedToolStripMenuItemClick);
+            // 
+            // doNotAssumeUnchangedToolStripMenuItem
+            // 
+            this.doNotAssumeUnchangedToolStripMenuItem.Name = "doNotAssumeUnchangedToolStripMenuItem";
+            this.doNotAssumeUnchangedToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.doNotAssumeUnchangedToolStripMenuItem.Text = "Do not assume unchanged";
+            this.doNotAssumeUnchangedToolStripMenuItem.Visible = false;
+            this.doNotAssumeUnchangedToolStripMenuItem.Click += new System.EventHandler(this.DoNotAssumeUnchangedToolStripMenuItemClick);
             // 
             // toolStripSeparator4
             // 
@@ -1380,6 +1399,8 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Button SolveMergeconflicts;
         private FileViewer SelectedDiff;
         private System.Windows.Forms.ToolStripMenuItem addFileTogitignoreToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem assumeUnchangedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem doNotAssumeUnchangedToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1621,6 +1621,7 @@ namespace GitUI.CommandsDialogs
         private void ShowAssumeUnchangedFilesToolStripMenuItemClick(object sender, EventArgs e)
         {
             showAssumeUnchangedFilesToolStripMenuItem.Checked = !showAssumeUnchangedFilesToolStripMenuItem.Checked;
+            doNotAssumeUnchangedToolStripMenuItem.Visible = showAssumeUnchangedFilesToolStripMenuItem.Checked;
             RescanChanges();
         }
 
@@ -1719,6 +1720,34 @@ namespace GitUI.CommandsDialogs
             var fileNames = Unstaged.SelectedItems.Select(item => item.Name).ToArray();
             if (UICommands.StartAddToGitIgnoreDialog(this, fileNames))
                 Initialize();
+        }
+
+        private void AssumeUnchangedToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            if (!Unstaged.SelectedItems.Any())
+                return;
+
+            SelectedDiff.Clear();
+            var fileNames = Unstaged.SelectedItems.Select(item => item.Name).ToArray();
+
+            bool wereErrors;
+            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.ToList(), true, out wereErrors);
+
+            Initialize();
+        }
+
+        private void DoNotAssumeUnchangedToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            if (!Unstaged.SelectedItems.Any())
+                return;
+
+            SelectedDiff.Clear();
+            var fileNames = Unstaged.SelectedItems.Select(item => item.Name).ToArray();
+
+            bool wereErrors;
+            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.ToList(), false, out wereErrors);
+
+            Initialize();
         }
 
         private void SelectedDiffExtraDiffArgumentsChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -420,6 +420,7 @@ namespace GitUI.CommandsDialogs
         {
             Func<IList<GitItemStatus>> getAllChangedFilesWithSubmodulesStatus = () => Module.GetAllChangedFilesWithSubmodulesStatus(
                     !showIgnoredFilesToolStripMenuItem.Checked,
+                    !showAssumeUnchangedFilesToolStripMenuItem.Checked,
                     showUntrackedFilesToolStripMenuItem.Checked ? UntrackedFilesMode.Default : UntrackedFilesMode.No);
 
             if (DoAsync)
@@ -1614,6 +1615,12 @@ namespace GitUI.CommandsDialogs
         private void ShowIgnoredFilesToolStripMenuItemClick(object sender, EventArgs e)
         {
             showIgnoredFilesToolStripMenuItem.Checked = !showIgnoredFilesToolStripMenuItem.Checked;
+            RescanChanges();
+        }
+
+        private void ShowAssumeUnchangedFilesToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            showAssumeUnchangedFilesToolStripMenuItem.Checked = !showAssumeUnchangedFilesToolStripMenuItem.Checked;
             RescanChanges();
         }
 


### PR DESCRIPTION
Fixes #2889 

:memo: The visibility of the context menu commands are not updated according to the current selection status. However, the **Do not assume unchanged** command only shows when the user has selected **Show assume unchanged files**.

:memo: A diff does not show for files that are assumed unchanged, even if they changed. This doesn't seem to be a problem and I wasn't sure the right way to fix it, so I left it for another time.