### PR TITLE
fix display of the "git clean" preview

### DIFF
--- a/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
@@ -142,6 +142,7 @@
             //
             // PreviewOutput
             //
+            this.PreviewOutput.AcceptsReturn = true;
             this.PreviewOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));


### PR DESCRIPTION
Enable the 'AcceptReturn' to be able to display the command output
on multiple lines