### PR TITLE
Feature: Syntax highlighting for commit/rebase dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommandlineHelp.resx
+++ b/GitUI/CommandsDialogs/FormCommandlineHelp.resx
@@ -135,7 +135,7 @@ clone [path]
 commit [--quiet]
 difftool filename
 filehistory filename
-fileeditor filename
+fileeditor [--syntax syntax_name] filename
 formatpatch
 gitbash
 gitignore

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -16,17 +16,23 @@ namespace GitUI.CommandsDialogs
         private string _fileName;
         private bool _formClosing = false;
 
-        public FormEditor(GitUICommands aCommands, string fileName, bool showWarning)
+        public FormEditor(GitUICommands aCommands, string fileName, bool showWarning, string highlightingSyntax)
             : base(aCommands)
         {
             InitializeComponent();
             Translate();
 
+            // set highlighting syntax
+            if (highlightingSyntax != null)
+                fileViewer.SetHighlighting(highlightingSyntax);
+
             // for translation form
             if (fileName != null)
                 OpenFile(fileName);
+
             fileViewer.TextChanged += (s, e) => HasChanges = true;
             fileViewer.TextLoaded += (s, e) => HasChanges = false;
+
             panelMessage.Visible = showWarning;
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             string editor = CommonLogic.GetGlobalEditor();
             if (string.IsNullOrEmpty(editor))
             {
-                GlobalConfigFileSettings.SetPathValue("core.editor", "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor");
+                GlobalConfigFileSettings.SetPathValue("core.editor", "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor --syntax GitCommit");
             }
 
             return true;

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -11,7 +11,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             return new Object[]
             {
-                "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor",
+                "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor --syntax GitCommit",
                 "vi",
                 "notepad",
                 GetNotepadPP(),

--- a/GitUI/Editor/CustomSyntaxStrategyManager.cs
+++ b/GitUI/Editor/CustomSyntaxStrategyManager.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor
+{
+    // simple manager which return highighting strategy implemented in current assembly
+    class CustomSyntaxStrategyManager
+    {
+        const string StrategySuffix = "HighlightingStrategy";
+
+        static readonly Dictionary<string, Type> StrategyTypes;
+
+        static CustomSyntaxStrategyManager()
+        {
+            try
+            {
+                StrategyTypes = typeof(CustomSyntaxStrategyManager).Assembly
+                    .GetTypes()
+                    .Where(t => !t.IsAbstract && typeof(IHighlightingStrategy).IsAssignableFrom(t))
+                    .ToDictionary(t => t.Name.EndsWith(StrategySuffix) ? t.Name.Substring(0, t.Name.Length - StrategySuffix.Length).ToUpperInvariant() : t.Name.ToUpperInvariant(), t => t)
+                ;
+            }
+            catch
+            {
+                StrategyTypes = new Dictionary<string, Type>();
+            }
+        }
+
+        public static IHighlightingStrategy TryFindCustomSyntaxStrategy(string syntax)
+        {
+            Type t;
+            if (!StrategyTypes.TryGetValue(syntax.ToUpperInvariant(), out t))
+                return null;
+
+            return (IHighlightingStrategy)Activator.CreateInstance(t);
+        }
+    }
+}

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -10,7 +10,6 @@ using System.Windows.Forms;
 using GitCommands;
 using GitUI.CommandsDialogs;
 using GitUI.Hotkey;
-using ICSharpCode.TextEditor.Util;
 using PatchApply;
 using GitCommands.Settings;
 using GitUI.Editor.Diff;
@@ -25,6 +24,7 @@ namespace GitUI.Editor
         private int _currentScrollPos = -1;
         private bool _currentViewIsPatch;
         private readonly IFileViewer _internalFileViewer;
+        private string _highlightingSyntax;
 
         public FileViewer()
         {
@@ -420,6 +420,12 @@ namespace GitUI.Editor
             _async.Load(loadPatchText, ViewPatch);
         }
 
+        public void SetHighlighting(string highlightingSyntax)
+        {
+            _highlightingSyntax = highlightingSyntax;
+            _internalFileViewer.SetHighlighting(highlightingSyntax);
+        }
+
         public void ViewText(string fileName, string text)
         {
             ResetForText(fileName);
@@ -615,7 +621,9 @@ namespace GitUI.Editor
         {
             Reset(false, true);
 
-            if (fileName == null)
+            if (_highlightingSyntax != null)
+                _internalFileViewer.SetHighlighting(_highlightingSyntax);
+            else if (fileName == null)
                 _internalFileViewer.SetHighlighting("Default");
             else
                 _internalFileViewer.SetHighlightingForFile(fileName);

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -165,7 +165,11 @@ namespace GitUI.Editor
 
         public void SetHighlighting(string syntax)
         {
-            TextEditor.SetHighlighting(syntax);
+            var strategy = CustomSyntaxStrategyManager.TryFindCustomSyntaxStrategy(syntax);
+            if (strategy != null)
+                TextEditor.Document.HighlightingStrategy = strategy;
+            else
+                TextEditor.SetHighlighting(syntax);
             TextEditor.Refresh();
         }
 

--- a/GitUI/Editor/GitCommitHighlightingStrategy.cs
+++ b/GitUI/Editor/GitCommitHighlightingStrategy.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
+using System.Drawing;
+
+namespace GitUI.Editor
+{
+    class GitCommitHighlightingStrategy : IHighlightingStrategy
+    {
+        readonly DefaultHighlightingStrategy _defaultHighlightingStrategy = new DefaultHighlightingStrategy();
+        readonly Dictionary<string, string> _properties = new Dictionary<string, string>();
+
+        public string Name
+        {
+            get
+            {
+                return "GitCommit";
+            }
+        }
+
+        public string[] Extensions
+        {
+            get
+            {
+                return new string[] { };
+            }
+        }
+
+        public Dictionary<string, string> Properties
+        {
+            get { return _properties; }
+        }
+
+        public HighlightColor GetColorFor(string name)
+        {
+            return _defaultHighlightingStrategy.GetColorFor(name);
+        }
+
+        public void MarkTokens(IDocument document, List<LineSegment> lines)
+        {
+            for (int i = 0; i < lines.Count; i++)
+            {
+                LineSegment line = lines[i];
+                line.Words = new List<TextWord>();
+
+                ColorLineRedGreen(document, line);
+
+                // and tell the text editor to redraw the changed line
+                document.RequestUpdate(new TextAreaUpdate(TextAreaUpdateType.SingleLine, line.LineNumber));
+            }
+        }
+
+        void ColorLineRedGreen(IDocument document, LineSegment line)
+        {
+            AddWord(document, line, 0, line.Length, IsComment(document, line));
+        }
+
+        static bool IsComment(IDocument document, LineSegment line)
+        {
+            for (int i = 0; i < line.Length; i++)
+            {
+                var c = document.GetCharAt(line.Offset + i);
+                if (Char.IsWhiteSpace(c))
+                    continue;
+
+                if (c == '#')
+                    return true;
+
+                return false;
+            }
+            return false;
+        }
+
+        void AddWord(IDocument document, LineSegment line, int startOffset, int endOffset, bool isComment)
+        {
+            if (startOffset == endOffset)
+                return;
+            var color = new HighlightColor(isComment ? Color.DarkGreen : Color.Black, false, false);
+            line.Words.Add(new TextWord(document, line, startOffset, endOffset - startOffset, color, false));
+        }
+
+        public void MarkTokens(IDocument document)
+        {
+            MarkTokens(document, new List<LineSegment>(document.LineSegmentCollection));
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -206,6 +206,8 @@
     <Compile Include="Editor\Diff\DiffViewerLineNumberCtrl.cs" />
     <Compile Include="Editor\Diff\LinePrefixHelper.cs" />
     <Compile Include="Editor\Diff\LineSegmentGetter.cs" />
+    <Compile Include="Editor\CustomSyntaxStrategyManager.cs" />
+    <Compile Include="Editor\GitCommitHighlightingStrategy.cs" />
     <Compile Include="HelperDialogs\FormBuildServerCredentials.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1804,7 +1804,7 @@ namespace GitUI
 
         public void RunCommand(string[] args)
         {
-            var arguments = InitializeArguments(args);
+            var arguments = InitializeArguments(ref args);
 
             if (args.Length <= 1)
                 return;
@@ -2107,17 +2107,38 @@ namespace GitUI
                 StartResolveConflictsDialog();
         }
 
-        private static Dictionary<string, string> InitializeArguments(string[] args)
+        private static Dictionary<string, string> InitializeArguments(ref string[] args)
         {
             Dictionary<string, string> arguments = new Dictionary<string, string>();
 
-            for (int i = 2; i < args.Length; i++)
+            List<string> argsList = args.ToList();
+
+            for (int i = 2; i < argsList.Count; i++)
             {
-                if (args[i].StartsWith("--") && i + 1 < args.Length && !args[i + 1].StartsWith("--"))
-                    arguments.Add(args[i].TrimStart('-'), args[++i]);
-                else if (args[i].StartsWith("--"))
-                    arguments.Add(args[i].TrimStart('-'), null);
+                if (!argsList[i].StartsWith("--"))
+                    continue;
+
+                // we found argument: either flag or with value
+
+                if (i + 1 < argsList.Count && !argsList[i + 1].StartsWith("--"))
+                {
+                    arguments.Add(argsList[i].TrimStart('-'), argsList[i + 1]);
+                    argsList.RemoveRange(i, 2);
+                }
+                else
+                {
+                    arguments.Add(argsList[i].TrimStart('-'), null);
+                    argsList.RemoveAt(i);
+                }
+
+                // decrement i, so we examine Ith element again because of shift
+                i--;
             }
+
+            // return updated arguemnts list
+            if (argsList.Count != args.Length)
+                args = argsList.ToArray();
+
             return arguments;
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1894,8 +1894,10 @@ namespace GitUI
                         Module = Module.SuperprojectModule;
                     RunFileHistoryCommand(args);
                     return;
-                case "fileeditor":  // filename
-                    if (!StartFileEditorDialog(args[2]))
+                case "fileeditor":  // filename [--syntax syntax_name]
+                    string syntax;
+                    arguments.TryGetValue("syntax", out syntax);
+                    if (!StartFileEditorDialog(args[2], highlightingSyntax: syntax))
                         System.Environment.ExitCode = -1;
                     return;
                 case "formatpatch":
@@ -2061,9 +2063,9 @@ namespace GitUI
             StartRebaseDialog(branch);
         }
 
-        public bool StartFileEditorDialog(string filename, bool showWarning = false)
+        public bool StartFileEditorDialog(string filename, bool showWarning = false, string highlightingSyntax = null)
         {
-            using (var formEditor = new FormEditor(this, filename, showWarning))
+            using (var formEditor = new FormEditor(this, filename, showWarning, highlightingSyntax))
                 return formEditor.ShowDialog() != DialogResult.Cancel;
         }
 


### PR DESCRIPTION
1. Add ability for specify syntax highlighting for GitExtensions editor via command line:
   `GitExtensions.exe fileeditor --syntax Python <path>`
2. Add simple coloring scheme `GitCommit` which has only definition for comment after #
3. Make default GitExtensions editor command line with syntax 'GitCommit'

Rebase example:

![image](https://cloud.githubusercontent.com/assets/703544/8850500/39dc7948-3151-11e5-9067-4d8464948d26.png)
