### PR TITLE
Fix crash when one of the stash is an autostash

### DIFF
--- a/GitCommands/Git/GitStash.cs
+++ b/GitCommands/Git/GitStash.cs
@@ -19,6 +19,7 @@ namespace GitCommands
         const string NameFormat = "stash@{{{0}}}";
         const string DefaultFormat = "WIP on ";
         const string CustomFormat = "On ";
+        const string AutostashFormat = "autostash";
         static int DefaultFormatLength = DefaultFormat.Length;
         static int CustomFormatLength = CustomFormat.Length;
 
@@ -34,6 +35,7 @@ namespace GitCommands
 
             // "stash@{i}: WIP on {branch}: {PreviousCommitMiniSHA} {PreviousCommitMessage}"
             // "stash@{i}: On {branch}: {Message}"
+            // "stash@{i}: autostash"
 
             _stash = stash;
             Index = i;
@@ -44,7 +46,8 @@ namespace GitCommands
             if (msgStart < stash.Length)
             {
                 Message = stash.Substring(msgStart).Trim();
-                FindBranch();
+                if(Message != AutostashFormat)
+                    FindBranch();
             }
         }
 

--- a/Plugins/GitUIPluginInterfaces/ISetting.cs
+++ b/Plugins/GitUIPluginInterfaces/ISetting.cs
@@ -34,6 +34,7 @@ namespace GitUIPluginInterfaces
         /// Loads setting value from settings to Control
         /// </summary>
         /// <param name="settings"></param>
+        /// <param name="areSettingsEffective"></param>
         void LoadSetting(ISettingsSource settings, bool areSettingsEffective);
 
         /// <summary>


### PR DESCRIPTION
When the stash was made by autostash, we can't find the branch name in the stash name
Add the support for this new format (Branch name is not provided but that's not a problem
because we use it nowhere...)

* fix swallowed exception when retrieving the number of stash (so it is not displayed)
* fix crash that prevent to use the stash form once there is an autostash and to delete the stash