### PR TITLE
Linux: fixed commit message textbox not being resizable

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1019,7 +1019,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.flowCommitButtons, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.toolbarCommit, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;


### PR DESCRIPTION
Panel with textbox was put in the wrong column.

Before:
![01](https://cloud.githubusercontent.com/assets/1286157/10274610/599658f4-6b48-11e5-999e-45328b7a6c8b.PNG)

After:
![02](https://cloud.githubusercontent.com/assets/1286157/10274613/60eba488-6b48-11e5-8fac-c049552552db.PNG)

