### PR TITLE
Implement support for .git/info/exclude

### DIFF
--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -15,17 +15,42 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _matchingFilesString = new TranslationString("{0} file(s) matched");
         private readonly TranslationString _updateStatusString = new TranslationString("Updating ...");
 
+        private readonly bool _localExclude;
         private readonly AsyncLoader _ignoredFilesLoader;
 
-        public FormAddToGitIgnore(GitUICommands aCommands, params string[] filePatterns)
+        public FormAddToGitIgnore(GitUICommands aCommands, bool localExclude, params string[] filePatterns)
             : base(aCommands)
         {
             InitializeComponent();
+            _localExclude = localExclude;
             _ignoredFilesLoader = new AsyncLoader();
             Translate();
 
             if (filePatterns != null)
                 FilePattern.Text = string.Join(Environment.NewLine, filePatterns);
+        }
+
+        private string ExcludeFileRelative
+        {
+            get
+            {
+                if (!_localExclude)
+                {
+                    return ".gitignore";
+                }
+                else
+                {
+                    return Path.Combine(".git", "info", "exclude");
+                }
+            }
+        }
+
+        private string ExcludeFile
+        {
+            get
+            {
+                return Module.WorkingDir + ExcludeFileRelative;
+            }
         }
 
         private void AddToIgnoreClick(object sender, EventArgs e)
