### PR TITLE
Search graph row index by commit hash using dictionary

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -252,21 +252,21 @@ namespace GitUI.BuildServerIntegration
 
             foreach (var commitHash in buildInfo.CommitHashList)
             {
-                int row = revisionGrid.TrySearchRevision(commitHash);
-                if (row >= 0)
+                var index = revisions.TryGetRevisionIndex(commitHash);
+                if (index.HasValue)
                 {
-                    var rowData = revisions.GetRowData(row);
+                    var rowData = revisions.GetRowData(index.Value);
                     if (rowData.BuildStatus == null ||
                         buildInfo.StartDate >= rowData.BuildStatus.StartDate)
                     {
                         rowData.BuildStatus = buildInfo;
 
                         if (BuildStatusImageColumnIndex != -1 &&
-                            revisions.Rows[row].Cells[BuildStatusImageColumnIndex].Displayed)
-                            revisions.UpdateCellValue(BuildStatusImageColumnIndex, row);
+                            revisions.Rows[index.Value].Cells[BuildStatusImageColumnIndex].Displayed)
+                            revisions.UpdateCellValue(BuildStatusImageColumnIndex, index.Value);
                         if (BuildStatusMessageColumnIndex != -1 &&
-                            revisions.Rows[row].Cells[BuildStatusImageColumnIndex].Displayed)
-                            revisions.UpdateCellValue(BuildStatusMessageColumnIndex, row);
+                            revisions.Rows[index.Value].Cells[BuildStatusImageColumnIndex].Displayed)
+                            revisions.UpdateCellValue(BuildStatusMessageColumnIndex, index.Value);
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1260,23 +1260,6 @@ namespace GitUI
             }
         }
 
-        internal int TrySearchRevision(string initRevision)
-        {
-            var rows = Revisions
-                .Rows
-                .Cast<DataGridViewRow>();
-            var revisions = rows
-                .Select(row => new { row.Index, GetRevision(row.Index).Guid });
-
-            var idx = revisions.FirstOrDefault(rev => rev.Guid == initRevision);
-            if (idx != null)
-            {
-                return idx.Index;
-            }
-
-            return -1;
-        }
-
         private string[] GetAllParents(string initRevision)
         {
             var revListParams = "rev-list ";
@@ -1292,19 +1275,17 @@ namespace GitUI
 
         private int SearchRevision(string initRevision)
         {
-            int index = TrySearchRevision(initRevision);
-            if (index >= 0)
-                return index;
+            var exactIndex = Revisions.TryGetRevisionIndex(initRevision);
+            if (exactIndex.HasValue)
+                return exactIndex.Value;
 
-            var rows = Revisions
-                .Rows
-                .Cast<DataGridViewRow>();
-            var dict = rows
-                .ToDictionary(row => GetRevision(row.Index).Guid, row => row.Index);
-            var allrevisions = GetAllParents(initRevision);
-            var graphRevision = allrevisions.FirstOrDefault(rev => dict.TryGetValue(rev, out index));
-            if (graphRevision != null)
-                return index;
+            foreach (var parentHash in GetAllParents(initRevision))
+            {
+                var parentIndex = Revisions.TryGetRevisionIndex(parentHash);
+                if (parentIndex.HasValue)
+                    return parentIndex.Value;
+            }
+
             return -1;
         }
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1267,6 +1267,16 @@ namespace GitUI.RevisionGridClasses
             return null;
         }
 
