### PR TITLE
2141 simplify calling prune remote branches

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1533,7 +1533,7 @@ namespace GitCommands
             if (string.IsNullOrEmpty(remote) && string.IsNullOrEmpty(remoteBranch) && string.IsNullOrEmpty(localBranch))
                 return "fetch " + progressOption;
 
-            return "fetch " + progressOption + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow);
+            return "fetch " + progressOption + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, prune);
         }
 
         public string PullCmd(string remote, string remoteBranch, string localBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false)
@@ -1545,10 +1545,10 @@ namespace GitCommands
             if (rebase)
                 pullArgs = "--rebase".Combine(" ", pullArgs);
 
-            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow);
+            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, false);
         }
 
-        private string GetFetchArgs(string remote, string remoteBranch, string localBranch, bool? fetchTags, bool isUnshallow)
+        private string GetFetchArgs(string remote, string remoteBranch, string localBranch, bool? fetchTags, bool isUnshallow, bool prune)
         {
             remote = remote.ToPosixPath();
 
@@ -1580,6 +1580,7 @@ namespace GitCommands
                 localBranchArguments = ":" + "refs/remotes/" + remote.Trim() + "/" + localBranch;
 
             string arguments = fetchTags == true ? " --tags" : fetchTags == false ? " --no-tags" : "";
+
 
             if(isUnshallow)
                 arguments += " --unshallow";

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1581,11 +1581,12 @@ namespace GitCommands
 
             string arguments = fetchTags == true ? " --tags" : fetchTags == false ? " --no-tags" : "";
 
+            string pruneArguments = prune ? " --prune" : "";
 
             if(isUnshallow)
                 arguments += " --unshallow";
 
-            return "\"" + remote.Trim() + "\" " + remoteBranchArguments + localBranchArguments + arguments;
+            return "\"" + remote.Trim() + "\" " + remoteBranchArguments + localBranchArguments + arguments + pruneArguments;
         }
 
         public string GetRebaseDir()

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1524,7 +1524,7 @@ namespace GitCommands
             return path.Contains(Path.DirectorySeparatorChar) || path.Contains(AppSettings.PosixPathSeparator.ToString());
         }
 
-        public string FetchCmd(string remote, string remoteBranch, string localBranch, bool? fetchTags = false, bool isUnshallow = false)
+        public string FetchCmd(string remote, string remoteBranch, string localBranch, bool? fetchTags = false, bool isUnshallow = false, bool prune = false)
         {
             var progressOption = "";
             if (GitCommandHelpers.VersionInUse.FetchCanAskForProgress)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1545,7 +1545,7 @@ namespace GitCommands
             if (rebase)
                 pullArgs = "--rebase".Combine(" ", pullArgs);
 
-            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, false);
+            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, prune && !rebase);
         }
 
         private string GetFetchArgs(string remote, string remoteBranch, string localBranch, bool? fetchTags, bool isUnshallow, bool prune)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1536,7 +1536,7 @@ namespace GitCommands
             return "fetch " + progressOption + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, prune);
         }
 
-        public string PullCmd(string remote, string remoteBranch, string localBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false)
+        public string PullCmd(string remote, string remoteBranch, string localBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false, bool prune = false)
         {
             var pullArgs = "";
             if (GitCommandHelpers.VersionInUse.FetchCanAskForProgress)

--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -515,6 +515,8 @@
             this.Prune.Size = new System.Drawing.Size(138, 17);
             this.Prune.TabIndex = 20;
             this.Prune.Text = "Prune remote branches";
+            this.Tooltip.SetToolTip(this.Prune, "Removes remote tracking branches that no longer exist on the remote (e.g. if some" +
+        "one else deleted them).\r\n\r\nActual command line (if checked): --prune\r\n");
             // 
             // FormPull
             // 

--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -131,7 +131,7 @@
             this.Unshallow.Size = new System.Drawing.Size(126, 17);
             this.Unshallow.TabIndex = 20;
             this.Unshallow.Text = "Download full history";
-            this.Tooltip.SetToolTip(this.Unshallow, resources.GetString("Unshallow.ToolTip"));
+            this.Tooltip.SetToolTip(this.Unshallow, "Fetches as much history from the remote source as possible.\nIf full history is available (if the source is not a shallow clone itself), then this repo will be a shallow clone no more.\n\nActual command line (if checked): --unshallow");
             this.Unshallow.Visible = false;
             // 
             // Pull

--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -29,19 +29,23 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormPull));
             this.Tooltip = new System.Windows.Forms.ToolTip(this.components);
             this.PullFromUrl = new System.Windows.Forms.RadioButton();
             this.PullFromRemote = new System.Windows.Forms.RadioButton();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
