### PR TITLE
fix: Unable to use '/' or '.' in branch name

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
@@ -101,7 +101,7 @@
             this.BranchNameTextBox.Name = "BranchNameTextBox";
             this.BranchNameTextBox.Size = new System.Drawing.Size(242, 21);
             this.BranchNameTextBox.TabIndex = 1;
-            this.BranchNameTextBox.TextChanged += new System.EventHandler(this.BranchNameTextBox_TextChanged);
+            this.BranchNameTextBox.Leave += new System.EventHandler(this.BranchNameTextBox_Leave);
             // 
             // chkbxOrphan
             // 

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -34,7 +34,7 @@ namespace GitUI.CommandsDialogs
         }
 
 
-        public IEnumerable<T> FindControls<T>(Control control) where T : Control
+        private IEnumerable<T> FindControls<T>(Control control) where T : Control
         {
             var controls = control.Controls.Cast<Control>().ToList();
             return controls.SelectMany(FindControls<T>)
@@ -43,7 +43,8 @@ namespace GitUI.CommandsDialogs
                            .Cast<T>();
         }
 
-        private void BranchNameTextBox_TextChanged(object sender, EventArgs e)
+
+        private void BranchNameTextBox_Leave(object sender, EventArgs e)
         {
             if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(GitBranchNameNormaliser.IsValidChar))
             {
@@ -64,12 +65,16 @@ namespace GitUI.CommandsDialogs
             {
                 label.AutoSize = true;
             }
-            
+
             BranchNameTextBox.Focus();
         }
 
         private void OkClick(object sender, EventArgs e)
         {
+            // Ok button set as the "AcceptButton" for the form
+            // if the user hits [Enter] at any point, we need to trigger BranchNameTextBox Leave event
+            Ok.Focus();
+
             string commitGuid = commitPickerSmallControl1.SelectedCommitHash;
             var branchName = BranchNameTextBox.Text.Trim();
 
@@ -115,7 +120,7 @@ namespace GitUI.CommandsDialogs
                     UICommands.UpdateSubmodules(this);
                 }
 
-                DialogResult = wasSuccessFul? DialogResult.OK : DialogResult.None;
+                DialogResult = wasSuccessFul ? DialogResult.OK : DialogResult.None;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The branch name textbox's change event auto replaces trailing '.' and '/' chars while the user is typing.
The normalisation is now invoked only when the textbox loses focus.

Fixes #3297