### PR TITLE
GitCommands: Avoid creating a fake remote ref on pull

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1579,7 +1579,7 @@ namespace GitCommands
             return "fetch " + progressOption + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, prune);
         }
 
-        public string PullCmd(string remote, string remoteBranch, string localBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false, bool prune = false)
+        public string PullCmd(string remote, string remoteBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false, bool prune = false)
         {
             var pullArgs = "";
             if (GitCommandHelpers.VersionInUse.FetchCanAskForProgress)
@@ -1588,7 +1588,7 @@ namespace GitCommands
             if (rebase)
                 pullArgs = "--rebase".Combine(" ", pullArgs);
 
-            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, localBranch, fetchTags, isUnshallow, prune && !rebase);
+            return "pull " + pullArgs + GetFetchArgs(remote, remoteBranch, null, fetchTags, isUnshallow, prune && !rebase);
         }
 
         private string GetFetchArgs(string remote, string remoteBranch, string localBranch, bool? fetchTags, bool isUnshallow, bool prune)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -490,7 +490,7 @@ namespace GitUI.CommandsDialogs
 
             Debug.Assert(Merge.Checked || Rebase.Checked);
 
-            return new FormRemoteProcess(Module, Module.PullCmd(source, curRemoteBranch, curLocalBranch, Rebase.Checked, GetTagsArg(), Unshallow.Checked, Prune.Checked))
+            return new FormRemoteProcess(Module, Module.PullCmd(source, curRemoteBranch, Rebase.Checked, GetTagsArg(), Unshallow.Checked, Prune.Checked))
                        {
                            HandleOnExitCallback = HandlePullOnExit
                        };

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -59,6 +59,40 @@ namespace GitCommandsTests.Git
         }
 
         [TestMethod]
+        public void TestFetchArguments()
+        {
+            GitModule module = new GitModule(null);
+            { // Using a registered remote creates a local branch (FIXME: Change that)
+                var fetchCmd = module.FetchCmd("origin", "some-branch", "local");
+                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/remotes/origin/local --no-tags", fetchCmd);
+            }
+            {
+                var fetchCmd = module.FetchCmd("origin", "some-branch", "local", true);
+                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/remotes/origin/local --tags", fetchCmd);
+            }
+            { // Using a URL as remote and passing a local branch creates the branch
+                var fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", "local");
+                Assert.AreEqual("fetch --progress \"https://host.com/repo\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+            }
+            { // Using a URL as remote and not passing a local branch
+                var fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", null);
+                Assert.AreEqual("fetch --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+            }
+            { // Pull doesn't accept a local branch ever
+                var fetchCmd = module.PullCmd("origin", "some-branch", false);
+                Assert.AreEqual("pull --progress \"origin\" +some-branch --no-tags", fetchCmd);
+            }
+            { // Not even for URL remote
+                var fetchCmd = module.PullCmd("https://host.com/repo", "some-branch", false);
+                Assert.AreEqual("pull --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+            }
+            { // Pull with rebase
+                var fetchCmd = module.PullCmd("origin", "some-branch", true);
+                Assert.AreEqual("pull --rebase --progress \"origin\" +some-branch --no-tags", fetchCmd);
+            }
+        }
+
+        [TestMethod]
         public void TestGetAllChangedFilesFromString()
         {
             GitModule module = new GitModule(null);


### PR DESCRIPTION
This was done in eb3fce806cb76d328b669adf8de9a04244436172.

Passing +refs/heads/remote-branch:refs/remotes/origin/local-branch is
plain wrong. It creates a local ref for a remote branch which doesn't
really exist (origin/local-branch).

We don't really need a persistent ref for the remote branch. Just
passing it as a raw argument is fine. It is fetched into FETCH_HEAD,
then the local branch is merged/rebased on top of it.