### PR TITLE
Enhancement to work with Git Merge --allow-unrelated-histories

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1138,7 +1138,7 @@ namespace GitCommands
             return string.Empty;
         }
 
-        public static string MergeBranchCmd(string branch, bool allowFastForward, bool squash, bool noCommit, string strategy)
+        public static string MergeBranchCmd(string branch, bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories)
         {
             StringBuilder command = new StringBuilder("merge");
 
@@ -1153,6 +1153,8 @@ namespace GitCommands
                 command.Append(" --squash");
             if (noCommit)
                 command.Append(" --no-commit");
+            if (allowUnrelatedHistories)
+                command.Append(" --allow-unrelated-histories");
 
             command.Append(" ");
             command.Append(branch);

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -11,6 +11,7 @@ namespace GitCommands
         private static readonly GitVersion v1_7_11 = new GitVersion("1.7.11");
         private static readonly GitVersion v1_8_5 = new GitVersion("1.8.5");
         private static readonly GitVersion v2_0_1 = new GitVersion("2.0.1");
+        private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
 
         public static readonly GitVersion LastSupportedVersion = v1_7_0;
 
@@ -66,6 +67,11 @@ namespace GitCommands
         public bool RaceConditionWhenGitStatusIsUpdatingIndex
         {
             get { return this < v2_0_1; }
+        }
+
+        public bool SupportMergeUnrelatedHistory
+        {
+            get { return this >= v2_9_0; }
         }
 
         public bool IsUnknown

--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -46,6 +46,7 @@
 			this.Currentbranch = new System.Windows.Forms.Label();
 			this.label2 = new System.Windows.Forms.Label();
 			this.helpImageDisplayUserControl1 = new GitUI.Help.HelpImageDisplayUserControl();
+			this.allowUnrelatedHistories = new System.Windows.Forms.CheckBox();
 			this.tableLayoutPanel1.SuspendLayout();
 			this.groupBox1.SuspendLayout();
 			this.SuspendLayout();
@@ -103,6 +104,7 @@
 			this.groupBox1.Controls.Add(this.Ok);
 			this.groupBox1.Controls.Add(this.Currentbranch);
 			this.groupBox1.Controls.Add(this.label2);
+			this.groupBox1.Controls.Add(this.allowUnrelatedHistories);
 			this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.groupBox1.Location = new System.Drawing.Point(596, 6);
 			this.groupBox1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
@@ -282,6 +284,16 @@
 			// FormMergeBranch
 			// 
 			this.AcceptButton = this.Ok;
+            // 
+            // allowUnrelatedHistories
+            // 
+            this.allowUnrelatedHistories.AutoSize = true;
+            this.allowUnrelatedHistories.Location = new System.Drawing.Point(26, 576);
+            this.allowUnrelatedHistories.Name = "allowUnrelatedHistories";
+            this.allowUnrelatedHistories.Size = new System.Drawing.Size(145, 17);
+            this.allowUnrelatedHistories.TabIndex = 10;
+            this.allowUnrelatedHistories.Text = "Allow Unrelated Histories";
+            this.allowUnrelatedHistories.UseVisualStyleBackColor = true;
 			this.AutoScaleDimensions = new System.Drawing.SizeF(192F, 192F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.ClientSize = new System.Drawing.Size(1408, 714);
@@ -320,5 +332,6 @@
         private BranchComboBox Branches;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private Help.HelpImageDisplayUserControl helpImageDisplayUserControl1;
+        private System.Windows.Forms.CheckBox allowUnrelatedHistories;
     }
 }

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -48,6 +48,11 @@ namespace GitUI.CommandsDialogs
                     Branches.SetSelectedText(merge);
             }
 
+            if (!GitCommandHelpers.VersionInUse.SupportMergeUnrelatedHistory)
+            {
+                allowUnrelatedHistories.Visible = false;
+                allowUnrelatedHistories.Checked = false;
+            }
             Branches.Select();
         }
 
@@ -57,7 +62,7 @@ namespace GitUI.CommandsDialogs
             AppSettings.DontCommitMerge = noCommit.Checked;
 
             var successfullyMerged = FormProcess.ShowDialog(this,
-                GitCommandHelpers.MergeBranchCmd(Branches.GetSelectedText(), fastForward.Checked, squash.Checked, noCommit.Checked, _NO_TRANSLATE_mergeStrategy.Text));
+                GitCommandHelpers.MergeBranchCmd(Branches.GetSelectedText(), fastForward.Checked, squash.Checked, noCommit.Checked, _NO_TRANSLATE_mergeStrategy.Text, allowUnrelatedHistories.Checked));
 
             var wasConflict = MergeConflictHandler.HandleMergeConflicts(UICommands, this, !noCommit.Checked);
 


### PR DESCRIPTION
Signed-off-by: Kevin <kmoens@lakeco.com>
Enhanced FormMergeBranch to include 2.9.0 version requirement of --allow-unrelated-histories
added new checkbox visible if 2.9.0 or higher.