### PR TITLE
Toggle the watermark in GotFocus/LostFocus event handlers (fixes #3491)

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -59,11 +59,12 @@
             this.TextBox.SelectionChanged += new System.EventHandler(this.TextBox_SelectionChanged);
             this.TextBox.SizeChanged += new System.EventHandler(this.TextBoxSizeChanged);
             this.TextBox.TextChanged += new System.EventHandler(this.TextBoxTextChanged);
-            this.TextBox.Enter += new System.EventHandler(this.TextBox_Enter);
             this.TextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyDown);
             this.TextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TextBox_KeyPress);
             this.TextBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyUp);
             this.TextBox.Leave += new System.EventHandler(this.TextBoxLeave);
+            this.TextBox.GotFocus += TextBox_GotFocus;
+            this.TextBox.LostFocus += TextBox_LostFocus;
             // 
             // AutoComplete
             // 

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -617,7 +617,6 @@ namespace GitUI.SpellChecker
 
         private void TextBoxLeave(object sender, EventArgs e)
         {
-            ShowWatermark();
             if (ActiveControl != AutoComplete)
                 CloseAutoComplete();
         }
@@ -709,11 +708,6 @@ namespace GitUI.SpellChecker
                 SelectionChanged(sender, e);
         }
 
-        private void TextBox_Enter(object sender, EventArgs e)
-        {
-            HideWatermark();
-        }
-
         private void ShowWatermark()
         {
             if (!ContainsFocus && string.IsNullOrEmpty(TextBox.Text) && TextBoxFont != null)
@@ -736,10 +730,14 @@ namespace GitUI.SpellChecker
             }
         }
 
-        public new bool Focus()
+         private void TextBox_LostFocus(object sender, EventArgs e)
+        {
+            ShowWatermark();
+        }
+
+        private void TextBox_GotFocus(object sender, EventArgs e)
         {
             HideWatermark();
-            return base.Focus();
         }
 
         private void CutMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
The Enter/Leave handlers are not called when the focus returns to the text box
after another focused window is closed.