### PR TITLE
Teamcity projects display done right...

### DIFF
--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -6,9 +7,10 @@ namespace TeamCityIntegration.Settings
 {
     public partial class TeamCityBuildChooser : Form
     {
-        private TeamCityAdapter _teamCityAdapter = new TeamCityAdapter();
-        private TreeNode _previouslySelectedBuild;
-        private string _teamCityServerUrl;
+        private readonly TeamCityAdapter _teamCityAdapter = new TeamCityAdapter();
+        private TreeNode _previouslySelectedProject;
+        public string TeamCityProjectName { get; private set; }
+        public string TeamCityBuildIdFilter { get; private set; }
 
         public TeamCityBuildChooser(string teamCityServerUrl, string teamCityProjectName, string teamCityBuildIdFilter)
         {
@@ -16,87 +18,92 @@ namespace TeamCityIntegration.Settings
 
             TeamCityProjectName = teamCityProjectName;
             TeamCityBuildIdFilter = teamCityBuildIdFilter;
-            _teamCityServerUrl = teamCityServerUrl;
-        }
-
-        struct Node
-        {
-            public string Name;
-            public bool Loaded;
-            public bool IsProject;
-            public string ParentProject;
-        }
-
-        public string TeamCityProjectName { get; set; }
-        public string TeamCityBuildIdFilter { get; set; }
-
-        public void LoadProjectsAndBuilds(string teamCityServerUrl)
-        {
             _teamCityAdapter.InitializeHttpClient(teamCityServerUrl);
-            var projects = _teamCityAdapter.GetAllProjects();
-            var loadingNode = new TreeNode("loading...");
-            treeViewTeamCityProjects.Nodes.Clear();
-            treeViewTeamCityProjects.Nodes.AddRange(projects.Select(p => new TreeNode(p)
-            {
-                Name = p,
-                Tag = new Node {IsProject = true, Loaded = false, Name = p}
-            }).OrderBy(p=>p.Name).ToArray());
 
-            foreach (TreeNode node in treeViewTeamCityProjects.Nodes)
+            var rootProject = _teamCityAdapter.GetProjectsTree();
+            var rootTreeNode = LoadTreeView(treeViewTeamCityProjects, rootProject);
+
+            rootTreeNode.Expand();
+        }
+
+        private void TeamCityBuildChooser_Load(object sender, EventArgs e)
+        {
+            ReselectPreviouslySelectedBuild();
+        }
+
+        private void ReselectPreviouslySelectedBuild()
+        {
+            if (_previouslySelectedProject == null)
+                return;
+
+            _previouslySelectedProject.Expand();
+            treeViewTeamCityProjects.SelectedNode = _previouslySelectedProject.Nodes.Find(TeamCityBuildIdFilter, false).FirstOrDefault()
+                ?? _previouslySelectedProject;
+        }
+
+        private TreeNode LoadTreeView(TreeView treeView, Project rootProject)
+        {
+            treeView.Nodes.Clear();
+            var rootNode = ConvertProjectInTreeNode(rootProject);
+            treeView.Nodes.Add(rootNode);
+            return rootNode;
+        }
+
+        private TreeNode ConvertProjectInTreeNode(Project project)
+        {
+            var projectNode = new TreeNode(project.Name)
             {
-                node.Nodes.Add((TreeNode) loadingNode.Clone());
+                Name = project.Name,
+                Tag = project,
+            };
+
+            projectNode.Nodes.AddRange(project.SubProjects.Select(ConvertProjectInTreeNode).OrderBy(p => p.Name).ToArray());
+            if (projectNode.Nodes.Count == 0)
+            {
+                projectNode.Nodes.Add(new TreeNode("Loading..."));
             }
 
-            if(!string.IsNullOrWhiteSpace(TeamCityProjectName))
+            if (TeamCityProjectName == project.Id)
             {
-                foreach (TreeNode node in treeViewTeamCityProjects.Nodes)
-                {
-                    if(node.Name == TeamCityProjectName)
-                    {
-                        treeViewTeamCityProjects.SelectedNode = node;
-                        node.Expand();
-                        break;
-                    }
-                }
+                _previouslySelectedProject = projectNode;
             }
+            return projectNode;
         }
 
         private void treeViewTeamCityProjects_BeforeExpand(object sender, TreeViewCancelEventArgs e)
         {
-            LoadSubProjects(e.Node);
+            LoadProjectBuilds(e.Node);
         }
 
-        private void LoadSubProjects(TreeNode treeNode)
+        private void LoadProjectBuilds(TreeNode treeNode)
         {
-            var node = (Node)treeNode.Tag;
-            if (node.IsProject && !node.Loaded)
+            var project = (Project)treeNode.Tag;
+            if (project.Builds == null)
             {
-                treeNode.Nodes.Clear();
-                var project = _teamCityAdapter.GetProjectChildren(node.Name);
+                project.Builds = _teamCityAdapter.GetProjectBuilds(project.Name);
 
-                var projectNodes = project.Projects.Select(p => new TreeNode(p)
+                //Remove "Loading..." node
+                if (treeNode.Nodes.Count == 1 && treeNode.Nodes[0].Tag == null)
                 {
-                    Name = p,
-                    Tag = new Node { IsProject = true, Loaded = false, Name = p, ParentProject = node.Name }
-                }).OrderBy(p => p.Name).ToArray();
-                treeNode.Nodes.AddRange(projectNodes);
+                    treeNode.Nodes.RemoveAt(0);
+                }
 
-                var buildNodes = project.Builds.Select(b => new TreeNode(b.Name + " (" + b.Id + ")")
+                var buildNodes = project.Builds.Select(b => new TreeNode(b.DisplayName)
                 {
                     Name = b.Id,
-                    Tag = new Node { IsProject = false, Loaded = true, Name = b.Id, ParentProject = node.Name }
-                }).OrderBy(p => p.Name).ToArray();
+                    ForeColor = Color.Blue,
+                    Tag = b
+                }).OrderBy(b => b.Name).ToArray();
                 treeNode.Nodes.AddRange(buildNodes);
-
-                //Find previous already selected build in the treeview
-                var previouslySelectedBuild = buildNodes.FirstOrDefault(n => n.Name == TeamCityBuildIdFilter
-                    && n.Parent.Name == TeamCityProjectName);
-                if (previouslySelectedBuild != null)
-                    _previouslySelectedBuild = previouslySelectedBuild;
             }
         }
 
         private void treeViewTeamCityProjects_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            SelectBuild();
