### PR TITLE
Revert "Pull Menu Items Should Honor the Don't Set As Default Option"

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2856,35 +2856,20 @@ namespace GitUI.CommandsDialogs
 
         private void mergeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!Settings.DonSetAsLastPullAction)
-                Module.LastPullAction = Settings.PullAction.Merge;
+            Module.LastPullAction = Settings.PullAction.Merge;
             PullToolStripMenuItemClick(sender, e);
-
-            //restore Settings.FormPullAction value
-            if (Settings.DonSetAsLastPullAction)
-                Module.LastPullActionToFormPullAction();
         }
 
         private void rebaseToolStripMenuItem1_Click(object sender, EventArgs e)
         {
-            if (!Settings.DonSetAsLastPullAction)
-                Module.LastPullAction = Settings.PullAction.Rebase;
+            Module.LastPullAction = Settings.PullAction.Rebase;
             PullToolStripMenuItemClick(sender, e);
-
-            //restore Settings.FormPullAction value
-            if (Settings.DonSetAsLastPullAction)
-                Module.LastPullActionToFormPullAction();
         }
 
         private void fetchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!Settings.DonSetAsLastPullAction)
-                Module.LastPullAction = Settings.PullAction.Fetch;
+            Module.LastPullAction = Settings.PullAction.Fetch;
             PullToolStripMenuItemClick(sender, e);
-
-            //restore Settings.FormPullAction value
-            if (Settings.DonSetAsLastPullAction)
-                Module.LastPullActionToFormPullAction();
         }
 
         private void pullToolStripMenuItem1_Click(object sender, EventArgs e)


### PR DESCRIPTION
Reverts gitextensions/gitextensions#3238

Actions are not set as default, but when DonSetAsLastPullAction is checked, then always the LastPullAction is preformed, regardless of chosen menu item.