### PR TITLE
Add Edit functionality in Advanced menu

### DIFF
--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -27,8 +27,6 @@ namespace GitCommands
 
                 Kill();
 
-                string quotedCmd = quoteString(cmd);
-
                 var executionStartTimestamp = DateTime.Now;
 
                 var startInfo = GitCommandHelpers.CreateProcessStartInfo(cmd, arguments, WorkingDirectory, GitModule.SystemEncoding);
@@ -36,7 +34,7 @@ namespace GitCommands
                 startInfo.CreateNoWindow = (!ssh && !AppSettings.ShowGitCommandLine);
 
                 //process used to execute external commands
-                return createProcess(startInfo, quotedCmd + " " + arguments, executionStartTimestamp);
+                return createProcess(startInfo, quoteString(cmd) + " " + arguments, executionStartTimestamp);
             }
             catch (Exception ex)
             {

--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -25,8 +25,6 @@ namespace GitCommands
             {
                 GitCommandHelpers.SetEnvironmentVariable();
 
-                var ssh = GitCommandHelpers.UseSsh(arguments);
-
                 Kill();
 
                 string quotedCmd = cmd;
@@ -36,6 +34,7 @@ namespace GitCommands
                 var executionStartTimestamp = DateTime.Now;
 
                 var startInfo = GitCommandHelpers.CreateProcessStartInfo(cmd, arguments, WorkingDirectory, GitModule.SystemEncoding);
+                var ssh = GitCommandHelpers.UseSsh(arguments);
                 startInfo.CreateNoWindow = (!ssh && !AppSettings.ShowGitCommandLine);
 
                 //process used to execute external commands

--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -27,9 +27,7 @@ namespace GitCommands
 
                 Kill();
 
-                string quotedCmd = cmd;
-                if (quotedCmd.IndexOf(' ') != -1)
-                    quotedCmd = quotedCmd.Quote();
+                string quotedCmd = quoteString(cmd);
 
                 var executionStartTimestamp = DateTime.Now;
 
@@ -46,6 +44,14 @@ namespace GitCommands
                 ex.Data.Add("arguments", arguments);
                 throw;
             }
+        }
+
+        private string quoteString(String cmd)
+        {
+            if (cmd.IndexOf(' ') != -1)
+                return cmd.Quote();
+
+            return cmd;
         }
 
         private Process createProcess(ProcessStartInfo startInfo, String log, DateTime executionStartTimestamp)

--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -49,7 +49,7 @@ namespace GitCommands
             }
         }
 
-        private string quoteString(String cmd)
+        private string quoteString(string cmd)
         {
             if (cmd.IndexOf(' ') != -1)
                 return cmd.Quote();
@@ -57,7 +57,7 @@ namespace GitCommands
             return cmd;
         }
 