+        }
+
+        private void buttonOK_Click(object sender, EventArgs e)
         {
             SelectBuild();
         }
@@ -106,49 +113,30 @@ namespace TeamCityIntegration.Settings
             if (treeViewTeamCityProjects.SelectedNode == null)
                 return;
 
-            var node = (Node) treeViewTeamCityProjects.SelectedNode.Tag;
-            if (node.IsProject)
+            var build = treeViewTeamCityProjects.SelectedNode.Tag as Build;
+            if (build == null)
                 return;
-            TeamCityProjectName = node.ParentProject;
-            TeamCityBuildIdFilter = node.Name;
+            TeamCityProjectName = build.ParentProject;
+            TeamCityBuildIdFilter = build.Id;
 
-            this.DialogResult = DialogResult.OK;
-            this.Close();
-        }
-
-        private void buttonOK_Click(object sender, EventArgs e)
-        {
-            SelectBuild();
+            DialogResult = DialogResult.OK;
+            Close();
         }
 
         private void buttonCancel_Click(object sender, EventArgs e)
         {
-            this.DialogResult = DialogResult.Cancel;
-            this.Close();
+            DialogResult = DialogResult.Cancel;
+            Close();
         }
 
         private bool IsBuildSelected(TreeNode selectedNode)
         {
-            if (selectedNode == null)
-                return false;
-
-            var node = (Node)selectedNode.Tag;
-            return !node.IsProject;
+            return selectedNode != null && selectedNode.Tag is Build;
         }
 
         private void treeViewTeamCityProjects_AfterSelect(object sender, TreeViewEventArgs e)
         {
             buttonOK.Enabled = IsBuildSelected(e.Node);
-        }
-
-        private void TeamCityBuildChooser_Load(object sender, EventArgs e)
-        {
-            LoadProjectsAndBuilds(_teamCityServerUrl);
-
-            if (_previouslySelectedBuild != null)
-            {
-                treeViewTeamCityProjects.SelectedNode = _previouslySelectedBuild;
-            }
         }
     }
 }

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
@@ -39,6 +39,7 @@ namespace TeamCityIntegration.Settings
             this.labelRegexError = new System.Windows.Forms.Label();
             this.CheckBoxLogAsGuest = new System.Windows.Forms.CheckBox();
             this.buttonProjectChooser = new System.Windows.Forms.Button();
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard = new System.Windows.Forms.LinkLabel();
             label13 = new System.Windows.Forms.Label();
             label1 = new System.Windows.Forms.Label();
             labelBuildFilter = new System.Windows.Forms.Label();
