### PR TITLE
Open diff form not in modal

### DIFF
--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -37,6 +37,8 @@ namespace GitUI.HelperDialogs
                 DiffFiles.SetDiff(_revision);
 
                 commitInfo.Revision = _revision;
+
+                Text = "Diff - " + _revision.Guid.Substring(0, 10) + " - " + _revision.AuthorDate + " - " + _revision.Author + " - " + Module.WorkingDir; ;
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1931,10 +1931,12 @@ namespace GitUI
             var selectedRevisions = GetSelectedRevisions();
             if (selectedRevisions.Any(rev => !GitRevision.IsArtificial(rev.Guid)))
             {
-                using (var form = new FormCommitDiff(UICommands, selectedRevisions[0].Guid))
+                Func<Form> provideForm = () =>
                 {
-                    form.ShowDialog(this);
-                }
+                    return new FormCommitDiff(UICommands, selectedRevisions[0].Guid);
+                };
+
+                UICommands.ShowModelessForm(this, false, null, null, provideForm);
             }
             else if (!selectedRevisions.Any())
             {


### PR DESCRIPTION
 Do not open commit diff form as modal anymore

Otherwise, that prevent to come back to the main browse history form and use it navigate to another commit (sometime useful...)

I have also add the feature to display some data of the commit opened in the title of the form to navigate more easily between opend forms.