### PR TITLE
Closes #3075 - The xcopy commands in copy_plugins.cmd lack quotation …

### DIFF
--- a/GitExtensions/copy_plugins.cmd
+++ b/GitExtensions/copy_plugins.cmd
@@ -5,7 +5,7 @@ echo Microsoft.TeamFoundation.WorkItemTracking.Client.DataStoreLoader.dll > excl
 echo Microsoft.WITDataStore.dll >> exclude.txt
 for /d %%I in ("%~p0\..\Plugins\*", "%~p0\..\Plugins\Statistics\*", "%~p0\..\Plugins\BuildServerIntegration\*") do (
     if exist "%%I\bin\%config%\" (
-        xcopy /y /r %%I\bin\%config%\*.dll Plugins\ /EXCLUDE:exclude.txt
-        xcopy /y /r %%I\bin\%config%\*.pdb Plugins\
+        xcopy /y /r "%%I\bin\%config%\*.dll" Plugins\ /EXCLUDE:exclude.txt
+        xcopy /y /r "%%I\bin\%config%\*.pdb" Plugins\
     )
 )


### PR DESCRIPTION
…marks and can't handle spaces in paths

Added missing quotation marks