### PR TITLE
Commit dialog honors value of `status.showUntrackedFiles'  git config.

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -229,7 +229,7 @@ namespace GitUI.CommandsDialogs
             ResetUnStaged.Visible = AppSettings.ShowResetUnstagedChanges;
             CommitAndPush.Visible = AppSettings.ShowCommitAndPush;
             AdjustCommitButtonPanelHeight();
-	    showUntrackedFilesToolStripMenuItem.Checked = !Module.RunGitCmd("config status.showUntrackedFiles").Trim().Equals("no");
+            showUntrackedFilesToolStripMenuItem.Checked = !Module.EffectiveConfigFile.GetValue("status.showUntrackedFiles").Equals("no");
         }
 
         private void AdjustCommitButtonPanelHeight()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -229,6 +229,7 @@ namespace GitUI.CommandsDialogs
             ResetUnStaged.Visible = AppSettings.ShowResetUnstagedChanges;
             CommitAndPush.Visible = AppSettings.ShowCommitAndPush;
             AdjustCommitButtonPanelHeight();
+	    showUntrackedFilesToolStripMenuItem.Checked = !Module.RunGitCmd("config status.showUntrackedFiles").Trim().Equals("no");
         }
 
         private void AdjustCommitButtonPanelHeight()


### PR DESCRIPTION
Hello, 

This is first time when I use GitHub to contribute to somebody's else project, also I have practically 0 experience with C#; so please forgive me if I do something patently wrong.  My small contribution tries to add feature described in https://github.com/gitextensions/gitextensions/issues/1872.
