### PR TITLE
Feature/2709 shallow clone

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -479,7 +479,7 @@ namespace GitCommands
             return CloneCmd(fromPath, toPath, false, false, string.Empty, null);
         }
 
-        public static string CloneCmd(string fromPath, string toPath, bool central, bool initSubmodules, string branch, int? depth)
+        public static string CloneCmd(string fromPath, string toPath, bool central, bool initSubmodules, string branch, int? depth, [Optional] bool? isSingleBranch)
         {
             var from = PathUtil.IsLocalFile(fromPath) ? fromPath.ToPosixPath() : fromPath;
             var to = toPath.ToPosixPath();
@@ -490,6 +490,8 @@ namespace GitCommands
                 options.Add("--recurse-submodules");
             if (depth.HasValue)
                 options.Add("--depth " + depth);
+            if(isSingleBranch.HasValue)
+                options.Add(isSingleBranch.Value ? "--single-branch" : "--no-single-branch");
             options.Add("--progress");
             if (!string.IsNullOrEmpty(branch))
                 options.Add("--branch " + branch);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1469,7 +1469,7 @@ namespace GitCommands
             return path.Contains(Path.DirectorySeparatorChar) || path.Contains(AppSettings.PosixPathSeparator.ToString());
         }
 
-        public string FetchCmd(string remote, string remoteBranch, string localBranch, bool? fetchTags = false)
+        public string FetchCmd(string remote, string remoteBranch, string localBranch, bool? fetchTags = false, bool isUnshallow = false)
         {
             var progressOption = "";
             if (GitCommandHelpers.VersionInUse.FetchCanAskForProgress)
@@ -1478,10 +1478,10 @@ namespace GitCommands
             if (string.IsNullOrEmpty(remote) && string.IsNullOrEmpty(remoteBranch) && string.IsNullOrEmpty(localBranch))
                 return "fetch " + progressOption;
 
-            return "fetch " + progressOption + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags);
+            return "fetch " + progressOption + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow);
         }
 
-        public string PullCmd(string remote, string remoteBranch, string localBranch, bool rebase, bool? fetchTags = false)
+        public string PullCmd(string remote, string remoteBranch, string localBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false)
         {
             var pullArgs = "";
             if (GitCommandHelpers.VersionInUse.FetchCanAskForProgress)
@@ -1490,10 +1490,10 @@ namespace GitCommands
             if (rebase)
                 pullArgs = "--rebase".Combine(" ", pullArgs);
 
-            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags);
+            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow);
         }
 
-        private string GetFetchArgs(string remote, string remoteBranch, string localBranch, bool? fetchTags)
+        private string GetFetchArgs(string remote, string remoteBranch, string localBranch, bool? fetchTags, bool isUnshallow)
         {
             remote = remote.ToPosixPath();
 
@@ -1525,6 +1525,9 @@ namespace GitCommands
                 localBranchArguments = ":" + "refs/remotes/" + remote.Trim() + "/" + localBranch;
 
             string arguments = fetchTags == true ? " --tags" : fetchTags == false ? " --no-tags" : "";
+
+            if(isUnshallow)
+                arguments += " --unshallow";
 
             return "\"" + remote.Trim() + "\" " + remoteBranchArguments + localBranchArguments + arguments;
         }

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -113,7 +113,7 @@ namespace GitUI.CommandsDialogs
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(112, 30);
             this.label1.TabIndex = 0;
-            this.label1.Text = "&Repository to clone:";
+            this.label1.Text = "Repository to &clone:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_From

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.Central = new System.Windows.Forms.RadioButton();
             this.Personal = new System.Windows.Forms.RadioButton();
             this.Ok = new System.Windows.Forms.Button();
@@ -32,6 +33,7 @@ namespace GitUI.CommandsDialogs
             this.brachLabel = new System.Windows.Forms.Label();
             this.Branches = new System.Windows.Forms.ComboBox();
             this.cbIntializeAllSubmodules = new System.Windows.Forms.CheckBox();
+            this.cbDownloadFullHistory = new System.Windows.Forms.CheckBox();
             this.Info = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.CentralRepository = new System.Windows.Forms.RadioButton();
@@ -39,6 +41,7 @@ namespace GitUI.CommandsDialogs
             this.LoadSSHKey = new System.Windows.Forms.Button();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.ttHints = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -225,13 +228,27 @@ namespace GitUI.CommandsDialogs
             this.cbIntializeAllSubmodules.AutoSize = true;
             this.cbIntializeAllSubmodules.Checked = true;
             this.cbIntializeAllSubmodules.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbIntializeAllSubmodules.Location = new System.Drawing.Point(15, 258);
+            this.cbIntializeAllSubmodules.Location = new System.Drawing.Point(15, 268);
             this.cbIntializeAllSubmodules.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbIntializeAllSubmodules.Name = "cbIntializeAllSubmodules";
             this.cbIntializeAllSubmodules.Size = new System.Drawing.Size(152, 19);
             this.cbIntializeAllSubmodules.TabIndex = 3;
             this.cbIntializeAllSubmodules.Text = "Initialize all submodules";
             this.cbIntializeAllSubmodules.UseVisualStyleBackColor = true;