@@ -49,7 +50,7 @@ namespace TeamCityIntegration.Settings
             // label13
             // 
             label13.AutoSize = true;
-            label13.Location = new System.Drawing.Point(3, 12);
+            label13.Location = new System.Drawing.Point(3, 41);
             label13.Name = "label13";
             label13.Size = new System.Drawing.Size(137, 17);
             label13.TabIndex = 0;
@@ -58,7 +59,7 @@ namespace TeamCityIntegration.Settings
             // label1
             // 
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(3, 43);
+            label1.Location = new System.Drawing.Point(3, 72);
             label1.Name = "label1";
             label1.Size = new System.Drawing.Size(90, 17);
             label1.TabIndex = 2;
@@ -67,7 +68,7 @@ namespace TeamCityIntegration.Settings
             // labelBuildFilter
             // 
             labelBuildFilter.AutoSize = true;
-            labelBuildFilter.Location = new System.Drawing.Point(3, 96);
+            labelBuildFilter.Location = new System.Drawing.Point(3, 125);
             labelBuildFilter.Name = "labelBuildFilter";
             labelBuildFilter.Size = new System.Drawing.Size(84, 17);
             labelBuildFilter.TabIndex = 4;
@@ -77,7 +78,7 @@ namespace TeamCityIntegration.Settings
             // 
             labelProjectNameComment.AutoSize = true;
             labelProjectNameComment.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
-            labelProjectNameComment.Location = new System.Drawing.Point(133, 67);
+            labelProjectNameComment.Location = new System.Drawing.Point(133, 96);
             labelProjectNameComment.Name = "labelProjectNameComment";
             labelProjectNameComment.Size = new System.Drawing.Size(210, 20);
             labelProjectNameComment.TabIndex = 6;
@@ -87,7 +88,7 @@ namespace TeamCityIntegration.Settings
             // 
             labelBuildIdFilter.AutoSize = true;
             labelBuildIdFilter.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
-            labelBuildIdFilter.Location = new System.Drawing.Point(133, 121);
+            labelBuildIdFilter.Location = new System.Drawing.Point(133, 150);
             labelBuildIdFilter.Name = "labelBuildIdFilter";
             labelBuildIdFilter.Size = new System.Drawing.Size(55, 20);
             labelBuildIdFilter.TabIndex = 7;
@@ -97,7 +98,7 @@ namespace TeamCityIntegration.Settings
             // 
             this.TeamCityServerUrl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.TeamCityServerUrl.Location = new System.Drawing.Point(136, 9);
+            this.TeamCityServerUrl.Location = new System.Drawing.Point(136, 38);
             this.TeamCityServerUrl.Name = "TeamCityServerUrl";
             this.TeamCityServerUrl.Size = new System.Drawing.Size(509, 23);
             this.TeamCityServerUrl.TabIndex = 1;
@@ -107,7 +108,7 @@ namespace TeamCityIntegration.Settings
             // 
             this.TeamCityProjectName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.TeamCityProjectName.Location = new System.Drawing.Point(136, 39);
+            this.TeamCityProjectName.Location = new System.Drawing.Point(136, 68);
             this.TeamCityProjectName.Name = "TeamCityProjectName";
             this.TeamCityProjectName.Size = new System.Drawing.Size(478, 23);
             this.TeamCityProjectName.TabIndex = 3;
@@ -116,7 +117,7 @@ namespace TeamCityIntegration.Settings
             // 
             this.TeamCityBuildIdFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.TeamCityBuildIdFilter.Location = new System.Drawing.Point(136, 93);
+            this.TeamCityBuildIdFilter.Location = new System.Drawing.Point(136, 122);
             this.TeamCityBuildIdFilter.Name = "TeamCityBuildIdFilter";
             this.TeamCityBuildIdFilter.Size = new System.Drawing.Size(509, 23);
             this.TeamCityBuildIdFilter.TabIndex = 5;