+            this.Unshallow = new System.Windows.Forms.CheckBox();
             this.Pull = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.helpImageDisplayUserControl1 = new GitUI.Help.HelpImageDisplayUserControl();
             this.panel2 = new System.Windows.Forms.Panel();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.comboBoxPullSource = new System.Windows.Forms.ComboBox();
             this._NO_TRANSLATE_Remotes = new System.Windows.Forms.ComboBox();
+            this.AddRemote = new System.Windows.Forms.Button();
+            this.comboBoxPullSource = new System.Windows.Forms.ComboBox();
+            this.folderBrowserButton1 = new GitUI.UserControls.FolderBrowserButton();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.Merge = new System.Windows.Forms.RadioButton();
@@ -59,9 +63,7 @@
             this.Mergetool = new System.Windows.Forms.Button();
             this.Stash = new System.Windows.Forms.Button();
             this.AutoStash = new System.Windows.Forms.CheckBox();
-            this.AddRemote = new System.Windows.Forms.Button();
-            this.folderBrowserButton1 = new GitUI.UserControls.FolderBrowserButton();
-            this.Unshallow = new System.Windows.Forms.CheckBox();
+            this.Prune = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -77,10 +79,9 @@
             // PullFromUrl
             // 
             this.PullFromUrl.AutoSize = true;
-            this.PullFromUrl.Location = new System.Drawing.Point(9, 59);
-            this.PullFromUrl.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PullFromUrl.Location = new System.Drawing.Point(7, 47);
             this.PullFromUrl.Name = "PullFromUrl";
-            this.PullFromUrl.Size = new System.Drawing.Size(49, 24);
+            this.PullFromUrl.Size = new System.Drawing.Size(38, 17);
             this.PullFromUrl.TabIndex = 3;
             this.PullFromUrl.Text = "Url";
             this.Tooltip.SetToolTip(this.PullFromUrl, "Url to pull from");
@@ -91,10 +92,9 @@
             // 
             this.PullFromRemote.AutoSize = true;
             this.PullFromRemote.Checked = true;
-            this.PullFromRemote.Location = new System.Drawing.Point(9, 24);
-            this.PullFromRemote.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PullFromRemote.Location = new System.Drawing.Point(7, 19);
             this.PullFromRemote.Name = "PullFromRemote";
-            this.PullFromRemote.Size = new System.Drawing.Size(82, 24);
+            this.PullFromRemote.Size = new System.Drawing.Size(62, 17);
             this.PullFromRemote.TabIndex = 0;
             this.PullFromRemote.TabStop = true;
             this.PullFromRemote.Text = "Remote";
@@ -105,10 +105,9 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(11, 28);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(9, 22);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(93, 20);
+            this.label1.Size = new System.Drawing.Size(67, 13);
             this.label1.TabIndex = 8;
             this.label1.Text = "Local branch";
             this.Tooltip.SetToolTip(this.label1, "Remote branch to pull. Leave empty to pull all branches.");
@@ -116,24 +115,34 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(10, 61);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(8, 49);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(110, 20);
+            this.label2.Size = new System.Drawing.Size(80, 13);
             this.label2.TabIndex = 7;
             this.label2.Text = "Remote branch";
             this.Tooltip.SetToolTip(this.label2, "Remote branch to pull. Leave empty to pull all branches.");
