### PR TITLE
fix: GitBranchNameOptionsTest fail due to localized exception message

### DIFF
--- a/GitExtensionsTest/GitCommands/Git/GitBranchNameOptionsTest.cs
+++ b/GitExtensionsTest/GitCommands/Git/GitBranchNameOptionsTest.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 
 namespace GitExtensionsTest.GitCommands.Git
 {
+    [SetCulture("")]
+    [SetUICulture("")]
     [TestFixture]
     public class GitBranchNameOptionsTest
     {


### PR DESCRIPTION
Force the unit tests to run with `CultureInfo.InvariantCulture` and thus not localise exception messages

Fixes #3306