### PR TITLE
Prevent crash due to invalid Build CI project name regex saved

### DIFF
--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
@@ -28,77 +28,56 @@ namespace TeamCityIntegration.Settings
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.Label label13;
+            System.Windows.Forms.Label label1;
+            System.Windows.Forms.Label labelBuildFilter;
+            System.Windows.Forms.Label labelProjectNameComment;
+            System.Windows.Forms.Label labelBuildIdFilter;
             this.TeamCityServerUrl = new System.Windows.Forms.TextBox();
             this.TeamCityProjectName = new System.Windows.Forms.TextBox();
             this.TeamCityBuildIdFilter = new System.Windows.Forms.TextBox();
-            this.label13 = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.labelBuildFilter = new System.Windows.Forms.Label();
-            this.labelProjectNameComment = new System.Windows.Forms.Label();
-            this.labelBuildIdFilter = new System.Windows.Forms.Label();
+            this.labelRegexError = new System.Windows.Forms.Label();
+            label13 = new System.Windows.Forms.Label();
+            label1 = new System.Windows.Forms.Label();
+            labelBuildFilter = new System.Windows.Forms.Label();
+            labelProjectNameComment = new System.Windows.Forms.Label();
+            labelBuildIdFilter = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // label13
             // 
             label13.AutoSize = true;
-            label13.Location = new System.Drawing.Point(3, 11);
+            label13.Location = new System.Drawing.Point(3, 12);
             label13.Name = "label13";
-            label13.Size = new System.Drawing.Size(116, 15);
+            label13.Size = new System.Drawing.Size(137, 17);
             label13.TabIndex = 0;
             label13.Text = "TeamCity server URL";
             // 
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(3, 40);
+            label1.Location = new System.Drawing.Point(3, 43);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(77, 15);
+            label1.Size = new System.Drawing.Size(90, 17);
             label1.TabIndex = 2;
             label1.Text = "Project name";
             // 
             // labelBuildFilter
             // 
             labelBuildFilter.AutoSize = true;
-            labelBuildFilter.Location = new System.Drawing.Point(3, 90);
+            labelBuildFilter.Location = new System.Drawing.Point(3, 96);
             labelBuildFilter.Name = "labelBuildFilter";
-            labelBuildFilter.Size = new System.Drawing.Size(76, 15);
+            labelBuildFilter.Size = new System.Drawing.Size(84, 17);
             labelBuildFilter.TabIndex = 4;
             labelBuildFilter.Text = "Build Id Filter";
-            // 
-            // TeamCityServerUrl
-            // 
-            this.TeamCityServerUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TeamCityServerUrl.Location = new System.Drawing.Point(136, 8);
-            this.TeamCityServerUrl.Name = "TeamCityServerUrl";
-            this.TeamCityServerUrl.Size = new System.Drawing.Size(318, 23);
-            this.TeamCityServerUrl.TabIndex = 1;
-            // 
-            // TeamCityProjectName
-            // 
-            this.TeamCityProjectName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TeamCityProjectName.Location = new System.Drawing.Point(136, 37);
-            this.TeamCityProjectName.Name = "TeamCityProjectName";
-            this.TeamCityProjectName.Size = new System.Drawing.Size(318, 23);
-            this.TeamCityProjectName.TabIndex = 3;
-            // 
-            // TeamCityBuildIdFilter
-            // 
-            this.TeamCityBuildIdFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TeamCityBuildIdFilter.Location = new System.Drawing.Point(136, 87);
-            this.TeamCityBuildIdFilter.Name = "TeamCityBuildIdFilter";
-            this.TeamCityBuildIdFilter.Size = new System.Drawing.Size(318, 23);
-            this.TeamCityBuildIdFilter.TabIndex = 5;
             // 
             // labelProjectNameComment
             // 
             labelProjectNameComment.AutoSize = true;
             labelProjectNameComment.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
-            labelProjectNameComment.Location = new System.Drawing.Point(133, 63);
+            labelProjectNameComment.Location = new System.Drawing.Point(133, 67);
             labelProjectNameComment.Name = "labelProjectNameComment";
-            labelProjectNameComment.Size = new System.Drawing.Size(173, 15);
+            labelProjectNameComment.Size = new System.Drawing.Size(210, 20);
             labelProjectNameComment.TabIndex = 6;
             labelProjectNameComment.Text = "Several names splitted by | char";
             // 
