### PR TITLE
Fix a couple of compiler warnings and nullrefs, including #3063

### DIFF
--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -66,7 +66,7 @@ namespace GitCommands
                 {
                     if (Delay > 0)
                     {
-                        Thread.Sleep(Delay);
+                        token.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(Delay));
                     }
                     if (!token.IsCancellationRequested)
                     {
@@ -105,13 +105,15 @@ namespace GitCommands
         public Task<T> Load<T>(Func<CancellationToken, T> loadContent, Action<T> onLoaded)
         {
             Cancel();
+            if (_cancelledTokenSource != null)
+                _cancelledTokenSource.Dispose();
             _cancelledTokenSource = new CancellationTokenSource();
             var token = _cancelledTokenSource.Token;
             return Task.Factory.StartNew(() => 
                 {
                     if (Delay > 0)
                     {
-                        Thread.Sleep(Delay);
+                        token.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(Delay));
                     }
                     if (token.IsCancellationRequested)
                     {
@@ -161,8 +163,9 @@ namespace GitCommands
 
         protected virtual void Dispose(bool disposing)
         {
-            if (_cancelledTokenSource != null)
-                _cancelledTokenSource.Dispose();
+            if (disposing)
+                if (_cancelledTokenSource != null)
+                    _cancelledTokenSource.Dispose();
         }
 
         public void Dispose()

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.Designer.cs
@@ -41,7 +41,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this._NO_TRANSLATE_Preview = new System.Windows.Forms.ListBox();
-            this.AddToIngore = new System.Windows.Forms.Button();
+            this.AddToIgnore = new System.Windows.Forms.Button();
             this.FilePattern = new System.Windows.Forms.TextBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.btnCancel = new System.Windows.Forms.Button();
@@ -139,16 +139,16 @@
             this._NO_TRANSLATE_Preview.Size = new System.Drawing.Size(575, 180);
             this._NO_TRANSLATE_Preview.TabIndex = 2;
             // 
-            // AddToIngore
+            // AddToIgnore
             // 
-            this.AddToIngore.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.AddToIngore.Location = new System.Drawing.Point(335, 7);
-            this.AddToIngore.Name = "AddToIngore";
-            this.AddToIngore.Size = new System.Drawing.Size(110, 25);
-            this.AddToIngore.TabIndex = 7;
-            this.AddToIngore.Text = "Ignore";
-            this.AddToIngore.UseVisualStyleBackColor = true;
-            this.AddToIngore.Click += new System.EventHandler(this.AddToIngoreClick);
+            this.AddToIgnore.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.AddToIgnore.Location = new System.Drawing.Point(335, 7);
+            this.AddToIgnore.Name = "AddToIgnore";
+            this.AddToIgnore.Size = new System.Drawing.Size(110, 25);
+            this.AddToIgnore.TabIndex = 7;
+            this.AddToIgnore.Text = "Ignore";
+            this.AddToIgnore.UseVisualStyleBackColor = true;
+            this.AddToIgnore.Click += new System.EventHandler(this.AddToIgnoreClick);
             // 
             // FilePattern
             // 
@@ -166,7 +166,7 @@
             // panel1
             // 
             this.panel1.Controls.Add(this.btnCancel);
-            this.panel1.Controls.Add(this.AddToIngore);
+            this.panel1.Controls.Add(this.AddToIgnore);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.panel1.Location = new System.Drawing.Point(0, 297);
             this.panel1.Name = "panel1";
@@ -198,7 +198,7 @@
             // 
             // FormAddToGitIgnore
             // 
-            this.AcceptButton = this.AddToIngore;
+            this.AcceptButton = this.AddToIgnore;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCancel;
@@ -228,7 +228,7 @@
 
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.ListBox _NO_TRANSLATE_Preview;
-        private System.Windows.Forms.Button AddToIngore;
+        private System.Windows.Forms.Button AddToIgnore;
         private System.Windows.Forms.TextBox FilePattern;
         private System.Windows.Forms.Panel noMatchPanel;
         private System.Windows.Forms.Label label2;

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.Designer.cs
@@ -13,11 +13,14 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            _ignoredFilesLoader.Cancel();
-
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                _ignoredFilesLoader.Cancel();
+                _ignoredFilesLoader.Dispose();
+                if (components != null)
+                {
+                    components.Dispose();
+                }
             }
             base.Dispose(disposing);
         }

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs
                 FilePattern.Text = string.Join(Environment.NewLine, filePatterns);
         }
 
-        private void AddToIngoreClick(object sender, EventArgs e)
+        private void AddToIgnoreClick(object sender, EventArgs e)
         {
             var patterns = GetCurrentPatterns().ToArray();
             if (patterns.Length == 0)

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -181,6 +181,7 @@ namespace GitUI
             {
                 localToolStripMenuItem.Dispose();
                 remoteToolStripMenuItem.Dispose();
+                tagsToolStripMenuItem.Dispose();
             }
         }
     }

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -1828,7 +1828,7 @@ Budete moci odesílat. {2}</target>
         <target>Přidat soubor(y) do .gitignore</target>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Ignorovat</target>
         

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -1823,7 +1823,7 @@ U heeft rechten om commits te verzenden. {2}
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Toevoegen aan .gitignore</target>
         

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -1827,7 +1827,7 @@ Vous aurez les droits de pousser. {2}</target>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Ignorer</target>
         

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -1825,7 +1825,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Ignorieren</target>
         

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -1792,7 +1792,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Aggiungi a .gitignore</target>
         

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -1821,7 +1821,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>.gitignoreに追加</target>
         

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -1811,7 +1811,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>무시</target>
         

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -1828,7 +1828,7 @@ Będziesz mieć uprawnienia wysyłania. {2}</target>
         <target>Dodaj plik(i) do .gitignore</target>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Ignoruj</target>
         

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -1777,7 +1777,7 @@ Você poderá realizar push. {2}</target>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Ignorar</target>
         

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -1476,7 +1476,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         
       </trans-unit>

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -1536,7 +1536,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         
       </trans-unit>

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -1828,7 +1828,7 @@ You will have push access. {2}</source>
         <target>Добавить файл(ы) в .gitignore</target>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Добавить</target>
         

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -1824,7 +1824,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>添加到.gitignore</target>
         

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -1823,7 +1823,7 @@ Tendrá acceso para hacer Push. {2}</target>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>Añadir a .gitignore</target>
         

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -1810,7 +1810,7 @@ You will have push access. {2}</source>
         <source>Add file(s) to .gitignore</source>
         
       </trans-unit>
