### PR TITLE
Fix for nullref when displaying settings for the Periodic Background Fetch plugin

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -90,6 +90,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
             _autoGenKeywords.Clear();
 
+            LoadSettings();
+
             foreach (var setting in settings)
             {                
                 _autoGenKeywords.Add(setting.Caption);


### PR DESCRIPTION
Attempting to view the settings for the background fetch plugin causes a nullref in the code, as decribed in #2860.

The fix attemps to ensure that `GetControl()` is called on the form settings elements before using the `UserControl` property, so that it does not throw when `_control` is null (because it was not initialized).

I'm not exactly sure if this is the proper fix, but doing that solved the issue for me.