### PR TITLE
Set focus to the tag name edit control when the create tag dialog is opened

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -35,7 +35,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormCreateTag_Load(object sender, EventArgs e)
         {
-            textBoxTagName.Focus();
+            textBoxTagName.Select();
             _currentRemote = Module.GetCurrentRemote();
             if (String.IsNullOrEmpty(_currentRemote))
                 _currentRemote = "origin";


### PR DESCRIPTION
Use Control.Select() instead of low-level Control.Focus().

Closes #3372.