### PR TITLE
Fix missing 7-Zip binary when building Mono archive

### DIFF
--- a/Setup/packages.config
+++ b/Setup/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="WiX.Toolset" version="3.8.1128.0" />
+  <package id="7-Zip.CommandLine" version="9.20.0" />
 </packages>


### PR DESCRIPTION
Fixes #3195