### PR TITLE
Check the 'AutoStash' checkbox when working directory is dirty

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -109,7 +109,8 @@ namespace GitUI.CommandsDialogs
                 Mergetool.Enabled = false;
                 Skip.Enabled = false;
                 Abort.Enabled = false;
-                chkStash.Enabled = Module.IsDirtyDir(); ;
+                chkStash.Enabled = Module.IsDirtyDir();
+                chkStash.Checked = chkStash.Enabled;
             }
 
             SolveMergeconflicts.Visible = Module.InTheMiddleOfConflictedMerge();


### PR DESCRIPTION
...to be able to do a rebase

Otherwise, if the working directory is dirty and that we forgot to check this option, the rebase fail and we have to start the rebase again... boring. :(

