### PR TITLE
Fix #3542: Do nothing if no selection in FormRunScriptSpecify

### DIFF
--- a/GitUI/HelperDialogs/FormRunScriptSpecify.cs
+++ b/GitUI/HelperDialogs/FormRunScriptSpecify.cs
@@ -29,8 +29,11 @@ namespace GitUI.HelperDialogs
 
         private void button1_Click(object sender, EventArgs e)
         {
-            ret = branchesListView.SelectedItems[0].Text;
-            Close();
+            if (branchesListView.SelectedItems.Count > 0)
+            {
+                ret = branchesListView.SelectedItems[0].Text;
+                Close();
+            }
         }
     }
 }


### PR DESCRIPTION
If nothing is selected in the dialog,
clicking the OK button will do nothing.

One possible fix for #3542 