-        private Process createProcess(ProcessStartInfo startInfo, String log, DateTime executionStartTimestamp)
+        private Process createProcess(ProcessStartInfo startInfo, string log, DateTime executionStartTimestamp)
         {
             var process = new Process();
             process.StartInfo = startInfo;

--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security.Permissions;
 
@@ -19,7 +20,7 @@ namespace GitCommands
         }
 
         [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
-        public Process CmdStartProcess(string cmd, string arguments)
+        public Process CmdStartProcess(string cmd, string arguments, Dictionary<string, string> envVariables)
         {
             try
             {
@@ -32,6 +33,10 @@ namespace GitCommands
                 var startInfo = GitCommandHelpers.CreateProcessStartInfo(cmd, arguments, WorkingDirectory, GitModule.SystemEncoding);
                 var ssh = GitCommandHelpers.UseSsh(arguments);
                 startInfo.CreateNoWindow = (!ssh && !AppSettings.ShowGitCommandLine);
+
+                foreach (var envVariable in envVariables)
+                    startInfo.EnvironmentVariables.Add(envVariable.Key, envVariable.Value);
+
 
                 //process used to execute external commands
                 return createProcess(startInfo, quoteString(cmd) + " " + arguments, executionStartTimestamp);

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -81,7 +81,7 @@ namespace GitUI
 
         public static bool ShowDialog(IWin32Window owner, string process, string arguments, string aWorkingDirectory, string input, bool useDialogSettings)
         {
-            using (var formProcess = new FormProcess(process, arguments, new Dictionary<String, String>(), aWorkingDirectory, input, useDialogSettings))
+            using (var formProcess = new FormProcess(process, arguments, new Dictionary<string, string>(), aWorkingDirectory, input, useDialogSettings))
             {
                 formProcess.ShowDialog(owner);
                 return !formProcess.ErrorOccurred();
@@ -90,7 +90,7 @@ namespace GitUI
 
         public static FormProcess ShowModeless(IWin32Window owner, string process, string arguments, string aWorkingDirectory, string input, bool useDialogSettings)
         {
-            FormProcess formProcess = new FormProcess(process, arguments, new Dictionary<String, String>(), aWorkingDirectory, input, useDialogSettings);
+            FormProcess formProcess = new FormProcess(process, arguments, new Dictionary<string, string>(), aWorkingDirectory, input, useDialogSettings);
 
             formProcess.ControlBox = true;
             formProcess.Show(owner);

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using ResourceManager;
+using System.Collections.Generic;
 
 namespace GitUI
 {
@@ -29,13 +30,13 @@ namespace GitUI
         { }
 
         public FormRemoteProcess(GitModule module, string process, string arguments)
-            : base(process, arguments, module.WorkingDir, null, true)
+            : base(process, arguments, new Dictionary<string, string>(), module.WorkingDir, null, true)
         {
             this.Module = module;
         }
 
         public FormRemoteProcess(GitModule module, string arguments)
-            : base(null, arguments, module.WorkingDir, null, true)
+            : base(null, arguments, new Dictionary<string, string>(), module.WorkingDir, null, true)
         {
             this.Module = module;
         }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7090,6 +7090,10 @@ This will just checkout on the submodule the commit determined by the superproje
         <source>Draw non relatives gray</source>
         <target />
       </trans-unit>
+	  <trans-unit id="editCommitToolStripMenuItem.Text">
+        <source>Edit commit</source>
+        <target />
+      </trans-unit>
       <trans-unit id="filterToolStripMenuItem.Text">
         <source>Set advanced filter</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7090,7 +7090,7 @@ This will just checkout on the submodule the commit determined by the superproje
         <source>Draw non relatives gray</source>
         <target />
       </trans-unit>
-	  <trans-unit id="editCommitToolStripMenuItem.Text">
+      <trans-unit id="editCommitToolStripMenuItem.Text">
         <source>Edit commit</source>
         <target />
       </trans-unit>

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -108,6 +108,7 @@ namespace GitUI
             this.cherryPickCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.archiveRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.manipulateCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fixupCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.squashCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -502,11 +503,19 @@ namespace GitUI
             // manipulateCommitToolStripMenuItem
             //
             this.manipulateCommitToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.editCommitToolStripMenuItem,
             this.fixupCommitToolStripMenuItem,
             this.squashCommitToolStripMenuItem});
             this.manipulateCommitToolStripMenuItem.Name = "manipulateCommitToolStripMenuItem";
             this.manipulateCommitToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
             this.manipulateCommitToolStripMenuItem.Text = "Advanced";
+            //
+            // editCommitToolStripMenuItem
+            //
+            this.editCommitToolStripMenuItem.Name = "editCommitToolStripMenuItem";
+            this.editCommitToolStripMenuItem.Size = new System.Drawing.Size(180, 24);
+            this.editCommitToolStripMenuItem.Text = "Edit commit";
+            this.editCommitToolStripMenuItem.Click += new System.EventHandler(this.EditCommitToolStripMenuItemClick);
             //
             // fixupCommitToolStripMenuItem
             //
@@ -764,6 +773,7 @@ namespace GitUI
         private System.Windows.Forms.Button CloneRepository;
         private System.Windows.Forms.ToolStripMenuItem showMergeCommitsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem manipulateCommitToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem editCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fixupCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem squashCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem renameBranchToolStripMenuItem;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1926,7 +1926,7 @@ namespace GitUI
 
         private void CreateTagToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             using (var frm = new FormCreateTag(UICommands, GetRevision(LastRowIndex)))
@@ -1940,7 +1940,7 @@ namespace GitUI
 
         private void ResetCurrentBranchToHereToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             var frm = new FormResetCurrentBranch(UICommands, GetRevision(LastRowIndex));
@@ -1949,7 +1949,7 @@ namespace GitUI
 
         private void CreateNewBranchToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             UICommands.DoActionOnRepo(() =>
@@ -2066,7 +2066,7 @@ namespace GitUI
 
         private void RevertCommitToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             UICommands.StartRevertCommitDialog(this, GetRevision(LastRowIndex));
@@ -2315,7 +2315,7 @@ namespace GitUI
 
         private void CheckoutRevisionToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             string revision = GetRevision(LastRowIndex).Guid;
@@ -2383,7 +2383,7 @@ namespace GitUI
 
         private void FixupCommitToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             UICommands.StartFixupCommitDialog(this, GetRevision(LastRowIndex));
@@ -2391,12 +2391,16 @@ namespace GitUI
 
         private void SquashCommitToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             UICommands.StartSquashCommitDialog(this, GetRevision(LastRowIndex));
         }
 
+        private bool ShouldStartDialog()
+        {
+            return Revisions.RowCount <= LastRowIndex || LastRowIndex < 0;
+        }
         internal void ShowRelativeDate_ToolStripMenuItemClick(object sender, EventArgs e)
         {
             AppSettings.RelativeDate = !AppSettings.RelativeDate;
@@ -2533,7 +2537,7 @@ namespace GitUI
 
         private void ContinueBisect(GitBisectOption bisectOption)
         {
-            if (Revisions.RowCount <= LastRowIndex || LastRowIndex < 0)
+            if (ShouldStartDialog())
                 return;
 
             FormProcess.ShowDialog(this, Module, GitCommandHelpers.ContinueBisectCmd(bisectOption, GetRevision(LastRowIndex).Guid), false);

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2392,7 +2392,7 @@ namespace GitUI
                 false /* shouldAutosquash */,
                 true /* shouldStash */);
 
-            Dictionary<string, string> envVariables = new Dictionary<String, String>();
+            Dictionary<string, string> envVariables = new Dictionary<string, string>();
             envVariables.Add("GIT_SEQUENCE_EDITOR", "sed -i -re '0,/pick/s//e/'");
             FormProcess.ReadDialog(this, null, rebaseCmd, envVariables, this.Module, null, true);
         }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2381,6 +2381,22 @@ namespace GitUI
             UICommands.StartCherryPickDialog(this, revisions);
         }
 
+        private void EditCommitToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            if (ShouldStartDialog())
+                return;
+
+            String rebaseCmd = GitCommandHelpers.RebaseCmd(GetRevision(LastRowIndex).ParentGuids[0],
+                true  /* isRebaseInteractive */,
+                false /* shouldPreserveMerges */,
+                false /* shouldAutosquash */,
+                true /* shouldStash */);
+
+            Dictionary<string, string> envVariables = new Dictionary<String, String>();
+            envVariables.Add("GIT_SEQUENCE_EDITOR", "sed -i -re '0,/pick/s//e/'");
+            FormProcess.ReadDialog(this, null, rebaseCmd, envVariables, this.Module, null, true);
+        }
+
         private void FixupCommitToolStripMenuItemClick(object sender, EventArgs e)
         {
             if (ShouldStartDialog())
@@ -2401,6 +2417,7 @@ namespace GitUI
         {
             return Revisions.RowCount <= LastRowIndex || LastRowIndex < 0;
         }
+
         internal void ShowRelativeDate_ToolStripMenuItemClick(object sender, EventArgs e)
         {
             AppSettings.RelativeDate = !AppSettings.RelativeDate;


### PR DESCRIPTION
Issue: 3166
Add Edit functionality in Advanced menu.
By clicking it, it will :

![gitextension_editmenu](https://cloud.githubusercontent.com/assets/3659358/14409726/1213b09a-ff1c-11e5-8608-9502c31ed93a.png)

Btw, If it's ok with you i will do the same for the functionality "rename" a commit.