@@ -106,16 +85,57 @@ namespace TeamCityIntegration.Settings
             // 
             labelBuildIdFilter.AutoSize = true;
             labelBuildIdFilter.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
-            labelBuildIdFilter.Location = new System.Drawing.Point(133, 113);
+            labelBuildIdFilter.Location = new System.Drawing.Point(133, 121);
             labelBuildIdFilter.Name = "labelBuildIdFilter";
-            labelBuildIdFilter.Size = new System.Drawing.Size(45, 15);
+            labelBuildIdFilter.Size = new System.Drawing.Size(55, 20);
             labelBuildIdFilter.TabIndex = 7;
             labelBuildIdFilter.Text = "Regexp";
             // 
+            // TeamCityServerUrl
+            // 
+            this.TeamCityServerUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TeamCityServerUrl.Location = new System.Drawing.Point(136, 9);
+            this.TeamCityServerUrl.Name = "TeamCityServerUrl";
+            this.TeamCityServerUrl.Size = new System.Drawing.Size(443, 23);
+            this.TeamCityServerUrl.TabIndex = 1;
+            // 
+            // TeamCityProjectName
+            // 
+            this.TeamCityProjectName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TeamCityProjectName.Location = new System.Drawing.Point(136, 39);
+            this.TeamCityProjectName.Name = "TeamCityProjectName";
+            this.TeamCityProjectName.Size = new System.Drawing.Size(443, 23);
+            this.TeamCityProjectName.TabIndex = 3;
+            // 
+            // TeamCityBuildIdFilter
+            // 
+            this.TeamCityBuildIdFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TeamCityBuildIdFilter.Location = new System.Drawing.Point(136, 93);
+            this.TeamCityBuildIdFilter.Name = "TeamCityBuildIdFilter";
+            this.TeamCityBuildIdFilter.Size = new System.Drawing.Size(443, 23);
+            this.TeamCityBuildIdFilter.TabIndex = 5;
+            this.TeamCityBuildIdFilter.TextChanged += new System.EventHandler(this.TeamCityBuildIdFilter_TextChanged);
+            // 
+            // labelRegexError
+            // 
+            this.labelRegexError.AutoSize = true;
+            this.labelRegexError.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            this.labelRegexError.ForeColor = System.Drawing.Color.Red;
+            this.labelRegexError.Location = new System.Drawing.Point(133, 152);
+            this.labelRegexError.Name = "labelRegexError";
+            this.labelRegexError.Size = new System.Drawing.Size(457, 20);
+            this.labelRegexError.TabIndex = 10;
+            this.labelRegexError.Text = "The \"Build Id Filter\" regular expression is not valid and won\'t be saved!";
+            this.labelRegexError.Visible = false;
+            // 
             // TeamCitySettingsUserControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.labelRegexError);
             this.Controls.Add(labelBuildIdFilter);
             this.Controls.Add(labelProjectNameComment);
             this.Controls.Add(labelBuildFilter);
@@ -126,7 +146,7 @@ namespace TeamCityIntegration.Settings
             this.Controls.Add(this.TeamCityServerUrl);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "TeamCitySettingsUserControl";
-            this.Size = new System.Drawing.Size(467, 136);
+            this.Size = new System.Drawing.Size(592, 186);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -137,10 +157,6 @@ namespace TeamCityIntegration.Settings
         private System.Windows.Forms.TextBox TeamCityServerUrl;
         private System.Windows.Forms.TextBox TeamCityProjectName;
         private System.Windows.Forms.TextBox TeamCityBuildIdFilter;
-        private System.Windows.Forms.Label label13;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label labelBuildFilter;
-        private System.Windows.Forms.Label labelProjectNameComment;
-        private System.Windows.Forms.Label labelBuildIdFilter;
+        private System.Windows.Forms.Label labelRegexError;
     }
 }

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -39,9 +39,17 @@ namespace TeamCityIntegration.Settings
 
         public void SaveSettings(ISettingsSource buildServerConfig)
         {
-            buildServerConfig.SetString("BuildServerUrl", TeamCityServerUrl.Text);
-            buildServerConfig.SetString("ProjectName", TeamCityProjectName.Text);
-            buildServerConfig.SetString("BuildIdFilter", TeamCityBuildIdFilter.Text);
+            if (BuildServerSettingsHelper.IsRegexValid(TeamCityBuildIdFilter.Text))
+            {
+                buildServerConfig.SetString("BuildServerUrl", TeamCityServerUrl.Text);
+                buildServerConfig.SetString("ProjectName", TeamCityProjectName.Text);
+                buildServerConfig.SetString("BuildIdFilter", TeamCityBuildIdFilter.Text);
+            }
+        }
+
+        private void TeamCityBuildIdFilter_TextChanged(object sender, System.EventArgs e)
+        {
+            labelRegexError.Visible = !BuildServerSettingsHelper.IsRegexValid(TeamCityBuildIdFilter.Text);
         }
     }
 }

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -73,7 +73,13 @@ namespace TeamCityIntegration
             this.buildServerWatcher = buildServerWatcher;
 
             ProjectNames = config.GetString("ProjectName", "").Split(new char[]{'|'}, StringSplitOptions.RemoveEmptyEntries);
