### PR TITLE
Feature/update repo status using rx

### DIFF
--- a/GitUI/UserControls/ToolStripGitStatus.Designer.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.Designer.cs
@@ -33,7 +33,6 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            new System.Windows.Forms.Timer(this.components);
             this.ignoredFilesTimer = new System.Windows.Forms.Timer(this.components);
             // 
             // ignoredFilesTimer

--- a/GitUI/UserControls/ToolStripGitStatus.Designer.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.Designer.cs
@@ -15,7 +15,10 @@
         {
             if (disposing && (components != null))
             {
-                _repoStatusObservable.Dispose();
+                if (_repoStatusSubscription != null)
+                {
+                    _repoStatusSubscription.Dispose();
+                }
                 components.Dispose();
             }
             base.Dispose(disposing);

--- a/GitUI/UserControls/ToolStripGitStatus.Designer.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.Designer.cs
@@ -15,6 +15,7 @@
         {
             if (disposing && (components != null))
             {
+                _repoStatusObservable.Dispose();
                 components.Dispose();
             }
             base.Dispose(disposing);
@@ -29,14 +30,8 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.timerRefresh = new System.Windows.Forms.Timer(this.components);
+            new System.Windows.Forms.Timer(this.components);
             this.ignoredFilesTimer = new System.Windows.Forms.Timer(this.components);
-            // 
-            // timerRefresh
-            // 
-            this.timerRefresh.Enabled = true;
-            this.timerRefresh.Interval = 500;
-            this.timerRefresh.Tick += new System.EventHandler(this.timerRefresh_Tick);
             // 
             // ignoredFilesTimer
             // 
@@ -47,7 +42,6 @@
 
         #endregion
 
-        private System.Windows.Forms.Timer timerRefresh;
         private System.Windows.Forms.Timer ignoredFilesTimer;
     }
 }

--- a/GitUI/UserControls/ToolStripGitStatus.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.cs
@@ -114,12 +114,14 @@ namespace GitUI
                 {
                     lock (SyncFetchingRepoStatus)
                     {
+                        var currentSkipInterval = skipInterval;
+
                         if (skipInterval > 0)
                         {
                             skipInterval -= 1;
                         }
 
-                        return skipInterval > 0;
+                        return currentSkipInterval > 0;
                     }
                 })
                 .Where(i => !UICommands.RepoChangedNotifier.IsLocked &&

--- a/GitUI/UserControls/ToolStripGitStatus.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.cs
@@ -45,9 +45,7 @@ namespace GitUI
 
         private IGitUICommandsSource _UICommandsSource;
         private readonly IObservable<List<GitItemStatus>> _repoStatusObservable;
-
-        [CanBeNull]
-        private IDisposable _repoStatusSubscription;
+        private readonly IDisposable _repoStatusSubscription;
 
         public IGitUICommandsSource UICommandsSource
         {
@@ -134,6 +132,8 @@ namespace GitUI
 
                     return GitCommandHelpers.GetAllChangedFilesFromString(Module, result);
                 })
+                .Timeout(TimeSpan.FromMilliseconds(MaxUpdatePeriod))
+                .Retry()
                 .SubscribeOn(TaskPoolScheduler.Default)
                 .ObserveOn(SynchronizationContext.Current);
 
@@ -318,7 +318,7 @@ namespace GitUI
                         Visible = true;
                         break;
 
-                    default: throw new NotImplementedException("Others status aren't implememted yet.");
+                    default: throw new NotImplementedException("Others status aren't implemented yet.");
                 }
             }
         }

--- a/GitUI/UserControls/ToolStripGitStatus.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.cs
@@ -311,6 +311,7 @@ namespace GitUI
                         _gitDirWatcher.EnableRaisingEvents = !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
                         Visible = true;
 
+                        // INFO minidfx 2015.01.16: Subscribe to the observable only when the property is set the first time to Started.
                         if (_repoStatusSubscription == null)
                         {
                             _repoStatusSubscription = _repoStatusObservable

--- a/GitUI/UserControls/ToolStripGitStatus.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.cs
@@ -292,17 +292,20 @@ namespace GitUI
             set
             {
                 _currentStatus = value;
+
                 switch (_currentStatus)
                 {
                     case WorkingStatus.Stopped:
                         _workTreeWatcher.EnableRaisingEvents = false;
                         _gitDirWatcher.EnableRaisingEvents = false;
                         Visible = false;
-                        return;
+                        break;
+
                     case WorkingStatus.Paused:
                         _workTreeWatcher.EnableRaisingEvents = false;
                         _gitDirWatcher.EnableRaisingEvents = false;
-                        return;
+                        break;
+
                     case WorkingStatus.Started:
                         _workTreeWatcher.EnableRaisingEvents = true;
                         _gitDirWatcher.EnableRaisingEvents = !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
@@ -320,10 +323,9 @@ namespace GitUI
                                         CurrentStatus = WorkingStatus.Stopped;
                                     });
                         }
+                        break;
 
-                        return;
-                    default:
-                        throw new NotSupportedException();
+                    default: throw new NotImplementedException("Others status aren't implememted yet.");
                 }
             }
         }

--- a/GitUI/UserControls/ToolStripGitStatus.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.cs
@@ -132,8 +132,6 @@ namespace GitUI
 
                     return GitCommandHelpers.GetAllChangedFilesFromString(Module, result);
                 })
-                //.Publish()
-                //.RefCount() // Uncomment these lines if you have many subscriptions!
                 .SubscribeOn(TaskPoolScheduler.Default)
                 .ObserveOn(SynchronizationContext.Current);
         }

--- a/GitUI/UserControls/ToolStripGitStatus.cs
+++ b/GitUI/UserControls/ToolStripGitStatus.cs
@@ -134,6 +134,10 @@ namespace GitUI
                 })
                 .SubscribeOn(TaskPoolScheduler.Default)
                 .ObserveOn(SynchronizationContext.Current);
+
+            _repoStatusSubscription = _repoStatusObservable.Subscribe(UpdateUI,
+                e => { CurrentStatus = WorkingStatus.Stopped; },
+                () => { CurrentStatus = WorkingStatus.Stopped; });
         }
 
         private void GitUICommandsChanged(object sender, GitUICommandsChangedEventArgs e)
@@ -310,20 +314,6 @@ namespace GitUI
                         _workTreeWatcher.EnableRaisingEvents = true;
                         _gitDirWatcher.EnableRaisingEvents = !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
                         Visible = true;
-
-                        // INFO minidfx 2015.01.16: Subscribe to the observable only when the property is set the first time to Started.
-                        if (_repoStatusSubscription == null)
-                        {
-                            _repoStatusSubscription = _repoStatusObservable
-                                .Subscribe(UpdateUI, e =>
-                                {
-                                    CurrentStatus = WorkingStatus.Stopped;
-                                },
-                                    () =>
-                                    {
-                                        CurrentStatus = WorkingStatus.Stopped;
-                                    });
-                        }
                         break;
 
                     default: throw new NotImplementedException("Others status aren't implememted yet.");


### PR DESCRIPTION
Hello,

I improved the way for updating the repository status using Reactive Extension keeping the previous rules because on some computers with some repositories the update is very slow.

The work for checking if any changes exists is done in ```TaskPoolScheduler``` and only the work for updating the UI is done on the ```SynchronizationContext``` scheduler.

The application is much reactive because the job isn't made on UI thread like the [Timer](https://msdn.microsoft.com/en-us/library/system.windows.forms.timer(v=vs.110).aspx#Anchor_6).

What do you think?