### PR TITLE
Prevent scrollbars by resizing the WebBrowser control of the GitHub3 plugin

### DIFF
--- a/Plugins/Github3/OAuth.Designer.cs
+++ b/Plugins/Github3/OAuth.Designer.cs
@@ -39,7 +39,7 @@ namespace Github3
             this.webBrowser1.Location = new System.Drawing.Point(0, 0);
             this.webBrowser1.MinimumSize = new System.Drawing.Size(20, 20);
             this.webBrowser1.Name = "webBrowser1";
-            this.webBrowser1.Size = new System.Drawing.Size(980, 600);
+            this.webBrowser1.Size = new System.Drawing.Size(1000, 580);
             this.webBrowser1.TabIndex = 0;
             this.webBrowser1.Navigated += new System.Windows.Forms.WebBrowserNavigatedEventHandler(this.web_Navigated);
             this.webBrowser1.Navigating += new System.Windows.Forms.WebBrowserNavigatingEventHandler(this.web_Navigating);
@@ -48,7 +48,7 @@ namespace Github3
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(980, 600);
+            this.ClientSize = new System.Drawing.Size(1000, 580);
             this.Controls.Add(this.webBrowser1);
             this.Name = "OAuth";
             this.ShowIcon = false;


### PR DESCRIPTION
The github login page used by the OAuth form in the github3 seems to require a viewport size of at least 1000 x 580 pixels. 

The current control was too small (not by a lot) which introduced horizontal and vertical scroll bars.

<i>note: the github login page first display a warning about IE7/8 which requires a larger size. But once it is dismissed, then the page does not have bars anymore. I'm not sure how to remove this warning from github, but it may be caused by http://stackoverflow.com/questions/4097593/how-to-put-the-webbrowser-control-into-ie9-into-standards which doe not seems like an easy fix)</i>