### PR TITLE
fix reset file menu item text

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1593,8 +1593,12 @@
     <None Include="Translation\Dutch.xlf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Translation\English.Plugins.xlf" />
-    <None Include="Translation\English.xlf" />
+    <None Include="Translation\English.Plugins.xlf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Translation\English.xlf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Translation\en_pseudo.Plugins.xlf" />
     <None Include="Translation\en_pseudo.xlf" />
     <None Include="Translation\French.Plugins.xlf">


### PR DESCRIPTION
When in English, every time the reset file menu items are displayed,
the commit message was appended ending wrong....

Adding "English" translation files
(Other way to solve problem presented in #3412)