### PR TITLE
Fix #3567 (Console Output sometime hide long text until click scroller)

### DIFF
--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -157,10 +157,10 @@ namespace GitUI.UserControls
             //if not disposed
             if (!IsDisposed)
             {
+                _editbox.Visible = true;
                 _editbox.Text += text;
                 _editbox.SelectionStart = _editbox.Text.Length;
                 _editbox.ScrollToCaret();
-                _editbox.Visible = true;
             }
         }
 


### PR DESCRIPTION
Make RichEditBox visible before insert text solves problem