+            // 
+            // cbDownloadFullHistory
+            // 
+            this.cbDownloadFullHistory.AutoSize = true;
+            this.cbDownloadFullHistory.Checked = true;
+            this.cbDownloadFullHistory.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbDownloadFullHistory.Location = new System.Drawing.Point(15, 293);
+            this.cbDownloadFullHistory.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
+            this.cbDownloadFullHistory.Name = "cbDownloadFullHistory";
+            this.cbDownloadFullHistory.Size = new System.Drawing.Size(139, 19);
+            this.cbDownloadFullHistory.TabIndex = 4;
+            this.cbDownloadFullHistory.Text = "Download full &history";
+            this.ttHints.SetToolTip(this.cbDownloadFullHistory, "The default Git behavior is to download all historical revisions.\nIf you turn thi" +
+        "s off, we\'ll only download the latest revision for all branches.\n\nActual command line: --depth 1 --no-single-branch");
             // 
             // Info
             // 
@@ -302,6 +319,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.Controls.Add(this.Info);
             this.tableLayoutPanel2.Controls.Add(this.groupBox1);
             this.tableLayoutPanel2.Controls.Add(this.cbIntializeAllSubmodules);
+            this.tableLayoutPanel2.Controls.Add(this.cbDownloadFullHistory);
             this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
@@ -312,7 +330,8 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(616, 321);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(616, 356);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // tableLayoutPanel3
@@ -324,7 +343,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel3.Controls.Add(this.Ok, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.LoadSSHKey, 0, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(5, 285);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(5, 320);
             this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(5);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
@@ -338,12 +357,12 @@ namespace GitUI.CommandsDialogs
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(616, 321);
+            this.ClientSize = new System.Drawing.Size(616, 356);
             this.Controls.Add(this.tableLayoutPanel2);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(933, 360);
+            this.MaximumSize = new System.Drawing.Size(933, 395);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(430, 360);
+            this.MinimumSize = new System.Drawing.Size(430, 395);
             this.Name = "FormClone";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Clone";
@@ -375,6 +394,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Label Info;
         private System.Windows.Forms.ComboBox Branches;
         private System.Windows.Forms.CheckBox cbIntializeAllSubmodules;
+        private System.Windows.Forms.CheckBox cbDownloadFullHistory;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_From;
@@ -383,5 +403,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+        private ToolTip ttHints;
     }
 }

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -51,7 +51,7 @@ namespace GitUI.CommandsDialogs
             this.Central.Location = new System.Drawing.Point(6, 42);
             this.Central.Name = "Central";
             this.Central.Size = new System.Drawing.Size(274, 17);
-            this.Central.TabIndex = 1;
+
             this.Central.Text = "Central repository, no working directory  (--bare --shared=all)";
             this.Central.UseVisualStyleBackColor = true;
             // 
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs
             this.Personal.Location = new System.Drawing.Point(6, 19);
             this.Personal.Name = "Personal";
             this.Personal.Size = new System.Drawing.Size(114, 17);
-            this.Personal.TabIndex = 0;
+
             this.Personal.TabStop = true;
             this.Personal.Text = "Personal repository";
             this.Personal.UseVisualStyleBackColor = true;
@@ -73,7 +73,7 @@ namespace GitUI.CommandsDialogs
             this.Ok.Location = new System.Drawing.Point(488, 3);
             this.Ok.Name = "Ok";
             this.Ok.Size = new System.Drawing.Size(115, 25);
-            this.Ok.TabIndex = 1;
+
             this.Ok.Text = "Clone";
             this.Ok.UseVisualStyleBackColor = true;
             this.Ok.Click += new System.EventHandler(this.OkClick);
@@ -86,14 +86,14 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_From, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.Branches, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.FromBrowse, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.ToBrowse, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.brachLabel, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_NewDirectory, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_To, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.ToBrowse, 2, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_NewDirectory, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.brachLabel, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.Branches, 1, 3);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(610, 122);
-            this.tableLayoutPanel1.TabIndex = 26;
+
             // 
             // label1
             // 
