### PR TITLE
Dispose the _fontOfSHAColumn field

### DIFF
--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -46,6 +46,12 @@ namespace GitUI
                     _authoredRevisionsBrush.Dispose();
                     _authoredRevisionsBrush = null;
                 }
+
+                if (_fontOfSHAColumn != null)
+                {
+                    _fontOfSHAColumn.Dispose();
+                    _fontOfSHAColumn = null;
+                }
             }
 
             if (disposing && (components != null))


### PR DESCRIPTION
Fixes build warning introduced in PR #3573.