### PR TITLE
Manage new format to detect detached HEAD (Git >v2.4)

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -331,7 +331,7 @@ namespace GitCommands
         /// <summary>"(no branch)"</summary>
         public static readonly string DetachedBranch = "(no branch)";
 
-        private static readonly string[] DetachedPrefixes = { "(no branch", "(detached from " };
+        private static readonly string[] DetachedPrefixes = { "(no branch", "(detached from ", "(HEAD detached at " };
 
         public AppSettings.PullAction LastPullAction
         {


### PR DESCRIPTION
which is now returned by the `git branch` command output:
"(HEAD detached at c299581)"

See https://github.com/git/git/commit/4b06318664638d306cad920fd86eb63b69739310