### PR TITLE
Mistery Newton Json Version 4.5

### DIFF
--- a/GitExtensions/app.config
+++ b/GitExtensions/app.config
@@ -28,6 +28,10 @@
         <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.5.0" newVersion="2.2.5.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings></connectionStrings>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _populateBuildServerTypeTask =
                 Task.Factory.StartNew(() =>
                         {
-                            var exports = ManagedExtensibility.CompositionContainer.GetExports<IBuildServerAdapter, IBuildServerTypeMetadata>();
+                            var exports = ManagedExtensibility.GetExports<IBuildServerAdapter, IBuildServerTypeMetadata>();
                             var buildServerTypes = exports.Select(export =>
                                 {
                                     var canBeLoaded = export.Metadata.CanBeLoaded;
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return null;
             var defaultProjectName = Module.WorkingDir.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).Last();
 
-            var exports = ManagedExtensibility.CompositionContainer.GetExports<IBuildServerSettingsUserControl, IBuildServerTypeMetadata>();
+            var exports = ManagedExtensibility.GetExports<IBuildServerSettingsUserControl, IBuildServerTypeMetadata>();
             var selectedExport = exports.SingleOrDefault(export => export.Metadata.BuildServerType == GetSelectedBuildServerType());
             if (selectedExport != null)
             {

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2012/TfsInterop.Vs2012.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2012/TfsInterop.Vs2012.csproj
@@ -45,6 +45,10 @@
       <HintPath>..\..\..\packages\Microsoft.TeamFoundation.Build.Client.11.0.60610.1\lib\Microsoft.TeamFoundation.Build.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2012/packages.config
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2012/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Microsoft.TeamFoundation.Build.Client" version="11.0.60610.1" targetFramework="net40-Client" />
   <package id="Microsoft.TeamFoundation.Client" version="11.0.51106.1" targetFramework="net40-Client" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40-client" />
 </packages>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2013/TfsInterop.Vs2013.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2013/TfsInterop.Vs2013.csproj
@@ -47,6 +47,10 @@
       <Private>True</Private>
       <HintPath>..\..\..\packages\Microsoft.TeamFoundation.Client-final.12.0.21005.1\lib\Microsoft.TeamFoundation.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2013/packages.config
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2013/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Microsoft.TeamFoundation.Build.Client-final" version="12.0.21005.1" targetFramework="net45" />
   <package id="Microsoft.TeamFoundation.Client-final" version="12.0.21005.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fix #2984 and #3041

- Added a binding redirect to 6.0 version of newton json, in case any dll is referencing  v4.5, for example `System.Http.Format.dll`

- Changed the MEF to load plugins into individual containers: the build server adapters were failed to be loaded because the MEF container tries to load all dlls from the Plugins folder in one go, the whole loading will be cancelled if one of the plugins failed. And the MEF also tries to load non-plugin dlls(more specifically, `System.Net.Http.dll`, `Microsoft.TeamFoundation.Build.Client.dll`). If any of these dlls failed to find their reference, no plugin can be loaded.