### PR TITLE
Fixed an exception when closing the application after closed FormCommitDiff

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1905,9 +1905,10 @@ namespace GitUI
             var selectedRevisions = GetSelectedRevisions();
             if (selectedRevisions.Any(rev => !GitRevision.IsArtificial(rev.Guid)))
             {
-                var form = new FormCommitDiff(UICommands, selectedRevisions[0].Guid);
-
-                form.ShowDialog(this);
+                using (var form = new FormCommitDiff(UICommands, selectedRevisions[0].Guid))
+                {
+                    form.ShowDialog(this);
+                }
             }
             else if (!selectedRevisions.Any())
             {


### PR DESCRIPTION
`selectedIndexChangeSubscription.Dispose();` in `FileStatusList.DisposeCustomResources` throws an `InvalidOperationException`,
saying that `Invoke or BeginInvoke cannot be called on a control until the window handle has been created.`

Steps to reproduce:

 * Double click a commit, it pops up the commit diff dialog
 * Close the dialog
 * Close the application.
 * An `InvalidOperationException` occurs.