@@ -112,7 +112,7 @@ namespace GitUI.CommandsDialogs
             this.label1.Location = new System.Drawing.Point(3, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(112, 30);
-            this.label1.TabIndex = 1;
+
             this.label1.Text = "&Repository to clone:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -125,7 +125,7 @@ namespace GitUI.CommandsDialogs
             this._NO_TRANSLATE_From.Location = new System.Drawing.Point(135, 3);
             this._NO_TRANSLATE_From.Name = "_NO_TRANSLATE_From";
             this._NO_TRANSLATE_From.Size = new System.Drawing.Size(372, 23);
-            this._NO_TRANSLATE_From.TabIndex = 2;
+
             this._NO_TRANSLATE_From.SelectedIndexChanged += new System.EventHandler(this.FromSelectedIndexChanged);
             this._NO_TRANSLATE_From.TextUpdate += new System.EventHandler(this.FromTextUpdate);
             // 
@@ -137,7 +137,7 @@ namespace GitUI.CommandsDialogs
             this.Branches.Location = new System.Drawing.Point(135, 93);
             this.Branches.Name = "Branches";
             this.Branches.Size = new System.Drawing.Size(372, 23);
-            this.Branches.TabIndex = 9;
+
             this.Branches.DropDown += new System.EventHandler(this.Branches_DropDown);
             // 
             // FromBrowse
@@ -146,7 +146,7 @@ namespace GitUI.CommandsDialogs
             this.FromBrowse.Location = new System.Drawing.Point(513, 3);
             this.FromBrowse.Name = "FromBrowse";
             this.FromBrowse.Size = new System.Drawing.Size(94, 24);
-            this.FromBrowse.TabIndex = 2;
+
             this.FromBrowse.Text = "&Browse";
             this.FromBrowse.UseVisualStyleBackColor = true;
             this.FromBrowse.Click += new System.EventHandler(this.FromBrowseClick);
@@ -157,7 +157,7 @@ namespace GitUI.CommandsDialogs
             this.ToBrowse.Location = new System.Drawing.Point(513, 33);
             this.ToBrowse.Name = "ToBrowse";
             this.ToBrowse.Size = new System.Drawing.Size(94, 24);
-            this.ToBrowse.TabIndex = 5;
+
             this.ToBrowse.Text = "B&rowse";
             this.ToBrowse.UseVisualStyleBackColor = true;
             this.ToBrowse.Click += new System.EventHandler(this.ToBrowseClick);
@@ -169,7 +169,7 @@ namespace GitUI.CommandsDialogs
             this.brachLabel.Location = new System.Drawing.Point(3, 90);
             this.brachLabel.Name = "brachLabel";
             this.brachLabel.Size = new System.Drawing.Size(47, 32);
-            this.brachLabel.TabIndex = 8;
+
             this.brachLabel.Text = "&Branch:";
             this.brachLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -180,7 +180,7 @@ namespace GitUI.CommandsDialogs
             this._NO_TRANSLATE_NewDirectory.Location = new System.Drawing.Point(135, 63);
             this._NO_TRANSLATE_NewDirectory.Name = "_NO_TRANSLATE_NewDirectory";
             this._NO_TRANSLATE_NewDirectory.Size = new System.Drawing.Size(372, 23);
-            this._NO_TRANSLATE_NewDirectory.TabIndex = 7;
+
             this._NO_TRANSLATE_NewDirectory.TextChanged += new System.EventHandler(this.NewDirectoryTextChanged);
             // 
             // label2
@@ -190,7 +190,7 @@ namespace GitUI.CommandsDialogs
             this.label2.Location = new System.Drawing.Point(3, 30);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(70, 30);
-            this.label2.TabIndex = 3;
+
             this.label2.Text = "&Destination:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -201,7 +201,7 @@ namespace GitUI.CommandsDialogs
             this.label3.Location = new System.Drawing.Point(3, 60);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(126, 30);
-            this.label3.TabIndex = 6;
+
             this.label3.Text = "&Subdirectory to create:";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -215,7 +215,7 @@ namespace GitUI.CommandsDialogs
             this._NO_TRANSLATE_To.Location = new System.Drawing.Point(135, 33);
             this._NO_TRANSLATE_To.Name = "_NO_TRANSLATE_To";
             this._NO_TRANSLATE_To.Size = new System.Drawing.Size(372, 23);
-            this._NO_TRANSLATE_To.TabIndex = 4;
+
             this._NO_TRANSLATE_To.DropDown += new System.EventHandler(this.ToDropDown);
             this._NO_TRANSLATE_To.SelectedIndexChanged += new System.EventHandler(this.ToSelectedIndexChanged);
             this._NO_TRANSLATE_To.TextUpdate += new System.EventHandler(this.ToTextUpdate);
@@ -229,7 +229,7 @@ namespace GitUI.CommandsDialogs
             this.cbIntializeAllSubmodules.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbIntializeAllSubmodules.Name = "cbIntializeAllSubmodules";
             this.cbIntializeAllSubmodules.Size = new System.Drawing.Size(152, 19);
-            this.cbIntializeAllSubmodules.TabIndex = 25;
+
             this.cbIntializeAllSubmodules.Text = "Initialize all submodules";
             this.cbIntializeAllSubmodules.UseVisualStyleBackColor = true;
             // 
@@ -243,7 +243,7 @@ namespace GitUI.CommandsDialogs
             this.Info.Margin = new System.Windows.Forms.Padding(9, 13, 9, 0);
             this.Info.Name = "Info";
             this.Info.Size = new System.Drawing.Size(598, 42);
-            this.Info.TabIndex = 10;
+
             this.Info.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // groupBox1
@@ -256,7 +256,7 @@ namespace GitUI.CommandsDialogs
             this.groupBox1.Margin = new System.Windows.Forms.Padding(9, 4, 9, 0);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(598, 68);
-            this.groupBox1.TabIndex = 11;
+
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Repository type";
             // 
@@ -266,7 +266,7 @@ namespace GitUI.CommandsDialogs
             this.CentralRepository.Location = new System.Drawing.Point(6, 42);
             this.CentralRepository.Name = "CentralRepository";
             this.CentralRepository.Size = new System.Drawing.Size(277, 19);
-            this.CentralRepository.TabIndex = 1;
+
             this.CentralRepository.Text = "P&ublic repository, no working directory  (--bare)";
             this.CentralRepository.UseVisualStyleBackColor = true;
             // 
@@ -277,7 +277,7 @@ namespace GitUI.CommandsDialogs
             this.PersonalRepository.Location = new System.Drawing.Point(6, 19);
             this.PersonalRepository.Name = "PersonalRepository";
             this.PersonalRepository.Size = new System.Drawing.Size(126, 19);
-            this.PersonalRepository.TabIndex = 0;
+
             this.PersonalRepository.TabStop = true;
             this.PersonalRepository.Text = "&Personal repository";
             this.PersonalRepository.UseVisualStyleBackColor = true;
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs
             this.LoadSSHKey.Location = new System.Drawing.Point(3, 3);
             this.LoadSSHKey.Name = "LoadSSHKey";
             this.LoadSSHKey.Size = new System.Drawing.Size(180, 25);
-            this.LoadSSHKey.TabIndex = 0;
+
             this.LoadSSHKey.Text = "&Load SSH key";
             this.LoadSSHKey.UseVisualStyleBackColor = true;
             this.LoadSSHKey.Click += new System.EventHandler(this.LoadSshKeyClick);
@@ -313,7 +313,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.Size = new System.Drawing.Size(616, 321);
-            this.tableLayoutPanel2.TabIndex = 1;
+
             // 
             // tableLayoutPanel3
             // 
@@ -330,7 +330,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(606, 31);
-            this.tableLayoutPanel3.TabIndex = 28;
+
             // 
             // FormClone
             // 

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs
 {
     partial class FormClone
     {
@@ -36,12 +38,10 @@
             this.PersonalRepository = new System.Windows.Forms.RadioButton();
             this.LoadSSHKey = new System.Windows.Forms.Button();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.panel1 = new System.Windows.Forms.Panel();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
-            this.panel1.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -225,7 +225,8 @@
             this.cbIntializeAllSubmodules.AutoSize = true;
             this.cbIntializeAllSubmodules.Checked = true;
             this.cbIntializeAllSubmodules.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbIntializeAllSubmodules.Location = new System.Drawing.Point(15, 126);
+            this.cbIntializeAllSubmodules.Location = new System.Drawing.Point(15, 258);
+            this.cbIntializeAllSubmodules.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbIntializeAllSubmodules.Name = "cbIntializeAllSubmodules";
             this.cbIntializeAllSubmodules.Size = new System.Drawing.Size(152, 19);
             this.cbIntializeAllSubmodules.TabIndex = 25;
@@ -238,9 +239,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.Info.BackColor = System.Drawing.SystemColors.Info;
             this.Info.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.Info.Location = new System.Drawing.Point(6, 10);
+            this.Info.Location = new System.Drawing.Point(9, 141);
+            this.Info.Margin = new System.Windows.Forms.Padding(9, 13, 9, 0);
             this.Info.Name = "Info";
-            this.Info.Size = new System.Drawing.Size(597, 42);
+            this.Info.Size = new System.Drawing.Size(598, 42);
             this.Info.TabIndex = 10;
             this.Info.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -250,9 +252,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.CentralRepository);
             this.groupBox1.Controls.Add(this.PersonalRepository);
-            this.groupBox1.Location = new System.Drawing.Point(9, 55);
+            this.groupBox1.Location = new System.Drawing.Point(9, 187);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(9, 4, 9, 0);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(594, 68);
+            this.groupBox1.Size = new System.Drawing.Size(598, 68);
             this.groupBox1.TabIndex = 11;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Repository type";
@@ -262,7 +265,7 @@
             this.CentralRepository.AutoSize = true;
             this.CentralRepository.Location = new System.Drawing.Point(6, 42);
             this.CentralRepository.Name = "CentralRepository";
-            this.CentralRepository.Size = new System.Drawing.Size(244, 19);
+            this.CentralRepository.Size = new System.Drawing.Size(277, 19);
             this.CentralRepository.TabIndex = 1;
             this.CentralRepository.Text = "P&ublic repository, no working directory  (--bare)";
             this.CentralRepository.UseVisualStyleBackColor = true;
@@ -295,29 +298,22 @@
             // 
             this.tableLayoutPanel2.ColumnCount = 1;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel1, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.panel1, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel1);
+            this.tableLayoutPanel2.Controls.Add(this.Info);
+            this.tableLayoutPanel2.Controls.Add(this.groupBox1);
+            this.tableLayoutPanel2.Controls.Add(this.cbIntializeAllSubmodules);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 3;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(616, 322);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(616, 321);
             this.tableLayoutPanel2.TabIndex = 1;
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.cbIntializeAllSubmodules);
-            this.panel1.Controls.Add(this.Info);
-            this.panel1.Controls.Add(this.groupBox1);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(3, 131);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(610, 147);
-            this.panel1.TabIndex = 27;
             // 
             // tableLayoutPanel3
             // 
