### PR TITLE
Unsubscribe the Activated event while displaying the prompt to stage …

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -859,9 +859,21 @@ namespace GitUI.CommandsDialogs
                         return;
                     }
 
-                    // there are no staged files, but there are unstaged files. Most probably user forgot to stage them.
-                    if (MessageBox.Show(this, _noFilesStagedButSuggestToCommitAllUnstaged.Text, _noStagedChanges.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
-                        return;
+                    try
+                    {
+                        // unsubscribe the event handler so that after the message box is closed, the RescanChanges call is suppressed
+                        // (otherwise it would move all changed files from staged back to unstaged file list)
+                        this.Activated -= FormCommitActivated;
+
+                        // there are no staged files, but there are unstaged files. Most probably user forgot to stage them.
+                        if (MessageBox.Show(this, _noFilesStagedButSuggestToCommitAllUnstaged.Text, _noStagedChanges.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+                            return;
+                    }
+                    finally
+                    {
+                        this.Activated += FormCommitActivated;
+                    }
+
                     StageAllAccordingToFilter();
                     // if staging failed (i.e. line endings conflict), user already got error message, don't try to commit empty changeset.
                     if (Staged.IsEmpty)


### PR DESCRIPTION
…all changes files (fixes #3589)

If the event is subscribed and option AppSettings.RefreshCommitDialogOnFormFocus is on, RescanChanges
is called immediately after the message box is closed which in turn reloads (asynchronously) the unstaged
file list and thus reverts the changes made by StageAllAccordingToFilter.