### PR TITLE
Settings / Scripts: Do not paste formatted text to 'arguments' edit box

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -393,6 +393,7 @@
             this.argumentsTextBox.Size = new System.Drawing.Size(773, 43);
             this.argumentsTextBox.TabIndex = 16;
             this.argumentsTextBox.Text = "";
+            this.argumentsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.argumentsTextBox_KeyDown);
             this.argumentsTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
             // 
             // labelOnEvent

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -339,9 +339,9 @@ Current Branch:
 
         private void argumentsTextBox_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Control && e.KeyCode == Keys.V)
+            if ((e.Control && e.KeyCode == Keys.V) || (e.Shift && e.KeyCode == Keys.Insert))
             {
-                ((RichTextBox)sender).Paste(DataFormats.GetFormat("Text"));
+                ((RichTextBox)sender).Paste(DataFormats.GetFormat(DataFormats.UnicodeText));
                 e.Handled = true;
             }
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -336,5 +336,14 @@ Current Branch:
 
             helpDisplayDialog.ShowDialog();
         }
+
+        private void argumentsTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.V)
+            {
+                ((RichTextBox)sender).Paste(DataFormats.GetFormat("Text"));
+                e.Handled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Here is no sense it insert formatted text and sometime it can break inserted text.

Use case: wiki (mediawiki engine) contains some instructions one of with contains link

![2017-02-27 18_27_35-editing git extensions section - dev wiki - internet explorer](https://cloud.githubusercontent.com/assets/703544/23367393/28882e48-fd1b-11e6-9670-08803a0751f5.png)


User copy this snippet from Internet Explorer (no problem with Firefox) browser to 'arguments' edit box, but it is mangled by formatting

![2017-02-27 18_28_19-gitextensions pr_custom-script-args-plain-text - git extensions](https://cloud.githubusercontent.com/assets/703544/23367400/303156ce-fd1b-11e6-9675-60777ae886a8.png)


Saved text incorrect - it contains extra `<>` in URL.