### PR TITLE
#2929 Fixed submodule's gitdir detection to avoid false positives for worktree gitdirs

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1296,7 +1296,7 @@ namespace GitCommands
                     if (line.StartsWith("gitdir:"))
                     {
                         string gitpath = line.Substring(7).Trim();
-                        int pos = gitpath.IndexOf("/.git/");
+                        int pos = gitpath.IndexOf("/.git/modules/");
                         if (pos != -1)
                         {
                             gitpath = gitpath.Substring(0, pos + 1).Replace('/', '\\');


### PR DESCRIPTION
Since v2.5 git supports worktrees whose gitdirs are located under the same .git as submodules,
so submodule detection string should be more specific to distinguish them.