@@ -39,7 +64,7 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var fileName = Module.WorkingDir + ".gitignore";
+                var fileName = ExcludeFile;
                 FileInfoExtensions.MakeFileTemporaryWritable(fileName, x =>
                 {
                     var gitIgnoreFileAddition = new StringBuilder();

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -12,6 +12,7 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormAddToGitIgnore : GitModuleForm
     {
+        private readonly TranslationString _addToLocalExcludeTitle = new TranslationString("Add file(s) to .git/info/exclude");
         private readonly TranslationString _matchingFilesString = new TranslationString("{0} file(s) matched");
         private readonly TranslationString _updateStatusString = new TranslationString("Updating ...");
 
@@ -26,6 +27,8 @@ namespace GitUI.CommandsDialogs
             _ignoredFilesLoader = new AsyncLoader();
             Translate();
 
+            if (localExclude)
+                Text = _addToLocalExcludeTitle.Text;
             if (filePatterns != null)
                 FilePattern.Text = string.Join(Environment.NewLine, filePatterns);
         }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -140,6 +140,8 @@ namespace GitUI.CommandsDialogs
             this.editgitignoreToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.editgitattributesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editmailmapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            this.editgitinfoexcludeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.gitMaintenanceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compressGitDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1310,6 +1312,8 @@ namespace GitUI.CommandsDialogs
             this.editgitattributesToolStripMenuItem,
             this.editmailmapToolStripMenuItem,
             this.menuitemSparse,
+            this.toolStripSeparator10,
+            this.editgitinfoexcludeToolStripMenuItem,
             this.toolStripSeparator4,
             this.gitMaintenanceToolStripMenuItem,
             this.repoSettingsToolStripMenuItem,
@@ -1384,6 +1388,18 @@ namespace GitUI.CommandsDialogs
             this.editmailmapToolStripMenuItem.Size = new System.Drawing.Size(261, 24);
             this.editmailmapToolStripMenuItem.Text = "Edit .mailmap";
             this.editmailmapToolStripMenuItem.Click += new System.EventHandler(this.EditMailMapToolStripMenuItemClick);
+            // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            this.toolStripSeparator10.Size = new System.Drawing.Size(258, 6);
+            // 
+            // editgitinfoexcludeToolStripMenuItem
+            // 
+            this.editgitinfoexcludeToolStripMenuItem.Name = "editgitinfoexcludeToolStripMenuItem";
+            this.editgitinfoexcludeToolStripMenuItem.Size = new System.Drawing.Size(261, 24);
+            this.editgitinfoexcludeToolStripMenuItem.Text = "Edit .git/info/exclude";
+            this.editgitinfoexcludeToolStripMenuItem.Click += new System.EventHandler(this.EditGitInfoExcludeToolStripMenuItemClick);
             // 
             // toolStripSeparator4
             // 
@@ -2244,5 +2260,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator7;
         private ToolStripMenuItem cherryPickSelectedDiffFileToolStripMenuItem;
         private ToolStripMenuItem menuitemSparse;
+        private ToolStripSeparator toolStripSeparator10;
+        private ToolStripMenuItem editgitinfoexcludeToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1635,7 +1635,12 @@ namespace GitUI.CommandsDialogs
 
         private void EditGitignoreToolStripMenuItem1Click(object sender, EventArgs e)
         {
-            UICommands.StartEditGitIgnoreDialog(this);
+            UICommands.StartEditGitIgnoreDialog(this, false);
+        }
+
+        private void EditGitInfoExcludeToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.StartEditGitIgnoreDialog(this, true);
         }
 
         private void SettingsToolStripMenuItem2Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -37,6 +37,7 @@ namespace GitUI.CommandsDialogs
             this.deleteFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.addFileTogitignoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.assumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.doNotAssumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -197,6 +198,7 @@ namespace GitUI.CommandsDialogs
             this.deleteFileToolStripMenuItem,
             this.toolStripSeparator5,
             this.addFileTogitignoreToolStripMenuItem,
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem,
             this.assumeUnchangedToolStripMenuItem,
             this.doNotAssumeUnchangedToolStripMenuItem,
             this.toolStripSeparator4,
@@ -313,6 +315,14 @@ namespace GitUI.CommandsDialogs
             this.addFileTogitignoreToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.addFileTogitignoreToolStripMenuItem.Text = "Add file to .gitignore";
             this.addFileTogitignoreToolStripMenuItem.Click += new System.EventHandler(this.AddFileTogitignoreToolStripMenuItemClick);
+            // 
+            // addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem
+            // 
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconAddToGitIgnore;
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Name = "addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem";
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Text = "Add file to .git/info/exclude";
+            this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Click += new System.EventHandler(this.AddFileToGitInfoExcludeToolStripMenuItemClick);
             // 
             // assumeUnchangedToolStripMenuItem
             // 
@@ -1409,6 +1419,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Button SolveMergeconflicts;
         private FileViewer SelectedDiff;
         private System.Windows.Forms.ToolStripMenuItem addFileTogitignoreToolStripMenuItem;
+        private ToolStripMenuItem addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem assumeUnchangedToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem doNotAssumeUnchangedToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -90,6 +90,7 @@ namespace GitUI.CommandsDialogs
             this.resetAlltrackedChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.editGitIgnoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editLocallyIgnoredFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteAllUntrackedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.selectionFilterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -708,6 +709,7 @@ namespace GitUI.CommandsDialogs
             this.resetAlltrackedChangesToolStripMenuItem,
             this.toolStripSeparator1,
             this.editGitIgnoreToolStripMenuItem,
+            this.editLocallyIgnoredFilesToolStripMenuItem,
             this.deleteAllUntrackedFilesToolStripMenuItem,
             this.toolStripMenuItem2,
             this.selectionFilterToolStripMenuItem});
@@ -786,6 +788,14 @@ namespace GitUI.CommandsDialogs
             this.editGitIgnoreToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
             this.editGitIgnoreToolStripMenuItem.Text = "Edit ignored files";
             this.editGitIgnoreToolStripMenuItem.Click += new System.EventHandler(this.EditGitIgnoreToolStripMenuItemClick);
+            // 
+            // editLocallyIgnoredFilesToolStripMenuItem
+            // 
+            this.editLocallyIgnoredFilesToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconEditGitIgnore;
+            this.editLocallyIgnoredFilesToolStripMenuItem.Name = "editLocallyIgnoredFilesToolStripMenuItem";
+            this.editLocallyIgnoredFilesToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            this.editLocallyIgnoredFilesToolStripMenuItem.Text = "Edit locally ignored files";
+            this.editLocallyIgnoredFilesToolStripMenuItem.Click += new System.EventHandler(this.EditGitInfoExcludeToolStripMenuItemClick);
             // 
             // deleteAllUntrackedFilesToolStripMenuItem
             // 