-            BuildIdFilter = new Regex(config.GetString("BuildIdFilter", ""), RegexOptions.Compiled);
+
+            var buildIdFilerSetting = config.GetString("BuildIdFilter", "");
+            if (!BuildServerSettingsHelper.IsRegexValid(buildIdFilerSetting))
+            {
+                return;
+            }
+            BuildIdFilter = new Regex(buildIdFilerSetting, RegexOptions.Compiled);
             var hostName = config.GetString("BuildServerUrl", null);
             if (!string.IsNullOrEmpty(hostName))
             {

--- a/Plugins/BuildServerIntegration/TfsIntegration/Settings/TfsSettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/Settings/TfsSettingsUserControl.Designer.cs
@@ -33,6 +33,7 @@ namespace TfsIntegration.Settings
             System.Windows.Forms.Label label2;
             System.Windows.Forms.Label label3;
             System.Windows.Forms.Label labelBuildIdFilter;
+            this.labelRegexError = new System.Windows.Forms.Label();
             this.TfsServer = new System.Windows.Forms.TextBox();
             this.TfsProjectName = new System.Windows.Forms.TextBox();
             this.TfsTeamCollectionName = new System.Windows.Forms.TextBox();
@@ -44,75 +45,39 @@ namespace TfsIntegration.Settings
             labelBuildIdFilter = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
-            // TfsServer
-            // 
-            this.TfsServer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TfsServer.Location = new System.Drawing.Point(162, 8);
-            this.TfsServer.Name = "TfsServer";
-            this.TfsServer.Size = new System.Drawing.Size(380, 23);
-            this.TfsServer.TabIndex = 1;
-            // 
-            // TfsProjectName
-            // 
-            this.TfsProjectName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TfsProjectName.Location = new System.Drawing.Point(162, 76);
-            this.TfsProjectName.Name = "TfsProjectName";
-            this.TfsProjectName.Size = new System.Drawing.Size(380, 23);
-            this.TfsProjectName.TabIndex = 3;
-            // 
-            // TfsTeamCollectionName
-            // 
-            this.TfsTeamCollectionName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TfsTeamCollectionName.Location = new System.Drawing.Point(162, 42);
-            this.TfsTeamCollectionName.Name = "TfsTeamCollectionName";
-            this.TfsTeamCollectionName.Size = new System.Drawing.Size(380, 23);
-            this.TfsTeamCollectionName.TabIndex = 2;
-            // 
-            // TfsBuildDefinitionNameFilter
-            // 
-            this.TfsBuildDefinitionNameFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.TfsBuildDefinitionNameFilter.Location = new System.Drawing.Point(162, 110);
-            this.TfsBuildDefinitionNameFilter.Name = "TfsBuildDefinitionNameFilter";
-            this.TfsBuildDefinitionNameFilter.Size = new System.Drawing.Size(380, 23);
-            this.TfsBuildDefinitionNameFilter.TabIndex = 4;
-            // 
             // label13
             // 
             label13.AutoSize = true;
-            label13.Location = new System.Drawing.Point(3, 11);
+            label13.Location = new System.Drawing.Point(3, 12);
             label13.Name = "label13";
-            label13.Size = new System.Drawing.Size(138, 15);
+            label13.Size = new System.Drawing.Size(163, 17);
             label13.TabIndex = 0;
             label13.Text = "Tfs server (Name or URL)";
             // 
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(3, 45);
+            label1.Location = new System.Drawing.Point(3, 48);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(125, 15);
+            label1.Size = new System.Drawing.Size(140, 17);
             label1.TabIndex = 2;
             label1.Text = "Team collection name";
             // 
             // label2
             // 
             label2.AutoSize = true;
-            label2.Location = new System.Drawing.Point(3, 79);
+            label2.Location = new System.Drawing.Point(3, 84);
             label2.Name = "label2";
-            label2.Size = new System.Drawing.Size(77, 15);
+            label2.Size = new System.Drawing.Size(90, 17);
             label2.TabIndex = 2;
             label2.Text = "Project name";
             // 
             // label3
             // 
             label3.AutoSize = true;
-            label3.Location = new System.Drawing.Point(3, 104);
+            label3.Location = new System.Drawing.Point(3, 111);
             label3.Name = "label3";
-            label3.Size = new System.Drawing.Size(137, 30);
+            label3.Size = new System.Drawing.Size(155, 34);
             label3.TabIndex = 2;
             label3.Text = "Build definition name\r\n(all existing if left empty)";
             // 
@@ -120,16 +85,66 @@ namespace TfsIntegration.Settings
             // 
             labelBuildIdFilter.AutoSize = true;
             labelBuildIdFilter.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
-            labelBuildIdFilter.Location = new System.Drawing.Point(159, 136);
+            labelBuildIdFilter.Location = new System.Drawing.Point(159, 145);
             labelBuildIdFilter.Name = "labelBuildIdFilter";
-            labelBuildIdFilter.Size = new System.Drawing.Size(45, 15);
+            labelBuildIdFilter.Size = new System.Drawing.Size(55, 20);
             labelBuildIdFilter.TabIndex = 8;
             labelBuildIdFilter.Text = "Regexp";
             // 
+            // labelRegexError
+            // 
+            this.labelRegexError.AutoSize = true;
+            this.labelRegexError.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            this.labelRegexError.ForeColor = System.Drawing.Color.Red;
+            this.labelRegexError.Location = new System.Drawing.Point(159, 176);
+            this.labelRegexError.Name = "labelRegexError";
+            this.labelRegexError.Size = new System.Drawing.Size(503, 20);
+            this.labelRegexError.TabIndex = 9;
+            this.labelRegexError.Text = "The \'Build definition name\' regular expression is not valid and won\'t be saved!";
+            this.labelRegexError.Visible = false;
+            // 
+            // TfsServer
+            // 
+            this.TfsServer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TfsServer.Location = new System.Drawing.Point(162, 9);
+            this.TfsServer.Name = "TfsServer";
+            this.TfsServer.Size = new System.Drawing.Size(496, 23);
+            this.TfsServer.TabIndex = 1;
+            // 
+            // TfsProjectName
+            // 
+            this.TfsProjectName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TfsProjectName.Location = new System.Drawing.Point(162, 81);
+            this.TfsProjectName.Name = "TfsProjectName";
+            this.TfsProjectName.Size = new System.Drawing.Size(496, 23);
+            this.TfsProjectName.TabIndex = 3;
+            // 
+            // TfsTeamCollectionName
+            // 
+            this.TfsTeamCollectionName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TfsTeamCollectionName.Location = new System.Drawing.Point(162, 45);
+            this.TfsTeamCollectionName.Name = "TfsTeamCollectionName";
+            this.TfsTeamCollectionName.Size = new System.Drawing.Size(496, 23);
+            this.TfsTeamCollectionName.TabIndex = 2;
+            // 
+            // TfsBuildDefinitionNameFilter
+            // 
+            this.TfsBuildDefinitionNameFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TfsBuildDefinitionNameFilter.Location = new System.Drawing.Point(162, 117);
+            this.TfsBuildDefinitionNameFilter.Name = "TfsBuildDefinitionNameFilter";
+            this.TfsBuildDefinitionNameFilter.Size = new System.Drawing.Size(496, 23);
+            this.TfsBuildDefinitionNameFilter.TabIndex = 4;
+            this.TfsBuildDefinitionNameFilter.TextChanged += new System.EventHandler(this.TfsBuildDefinitionNameFilter_TextChanged);
+            // 
             // TfsSettingsUserControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.labelRegexError);
             this.Controls.Add(labelBuildIdFilter);
             this.Controls.Add(label3);
             this.Controls.Add(label2);
@@ -141,7 +156,7 @@ namespace TfsIntegration.Settings
             this.Controls.Add(this.TfsServer);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "TfsSettingsUserControl";
-            this.Size = new System.Drawing.Size(550, 157);
+            this.Size = new System.Drawing.Size(666, 216);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -153,5 +168,6 @@ namespace TfsIntegration.Settings
         private System.Windows.Forms.TextBox TfsProjectName;
         private System.Windows.Forms.TextBox TfsTeamCollectionName;
         private System.Windows.Forms.TextBox TfsBuildDefinitionNameFilter;
+        private System.Windows.Forms.Label labelRegexError;
     }
 }

