### PR TITLE
Save the AppSetting before logoff

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1644,6 +1644,7 @@ namespace GitUI.CommandsDialogs
 
         private static void SaveApplicationSettings()
         {
+            AppSettings.SaveSettings();
             Properties.Settings.Default.Save();
         }
 


### PR DESCRIPTION
Don't want to change the infrastructure too much, so just save the settings before logoff.

Fix #3576 