### PR TITLE
Some work to sanitise colours for dark operating system themes.

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.Designer.cs
@@ -42,7 +42,7 @@
             // Delete
             // 
             this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.Delete.ForeColor = System.Drawing.Color.Black;
+            this.Delete.ForeColor = System.Drawing.SystemColors.ControlText;
             this.Delete.Image = global::GitUI.Properties.Resources.IconBranchDelete;
             this.Delete.Location = new System.Drawing.Point(439, 65);
             this.Delete.Name = "Delete";

--- a/GitUI/CommandsDialogs/FormDeleteTag.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.Designer.cs
@@ -43,7 +43,7 @@
             // Ok
             // 
             this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.Ok.ForeColor = System.Drawing.Color.Black;
+            this.Ok.ForeColor = System.Drawing.SystemColors.ControlText;
             this.Ok.Location = new System.Drawing.Point(369, 10);
             this.Ok.Name = "Ok";
             this.Ok.Size = new System.Drawing.Size(75, 25);

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.Designer.cs
@@ -46,9 +46,9 @@
             // 
             // btStageCurrent
             // 
-            this.btStageCurrent.ForeColor = System.Drawing.Color.Black;
             this.btStageCurrent.Location = new System.Drawing.Point(392, 212);
             this.btStageCurrent.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btStageCurrent.ForeColor = System.Drawing.SystemColors.ControlText;
             this.btStageCurrent.Name = "btStageCurrent";
             this.btStageCurrent.Size = new System.Drawing.Size(190, 31);
             this.btStageCurrent.TabIndex = 16;
@@ -149,7 +149,7 @@
             // 
             // btOpenSubmodule
             // 
-            this.btOpenSubmodule.ForeColor = System.Drawing.Color.Black;
+            this.btOpenSubmodule.ForeColor = System.Drawing.SystemColors.ControlText;
             this.btOpenSubmodule.Image = global::GitUI.Properties.Resources.IconFolderSubmodule;
             this.btOpenSubmodule.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btOpenSubmodule.Location = new System.Drawing.Point(19, 212);
@@ -186,9 +186,9 @@
             // 
             // btCheckoutBranch
             // 
-            this.btCheckoutBranch.ForeColor = System.Drawing.Color.Black;
             this.btCheckoutBranch.Location = new System.Drawing.Point(203, 212);
             this.btCheckoutBranch.Margin = new System.Windows.Forms.Padding(4);
+            this.btCheckoutBranch.ForeColor = System.Drawing.SystemColors.ControlText;
             this.btCheckoutBranch.Name = "btCheckoutBranch";
             this.btCheckoutBranch.Size = new System.Drawing.Size(181, 31);
             this.btCheckoutBranch.TabIndex = 17;

--- a/GitUI/CommandsDialogs/FormRenameBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.Designer.cs
@@ -39,7 +39,7 @@
             // 
             this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.Ok.AutoSize = true;
-            this.Ok.ForeColor = System.Drawing.Color.Black;
+            this.Ok.ForeColor = System.Drawing.SystemColors.ControlText;
             this.Ok.Location = new System.Drawing.Point(422, 7);
             this.Ok.Name = "Ok";
             this.Ok.Size = new System.Drawing.Size(59, 28);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.Designer.cs
@@ -168,6 +168,7 @@
             this.translationConfig.FlatAppearance.BorderSize = 0;
             this.translationConfig.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.translationConfig.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.translationConfig.ForeColor = System.Drawing.Color.Black;
             this.translationConfig.Location = new System.Drawing.Point(3, 308);
             this.translationConfig.Name = "translationConfig";
             this.translationConfig.Size = new System.Drawing.Size(1116, 29);
@@ -186,6 +187,7 @@
             this.DiffTool.FlatAppearance.BorderSize = 0;
             this.DiffTool.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.DiffTool.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.DiffTool.ForeColor = System.Drawing.Color.Black;
             this.DiffTool.Location = new System.Drawing.Point(3, 138);
             this.DiffTool.Name = "DiffTool";
             this.DiffTool.Size = new System.Drawing.Size(1116, 29);
@@ -204,6 +206,7 @@
             this.SshConfig.FlatAppearance.BorderSize = 0;
             this.SshConfig.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.SshConfig.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.SshConfig.ForeColor = System.Drawing.Color.Black;
             this.SshConfig.Location = new System.Drawing.Point(3, 274);
             this.SshConfig.Name = "SshConfig";
             this.SshConfig.Size = new System.Drawing.Size(1116, 29);
@@ -222,6 +225,7 @@
             this.GitBinFound.FlatAppearance.BorderSize = 0;
             this.GitBinFound.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.GitBinFound.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.GitBinFound.ForeColor = System.Drawing.Color.Black;
             this.GitBinFound.Location = new System.Drawing.Point(3, 206);
             this.GitBinFound.Name = "GitBinFound";
             this.GitBinFound.Size = new System.Drawing.Size(1116, 29);
@@ -273,6 +277,7 @@
             this.GitFound.FlatAppearance.BorderSize = 0;
             this.GitFound.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.GitFound.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.GitFound.ForeColor = System.Drawing.Color.Black;
             this.GitFound.Location = new System.Drawing.Point(3, 36);
             this.GitFound.Name = "GitFound";
             this.GitFound.Size = new System.Drawing.Size(1116, 29);
@@ -291,6 +296,7 @@
             this.MergeTool.FlatAppearance.BorderSize = 0;
             this.MergeTool.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.MergeTool.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.MergeTool.ForeColor = System.Drawing.Color.Black;
             this.MergeTool.Location = new System.Drawing.Point(3, 104);
             this.MergeTool.Name = "MergeTool";
             this.MergeTool.Size = new System.Drawing.Size(1116, 29);
