### PR TITLE
fix #3293 Support multi Selection in diff tab

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1241,6 +1241,18 @@ namespace GitCommands
             set { SetBool("UseConsoleEmulatorForCommands", value); }
         }
 
+        public static bool CheckForDiffViewerSelectedFilesLimitNumber
+        {
+            get { return GetBool("CheckForDiffViewerSelectedFilesLimitNumber", true); }
+            set { SetBool("CheckForDiffViewerSelectedFilesLimitNumber", value); }
+        }
+
+        public static int DiffViewerSelectedFilesLimitNumber
+        {
+            get { return GetInt("DiffViewerSelectedFilesLimitNumber", 10); }
+            set { SetInt("DiffViewerSelectedFilesLimitNumber", value); }
+        }
+
         public static string GetGitExtensionsFullPath()
         {
             return Application.ExecutablePath;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1954,10 +1954,14 @@ namespace GitUI.CommandsDialogs
 
         private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (DiffFiles.SelectedItem == null)
+            var selectedItems = DiffFiles.SelectedItems;
+            if (selectedItems == null ||
+                selectedItems.Count() == 0 ||
+                !checkDiffSelectedItemsLimit(selectedItems.ToList()))
+            {
                 return;
+            }
 
-            var selectedItem = DiffFiles.SelectedItem;
             GitUIExtensions.DiffWithRevisionKind diffKind;
 
             if (sender == aLocalToolStripMenuItem)
@@ -1976,7 +1980,10 @@ namespace GitUI.CommandsDialogs
 
             string parentGuid = RevisionGrid.GetSelectedRevisions().Count() == 1 ? DiffFiles.SelectedItemParent : null;
 
-            RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+            foreach (var selectedItem in selectedItems)
+            {
+                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+            }
         }
 
         private void AddWorkingdirDropDownItem(Repository repo, string caption)
@@ -2729,7 +2736,6 @@ namespace GitUI.CommandsDialogs
             var isCombinedDiff = isExcactlyOneItemSelected &&
                 DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
             var enabled = isExcactlyOneItemSelected && !isCombinedDiff;
-            openWithDifftoolToolStripMenuItem.Enabled = enabled;
             saveAsToolStripMenuItem1.Enabled = enabled;
             cherryPickSelectedDiffFileToolStripMenuItem.Enabled = enabled;
             diffShowInFileTreeToolStripMenuItem.Enabled = isExcactlyOneItemSelected;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1814,16 +1814,15 @@ namespace GitUI.CommandsDialogs
 
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (!Unstaged.SelectedItems.Any())
+            if (!Unstaged.SelectedItems.Any() || !checkDiffSelectedItemsLimit(Unstaged.SelectedItems.ToList()))
                 return;
 
-            var item = Unstaged.SelectedItem;
-            var fileName = item.Name;
-
-            var cmdOutput = Module.OpenWithDifftool(fileName);
-
-            if (!string.IsNullOrEmpty(cmdOutput))
-                MessageBox.Show(this, cmdOutput);
+            foreach (var item in Unstaged.SelectedItems)
+            {
+                var cmdOutput = Module.OpenWithDifftool(item.Name);
+                if (!string.IsNullOrEmpty(cmdOutput))
+                    MessageBox.Show(this, cmdOutput);
+            }
         }
 
 
@@ -2436,6 +2435,9 @@ namespace GitUI.CommandsDialogs
 
         private void toolStripMenuItem9_Click(object sender, EventArgs e)
         {
+            if (!Staged.SelectedItems.Any() || !checkDiffSelectedItemsLimit(Staged.SelectedItems.ToList()))
+                return;
+
             foreach (var item in Staged.SelectedItems)
             {
                 string output = Module.OpenWithDifftool(item.Name, null, null, null, "--cached");

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -110,10 +110,12 @@ namespace GitUI.CommandsDialogs
 
         private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (DiffFiles.SelectedItem == null)
+            var selectedItems = DiffFiles.SelectedItems;
+            if (selectedItems == null ||
+                selectedItems.Count() == 0 ||
+                !checkDiffSelectedItemsLimit(selectedItems.ToList()))
                 return;
 
-            var selectedItem = DiffFiles.SelectedItem;
             GitUIExtensions.DiffWithRevisionKind diffKind;
 
             if (sender == aLocalToolStripMenuItem)
@@ -132,7 +134,10 @@ namespace GitUI.CommandsDialogs
 
             string parentGuid = RevisionGrid.GetSelectedRevisions().Count() == 1 ? DiffFiles.SelectedItemParent : null;
 
-            RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+            foreach (var selectedItem in selectedItems)
+            {
+                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+            }
         }
 
         private void copyFilenameToClipboardToolStripMenuItem1_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -37,9 +37,14 @@
             this.chkAddTrackingRef = new System.Windows.Forms.CheckBox();
             this.chkPushNewBranch = new System.Windows.Forms.CheckBox();
             this.chkAutoPopStashAfterCheckout = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanelForDiffViewer = new System.Windows.Forms.TableLayoutPanel();
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber = new System.Windows.Forms.CheckBox();
+            this.upDownDiffViewerSelectedFilesLimitNumber = new System.Windows.Forms.NumericUpDown();
             this.tableLayoutPanel2.SuspendLayout();
             this.CheckoutGB.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
+            this.tableLayoutPanelForDiffViewer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.upDownDiffViewerSelectedFilesLimitNumber)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanel2
@@ -54,7 +59,7 @@
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(501, 200);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(457, 202);
             this.tableLayoutPanel2.TabIndex = 2;
             // 
             // CheckoutGB
