### PR TITLE
Linux: fixed Open repository form not closable

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
@@ -59,7 +59,6 @@
             // Load
             // 
             this.Load.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.Load.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.Load.Image = global::GitUI.Properties.Resources.IconRepoOpen;
             this.Load.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.Load.Location = new System.Drawing.Point(296, 45);
@@ -97,7 +96,6 @@
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Open local repository";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Open_FormClosing);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -46,20 +46,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             if (Directory.Exists(_NO_TRANSLATE_Directory.Text))
             {
                 choosenModule = new GitModule(_NO_TRANSLATE_Directory.Text);
-
                 Repositories.AddMostRecentRepository(choosenModule.WorkingDir);
+                Close();
             }
             else
             {
-                DialogResult = DialogResult.None;
                 MessageBox.Show(this, _warningOpenFailed.Text, _warningOpenFailedCaption.Text);
             }
-        }
-
-        private void Open_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            if (DialogResult == DialogResult.None)
-                e.Cancel = true;
         }
 
         private void DirectoryKeyPress(object sender, KeyPressEventArgs e)


### PR DESCRIPTION
### Problem description:

On Windows when user closes dialog, its DialogResult is set to Cancel. But on Linux/Mono it remains None for some reason.

And we were using DialogResult.None as an indicator for an attempt to load non-existing directory => so we didn't allow dialog to close.

### Solution:

Simplified code to not use DialogResult checks.