### PR TITLE
Ability to Release New Version of GitExtensions Using GitHub's Release Feature

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -71,6 +71,10 @@
     <Reference Include="PSTaskDialog">
       <HintPath>..\Bin\PSTaskDialog.dll</HintPath>
     </Reference>
+    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RestSharp.105.0.1\lib\net4-client\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core">


### PR DESCRIPTION
With these changes we are now able to release new version of GitExtensions using GitHub's release feature.

to use it:
- Create a new release with the version/tag number in the format of `Major.Minor.Patch.Build` for example:  `2.49.1.1`
- Upload the new version of GitExtension with the version number in the file name, for example: `GitExtensions-2.49.1.1-Setup.msi` (`GitExtensions-2.49.1.1-Mono.zip` for mono)
- Fill the description of the new release with the changelog

The end user will see:

![checknewversion](https://cloud.githubusercontent.com/assets/596334/16544795/4b34f2a6-4145-11e6-9821-3d87633df511.png)
- The `Show ChangeLog` will navigate to the GitHub's release page of that version
- The `Download Now` will download the setup using the default browser

Of course we still need to release the first version using sourceforge for the existing v2.48 users.
