### PR TITLE
"Illegal Characters in Path" if %PATH% Contains Quotes #2924

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -181,7 +181,30 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             string path = string.Concat(Environment.GetEnvironmentVariable("path", EnvironmentVariableTarget.User), ";",
                                         Environment.GetEnvironmentVariable("path", EnvironmentVariableTarget.Machine));
 
-            return path.Split(';').Any(dir => File.Exists(dir + " \\" + fileName) || File.Exists(Path.Combine(dir, fileName)));
+            foreach(string rawdir in path.Split(';'))
+            {
+                string dir = rawdir;
+                dir = dir.Trim();
+                // Usually, paths with spaces are not quoted on %PATH%, but it's well possible, and .NET won't consume a quoted path
+                // This does not handle the full grammar of the %PATH%, but at least prevents Illegal Characters in Path exceptions (see #2924)
+                if((dir.Length >= 2) && (dir[0] == '"') && (dir[dir.Length - 1] == '"'))
+                    dir = dir.Substring(1, dir.Length - 2);
+                if(dir.Length == 0)
+                    continue;
+                try
+                {
+                    if(File.Exists(dir + " \\" + fileName) || File.Exists(Path.Combine(dir, fileName)))
+                        return true;
+                }
+                catch(ArgumentException /* e.g. illegal characters in path — might get any from %PATH% */)
+                {
+                }
+                catch(IOException /* problems checking file existence in FS */)
+                {
+                }
+            }
+
+            return false;
         }
 
         public bool SolveMergeToolForKDiff()


### PR DESCRIPTION
Added unquoting.
Added ignoring of certain exceptions which might result from invalid %PATH% while checking for file existence, assuming it does not exist.

#2924