### PR TITLE
Fix "Host Fingerprint not registered" Plink handling on clone

### DIFF
--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -163,8 +163,14 @@ namespace GitUI
                 {
                     if (MessageBox.Show(this, _fingerprintNotRegistredText.Text, _fingerprintNotRegistredTextCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
                     {
-                        string remoteUrl = Module.GetPathSetting(string.Format(SettingKeyString.RemoteUrl, Remote));
-                        remoteUrl = string.IsNullOrEmpty(remoteUrl) ? Remote : remoteUrl;
+                        string remoteUrl;
+                        if (string.IsNullOrEmpty(UrlTryingToConnect))
+                        {
+                            remoteUrl = Module.GetPathSetting(string.Format(SettingKeyString.RemoteUrl, Remote));
+                            remoteUrl = string.IsNullOrEmpty(remoteUrl) ? Remote : remoteUrl;
+                        }
+                        else
+                            remoteUrl = UrlTryingToConnect;
                         remoteUrl = GitCommandHelpers.GetPlinkCompatibleUrl(remoteUrl);
 
                         Module.RunExternalCmdShowConsole("cmd.exe", string.Format("/k \"\"{0}\" {1}\"", AppSettings.Plink, remoteUrl));


### PR DESCRIPTION
When using Plink and pulling or pushing to/from a remote with an untrusted host fingerprint GitExtensions offers to open plink in a new command prompt window so the user can interactively press Y to trust the fingerprint.

However, this currently does not work correctly for clone. plink is called with an emptry string instead of the remote URL. This commit fixes that.