+            // 
+            // Unshallow
+            // 
+            this.Unshallow.AutoSize = true;
+            this.Unshallow.Location = new System.Drawing.Point(7, 387);
+            this.Unshallow.Margin = new System.Windows.Forms.Padding(7, 2, 2, 2);
+            this.Unshallow.Name = "Unshallow";
+            this.Unshallow.Size = new System.Drawing.Size(126, 17);
+            this.Unshallow.TabIndex = 20;
+            this.Unshallow.Text = "Download full history";
+            this.Tooltip.SetToolTip(this.Unshallow, resources.GetString("Unshallow.ToolTip"));
+            this.Unshallow.Visible = false;
             // 
             // Pull
             // 
             this.Pull.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.Pull.Image = global::GitUI.Properties.Resources.ArrowDown;
             this.Pull.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.Pull.Location = new System.Drawing.Point(609, 10);
-            this.Pull.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.Pull.MinimumSize = new System.Drawing.Size(150, 31);
+            this.Pull.Location = new System.Drawing.Point(489, 8);
+            this.Pull.MinimumSize = new System.Drawing.Size(120, 25);
             this.Pull.Name = "Pull";
-            this.Pull.Size = new System.Drawing.Size(155, 31);
+            this.Pull.Size = new System.Drawing.Size(124, 25);
             this.Pull.TabIndex = 40;
             this.Pull.Text = "&Pull";
             this.Pull.UseVisualStyleBackColor = true;
@@ -152,7 +161,7 @@
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 1;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(842, 599);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(674, 479);
             this.tableLayoutPanel1.TabIndex = 16;
             // 
             // helpImageDisplayUserControl1
@@ -167,11 +176,10 @@
             this.helpImageDisplayUserControl1.IsExpanded = true;
             this.helpImageDisplayUserControl1.IsOnHoverShowImage2 = false;
             this.helpImageDisplayUserControl1.IsOnHoverShowImage2NoticeText = "Hover to see scenario when fast forward is possible.";
-            this.helpImageDisplayUserControl1.Location = new System.Drawing.Point(4, 4);
-            this.helpImageDisplayUserControl1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.helpImageDisplayUserControl1.MinimumSize = new System.Drawing.Size(50, 112);
+            this.helpImageDisplayUserControl1.Location = new System.Drawing.Point(3, 3);
+            this.helpImageDisplayUserControl1.MinimumSize = new System.Drawing.Size(40, 83);
             this.helpImageDisplayUserControl1.Name = "helpImageDisplayUserControl1";
-            this.helpImageDisplayUserControl1.Size = new System.Drawing.Size(50, 591);
+            this.helpImageDisplayUserControl1.Size = new System.Drawing.Size(40, 473);
             this.helpImageDisplayUserControl1.TabIndex = 10;
             this.helpImageDisplayUserControl1.UniqueIsExpandedSettingsId = "Pull";
             // 
@@ -179,10 +187,9 @@
             // 
             this.panel2.Controls.Add(this.tableLayoutPanel2);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel2.Location = new System.Drawing.Point(62, 4);
-            this.panel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.panel2.Location = new System.Drawing.Point(49, 3);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(776, 591);
+            this.panel2.Size = new System.Drawing.Size(622, 473);
             this.panel2.TabIndex = 19;
             // 
             // tableLayoutPanel2
@@ -194,20 +201,21 @@
             this.tableLayoutPanel2.Controls.Add(this.groupBox3, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.groupBox4, 0, 3);
             this.tableLayoutPanel2.Controls.Add(this.Unshallow, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.Prune, 0, 5);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 6;
+            this.tableLayoutPanel2.RowCount = 7;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(776, 591);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(622, 473);
             this.tableLayoutPanel2.TabIndex = 42;
             // 
             // groupBox2
@@ -220,27 +228,12 @@
             this.groupBox2.Controls.Add(this.PullFromUrl);
             this.groupBox2.Controls.Add(this.comboBoxPullSource);
             this.groupBox2.Controls.Add(this.folderBrowserButton1);
-            this.groupBox2.Location = new System.Drawing.Point(4, 4);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox2.Location = new System.Drawing.Point(3, 3);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox2.Size = new System.Drawing.Size(768, 95);
+            this.groupBox2.Size = new System.Drawing.Size(616, 76);
             this.groupBox2.TabIndex = 6;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Pull from";
