### PR TITLE
Fix p4merge diff settings

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -171,8 +171,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
                     exeName = "kdiff3.exe";
 
-                    return FindFileInFolders(exeName, kdiff3path, @"KDiff3\",
-                                                          regkdiff3path);
+                    return FindFileInFolders(exeName, kdiff3path, @"KDiff3\", regkdiff3path);
+                case "p4merge":
+                    string p4mergepath = UnquoteString(GetGlobalSetting(settings, "difftool.p4merge.path"));
+                    exeName = "p4merge.exe";
+                    return FindFileInFolders(exeName, p4mergepath, @"Perforce\");
                 case "meld":
                     string difftoolMeldPath = UnquoteString(GetGlobalSetting(settings, "difftool.meld.path"));
                     string programFilesMeldPath = @"Meld\meld\";

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -197,7 +197,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             if (!EnvUtils.RunningOnWindows())
                 return;
 
-            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()), MergetoolPath.Text.Trim());
+            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text.Trim()), DifftoolPath.Text.Trim());
             string exeName;
             string exeFile;
             if (!String.IsNullOrEmpty(DifftoolPath.Text))


### PR DESCRIPTION
The diff tool for p4merge was not working and the settings remained empty.