### PR TITLE
Fix build of wix project that complains about missing Newtonsoft.Json.dll

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -61,6 +61,10 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SmartFormat, Version=1.6.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SmartFormat.NET.1.6.1.0\lib\net40-Client\SmartFormat.dll</HintPath>
       <Private>True</Private>

--- a/GitExtensions/packages.config
+++ b/GitExtensions/packages.config
@@ -3,5 +3,6 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40-Client" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40-Client" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40-Client" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40-Client" />
   <package id="SmartFormat.NET" version="1.6.1.0" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
When attempting to build the wix project, it fails when looking for `..\GitExtensions\bin\Release\Newtonsoft.Json.dll` (relative from the Setup folder) which is not present after a checkout of the repository followed by a clean build.

It is probably because the GitExtensions main project does not reference this dll directly, and so it is not copied in the `bin\Release` folder.

Adding the JSON.Net nuget package to the GitExtension project seems to fix the issue for me, by forcing VS to copy the dll when building the project.

If there is a better way to fix this, please discard this PR.