-            // 
-            // comboBoxPullSource
-            // 
-            this.comboBoxPullSource.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.comboBoxPullSource.Enabled = false;
-            this.comboBoxPullSource.FormattingEnabled = true;
-            this.comboBoxPullSource.Location = new System.Drawing.Point(185, 58);
-            this.comboBoxPullSource.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.comboBoxPullSource.Name = "comboBoxPullSource";
-            this.comboBoxPullSource.Size = new System.Drawing.Size(379, 28);
-            this.comboBoxPullSource.TabIndex = 4;
-            this.comboBoxPullSource.Validating += new System.ComponentModel.CancelEventHandler(this.PullSourceValidating);
             // 
             // _NO_TRANSLATE_Remotes
             // 
@@ -249,24 +242,56 @@
             this._NO_TRANSLATE_Remotes.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this._NO_TRANSLATE_Remotes.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this._NO_TRANSLATE_Remotes.FormattingEnabled = true;
-            this._NO_TRANSLATE_Remotes.Location = new System.Drawing.Point(185, 20);
-            this._NO_TRANSLATE_Remotes.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this._NO_TRANSLATE_Remotes.Location = new System.Drawing.Point(148, 16);
             this._NO_TRANSLATE_Remotes.Name = "_NO_TRANSLATE_Remotes";
-            this._NO_TRANSLATE_Remotes.Size = new System.Drawing.Size(379, 28);
+            this._NO_TRANSLATE_Remotes.Size = new System.Drawing.Size(306, 21);
             this._NO_TRANSLATE_Remotes.TabIndex = 1;
             this._NO_TRANSLATE_Remotes.TextChanged += new System.EventHandler(this.Remotes_TextChanged);
             this._NO_TRANSLATE_Remotes.Validating += new System.ComponentModel.CancelEventHandler(this.RemotesValidating);
+            // 
+            // AddRemote
+            // 
+            this.AddRemote.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.AddRemote.Image = global::GitUI.Properties.Resources.IconRemotes;
+            this.AddRemote.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.AddRemote.Location = new System.Drawing.Point(460, 14);
+            this.AddRemote.Name = "AddRemote";
+            this.AddRemote.Size = new System.Drawing.Size(150, 25);
+            this.AddRemote.TabIndex = 2;
+            this.AddRemote.Text = "Manage remotes";
+            this.AddRemote.UseVisualStyleBackColor = true;
+            this.AddRemote.Click += new System.EventHandler(this.AddRemoteClick);
+            // 
+            // comboBoxPullSource
+            // 
+            this.comboBoxPullSource.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.comboBoxPullSource.Enabled = false;
+            this.comboBoxPullSource.FormattingEnabled = true;
+            this.comboBoxPullSource.Location = new System.Drawing.Point(148, 46);
+            this.comboBoxPullSource.Name = "comboBoxPullSource";
+            this.comboBoxPullSource.Size = new System.Drawing.Size(306, 21);
+            this.comboBoxPullSource.TabIndex = 4;
+            this.comboBoxPullSource.Validating += new System.ComponentModel.CancelEventHandler(this.PullSourceValidating);
+            // 
+            // folderBrowserButton1
+            // 
+            this.folderBrowserButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.folderBrowserButton1.Enabled = false;
+            this.folderBrowserButton1.Location = new System.Drawing.Point(460, 45);
+            this.folderBrowserButton1.Name = "folderBrowserButton1";
+            this.folderBrowserButton1.PathShowingControl = this.comboBoxPullSource;
+            this.folderBrowserButton1.Size = new System.Drawing.Size(150, 25);
+            this.folderBrowserButton1.TabIndex = 5;
             // 
             // groupBox1
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.flowLayoutPanel1);
-            this.groupBox1.Location = new System.Drawing.Point(4, 213);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox1.Location = new System.Drawing.Point(3, 169);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox1.Size = new System.Drawing.Size(768, 129);
+            this.groupBox1.Size = new System.Drawing.Size(616, 103);
             this.groupBox1.TabIndex = 10;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Merge options";