--- a/Plugins/BuildServerIntegration/TfsIntegration/Settings/TfsSettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/Settings/TfsSettingsUserControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.Composition;
 using System.Windows.Forms;
 using GitCommands.Settings;
@@ -40,10 +41,18 @@ namespace TfsIntegration.Settings
 
         public void SaveSettings(ISettingsSource buildServerConfig)
         {
-            buildServerConfig.SetString("TfsServer", TfsServer.Text);
-            buildServerConfig.SetString("TfsTeamCollectionName", TfsTeamCollectionName.Text);
-            buildServerConfig.SetString("ProjectName", TfsProjectName.Text);
-            buildServerConfig.SetString("TfsBuildDefinitionName", TfsBuildDefinitionNameFilter.Text);
+            if (BuildServerSettingsHelper.IsRegexValid(TfsBuildDefinitionNameFilter.Text))
+            {
+                buildServerConfig.SetString("TfsServer", TfsServer.Text);
+                buildServerConfig.SetString("TfsTeamCollectionName", TfsTeamCollectionName.Text);
+                buildServerConfig.SetString("ProjectName", TfsProjectName.Text);
+                buildServerConfig.SetString("TfsBuildDefinitionName", TfsBuildDefinitionNameFilter.Text);
+            }
+        }
+
+        private void TfsBuildDefinitionNameFilter_TextChanged(object sender, EventArgs e)
+        {
+            labelRegexError.Visible = !BuildServerSettingsHelper.IsRegexValid(TfsBuildDefinitionNameFilter.Text);
         }
     }
 }

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
@@ -60,7 +60,13 @@ namespace TfsIntegration
             _tfsServer = config.GetString("TfsServer", null);
             _tfsTeamCollectionName = config.GetString("TfsTeamCollectionName", null);
             _projectName = config.GetString("ProjectName", null);
