### PR TITLE
TeamCityAdapter should be able to use provided credentials

### DIFF
--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -60,30 +60,39 @@ namespace TeamCityIntegration
 
         private CookieContainer _teamCityNtlmAuthCookie;
 
-        private CookieContainer TeamCityNtlmAuthCookie
-        {
-            get
-            {
-                return _teamCityNtlmAuthCookie ?? (_teamCityNtlmAuthCookie = GetTeamCityNtlmAuthCookie(httpClient.BaseAddress.AbsoluteUri));
-            }
-        }
-
         private string HostName { get; set; }
 
         private string[] ProjectNames { get; set; }
 
         private Regex BuildIdFilter { get; set; }
 
-        private CookieContainer GetTeamCityNtlmAuthCookie (string serverUrl)
+        private CookieContainer GetTeamCityNtlmAuthCookie (string serverUrl, IBuildServerCredentials buildServerCredentials)
         {
+            if (_teamCityNtlmAuthCookie != null)
+            {
+                return _teamCityNtlmAuthCookie;
+            }
+
             string url = serverUrl + "ntlmLogin.html";
             var cookieContainer = new CookieContainer();
             var request = (HttpWebRequest)HttpWebRequest.Create (url);
             request.CookieContainer = cookieContainer;
-            request.Credentials = CredentialCache.DefaultCredentials;
+
+            if (buildServerCredentials != null
+                && !String.IsNullOrEmpty(buildServerCredentials.Username)
+                && !String.IsNullOrEmpty(buildServerCredentials.Password))
+            {
+                request.Credentials = new NetworkCredential(buildServerCredentials.Username, buildServerCredentials.Password);
+            }
+            else
+            {
+                request.Credentials = CredentialCache.DefaultCredentials;
+            }
             request.PreAuthenticate = true;
             request.GetResponse();
-            return cookieContainer;
+
+            _teamCityNtlmAuthCookie = cookieContainer;
+            return _teamCityNtlmAuthCookie;
         }
 
         public string LogAsGuestUrlParameter { get; set; }
@@ -380,7 +389,7 @@ namespace TeamCityIntegration
 
             if (unauthorized)
             {
-                var buildServerCredentials = buildServerWatcher.GetBuildServerCredentials(this, true);
+                var buildServerCredentials = buildServerWatcher.GetBuildServerCredentials(this, false);
                 var useBuildServerCredentials = buildServerCredentials != null
                                                 && !buildServerCredentials.UseGuestAccess
                                                 && (string.IsNullOrWhiteSpace(buildServerCredentials.Username) && string.IsNullOrWhiteSpace(buildServerCredentials.Password));
@@ -391,7 +400,7 @@ namespace TeamCityIntegration
                 }
                 else
                 {
-                    UpdateHttpClientOptionsNtlmAuth();
+                    UpdateHttpClientOptionsNtlmAuth(buildServerCredentials);
                     return GetStreamAsync (restServicePath, cancellationToken);
                 }
 
@@ -404,7 +413,7 @@ namespace TeamCityIntegration
 #endif
         }
 
-        public void UpdateHttpClientOptionsNtlmAuth()
+        public void UpdateHttpClientOptionsNtlmAuth(IBuildServerCredentials buildServerCredentials)
         {
             try
             {
@@ -413,7 +422,7 @@ namespace TeamCityIntegration
 
                 httpClientHostSuffix = "httpAuth";
                 CreateNewHttpClient (HostName);
-                httpClientHandler.CookieContainer = TeamCityNtlmAuthCookie;
+                httpClientHandler.CookieContainer = GetTeamCityNtlmAuthCookie(httpClient.BaseAddress.AbsoluteUri, buildServerCredentials);
             }
             catch (Exception exception)
             {

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -389,7 +389,7 @@ namespace TeamCityIntegration
 
             if (unauthorized)
             {
-                var buildServerCredentials = buildServerWatcher.GetBuildServerCredentials(this, false);
+                var buildServerCredentials = buildServerWatcher.GetBuildServerCredentials(this, true);
                 var useBuildServerCredentials = buildServerCredentials != null
                                                 && !buildServerCredentials.UseGuestAccess
                                                 && (string.IsNullOrWhiteSpace(buildServerCredentials.Username) && string.IsNullOrWhiteSpace(buildServerCredentials.Password));


### PR DESCRIPTION
**Do you want to request a *feature* or report a *bug*?**
bug

**What is the current behavior?**
TeamCityAdapter uses basic http authentication or ntlm with CredentialCache.DefaultCredentials

**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem.**
It should be able to use provided credentials for ntlm authentication

**What is the expected behavior?**
Ntlm authentication should use provided credentials (if present) and successfully authorize
(this PR works well with all TeamCity instances that we have)

**Which versions of GIT and which versions of Windows are affected by this issue? Did this work in previous versions of our tool?**
Probably all versions, never worked