### PR TITLE
Feature/visibility adjustments

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -54,7 +54,7 @@ namespace GitUI
         private readonly TranslationString _cannotHighlightSelectedBranch = new TranslationString("Cannot highlight selected branch when revision graph is loading.");
         private readonly TranslationString _noRevisionFoundError = new TranslationString("No revision found.");
 
-        private const int NodeDimension = 8;
+        private const int NodeDimension = 10;
         private const int LaneWidth = 13;
         private const int LaneLineWidth = 2;
         private const int MaxSuperprojectRefs = 4;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1414,7 +1414,13 @@ namespace GitUI
             }
             else
             {
-                e.Graphics.FillRectangle(Brushes.White, e.CellBounds);
+                if (e.RowIndex % 2 == 0)
+                {
+                    Brush brush = new SolidBrush(Color.FromArgb(255, 240, 240, 240));
+                    e.Graphics.FillRectangle(brush, e.CellBounds);
+                }
+                else
+                    e.Graphics.FillRectangle(Brushes.White, e.CellBounds);
             }
 
             Color foreColor;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1416,11 +1416,14 @@ namespace GitUI
             {
                 if (e.RowIndex % 2 == 0)
                 {
+                    e.Graphics.FillRectangle(Brushes.White, e.CellBounds);
+                }
+                else
+                {
                     Brush brush = new SolidBrush(Color.FromArgb(255, 240, 240, 240));
                     e.Graphics.FillRectangle(brush, e.CellBounds);
                 }
-                else
-                    e.Graphics.FillRectangle(Brushes.White, e.CellBounds);
+                    
             }
 
             Color foreColor;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -130,7 +130,7 @@ namespace GitUI.RevisionGridClasses
             RowHeadersDefaultCellStyle.Font = SystemFonts.DefaultFont;
             RowTemplate.DefaultCellStyle.Font = SystemFonts.DefaultFont;
 
-            _whiteBorderPen = new Pen(Brushes.White, _laneLineWidth + 2);
+            _whiteBorderPen = new Pen(Brushes.White, _laneLineWidth);
             _blackBorderPen = new Pen(Brushes.Black, _laneLineWidth + 1);
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer, true);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -542,7 +542,7 @@ namespace GitUI.RevisionGridClasses
             if ((e.State & DataGridViewElementStates.Visible) == 0 || e.ColumnIndex != 0)
                 return;
 
-            var standardBrush = (e.RowIndex % 2 == 0) ? new SolidBrush(Color.FromArgb(255, 240, 240, 240)) : Brushes.White;
+            var standardBrush = (e.RowIndex % 2 == 0) ? Brushes.White : new SolidBrush(Color.FromArgb(255, 240, 240, 240));
             var brush = (e.State & DataGridViewElementStates.Selected) == DataGridViewElementStates.Selected
                             ? _selectionBrush : standardBrush;
             e.Graphics.FillRectangle(brush, e.CellBounds);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -52,7 +52,7 @@ namespace GitUI.RevisionGridClasses
 
         #endregion
 
-        private int _nodeDimension = 8;
+        private int _nodeDimension = 10;
         private int _laneWidth = 13;
         private int _laneLineWidth = 2;
         private const int MaxLanes = 40;
@@ -1287,8 +1287,6 @@ namespace GitUI.RevisionGridClasses
 
             return childrenIds;
         }
-
-
 
         private void dataGrid_Resize(object sender, EventArgs e)
         {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -542,8 +542,9 @@ namespace GitUI.RevisionGridClasses
             if ((e.State & DataGridViewElementStates.Visible) == 0 || e.ColumnIndex != 0)
                 return;
 
+            var standardBrush = (e.RowIndex % 2 == 0) ? new SolidBrush(Color.FromArgb(255, 240, 240, 240)) : Brushes.White;
             var brush = (e.State & DataGridViewElementStates.Selected) == DataGridViewElementStates.Selected
-                            ? _selectionBrush : Brushes.White;
+                            ? _selectionBrush : standardBrush;
             e.Graphics.FillRectangle(brush, e.CellBounds);
 
             Rectangle srcRect = DrawGraph(e.RowIndex);


### PR DESCRIPTION
Hello!

here is another pull request (first, with more verbose comment, is https://github.com/gitextensions/gitextensions/pull/3198)

On this branch I made slight visibility adjustments for the grid (very minor ones and may be not mature, but they, in my opinion, improve visual perception): striped alternating rows and "decreased" white outlining for the branches

Here are screenshots (as you requested in Contributing.md):

Alternating rows change is visible here:
![rows](https://cloud.githubusercontent.com/assets/16781381/15143740/88ca9ed2-16ab-11e6-9b77-b4116d731b4d.JPG)

White outlining decrease is visible here:
![selectedrows](https://cloud.githubusercontent.com/assets/16781381/15143749/8cfe280c-16ab-11e6-97e8-beee36ca2af8.JPG)

As for alternating Rows, ideally I think their should be an option to select their color int the Settings->Colors, so that people can have then totally white background as before (if they select White for alternated color). Or any other color, and then they get striped rows. 
But I didn't want to make people bother with translation of a new string, so for now (it is a premature pull request anyway just to know if you like the change) I hardcoded the colors. I, if necessary in general, can do german, russian and french translations. 

Anyhow, thanks for a nice product!
