### PR TITLE
Avoid deadlock by the "ordered locking" approach

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -260,6 +260,7 @@ namespace GitUI.RevisionGridClasses
             }
             set
             {
+                lock (_backgroundEvent)
                 lock (_graphData)
                 {
                     ClearSelection();


### PR DESCRIPTION
Setting CurrentCell through its callback calls ShowRevisionGraph(),
which calls _backgroundEvent.Set()

Assume locking _backgroundEvent should be done earlier like
in other functions

Fixes: https://github.com/gitextensions/gitextensions/issues/2977