### PR TITLE
Fix automatically configured path to linux tools

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 gitpath = possibleNewPath.Trim();
             }
 
-            foreach (var toolsPath in new[] { @"usr\bin\", @"bin\" })
+            foreach (var toolsPath in new[] { @"bin\", @"usr\bin\" })
             {
                 gitpath = gitpath.Replace(@"\cmd\git.exe", @"\" + toolsPath)
                     .Replace(@"\cmd\git.cmd", @"\" + toolsPath)


### PR DESCRIPTION
The fix is to try `/bin` before `/usr/bin`. Both Git bash and reading system config work fine with the fix.

I'm not sure if we need `/usr/bin` at all because `/usr` is invalid prefix for `/etc/gitconfig`. But it was added in 5f8e660be5c913f26b59822530956478a8b58579 for some reason.

Closes #2950.