### PR TITLE
Fix build on case-sensitive filesystems

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1941,12 +1941,12 @@
   <Import Project="..\FxCop.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
-  <Import Project="..\packages\ConEmu.Core.16.7.10.0\build\ConEmu.Core.Targets" Condition="Exists('..\packages\ConEmu.Core.16.7.10.0\build\ConEmu.Core.Targets')" />
+  <Import Project="..\packages\ConEmu.Core.16.7.10.0\Build\ConEmu.Core.Targets" Condition="Exists('..\packages\ConEmu.Core.16.7.10.0\Build\ConEmu.Core.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ConEmu.Core.16.9.14.0\build\ConEmu.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ConEmu.Core.16.9.14.0\build\ConEmu.Core.Targets'))" />
+    <Error Condition="!Exists('..\packages\ConEmu.Core.16.9.14.0\Build\ConEmu.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ConEmu.Core.16.9.14.0\Build\ConEmu.Core.Targets'))" />
   </Target>
-  <Import Project="..\packages\ConEmu.Core.16.9.14.0\build\ConEmu.Core.Targets" Condition="Exists('..\packages\ConEmu.Core.16.9.14.0\build\ConEmu.Core.Targets')" />
+  <Import Project="..\packages\ConEmu.Core.16.9.14.0\Build\ConEmu.Core.Targets" Condition="Exists('..\packages\ConEmu.Core.16.9.14.0\Build\ConEmu.Core.Targets')" />
 </Project>


### PR DESCRIPTION
Running `nuget restore GitExtensionsMono.sln` creates `packages\ConEmu.Core.16.9.14.0\Build` directory (Build starts with uppercase)
There was another build error in `GitExtensionsTest/GitCommands/Helpers/PathUtilTest.cs` because of treating warnings as errors. I do not know what the intended behavior of that test is so I left out fixing it here.

Fixes #3335