### PR TITLE
Add newtonsoft.Json version bindingRedirect for system.http.format

### DIFF
--- a/GitExtensions/app.config
+++ b/GitExtensions/app.config
@@ -28,6 +28,10 @@
         <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings></connectionStrings>


### PR DESCRIPTION
So system.http.format can use the newer version of newtonsoft.json.dll that is being used by gitextensions.
Otherwise the program won't be able to load the build server adapters properly and consequently fails to retrieve and show the build results in the revision grid.
Also fails to show the build server types in the dropdown list in the build server integration settings page.

Fixes #2984