### PR TITLE
feature: Allow auto-normalisation of branch name

### DIFF
--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GitCommands.Git
+{
+    /// <summary>
+    /// Provides ability to ensure compliance with the GIT branch naming conventions.
+    /// </summary>
+    public interface IGitBranchNameNormaliser
+    {
+        /// <summary>
+        /// Ensures that the branch name meets the GIT branch naming conventions.
+        /// For more details refer to <see href="https://www.git-scm.com/docs/git-check-ref-format/1.8.2"/>.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        string Normalise(string branchName, GitBranchNameOptions options);
+    }
+
+    /*
+
+        DESCRIPTION
+        Checks if a given refname is acceptable, and exits with a non-zero status if it is not.
+
+        A reference is used in Git to specify branches and tags. A branch head is stored in the refs/heads hierarchy, while a tag is stored in the refs/tags hierarchy of the ref namespace (typically in $GIT_DIR/refs/heads and $GIT_DIR/refs/tags directories or, as entries in file $GIT_DIR/packed-refs if refs are packed by git gc).
+
+        Git imposes the following rules on how references are named:
+
+        1. They can include slash '/' for hierarchical (directory) grouping, but no slash-separated component can begin with a dot '.' or end with the sequence '.lock'.
+
+        2. They must contain at least one '/'. This enforces the presence of a category like 'heads/', 'tags/' etc. but the actual names are not restricted. If the --allow-onelevel option is used, this rule is waived.
+
+        3. They cannot have two consecutive dots '..' anywhere.
+
+        4. They cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 DEL), space, tilde '~', caret '^', or colon ':' anywhere.
+
+        5. They cannot have question-mark '?', asterisk '*', or open bracket '[' anywhere. See the --refspec-pattern option below for an exception to this rule.
+
+        6. They cannot begin or end with a slash '/' or contain multiple consecutive slashes (see the --normalize option below for an exception to this rule)
+
+        7. They cannot end with a dot '.'.
+
+        8. They cannot contain a sequence '@{'.
+
+        9. They cannot contain a '\'.
+
+        These rules make it easy for shell script based tools to parse reference names, pathname expansion by the shell when a reference name is used unquoted (by mistake), and also avoids ambiguities in certain reference name expressions (see gitrevisions(7)):
+
+        1. A double-dot '..' is often used as in 'ref1..ref2', and in some contexts this notation means '^ref1 ref2' (i.e. not in 'ref1' and in 'ref2').
+
+        2. A tilde '~' and caret '^' are used to introduce the postfix nth parent and peel onion operation.
+
+        3. A colon ':' is used as in 'srcref:dstref' to mean "use srcref\s value and store it in dstref" in fetch and push operations. It may also be used to select a specific object such as with git cat-file': "git cat-file blob v1.3.3:refs.c".
+
+        4. at-open-brace '@{' is used as a notation to access a reflog entry.
+
+        With the --branch option, it expands the “previous branch syntax” @{-n}. For example, @{-1} is a way to refer the last branch you were on. This option should be used by porcelains to accept this syntax anywhere a branch name is expected, so they can act as if you typed the branch name.
+
+    */
+
+    /// <summary>
+    /// Ensures compliance with the GIT branch naming conventions.
+    /// </summary>
+    public sealed class GitBranchNameNormaliser : IGitBranchNameNormaliser
+    {
+        /// <summary>
+        /// Ensures that the branch name meets the GIT branch naming conventions.
+        /// For more details refer to <see href="https://www.git-scm.com/docs/git-check-ref-format/1.8.2"/>.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        public string Normalise(string branchName, GitBranchNameOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(branchName))
+            {
+                return string.Empty;
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException("options");
+            }
+
+            // run rules in reverse order
+            branchName = Rule09(branchName, options);
+            branchName = Rule08(branchName, options);
+            branchName = Rule07(branchName, options);
+            branchName = Rule05(branchName, options);
+            branchName = Rule04(branchName, options);
+            branchName = Rule03(branchName, options);
+            // rule #2 is not applicable
+            // rule #6 runs as second last to ensure no consecutive '/' are left after previous normalisations
+            branchName = Rule06(branchName, options);
+            branchName = Rule01(branchName, options);
+
+            return branchName;
+        }
+
+
+        /// <summary>
+        /// Indicates whether the given character can be used in a branch name.
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns></returns>
+        public static bool IsValidChar(char c)
+        {
+            return (c > 39 && c < 177) &&
+                    c != ' ' && c != '~' && c != '^' && c != ':' &&
+                    Array.IndexOf(Path.GetInvalidPathChars(), c) < 0;
+        }
+
+
+        /// <summary>
+        /// Branch name can include slash '/' for hierarchical (directory) grouping, 
+        /// but no slash-separated component can begin with a dot '.' or end with the sequence '.lock'.
+        /// </summary>
+        /// <param name="branchName"></param>
+        /// <param name="options"></param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule01(string branchName, GitBranchNameOptions options)
+        {
+            var tokens = branchName.Split('/').ToList();
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                if (tokens[i].StartsWith("."))
+                {
+                    tokens[i] = Regex.Replace(tokens[i], "^(\\.)*", options.ReplacementToken);
+                }
+                if (tokens[i].EndsWith(".lock", StringComparison.OrdinalIgnoreCase))
+                {
+                    tokens[i] = Regex.Replace(tokens[i], "(\\.lock)$", options.ReplacementToken + "lock");
+                }
+            }
+            return tokens.Join("/");
+        }
+
+        /// <summary>
+        /// Branch name cannot have two consecutive dots '..' anywhere.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule03(string branchName, GitBranchNameOptions options)
+        {
+            return Regex.Replace(branchName, "\\.{2,}", options.ReplacementToken);
+        }
+
+        /// <summary>
+        /// Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 'DEL'), 
+        /// space, tilde '~', caret '^', or colon ':' anywhere.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule04(string branchName, GitBranchNameOptions options)
+        {
+            var result = new StringBuilder(branchName.Length);
+            foreach (char t in branchName)
+            {
+                if (IsValidChar(t))
+                {
+                    result.Append(t);
+                }
+                else
+                {
+                    result.Append(options.ReplacementToken);
+                }
+            }
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Branch name cannot have question-mark '?', asterisk '*', or open bracket '[' anywhere.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule05(string branchName, GitBranchNameOptions options)
+        {
+            return Regex.Replace(branchName, "(\\?|\\*|\\[)", options.ReplacementToken);
+        }
+
+        /// <summary>
+        /// Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule06(string branchName, GitBranchNameOptions options)
+        {
+            branchName = Regex.Replace(branchName, @"(\/{2,})", "/");
+            if (branchName.StartsWith("/"))
+            {
+                branchName = branchName.Substring(1);
+            }
+            if (branchName.EndsWith("/"))
+            {
+                branchName = branchName.Substring(0, branchName.Length - 1);
+            }
+            return branchName;
+        }
+
+        /// <summary>
+        /// Branch name end with a dot '.'.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule07(string branchName, GitBranchNameOptions options)
+        {
+            return Regex.Replace(branchName, "(\\.{1,})$", options.ReplacementToken);
+        }
+
+        /// <summary>
+        /// Branch name cannot contain a sequence '@{'.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule08(string branchName, GitBranchNameOptions options)
+        {
+            return Regex.Replace(branchName, "(@\\{)", options.ReplacementToken);
+        }
+
+        /// <summary>
+        /// Branch name cannot contain a '\'.
+        /// </summary>
+        /// <param name="branchName">Name of the branch.</param>
+        /// <param name="options">The options.</param>
+        /// <returns>Normalised branch name.</returns>
+        internal string Rule09(string branchName, GitBranchNameOptions options)
+        {
+            return Regex.Replace(branchName, @"(\\{1,})", options.ReplacementToken);
+        }
+    }
+}