-            _tfsBuildDefinitionNameFilter = new Regex(config.GetString("TfsBuildDefinitionName", ""), RegexOptions.Compiled);
+            var tfsBuildDefinitionNameFilterSetting = config.GetString("TfsBuildDefinitionName", "");
+            if (!BuildServerSettingsHelper.IsRegexValid(tfsBuildDefinitionNameFilterSetting))
+            {
+                return;
+            }
+
+            _tfsBuildDefinitionNameFilter = new Regex(tfsBuildDefinitionNameFilterSetting, RegexOptions.Compiled);
 
             if (!string.IsNullOrEmpty(_tfsServer)
                 && !string.IsNullOrEmpty(_tfsTeamCollectionName)

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildServerSettingsHelper.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildServerSettingsHelper.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel.Composition;
+using System.Text.RegularExpressions;
+
+namespace GitUIPluginInterfaces.BuildServerIntegration
+{
+    public static class BuildServerSettingsHelper
+    {
+        public static bool IsRegexValid(string regexText)
+        {
+            try
+            {
+                new Regex(regexText);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -75,6 +75,7 @@
     <Compile Include="BuildServerIntegration\BuildInfo.cs" />
     <Compile Include="BuildServerIntegration\BuildServerAdapterMetadataAttribute.cs" />
     <Compile Include="BuildServerIntegration\BuildServerCredentials.cs" />
+    <Compile Include="BuildServerIntegration\BuildServerSettingsHelper.cs" />
     <Compile Include="BuildServerIntegration\BuildServerSettingsUserControlMetadata.cs" />
     <Compile Include="BuildServerIntegration\IBuildServerAdapter.cs" />
     <Compile Include="BuildServerIntegration\IBuildServerCredentials.cs" />


### PR DESCRIPTION
For Tfs and TeamCity server integration plugin, that accept Regex to follow
build results of multiple projects, a crash could occur if the regex saved was not
a valid regex.

This commit:
* prevent the saving of a not valid regex
* alert the user that the regex is not valid
* disable the build server integration plugin if a not valid regex was already saved