@@ -65,7 +70,7 @@
             this.CheckoutGB.Dock = System.Windows.Forms.DockStyle.Top;
             this.CheckoutGB.Location = new System.Drawing.Point(3, 3);
             this.CheckoutGB.Name = "CheckoutGB";
-            this.CheckoutGB.Size = new System.Drawing.Size(495, 194);
+            this.CheckoutGB.Size = new System.Drawing.Size(451, 196);
             this.CheckoutGB.TabIndex = 0;
             this.CheckoutGB.TabStop = false;
             this.CheckoutGB.Text = "Don\'t ask to confirm to (use with caution)";
@@ -82,35 +87,37 @@
             this.tableLayoutPanel3.Controls.Add(this.chkAddTrackingRef, 0, 3);
             this.tableLayoutPanel3.Controls.Add(this.chkPushNewBranch, 0, 4);
             this.tableLayoutPanel3.Controls.Add(this.chkAutoPopStashAfterCheckout, 0, 2);
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(6, 22);
+            this.tableLayoutPanel3.Controls.Add(this.tableLayoutPanelForDiffViewer, 0, 6);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 12);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 6;
+            this.tableLayoutPanel3.RowCount = 7;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(483, 150);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(442, 164);
             this.tableLayoutPanel3.TabIndex = 1;
             // 
-            // cbUpdateModules
+            // chkUpdateModules
             // 
             this.chkUpdateModules.AutoSize = true;
-            this.chkUpdateModules.Location = new System.Drawing.Point(3, 128);
-            this.chkUpdateModules.Name = "cbUpdateModules";
-            this.chkUpdateModules.Size = new System.Drawing.Size(201, 19);
+            this.chkUpdateModules.Location = new System.Drawing.Point(3, 118);
+            this.chkUpdateModules.Name = "chkUpdateModules";
+            this.chkUpdateModules.Size = new System.Drawing.Size(181, 17);
             this.chkUpdateModules.TabIndex = 6;
             this.chkUpdateModules.Text = "Update submodules on checkout";
-            this.chkUpdateModules.UseVisualStyleBackColor = true;
             this.chkUpdateModules.ThreeState = true;
+            this.chkUpdateModules.UseVisualStyleBackColor = true;
             // 
             // chkAmend
             // 
             this.chkAmend.AutoSize = true;
             this.chkAmend.Location = new System.Drawing.Point(3, 3);
             this.chkAmend.Name = "chkAmend";
-            this.chkAmend.Size = new System.Drawing.Size(131, 19);
+            this.chkAmend.Size = new System.Drawing.Size(115, 17);
             this.chkAmend.TabIndex = 0;
             this.chkAmend.Text = "Amend last commit";
             this.chkAmend.UseVisualStyleBackColor = true;
@@ -118,9 +125,9 @@
             // chkAutoPopStashAfterPull
             // 
             this.chkAutoPopStashAfterPull.AutoSize = true;
-            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 28);
+            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 26);
             this.chkAutoPopStashAfterPull.Name = "chkAutoPopStashAfterPull";
-            this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(448, 19);
+            this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(409, 17);
             this.chkAutoPopStashAfterPull.TabIndex = 1;
             this.chkAutoPopStashAfterPull.Text = "Apply stashed changes after successful pull (stash will be popped automatically)";
             this.chkAutoPopStashAfterPull.ThreeState = true;
@@ -129,9 +136,9 @@
             // chkAddTrackingRef
             // 
             this.chkAddTrackingRef.AutoSize = true;
-            this.chkAddTrackingRef.Location = new System.Drawing.Point(3, 78);
+            this.chkAddTrackingRef.Location = new System.Drawing.Point(3, 72);
             this.chkAddTrackingRef.Name = "chkAddTrackingRef";