@@ -328,7 +324,7 @@
             this.tableLayoutPanel3.Controls.Add(this.Ok, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.LoadSSHKey, 0, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(5, 286);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(5, 285);
             this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(5);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
@@ -341,7 +337,8 @@
             this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(616, 322);
+            this.AutoSize = true;
+            this.ClientSize = new System.Drawing.Size(616, 321);
             this.Controls.Add(this.tableLayoutPanel2);
             this.MaximizeBox = false;
             this.MaximumSize = new System.Drawing.Size(933, 360);
@@ -357,8 +354,6 @@
             this.groupBox1.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
             this.tableLayoutPanel3.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -387,7 +382,6 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
     }
 }

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -248,7 +248,7 @@ namespace GitUI.CommandsDialogs
             this.cbDownloadFullHistory.TabIndex = 4;
             this.cbDownloadFullHistory.Text = "Download full &history";
             this.ttHints.SetToolTip(this.cbDownloadFullHistory, "The default Git behavior is to download all historical revisions.\nIf you turn thi" +
-        "s off, we\'ll only download the latest revision for all branches.\n\nActual command line: --depth 1 --no-single-branch");
+        "s off, we\'ll only download the latest revision for all branches.\n\nActual command line (if unchecked): --depth 1 --no-single-branch");
             // 
             // Info
             // 

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -23,14 +23,14 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_From = new System.Windows.Forms.ComboBox();
-            this.Branches = new System.Windows.Forms.ComboBox();
             this.FromBrowse = new System.Windows.Forms.Button();