--- a/GitCommands/Git/GitBranchNameOptions.cs
+++ b/GitCommands/Git/GitBranchNameOptions.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace GitCommands.Git
+{
+    /// <summary>
+    /// Options used by <see cref="GitBranchNameNormaliser"/> to ensures compliance with the GIT branch naming conventions.
+    /// </summary>
+    public sealed class GitBranchNameOptions
+    {
+        public GitBranchNameOptions(string replacementToken)
+        {
+            if (!string.IsNullOrEmpty(replacementToken))
+            {
+                if (replacementToken.Length > 1)
+                {
+                    throw new ArgumentOutOfRangeException("replacementToken", "Replacement token must be a single character");
+                }
+                if (!GitBranchNameNormaliser.IsValidChar(replacementToken[0]))
+                {
+                    throw new ArgumentOutOfRangeException("replacementToken", string.Format("Replacement token invalid: '{0}'", replacementToken));
+                }
+            }
+            ReplacementToken = replacementToken ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the character which will replace all invalid characters in git branch name.
+        /// </summary>
+        /// <seealso cref="GitBranchNameNormaliser"/>.
+        public string ReplacementToken { get; private set; }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -85,6 +85,8 @@
     <Compile Include="ExceptionUtils.cs" />
     <Compile Include="FileHelper.cs" />
     <Compile Include="Git\AuthorEmailEqualityComparer.cs" />
+    <Compile Include="Git\GitBranchNameNormaliser.cs" />
+    <Compile Include="Git\GitBranchNameOptions.cs" />
     <Compile Include="Logging\CommandLogEntry.cs" />
     <Compile Include="RemoteActionResult.cs" />
     <Compile Include="Settings\BasicSettingTypes.cs" />

--- a/GitCommands/Properties/AssemblyInfo.cs
+++ b/GitCommands/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 [assembly: System.CLSCompliant(true)]
+
+[assembly: InternalsVisibleTo("GitExtensionsTest")]

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -64,6 +64,30 @@ namespace GitCommands
             }
         }
 
+        public static bool AutoNormaliseBranchName
+        {
+            get { return GetBool("AutoNormaliseBranchName", true); }
+            set { SetBool("AutoNormaliseBranchName", value); }
+        }
+
+        public static string AutoNormaliseSymbol
+        {
+            // when persisted "" is treated as null, so use "+" instead
+            get
+            {
+                var value = GetString("AutoNormaliseSymbol", "_");
+                return (value == "+") ? "" : value;
+            }
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    value = "+";
+                }
+                SetString("AutoNormaliseSymbol", value);
+            }
+        }
+
         public static void UsingContainer(RepoDistSettings aSettingsContainer, Action action)
         {
             SettingsContainer.LockedAction(() =>
@@ -246,8 +270,8 @@ namespace GitCommands
 
         public static bool AddNewlineToCommitMessageWhenMissing
         {
-            get { return GetBool ("addnewlinetocommitmessagewhenmissing", true); }
-            set { SetBool ("addnewlinetocommitmessagewhenmissing", value); }
+            get { return GetBool("addnewlinetocommitmessagewhenmissing", true); }
+            set { SetBool("addnewlinetocommitmessagewhenmissing", value); }
         }
 
         public static string LastCommitMessage
@@ -282,8 +306,8 @@ namespace GitCommands
 
         public static bool ProvideAutocompletion
         {
-          get { return GetBool("provideautocompletion", true); }
-          set { SetBool("provideautocompletion", value); }
+            get { return GetBool("provideautocompletion", true); }
+            set { SetBool("provideautocompletion", value); }
         }
 
         public static string TruncatePathMethod
@@ -851,7 +875,7 @@ namespace GitCommands
             set { SetBool("showdiffforallparents", value); }
         }
 
-		public static string RecentWorkingDir
+        public static string RecentWorkingDir
         {
             get { return GetString("RecentWorkingDir", null); }
             set { SetString("RecentWorkingDir", value); }

--- a/GitExtensionsTest/GitCommands/Git/GitBranchNameNormaliserTest.cs
+++ b/GitExtensionsTest/GitCommands/Git/GitBranchNameNormaliserTest.cs
@@ -1,0 +1,134 @@
+﻿using FluentAssertions;
+using GitCommands.Git;
+using NUnit.Framework;
+
+namespace GitExtensionsTest.GitCommands.Git
+{
+    [TestFixture]
+    public sealed class GitBranchNameNormaliserTest
+    {
+        private GitBranchNameNormaliser _gitBranchNameNormaliser;
+        private GitBranchNameOptions _gitBranchNameOptions;
+
+        [SetUp]
+        public void Setup()
+        {
+            _gitBranchNameNormaliser = new GitBranchNameNormaliser();
+            _gitBranchNameOptions = new GitBranchNameOptions("_");
+        }
+
+
+        [TestCase("[BUG-1234] some long description located [//test/*/dir?/.lock]{3,} and <foo:bar\\can>...", "_", "_BUG-1234]_some_long_description_located__/test/_/dir_/_lock]{3,}_and__foo_bar_can__")]
+        [TestCase("[BUG-1234] some long description located [//test/*/dir?/.lock]{3,} and <foo:bar\\can>...", "-", "-BUG-1234]-some-long-description-located--/test/-/dir-/-lock]{3,}-and--foo-bar-can--")]
+        [TestCase("[BUG-1234] some long description located [//test/*/dir?/.lock]{3,} and <foo:bar\\can>...", "", "BUG-1234]somelongdescriptionlocated/test/dir/lock]{3,}andfoobarcan")]
+        public void Normalise(string input, string replacementToken, string expected)
+        {
+            _gitBranchNameOptions = new GitBranchNameOptions(replacementToken);
+            _gitBranchNameNormaliser.Normalise(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+
+        // They can include slash / for hierarchical (directory) grouping, 
+        // but no slash-separated component can begin with a dot . or end with the sequence .lock.
+        [TestCase(".test", "_test")]
+        [TestCase("hierarchy/.test", "hierarchy/_test")]
+        [TestCase("hierarchy/.test/foo", "hierarchy/_test/foo")]
+        [TestCase(".lock", "_lock")]
+        [TestCase("pad.lock", "pad_lock")]
+        [TestCase("pad.lock.lock", "pad.lock_lock")]
+        [TestCase("hierarchy/sher.lock", "hierarchy/sher_lock")]
+        [TestCase("hierarchy/sher.lok", "hierarchy/sher.lok")]
+        [TestCase("hierarchy/sher.lock/foo", "hierarchy/sher_lock/foo")]
+        [TestCase("hierarchy/sher.lok/foo", "hierarchy/sher.lok/foo")]
+        public void Normalise_rule01(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule01(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // They cannot have two consecutive dots .. anywhere.
+        [TestCase("..test", "_test")]
+        [TestCase("...test", "_test")]
+        [TestCase("hierarchy/..test", "hierarchy/_test")]
+        [TestCase("hierarchy/...test", "hierarchy/_test")]
+        [TestCase("hierarchy/..test/foo", "hierarchy/_test/foo")]
+        [TestCase("hierarchy/...test/foo", "hierarchy/_test/foo")]
+        [TestCase("..lock", "_lock")]
+        [TestCase("pad..lock", "pad_lock")]
+        [TestCase("pad...lock", "pad_lock")]
+        [TestCase("hierarchy/sher..lock", "hierarchy/sher_lock")]
+        [TestCase("padlock...", "padlock_")]
+        [TestCase("hierarchy/sher...lock", "hierarchy/sher_lock")]
+        [TestCase("hierarchy/sher..lock/foo", "hierarchy/sher_lock/foo")]
+        [TestCase("hierarchy/sher...lock/foo", "hierarchy/sher_lock/foo")]
+        [TestCase("hierarchy/sher..lok/foo", "hierarchy/sher_lok/foo")]
+        [TestCase("hier.....archy/sher...lok/fo..o", "hier_archy/sher_lok/fo_o")]
+        public void Normalise_rule03(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule03(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 'DEL'), 
+        // space, tilde '~', caret '^', or colon ':' anywhere.
+        [TestCase("test:test", "test_test")]
+        [TestCase("test test", "test_test")]
+        [TestCase("test^test", "test_test")]
+        [TestCase("test~test", "test_test")]
+        [TestCase("hier archy:sher~lok/fo^o", "hier_archy_sher_lok/fo_o")]
+        public void Normalise_rule04(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule04(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name cannot have question-mark '?', asterisk '*', or open bracket '[' anywhere.
+        [TestCase("test?", "test_")]
+        [TestCase("?test", "_test")]
+        [TestCase("test???test", "test___test")]
+        [TestCase("test*", "test_")]
+        [TestCase("*test", "_test")]
+        [TestCase("test***test", "test___test")]
+        [TestCase("test[foo]", "test_foo]")]
+        [TestCase("[test]", "_test]")]
+        [TestCase("testing?[*]*test", "testing___]_test")]
+        public void Normalise_rule05(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule05(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
+        [TestCase("test/", "test")]
+        [TestCase("/test", "test")]
+        [TestCase("/test/", "test")]
+        [TestCase("/test/test/", "test/test")]
+        [TestCase("///test///test///", "test/test")]
+        public void Normalise_rule06(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule06(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name end with a dot '.'.
+        [TestCase("test.", "test_")]
+        [TestCase("test..", "test_")]
+        [TestCase("test...", "test_")]
+        public void Normalise_rule07(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule07(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name cannot contain a sequence '@{'.
+        [TestCase("@{", "_")]
+        [TestCase("@{test}", "_test}")]
+        [TestCase("test@foo", "test@foo")]
+        [TestCase("test@{bla}", "test_bla}")]
+        public void Normalise_rule08(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule08(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name cannot contain a '\'.
+        [TestCase(@"test\foo\\bar\", "test_foo_bar_")]
+        public void Normalise_rule09(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule09(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+    }
+}

--- a/GitExtensionsTest/GitCommands/Git/GitBranchNameOptionsTest.cs
+++ b/GitExtensionsTest/GitCommands/Git/GitBranchNameOptionsTest.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using FluentAssertions;
+using GitCommands.Git;
+using NUnit.Framework;
+
+namespace GitExtensionsTest.GitCommands.Git
+{
+    [TestFixture]
+    public class GitBranchNameOptionsTest
+    {
+        [TestCase(null, "")]
+        [TestCase("", "")]
+        public void ReplacementToken_can_be_null_or_empty(string token, string expected) {
+            var options = new GitBranchNameOptions(token);
+
+            options.ReplacementToken.Should().Be(expected);
+        }
+
+        [Test]
+        public void ReplacementToken_cant_be_multichar()
+        {
+            ((Action)(() => new GitBranchNameOptions("aaa"))).ShouldThrow<ArgumentOutOfRangeException>()
+                .WithMessage("Replacement token must be a single character\r\nParameter name: replacementToken");
+        }
+
+        [TestCase(" ", ' ')]
+        [TestCase("~", '~')]
+        [TestCase("^", '^')]
+        [TestCase("~", '~')]
+        [TestCase(":", ':')]
+        public void ReplacementToken_cant_be_invalid(string token, char expected)
+        {
+            ((Action)(() => new GitBranchNameOptions(token))).ShouldThrow<ArgumentOutOfRangeException>()
+                .WithMessage(string.Format("Replacement token invalid: '{0}'\r\nParameter name: replacementToken", expected));
+        }
+    }
+}

--- a/GitExtensionsTest/GitExtensionsTest.csproj
+++ b/GitExtensionsTest/GitExtensionsTest.csproj
@@ -87,6 +87,8 @@
   <ItemGroup>
     <Compile Include="GitCommands\CommitInformationTest.cs" />
     <Compile Include="GitCommands\Config\ConfigFileTest.cs" />
+    <Compile Include="GitCommands\Git\GitBranchNameNormaliserTest.cs" />
+    <Compile Include="GitCommands\Git\GitBranchNameOptionsTest.cs" />
     <Compile Include="GitCommands\Git\GitCommandHelpersTest.cs" />
     <Compile Include="GitCommands\Git\EncodingHelperTest.cs" />
     <Compile Include="GitCommands\Helpers\FileInfoExtensions.cs" />

--- a/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
@@ -29,66 +29,117 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.Orphan = new System.Windows.Forms.CheckBox();
-            this.ClearOrphan = new System.Windows.Forms.CheckBox();
-            this.Ok = new System.Windows.Forms.Button();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.label2 = new System.Windows.Forms.Label();
             this.commitPickerSmallControl1 = new GitUI.UserControls.CommitPickerSmallControl();
-            this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
-            this.table = new System.Windows.Forms.TableLayoutPanel();
-            this.BranchNameTextBox = new System.Windows.Forms.TextBox();
+            this.chkbxCheckoutAfterCreate = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.BranchNameTextBox = new System.Windows.Forms.TextBox();
+            this.chkbxOrphan = new System.Windows.Forms.CheckBox();
+            this.chkbxClearOrphan = new System.Windows.Forms.CheckBox();
+            this.Ok = new System.Windows.Forms.Button();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.CheckoutAfterCreate = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
-            this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
-            this.CheckoutAfterCreate = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.ClearOrphan = new System.Windows.Forms.Label();
+            this.Orphan = new System.Windows.Forms.Label();
+            this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
             this.tableLayoutPanel1.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
-            this.table.SuspendLayout();
             this.groupBox1.SuspendLayout();
-            this.flowLayoutPanel2.SuspendLayout();
-            this.flowLayoutPanel3.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
-            // Orphan
+            // label2
             // 
-            this.Orphan.AutoSize = true;
-            this.Orphan.Location = new System.Drawing.Point(3, 3);
-            this.Orphan.Name = "Orphan";
-            this.Orphan.Size = new System.Drawing.Size(101, 19);
-            this.Orphan.TabIndex = 7;
-            this.Orphan.Text = "Create orphan";
-            this.toolTip.SetToolTip(this.Orphan, "New branch will have NO parents");
-            this.Orphan.UseVisualStyleBackColor = true;
-            this.Orphan.CheckedChanged += new System.EventHandler(this.Orphan_CheckedChanged);
+            this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label2.Location = new System.Drawing.Point(3, 31);
+            this.label2.Margin = new System.Windows.Forms.Padding(3);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(214, 22);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Create b&ranch at this revision";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // ClearOrphan
+            // commitPickerSmallControl1
             // 
-            this.ClearOrphan.AutoSize = true;
-            this.ClearOrphan.Checked = true;
-            this.ClearOrphan.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.ClearOrphan.Enabled = false;
-            this.ClearOrphan.Location = new System.Drawing.Point(110, 3);
-            this.ClearOrphan.Name = "ClearOrphan";
-            this.ClearOrphan.Size = new System.Drawing.Size(170, 19);
-            this.ClearOrphan.TabIndex = 8;
-            this.ClearOrphan.Text = "Clear working directory and index";
-            this.toolTip.SetToolTip(this.ClearOrphan, "Remove files from the working directory and from the index");
-            this.ClearOrphan.UseVisualStyleBackColor = true;
+            this.commitPickerSmallControl1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.commitPickerSmallControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commitPickerSmallControl1.Location = new System.Drawing.Point(223, 31);
+            this.commitPickerSmallControl1.MinimumSize = new System.Drawing.Size(100, 26);
+            this.commitPickerSmallControl1.Name = "commitPickerSmallControl1";
+            this.commitPickerSmallControl1.Size = new System.Drawing.Size(242, 26);
+            this.commitPickerSmallControl1.TabIndex = 3;
+            // 
+            // chkbxCheckoutAfterCreate
+            // 
+            this.chkbxCheckoutAfterCreate.AutoSize = true;
+            this.chkbxCheckoutAfterCreate.Checked = true;
+            this.chkbxCheckoutAfterCreate.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkbxCheckoutAfterCreate.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkbxCheckoutAfterCreate.Location = new System.Drawing.Point(223, 59);
+            this.chkbxCheckoutAfterCreate.Name = "chkbxCheckoutAfterCreate";
+            this.chkbxCheckoutAfterCreate.Size = new System.Drawing.Size(242, 22);
+            this.chkbxCheckoutAfterCreate.TabIndex = 5;
+            this.chkbxCheckoutAfterCreate.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(3, 3);
+            this.label1.Margin = new System.Windows.Forms.Padding(3);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(214, 22);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "&Branch name";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // BranchNameTextBox
+            // 
+            this.BranchNameTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BranchNameTextBox.Location = new System.Drawing.Point(223, 3);
+            this.BranchNameTextBox.Name = "BranchNameTextBox";
+            this.BranchNameTextBox.Size = new System.Drawing.Size(242, 21);
+            this.BranchNameTextBox.TabIndex = 1;
+            this.BranchNameTextBox.TextChanged += new System.EventHandler(this.BranchNameTextBox_TextChanged);
+            // 
+            // chkbxOrphan
+            // 
+            this.chkbxOrphan.AutoSize = true;
+            this.chkbxOrphan.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkbxOrphan.Location = new System.Drawing.Point(217, 3);
+            this.chkbxOrphan.Name = "chkbxOrphan";
+            this.chkbxOrphan.Size = new System.Drawing.Size(236, 22);
+            this.chkbxOrphan.TabIndex = 1;
+            this.toolTip.SetToolTip(this.chkbxOrphan, "New branch will have NO parents");
+            this.chkbxOrphan.UseVisualStyleBackColor = true;
+            this.chkbxOrphan.CheckedChanged += new System.EventHandler(this.Orphan_CheckedChanged);
+            // 
+            // chkbxClearOrphan
+            // 
+            this.chkbxClearOrphan.AutoSize = true;
+            this.chkbxClearOrphan.Checked = true;
+            this.chkbxClearOrphan.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkbxClearOrphan.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkbxClearOrphan.Enabled = false;
+            this.chkbxClearOrphan.Location = new System.Drawing.Point(217, 31);
+            this.chkbxClearOrphan.Name = "chkbxClearOrphan";
+            this.chkbxClearOrphan.Size = new System.Drawing.Size(236, 22);
+            this.chkbxClearOrphan.TabIndex = 3;
+            this.toolTip.SetToolTip(this.chkbxClearOrphan, "Remove files from the working directory and from the index");
+            this.chkbxClearOrphan.UseVisualStyleBackColor = true;
             // 
             // Ok
             // 
             this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.Ok.Image = global::GitUI.Properties.Resources.IconBranchCreate;
-            this.Ok.Location = new System.Drawing.Point(311, 8);
+            this.Ok.Location = new System.Drawing.Point(337, 169);
+            this.Ok.MinimumSize = new System.Drawing.Size(0, 30);
             this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(128, 25);
-            this.Ok.TabIndex = 4;
-            this.Ok.Text = "Create branch";
+            this.Ok.Size = new System.Drawing.Size(128, 30);
+            this.Ok.TabIndex = 7;
+            this.Ok.Text = "&Create branch";
             this.Ok.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.Ok.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.Ok.UseVisualStyleBackColor = true;
@@ -96,199 +147,153 @@
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 220F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.gotoUserManualControl1, 0, 5);
-            this.tableLayoutPanel1.Controls.Add(this.table, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel3, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.commitPickerSmallControl1, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.BranchNameTextBox, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.CheckoutAfterCreate, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.chkbxCheckoutAfterCreate, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.Ok, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.gotoUserManualControl1, 0, 4);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 8);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 6;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowCount = 5;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(448, 216);
-            this.tableLayoutPanel1.TabIndex = 12;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(468, 195);
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
-            // flowLayoutPanel1
+            // CheckoutAfterCreate
             // 
-            this.flowLayoutPanel1.Controls.Add(this.label2);
-            this.flowLayoutPanel1.Controls.Add(this.commitPickerSmallControl1);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 3);
-            this.flowLayoutPanel1.MinimumSize = new System.Drawing.Size(50, 30);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(442, 34);
-            this.flowLayoutPanel1.TabIndex = 1;
+            this.CheckoutAfterCreate.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.CheckoutAfterCreate.Location = new System.Drawing.Point(3, 59);
+            this.CheckoutAfterCreate.Margin = new System.Windows.Forms.Padding(3);
+            this.CheckoutAfterCreate.Name = "CheckoutAfterCreate";
+            this.CheckoutAfterCreate.Size = new System.Drawing.Size(214, 22);
+            this.CheckoutAfterCreate.TabIndex = 4;
+            this.CheckoutAfterCreate.Text = "Checkout &after create";
+            this.CheckoutAfterCreate.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // label2
+            // groupBox1
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 5);
-            this.label2.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(160, 15);
-            this.label2.TabIndex = 1;
-            this.label2.Text = "Create branch at this revision";
+            this.groupBox1.AutoSize = true;
+            this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.SetColumnSpan(this.groupBox1, 2);
+            this.groupBox1.Controls.Add(this.tableLayoutPanel2);
+            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox1.Location = new System.Drawing.Point(3, 87);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(462, 76);
+            this.groupBox1.TabIndex = 6;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Orphan";
             // 
-            // commitPickerSmallControl1
+            // tableLayoutPanel2
             // 
-            this.commitPickerSmallControl1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.commitPickerSmallControl1.Location = new System.Drawing.Point(169, 3);
-            this.commitPickerSmallControl1.MinimumSize = new System.Drawing.Size(100, 26);
-            this.commitPickerSmallControl1.Name = "commitPickerSmallControl1";
-            this.commitPickerSmallControl1.Size = new System.Drawing.Size(207, 26);
-            this.commitPickerSmallControl1.TabIndex = 0;
+            this.tableLayoutPanel2.AutoSize = true;
+            this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 214F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.ClearOrphan, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.chkbxClearOrphan, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.chkbxOrphan, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.Orphan, 0, 0);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 17);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(456, 56);
+            this.tableLayoutPanel2.TabIndex = 0;
+            // 
+            // ClearOrphan
+            // 
+            this.ClearOrphan.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ClearOrphan.Location = new System.Drawing.Point(3, 31);
+            this.ClearOrphan.Margin = new System.Windows.Forms.Padding(3);
+            this.ClearOrphan.Name = "ClearOrphan";
+            this.ClearOrphan.Size = new System.Drawing.Size(208, 22);
+            this.ClearOrphan.TabIndex = 2;
+            this.ClearOrphan.Text = "Clear &working directory and index";
+            this.ClearOrphan.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // Orphan
+            // 
+            this.Orphan.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Orphan.Location = new System.Drawing.Point(3, 3);
+            this.Orphan.Margin = new System.Windows.Forms.Padding(3);
+            this.Orphan.Name = "Orphan";
+            this.Orphan.Size = new System.Drawing.Size(208, 22);
+            this.Orphan.TabIndex = 0;
+            this.Orphan.Text = "Create or&phan";
+            this.Orphan.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // gotoUserManualControl1
             // 
             this.gotoUserManualControl1.AutoSize = true;
-            this.gotoUserManualControl1.Location = new System.Drawing.Point(3, 189);
+            this.gotoUserManualControl1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.gotoUserManualControl1.Location = new System.Drawing.Point(3, 174);
             this.gotoUserManualControl1.ManualSectionAnchorName = "create-branch";
             this.gotoUserManualControl1.ManualSectionSubfolder = "branches";
+            this.gotoUserManualControl1.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
             this.gotoUserManualControl1.MinimumSize = new System.Drawing.Size(70, 20);
             this.gotoUserManualControl1.Name = "gotoUserManualControl1";
             this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 20);
-            this.gotoUserManualControl1.TabIndex = 11;
-            // 
-            // table
-            // 
-            this.table.AutoSize = true;
-            this.table.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.table.ColumnCount = 3;
-            this.table.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.table.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.table.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.table.Controls.Add(this.Ok, 2, 0);
-            this.table.Controls.Add(this.BranchNameTextBox, 1, 0);
-            this.table.Controls.Add(this.label1, 0, 0);
-            this.table.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.table.Location = new System.Drawing.Point(3, 43);
-            this.table.Name = "table";
-            this.table.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
-            this.table.RowCount = 1;
-            this.table.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.table.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
-            this.table.Size = new System.Drawing.Size(442, 34);
-            this.table.TabIndex = 1;
-            // 
-            // BranchNameTextBox
-            // 
-            this.BranchNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.BranchNameTextBox.Location = new System.Drawing.Point(86, 8);
-            this.BranchNameTextBox.Name = "BranchNameTextBox";
-            this.BranchNameTextBox.Size = new System.Drawing.Size(219, 23);
-            this.BranchNameTextBox.TabIndex = 3;
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 8);
-            this.label1.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(77, 15);
-            this.label1.TabIndex = 5;
-            this.label1.Text = "Branch name";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.flowLayoutPanel2);
-            this.groupBox1.Location = new System.Drawing.Point(3, 113);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(438, 50);
-            this.groupBox1.TabIndex = 10;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Orphan";
-            // 
-            // flowLayoutPanel2
-            // 
-            this.flowLayoutPanel2.Controls.Add(this.Orphan);
-            this.flowLayoutPanel2.Controls.Add(this.ClearOrphan);
-            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 19);
-            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(432, 28);
-            this.flowLayoutPanel2.TabIndex = 0;
-            // 
-            // flowLayoutPanel3
-            // 
-            this.flowLayoutPanel3.Controls.Add(this.CheckoutAfterCreate);
-            this.flowLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel3.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel3.Location = new System.Drawing.Point(3, 83);
-            this.flowLayoutPanel3.Name = "flowLayoutPanel3";
-            this.flowLayoutPanel3.Size = new System.Drawing.Size(442, 24);
-            this.flowLayoutPanel3.TabIndex = 2;
-            // 
-            // CheckoutAfterCreate
-            // 
-            this.CheckoutAfterCreate.AutoSize = true;
-            this.CheckoutAfterCreate.Checked = true;
-            this.CheckoutAfterCreate.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CheckoutAfterCreate.Location = new System.Drawing.Point(300, 3);
-            this.CheckoutAfterCreate.Name = "CheckoutAfterCreate";
-            this.CheckoutAfterCreate.Size = new System.Drawing.Size(139, 19);
-            this.CheckoutAfterCreate.TabIndex = 6;
-            this.CheckoutAfterCreate.Text = "Checkout after create";
-            this.CheckoutAfterCreate.UseVisualStyleBackColor = true;
+            this.gotoUserManualControl1.TabIndex = 8;
             // 
             // FormCreateBranch
             // 
             this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(454, 222);
+            this.ClientSize = new System.Drawing.Size(484, 211);
             this.Controls.Add(this.tableLayoutPanel1);
+            this.DoubleBuffered = true;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(470, 260);
+            this.MinimumSize = new System.Drawing.Size(480, 250);
             this.Name = "FormCreateBranch";
-            this.Padding = new System.Windows.Forms.Padding(3);
+            this.Padding = new System.Windows.Forms.Padding(8);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Create branch";
             this.Shown += new System.EventHandler(this.FormCreateBranch_Shown);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
-            this.table.ResumeLayout(false);
-            this.table.PerformLayout();
             this.groupBox1.ResumeLayout(false);
-            this.flowLayoutPanel2.ResumeLayout(false);
-            this.flowLayoutPanel2.PerformLayout();
-            this.flowLayoutPanel3.ResumeLayout(false);
-            this.flowLayoutPanel3.PerformLayout();
+            this.groupBox1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.TableLayoutPanel table;
-        private System.Windows.Forms.CheckBox Orphan;
+        private System.Windows.Forms.CheckBox chkbxOrphan;
         private System.Windows.Forms.ToolTip toolTip;
-        private System.Windows.Forms.CheckBox ClearOrphan;
-        private System.Windows.Forms.Button Ok;
+        private System.Windows.Forms.CheckBox chkbxClearOrphan;
         private System.Windows.Forms.TextBox BranchNameTextBox;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.Label label2;
         private UserControls.CommitPickerSmallControl commitPickerSmallControl1;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
         private UserControls.GotoUserManualControl gotoUserManualControl1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel3;
-        private System.Windows.Forms.CheckBox CheckoutAfterCreate;
+        private System.Windows.Forms.Button Ok;
+        private System.Windows.Forms.CheckBox chkbxCheckoutAfterCreate;
+        private System.Windows.Forms.Label CheckoutAfterCreate;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Label ClearOrphan;
+        private System.Windows.Forms.Label Orphan;
     }
 }

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -1,33 +1,70 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormCreateBranch : GitModuleForm
     {
-        private readonly TranslationString _noRevisionSelected =
-            new TranslationString("Select 1 revision to create the branch on.");
-        private readonly TranslationString _branchNameIsEmpty =
-            new TranslationString("Enter branch name.");
-        private readonly TranslationString _branchNameIsNotValud =
-            new TranslationString("“{0}” is not valid branch name.");
+        private readonly TranslationString _noRevisionSelected = new TranslationString("Select 1 revision to create the branch on.");
+        private readonly TranslationString _branchNameIsEmpty = new TranslationString("Enter branch name.");
+        private readonly TranslationString _branchNameIsNotValud = new TranslationString("“{0}” is not valid branch name.");
+        private readonly IGitBranchNameNormaliser _branchNameNormaliser;
+        private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
 
-        public FormCreateBranch(GitUICommands aCommands, GitRevision revision)
+
+        public FormCreateBranch(GitUICommands aCommands, GitRevision revision, IGitBranchNameNormaliser branchNameNormaliser = null)
             : base(aCommands)
         {
+            _branchNameNormaliser = branchNameNormaliser ?? new GitBranchNameNormaliser();
+
             InitializeComponent();
             Translate();
 
             commitPickerSmallControl1.UICommandsSource = this;
             if (IsUICommandsInitialized)
+            {
                 commitPickerSmallControl1.SetSelectedCommitHash(revision == null ? Module.GetCurrentCheckout() : revision.Guid);
+            }
+        }
+
+
+        public IEnumerable<T> FindControls<T>(Control control) where T : Control
+        {
+            var controls = control.Controls.Cast<Control>().ToList();
+            return controls.SelectMany(FindControls<T>)
+                           .Concat(controls)
+                           .Where(c => c.GetType() == typeof(T))
+                           .Cast<T>();
+        }
+
+        private void BranchNameTextBox_TextChanged(object sender, EventArgs e)
+        {
+            if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(GitBranchNameNormaliser.IsValidChar))
+            {
+                return;
+            }
+
+            var caretPosition = BranchNameTextBox.SelectionStart;
+            var branchName = _branchNameNormaliser.Normalise(BranchNameTextBox.Text, _gitBranchNameOptions);
+            BranchNameTextBox.Text = branchName;
+            BranchNameTextBox.SelectionStart = caretPosition;
         }
 
         private void FormCreateBranch_Shown(object sender, EventArgs e)
         {
+            // ensure all labels are wrapped if required
+            // this must happen only after the label texts have been set
+            foreach (var label in FindControls<Label>(this))
+            {
+                label.AutoSize = true;
+            }
+            
             BranchNameTextBox.Focus();
         }
 
@@ -57,23 +94,23 @@ namespace GitUI.CommandsDialogs
                 }
 
                 string cmd;
-                if (Orphan.Checked)
+                if (chkbxOrphan.Checked)
                 {
                     cmd = GitCommandHelpers.CreateOrphanCmd(branchName, commitGuid);
                 }
                 else
                 {
-                    cmd = GitCommandHelpers.BranchCmd(branchName, commitGuid, CheckoutAfterCreate.Checked);
+                    cmd = GitCommandHelpers.BranchCmd(branchName, commitGuid, chkbxCheckoutAfterCreate.Checked);
                 }
 
                 bool wasSuccessFul = FormProcess.ShowDialog(this, cmd);
-                if (Orphan.Checked && wasSuccessFul && ClearOrphan.Checked)
+                if (chkbxOrphan.Checked && wasSuccessFul && chkbxClearOrphan.Checked)
                 {// orphan AND orphan creation success AND clear
                     cmd = GitCommandHelpers.RemoveCmd();
                     FormProcess.ShowDialog(this, cmd);
                 }
 
-                if (wasSuccessFul && CheckoutAfterCreate.Checked)
+                if (wasSuccessFul && chkbxCheckoutAfterCreate.Checked)
                 {
                     UICommands.UpdateSubmodules(this);
                 }
@@ -86,15 +123,15 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        void Orphan_CheckedChanged(object sender, EventArgs e)
+        private void Orphan_CheckedChanged(object sender, EventArgs e)
         {
-            bool isOrphan = Orphan.Checked;
-            ClearOrphan.Enabled = isOrphan;
-            
-            CheckoutAfterCreate.Enabled = (isOrphan == false);// auto-checkout for orphan
+            bool isOrphan = chkbxOrphan.Checked;
+            chkbxClearOrphan.Enabled = isOrphan;
+
+            chkbxCheckoutAfterCreate.Enabled = (isOrphan == false);// auto-checkout for orphan
             if (isOrphan)
             {
-                CheckoutAfterCreate.Checked = true;
+                chkbxCheckoutAfterCreate.Checked = true;
             }
         }
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
@@ -34,6 +34,7 @@
             this.DiffViewerGB = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanelForDiffViewer = new System.Windows.Forms.TableLayoutPanel();
             this.chkOmitUninterestingDiff = new System.Windows.Forms.CheckBox();
+            this.chkRememberIgnoreWhiteSpacePreference = new System.Windows.Forms.CheckBox();
             this.CheckoutGB = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.chkAlwaysShowCheckoutDlg = new System.Windows.Forms.CheckBox();
@@ -43,8 +44,11 @@
             this.chkCheckForRCVersions = new System.Windows.Forms.CheckBox();
             this.chkAlwaysShowAdvOpt = new System.Windows.Forms.CheckBox();
             this.chkDontSHowHelpImages = new System.Windows.Forms.CheckBox();
-            this.chkRememberIgnoreWhiteSpacePreference = new System.Windows.Forms.CheckBox();
             this.chkConsoleEmulator = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+            this.chkAutoNormaliseBranchName = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.cboAutoNormaliseSymbol = new System.Windows.Forms.ComboBox();
             this.tooltip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel2.SuspendLayout();
             this.DiffViewerGB.SuspendLayout();
@@ -53,6 +57,7 @@
             this.tableLayoutPanel3.SuspendLayout();
             this.GeneralGB.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel4.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel2
@@ -70,7 +75,7 @@
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(443, 337);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(399, 373);
             this.tableLayoutPanel2.TabIndex = 1;
             // 
             // DiffViewerGB
@@ -79,9 +84,9 @@
             this.DiffViewerGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.DiffViewerGB.Controls.Add(this.tableLayoutPanelForDiffViewer);
             this.DiffViewerGB.Dock = System.Windows.Forms.DockStyle.Top;
-            this.DiffViewerGB.Location = new System.Drawing.Point(3, 241);
+            this.DiffViewerGB.Location = new System.Drawing.Point(3, 283);
             this.DiffViewerGB.Name = "DiffViewerGB";
-            this.DiffViewerGB.Size = new System.Drawing.Size(437, 93);
+            this.DiffViewerGB.Size = new System.Drawing.Size(393, 87);
             this.DiffViewerGB.TabIndex = 2;
             this.DiffViewerGB.TabStop = false;
             this.DiffViewerGB.Text = "Diff Viewer";
@@ -102,15 +107,15 @@
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanelForDiffViewer.Size = new System.Drawing.Size(286, 50);
+            this.tableLayoutPanelForDiffViewer.Size = new System.Drawing.Size(255, 46);
             this.tableLayoutPanelForDiffViewer.TabIndex = 1;
             // 
             // chkOmitUninterestingDiff
             // 
             this.chkOmitUninterestingDiff.AutoSize = true;
-            this.chkOmitUninterestingDiff.Location = new System.Drawing.Point(3, 28);
+            this.chkOmitUninterestingDiff.Location = new System.Drawing.Point(3, 26);
             this.chkOmitUninterestingDiff.Name = "chkOmitUninterestingDiff";
-            this.chkOmitUninterestingDiff.Size = new System.Drawing.Size(280, 19);
+            this.chkOmitUninterestingDiff.Size = new System.Drawing.Size(249, 17);
             this.chkOmitUninterestingDiff.TabIndex = 6;
             this.chkOmitUninterestingDiff.Text = "Omit uninteresting changes from combined diff";
             this.chkOmitUninterestingDiff.UseVisualStyleBackColor = true;
@@ -120,8 +125,8 @@
             this.chkRememberIgnoreWhiteSpacePreference.AutoSize = true;
             this.chkRememberIgnoreWhiteSpacePreference.Location = new System.Drawing.Point(3, 3);
             this.chkRememberIgnoreWhiteSpacePreference.Name = "chkRememberIgnoreWhiteSpacePreference";
-            this.chkRememberIgnoreWhiteSpacePreference.Size = new System.Drawing.Size(269, 19);
-            this.chkRememberIgnoreWhiteSpacePreference.TabIndex = 5;
+            this.chkRememberIgnoreWhiteSpacePreference.Size = new System.Drawing.Size(247, 17);
+            this.chkRememberIgnoreWhiteSpacePreference.TabIndex = 4;
             this.chkRememberIgnoreWhiteSpacePreference.Text = "Remember the ignore-white-space preference";
             this.chkRememberIgnoreWhiteSpacePreference.UseVisualStyleBackColor = true;
             // 
@@ -133,7 +138,7 @@
             this.CheckoutGB.Dock = System.Windows.Forms.DockStyle.Top;
             this.CheckoutGB.Location = new System.Drawing.Point(3, 3);
             this.CheckoutGB.Name = "CheckoutGB";
-            this.CheckoutGB.Size = new System.Drawing.Size(437, 108);
+            this.CheckoutGB.Size = new System.Drawing.Size(393, 100);
             this.CheckoutGB.TabIndex = 0;
             this.CheckoutGB.TabStop = false;
             this.CheckoutGB.Text = "Checkout";
@@ -151,7 +156,7 @@
             this.tableLayoutPanel3.RowCount = 2;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(422, 65);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(378, 59);
             this.tableLayoutPanel3.TabIndex = 1;
             // 
             // chkAlwaysShowCheckoutDlg
@@ -159,7 +164,7 @@
             this.chkAlwaysShowCheckoutDlg.AutoSize = true;
             this.chkAlwaysShowCheckoutDlg.Location = new System.Drawing.Point(3, 3);
             this.chkAlwaysShowCheckoutDlg.Name = "chkAlwaysShowCheckoutDlg";
-            this.chkAlwaysShowCheckoutDlg.Size = new System.Drawing.Size(182, 19);
+            this.chkAlwaysShowCheckoutDlg.Size = new System.Drawing.Size(165, 17);
             this.chkAlwaysShowCheckoutDlg.TabIndex = 0;
             this.chkAlwaysShowCheckoutDlg.Text = "Always show checkout dialog";
             this.chkAlwaysShowCheckoutDlg.UseVisualStyleBackColor = true;
@@ -167,9 +172,9 @@
             // chkUseLocalChangesAction
             // 
             this.chkUseLocalChangesAction.AutoSize = true;
-            this.chkUseLocalChangesAction.Location = new System.Drawing.Point(3, 28);
+            this.chkUseLocalChangesAction.Location = new System.Drawing.Point(3, 26);
             this.chkUseLocalChangesAction.Name = "chkUseLocalChangesAction";
-            this.chkUseLocalChangesAction.Size = new System.Drawing.Size(416, 34);
+            this.chkUseLocalChangesAction.Size = new System.Drawing.Size(372, 30);
             this.chkUseLocalChangesAction.TabIndex = 1;
             this.chkUseLocalChangesAction.Text = "Use last chosen \"local changes\" action as default action.\r\nThis action will be pe" +
     "rformed without warning while checking out branch.";
@@ -181,9 +186,9 @@
             this.GeneralGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.GeneralGB.Controls.Add(this.tableLayoutPanel1);
             this.GeneralGB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GeneralGB.Location = new System.Drawing.Point(3, 117);
+            this.GeneralGB.Location = new System.Drawing.Point(3, 109);
             this.GeneralGB.Name = "GeneralGB";
-            this.GeneralGB.Size = new System.Drawing.Size(437, 163);
+            this.GeneralGB.Size = new System.Drawing.Size(393, 168);
             this.GeneralGB.TabIndex = 1;
             this.GeneralGB.TabStop = false;
             this.GeneralGB.Text = "General";
@@ -198,24 +203,26 @@
             this.tableLayoutPanel1.Controls.Add(this.chkAlwaysShowAdvOpt, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.chkDontSHowHelpImages, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.chkConsoleEmulator, 0, 4);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(6, 21);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 5);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 17);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 5;
+            this.tableLayoutPanel1.RowCount = 6;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(361, 120);
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(387, 148);
             this.tableLayoutPanel1.TabIndex = 1;
             // 
             // chkCheckForRCVersions
             // 
             this.chkCheckForRCVersions.AutoSize = true;
-            this.chkCheckForRCVersions.Location = new System.Drawing.Point(3, 53);
+            this.chkCheckForRCVersions.Location = new System.Drawing.Point(3, 49);
             this.chkCheckForRCVersions.Name = "chkCheckForRCVersions";
-            this.chkCheckForRCVersions.Size = new System.Drawing.Size(217, 19);
+            this.chkCheckForRCVersions.Size = new System.Drawing.Size(203, 17);
             this.chkCheckForRCVersions.TabIndex = 3;
             this.chkCheckForRCVersions.Text = "Check for release candidate versions";
             this.chkCheckForRCVersions.UseVisualStyleBackColor = true;
@@ -223,9 +230,9 @@
             // chkAlwaysShowAdvOpt
             // 
             this.chkAlwaysShowAdvOpt.AutoSize = true;
-            this.chkAlwaysShowAdvOpt.Location = new System.Drawing.Point(3, 28);
+            this.chkAlwaysShowAdvOpt.Location = new System.Drawing.Point(3, 26);
             this.chkAlwaysShowAdvOpt.Name = "chkAlwaysShowAdvOpt";
-            this.chkAlwaysShowAdvOpt.Size = new System.Drawing.Size(191, 19);
+            this.chkAlwaysShowAdvOpt.Size = new System.Drawing.Size(176, 17);
             this.chkAlwaysShowAdvOpt.TabIndex = 2;
             this.chkAlwaysShowAdvOpt.Text = "Always show advanced options";
             this.chkAlwaysShowAdvOpt.UseVisualStyleBackColor = true;
@@ -235,32 +242,78 @@
             this.chkDontSHowHelpImages.AutoSize = true;
             this.chkDontSHowHelpImages.Location = new System.Drawing.Point(3, 3);
             this.chkDontSHowHelpImages.Name = "chkDontSHowHelpImages";
-            this.chkDontSHowHelpImages.Size = new System.Drawing.Size(153, 19);
+            this.chkDontSHowHelpImages.Size = new System.Drawing.Size(138, 17);
             this.chkDontSHowHelpImages.TabIndex = 1;
             this.chkDontSHowHelpImages.Text = "Don\'t show help images";
             this.chkDontSHowHelpImages.UseVisualStyleBackColor = true;
-            // 
-            // chkRememberIgnoreWhiteSpacePreference
-            // 
-            this.chkRememberIgnoreWhiteSpacePreference.AutoSize = true;
-            this.chkRememberIgnoreWhiteSpacePreference.Location = new System.Drawing.Point(3, 78);
-            this.chkRememberIgnoreWhiteSpacePreference.Name = "chkRememberIgnoreWhiteSpacePreference";
-            this.chkRememberIgnoreWhiteSpacePreference.Size = new System.Drawing.Size(269, 19);
-            this.chkRememberIgnoreWhiteSpacePreference.TabIndex = 4;
-            this.chkRememberIgnoreWhiteSpacePreference.Text = "Remember the ignore-white-space preference";
-            this.chkRememberIgnoreWhiteSpacePreference.UseVisualStyleBackColor = true;
             // 
             // chkConsoleEmulator
             // 
             this.chkConsoleEmulator.AutoSize = true;
             this.chkConsoleEmulator.Dock = System.Windows.Forms.DockStyle.Top;
-            this.chkConsoleEmulator.Location = new System.Drawing.Point(3, 103);
+            this.chkConsoleEmulator.Location = new System.Drawing.Point(3, 72);
             this.chkConsoleEmulator.Name = "chkConsoleEmulator";
-            this.chkConsoleEmulator.Size = new System.Drawing.Size(355, 14);
+            this.chkConsoleEmulator.Size = new System.Drawing.Size(381, 17);
             this.chkConsoleEmulator.TabIndex = 4;
             this.chkConsoleEmulator.Text = "Use Console Emulator for console output in command dialogs";
             this.tooltip.SetToolTip(this.chkConsoleEmulator, resources.GetString("chkConsoleEmulator.ToolTip"));
             this.chkConsoleEmulator.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanel4
+            // 
+            this.tableLayoutPanel4.AutoSize = true;
+            this.tableLayoutPanel4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel4.ColumnCount = 2;
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel4.Controls.Add(this.chkAutoNormaliseBranchName, 0, 0);
+            this.tableLayoutPanel4.Controls.Add(this.label1, 0, 1);
+            this.tableLayoutPanel4.Controls.Add(this.cboAutoNormaliseSymbol, 1, 1);
+            this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 95);
+            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+            this.tableLayoutPanel4.RowCount = 2;
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(381, 50);
+            this.tableLayoutPanel4.TabIndex = 5;
+            // 
+            // chkAutoNormaliseBranchName
+            // 
+            this.chkAutoNormaliseBranchName.AutoSize = true;
+            this.tableLayoutPanel4.SetColumnSpan(this.chkAutoNormaliseBranchName, 2);
+            this.chkAutoNormaliseBranchName.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkAutoNormaliseBranchName.Location = new System.Drawing.Point(3, 3);
+            this.chkAutoNormaliseBranchName.Name = "chkAutoNormaliseBranchName";
+            this.chkAutoNormaliseBranchName.Size = new System.Drawing.Size(375, 17);
+            this.chkAutoNormaliseBranchName.TabIndex = 6;
+            this.chkAutoNormaliseBranchName.Text = "Auto normalise branch name";
+            this.tooltip.SetToolTip(this.chkAutoNormaliseBranchName, resources.GetString("chkAutoNormaliseBranchName.ToolTip"));
+            this.chkAutoNormaliseBranchName.UseVisualStyleBackColor = true;
+            this.chkAutoNormaliseBranchName.CheckedChanged += new System.EventHandler(this.chkAutoNormaliseBranchName_CheckedChanged);
+            // 
+            // label1
+            // 
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(3, 23);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(100, 27);
+            this.label1.TabIndex = 7;
+            this.label1.Text = "Symbol to use:";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // cboAutoNormaliseSymbol
+            // 
+            this.cboAutoNormaliseSymbol.DisplayMember = "Key";
+            this.cboAutoNormaliseSymbol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboAutoNormaliseSymbol.Enabled = false;
+            this.cboAutoNormaliseSymbol.FormattingEnabled = true;
+            this.cboAutoNormaliseSymbol.Location = new System.Drawing.Point(109, 26);
+            this.cboAutoNormaliseSymbol.Name = "cboAutoNormaliseSymbol";
+            this.cboAutoNormaliseSymbol.Size = new System.Drawing.Size(81, 21);
+            this.cboAutoNormaliseSymbol.TabIndex = 8;
+            this.cboAutoNormaliseSymbol.ValueMember = "Value";
+            // 
             // tooltip
             // 
             this.tooltip.AutoPopDelay = 30000;
@@ -272,7 +325,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.Controls.Add(this.tableLayoutPanel2);
             this.Name = "AdvancedSettingsPage";
-            this.Size = new System.Drawing.Size(1758, 956);
+            this.Size = new System.Drawing.Size(1059, 891);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.DiffViewerGB.ResumeLayout(false);
@@ -287,6 +340,8 @@
             this.GeneralGB.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.tableLayoutPanel4.ResumeLayout(false);
+            this.tableLayoutPanel4.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -310,5 +365,9 @@
         private System.Windows.Forms.CheckBox chkOmitUninterestingDiff;
         private System.Windows.Forms.CheckBox chkConsoleEmulator;
         private System.Windows.Forms.ToolTip tooltip;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
+        private System.Windows.Forms.CheckBox chkAutoNormaliseBranchName;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ComboBox cboAutoNormaliseSymbol;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
@@ -9,6 +9,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComponent();
             Text = "Advanced";
             Translate();
+
+            var autoNormaliseSymbols = new[] {
+                new { Key =  "_", Value = "_" },
+                new { Key =  "-", Value = "-" },
+                new { Key =  "(none)", Value = "" },
+            };
+            cboAutoNormaliseSymbol.DataSource = autoNormaliseSymbols;
+            cboAutoNormaliseSymbol.SelectedIndex = 0;
         }
 
         protected override void SettingsToPage()
@@ -21,6 +29,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkRememberIgnoreWhiteSpacePreference.Checked = AppSettings.RememberIgnoreWhiteSpacePreference;
             chkOmitUninterestingDiff.Checked = AppSettings.OmitUninterestingDiff;
             chkConsoleEmulator.Checked = AppSettings.UseConsoleEmulatorForCommands;
+            chkAutoNormaliseBranchName.Checked = AppSettings.AutoNormaliseBranchName;
+            cboAutoNormaliseSymbol.Enabled = chkAutoNormaliseBranchName.Checked;
+            cboAutoNormaliseSymbol.SelectedValue = AppSettings.AutoNormaliseSymbol;
         }
 
         protected override void PageToSettings()
@@ -33,11 +44,19 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RememberIgnoreWhiteSpacePreference = chkRememberIgnoreWhiteSpacePreference.Checked;
             AppSettings.OmitUninterestingDiff = chkOmitUninterestingDiff.Checked;
             AppSettings.UseConsoleEmulatorForCommands = chkConsoleEmulator.Checked;
+            AppSettings.AutoNormaliseBranchName = chkAutoNormaliseBranchName.Checked;
+            AppSettings.AutoNormaliseSymbol = (string)cboAutoNormaliseSymbol.SelectedValue;
         }
 
         public static SettingsPageReference GetPageReference()
         {
             return new SettingsPageReferenceByType(typeof(AdvancedSettingsPage));
+        }
+
+
+        private void chkAutoNormaliseBranchName_CheckedChanged(object sender, System.EventArgs e)
+        {
+            cboAutoNormaliseSymbol.Enabled = chkAutoNormaliseBranchName.Checked;
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.resx
@@ -128,4 +128,12 @@ If no, redirects select strings from stdout/stderr into an edit box. This is the
 
 Turn off if you experience problems with the console emulator.</value>
   </data>
+  <data name="chkAutoNormaliseBranchName.ToolTip" xml:space="preserve">
+    <value>Controls how console programs output is displayed in command progress dialogs, like Clone or Pull.
+
+If yes, embeds the fully functional console emulator. This is experimental and might have side-effects.
+If no, redirects select strings from stdout/stderr into an edit box. This is the classic mode.
+
+Turn off if you experience problems with the console emulator.</value>
+  </data>
 </root>


### PR DESCRIPTION
Git spec imposes a number of rules on how branches are named.
The rules can be found at https://www.git-scm.com/docs/git-check-ref-format/1.8.2

The feature allows to automatically check for compliance when the user
creates a new branch (by typing in or inserting from the clipboard).

The FormCreateBranch UI is reworked to provide a toggle for the option.

------------

**Existing dialog:**
![image](https://cloud.githubusercontent.com/assets/4403806/16545498/40aba566-4170-11e6-9049-62d49646ff94.png)

**New dialog:**
Attempting to create a branch with name `[BUG-1234] some long description located [//test/*/dir?/.lock]{3,} and <foo:bar\\can>...` yeilds the following result:
![image](https://cloud.githubusercontent.com/assets/4403806/16559853/1c9845b2-4233-11e6-92a2-8dd57d796285.png)