-            this.chkAddTrackingRef.Size = new System.Drawing.Size(289, 19);
+            this.chkAddTrackingRef.Size = new System.Drawing.Size(267, 17);
             this.chkAddTrackingRef.TabIndex = 4;
             this.chkAddTrackingRef.Text = "Add a tracking reference for newly pushed branch";
             this.chkAddTrackingRef.UseVisualStyleBackColor = true;
@@ -139,9 +146,9 @@
             // chkPushNewBranch
             // 
             this.chkPushNewBranch.AutoSize = true;
-            this.chkPushNewBranch.Location = new System.Drawing.Point(3, 103);
+            this.chkPushNewBranch.Location = new System.Drawing.Point(3, 95);
             this.chkPushNewBranch.Name = "chkPushNewBranch";
-            this.chkPushNewBranch.Size = new System.Drawing.Size(205, 19);
+            this.chkPushNewBranch.Size = new System.Drawing.Size(190, 17);
             this.chkPushNewBranch.TabIndex = 3;
             this.chkPushNewBranch.Text = "Push a new branch for the remote";
             this.chkPushNewBranch.UseVisualStyleBackColor = true;
@@ -149,28 +156,75 @@
             // chkAutoPopStashAfterCheckout
             // 
             this.chkAutoPopStashAfterCheckout.AutoSize = true;
-            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 53);
+            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 49);
             this.chkAutoPopStashAfterCheckout.Name = "chkAutoPopStashAfterCheckout";
-            this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(477, 19);
+            this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(436, 17);
             this.chkAutoPopStashAfterCheckout.TabIndex = 5;
             this.chkAutoPopStashAfterCheckout.Text = "Apply stashed changes after successful checkout (stash will be popped automatical" +
     "ly)";
             this.chkAutoPopStashAfterCheckout.ThreeState = true;
             this.chkAutoPopStashAfterCheckout.UseVisualStyleBackColor = true;
             // 
+            // tableLayoutPanelForDiffViewer
+            // 
+            this.tableLayoutPanelForDiffViewer.ColumnCount = 2;
+            this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 62.18182F));
+            this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 37.81818F));
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkCheckForDiffViewerSelectedFilesLimitNumber, 0, 0);
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.upDownDiffViewerSelectedFilesLimitNumber, 1, 0);
+            this.tableLayoutPanelForDiffViewer.Location = new System.Drawing.Point(3, 141);
+            this.tableLayoutPanelForDiffViewer.Name = "tableLayoutPanelForDiffViewer";
+            this.tableLayoutPanelForDiffViewer.RowCount = 1;
+            this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
+            this.tableLayoutPanelForDiffViewer.Size = new System.Drawing.Size(275, 20);
+            this.tableLayoutPanelForDiffViewer.TabIndex = 7;
+            // 
+            // chkCheckForDiffViewerSelectedFilesLimitNumber
+            // 
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.AutoSize = true;
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.Location = new System.Drawing.Point(0, 3);
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.Name = "chkCheckForDiffViewerSelectedFilesLimitNumber";
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.Size = new System.Drawing.Size(168, 17);
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.TabIndex = 0;
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.Text = "Warn if selected files exceed:";
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.UseVisualStyleBackColor = true;
+            this.chkCheckForDiffViewerSelectedFilesLimitNumber.CheckedChanged += new System.EventHandler(this.chkCheckForDiffViewerSelectedFilesLimitNumber_CheckedChanged);
+            // 
+            // upDownDiffViewerSelectedFilesLimitNumber
+            // 
+            this.upDownDiffViewerSelectedFilesLimitNumber.Location = new System.Drawing.Point(174, 0);
+            this.upDownDiffViewerSelectedFilesLimitNumber.Margin = new System.Windows.Forms.Padding(3, 0, 3, 3);
+            this.upDownDiffViewerSelectedFilesLimitNumber.Minimum = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.upDownDiffViewerSelectedFilesLimitNumber.Name = "upDownDiffViewerSelectedFilesLimitNumber";
+            this.upDownDiffViewerSelectedFilesLimitNumber.Size = new System.Drawing.Size(40, 21);
+            this.upDownDiffViewerSelectedFilesLimitNumber.TabIndex = 1;
+            this.upDownDiffViewerSelectedFilesLimitNumber.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            // 
             // ConfirmationsSettingsPage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel2);
             this.Name = "ConfirmationsSettingsPage";
-            this.Size = new System.Drawing.Size(1271, 634);
+            this.Size = new System.Drawing.Size(977, 394);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.CheckoutGB.ResumeLayout(false);
             this.CheckoutGB.PerformLayout();
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
+            this.tableLayoutPanelForDiffViewer.ResumeLayout(false);
+            this.tableLayoutPanelForDiffViewer.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.upDownDiffViewerSelectedFilesLimitNumber)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -187,6 +241,9 @@
         private System.Windows.Forms.CheckBox chkAddTrackingRef;
         private System.Windows.Forms.CheckBox chkAutoPopStashAfterCheckout;
         private System.Windows.Forms.CheckBox chkUpdateModules;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelForDiffViewer;
