### PR TITLE
Fix 3042: crash on commit dialog during autocomplete

### DIFF
--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -118,7 +118,15 @@ namespace GitUI.AutoCompletion
             if (content != null)
                 return content;
 
-            return File.ReadAllText(Path.Combine(module.WorkingDir, file.Name));
+            // Try to read the contents of the file: if it cannot be read, skip the operation silently.
+            try
+            {
+                return File.ReadAllText(Path.Combine(module.WorkingDir, file.Name));
+            }
+            catch
+            {
+                return "";
+            }
         }
     }
 }


### PR DESCRIPTION
If an attempt is made to enter a message in the commit dialog
when one of the changed files is not readable, GitExtensions
terminates with an unhandled exception.

Catch the exception thrown during the failed read operation,
and ignore it.