@@ -279,10 +304,9 @@
             this.flowLayoutPanel1.Controls.Add(this.Fetch);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 24);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 17);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(760, 101);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(610, 83);
             this.flowLayoutPanel1.TabIndex = 11;
             this.flowLayoutPanel1.WrapContents = false;
             // 
@@ -292,11 +316,10 @@
             this.Merge.Checked = true;
             this.Merge.Image = global::GitUI.Properties.Resources.IconMerge;
             this.Merge.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.Merge.Location = new System.Drawing.Point(4, 4);
-            this.Merge.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Merge.Location = new System.Drawing.Point(3, 3);
             this.Merge.Name = "Merge";
             this.Merge.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
-            this.Merge.Size = new System.Drawing.Size(319, 26);
+            this.Merge.Size = new System.Drawing.Size(239, 19);
             this.Merge.TabIndex = 8;
             this.Merge.TabStop = true;
             this.Merge.Text = "&Merge remote branch into current branch";
@@ -308,11 +331,10 @@
             // 
             this.Rebase.AutoSize = true;
             this.Rebase.Image = global::GitUI.Properties.Resources.IconRebase;
-            this.Rebase.Location = new System.Drawing.Point(4, 38);
-            this.Rebase.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Rebase.Location = new System.Drawing.Point(3, 28);
             this.Rebase.Name = "Rebase";
             this.Rebase.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
-            this.Rebase.Size = new System.Drawing.Size(624, 26);
+            this.Rebase.Size = new System.Drawing.Size(468, 19);
             this.Rebase.TabIndex = 9;
             this.Rebase.Text = "&Rebase current branch on top of remote branch, creates linear history (use with " +
     "caution)";
@@ -323,11 +345,10 @@
             // Fetch
             // 
             this.Fetch.AutoSize = true;
-            this.Fetch.Location = new System.Drawing.Point(4, 72);
-            this.Fetch.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Fetch.Location = new System.Drawing.Point(3, 53);
             this.Fetch.Name = "Fetch";
             this.Fetch.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
-            this.Fetch.Size = new System.Drawing.Size(305, 26);
+            this.Fetch.Size = new System.Drawing.Size(225, 19);
             this.Fetch.TabIndex = 10;
             this.Fetch.Text = "Do not merge, only &fetch remote changes";
             this.Fetch.UseVisualStyleBackColor = true;
@@ -341,33 +362,31 @@
             this.groupBox3.Controls.Add(this.label1);
             this.groupBox3.Controls.Add(this.Branches);
             this.groupBox3.Controls.Add(this.label2);
-            this.groupBox3.Location = new System.Drawing.Point(4, 107);
-            this.groupBox3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox3.Location = new System.Drawing.Point(3, 85);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox3.Size = new System.Drawing.Size(768, 98);
+            this.groupBox3.Size = new System.Drawing.Size(616, 78);
             this.groupBox3.TabIndex = 8;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Branch";
             // 
             // localBranch
             // 
-            this.localBranch.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.localBranch.Location = new System.Drawing.Point(188, 18);
-            this.localBranch.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.localBranch.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.localBranch.Location = new System.Drawing.Point(150, 14);
             this.localBranch.Name = "localBranch";
-            this.localBranch.Size = new System.Drawing.Size(379, 27);
+            this.localBranch.Size = new System.Drawing.Size(306, 21);
             this.localBranch.TabIndex = 9;
             this.localBranch.Leave += new System.EventHandler(this.localBranch_Leave);
             // 
             // Branches
             // 
-            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.Branches.FormattingEnabled = true;
-            this.Branches.Location = new System.Drawing.Point(188, 58);
-            this.Branches.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Branches.Location = new System.Drawing.Point(150, 46);
             this.Branches.Name = "Branches";
-            this.Branches.Size = new System.Drawing.Size(379, 28);
+            this.Branches.Size = new System.Drawing.Size(306, 21);
             this.Branches.TabIndex = 6;
             this.Branches.DropDown += new System.EventHandler(this.BranchesDropDown);
             // 
@@ -376,11 +395,9 @@
             this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox4.Controls.Add(this.flowLayoutPanel2);
