### PR TITLE
Feature #2289 – Sparse Checkout

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -214,6 +214,7 @@ namespace GitUI.CommandsDialogs
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.commitcountPerUserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gitcommandLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuitemSparse = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.cherryPickSelectedDiffFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 #if !__MonoCS__ || Mono212Released //waiting for mono 2.12
@@ -1307,6 +1308,7 @@ namespace GitUI.CommandsDialogs
             this.editgitignoreToolStripMenuItem1,
             this.editgitattributesToolStripMenuItem,
             this.editmailmapToolStripMenuItem,
+            this.menuitemSparse,
             this.toolStripSeparator4,
             this.gitMaintenanceToolStripMenuItem,
             this.repoSettingsToolStripMenuItem,
@@ -1945,6 +1947,13 @@ namespace GitUI.CommandsDialogs
             this.menuStrip1.Size = new System.Drawing.Size(1154, 28);
             this.menuStrip1.TabIndex = 3;
             // 
+            // menuitemSparse
+            // 
+            this.menuitemSparse.Name = "menuitemSparse";
+            this.menuitemSparse.Size = new System.Drawing.Size(221, 22);
+            this.menuitemSparse.Text = "Sparse Working Copy…";
+            this.menuitemSparse.Click += new System.EventHandler(this.menuitemSparseWorkingCopy_Click);
+            // 
             // commitcountPerUserToolStripMenuItem
             // 
             this.commitcountPerUserToolStripMenuItem.Image = global::GitUI.Properties.Resources.statistic;
@@ -2233,5 +2242,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem gitcommandLogToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator7;
         private ToolStripMenuItem cherryPickSelectedDiffFileToolStripMenuItem;
+        private ToolStripMenuItem menuitemSparse;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3373,5 +3373,10 @@ namespace GitUI.CommandsDialogs
             }
             base.Dispose(disposing);
         }