+        private System.Windows.Forms.CheckBox chkCheckForDiffViewerSelectedFilesLimitNumber;
+        private System.Windows.Forms.NumericUpDown upDownDiffViewerSelectedFilesLimitNumber;
 
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -20,6 +20,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkPushNewBranch.Checked = AppSettings.DontConfirmPushNewBranch;
             chkAddTrackingRef.Checked = AppSettings.DontConfirmAddTrackingRef;
             chkUpdateModules.CheckState = AppSettings.UpdateSubmodulesOnCheckout.ToCheckboxState();
+            chkCheckForDiffViewerSelectedFilesLimitNumber.Checked = AppSettings.CheckForDiffViewerSelectedFilesLimitNumber;
+            upDownDiffViewerSelectedFilesLimitNumber.Enabled = AppSettings.CheckForDiffViewerSelectedFilesLimitNumber;
+            upDownDiffViewerSelectedFilesLimitNumber.Value = AppSettings.DiffViewerSelectedFilesLimitNumber;
         }
 
         protected override void PageToSettings()
@@ -30,11 +33,18 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.DontConfirmPushNewBranch = chkPushNewBranch.Checked;
             AppSettings.DontConfirmAddTrackingRef = chkAddTrackingRef.Checked;
             AppSettings.UpdateSubmodulesOnCheckout = chkUpdateModules.CheckState.ToBoolean();
+            AppSettings.CheckForDiffViewerSelectedFilesLimitNumber = chkCheckForDiffViewerSelectedFilesLimitNumber.Checked;
+            AppSettings.DiffViewerSelectedFilesLimitNumber = (int)upDownDiffViewerSelectedFilesLimitNumber.Value;
         }
 
         public static SettingsPageReference GetPageReference()
         {
             return new SettingsPageReferenceByType(typeof(ConfirmationsSettingsPage));
+        }
+
+        private void chkCheckForDiffViewerSelectedFilesLimitNumber_CheckedChanged(object sender, System.EventArgs e)
+        {
+            upDownDiffViewerSelectedFilesLimitNumber.Enabled = chkCheckForDiffViewerSelectedFilesLimitNumber.Checked;
         }
     }
 

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -2,6 +2,8 @@
 using System.ComponentModel;
 using System.Windows.Forms;
 using GitCommands;
+using ResourceManager;
+using System.Collections.Generic;
 
 namespace GitUI
 {
@@ -9,6 +11,10 @@ namespace GitUI
     /// <see cref="GitModule"/> and <see cref="GitUICommands"/>.</summary>
     public class GitModuleForm : GitExtensionsForm, IGitUICommandsSource
     {
+        private readonly TranslationString diffWarnLimitExceeded = new TranslationString("Selected files number exceed limit");
+
+        private readonly TranslationString diffWarnLimitExceededConfirmation = new TranslationString("{0} selected files exceed limit of {1}.\nDo you want to continue?");
+
         private GitUICommands _uiCommands;
         /// <summary>Gets a <see cref="GitUICommands"/> reference.</summary>
         [Browsable(false)]
@@ -71,6 +77,25 @@ namespace GitUI
         protected bool ExecuteScriptCommand(int command)
         {
             return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command);
+        }
+
+        protected bool checkDiffSelectedItemsLimit(List<GitItemStatus> list)
+        {
+            bool ret = true;
+
+            if (AppSettings.CheckForDiffViewerSelectedFilesLimitNumber)
+            {
+                var diffViewerSelectedFilesLimitNumber = AppSettings.DiffViewerSelectedFilesLimitNumber;
+                if (list.Count > diffViewerSelectedFilesLimitNumber)
+                {
+                    if (MessageBox.Show(this, string.Format(diffWarnLimitExceededConfirmation.Text, list.Count, diffViewerSelectedFilesLimitNumber), diffWarnLimitExceeded.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+                    {
+                        ret = false;
+                    }
+                }
+            }
+
+            return ret;
         }
     }
 }


### PR DESCRIPTION
Sorry - not able to reopen [closed pull request](3298) after fixing the conflit. I create a new one.

Please find below fixed comments:
Can you add a confirmation when an user has selected more than 10 files to be opened in external diff tool? => Added

Warning option added to GitCommands\Settings\AppSettings.cs => Option added to AppSettngs.

Below how it looks:

![gitextensions-settings](https://cloud.githubusercontent.com/assets/6384703/18207466/d6a1dc1e-711a-11e6-92c7-c3c85c2ae6c8.png)

![gitextensions-warn-message](https://cloud.githubusercontent.com/assets/6384703/18207487/e02d362a-711a-11e6-8163-ac2b69f1d6bd.png)
