### PR TITLE
Don't offer the user to commit after merge conflict resolution if "Do not commit" was checked before merge

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -59,7 +59,7 @@ namespace GitUI.CommandsDialogs
             var successfullyMerged = FormProcess.ShowDialog(this,
                 GitCommandHelpers.MergeBranchCmd(Branches.GetSelectedText(), fastForward.Checked, squash.Checked, noCommit.Checked, _NO_TRANSLATE_mergeStrategy.Text));
 
-            var wasConflict = MergeConflictHandler.HandleMergeConflicts(UICommands, this);
+            var wasConflict = MergeConflictHandler.HandleMergeConflicts(UICommands, this, !noCommit.Checked);
 
             if (successfullyMerged || wasConflict)
             {


### PR DESCRIPTION
Pass offerCommit=false to MergeConflictHandler.HandleMergeConflicts() if "Do not commit" is checked.

Closes #3441.