### PR TITLE
Invalid Character in FormBrowse.Designer.cs

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -1951,7 +1951,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.menuitemSparse.Name = "menuitemSparse";
             this.menuitemSparse.Size = new System.Drawing.Size(221, 22);
-            this.menuitemSparse.Text = "Sparse Working Copy…";
+            this.menuitemSparse.Text = "Sparse Working Copy";
             this.menuitemSparse.Click += new System.EventHandler(this.menuitemSparseWorkingCopy_Click);
             // 
             // commitcountPerUserToolStripMenuItem


### PR DESCRIPTION
If you copy the changed lines to notepad++, you will see a `?` at the end, hence failed to build.

Fixes #3185