@@ -127,7 +128,7 @@ namespace TeamCityIntegration.Settings
             this.labelRegexError.AutoSize = true;
             this.labelRegexError.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
             this.labelRegexError.ForeColor = System.Drawing.Color.Red;
-            this.labelRegexError.Location = new System.Drawing.Point(188, 121);
+            this.labelRegexError.Location = new System.Drawing.Point(188, 150);
             this.labelRegexError.Name = "labelRegexError";
             this.labelRegexError.Size = new System.Drawing.Size(457, 20);
             this.labelRegexError.TabIndex = 10;
@@ -137,7 +138,7 @@ namespace TeamCityIntegration.Settings
             // CheckBoxLogAsGuest
             // 
             this.CheckBoxLogAsGuest.AutoSize = true;
-            this.CheckBoxLogAsGuest.Location = new System.Drawing.Point(137, 148);
+            this.CheckBoxLogAsGuest.Location = new System.Drawing.Point(137, 177);
             this.CheckBoxLogAsGuest.Name = "CheckBoxLogAsGuest";
             this.CheckBoxLogAsGuest.Size = new System.Drawing.Size(268, 21);
             this.CheckBoxLogAsGuest.TabIndex = 11;
@@ -147,7 +148,7 @@ namespace TeamCityIntegration.Settings
             // buttonProjectChooser
             // 
             this.buttonProjectChooser.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonProjectChooser.Location = new System.Drawing.Point(617, 38);
+            this.buttonProjectChooser.Location = new System.Drawing.Point(617, 67);
             this.buttonProjectChooser.Name = "buttonProjectChooser";
             this.buttonProjectChooser.Size = new System.Drawing.Size(28, 25);
             this.buttonProjectChooser.TabIndex = 12;
@@ -155,10 +156,22 @@ namespace TeamCityIntegration.Settings
             this.buttonProjectChooser.UseVisualStyleBackColor = true;
             this.buttonProjectChooser.Click += new System.EventHandler(this.buttonProjectChooser_Click);
             // 
+            // lnkExtractDataFromBuildUrlCopiedInTheClipboard
+            // 
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.AutoSize = true;
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Location = new System.Drawing.Point(168, 11);
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Name = "lnkExtractDataFromBuildUrlCopiedInTheClipboard";
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Size = new System.Drawing.Size(357, 17);
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.TabIndex = 13;
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.TabStop = true;
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Text = "Extract the data from the build url copied in the clipboard";
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkExtractDataFromBuildUrlCopiedInTheClipboard_LinkClicked);
+            // 
             // TeamCitySettingsUserControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.lnkExtractDataFromBuildUrlCopiedInTheClipboard);
             this.Controls.Add(this.buttonProjectChooser);
             this.Controls.Add(this.CheckBoxLogAsGuest);
             this.Controls.Add(this.labelRegexError);
@@ -172,7 +185,7 @@ namespace TeamCityIntegration.Settings
             this.Controls.Add(this.TeamCityServerUrl);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "TeamCitySettingsUserControl";
-            this.Size = new System.Drawing.Size(658, 188);
+            this.Size = new System.Drawing.Size(658, 223);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -186,5 +199,6 @@ namespace TeamCityIntegration.Settings
         private System.Windows.Forms.Label labelRegexError;
         private System.Windows.Forms.CheckBox CheckBoxLogAsGuest;
         private System.Windows.Forms.Button buttonProjectChooser;
