### PR TITLE
Improvement for #3464 (Background fetch plugin - Not working)

### DIFF
--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -58,7 +58,18 @@ namespace BackgroundFetch
             {
                 cancellationToken =
                     Observable.Timer(TimeSpan.FromSeconds(Math.Max(5, fetchInterval)))
-                              .SkipWhile(i => gitModule.IsRunningGitProcess())
+                              .SelectMany(i => {
+                                // if git not runing - start fetch immediately
+                                if (!gitModule.IsRunningGitProcess())
+                                    return Observable.Return(i);
+
+                                // in other case - every 5 seconds check if git still runnnig
+                                return Observable
+                                    .Interval(TimeSpan.FromSeconds(5))
+                                    .SkipWhile(ii => gitModule.IsRunningGitProcess())
+                                    .FirstAsync()
+                                ;
+                              })
                               .Repeat()
                               .ObserveOn(ThreadPoolScheduler.Instance)
                               .Subscribe(i =>


### PR DESCRIPTION
If fetch interval is relatively big (30 minutes) then accidentally running git.exe can delay update from 30 minutes to 60 or even more (depends on you luck).

Proposed solution - retry every 5 seconds if interval started but blocked by running git.exe