### PR TITLE
fix: Incorrect GetRefs tags

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -69,7 +69,7 @@ namespace GitUI.CommandsDialogs
 
             Branches.Select();
 
-            refs = Module.GetRefs(true, true).OfType<GitRef>().ToList();
+            refs = Module.GetRefs(false, true).OfType<GitRef>().ToList();
             cboTo.DataSource = refs;
             cboTo.DisplayMember = "Name";
 


### PR DESCRIPTION
Rollback incorrect copy-paste

Fixes a bug introduced in #3478.