-            this.ToBrowse = new System.Windows.Forms.Button();
-            this.brachLabel = new System.Windows.Forms.Label();
-            this._NO_TRANSLATE_NewDirectory = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_To = new System.Windows.Forms.ComboBox();
+            this.ToBrowse = new System.Windows.Forms.Button();
+            this.label3 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_NewDirectory = new System.Windows.Forms.TextBox();
+            this.brachLabel = new System.Windows.Forms.Label();
+            this.Branches = new System.Windows.Forms.ComboBox();
             this.cbIntializeAllSubmodules = new System.Windows.Forms.CheckBox();
             this.Info = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -51,7 +51,7 @@ namespace GitUI.CommandsDialogs
             this.Central.Location = new System.Drawing.Point(6, 42);
             this.Central.Name = "Central";
             this.Central.Size = new System.Drawing.Size(274, 17);
-
+            this.Central.TabIndex = 0;
             this.Central.Text = "Central repository, no working directory  (--bare --shared=all)";
             this.Central.UseVisualStyleBackColor = true;
             // 
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs
             this.Personal.Location = new System.Drawing.Point(6, 19);
             this.Personal.Name = "Personal";
             this.Personal.Size = new System.Drawing.Size(114, 17);
-
+            this.Personal.TabIndex = 0;
             this.Personal.TabStop = true;
             this.Personal.Text = "Personal repository";
             this.Personal.UseVisualStyleBackColor = true;
@@ -73,7 +73,7 @@ namespace GitUI.CommandsDialogs
             this.Ok.Location = new System.Drawing.Point(488, 3);
             this.Ok.Name = "Ok";
             this.Ok.Size = new System.Drawing.Size(115, 25);
-
+            this.Ok.TabIndex = 0;
             this.Ok.Text = "Clone";
             this.Ok.UseVisualStyleBackColor = true;
             this.Ok.Click += new System.EventHandler(this.OkClick);
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(610, 122);
-
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
             // label1
             // 
