### PR TITLE
{WorkingDir} Parameter for Scripts 

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -16,6 +16,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _scriptSettingsPageHelpDisplayContent = new TranslationString(@"User Input:
 {UserInput}
 
+Working Dir:
+{WorkingDir}
+
 Selected Commits:
 {sHashes}
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -85,7 +85,6 @@ namespace GitUI.Script
             string argument = scriptInfo.Arguments;
 
             string command = OverrideCommandWhenNecessary(originalCommand);
-
             var allSelectedRevisions = new List<GitRevision>();
 
             GitRevision selectedRevision = null;
@@ -316,8 +315,12 @@ namespace GitUI.Script
                             argument = argument.Replace(option, Prompt.UserInput);
                         }
                         break;
+                    case "{WorkingDir}":
+                        argument = argument.Replace(option, aModule.WorkingDir);
+                        break;
                 }
             }
+            command = ExpandCommandVariables(command,aModule);
 
             if (!scriptInfo.RunInBackground)
                 FormProcess.ShowDialog(owner, command, argument, aModule.WorkingDir, null, true);
@@ -329,6 +332,12 @@ namespace GitUI.Script
                     aModule.RunExternalCmdDetached(command, argument);
             }
             return !scriptInfo.RunInBackground;
+        }
+
+        private static string ExpandCommandVariables(string originalCommand, GitModule aModule)
+        {
+            return originalCommand.Replace("{WorkingDir}", aModule.WorkingDir);
+           
         }
 
         private static GitRevision CalculateSelectedRevision(RevisionGrid revisionGrid, List<GitRef> selectedRemoteBranches,
@@ -426,7 +435,8 @@ namespace GitUI.Script
                         "{cDefaultRemote}",
                         "{cDefaultRemoteUrl}",
                         "{cDefaultRemotePathFromUrl}",
-                        "{UserInput}"
+                        "{UserInput}",
+                        "{WorkingDir}"
                     };
                 return options;
             }


### PR DESCRIPTION
{WorkingDir} Parameter could be used even in the script path to be able to call the scripts saved in the repository folder (needed for relative path) or pass the folder as parameter to scripts.