+        public int? TryGetRevisionIndex(string guid)
+        {
+            Node node;
+
+            if (_graphData.Nodes.TryGetValue(guid, out node))
+                return node.Index;
+
+            return null;
+        }
+
         public List<string> GetRevisionChildren(string guid)
         {
             Node node;


### PR DESCRIPTION
Previous implementation used O(n) linear lookup with tons of memory garbage
for locating grid row index by corresponding commit's hash.
When build server integration is turned on, applying build results took enormous O(n*m),
where “n” is commit graph rows count and “m” is build results count.

Dictionary gives O(1) complexity regardless of rows count
and at the same time is lightweight from linq and GC overhead point of view

I have a huge repo with ~100K commits, where ~600-700 of them have recent build results on the CI server. In my case this optimization improved performance more than 1000 times (94 ms vs 0,07 ms per CI build). Previously I had to wait for about a minute after almost each GE operation (change repo, make a commit, pull/push, just refresh, etc). It was very annoying. Now there is no more UI freeze, the app is responsible immediately after previous operation.

Before:
```
100,00%   OnBuildInfoUpdate  •  43 062 ms  •  457 calls  •  GitUI.BuildServerIntegration.BuildServerWatcher.OnBuildInfoUpdate
  99,98%   TrySearchRevision  •  43 052 ms  •  669 calls  •  GitUI.RevisionGrid.TrySearchRevision
    99,97%   FirstOrDefault  •  43 050 ms  •  669 calls  •  System.Linq.Enumerable.FirstOrDefault
      83,51%   MoveNext  •  35 962 ms  •  19 883 228 calls  •  System.Linq.Enumerable+WhereSelectEnumerableIterator`2.MoveNext
        45,20%   <TrySearchRevision>b__27  •  19 464 ms  •  19 883 011 calls  •  GitUI.RevisionGrid.<TrySearchRevision>b__27
          27,90%   GetRevision  •  12 013 ms  •  19 883 011 calls  •  GitUI.RevisionGrid.GetRevision
            25,21%   GetRowData  •  10 854 ms  •  19 883 011 calls  •  GitUI.RevisionGridClasses.DvcsGraph.GetRowData
              15,41%   get_Item  •  6 635 ms  •  19 883 011 calls  •  GitUI.RevisionGridClasses.DvcsGraph+Graph.get_Item
                13,19%   get_Item  •  5 679 ms  •  19 883 011 calls  •  GitUI.RevisionGridClasses.DvcsGraph+Lanes.get_Item
                  >3,62%   DvcsGraph+Lanes+SavedLaneRow..ctor  •  1 559 ms  •  19 757 442 calls  •  GitUI.RevisionGridClasses.DvcsGraph+Lanes+SavedLaneRow..ctor
                   1,73%   get_Item  •  743 ms  •  19 883 011 calls  •  System.Collections.Generic.List`1.get_Item
                   1,58%   get_Count  •  679 ms  •  39 640 453 calls  •  System.Collections.Generic.List`1.get_Count
                   0,23%   [Garbage collection]  •  101 ms  •  203 calls
               0,98%   get_Node  •  422 ms  •  19 883 011 calls  •  GitUI.RevisionGridClasses.DvcsGraph+Lanes+SavedLaneRow.get_Node
               0,82%   Enter  •  354 ms  •  19 883 011 calls  •  System.Threading.Monitor.Enter
           6,47%   get_Guid  •  2 785 ms  •  19 883 011 calls  •  GitCommands.GitRevision.get_Guid
          >2,48%   <>f__AnonymousType3`2..ctor  •  1 067 ms  •  19 883 011 calls  •  <>f__AnonymousType3`2..ctor
           1,59%   get_Index  •  683 ms  •  39 766 022 calls  •  System.Windows.Forms.DataGridViewBand.get_Index
           0,10%   [Garbage collection]  •  45 ms  •  138 calls
        31,87%   MoveNext  •  13 726 ms  •  19 883 228 calls  •  System.Linq.Enumerable+<CastIterator>d__94`1.MoveNext
          >21,81%   get_Item  •  9 391 ms  •  19 883 011 calls  •  System.Windows.Forms.DataGridViewRowCollection.get_Item
          >2,87%   get_Current  •  1 234 ms  •  19 883 011 calls  •  System.Windows.Forms.DataGridViewRowCollection+UnsharingRowEnumerator.get_Current
          >2,70%   MoveNext  •  1 162 ms  •  19 883 228 calls  •  System.Windows.Forms.DataGridViewRowCollection+UnsharingRowEnumerator.MoveNext
           0,00%   2 functions hidden  •  0 ms total  •  886 calls total
         1,11%   get_Current  •  479 ms  •  19 883 011 calls  •  System.Linq.Enumerable+<CastIterator>d__94`1.get_Current
         0,00%   2 functions hidden  •  0 ms total  •  886 calls total
      11,60%   <TrySearchRevision>b__28  •  4 995 ms  •  19 883 011 calls  •  GitUI.RevisionGrid+<>c__DisplayClass29.<TrySearchRevision>b__28
         1,18%   get_Guid  •  506 ms  •  19 883 011 calls  •  <>f__AnonymousType3`2.get_Guid
         1,12%   Equals  •  480 ms  •  19 883 011 calls  •  System.String.Equals
         1,03%   EqualsHelper  •  445 ms  •  19 883 011 calls  •  System.String.EqualsHelper
         0,86%   op_Equality  •  372 ms  •  19 883 011 calls  •  System.String.op_Equality
       1,26%   get_Current  •  544 ms  •  19 883 011 calls  •  System.Linq.Enumerable+Iterator`1.get_Current
```

After:
```
100,00%   OnBuildInfoUpdate  •  29 ms  •  395 calls  •  GitUI.BuildServerIntegration.BuildServerWatcher.OnBuildInfoUpdate
   86,84%   get_Item  •  26 ms  •  706 calls  •  System.Windows.Forms.DataGridViewRowCollection.get_Item
  4,17%   TrySearchRevision  •  1 ms  •  607 calls  •  GitUI.RevisionGrid.TrySearchRevision
    3,66%   GetRevisionIndex  •  1 ms  •  607 calls  •  GitUI.RevisionGridClasses.DvcsGraph.GetRevisionIndex
       3,21%   TryGetValue  •  1 ms  •  607 calls  •  System.Collections.Generic.Dictionary`2.TryGetValue
  >2,46%   GetRowData  •  1 ms  •  390 calls  •  GitUI.RevisionGridClasses.DvcsGraph.GetRowData
```