### PR TITLE
fix: Branch name normalisation is too restrictive

### DIFF
--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -109,7 +109,7 @@ namespace GitCommands.Git
         /// <returns></returns>
         public static bool IsValidChar(char c)
         {
-            return (c > 39 && c < 177) &&
+            return (c > 39 && c < 127) &&
                     c != ' ' && c != '~' && c != '^' && c != ':' &&
                     Array.IndexOf(Path.GetInvalidPathChars(), c) < 0;
         }
@@ -151,8 +151,9 @@ namespace GitCommands.Git
         }
 
         /// <summary>
-        /// Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 'DEL'), 
+        /// Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \127 'DEL'),
         /// space, tilde '~', caret '^', or colon ':' anywhere.
+        /// Also allow any valid Unicode letters.
         /// </summary>
         /// <param name="branchName">Name of the branch.</param>
         /// <param name="options">The options.</param>
@@ -162,7 +163,7 @@ namespace GitCommands.Git
             var result = new StringBuilder(branchName.Length);
             foreach (char t in branchName)
             {
-                if (IsValidChar(t))
+                if (IsValidChar(t) || char.IsLetterOrDigit(t))
                 {
                     result.Append(t);
                 }

--- a/GitExtensionsTest/GitCommands/Git/GitBranchNameNormaliserTest.cs
+++ b/GitExtensionsTest/GitCommands/Git/GitBranchNameNormaliserTest.cs
@@ -67,13 +67,17 @@ namespace GitExtensionsTest.GitCommands.Git
             _gitBranchNameNormaliser.Rule03(input, _gitBranchNameOptions).Should().Be(expected);
         }
 
-        // Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \177 'DEL'), 
+        // Branch name cannot have ASCII control characters (i.e. bytes whose values are lower than \040, or \127 'DEL'), 
         // space, tilde '~', caret '^', or colon ':' anywhere.
         [TestCase("test:test", "test_test")]
         [TestCase("test test", "test_test")]
         [TestCase("test^test", "test_test")]
         [TestCase("test~test", "test_test")]
         [TestCase("hier archy:sher~lok/fo^o", "hier_archy_sher_lok/fo_o")]
+        [TestCase("błąd", "błąd")]
+        [TestCase("привет, ё-маё!", "привет,_ё-маё_")]
+        [TestCase("Pokémon 195", "Pokémon_195")]
+        [TestCase("Anhörung`!@#$%", "Anhörung`_@___")]
         public void Normalise_rule04(string input, string expected)
         {
             _gitBranchNameNormaliser.Rule04(input, _gitBranchNameOptions).Should().Be(expected);


### PR DESCRIPTION
Branch name normalisation now allows valid Unicode letters.

Fixes #3301