@@ -112,7 +112,7 @@ namespace GitUI.CommandsDialogs
             this.label1.Location = new System.Drawing.Point(3, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(112, 30);
-
+            this.label1.TabIndex = 0;
             this.label1.Text = "&Repository to clone:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -125,20 +125,9 @@ namespace GitUI.CommandsDialogs
             this._NO_TRANSLATE_From.Location = new System.Drawing.Point(135, 3);
             this._NO_TRANSLATE_From.Name = "_NO_TRANSLATE_From";
             this._NO_TRANSLATE_From.Size = new System.Drawing.Size(372, 23);
-
+            this._NO_TRANSLATE_From.TabIndex = 1;
             this._NO_TRANSLATE_From.SelectedIndexChanged += new System.EventHandler(this.FromSelectedIndexChanged);
             this._NO_TRANSLATE_From.TextUpdate += new System.EventHandler(this.FromTextUpdate);
-            // 
-            // Branches
-            // 
-            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.Branches.FormattingEnabled = true;
-            this.Branches.Location = new System.Drawing.Point(135, 93);
-            this.Branches.Name = "Branches";
-            this.Branches.Size = new System.Drawing.Size(372, 23);
-
-            this.Branches.DropDown += new System.EventHandler(this.Branches_DropDown);
             // 
             // FromBrowse
             // 
@@ -146,42 +135,10 @@ namespace GitUI.CommandsDialogs
             this.FromBrowse.Location = new System.Drawing.Point(513, 3);
             this.FromBrowse.Name = "FromBrowse";
             this.FromBrowse.Size = new System.Drawing.Size(94, 24);
-
+            this.FromBrowse.TabIndex = 2;
             this.FromBrowse.Text = "&Browse";
             this.FromBrowse.UseVisualStyleBackColor = true;
             this.FromBrowse.Click += new System.EventHandler(this.FromBrowseClick);
-            // 
-            // ToBrowse
-            // 
-            this.ToBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.ToBrowse.Location = new System.Drawing.Point(513, 33);
-            this.ToBrowse.Name = "ToBrowse";
-            this.ToBrowse.Size = new System.Drawing.Size(94, 24);
-
-            this.ToBrowse.Text = "B&rowse";
-            this.ToBrowse.UseVisualStyleBackColor = true;
-            this.ToBrowse.Click += new System.EventHandler(this.ToBrowseClick);
-            // 
-            // brachLabel
-            // 
-            this.brachLabel.AutoSize = true;
-            this.brachLabel.Dock = System.Windows.Forms.DockStyle.Left;
-            this.brachLabel.Location = new System.Drawing.Point(3, 90);
-            this.brachLabel.Name = "brachLabel";
-            this.brachLabel.Size = new System.Drawing.Size(47, 32);
-
-            this.brachLabel.Text = "&Branch:";
-            this.brachLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // _NO_TRANSLATE_NewDirectory
-            // 
-            this._NO_TRANSLATE_NewDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._NO_TRANSLATE_NewDirectory.Location = new System.Drawing.Point(135, 63);
-            this._NO_TRANSLATE_NewDirectory.Name = "_NO_TRANSLATE_NewDirectory";
-            this._NO_TRANSLATE_NewDirectory.Size = new System.Drawing.Size(372, 23);
-
-            this._NO_TRANSLATE_NewDirectory.TextChanged += new System.EventHandler(this.NewDirectoryTextChanged);
             // 
             // label2
             // 
@@ -190,20 +147,9 @@ namespace GitUI.CommandsDialogs
             this.label2.Location = new System.Drawing.Point(3, 30);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(70, 30);
-
+            this.label2.TabIndex = 3;
             this.label2.Text = "&Destination:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Left;
-            this.label3.Location = new System.Drawing.Point(3, 60);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(126, 30);
-
-            this.label3.Text = "&Subdirectory to create:";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_To
             // 
@@ -215,10 +161,64 @@ namespace GitUI.CommandsDialogs
             this._NO_TRANSLATE_To.Location = new System.Drawing.Point(135, 33);
             this._NO_TRANSLATE_To.Name = "_NO_TRANSLATE_To";
             this._NO_TRANSLATE_To.Size = new System.Drawing.Size(372, 23);
-
+            this._NO_TRANSLATE_To.TabIndex = 4;
             this._NO_TRANSLATE_To.DropDown += new System.EventHandler(this.ToDropDown);
             this._NO_TRANSLATE_To.SelectedIndexChanged += new System.EventHandler(this.ToSelectedIndexChanged);
             this._NO_TRANSLATE_To.TextUpdate += new System.EventHandler(this.ToTextUpdate);
+            // 
+            // ToBrowse
+            // 
+            this.ToBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.ToBrowse.Location = new System.Drawing.Point(513, 33);
+            this.ToBrowse.Name = "ToBrowse";
+            this.ToBrowse.Size = new System.Drawing.Size(94, 24);
+            this.ToBrowse.TabIndex = 5;
+            this.ToBrowse.Text = "B&rowse";
+            this.ToBrowse.UseVisualStyleBackColor = true;
+            this.ToBrowse.Click += new System.EventHandler(this.ToBrowseClick);
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Dock = System.Windows.Forms.DockStyle.Left;
+            this.label3.Location = new System.Drawing.Point(3, 60);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(126, 30);
+            this.label3.TabIndex = 6;
+            this.label3.Text = "&Subdirectory to create:";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // _NO_TRANSLATE_NewDirectory
+            // 
+            this._NO_TRANSLATE_NewDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this._NO_TRANSLATE_NewDirectory.Location = new System.Drawing.Point(135, 63);
+            this._NO_TRANSLATE_NewDirectory.Name = "_NO_TRANSLATE_NewDirectory";
+            this._NO_TRANSLATE_NewDirectory.Size = new System.Drawing.Size(372, 23);
+            this._NO_TRANSLATE_NewDirectory.TabIndex = 7;
+            this._NO_TRANSLATE_NewDirectory.TextChanged += new System.EventHandler(this.NewDirectoryTextChanged);
+            // 
+            // brachLabel
+            // 
+            this.brachLabel.AutoSize = true;
+            this.brachLabel.Dock = System.Windows.Forms.DockStyle.Left;
+            this.brachLabel.Location = new System.Drawing.Point(3, 90);
+            this.brachLabel.Name = "brachLabel";
+            this.brachLabel.Size = new System.Drawing.Size(47, 32);
+            this.brachLabel.TabIndex = 8;
+            this.brachLabel.Text = "&Branch:";
+            this.brachLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // Branches
+            // 
+            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.Branches.FormattingEnabled = true;
+            this.Branches.Location = new System.Drawing.Point(135, 93);
+            this.Branches.Name = "Branches";
+            this.Branches.Size = new System.Drawing.Size(372, 23);
+            this.Branches.TabIndex = 9;
+            this.Branches.DropDown += new System.EventHandler(this.Branches_DropDown);
             // 
             // cbIntializeAllSubmodules
             // 
@@ -229,7 +229,7 @@ namespace GitUI.CommandsDialogs
             this.cbIntializeAllSubmodules.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbIntializeAllSubmodules.Name = "cbIntializeAllSubmodules";
             this.cbIntializeAllSubmodules.Size = new System.Drawing.Size(152, 19);
-
+            this.cbIntializeAllSubmodules.TabIndex = 3;
             this.cbIntializeAllSubmodules.Text = "Initialize all submodules";
             this.cbIntializeAllSubmodules.UseVisualStyleBackColor = true;
             // 
@@ -243,7 +243,7 @@ namespace GitUI.CommandsDialogs
             this.Info.Margin = new System.Windows.Forms.Padding(9, 13, 9, 0);
             this.Info.Name = "Info";
             this.Info.Size = new System.Drawing.Size(598, 42);
-
+            this.Info.TabIndex = 1;
             this.Info.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // groupBox1
@@ -256,7 +256,7 @@ namespace GitUI.CommandsDialogs
             this.groupBox1.Margin = new System.Windows.Forms.Padding(9, 4, 9, 0);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(598, 68);
-
+            this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Repository type";
             // 
@@ -266,7 +266,7 @@ namespace GitUI.CommandsDialogs
             this.CentralRepository.Location = new System.Drawing.Point(6, 42);
             this.CentralRepository.Name = "CentralRepository";
             this.CentralRepository.Size = new System.Drawing.Size(277, 19);
-
+            this.CentralRepository.TabIndex = 0;
             this.CentralRepository.Text = "P&ublic repository, no working directory  (--bare)";
             this.CentralRepository.UseVisualStyleBackColor = true;
             // 
@@ -277,7 +277,7 @@ namespace GitUI.CommandsDialogs
             this.PersonalRepository.Location = new System.Drawing.Point(6, 19);
             this.PersonalRepository.Name = "PersonalRepository";
             this.PersonalRepository.Size = new System.Drawing.Size(126, 19);
-
+            this.PersonalRepository.TabIndex = 1;
             this.PersonalRepository.TabStop = true;
             this.PersonalRepository.Text = "&Personal repository";
             this.PersonalRepository.UseVisualStyleBackColor = true;
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs
             this.LoadSSHKey.Location = new System.Drawing.Point(3, 3);
             this.LoadSSHKey.Name = "LoadSSHKey";
             this.LoadSSHKey.Size = new System.Drawing.Size(180, 25);
-
+            this.LoadSSHKey.TabIndex = 1;
             this.LoadSSHKey.Text = "&Load SSH key";
             this.LoadSSHKey.UseVisualStyleBackColor = true;
             this.LoadSSHKey.Click += new System.EventHandler(this.LoadSshKeyClick);
@@ -313,7 +313,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.Size = new System.Drawing.Size(616, 321);
-
+            this.tableLayoutPanel2.TabIndex = 0;
             // 
             // tableLayoutPanel3
             // 
@@ -330,7 +330,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(606, 31);
-
+            this.tableLayoutPanel3.TabIndex = 4;
             // 
             // FormClone
             // 

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -138,7 +138,7 @@ namespace GitUI.CommandsDialogs
                     Directory.CreateDirectory(dirTo);
 
                 var cloneCmd = GitCommandHelpers.CloneCmd(_NO_TRANSLATE_From.Text, dirTo,
-                            CentralRepository.Checked, cbIntializeAllSubmodules.Checked, Branches.Text, null);
+                            CentralRepository.Checked, cbIntializeAllSubmodules.Checked, Branches.Text, (cbDownloadFullHistory.Checked ? default(int?) : 1));
                 using (var fromProcess = new FormRemoteProcess(Module, AppSettings.GitCommand, cloneCmd))
                 {
                     fromProcess.SetUrlTryingToConnect(_NO_TRANSLATE_From.Text);

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -137,8 +137,22 @@ namespace GitUI.CommandsDialogs
                 if (!Directory.Exists(dirTo))
                     Directory.CreateDirectory(dirTo);
 
+                // Shallow clone params
+                int? depth = null;
+                bool? isSingleBranch = null;
+                if(!cbDownloadFullHistory.Checked)
+                {
+                    depth = 1;
+                    // Single branch considerations:
+                    // If neither depth nor single-branch family params are specified, then it's like no-single-branch by default.
+                    // If depth is specified, then single-branch is assumed.
+                    // But with single-branch it's really nontrivial to switch to another branch in the GUI, and it's very hard in cmdline (obvious choices to fetch another branch lead to local repo corruption).
+                    // So let's reset it to no-single-branch to (a) have the same branches behavior as with full clone, and (b) make it easier for users when switching branches.
+                    isSingleBranch = false;
+                }
+
                 var cloneCmd = GitCommandHelpers.CloneCmd(_NO_TRANSLATE_From.Text, dirTo,
-                            CentralRepository.Checked, cbIntializeAllSubmodules.Checked, Branches.Text, (cbDownloadFullHistory.Checked ? default(int?) : 1));
+                            CentralRepository.Checked, cbIntializeAllSubmodules.Checked, Branches.Text, depth, isSingleBranch);
                 using (var fromProcess = new FormRemoteProcess(Module, AppSettings.GitCommand, cloneCmd))
                 {
                     fromProcess.SetUrlTryingToConnect(_NO_TRANSLATE_From.Text);

--- a/GitUI/CommandsDialogs/FormClone.resx
+++ b/GitUI/CommandsDialogs/FormClone.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ttHints.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -61,6 +61,7 @@
             this.AutoStash = new System.Windows.Forms.CheckBox();
             this.AddRemote = new System.Windows.Forms.Button();
             this.folderBrowserButton1 = new GitUI.UserControls.FolderBrowserButton();
+            this.Unshallow = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -192,12 +193,14 @@
             this.tableLayoutPanel2.Controls.Add(this.groupBox1, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this.groupBox3, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.groupBox4, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.Unshallow, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 5);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 5;
+            this.tableLayoutPanel2.RowCount = 6;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -375,7 +378,7 @@
             this.groupBox4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox4.Size = new System.Drawing.Size(768, 155);
+            this.groupBox4.Size = new System.Drawing.Size(768, 130);
             this.groupBox4.TabIndex = 15;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Tag options";
@@ -517,6 +520,17 @@
             this.folderBrowserButton1.Size = new System.Drawing.Size(188, 31);
             this.folderBrowserButton1.TabIndex = 5;
             // 
+            // Unshallow
+            // 
+            this.Unshallow.AutoSize = true;
+            this.Unshallow.Margin = new System.Windows.Forms.Padding(9, 3, 3, 3);
+            this.Unshallow.Name = "Unshallow";
+            this.Unshallow.Size = new System.Drawing.Size(139, 19);
+            this.Unshallow.TabIndex = 20;
+            this.Unshallow.Text = "Download full history";
+            this.Tooltip.SetToolTip(this.Unshallow, "Fetches as much history from the remote source as possible.\nIf full history is available (if the source is not a shallow clone itself), then this repo will be a shallow clone no more.\n\nActual command line (if checked): --unshallow");
+            this.Unshallow.Visible = false;
+            // 
             // FormPull
             // 
             this.AcceptButton = this.Pull;
@@ -589,5 +603,6 @@
         private System.Windows.Forms.GroupBox groupBox4;
         private System.Windows.Forms.Button AddRemote;
         private UserControls.FolderBrowserButton folderBrowserButton1;
+        private System.Windows.Forms.CheckBox Unshallow;
     }
 }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -123,6 +123,15 @@ namespace GitUI.CommandsDialogs
             {
                 Branches.Text = defaultRemoteBranch;
             }
