### PR TITLE
Stash:  Use auto stash setting instead of manual stash setting for browse/commit form.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1786,7 +1786,7 @@ namespace GitUI.CommandsDialogs
 
         private void StashChangesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash);
+            UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInAutoStash);
         }
 
         private void StashPopToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2312,7 +2312,7 @@ namespace GitUI.CommandsDialogs
             foreach (var item in unStagedFiles.Where(it => it.IsSubmodule))
             {
                 GitUICommands uiCmds = new GitUICommands(Module.GetSubmodule(item.Name));
-                uiCmds.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash);
+                uiCmds.StashSave(this, AppSettings.IncludeUntrackedFilesInAutoStash);
             }
 
             Initialize();


### PR DESCRIPTION
The existing behavior was very difficult to understand; I was unable to learn
it without examining the Git Extensions source code myself.  Specifically, it's
a natural user expectation that if you check "Include untracked files in stash"
in the Settings dialog, this setting will be honored when choosing to make a
stash from the main Browse dialog.  This commit makes it so.