-      <trans-unit id="AddToIngore.Text">
+      <trans-unit id="AddToIgnore.Text">
         <source>Ignore</source>
         <target>添加到.gitignore</target>
         

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3035,31 +3035,39 @@ namespace GitUI
         private void goToParentToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var r = GetRevision(LastRowIndex);
-
-            if (_parentChildNavigationHistory.HasPreviousParent)
-                _parentChildNavigationHistory.NavigateToPreviousParent(r.Guid);
-            else if (r.HasParent())
-                _parentChildNavigationHistory.NavigateToParent(r.Guid, r.ParentGuids[0]);
+            if (r != null)
+            {
+                if (_parentChildNavigationHistory.HasPreviousParent)
+                    _parentChildNavigationHistory.NavigateToPreviousParent(r.Guid);
+                else if (r.HasParent())
+                    _parentChildNavigationHistory.NavigateToParent(r.Guid, r.ParentGuids[0]);
+            }
         }
 
         private void goToChildToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var r = GetRevision(LastRowIndex);
-            var children = GetRevisionChildren(r.Guid);
+            if (r != null)
+            {
+                var children = GetRevisionChildren(r.Guid);
 
-            if (_parentChildNavigationHistory.HasPreviousChild)
-                _parentChildNavigationHistory.NavigateToPreviousChild(r.Guid);
-            else if (children.Any())
-                _parentChildNavigationHistory.NavigateToChild(r.Guid, children[0]);
+                if (_parentChildNavigationHistory.HasPreviousChild)
+                    _parentChildNavigationHistory.NavigateToPreviousChild(r.Guid);
+                else if (children.Any())
+                    _parentChildNavigationHistory.NavigateToChild(r.Guid, children[0]);
+            }
         }
 
         private void copyToClipboardToolStripMenuItem_DropDownOpened(object sender, EventArgs e)
         {
-            var revision = GetRevision(LastRowIndex);
-            CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(hashCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(revision.Guid, 15));
-            CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(messageCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(revision.Subject, 30));
-            CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(authorCopyToolStripMenuItem, revision.Author);
-            CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(dateCopyToolStripMenuItem, revision.CommitDate.ToString());
+            var r = GetRevision(LastRowIndex);
+            if (r != null)
+            {
+                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(hashCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(r.Guid, 15));
+                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(messageCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(r.Subject, 30));
+                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(authorCopyToolStripMenuItem, r.Author);
+                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(dateCopyToolStripMenuItem, r.CommitDate.ToString());
+            }
         }
 
         public void GoToRef(string refName, bool showNoRevisionMsg)

--- a/Plugins/Github3/GithubRepo.cs
+++ b/Plugins/Github3/GithubRepo.cs
@@ -74,9 +74,18 @@ namespace Github3
 
         public List<IPullRequestInformation> GetPullRequests()
         {
-            if (repo == null)
-                return new List<IPullRequestInformation>();
-            return repo.GetPullRequests().Select(pullrequest => (IPullRequestInformation)new GithubPullRequest(pullrequest)).ToList();
+            if (repo != null)
+            {
+                var pullRequests = repo.GetPullRequests();
+                if (pullRequests != null)
+                {
+                    return pullRequests
+                        .Select(pr => (IPullRequestInformation)new GithubPullRequest(pr))
+                        .ToList();
+                }
+            }
+
+            return new List<IPullRequestInformation>();
         }
 
         public int CreatePullRequest(string myBranch, string remoteBranch, string title, string body)


### PR DESCRIPTION
Fixed the problem behind #3063 (null reference exception in the revision grid).
Fixed another null reference problem when opening the pull request dialog.
Fixed two compiler warnings (CA2213 - disposable object not being disposed in Dispose)
Fixed a typo in the git ignore dialog.