@@ -1431,6 +1441,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem resetAlltrackedChangesToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripMenuItem editGitIgnoreToolStripMenuItem;
+        private ToolStripMenuItem editLocallyIgnoredFilesToolStripMenuItem;
         private ToolStripMenuItem deleteAllUntrackedFilesToolStripMenuItem;
         private ToolStripEx toolbarStaged;
         private FileStatusList Staged;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1527,7 +1527,13 @@ namespace GitUI.CommandsDialogs
 
         private void EditGitIgnoreToolStripMenuItemClick(object sender, EventArgs e)
         {
-            UICommands.StartEditGitIgnoreDialog(this);
+            UICommands.StartEditGitIgnoreDialog(this, false);
+            Initialize();
+        }
+
+        private void EditGitInfoExcludeToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.StartEditGitIgnoreDialog(this, false);
             Initialize();
         }
 
@@ -1718,7 +1724,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
             var fileNames = Unstaged.SelectedItems.Select(item => item.Name).ToArray();
-            if (UICommands.StartAddToGitIgnoreDialog(this, fileNames))
+            if (UICommands.StartAddToGitIgnoreDialog(this, false, fileNames))
                 Initialize();
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1719,12 +1719,22 @@ namespace GitUI.CommandsDialogs
 
         private void AddFileTogitignoreToolStripMenuItemClick(object sender, EventArgs e)
         {
+            HandleExcludeFileClick(false);
+        }
+
+        private void AddFileToGitInfoExcludeToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            HandleExcludeFileClick(true);
+        }
+
+        private void HandleExcludeFileClick(bool localExclude)
+        {
             if (!Unstaged.SelectedItems.Any())
                 return;
 
             SelectedDiff.Clear();
             var fileNames = Unstaged.SelectedItems.Select(item => item.Name).ToArray();
-            if (UICommands.StartAddToGitIgnoreDialog(this, false, fileNames))
+            if (UICommands.StartAddToGitIgnoreDialog(this, localExclude, fileNames))
                 Initialize();
         }
 

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -10,6 +10,9 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormGitIgnore : GitModuleForm
     {
+        private readonly TranslationString _editLocalExcludeTitle =
+            new TranslationString("Edit .git/info/exclude");
+
         private readonly TranslationString _gitignoreOnlyInWorkingDirSupported =
             new TranslationString(".gitignore is only supported when there is a working directory.");
         private readonly TranslationString _gitignoreOnlyInWorkingDirSupportedCaption =
@@ -69,6 +72,9 @@ namespace GitUI.CommandsDialogs
             _localExclude = localExclude;
             InitializeComponent();
             Translate();
+
+            if (localExclude)
+                Text = _editLocalExcludeTitle.Text;
         }
 
         private string ExcludeFileRelative

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -25,6 +25,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _saveFileQuestionCaption =
             new TranslationString("Save changes?");
 
+        private bool _localExclude;
         private string _originalGitIgnoreFileContent = string.Empty;
 
         #region default patterns
@@ -62,11 +63,35 @@ namespace GitUI.CommandsDialogs
         };
         #endregion
 
-        public FormGitIgnore(GitUICommands aCommands)
+        public FormGitIgnore(GitUICommands aCommands, bool localExclude)
             : base(aCommands)
         {
+            _localExclude = localExclude;
             InitializeComponent();
             Translate();
+        }
+
+        private string ExcludeFileRelative
+        {
+            get
+            {
+                if (!_localExclude)
+                {
+                    return ".gitignore";
+                }
+                else
+                {
+                    return Path.Combine(".git", "info", "exclude");
+                }
+            }
+        }
+
+        private string ExcludeFile
+        {
+            get
+            {
+                return Module.WorkingDir + ExcludeFileRelative;
+            }
         }
 
         protected override void OnRuntimeLoad(EventArgs e)
