### PR TITLE
Full row select in Push dialog / Push multiple branches

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -437,6 +437,7 @@
             this.BranchGrid.Location = new System.Drawing.Point(3, 17);
             this.BranchGrid.Name = "BranchGrid";
             this.BranchGrid.RowHeadersVisible = false;
+            this.BranchGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.BranchGrid.Size = new System.Drawing.Size(594, 61);
             this.BranchGrid.TabIndex = 0;
             this.BranchGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.BranchGrid_CurrentCellDirtyStateChanged);


### PR DESCRIPTION
Push dialog, Push multiple branches tab

'Delete' checkbox and branch name are not close enough to be sure that checked checkbox in the same row with desired branch. This is especially true on big display.

![2017-02-24 16_19_16-push d__work_gitextensions_](https://cloud.githubusercontent.com/assets/703544/23304883/28822e96-faad-11e6-9c30-3231f85cbe6b.png)

With 'full row select' it is more clear.

![2017-02-24 16_22_33-push d__work_gitextensions_](https://cloud.githubusercontent.com/assets/703544/23304956/8288a988-faad-11e6-9f1a-2e3751764be9.png)


