### PR TITLE
Bugfix for wrong urlPrefix when Collection is used

### DIFF
--- a/Plugins/BuildServerIntegration/TfsInterop.Common/TfsHelper.cs
+++ b/Plugins/BuildServerIntegration/TfsInterop.Common/TfsHelper.cs
@@ -60,7 +60,7 @@ namespace TfsInterop
                 else
                 {
                     url = "http://" + _hostname + ":8080/tfs/" + teamCollection;
-                    _urlPrefix = "http://" + hostname + ":8080/tfs/Build/Build.aspx?artifactMoniker=";
+                    _urlPrefix = "http://" + hostname + ":8080/tfs/"+(String.IsNullOrEmpty(teamCollection)? "" : teamCollection+"/")+"Build/Build.aspx?artifactMoniker=";
                 }
 
                 _tfsCollection = new TfsTeamProjectCollection(new Uri(url), new TfsClientCredentials());


### PR DESCRIPTION
When Collection is used on TFS, the prefix is wrong for the Moniker. The url must have collection name inside it.