### PR TITLE
Cleanup string extensions

### DIFF
--- a/GitCommands/Git/GitCheckoutBranchCmd.cs
+++ b/GitCommands/Git/GitCheckoutBranchCmd.cs
@@ -56,7 +56,7 @@ namespace GitCommands.Git
                     yield return "-B " + NewBranchName.Quote();
             }
 
-            yield return BranchName.QuoteNE();
+            yield return BranchName.Quote(false);
         }
 
         public override bool AccessesRemote()

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -122,7 +122,7 @@ namespace GitCommands
             }
         }
 
-	    public static ProcessStartInfo CreateProcessStartInfo(string fileName, string arguments, string workingDirectory, Encoding outputEncoding)
+        public static ProcessStartInfo CreateProcessStartInfo(string fileName, string arguments, string workingDirectory, Encoding outputEncoding)
         {
             return new ProcessStartInfo
             {
@@ -162,7 +162,7 @@ namespace GitCommands
             return startProcess;
         }
 
-	    public static bool UseSsh(string arguments)
+        public static bool UseSsh(string arguments)
         {
             var x = !Plink() && GetArgumentsRequiresSsh(arguments);
             return x || arguments.Contains("plink");
@@ -664,7 +664,7 @@ namespace GitCommands
                 cmd += " -u";
             if (keepIndex)
                 cmd += " --keep-index";
-            cmd = cmd.Combine(" ", message.QuoteNE());
+            cmd = cmd.Combine(" ", message.Quote(false));
 
             return cmd;
         }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -877,7 +877,7 @@ namespace GitCommands
 
             var list = new List<ConflictData>();
 
-            var unmerged = RunGitCmd("ls-files -z --unmerged " + filename.QuoteNE()).Split(new[] { '\0', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            var unmerged = RunGitCmd("ls-files -z --unmerged " + filename.Quote(false)).Split(new[] { '\0', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             var item = new ConflictedFileData[3];
 
@@ -2965,7 +2965,7 @@ namespace GitCommands
             if (!oldFileName.IsNullOrEmpty())
                 oldFileName = oldFileName.Quote();
 
-            string args = string.Join(" ", extraDiffArguments, revision2.QuoteNE(), revision1.QuoteNE(), "--", filename, oldFileName);
+            string args = string.Join(" ", extraDiffArguments, revision2.Quote(false), revision1.Quote(false), "--", filename, oldFileName);
             RunGitCmdDetached("difftool --gui --no-prompt " + args);
             return output;
         }

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -154,7 +154,7 @@
     <Compile Include="Statistics\ImpactLoader.cs" />
     <Compile Include="FileInfoExtensions.cs" />
     <Compile Include="SynchronizedProcessReader.cs" />
-    <Compile Include="System.cs" />
+    <Compile Include="StringExtensions.cs" />
     <Compile Include="Utils\JsonSerializer.cs" />
     <Compile Include="Utils\RFC2047Decoder.cs" />
     <Compile Include="Utils\WeakRefCache.cs" />

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -1,9 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
-namespace System
+namespace GitCommands
 {
     public static class StringExtensions
     {
@@ -23,7 +24,7 @@ namespace System
                 return null;
         }
 
-        public static String TakeUntilStr(this string str, String untilStr)
+        public static string TakeUntilStr(this string str, string untilStr)
         {
             if (str == null)
                 return null;
@@ -59,7 +60,6 @@ namespace System
             return string.IsNullOrEmpty(s);
         }
 
-
         public static string Combine(this string left, string sep, string right)
         {
             if (left.IsNullOrEmpty())
@@ -71,42 +71,45 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes string if it is not null
+        /// Surrounds the supplied string with double quotes (").
         /// </summary>
-        public static string Quote(this string s)
+        /// <returns>
+        /// <para><see cref="string.Empty"/>, if the supplied string is <see langword="null"/>, or</para>
+        /// <para><see cref="string.Empty"/>, if the supplied string is <see cref="string.Empty"/> and <paramref name="quoteEmptyString"/> is <see langword="false"/>, or</para>
+        /// <para>the supplied string surrounded with double quotes.</para>
+        /// </returns>
+        public static string Quote(this string s, bool quoteEmptyString = true)
         {
-            return s.Quote("\"");
+            return s.Quote("\"", quoteEmptyString);
         }
 
         /// <summary>
-        /// Quotes this string with the specified <paramref name="quotationMark"/>
+        /// Surrounds the supplied string with specified <paramref name="quotationMark"/>.
         /// </summary>
-        public static string Quote(this string s, string quotationMark)
+        /// <returns>
+        /// <para><see cref="string.Empty"/>, if the supplied string is <see langword="null"/>, or</para>
+        /// <para><see cref="string.Empty"/>, if the supplied string is <see cref="string.Empty"/> and <paramref name="quoteEmptyString"/> is <see langword="false"/>, or</para>
+        /// <para>the supplied string surrounded with provided quotes.</para>
+        /// </returns>
+        public static string Quote(this string s, string quotationMark, bool quoteEmptyString = true)
         {
-            if (s == null)
+            if (s == null || (!quoteEmptyString && string.IsNullOrEmpty(s)))
+            {
                 return string.Empty;
-
+            }
             return quotationMark + s + quotationMark;
         }
 
         /// <summary>
-        /// Quotes this string if it is not null and not empty
+        /// Surrounds the supplied string with parentheses.
         /// </summary>
-        /// <param name="s"></param>
-        /// <returns></returns>
-        public static string QuoteNE(this string s)
+        /// <returns>
+        /// <para><see cref="string.Empty"/>, if the supplied string is <see langword="null"/> or <see cref="string.Empty"/>, or</para>
+        /// <para>the supplied string surrounded with parentheses.</para>
+        /// </returns>
+        public static string AddParentheses(this string s)
         {
-            return s.IsNullOrEmpty() ? (s ?? string.Empty) : s.Quote("\"");
-        }
-
-        /// <summary>
-        /// Adds parentheses if string is not null and not empty
-        /// </summary>
-        /// <param name="s"></param>
-        /// <returns></returns>
-        public static string AddParenthesesNE(this string s)
-        {
-            return s.IsNullOrEmpty() ? s : "(" + s + ")";
+            return s.IsNullOrEmpty() ? (s ?? string.Empty) : "(" + s + ")";
         }
 
         /// <summary>
@@ -123,12 +126,6 @@ namespace System
         public static bool IsNullOrWhiteSpace([CanBeNull] this string value)
         {
             return string.IsNullOrWhiteSpace(value);
-        }
-
-        /// <summary>Indicates whether the specified string is neither null, nor empty, nor has only whitespace.</summary>
-        public static bool IsNotNullOrWhitespace([CanBeNull] this string value)
-        {
-            return !value.IsNullOrWhiteSpace();
         }
 
         /// <summary>
@@ -160,47 +157,10 @@ namespace System
             return sb.ToString();
         }
 
-        /// <summary>Split a string, removing empty entries, then trim whitespace.</summary>
-        public static IEnumerable<string> SplitThenTrim(this string value, params string[] separator)
-        {
-            return value
-                .Split(separator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(s => s.Trim());
-        }
-
-        /// <summary>Split a string, removing empty entries, then trim whitespace.</summary>
-        public static IEnumerable<string> SplitThenTrim(this string value, params char[] separator)
-        {
-            return value
-                .Split(separator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(s => s.Trim());
-        }
-
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
         public static string[] SplitLines(this string value)
         {
             return value.Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
-        }
-
-        /// <summary>Split a string, delimited by line-breaks, excluding empty entries; then trim whitespace.</summary>
-        public static IEnumerable<string> SplitLinesThenTrim(this string value)
-        {
-            return value.SplitThenTrim(NewLineSeparator);
-        }
-
-        /// <summary>Gets the text after the last separator.
-        /// If NO separator OR ends with separator, returns the original value.</summary>
-        public static string SubstringAfterLastSafe(this string value, string separator)
-        {// ex: "origin/master" -> "master"
-            if (value.EndsWith(separator) || !value.Contains(separator))
-            {// "origin/master/" OR "master" -> return original
-                return value;
-            }
-            return value.Substring(1 + value.LastIndexOf(separator, StringComparison.InvariantCultureIgnoreCase));
-        }
-        public static string SubstringAfterFirst(this string value, string separator)
-        {
-            return value.Substring(1 + value.IndexOf(separator, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -96,7 +96,7 @@ namespace System
         /// <returns></returns>
         public static string QuoteNE(this string s)
         {
-            return s.IsNullOrEmpty() ? s : s.Quote("\"");
+            return s.IsNullOrEmpty() ? (s ?? string.Empty) : s.Quote("\"");
         }
 
         /// <summary>

--- a/GitExtensionsTest/GitCommands/StringExtensionsTests.cs
+++ b/GitExtensionsTest/GitCommands/StringExtensionsTests.cs
@@ -1,0 +1,40 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace GitExtensionsTest.GitCommands
+{
+    [TestFixture]
+    public class StringExtensionsTests
+    {
+        [TestCase(null, "")]
+        [TestCase("", "\"\"")]
+        [TestCase(" ", "\" \"")]
+        public void Quote_default(string s, string expected)
+        {
+            var result = s.Quote();
+
+            result.Should().Be(expected);
+        }
+
+        [TestCase(null, "'", "")]
+        [TestCase("", "'", "''")]
+        [TestCase(" ", "'", "' '")]
+        public void Quote(string s, string quote, string expected)
+        {
+            var result = s.Quote(quote);
+
+            result.Should().Be(expected);
+        }
+
+        [TestCase(null, "")]
+        [TestCase("", "")]
+        [TestCase(" ", "\" \"")]
+        public void QuoteNE(string s, string expected)
+        {
+            var result = s.QuoteNE();
+
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/GitExtensionsTest/GitCommands/StringExtensionsTests.cs
+++ b/GitExtensionsTest/GitCommands/StringExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using FluentAssertions;
+using GitCommands;
 using NUnit.Framework;
 
 namespace GitExtensionsTest.GitCommands
@@ -7,32 +8,50 @@ namespace GitExtensionsTest.GitCommands
     [TestFixture]
     public class StringExtensionsTests
     {
-        [TestCase(null, "")]
-        [TestCase("", "\"\"")]
-        [TestCase(" ", "\" \"")]
-        public void Quote_default(string s, string expected)
+        [TestCase(null, null, "")]
+        [TestCase(null, true, "")]
+        [TestCase(null, false, "")]
+        [TestCase("", null, "\"\"")]
+        [TestCase("", true, "\"\"")]
+        [TestCase("", false, "")]
+        [TestCase(" ", null, "\" \"")]
+        [TestCase(" ", true, "\" \"")]
+        [TestCase(" ", false, "\" \"")]
+        public void Quote(string s, bool? quoteEmptyString, string expected)
         {
-            var result = s.Quote();
+            string result;
+            if (!quoteEmptyString.HasValue)
+            {
+                result = s.Quote();
+            }
+            else
+            {
+                result = s.Quote(quoteEmptyString.Value);
+            }
 
             result.Should().Be(expected);
         }
 
-        [TestCase(null, "'", "")]
-        [TestCase("", "'", "''")]
-        [TestCase(" ", "'", "' '")]
-        public void Quote(string s, string quote, string expected)
+        [TestCase(null, "'", null, "")]
+        [TestCase(null, "'", true, "")]
+        [TestCase(null, "'", false, "")]
+        [TestCase("", "'", null, "''")]
+        [TestCase("", "'", true, "''")]
+        [TestCase("", "'", false, "")]
+        [TestCase(" ", "'", null, "' '")]
+        [TestCase(" ", "'", true, "' '")]
+        [TestCase(" ", "'", false, "' '")]
+        public void Quote(string s, string quote, bool? quoteEmptyString, string expected)
         {
-            var result = s.Quote(quote);
-
-            result.Should().Be(expected);
-        }
-
-        [TestCase(null, "")]
-        [TestCase("", "")]
-        [TestCase(" ", "\" \"")]
-        public void QuoteNE(string s, string expected)
-        {
-            var result = s.QuoteNE();
+            string result;
+            if (!quoteEmptyString.HasValue)
+            {
+                result = s.Quote(quote);
+            }
+            else
+            {
+                result = s.Quote(quote, quoteEmptyString.Value);
+            }
 
             result.Should().Be(expected);
         }

--- a/GitExtensionsTest/GitExtensionsTest.csproj
+++ b/GitExtensionsTest/GitExtensionsTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="GitCommands\Helpers\PathUtilTest.cs" />
     <Compile Include="GitCommands\Patch\PatchManagerTest.cs" />
     <Compile Include="GitCommands\Patch\PatchTest.cs" />
+    <Compile Include="GitCommands\StringExtensionsTests.cs" />
     <Compile Include="GitUI\AuthorEmailBasedRevisionHighlightingFixture.cs" />
     <Compile Include="GitUI\Editor\Diff\DiffLineNumAnalyzerFixture.cs" />
     <Compile Include="GitUI\Editor\Diff\LinePrefixHelperFixture.cs" />

--- a/GitExtensionsTest/GitUI/SingleHtmlUserManualFixture.cs
+++ b/GitExtensionsTest/GitUI/SingleHtmlUserManualFixture.cs
@@ -2,6 +2,7 @@
 using GitUI.UserManual;
 using NUnit.Framework;
 using FluentAssertions;
+using GitCommands;
 
 namespace GitExtensionsTest.GitUI
 {

--- a/GitExtensionsTest/Properties/AssemblyInfo.cs
+++ b/GitExtensionsTest/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -115,7 +115,7 @@ namespace GitUI.CommandsDialogs
                     try
                     {
                         // If the from directory is filled with the pushUrl from current working directory, set the destination directory to the parent
-                        if (pushUrl.IsNotNullOrWhitespace() && _NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && Module.WorkingDir.IsNotNullOrWhitespace())
+                        if (!pushUrl.IsNullOrWhiteSpace() && _NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && !Module.WorkingDir.IsNullOrWhiteSpace())
                             _NO_TRANSLATE_To.Text = Path.GetDirectoryName(Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar));
 
                     }
@@ -127,7 +127,7 @@ namespace GitUI.CommandsDialogs
             }
 
             //if there is no destination directory, then use current working directory
-            if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && Module.WorkingDir.IsNotNullOrWhitespace())
+            if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && !Module.WorkingDir.IsNullOrWhiteSpace())
                 _NO_TRANSLATE_To.Text = Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar);
 
             FromTextUpdate(null, null);

--- a/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using GitCommands;
 
 namespace GitUI.CommandsDialogs
 {
@@ -34,7 +35,7 @@ namespace GitUI.CommandsDialogs
 
         private void btnCompare_Click(object sender, EventArgs e)
         {
-            if (branchSelector.SelectedBranchName.IsNotNullOrWhitespace())
+            if (!branchSelector.SelectedBranchName.IsNullOrWhiteSpace())
             {
                 BranchName = branchSelector.SelectedBranchName;
                 DialogResult = DialogResult.OK;

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -273,7 +273,7 @@ namespace GitUI.CommandsDialogs
                     track = selectedLocalBranch != null && string.IsNullOrEmpty(selectedLocalBranch.TrackingRemote) &&
                             !_gitRemoteController.Remotes.Any(x => _NO_TRANSLATE_Branch.Text.StartsWith(x.Name, StringComparison.OrdinalIgnoreCase));
                     var autoSetupMerge = Module.EffectiveConfigFile.GetValue("branch.autoSetupMerge");
-                    if (autoSetupMerge.IsNotNullOrWhitespace() && autoSetupMerge.ToLowerInvariant() == "false")
+                    if (!autoSetupMerge.IsNullOrWhiteSpace() && autoSetupMerge.ToLowerInvariant() == "false")
                     {
                         track = false;
                     }
@@ -739,7 +739,7 @@ namespace GitUI.CommandsDialogs
 
         private void EnableLoadSshButton()
         {
-            LoadSSHKey.Visible = _selectedRemote.PuttySshKey.IsNotNullOrWhitespace();
+            LoadSSHKey.Visible = !_selectedRemote.PuttySshKey.IsNullOrWhiteSpace();
         }
 
         private void LoadSshKeyClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
 using ResourceManager;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -355,7 +355,7 @@ namespace GitUI
         {
             Func<bool> action = () =>
             {
-                FormProcess.ShowDialog(owner, Module, "stash branch " + branchName.Quote().Combine(" ", stash.QuoteNE()));
+                FormProcess.ShowDialog(owner, Module, "stash branch " + branchName.Quote().Combine(" ", stash.Quote(false)));
                 return true;
             };
 

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
+using GitCommands;
 
 namespace GitUI.Hotkey
 {

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitUI.HelperDialogs;
 
 namespace GitUI.UserControls

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -69,7 +69,7 @@ namespace GitUI
                 if (fileName.Equals(oldFileName))
                     oldFileName = null;
 
-                return fileName.Combine(" ", oldFileName.AddParenthesesNE());
+                return fileName.Combine(" ", oldFileName.AddParentheses());
             }
 
             if ((!truncatePathMethod.Equals("compact", StringComparison.OrdinalIgnoreCase) || !EnvUtils.RunningOnWindows()) &&

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2172,7 +2172,7 @@ namespace GitUI
             bisectSkipRevisionToolStripMenuItem.Visible = inTheMiddleOfBisect;
             stopBisectToolStripMenuItem.Visible = inTheMiddleOfBisect;
             bisectSeparator.Visible = inTheMiddleOfBisect;
-            compareWithCurrentBranchToolStripMenuItem.Visible = Module.GetSelectedBranch().IsNotNullOrWhitespace();
+            compareWithCurrentBranchToolStripMenuItem.Visible = !Module.GetSelectedBranch().IsNullOrWhiteSpace();
 
             var revision = GetRevision(LastRowIndex);
 

--- a/GitUI/UserManual/StandardHtmlUserManual.cs
+++ b/GitUI/UserManual/StandardHtmlUserManual.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using GitCommands;
 
 namespace GitUI.UserManual
 {

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -10,6 +10,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GitCommands;
 using GitCommands.Utils;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
@@ -162,7 +163,7 @@ namespace AppVeyorIntegration
                 Timeout = TimeSpan.FromMinutes(2),
                 BaseAddress = new Uri(baseUrl, UriKind.Absolute),
             };
-            if (accountToken.IsNotNullOrWhitespace())
+            if (!accountToken.IsNullOrWhiteSpace())
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accountToken);
             }


### PR DESCRIPTION
* Fix namespace
* Remove QuoteNE() method merging the functionality into Quote()
* Rename AddParenthesesNE() -> AddParentheses()
* Remove IsNotNullOrWhitespace()
* Remove unused methods