### PR TITLE
Fix diff for the root commit

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -333,7 +333,8 @@ namespace GitCommands
                             _revision.Refs.AddRange(gitRefs);
                     }
 
-                    _revision.ParentGuids = lines[2].Split(new char[] { ' ' });
+                    // RemoveEmptyEntries is required for root commits. They should have empty list of parents.
+                    _revision.ParentGuids = lines[2].Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     _revision.TreeGuid = lines[3];
 
                     _revision.Author = lines[4];


### PR DESCRIPTION
GitUI.FileStatusList.SetDiff(GitRevision) expected GitRevision.ParentGuids to be null or empty,
but it had one element with empty string. The fix is to make ParentGuids empty for root commits.

Closes #3067.