### PR TITLE
Fix problem with incorrect building command line arguments

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -504,14 +505,10 @@ namespace GitUI.CommandsDialogs
                 {
                     if (!form.ProcessArguments.Contains(" -f ") && !form.ProcessArguments.Contains(" --force"))
                     {
-                        if (GitCommandHelpers.VersionInUse.SupportPushForceWithLease)
-                        {
-                            form.ProcessArguments = form.ProcessArguments.Replace("push", "push --force-with-lease");
-                        }
-                        else
-                        {
-                            form.ProcessArguments = form.ProcessArguments.Replace("push", "push -f");
-                        }
+                        Trace.Assert(form.ProcessArguments.StartsWith("push "), "Arguments should start with 'push' command");
+
+                        string forceArg = GitCommandHelpers.VersionInUse.SupportPushForceWithLease ? " --force-with-lease" : " -f";
+                        form.ProcessArguments = form.ProcessArguments.Insert("push".Length, forceArg);
                     }
                     form.Retry();
                     return true;


### PR DESCRIPTION
Situation:

Branch name contains word `push` (for example `pr/fix-cmdline-in-retry-push-with-force`)
 and remote reject push due to non-fast-forward
 and user select `retry with force`

then word `push` in branch name was replaced with 'push --force-with-lease' by `.Replace("push", "push --force-with-lease")`