### PR TITLE
Fix Shell Extension leaks and general cleanup

### DIFF
--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -676,7 +676,7 @@ void CGitExtensionsShellEx::RunGitEx(const TCHAR* command)
 STDMETHODIMP CGitExtensionsShellEx::InvokeCommand(LPCMINVOKECOMMANDINFO pCmdInfo)
 {
     // If lpVerb really points to a string, ignore this function call and bail out.
-    if (pCmdInfo == NULL || 0 != HIWORD(pCmdInfo->lpVerb))
+    if (pCmdInfo == NULL || !IS_INTRESOURCE(pCmdInfo->lpVerb))
         return E_INVALIDARG;
 
     int invokeId = LOWORD(pCmdInfo->lpVerb);

--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -110,7 +110,10 @@ STDMETHODIMP CGitExtensionsShellEx::Initialize(LPCITEMIDLIST pidlFolder, LPDATAO
 
     // Make sure it worked.
     if (NULL == hDrop)
+    {
+        ReleaseStgMedium(&stg);
         return E_INVALIDARG;
+    }
 
     // Sanity check - make sure there is at least one filename.
     UINT uNumFiles = DragQueryFile(hDrop, 0xFFFFFFFF, NULL, 0);

--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -53,6 +53,18 @@ const wchar_t* const gitExCommandNames[] =
 
 C_ASSERT(gcMaxValue == _countof(gitExCommandNames));
 
+// Forward declaration of functions not declared in the header
+static CString GetRegistryValue (HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path);
+static bool GetRegistryBoolValue(HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path);
+static bool DisplayInSubmenu(CString settings, int id);
+
+static HRESULT Create32BitHBITMAP(HDC hdc, const SIZE* psize, __deref_opt_out void** ppvBits, __out HBITMAP* phBmp);
+static bool HasAlpha(__in ARGB* pargb, SIZE& sizImage, int cxRow);
+static HRESULT ConvertToPARGB32(HDC hdc, __inout ARGB* pargb, HBITMAP hbmp, SIZE& sizImage, int cxRow);
+
+static bool ValidWorkingDir(const std::wstring& dir);
+static bool IsValidGitDir(TCHAR m_szFile[]);
+
 /////////////////////////////////////////////////////////////////////////////
 // CGitExtensionsShellEx
 
@@ -196,7 +208,7 @@ HBITMAP CGitExtensionsShellEx::IconToBitmapPARGB32(UINT uIcon)
     return hBmp;
 }
 
-HRESULT CGitExtensionsShellEx::Create32BitHBITMAP(HDC hdc, const SIZE* psize, __deref_opt_out void** ppvBits, __out HBITMAP* phBmp)
+static HRESULT Create32BitHBITMAP(HDC hdc, const SIZE* psize, __deref_opt_out void** ppvBits, __out HBITMAP* phBmp)
 {
     *phBmp = NULL;
 
@@ -249,7 +261,7 @@ HRESULT CGitExtensionsShellEx::ConvertBufferToPARGB32(HPAINTBUFFER hPaintBuffer,
     return hr;
 }
 
-bool CGitExtensionsShellEx::HasAlpha(__in ARGB* pargb, SIZE& sizImage, int cxRow)
+static bool HasAlpha(__in ARGB* pargb, SIZE& sizImage, int cxRow)
 {
     ULONG cxDelta = cxRow - sizImage.cx;
     for (ULONG y = sizImage.cy; y; --y)
@@ -268,7 +280,7 @@ bool CGitExtensionsShellEx::HasAlpha(__in ARGB* pargb, SIZE& sizImage, int cxRow
     return false;
 }
 
-HRESULT CGitExtensionsShellEx::ConvertToPARGB32(HDC hdc, __inout ARGB* pargb, HBITMAP hbmp, SIZE& sizImage, int cxRow)
+static HRESULT ConvertToPARGB32(HDC hdc, __inout ARGB* pargb, HBITMAP hbmp, SIZE& sizImage, int cxRow)
 {
     BITMAPINFO bmi;
     ZeroMemory(&bmi, sizeof(bmi));
@@ -333,7 +345,7 @@ bool IsFileExists(LPCWSTR str)
     return (dwAttrib != INVALID_FILE_ATTRIBUTES) && ((dwAttrib & FILE_ATTRIBUTE_DIRECTORY) == 0);
 }
 
-bool CGitExtensionsShellEx::ValidWorkingDir(const std::wstring& dir)
+static bool ValidWorkingDir(const std::wstring& dir)
 {
     if (dir.empty())
         return false;
@@ -346,7 +358,7 @@ bool CGitExtensionsShellEx::ValidWorkingDir(const std::wstring& dir)
         IsExists(dir + L"\\refs\\");
 }
 
-bool CGitExtensionsShellEx::IsValidGitDir(TCHAR m_szFile[])
+static bool IsValidGitDir(TCHAR m_szFile[])
 {
     if (m_szFile[0] == '\0')
         return false;
@@ -561,7 +573,7 @@ UINT CGitExtensionsShellEx::AddMenuItem(HMENU hMenu, LPTSTR text, int resource, 
     return id;
 }
 
-bool CGitExtensionsShellEx::DisplayInSubmenu(CString settings, int id)
+static bool DisplayInSubmenu(CString settings, int id)
 {
     if (settings.GetLength() < id)
     {
@@ -705,7 +717,7 @@ STDMETHODIMP CGitExtensionsShellEx::HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPA
     return S_OK;
 }
 
-CString CGitExtensionsShellEx::GetRegistryValue(HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path)
+static CString GetRegistryValue(HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path)
 {
     HKEY key;
     long res = RegOpenKeyEx(hOpenKey,szKey, 0, KEY_READ | KEY_WOW64_32KEY, &key);
@@ -736,7 +748,7 @@ CString CGitExtensionsShellEx::GetRegistryValue(HKEY hOpenKey, LPCTSTR szKey, LP
     return tempStr;
 }
 
-bool CGitExtensionsShellEx::GetRegistryBoolValue(HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path)
+static bool GetRegistryBoolValue(HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path)
 {
     CString value = GetRegistryValue(hOpenKey, szKey, path);
     if (value.IsEmpty())

--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -15,7 +15,7 @@ void XTrace(LPCTSTR lpszFormat, ...)
     va_start(args, lpszFormat);
     int nBuf;
     TCHAR szBuffer[512]; // get rid of this hard-coded buffer
-    nBuf = _vsntprintf(szBuffer, 511, lpszFormat, args);
+    nBuf = _vsntprintf_s(szBuffer, 512, 511, lpszFormat, args);
     ::OutputDebugString(szBuffer);
     va_end(args);
 }

--- a/GitExtensionsShellEx/GitExtensionsShellEx.h
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.h
@@ -48,6 +48,7 @@ class ATL_NO_VTABLE CGitExtensionsShellEx :
 {
 public:
     CGitExtensionsShellEx();
+    virtual ~CGitExtensionsShellEx();
 
     DECLARE_REGISTRY_RESOURCEID(IDR_GITEXTENSIONSSHELLEX)
 
@@ -83,9 +84,11 @@ private:
     std::map<UINT, HBITMAP> bitmaps;
     std::map<int, int> commandsId;
 
+    HMODULE hUxTheme;
     FN_GetBufferedPaintBits pfnGetBufferedPaintBits;
     FN_BeginBufferedPaint pfnBeginBufferedPaint;
     FN_EndBufferedPaint pfnEndBufferedPaint;
+    bool BufferedPaintAvailable;
 
     HBITMAP IconToBitmapPARGB32(UINT uIcon);
     HRESULT ConvertBufferToPARGB32(HPAINTBUFFER hPaintBuffer, HDC hdc, HICON hicon, SIZE& sizIcon);

--- a/GitExtensionsShellEx/GitExtensionsShellEx.h
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.h
@@ -73,11 +73,11 @@ public:
     // IContextMenu3
     STDMETHODIMP HandleMenuMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT* pResult);
 
+private:
     void RunGitEx(const TCHAR* command);
 
     UINT AddMenuItem(HMENU hmenu, LPTSTR text, int resource, UINT firstId, UINT id, UINT position, bool isSubMenu);
 
-protected:
     TCHAR m_szFile[MAX_PATH];
     std::map<UINT_PTR, int> myIDMap;
     std::map<UINT, HBITMAP> bitmaps;
@@ -87,18 +87,8 @@ protected:
     FN_BeginBufferedPaint pfnBeginBufferedPaint;
     FN_EndBufferedPaint pfnEndBufferedPaint;
 
-    CString GetRegistryValue(HKEY	hOpenKey, LPCTSTR szKey, LPCTSTR path);
-    bool GetRegistryBoolValue(HKEY	hOpenKey, LPCTSTR szKey, LPCTSTR path);
-    bool DisplayInSubmenu(CString settings, int id);
-
     HBITMAP IconToBitmapPARGB32(UINT uIcon);
-    HRESULT Create32BitHBITMAP(HDC hdc, const SIZE* psize, __deref_opt_out void** ppvBits, __out HBITMAP* phBmp);
     HRESULT ConvertBufferToPARGB32(HPAINTBUFFER hPaintBuffer, HDC hdc, HICON hicon, SIZE& sizIcon);
-    bool HasAlpha(__in ARGB* pargb, SIZE& sizImage, int cxRow);
-    HRESULT ConvertToPARGB32(HDC hdc, __inout ARGB* pargb, HBITMAP hbmp, SIZE& sizImage, int cxRow);
-
-    bool ValidWorkingDir(const std::wstring& dir);
-    bool IsValidGitDir(TCHAR m_szFile[]);
 };
 
 #endif //__GITEXTENSIONSSHELLEX_H_

--- a/GitExtensionsShellEx/GitExtensionsShellEx.h
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.h
@@ -9,6 +9,8 @@
 
 typedef DWORD ARGB;
 
+typedef HRESULT (WINAPI *FN_BufferedPaintInit) (void);
+typedef HRESULT (WINAPI *FN_BufferedPaintUnInit) (void);
 typedef HRESULT (WINAPI *FN_GetBufferedPaintBits) (HPAINTBUFFER hBufferedPaint, RGBQUAD **ppbBuffer, int *pcxRow);
 typedef HPAINTBUFFER (WINAPI *FN_BeginBufferedPaint) (HDC hdcTarget, const RECT *prcTarget, BP_BUFFERFORMAT dwFormat, BP_PAINTPARAMS *pPaintParams, HDC *phdc);
 typedef HRESULT (WINAPI *FN_EndBufferedPaint) (HPAINTBUFFER hBufferedPaint, BOOL fUpdateTarget);
@@ -85,10 +87,13 @@ private:
     std::map<int, int> commandsId;
 
     HMODULE hUxTheme;
+    FN_BufferedPaintInit pfnBufferedPaintInit;
+    FN_BufferedPaintUnInit pfnBufferedPaintUnInit;
     FN_GetBufferedPaintBits pfnGetBufferedPaintBits;
     FN_BeginBufferedPaint pfnBeginBufferedPaint;
     FN_EndBufferedPaint pfnEndBufferedPaint;
     bool BufferedPaintAvailable;
+    bool BufferedPaintInitialized;
 
     HBITMAP IconToBitmapPARGB32(UINT uIcon);
     HRESULT ConvertBufferToPARGB32(HPAINTBUFFER hPaintBuffer, HDC hdc, HICON hicon, SIZE& sizIcon);


### PR DESCRIPTION
The Git Extensions shell extension was caught leaking GDI objects on my Windows 7 computer, eventually leading to the explorer.exe process dying an untimely death.

I fixed this leak and also cleaned up other code in the shell extension, fixing other undefined behavior and leaked resources as I found them.