@@ -309,6 +315,7 @@
             this.UserNameSet.FlatAppearance.BorderSize = 0;
             this.UserNameSet.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.UserNameSet.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.UserNameSet.ForeColor = System.Drawing.Color.Black;
             this.UserNameSet.Location = new System.Drawing.Point(3, 70);
             this.UserNameSet.Name = "UserNameSet";
             this.UserNameSet.Size = new System.Drawing.Size(1116, 29);
@@ -327,6 +334,7 @@
             this.ShellExtensionsRegistered.FlatAppearance.BorderSize = 0;
             this.ShellExtensionsRegistered.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.ShellExtensionsRegistered.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ShellExtensionsRegistered.ForeColor = System.Drawing.Color.Black;
             this.ShellExtensionsRegistered.Location = new System.Drawing.Point(3, 172);
             this.ShellExtensionsRegistered.Name = "ShellExtensionsRegistered";
             this.ShellExtensionsRegistered.Size = new System.Drawing.Size(1116, 29);
@@ -345,6 +353,7 @@
             this.GitExtensionsInstall.FlatAppearance.BorderSize = 0;
             this.GitExtensionsInstall.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(192)))), ((int)(((byte)(255)))));
             this.GitExtensionsInstall.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.GitExtensionsInstall.ForeColor = System.Drawing.Color.Black;
             this.GitExtensionsInstall.Location = new System.Drawing.Point(3, 240);
             this.GitExtensionsInstall.Name = "GitExtensionsInstall";
             this.GitExtensionsInstall.Size = new System.Drawing.Size(1116, 29);

--- a/GitUI/Editor/ColorHelper.cs
+++ b/GitUI/Editor/ColorHelper.cs
@@ -6,12 +6,48 @@ namespace GitUI.Editor
     {
         public static Color GetForeColorForBackColor(Color backColor)
         {
-            if ((backColor.R > 130 ||
-                 backColor.B > 130 ||
-                 backColor.G > 130) &&
-                backColor.R + backColor.B + backColor.G > 350)
-                return Color.Black;
-            return Color.White;
+            return IsLightColor(backColor)? Color.Black : Color.White;
+        }
+
+        public static bool IsLightColor(Color color)
+        {
+            if ((color.R > 130 ||
+                 color.B > 130 ||
+                 color.G > 130) &&
+                color.R + color.B + color.G > 350)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public static Color AdjustColor(Color color, int amount = 10)
+        {
+            return Color.FromArgb(
+                color.R + amount,
+                color.G + amount,
+                color.B + amount);
+        }
+
+        public static Color MakeColorLighter(Color color)
+        {
+            return AdjustColor(color);
+        }
+
+        public static Color MakeColorDarker(Color color)
+        {
+            return AdjustColor(color, -10);
+        }
+
+        public static int GetColorBrightnessIndex(Color c)
+        {
+            // From: http://www.had2know.com/technology/color-contrast-calculator-web-design.html
+            return (299*c.R + 587*c.G + 114*c.B) / 1000;
+        }
+
+        public static int GetColorBrightnessDifference(Color a, Color b)
+        {
+            return System.Math.Abs( GetColorBrightnessIndex(a) - GetColorBrightnessIndex(b) );
         }
     }
 }

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
@@ -64,6 +64,7 @@
             // 
             this.Hard.AutoSize = true;
             this.Hard.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(128)))));
+            this.Hard.ForeColor = System.Drawing.Color.Black;
             this.Hard.Location = new System.Drawing.Point(13, 102);
             this.Hard.Name = "Hard";
             this.Hard.Size = new System.Drawing.Size(323, 34);
@@ -77,6 +78,7 @@
             this.Mixed.AutoSize = true;
             this.Mixed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
             this.Mixed.Checked = true;
+            this.Mixed.ForeColor = System.Drawing.Color.Black;
             this.Mixed.Location = new System.Drawing.Point(13, 64);
             this.Mixed.Name = "Mixed";
             this.Mixed.Size = new System.Drawing.Size(276, 19);
@@ -89,6 +91,7 @@
             // 
             this.Soft.AutoSize = true;
             this.Soft.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(128)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
+            this.Soft.ForeColor = System.Drawing.Color.Black;
             this.Soft.Location = new System.Drawing.Point(13, 28);
             this.Soft.Name = "Soft";
             this.Soft.Size = new System.Drawing.Size(257, 19);


### PR DESCRIPTION
Partially Fixes #1947 ?
(NB: Have limited time to contribute, but this seems to fix the worst of the issue)

Changes proposed in this pull request:
 - Change main listview background to use system colours
 - Various changes to control text to use system colours
 - Change system-colour to hard-coded colour for various items which have hard-coded background colours
- TODO: More colour fixes
 
Screenshots before and after (if PR changes UI):
- Before (NB: previously used a different dark theme which made the text completely invisible, as per the original bug report):
![image](https://cloud.githubusercontent.com/assets/615724/24682187/458f183a-1990-11e7-802a-147d4c090afb.png)

-After:
Default Windows 10 theme:
![image](https://cloud.githubusercontent.com/assets/615724/24682389/52dc4a20-1991-11e7-950b-e0de6ee2666e.png)

Dark Windows 10 theme:
![image](https://cloud.githubusercontent.com/assets/615724/24682200/51feaa7c-1990-11e7-9240-56ba9e4d2b3d.png)


How did I test this code:
 - Tried new code on Windows 10 with borth standard and dark theme installed.
 - TODO: Test on Linux/other platforms

Has been tested on (remove any that don't apply):
 - GIT 2.9.2
 - Windows 10