-            this.groupBox4.Location = new System.Drawing.Point(4, 350);
-            this.groupBox4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox4.Location = new System.Drawing.Point(3, 278);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBox4.Size = new System.Drawing.Size(768, 130);
+            this.groupBox4.Size = new System.Drawing.Size(616, 104);
             this.groupBox4.TabIndex = 15;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Tag options";
@@ -393,10 +410,9 @@
             this.flowLayoutPanel2.Controls.Add(this.AllTags);
             this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel2.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(4, 24);
-            this.flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 17);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(760, 127);
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(610, 84);
             this.flowLayoutPanel2.TabIndex = 16;
             this.flowLayoutPanel2.WrapContents = false;
             // 
@@ -404,11 +420,10 @@
             // 
             this.ReachableTags.AutoSize = true;
             this.ReachableTags.Checked = true;
-            this.ReachableTags.Location = new System.Drawing.Point(4, 4);
-            this.ReachableTags.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.ReachableTags.Location = new System.Drawing.Point(3, 3);
             this.ReachableTags.Name = "ReachableTags";
             this.ReachableTags.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
-            this.ReachableTags.Size = new System.Drawing.Size(502, 26);
+            this.ReachableTags.Size = new System.Drawing.Size(365, 19);
             this.ReachableTags.TabIndex = 17;
             this.ReachableTags.TabStop = true;
             this.ReachableTags.Text = "Follow tagopt, if not specified, fetch tags reachable from remote HEAD";
@@ -417,11 +432,10 @@
             // NoTags
             // 
             this.NoTags.AutoSize = true;
-            this.NoTags.Location = new System.Drawing.Point(4, 38);
-            this.NoTags.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.NoTags.Location = new System.Drawing.Point(3, 28);
             this.NoTags.Name = "NoTags";
             this.NoTags.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
-            this.NoTags.Size = new System.Drawing.Size(112, 26);
+            this.NoTags.Size = new System.Drawing.Size(86, 19);
             this.NoTags.TabIndex = 18;
             this.NoTags.Text = "Fetch no tag";
             this.NoTags.UseVisualStyleBackColor = true;
@@ -429,11 +443,10 @@
             // AllTags
             // 
             this.AllTags.AutoSize = true;
-            this.AllTags.Location = new System.Drawing.Point(4, 72);
-            this.AllTags.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AllTags.Location = new System.Drawing.Point(3, 53);
             this.AllTags.Name = "AllTags";
             this.AllTags.Padding = new System.Windows.Forms.Padding(0, 1, 0, 1);
-            this.AllTags.Size = new System.Drawing.Size(117, 26);
+            this.AllTags.Size = new System.Drawing.Size(89, 19);
             this.AllTags.TabIndex = 19;
             this.AllTags.Text = "Fetch all tags";
             this.AllTags.UseVisualStyleBackColor = true;
@@ -452,22 +465,20 @@
             this.tableLayoutPanel3.Controls.Add(this.Stash, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.AutoStash, 2, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(4, 536);
-            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 430);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.Padding = new System.Windows.Forms.Padding(0, 6, 0, 6);
+            this.tableLayoutPanel3.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(768, 51);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(616, 41);
             this.tableLayoutPanel3.TabIndex = 42;
             // 
             // Mergetool
             // 
             this.Mergetool.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.Mergetool.Location = new System.Drawing.Point(4, 10);
-            this.Mergetool.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Mergetool.Location = new System.Drawing.Point(3, 8);
             this.Mergetool.Name = "Mergetool";
-            this.Mergetool.Size = new System.Drawing.Size(176, 31);
+            this.Mergetool.Size = new System.Drawing.Size(141, 25);
             this.Mergetool.TabIndex = 11;
             this.Mergetool.Text = "Solve conflicts";
             this.Mergetool.UseVisualStyleBackColor = true;
@@ -476,10 +487,9 @@
             // Stash
             // 
             this.Stash.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.Stash.Location = new System.Drawing.Point(188, 10);
-            this.Stash.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Stash.Location = new System.Drawing.Point(150, 8);
             this.Stash.Name = "Stash";
