### PR TITLE
fix: Branch rename does not auto normalise

### DIFF
--- a/GitUI/CommandsDialogs/FormRenameBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.Designer.cs
@@ -31,7 +31,7 @@
             this.Ok = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
-            this.Branches = new System.Windows.Forms.TextBox();
+            this.BranchNameTextBox = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -58,7 +58,7 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.Ok, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.Branches, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.BranchNameTextBox, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -72,20 +72,21 @@
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.AutoSize = true;
             this.label1.ForeColor = System.Drawing.Color.Black;
-            this.label1.Location = new System.Drawing.Point(3, 10);
+            this.label1.Location = new System.Drawing.Point(3, 12);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(63, 21);
+            this.label1.Size = new System.Drawing.Size(57, 18);
             this.label1.TabIndex = 3;
             this.label1.Text = "New name";
             this.label1.UseCompatibleTextRendering = true;
             // 
-            // Branches
+            // BranchNameTextBox
             // 
-            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.Branches.Location = new System.Drawing.Point(72, 9);
-            this.Branches.Name = "Branches";
-            this.Branches.Size = new System.Drawing.Size(344, 23);
-            this.Branches.TabIndex = 4;
+            this.BranchNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.BranchNameTextBox.Location = new System.Drawing.Point(66, 10);
+            this.BranchNameTextBox.Name = "BranchNameTextBox";
+            this.BranchNameTextBox.Size = new System.Drawing.Size(350, 21);
+            this.BranchNameTextBox.TabIndex = 4;
+            this.BranchNameTextBox.Leave += new System.EventHandler(this.BranchNameTextBox_Leave);
             // 
             // FormRenameBranch
             // 
@@ -111,7 +112,7 @@
         #endregion
 
         private System.Windows.Forms.Button Ok;
-        private System.Windows.Forms.TextBox Branches;
+        private System.Windows.Forms.TextBox BranchNameTextBox;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }

--- a/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Git;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -8,22 +11,44 @@ namespace GitUI.CommandsDialogs
     public sealed partial class FormRenameBranch : GitModuleForm
     {
         private readonly TranslationString _branchRenameFailed = new TranslationString("Rename failed.");
+        private readonly IGitBranchNameNormaliser _branchNameNormaliser;
+        private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
+        private readonly string _oldName;
 
-        private readonly string oldName;
 
-        public FormRenameBranch(GitUICommands aCommands, string defaultBranch)
+        public FormRenameBranch(GitUICommands aCommands, string defaultBranch, IGitBranchNameNormaliser branchNameNormaliser = null)
             : base(aCommands)
         {
+            _branchNameNormaliser = branchNameNormaliser ?? new GitBranchNameNormaliser();
+
             InitializeComponent();
             Translate();
-            Branches.Text = defaultBranch;
-            oldName = defaultBranch;
+            BranchNameTextBox.Text = defaultBranch;
+            _oldName = defaultBranch;
+        }
+
+
+        private void BranchNameTextBox_Leave(object sender, EventArgs e)
+        {
+            if (!AppSettings.AutoNormaliseBranchName || !BranchNameTextBox.Text.Any(GitBranchNameNormaliser.IsValidChar))
+            {
+                return;
+            }
+
+            var caretPosition = BranchNameTextBox.SelectionStart;
+            var branchName = _branchNameNormaliser.Normalise(BranchNameTextBox.Text, _gitBranchNameOptions);
+            BranchNameTextBox.Text = branchName;
+            BranchNameTextBox.SelectionStart = caretPosition;
         }
 
         private void OkClick(object sender, EventArgs e)
         {
-            var newName = Branches.Text;
-            if (newName.Equals(oldName))
+            // Ok button set as the "AcceptButton" for the form
+            // if the user hits [Enter] at any point, we need to trigger BranchNameTextBox Leave event
+            Ok.Focus();
+
+            var newName = BranchNameTextBox.Text;
+            if (newName.Equals(_oldName))
             {
                 DialogResult = DialogResult.Cancel;
                 return;
@@ -31,11 +56,13 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var renameBranchResult = Module.RenameBranch(oldName, newName);
+                var renameBranchResult = Module.RenameBranch(_oldName, newName);
 
                 if (!string.IsNullOrEmpty(renameBranchResult))
+                {
                     MessageBox.Show(this, _branchRenameFailed.Text + Environment.NewLine + renameBranchResult, Text,
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Branch renaming now auto normalises the branch name the same way as whenever a new branch is created.
Fixes #3424