### PR TITLE
Added no verify option to allow to bypass git hooks #1982

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1992,11 +1992,14 @@ namespace GitCommands
             return patchFiles;
         }
 
-        public string CommitCmd(bool amend, bool signOff = false, string author = "", bool useExplicitCommitMessage = true)
+        public string CommitCmd(bool amend, bool signOff = false, string author = "", bool useExplicitCommitMessage = true, bool noVerify = false)
         {
             string command = "commit";
             if (amend)
                 command += " --amend";
+
+            if (noVerify)
+                command += " --no-verify";
 
             if (signOff)
                 command += " --signoff";

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -132,6 +132,7 @@ namespace GitUI.CommandsDialogs
             this.signOffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolAuthorLabelItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolAuthor = new System.Windows.Forms.ToolStripTextBox();
+            this.noVerifyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.commitTemplatesToolStripMenuItem = new System.Windows.Forms.ToolStripDropDownButton();
             this.commitStatusStrip = new System.Windows.Forms.StatusStrip();
             this.commitAuthorStatus = new System.Windows.Forms.ToolStripStatusLabel();
@@ -643,6 +644,7 @@ namespace GitUI.CommandsDialogs
             // Unstaged
             // 
             this.Unstaged.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Unstaged.FilterVisible = false;
             this.Unstaged.Location = new System.Drawing.Point(0, 0);
             this.Unstaged.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Unstaged.Name = "Unstaged";
@@ -852,6 +854,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.Staged.ContextMenuStrip = this.StagedFileContext;
             this.Staged.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Staged.FilterVisible = false;
             this.Staged.Location = new System.Drawing.Point(0, 28);
             this.Staged.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Staged.Name = "Staged";
@@ -1188,7 +1191,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator2,
             this.signOffToolStripMenuItem,
             this.toolAuthorLabelItem,
-            this.toolAuthor});
+            this.toolAuthor,
+            this.noVerifyToolStripMenuItem});
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
             this.toolStripMenuItem3.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.toolStripMenuItem3.Size = new System.Drawing.Size(62, 23);
@@ -1243,12 +1247,19 @@ namespace GitUI.CommandsDialogs
             this.toolAuthor.Leave += new System.EventHandler(this.toolAuthor_Leave);
             this.toolAuthor.TextChanged += new System.EventHandler(this.toolAuthor_TextChanged);
             // 
+            // noVerifyToolStripMenuItem
+            // 
+            this.noVerifyToolStripMenuItem.CheckOnClick = true;
+            this.noVerifyToolStripMenuItem.Name = "noVerifyToolStripMenuItem";
+            this.noVerifyToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
+            this.noVerifyToolStripMenuItem.Text = "No verify";
+            // 
             // commitTemplatesToolStripMenuItem
             // 
             this.commitTemplatesToolStripMenuItem.Image = global::GitUI.Properties.Resources.CommitTemplates;
             this.commitTemplatesToolStripMenuItem.Name = "commitTemplatesToolStripMenuItem";
             this.commitTemplatesToolStripMenuItem.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.commitTemplatesToolStripMenuItem.Size = new System.Drawing.Size(135, 23);
+            this.commitTemplatesToolStripMenuItem.Size = new System.Drawing.Size(135, 20);
             this.commitTemplatesToolStripMenuItem.Text = "Commit &templates";
             this.commitTemplatesToolStripMenuItem.DropDownOpening += new System.EventHandler(this.commitTemplatesToolStripMenuItem_DropDownOpening);
             // 
@@ -1497,5 +1508,6 @@ namespace GitUI.CommandsDialogs
         private CheckBox StageInSuperproject;
         private Button ResetUnStaged;
         private ToolStripMenuItem resetUnstagedChangesToolStripMenuItem;
+        private ToolStripMenuItem noVerifyToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -921,7 +921,7 @@ namespace GitUI.CommandsDialogs
 
                 ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCommit);
 
-                var errorOccurred = !FormProcess.ShowDialog(this, Module.CommitCmd(amend, signOffToolStripMenuItem.Checked, toolAuthor.Text, _useFormCommitMessage));
+                var errorOccurred = !FormProcess.ShowDialog(this, Module.CommitCmd(amend, signOffToolStripMenuItem.Checked, toolAuthor.Text, _useFormCommitMessage, noVerifyToolStripMenuItem.Checked));
 
                 UICommands.RepoChangedNotifier.Notify();
 
@@ -929,6 +929,7 @@ namespace GitUI.CommandsDialogs
                     return;
 
                 Amend.Checked = false;
+                noVerifyToolStripMenuItem.Checked = false;
 
                 ScriptManager.RunEventScripts(this, ScriptEvent.AfterCommit);
 


### PR DESCRIPTION
As some people noted, it is sometimes useful to be able to bypass git commit hooks #1982. This is how user interface looks like:

![no verify](https://cloud.githubusercontent.com/assets/2787454/18029060/6fd13954-6c96-11e6-8829-e77161315432.png)

Please consider accepting this PR.