-            this.Stash.Size = new System.Drawing.Size(165, 31);
+            this.Stash.Size = new System.Drawing.Size(132, 25);
             this.Stash.TabIndex = 12;
             this.Stash.Text = "Stash changes";
             this.Stash.UseVisualStyleBackColor = true;
@@ -489,61 +499,33 @@
             // 
             this.AutoStash.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.AutoStash.AutoSize = true;
-            this.AutoStash.Location = new System.Drawing.Point(361, 13);
-            this.AutoStash.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AutoStash.Location = new System.Drawing.Point(288, 12);
             this.AutoStash.Name = "AutoStash";
-            this.AutoStash.Size = new System.Drawing.Size(100, 24);
+            this.AutoStash.Size = new System.Drawing.Size(78, 17);
             this.AutoStash.TabIndex = 13;
             this.AutoStash.Text = "Auto stash";
             this.AutoStash.UseVisualStyleBackColor = true;
             // 
-            // AddRemote
+            // Prune
             // 
-            this.AddRemote.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.AddRemote.Image = global::GitUI.Properties.Resources.IconRemotes;
-            this.AddRemote.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.AddRemote.Location = new System.Drawing.Point(572, 18);
-            this.AddRemote.Margin = new System.Windows.Forms.Padding(4);
-            this.AddRemote.Name = "AddRemote";
-            this.AddRemote.Size = new System.Drawing.Size(188, 31);
-            this.AddRemote.TabIndex = 2;
-            this.AddRemote.Text = "Manage remotes";
-            this.AddRemote.UseVisualStyleBackColor = true;
-            this.AddRemote.Click += new System.EventHandler(this.AddRemoteClick);
-            // 
-            // folderBrowserButton1
-            // 
-            this.folderBrowserButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.folderBrowserButton1.Enabled = false;
-            this.folderBrowserButton1.Location = new System.Drawing.Point(572, 56);
-            this.folderBrowserButton1.Margin = new System.Windows.Forms.Padding(4);
-            this.folderBrowserButton1.Name = "folderBrowserButton1";
-            this.folderBrowserButton1.PathShowingControl = this.comboBoxPullSource;
-            this.folderBrowserButton1.Size = new System.Drawing.Size(188, 31);
-            this.folderBrowserButton1.TabIndex = 5;
-            // 
-            // Unshallow
-            // 
-            this.Unshallow.AutoSize = true;
-            this.Unshallow.Margin = new System.Windows.Forms.Padding(9, 3, 3, 3);
-            this.Unshallow.Name = "Unshallow";
-            this.Unshallow.Size = new System.Drawing.Size(139, 19);
-            this.Unshallow.TabIndex = 20;
-            this.Unshallow.Text = "Download full history";
-            this.Tooltip.SetToolTip(this.Unshallow, "Fetches as much history from the remote source as possible.\nIf full history is available (if the source is not a shallow clone itself), then this repo will be a shallow clone no more.\n\nActual command line (if checked): --unshallow");
-            this.Unshallow.Visible = false;
+            this.Prune.AutoSize = true;
+            this.Prune.Location = new System.Drawing.Point(7, 408);
+            this.Prune.Margin = new System.Windows.Forms.Padding(7, 2, 2, 2);
+            this.Prune.Name = "Prune";
+            this.Prune.Size = new System.Drawing.Size(138, 17);
+            this.Prune.TabIndex = 20;
+            this.Prune.Text = "Prune remote branches";
             // 
             // FormPull
             // 
             this.AcceptButton = this.Pull;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(842, 599);
+            this.ClientSize = new System.Drawing.Size(674, 479);
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(858, 626);
+            this.MinimumSize = new System.Drawing.Size(690, 508);
             this.Name = "FormPull";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Pull";
@@ -606,5 +588,6 @@
         private System.Windows.Forms.Button AddRemote;
         private UserControls.FolderBrowserButton folderBrowserButton1;
         private System.Windows.Forms.CheckBox Unshallow;
+        private System.Windows.Forms.CheckBox Prune;
     }
 }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -475,7 +475,7 @@ namespace GitUI.CommandsDialogs
 
             Debug.Assert(Merge.Checked || Rebase.Checked);
 