+
+            // If this repo is shallow, show an option to Unshallow
+            if(aCommands != null)
+            {
+                // Detect by presence of the shallow file, not 100% sure it's the best way, but it's created upon shallow cloning and removed upon unshallowing
+                bool isRepoShallow = File.Exists(Path.Combine(aCommands.Module.GetGitDirectory(), "shallow"));
+                if(isRepoShallow)
+                    Unshallow.Visible = true;
+            }
         }
 
         private void Init(string defaultRemote)
@@ -455,12 +464,12 @@ namespace GitUI.CommandsDialogs
         {
             if (Fetch.Checked)
             {
-                return new FormRemoteProcess(Module, Module.FetchCmd(source, curRemoteBranch, curLocalBranch, GetTagsArg()));
+                return new FormRemoteProcess(Module, Module.FetchCmd(source, curRemoteBranch, curLocalBranch, GetTagsArg(), Unshallow.Checked));
             }
 
             Debug.Assert(Merge.Checked || Rebase.Checked);
 
-            return new FormRemoteProcess(Module, Module.PullCmd(source, curRemoteBranch, curLocalBranch, Rebase.Checked, GetTagsArg()))
+            return new FormRemoteProcess(Module, Module.PullCmd(source, curRemoteBranch, curLocalBranch, Rebase.Checked, GetTagsArg(), Unshallow.Checked))
                        {
                            HandleOnExitCallback = HandlePullOnExit
                        };


### PR DESCRIPTION
Implemented #2709:

— A checkbox in the Clone dialog:
![untitled20150812183506](https://cloud.githubusercontent.com/assets/2332070/9228390/ee24e12c-4120-11e5-96cf-3028b2172dff.png)

— A checkbox in the Pull dialog to unshallow (only in shallow repos):
![untitled20150812183631](https://cloud.githubusercontent.com/assets/2332070/9228419/14f726e8-4121-11e5-8a0a-b59b030c3a5c.png)

Both with tooltips, incl specific cmdline options that they're going to use.