+        private System.Windows.Forms.LinkLabel lnkExtractDataFromBuildUrlCopiedInTheClipboard;
     }
 }

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -14,7 +14,13 @@ namespace TeamCityIntegration.Settings
     public partial class TeamCitySettingsUserControl : GitExtensionsControl, IBuildServerSettingsUserControl
     {
         private string _defaultProjectName;
-        private TeamCityAdapter _teamCityAdapter = new TeamCityAdapter();
+        private readonly TeamCityAdapter _teamCityAdapter = new TeamCityAdapter();
+        private readonly TranslationString _failToLoadProjectMessage = new TranslationString("Fail to load the projects and build list." + Environment.NewLine + "Please verify the server url.");
+        private readonly TranslationString _failToLoadProjectCaption = new TranslationString("Error when loading the projects and build list");
+        private readonly TranslationString _failToExtractDataFromClipboardMessage = new TranslationString( "The clipboard doesn't contain a valid build url." + Environment.NewLine + Environment.NewLine +
+                "Please copy in the clipboard the url of the build before retrying." + Environment.NewLine +
+                "(Should contains at least the parameter\"buildTypeId\")");
+        private readonly TranslationString _failToExtractDataFromClipboardCaption = new TranslationString("Build url not valid");
 
         public TeamCitySettingsUserControl()
         {
@@ -72,9 +78,7 @@ namespace TeamCityIntegration.Settings
             }
             catch (Exception)
             {
-                MessageBox.Show(this,
-                    "Fail to load the projects and build list." + Environment.NewLine + "Please verify the server url.",
-                    "Error when loading the projects and build list", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _failToLoadProjectMessage.Text, _failToLoadProjectCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -88,7 +92,7 @@ namespace TeamCityIntegration.Settings
             buttonProjectChooser.Enabled = !string.IsNullOrWhiteSpace(TeamCityServerUrl.Text);
         }
 
-        Regex teamcityBuildUrlParameters = new Regex(@"(\?|\&)([^=]+)\=([^&]+)");
+        readonly Regex _teamcityBuildUrlParameters = new Regex(@"(\?|\&)([^=]+)\=([^&]+)");
         private void lnkExtractDataFromBuildUrlCopiedInTheClipboard_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             if (Clipboard.ContainsText() && Clipboard.GetText().Contains("buildTypeId="))
@@ -98,7 +102,7 @@ namespace TeamCityIntegration.Settings
                 TeamCityServerUrl.Text = teamCityServerUrl;
                 _teamCityAdapter.InitializeHttpClient(teamCityServerUrl);
 
-                var paramResults = teamcityBuildUrlParameters.Matches(buildUri.Query);
+                var paramResults = _teamcityBuildUrlParameters.Matches(buildUri.Query);
                 foreach (Match paramResult in paramResults)
                 {
                     if (paramResult.Success)
@@ -114,10 +118,7 @@ namespace TeamCityIntegration.Settings
                 }
             }
 
-            MessageBox.Show(this,
-                "The clipboard doesn't contain a valid build url." + Environment.NewLine + Environment.NewLine +
-                "Please copy in the clipboard the url of the build before retrying." + Environment.NewLine +
-                "(Should contains at least the parameter\"buildTypeId\")", "Build url not valid",
+            MessageBox.Show(this, _failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text,
                 MessageBoxButtons.OK, MessageBoxIcon.Warning);
 
         }

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -421,6 +421,11 @@ namespace TeamCityIntegration
             return GetXmlResponseAsync(string.Format("builds/id:{0}", buildId), cancellationToken);
         }
 
+        private Task<XDocument> GetBuildTypeFromIdXmlResponseAsync(string buildId, CancellationToken cancellationToken)
+        {
+            return GetXmlResponseAsync(string.Format("buildTypes/id:{0}", buildId), cancellationToken);
+        }
+
         private Task<XDocument> GetProjectFromNameXmlResponseAsync(string projectName, CancellationToken cancellationToken)
         {
             return GetXmlResponseAsync(string.Format("projects/{0}", projectName), cancellationToken);
@@ -521,6 +526,18 @@ namespace TeamCityIntegration
                 Name = (string) e.Attribute("name"),
                 ParentProject = (string) e.Attribute("projectId")
             }).ToList();
+        }
+
+        public Build GetBuildType(string buildId)
+        {
+            var projectsRootElement = GetBuildTypeFromIdXmlResponseAsync(buildId, CancellationToken.None).Result;
+            var buildType = projectsRootElement.Root;
+            return new Build
+            {
+                Id = buildId,
+                Name = (string) buildType.Attribute("name"),
+                ParentProject = (string) buildType.Attribute("projectId")
+            };
         }
     }
 


### PR DESCRIPTION
Being able to use 2.49 (stable version) at work and with a real TeamCity with a lot of projects, I discover that I didn't displayed the projects in the build chooser treeview :( Mea culpa. edit: that do the work but not as good as it should...

This is the fix to display them the right way.

I have also improved the way it is displayed (the name of the projects are displayed instead of the id, and colored the build nodes in blue) to make use of the build chooser a lot easier.

Bonus: I have also added another way of providing the needed informations which consist in extracting the data from the build url that was previously copied by the user in the clipboard. In fact, I think that's a more convenient way to do (and easier to code) and I would have developped this solution only if I thought about it before...

There is some info and urls in the commit messages to easily test the fix and the new feature...