+
+        private void menuitemSparseWorkingCopy_Click(object sender, EventArgs e)
+        {
+            UICommands.StartSparseWorkingCopyDialog(this);
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+using GitCommands;
+
+using GitUI.Editor;
+
+using JetBrains.Annotations;
+
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs
+{
+    public sealed class FormSparseWorkingCopy : GitModuleForm
+    {
+        private IDisposable _disposable1;
+
+        public FormSparseWorkingCopy(GitUICommands aCommands)
+            : base(aCommands)
+        {
+            CreateView(new FormSparseWorkingCopyViewModel(aCommands));
+            Translate();
+        }
+
+        private void BindSaveOnClose(FormSparseWorkingCopyViewModel sparse)
+        {
+            Closing += (sender, args) =>
+            {
+                try
+                {
+                    // Save on OK — even if not dirty, to upd the rules if checkbox is ON
+                    if(DialogResult == DialogResult.OK)
+                    {
+                        sparse.SaveChanges();
+                        return;
+                    }
+
+                    // Closing/canceling, prompt to save if dirty
+                    if(sparse.IsWithUnsavedChanges())
+                    {
+                        switch(MessageBox.Show(this, Globalized.Strings.YouHaveMadeChangesToSettingsOrRulesWouldYouLikeToSaveThem.Text, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.Cancel.Text, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
+                        {
+                        case DialogResult.Yes:
+                            sparse.SaveChanges();
+                            break;
+                        case DialogResult.No:
+                            // Just exit
+                            break;
+                        default:
+                            // Cancel, or error
+                            args.Cancel = true;
+                            break;
+                        }
+                    }
+                }
+                catch(Exception ex)
+                {
+                    MessageBox.Show(ActiveForm, Globalized.Strings.CouldNotSave.Text + "\n\n" + ex.Message, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.SaveFile.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            };
+        }
+
+        private void CreateView(FormSparseWorkingCopyViewModel sparse)
+        {
+            Text = Globalized.Strings.SparseWorkingCopy.Text;
+            AutoScaleMode = AutoScaleMode.Dpi;
+            StartPosition = FormStartPosition.CenterParent;
+            MinimumSize = new Size(800, 600);
+
+            // Tooltips support for the form
+            var componentcontainer = new Container();
+            _disposable1 = componentcontainer;
+            var tooltip = new ToolTip(componentcontainer) {AutomaticDelay = (int)TimeSpan.FromSeconds(10).TotalMilliseconds};
+
+            Panel panelHeader = CreateViewHeader();
+
+            Button btnSave;
+            Button btnCancel;
+            Panel panelFooter = CreateViewFooter(sparse, tooltip, out btnSave, out btnCancel);
+
+            Control panelOnOff = CreateViewOnOff(sparse, tooltip);
+
+            Panel panelRules = CreateViewRules(sparse, tooltip, this);
+
+            sparse.FirePropertyChanged(); // Initial binding
+
+            Controls.Add(new TableLayoutPanel() {Dock = DockStyle.Fill, Padding = Padding.Empty, Margin = Padding.Empty, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, Controls = {panelHeader, CreateViewSeparator(), panelOnOff, panelRules, CreateViewSeparator(), panelFooter}, RowStyles = {new RowStyle(), new RowStyle(), new RowStyle(), new RowStyle(SizeType.Percent, 100)}});
+
+            AcceptButton = btnSave;
+            CancelButton = btnCancel;
+
+            BindSaveOnClose(sparse);
+
+            // Special binding: as the editor takes Enter for itself, bind Ctrl+Enter to commit
+            KeyPreview = true;
+            PreviewKeyDown += (sender, args) =>
+            {
+                if(args.KeyData == (Keys.Enter | Keys.Control))
+                {
+                    DialogResult = DialogResult.OK;
+                    Close();
+                }
+            };
+        }
+
+        private static Panel CreateViewFooter(FormSparseWorkingCopyViewModel sparse, ToolTip tooltip, out Button btnSave, out Button btnCancel)
+        {
+            var tableFooterButtons = new TableLayoutPanel() {BackColor = SystemColors.ControlLightLight, Dock = DockStyle.Fill, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, ColumnCount = 4, RowCount = 1, Margin = Padding.Empty, ColumnStyles = {new ColumnStyle(SizeType.Percent, 100)}, Padding = new Padding(10, 15, 10, 15), CellBorderStyle = TableLayoutPanelCellBorderStyle.None};
+
+            CheckBox check;
+            tableFooterButtons.Controls.Add(check = new CheckBox() {Text = Globalized.Strings.RefreshWorkingCopyUsingTheCurrentSettingsAndRules.Text, Checked = sparse.IsRefreshWorkingCopyOnSave, AutoSize = true, Dock = DockStyle.Fill, Margin = Padding.Empty});
+            check.CheckedChanged += delegate { sparse.IsRefreshWorkingCopyOnSave = check.Checked; };
+            tooltip.SetToolTip(check, string.Format(Globalized.Strings.RefreshWorkingCopyCheckboxHint.Text, FormSparseWorkingCopyViewModel.RefreshWorkingCopyCommandName));
+
+            tableFooterButtons.Controls.Add(btnSave = new Button {Width = 75, Height = 23, Text = Globalized.Strings.Save.Text, DialogResult = DialogResult.OK, Dock = DockStyle.Bottom, UseVisualStyleBackColor = true, Margin = Padding.Empty});
+
+            tableFooterButtons.Controls.Add(new Control {Width = 10, Dock = DockStyle.Fill});
+
+            tableFooterButtons.Controls.Add(btnCancel = new Button {Width = 75, Height = 23, Text = Globalized.Strings.Cancel.Text, DialogResult = DialogResult.Cancel, Dock = DockStyle.Bottom, UseVisualStyleBackColor = true, Margin = Padding.Empty});
+
+            return tableFooterButtons;
+        }
+
+        private static Panel CreateViewHeader()
+        {
+            var panelHeaderMain = new TableLayoutPanel() {BackColor = SystemColors.ControlLightLight, Dock = DockStyle.Fill, AutoSize = true, Margin = Padding.Empty, Padding = Padding.Empty, RowCount = 2, ColumnCount = 1};
+
+            Label labelTitle;
+            panelHeaderMain.Controls.Add(labelTitle = new Label() {Text = Globalized.Strings.SparseWorkingCopy.Text, Dock = DockStyle.Bottom, AutoSize = true, Margin = new Padding(10, 10, 10, 0)});
+            labelTitle.Font = new Font(labelTitle.Font, FontStyle.Bold);
+
+            panelHeaderMain.Controls.Add(new Label() {Text = Globalized.Strings.HeaderDetailsText.Text, Dock = DockStyle.Bottom, AutoSize = true, Margin = new Padding(25, 6, 10, 10)});
+
+            return panelHeaderMain;
+        }
+
+        private static Control CreateViewOnOff(FormSparseWorkingCopyViewModel sparse, ToolTip tooltip)
+        {
+            // When disabled: hint-like panel to enable
+            var panelWhenDisabled = new TableLayoutPanel() {BackColor = SystemColors.Info, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, Dock = DockStyle.Bottom, ColumnCount = 2, RowCount = 1, ColumnStyles = {new ColumnStyle(SizeType.Percent, 100)}, Margin = Padding.Empty, Padding = new Padding(10, 5, 10, 5)};
+            panelWhenDisabled.Controls.Add(new Label() {ForeColor = SystemColors.InfoText, Text = Globalized.Strings.SparseWorkingCopySupportHasNotBeenEnabledForThisRepository.Text, Dock = DockStyle.Fill, AutoSize = true, TextAlign = ContentAlignment.MiddleLeft, Margin = Padding.Empty});
+            Button btnEnable;
+            panelWhenDisabled.Controls.Add(btnEnable = new Button {Width = 75, Height = 23, Text = Globalized.Strings.Enable.Text, Anchor = AnchorStyles.Bottom | AnchorStyles.Right, Dock = DockStyle.Right, UseVisualStyleBackColor = true, Margin = Padding.Empty});
+            btnEnable.Click += delegate { sparse.IsSparseCheckoutEnabled = true; };
+            tooltip.SetToolTip(btnEnable, string.Format(Globalized.Strings.SetsTheGitPropertyToTrueForTheLocalRepository.Text, FormSparseWorkingCopyViewModel.SettingCoreSparseCheckout));
+            sparse.PropertyChanged += delegate { panelWhenDisabled.Visible = !sparse.IsSparseCheckoutEnabled; };
+
+            // When-disabled case should have a separator
+            Control separatorWhenDisabled = CreateViewSeparator(DockStyle.Bottom);
+            sparse.PropertyChanged += delegate { separatorWhenDisabled.Visible = !sparse.IsSparseCheckoutEnabled; };
+
+            // When enabled: a less bold link to disable
+            string sLabelBeforeLink = Globalized.Strings.SparseWorkingCopySupportIsEnabled.Text + ' ';
+            string sLabelWithLink = sLabelBeforeLink + Globalized.Strings.DisableForThisRepository.Text;
+            var labelWhenEnabled = new LinkLabel() {Text = sLabelWithLink, Dock = DockStyle.Bottom, AutoSize = true, Padding = new Padding(10, 10, 10, 5), FlatStyle = FlatStyle.System, UseCompatibleTextRendering = true};
+            labelWhenEnabled.Links.Add(new LinkLabel.Link(sLabelBeforeLink.Length, sLabelWithLink.Length - sLabelBeforeLink.Length));
+            labelWhenEnabled.LinkClicked += delegate { sparse.IsSparseCheckoutEnabled = false; };
+            tooltip.SetToolTip(labelWhenEnabled, string.Format(Globalized.Strings.SetsTheGitPropertyToFalseForTheLocalRepository.Text, FormSparseWorkingCopyViewModel.SettingCoreSparseCheckout));
+            sparse.PropertyChanged += delegate { labelWhenEnabled.Visible = sparse.IsSparseCheckoutEnabled; };
+
+            return new Panel() {Dock = DockStyle.Fill, Controls = {panelWhenDisabled, separatorWhenDisabled, labelWhenEnabled}, Margin = Padding.Empty, Padding = Padding.Empty, AutoSize = true};
+        }
+
+        private static Panel CreateViewRules(FormSparseWorkingCopyViewModel sparse, ToolTip tooltip, IGitUICommandsSource cmdsource)
+        {
+            // Label
+            var label1 = new Label() {AutoSize = true, Text = Globalized.Strings.SpecifyTheRulesForIncludingOrExcludingFilesAndDirectories.Text, Dock = DockStyle.Top, Padding = new Padding(10, 5, 10, 0)};
+            var label2 = new Label() {AutoSize = true, Text = Globalized.Strings.SpecifyTheRulesForIncludingOrExcludingFilesAndDirectoriesLine2.Text, Dock = DockStyle.Top, Padding = new Padding(25, 3, 10, 3), ForeColor = SystemColors.GrayText};
+            sparse.PropertyChanged += delegate { label1.Visible = label2.Visible = sparse.IsSparseCheckoutEnabled; };
+
+            // Text editor
+            var editor = new FileViewer() {Dock = DockStyle.Fill, UICommandsSource = cmdsource, IsReadOnly = false};
+            editor.TextLoaded += (sender, args) => sparse.SetRulesTextAsOnDisk(editor.GetText());
+            try
+            {
+                FileInfo sparsefile = sparse.GetPathToSparseCheckoutFile();
+                if(sparsefile.Exists)
+                    editor.ViewFile(sparsefile.FullName);
+            }
+            catch(Exception ex)
+            {
+                MessageBox.Show(ActiveForm, Globalized.Strings.CannotLoadTheTextOfTheSparseFile.Text + "\n\n" + ex.Message, Globalized.Strings.SparseWorkingCopy.Text + " – " + Globalized.Strings.LoadFile.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            editor.TextChanged += (sender, args) => sparse.RulesText = editor.GetText() ?? "";
+            tooltip.SetToolTip(editor, Globalized.Strings.EditsTheContentsOfTheGitInfoSparseCheckoutFile.Text);
+            Control separator = CreateViewSeparator(DockStyle.Top);
+            sparse.PropertyChanged += delegate { editor.Visible = separator.Visible = sparse.IsSparseCheckoutEnabled; };
+
+            var panel = new Panel() {Margin = Padding.Empty, Padding = Padding.Empty, Controls = {editor, separator, label2, label1}, AutoSize = true, Dock = DockStyle.Fill};
+
+            return panel;
+        }
+
+        [NotNull]
+        private static Control CreateViewSeparator([Optional] DockStyle? dock)
+        {
+            return new Control() {Height = 2, BackColor = SystemColors.ControlDark, Dock = dock ?? DockStyle.Fill, Padding = Padding.Empty, Margin = Padding.Empty};
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if(disposing)
+            {
+                if(_disposable1 != null)
+                    _disposable1.Dispose();
+            }
+        }
+
+        private class Globalized : Translate
+        {
+            public static readonly Globalized Strings = new Globalized();
+
+            private Globalized()
+            {
+                Translator.Translate(this, AppSettings.CurrentTranslation);
+            }
+
+            public readonly TranslationString Cancel = new TranslationString("Cancel");
+
+            public readonly TranslationString CannotLoadTheTextOfTheSparseFile = new TranslationString("Cannot load the text of the sparse file.");
+
+            public readonly TranslationString CouldNotSave = new TranslationString("Could not save the modified settings and rules.");
+
+            public readonly TranslationString DisableForThisRepository = new TranslationString("Disable for this repository");
+
+            public readonly TranslationString EditsTheContentsOfTheGitInfoSparseCheckoutFile = new TranslationString("Edits the contents of the “.git/info/sparse-checkout” file.");
+
+            public readonly TranslationString Enable = new TranslationString("&Enable");
+
+            public readonly TranslationString HeaderDetailsText = new TranslationString("Need only a small part of a large repository?\nWith sparse checkout, you can skip the rest from being extracted into your working copy.");
+
+            public readonly TranslationString LoadFile = new TranslationString("Load File");
+
+            public readonly TranslationString RefreshWorkingCopyCheckboxHint = new TranslationString("As the sparse working copy rules are changed, it might become outdated.\nRefreshes the working copy against the current set of the rules to restore any missing files and remove any extra files.\n\nnActual command line: {0}");
+
+            public readonly TranslationString RefreshWorkingCopyUsingTheCurrentSettingsAndRules = new TranslationString("Refresh working copy using the current settings and rules");
+
+            public readonly TranslationString Save = new TranslationString("&Save");
+
+            public readonly TranslationString SaveFile = new TranslationString("Save File");
+
+            public readonly TranslationString SetsTheGitPropertyToFalseForTheLocalRepository = new TranslationString("Sets the Git property “{0}” to False for the local repository.");
+
+            public readonly TranslationString SetsTheGitPropertyToTrueForTheLocalRepository = new TranslationString("Sets the Git property “{0}” to True for the local repository.");
+
+            public readonly TranslationString SparseWorkingCopy = new TranslationString("Sparse Working Copy");
+
+            public readonly TranslationString SparseWorkingCopySupportHasNotBeenEnabledForThisRepository = new TranslationString("Git Sparse feature has not been enabled for this repository.");
+
+            public readonly TranslationString SparseWorkingCopySupportIsEnabled = new TranslationString("Git Sparse feature is currently enabled.");
+
+            public readonly TranslationString SpecifyTheRulesForIncludingOrExcludingFilesAndDirectories = new TranslationString("Specify the pass-filter rules for files and directories:");
+
+            public readonly TranslationString SpecifyTheRulesForIncludingOrExcludingFilesAndDirectoriesLine2 = new TranslationString("The rules have the same format as the “.gitignore” file, matched items are included. To exclude, prefix a rule with an exclamation mark “!”.\n“#” comments a line. This is only a filter, so it cannot change the structure like pulling up a deep subfolder to the first level.");
+
+            public readonly TranslationString YouHaveMadeChangesToSettingsOrRulesWouldYouLikeToSaveThem = new TranslationString("You have made changes to settings or rules.\nWould you like to save them?");
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -20,11 +20,11 @@ namespace GitUI.CommandsDialogs
         [CanBeNull]
         private IDisposable _disposable1;
 
-        public FormSparseWorkingCopy([NotNull] GitUICommands aCommands)
+        public FormSparseWorkingCopy([CanBeNull] GitUICommands aCommands /* Translation tests set it to NULL */)
             : base(aCommands)
         {
             if(aCommands == null)
-                throw new ArgumentNullException("aCommands");
+                return;
             var sparse = new FormSparseWorkingCopyViewModel(aCommands);
             BindToViewModelGlobal(sparse);
             CreateView(sparse);

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -1,0 +1,200 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows.Forms;
+
+using GitCommands;
+
+using JetBrains.Annotations;
+
+namespace GitUI.CommandsDialogs
+{
+    public class FormSparseWorkingCopyViewModel : INotifyPropertyChanged
+    {
+        public static readonly string RefreshWorkingCopyCommandName = "read-tree -m -u HEAD";
+
+        public static readonly string SettingCoreSparseCheckout = "core.sparseCheckout";
+
+        private readonly GitUICommands _gitcommands;
+
+        private bool _isRefreshWorkingCopyOnSave = true /* on by default, otherwise index bitmap won't be updated */;
+
+        private bool _isSparseCheckoutEnabled;
+
+        /// <summary>
+        /// Remembers what were in settings, to check <see cref="IsSparseCheckoutEnabled" /> against to tell if modified.
+        /// </summary>
+        private bool _isSparseCheckoutEnabledAsSaved;
+
+        [CanBeNull]
+        private string _sRulesText;
+
+        /// <summary>
+        /// Remembers what were loaded from disk, to check <see cref="RulesText" /> against to tell if modified.
+        /// NULL until loaded.
+        /// </summary>
+        [CanBeNull]
+        private string _sRulesTextAsOnDisk;
+
+        public FormSparseWorkingCopyViewModel([NotNull] GitUICommands gitcommands)
+        {
+            _gitcommands = gitcommands;
+            if(gitcommands == null)
+                throw new ArgumentNullException("gitcommands");
+            _isSparseCheckoutEnabled = _isSparseCheckoutEnabledAsSaved = GetCurrentSparseEnabledState();
+        }
+
+        /// <summary>
+        /// Whether to run the cmd to refresh WC when closing w/save.
+        /// </summary>
+        public bool IsRefreshWorkingCopyOnSave
+        {
+            get
+            {
+                return _isRefreshWorkingCopyOnSave;
+            }
+            set
+            {
+                _isRefreshWorkingCopyOnSave = value;
+                FirePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Tells whether the rules have been edited in the UI against what's on disk.
+        /// </summary>
+        public bool IsRulesTextChanged
+        {
+            get
+            {
+                return (_sRulesText != null) && (_sRulesText != (_sRulesTextAsOnDisk ?? ""));
+            }
+        }
+
+        /// <summary>
+        /// Current UI state of the Git sparse option.
+        /// </summary>
+        public bool IsSparseCheckoutEnabled
+        {
+            get
+            {
+                return _isSparseCheckoutEnabled;
+            }
+            set
+            {
+                if(value == _isSparseCheckoutEnabled)
+                    return;
+                _isSparseCheckoutEnabled = value;
+                FirePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Current UI state of the sparse WC rules text. NULL if n/a.
+        /// </summary>
+        [CanBeNull]
+        public string RulesText
+        {
+            get
+            {
+                return _sRulesText;
+            }
+            set
+            {
+                if(_sRulesText == value)
+                    return;
+                _sRulesText = value;
+                FirePropertyChanged();
+            }
+        }
+
+        public void FirePropertyChanged()
+        {
+            PropertyChanged(this, new PropertyChangedEventArgs(""));
+        }
+
+        /// <summary>
+        /// Read from settings.
+        /// </summary>
+        public bool GetCurrentSparseEnabledState()
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(_gitcommands.Module.GetEffectiveSetting(SettingCoreSparseCheckout), Boolean.TrueString);
+        }
+
+        /// <summary>
+        /// Path to the file with the sparse WC rules.
+        /// </summary>
+        [NotNull]
+        public FileInfo GetPathToSparseCheckoutFile()
+        {
+            return new FileInfo(Path.Combine(Path.Combine(_gitcommands.GitModule.GetGitDirectory(), "info"), "sparse-checkout"));
+        }
+
+        /// <summary>
+        /// Checks if got anything to save. Can cancel without confirmation if not dirty.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsWithUnsavedChanges()
+        {
+            if(IsSparseCheckoutEnabled != _isSparseCheckoutEnabledAsSaved)
+                return true;
+            if(IsRulesTextChanged)
+                return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Re-applies the current options/rules to the WC.
+        /// </summary>
+        public void RefreshWorkingCopy()
+        {
+            // Re-apply tree to the index
+            // TODO: check how it affects the uncommitted working copy changes
+            using(var fromProcess = new FormRemoteProcess(_gitcommands.Module, AppSettings.GitCommand, RefreshWorkingCopyCommandName))
+                fromProcess.ShowDialog(Form.ActiveForm);
+        }
+
+        /// <summary>
+        /// Saves changes (if modified), and refresh WC.
+        /// </summary>
+        public void SaveChanges()
+        {
+            // Don't abort if !IsWithUnsavedChanges because we have to run IsRefreshWorkingCopyOnSave in either case (e.g. if edited by hand or got outdated)
+
+            // Enabled state for the repo
+            if(IsSparseCheckoutEnabled != _isSparseCheckoutEnabledAsSaved)
+            {
+                _gitcommands.Module.SetSetting(SettingCoreSparseCheckout, IsSparseCheckoutEnabled.ToString().ToLowerInvariant());
+                _isSparseCheckoutEnabledAsSaved = IsSparseCheckoutEnabled;
+            }
+
+            // Rules set
+            if(IsRulesTextChanged)
+            {
+                string sNewText = RulesText ?? "";
+                File.WriteAllBytes(GetPathToSparseCheckoutFile().FullName, GitModule.SystemEncoding.GetBytes(sNewText));
+                SetRulesTextAsOnDisk(sNewText); // Update if OK
+            }
+
+            // Refresh WC (if chose to Save, run this regardless of the modifications)
+            if(IsRefreshWorkingCopyOnSave)
+                RefreshWorkingCopy();
+        }
+
+        /// <summary>
+        /// As view loads the text in its impl of the editor, tells the exact on-disk text when it gets known.
+        /// </summary>
+        /// <param name="text"></param>
+        public void SetRulesTextAsOnDisk([NotNull] string text)
+        {
+            if(text == null)
+                throw new ArgumentNullException("text");
+            _sRulesTextAsOnDisk = text;
+        }
+
+        /// <summary>
+        /// Fires on any prop change. Lightweight reactive.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged = delegate { };
+    }
+}

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -116,6 +116,8 @@ namespace GitUI
                         parent = parent.Parent;
                 }
 
+                if(cmdsSrc == null)
+                    throw new InvalidOperationException("The UI Command Source is not available for this control. Are you calling methods before adding it to the parent control?");
                 UICommandsSource = cmdsSrc;
             }
         }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -130,11 +130,15 @@
     <Compile Include="CommandsDialogs\BrowseDialog\FormBrowseMenuCommands.cs" />
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommand.cs" />
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommandsBase.cs" />
+    <Compile Include="CommandsDialogs\FormSparseWorkingCopyViewModel.cs" />
     <Compile Include="CommandsDialogs\FormMergeSubmodule.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="CommandsDialogs\FormMergeSubmodule.Designer.cs">
       <DependentUpon>FormMergeSubmodule.cs</DependentUpon>
+    </Compile>
+    <Compile Include="CommandsDialogs\FormSparseWorkingCopy.cs">
+      <SubType>Form</SubType>
     </Compile>
     <Compile Include="CommandsDialogs\RepoHosting\CreatePullRequestForm.cs">
       <SubType>Form</SubType>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -12,6 +12,9 @@ using GitUI.CommandsDialogs.SettingsDialog;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.RepositoryHosts;
 using Gravatar;
+
+using JetBrains.Annotations;
+
 using Settings = GitCommands.AppSettings;
 
 namespace GitUI
@@ -153,6 +156,10 @@ namespace GitUI
 
         public event GitUIEventHandler PreBrowseInitialize;
         public event GitUIEventHandler PostBrowseInitialize;
+
+        public event GitUIEventHandler PreSparseWorkingCopy;
+        public event GitUIPostActionEventHandler PostSparseWorkingCopy;
+
         /// <summary>
         /// listeners for changes being made to repository
         /// </summary>
@@ -897,6 +904,24 @@ namespace GitUI
         public bool StartViewPatchDialog()
         {
             return StartViewPatchDialog(null, null);
+        }
+
+        public bool StartSparseWorkingCopyDialog()
+        {
+            return StartSparseWorkingCopyDialog(null);
+        }
+
+        public bool StartSparseWorkingCopyDialog([CanBeNull] IWin32Window owner)
+        {
+            Func<bool> action = () =>
+            {
+                using(var form = new FormSparseWorkingCopy(this))
+                    form.ShowDialog(owner);
+
+                return true;
+            };
+
+            return DoActionOnRepo(owner, true, false, PreSparseWorkingCopy, PostSparseWorkingCopy, action);
         }
 
         public bool StartFormatPatchDialog(IWin32Window owner)

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -51,6 +51,7 @@ namespace GitUIPluginInterfaces
         event GitUIPostActionEventHandler PostUpdateSubmodules;
         event GitUIPostActionEventHandler PostVerifyDatabase;
         event GitUIPostActionEventHandler PostViewPatch;
+        event GitUIPostActionEventHandler PostSparseWorkingCopy;
         event GitUIEventHandler PostBrowseInitialize;
         event GitUIEventHandler PostRegisterPlugin;
         event GitUIEventHandler PreAddFiles;
@@ -94,6 +95,7 @@ namespace GitUIPluginInterfaces
         event GitUIEventHandler PreVerifyDatabase;
         event GitUIEventHandler PreViewPatch;
         event GitUIEventHandler PreBrowseInitialize;
+        event GitUIEventHandler PreSparseWorkingCopy;
         
         IGitModule GitModule { get; }
         string GitCommand(string arguments);
@@ -153,5 +155,6 @@ namespace GitUIPluginInterfaces
         bool StartUpdateSubmodulesDialog();
         bool StartVerifyDatabaseDialog();
         bool StartViewPatchDialog();
+        bool StartSparseWorkingCopyDialog();
     }
 }


### PR DESCRIPTION
Initial support for sparse working copies (#2289).
This implementation adds a single main menu command which shows a dialog to control three aspects of sparse working copies:
* Enable/disable sparse for this repo in git config.
* Edit the pass filter.
* Refresh working copy against the current set of the rules.

Tried to make it self-explanatory somewhat.

Dialog view when sparse not enabled:

![untitled20150816065532](https://cloud.githubusercontent.com/assets/2332070/9291910/fc2dbada-43e3-11e5-9044-c9a340f5226f.png)

Dialog view when sparse is enabled (enable/disable toggles between these views):

![untitled20150816065630](https://cloud.githubusercontent.com/assets/2332070/9291917/593299da-43e4-11e5-8b52-0a9a39386524.png)

