### PR TITLE
fixes stash plugin to allow subfolders in stash URL

### DIFF
--- a/Plugins/Stash/Settings.cs
+++ b/Plugins/Stash/Settings.cs
@@ -9,7 +9,7 @@ namespace Stash
     class Settings
     {
         private const string StashHttpRegex =
-            @"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-]+)):?(\d+)?\/scm\/(?<project>~?([\w\-]+))\/(?<repo>([\w\-]+)).git";
+            @"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-\/]+?)):?(\d+)?\/scm\/(?<project>~?([\w\-]+?))\/(?<repo>([\w\-]+)).git";
         private const string StashSshRegex =
             @"ssh:\/\/([\w\.]+\@)(?<url>([a-zA-Z0-9\.\-]+)):?(\d+)?\/(?<project>~?([\w\-]+))\/(?<repo>([\w\-]+)).git";
 


### PR DESCRIPTION
Currently it is not possible to use stash URLs with subfolders (virtual directory)
For instance this URL is not working: https://user@stash.domain.com/subfolder/scm/projec-t1/project-1.git