@@ -80,8 +105,8 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (File.Exists(Module.WorkingDir + ".gitignore"))
-                    _NO_TRANSLATE_GitIgnoreEdit.ViewFile(Module.WorkingDir + ".gitignore");
+                if (File.Exists(ExcludeFile))
+                    _NO_TRANSLATE_GitIgnoreEdit.ViewFile(ExcludeFile);
             }
             catch (Exception ex)
             {
@@ -103,7 +128,7 @@ namespace GitUI.CommandsDialogs
             {
                 FileInfoExtensions
                     .MakeFileTemporaryWritable(
-                        Module.WorkingDir + ".gitignore",
+                        ExcludeFile,
                         x =>
                         {
                             var fileContent = _NO_TRANSLATE_GitIgnoreEdit.GetText();
@@ -164,7 +189,7 @@ namespace GitUI.CommandsDialogs
             // workaround to prevent GitIgnoreFileLoaded event handling (it causes wrong _originalGitIgnoreFileContent update)
             // TODO: implement in FileViewer separate events for loading text from file and for setting text directly via ViewText
             _NO_TRANSLATE_GitIgnoreEdit.TextLoaded -= GitIgnoreFileLoaded;
-            _NO_TRANSLATE_GitIgnoreEdit.ViewText(".gitignore",
+            _NO_TRANSLATE_GitIgnoreEdit.ViewText(ExcludeFileRelative,
                 currentFileContent + Environment.NewLine +
                 string.Join(Environment.NewLine, patternsToAdd) + Environment.NewLine + string.Empty);
             _NO_TRANSLATE_GitIgnoreEdit.TextLoaded += GitIgnoreFileLoaded;
@@ -173,7 +198,7 @@ namespace GitUI.CommandsDialogs
         private void AddPattern_Click(object sender, EventArgs e)
         {
             SaveGitIgnore();
-            UICommands.StartAddToGitIgnoreDialog(this, "*.dll");
+            UICommands.StartAddToGitIgnoreDialog(this, _localExclude, "*.dll");
             LoadGitIgnore();
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1210,11 +1210,11 @@ namespace GitUI
             return StartDeleteTagDialog(null, "");
         }
 
-        public bool StartEditGitIgnoreDialog(IWin32Window owner)
+        public bool StartEditGitIgnoreDialog(IWin32Window owner, bool localExcludes)
         {
             Func<bool> action = () =>
             {
-                using (var form = new FormGitIgnore(this))
+                using (var form = new FormGitIgnore(this, localExcludes))
                     form.ShowDialog(owner);
 
                 return true;
@@ -1223,17 +1223,16 @@ namespace GitUI
             return DoActionOnRepo(owner, true, false, PreEditGitIgnore, PostEditGitIgnore, action);
         }
 
-        public bool StartEditGitIgnoreDialog()
+        public bool StartEditGitIgnoreDialog(bool localExcludes)
         {
-            return StartEditGitIgnoreDialog(null);
+            return StartEditGitIgnoreDialog(null, localExcludes);
         }
 
-        public bool StartAddToGitIgnoreDialog(IWin32Window owner, params string[] filePattern)
+        public bool StartAddToGitIgnoreDialog(IWin32Window owner, bool localExclude, params string[] filePattern)
         {
-
             Func<bool> action = () =>
             {
-                using (var frm = new FormAddToGitIgnore(this, filePattern))
+                using (var frm = new FormAddToGitIgnore(this, localExclude, filePattern))
                     frm.ShowDialog(owner);
 
                 return true;
@@ -1905,7 +1904,7 @@ namespace GitUI
                     Module.RunBash();
                     return;
                 case "gitignore":
-                    StartEditGitIgnoreDialog();
+                    StartEditGitIgnoreDialog(false);
                     return;
                 case "init":        // [path]
                     RunInitCommand(args);

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2023,7 +2023,7 @@ namespace GitUI
 
         private void GitIgnoreClick(object sender, EventArgs e)
         {
-            UICommands.StartEditGitIgnoreDialog(this);
+            UICommands.StartEditGitIgnoreDialog(this, false);
         }
 
         internal void InvalidateRevisions()

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -129,7 +129,7 @@ namespace GitUIPluginInterfaces
         bool StartCreateTagDialog();
         bool StartDeleteBranchDialog(string branch);
         bool StartDeleteTagDialog();
-        bool StartEditGitIgnoreDialog();
+        bool StartEditGitIgnoreDialog(bool localExcludes);
         void StartFileHistoryDialog(string fileName);
         bool StartFormatPatchDialog();
         bool StartGitCommandProcessDialog(string arguments);


### PR DESCRIPTION
Fixes #2194

> :warning: This is totally untested, but I figured I could at least push a branch with a working start for this feature.