-            return new FormRemoteProcess(Module, Module.PullCmd(source, curRemoteBranch, curLocalBranch, Rebase.Checked, GetTagsArg(), Unshallow.Checked))
+            return new FormRemoteProcess(Module, Module.PullCmd(source, curRemoteBranch, curLocalBranch, Rebase.Checked, GetTagsArg(), Unshallow.Checked, Prune.Checked))
                        {
                            HandleOnExitCallback = HandlePullOnExit
                        };

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -802,7 +802,7 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Image2 = Resources.HelpPullMergeFastForward;
             helpImageDisplayUserControl1.IsOnHoverShowImage2 = true;
             AllTags.Enabled = false;
-            Prune.Enabled = false;
+            Prune.Enabled = true;
             if (AllTags.Checked)
                 ReachableTags.Checked = true;
         }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -117,7 +117,7 @@ namespace GitUI.CommandsDialogs
             Fetch.Checked = Settings.FormPullAction == Settings.PullAction.Fetch;
             localBranch.Enabled = Fetch.Checked;
             AutoStash.Checked = Settings.AutoStash;
-            Prune.Enabled = Fetch.Checked;
+            Prune.Enabled = Settings.FormPullAction == Settings.PullAction.Merge || Settings.FormPullAction == Settings.PullAction.Fetch;
 
             ErrorOccurred = false;
 

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -117,6 +117,7 @@ namespace GitUI.CommandsDialogs
             Fetch.Checked = Settings.FormPullAction == Settings.PullAction.Fetch;
             localBranch.Enabled = Fetch.Checked;
             AutoStash.Checked = Settings.AutoStash;
+            Prune.Enabled = Fetch.Checked;
 
             ErrorOccurred = false;
 
@@ -801,6 +802,7 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Image2 = Resources.HelpPullMergeFastForward;
             helpImageDisplayUserControl1.IsOnHoverShowImage2 = true;
             AllTags.Enabled = false;
+            Prune.Enabled = false;
             if (AllTags.Checked)
                 ReachableTags.Checked = true;
         }
@@ -812,6 +814,7 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Image1 = Resources.HelpPullRebase;
             helpImageDisplayUserControl1.IsOnHoverShowImage2 = false;
             AllTags.Enabled = false;
+            Prune.Enabled = false;
             if (AllTags.Checked)
                 ReachableTags.Checked = true;
         }
@@ -822,6 +825,7 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Image1 = Resources.HelpPullFetch;
             helpImageDisplayUserControl1.IsOnHoverShowImage2 = false;
             AllTags.Enabled = true;
+            Prune.Enabled = true;
         }
 
         private void PullSourceValidating(object sender, CancelEventArgs e)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -470,7 +470,7 @@ namespace GitUI.CommandsDialogs
         {
             if (Fetch.Checked)
             {
-                return new FormRemoteProcess(Module, Module.FetchCmd(source, curRemoteBranch, curLocalBranch, GetTagsArg(), Unshallow.Checked));
+                return new FormRemoteProcess(Module, Module.FetchCmd(source, curRemoteBranch, curLocalBranch, GetTagsArg(), Unshallow.Checked, Prune.Checked));
             }
 
             Debug.Assert(Merge.Checked || Rebase.Checked);


### PR DESCRIPTION
Adds a checkbox to the pull form which when selected will append --prune to the command line:

![2141-simplify-calling-prune--fetch-selected](https://cloud.githubusercontent.com/assets/22169186/18471044/af799b96-79a7-11e6-956a-4bde9501890d.png)

When Merge is selected, the prune checkbox is still enabled:

![2141-simplify-calling-prune--merge-selected](https://cloud.githubusercontent.com/assets/22169186/19031153/4a78a2ca-894a-11e6-9feb-fad9ba2b20ce.png)

When Rebase is selected, the prune checkbox is disabled and --prune will not be appended:

![2141-simplify-calling-prune--rebase-selected](https://cloud.githubusercontent.com/assets/22169186/19031155/524f98aa-894a-11e6-862f-ca2ba683692a.png)
