### PR TITLE
fix reset file menu item text

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -165,6 +165,11 @@ namespace GitUI.CommandsDialogs
         private readonly FormBrowseMenuCommands _formBrowseMenuCommands;
 #pragma warning restore 0414
 
+        private string _resetFileToSelectedToolStripMenuItemOriginalText;
+        private string _resetFileToParentToolStripMenuItemOriginalText;
+        private string _resetFileToFirstToolStripMenuItemOriginalText;
+        private string _resetFileToSecondToolStripMenuItemOriginalText;
+
         /// <summary>
         /// For VS designer
         /// </summary>
@@ -203,6 +208,7 @@ namespace GitUI.CommandsDialogs
             _filterBranchHelper = new FilterBranchHelper(toolStripBranchFilterComboBox, toolStripBranchFilterDropDownButton, RevisionGrid);
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
 
+            SaveItemsOriginalText();
             Translate();
 
             if (Settings.ShowGitStatusInBrowseToolbar)
@@ -268,6 +274,7 @@ namespace GitUI.CommandsDialogs
 
             FillTerminalTab();
         }
+
 
         private new void Translate()
         {
@@ -2974,6 +2981,14 @@ namespace GitUI.CommandsDialogs
             Settings.SetNextPullActionAsDefault = false;
         }
 
+        private void SaveItemsOriginalText()
+        {
+            _resetFileToSelectedToolStripMenuItemOriginalText = resetFileToSelectedToolStripMenuItem.Text;
+            _resetFileToParentToolStripMenuItemOriginalText = resetFileToParentToolStripMenuItem.Text;
+            _resetFileToFirstToolStripMenuItemOriginalText = resetFileToFirstToolStripMenuItem.Text;
+            _resetFileToSecondToolStripMenuItemOriginalText = resetFileToSecondToolStripMenuItem.Text;
+        }
+
         private void resetFileToToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
             IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
@@ -2982,12 +2997,14 @@ namespace GitUI.CommandsDialogs
             if (selectedRevsCount == 1)
             {
                 resetFileToSelectedToolStripMenuItem.Visible = true;
+                resetFileToSelectedToolStripMenuItem.Text = _resetFileToSelectedToolStripMenuItemOriginalText;
                 TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
                 resetFileToSelectedToolStripMenuItem.Text += " (" + revisions[0].Subject.ShortenTo(50) + ")";
 
                 if (revisions[0].HasParent())
                 {
                     resetFileToParentToolStripMenuItem.Visible = true;
+                    resetFileToParentToolStripMenuItem.Text = _resetFileToParentToolStripMenuItemOriginalText;
                     TranslateItem(resetFileToParentToolStripMenuItem.Name, resetFileToParentToolStripMenuItem);
                     GitRevision parentRev = RevisionGrid.GetRevision(revisions[0].ParentGuids[0]);
                     if (parentRev != null)
@@ -3009,10 +3026,12 @@ namespace GitUI.CommandsDialogs
             if (selectedRevsCount == 2)
             {
                 resetFileToFirstToolStripMenuItem.Visible = true;
+                resetFileToFirstToolStripMenuItem.Text = _resetFileToFirstToolStripMenuItemOriginalText;
                 TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
                 resetFileToFirstToolStripMenuItem.Text += " (" + revisions[1].Subject.ShortenTo(50) + ")";
 
                 resetFileToSecondToolStripMenuItem.Visible = true;
+                resetFileToSecondToolStripMenuItem.Text = _resetFileToSecondToolStripMenuItemOriginalText;
                 TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
                 resetFileToSecondToolStripMenuItem.Text += " (" + revisions[0].Subject.ShortenTo(50) + ")";
             }


### PR DESCRIPTION
When in English, every time the reset file menu items are displayed,
the commit message was appended ending wrong....

Before appending the commit message text, we restore to the original version