### PR TITLE
feat: Ref rename and delete from keyboard

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -330,6 +330,12 @@
     <Compile Include="UserControls\RevisionGridClasses\NavigationHistory.cs" />
     <Compile Include="UserControls\RevisionGridClasses\ParentChildNavigationHistory.cs" />
     <Compile Include="UserControls\AuthorEmailBasedRevisionHighlighting.cs" />
+    <Compile Include="UserControls\RevisionGridClasses\FormQuickGitRefSelector.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UserControls\RevisionGridClasses\FormQuickGitRefSelector.Designer.cs">
+      <DependentUpon>FormQuickGitRefSelector.cs</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\RevisionGridUtils.cs" />
     <Compile Include="UserControls\TextEventArgs.cs" />
     <Compile Include="UserControls\WebBrowserCtrl.cs">
@@ -1534,6 +1540,9 @@
     <EmbeddedResource Include="UserControls\RevisionGrid.resx">
       <DependentUpon>RevisionGrid.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserControls\RevisionGridClasses\FormQuickGitRefSelector.resx">
+      <DependentUpon>FormQuickGitRefSelector.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\ToolStripGitStatus.resx">
       <DependentUpon>ToolStripGitStatus.cs</DependentUpon>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5133,6 +5133,22 @@ Are you sure you want to push this branch?</source>
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="FormQuickGitRefSelector" source-language="en">
+    <body>
+      <trans-unit id="_actionDelete.Text">
+        <source>Delete</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_actionRename.Text">
+        <source>Rename</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_tag.Text">
+        <source>tag</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="FormRebase" source-language="en">
     <body>
       <trans-unit id="$this.Text">

--- a/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.Designer.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.Designer.cs
@@ -1,0 +1,107 @@
+﻿namespace GitUI.UserControls.RevisionGridClasses
+{
+    partial class FormQuickGitRefSelector
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lbxRefs = new System.Windows.Forms.ListBox();
+            this.btnAction = new System.Windows.Forms.Button();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // lbxRefs
+            // 
+            this.lbxRefs.DisplayMember = "Label";
+            this.lbxRefs.FormattingEnabled = true;
+            this.lbxRefs.Items.AddRange(new object[] {
+            "local1 (ref)",
+            "local2 (ref)",
+            "tag1 (tag)",
+            "tag2 (tag)",
+            "1",
+            "2",
+            "3",
+            "4"});
+            this.lbxRefs.Location = new System.Drawing.Point(2, 2);
+            this.lbxRefs.Name = "lbxRefs";
+            this.lbxRefs.Size = new System.Drawing.Size(275, 108);
+            this.lbxRefs.TabIndex = 0;
+            this.lbxRefs.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lbxRefs_MouseDoubleClick);
+            // 
+            // btnAction
+            // 
+            this.btnAction.AutoSize = true;
+            this.btnAction.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.btnAction.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnAction.Location = new System.Drawing.Point(197, 3);
+            this.btnAction.MinimumSize = new System.Drawing.Size(75, 0);
+            this.btnAction.Name = "btnAction";
+            this.btnAction.Size = new System.Drawing.Size(75, 23);
+            this.btnAction.TabIndex = 1;
+            this.btnAction.Text = "Action";
+            this.btnAction.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel1.Controls.Add(this.btnAction);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 117);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(275, 29);
+            this.flowLayoutPanel1.TabIndex = 2;
+            // 
+            // FormQuickGitRefSelector
+            // 
+            this.AcceptButton = this.btnAction;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.ClientSize = new System.Drawing.Size(279, 146);
+            this.Controls.Add(this.lbxRefs);
+            this.Controls.Add(this.flowLayoutPanel1);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "FormQuickGitRefSelector";
+            this.Padding = new System.Windows.Forms.Padding(2, 2, 2, 0);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ListBox lbxRefs;
+        private System.Windows.Forms.Button btnAction;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+    }
+}

--- a/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using GitUIPluginInterfaces;
+using ResourceManager;
+
+namespace GitUI.UserControls.RevisionGridClasses
+{
+    public partial class FormQuickGitRefSelector : GitModuleForm
+    {
+        private readonly TranslationString _actionRename = new TranslationString("Rename");
+        private readonly TranslationString _actionDelete = new TranslationString("Delete");
+        private readonly TranslationString _tag = new TranslationString("tag");
+        private const short MaxVisibleItemsWithoutScroll = 8;
+        private const short MaxRefLength = 100;
+
+
+        public FormQuickGitRefSelector()
+        {
+            InitializeComponent();
+            Translate();
+        }
+
+
+        /// <summary>
+        /// Gets the ref selected by the user.
+        /// </summary>
+        public IGitRef SelectedRef => (lbxRefs.SelectedItem as DisplyGitRef)?.Item;
+
+
+        public void Init(Action action, IGitRef[] refs)
+        {
+            switch (action)
+            {
+                case Action.Delete:
+                    {
+                        btnAction.Text = _actionDelete.Text;
+                    }
+                    break;
+                case Action.Rename:
+                    {
+                        btnAction.Text = _actionRename.Text;
+                    }
+                    break;
+            }
+
+            lbxRefs.Items.Clear();
+            if (refs == null || refs.Length < 1)
+            {
+                DialogResult = DialogResult.Cancel;
+                Close();
+                return;
+            }
+
+            // constrain the listbox min width, otherwise the button may not have enough space
+            var longestItemWidth = 150f;
+            try
+            {
+                lbxRefs.BeginUpdate();
+
+                using (Graphics graphics = lbxRefs.CreateGraphics())
+                {
+                    foreach (var gitRef in refs.OrderBy(r => r.IsTag).ThenBy(r => r.Name))
+                    {
+                        var suffix = gitRef.IsTag ? $" ({_tag.Text})" : string.Empty;
+                        var item = new DisplyGitRef
+                        {
+                            Label = $"{gitRef.Name}{suffix}",
+                            Item = gitRef
+                        };
+                        lbxRefs.Items.Add(item);
+
+                        // assume that the branch names or tags are never longer than MaxRefLength symbols long
+                        // if they are (sanity!) - don't resize past beyond certain limit
+                        var label = item.Label.Length > MaxRefLength ? item.Label.Substring(0, MaxRefLength) : item.Label;
+                        longestItemWidth = Math.Max(longestItemWidth, graphics.MeasureString(label, lbxRefs.Font).Width);
+                    }
+                }
+            }
+            finally
+            {
+                // what is this magic number "MaxVisibleItemsWithoutScroll + 0.5"?
+                // we are limiting number of visible items in the listbox before enabling vscroll, this is to reduce the risk of not fitting on user's screen.
+                // when listbox.IntergralHeight=true, the listbox automatically calculates its size and only show full items (i.e. you can't render it
+                // at 20px high if the ItemHeight=13px, it can only be 13, 26, 39 etc (NB: slightly more if you account for the furniture)).
+                // listbox.PreferredHeight returns the height of the listbox showing all items.
+                // for some strange reason, MaxVisibleItemsWithoutScroll*listbox.ItemHeight renders the listbox showing MaxVisibleItemsWithoutScroll-1 items.
+                // to fix this, trick the listbox and set its height to show MaxVisibleItemsWithoutScroll+0.5
+                // this internally forces it to re-calculates its bounds and then to calculate its preferred height
+                lbxRefs.Height = Math.Min(lbxRefs.PreferredHeight, (int)((MaxVisibleItemsWithoutScroll + 0.5) * lbxRefs.ItemHeight));
+                lbxRefs.Width = (int)longestItemWidth;
+                lbxRefs.EndUpdate();
+                lbxRefs.SelectedIndex = 0;
+                lbxRefs.Focus();
+
+                // resize the form to look nice
+                Size = new Size(lbxRefs.Width + Padding.Left + Padding.Right,
+                                lbxRefs.Height + Padding.Top + flowLayoutPanel1.Height);
+
+            }
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.Escape)
+            {
+                DialogResult = DialogResult.Cancel;
+                Close();
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+
+        private void lbxRefs_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            AcceptButton.PerformClick();
+        }
+
+
+        public enum Action
+        {
+            Rename = 0,
+            Delete
+        }
+
+        private class DisplyGitRef
+        {
+            public string Label { get; set; }
+            public IGitRef Item { get; set; }
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.resx
+++ b/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/UserControls/RevisionGridClasses/GitRefListsForRevision.cs
+++ b/GitUI/UserControls/RevisionGridClasses/GitRefListsForRevision.cs
@@ -1,10 +1,11 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using GitCommands;
 using GitUIPluginInterfaces;
 
 namespace GitUI.UserControls.RevisionGridClasses
 {
-    class GitRefListsForRevision
+    internal class GitRefListsForRevision
     {
         private readonly IGitRef[] _allBranches;
         private readonly IGitRef[] _localBranches;
@@ -15,45 +16,52 @@ namespace GitUI.UserControls.RevisionGridClasses
         {
             _allBranches = revision.Refs.Where(h => !h.IsTag && (h.IsHead || h.IsRemote)).ToArray();
             _localBranches = _allBranches.Where(b => !b.IsRemote).ToArray();
-            _branchesWithNoIdenticalRemotes = _allBranches.Where(
-                b => !b.IsRemote || !_localBranches.Any(lb => lb.TrackingRemote == b.Remote && lb.MergeWith == b.LocalName)).ToArray();
+            _branchesWithNoIdenticalRemotes = _allBranches.Where(b => !b.IsRemote || 
+                                                                      !_localBranches.Any(lb => lb.TrackingRemote == b.Remote && lb.MergeWith == b.LocalName))
+                                                          .ToArray();
 
             _tags = revision.Refs.Where(h => h.IsTag).ToArray();
         }
 
-        public IGitRef[] AllBranches
-        {
-            get { return _allBranches; }
-        }
 
-        public IGitRef[] LocalBranches
-        {
-            get { return _localBranches; }
-        }
+        public IEnumerable<IGitRef> AllBranches => _allBranches.AsEnumerable();
 
-        public IGitRef[] BranchesWithNoIdenticalRemotes
-        {
-            get { return _branchesWithNoIdenticalRemotes; }
-        }
+        public IEnumerable<IGitRef> AllTags => _tags.AsEnumerable();
 
-        public IGitRef[] AllTags
-        {
-            get { return _tags; }
-        }
+        public IEnumerable<IGitRef> BranchesWithNoIdenticalRemotes => _branchesWithNoIdenticalRemotes.AsEnumerable();
+
 
         public string[] GetAllBranchNames()
         {
-            return AllBranches.Select(b => b.Name).ToArray();
+            return _allBranches.Select(b => b.Name).ToArray();
         }
 
         public string[] GetAllNonRemoteBranchNames()
         {
-            return AllBranches.Where(head => !head.IsRemote).Select(b => b.Name).ToArray();
+            return _allBranches.Where(head => !head.IsRemote).Select(b => b.Name).ToArray();
         }
 
         public string[] GetAllTagNames()
         {
             return AllTags.Select(t => t.Name).ToArray();
+        }
+
+        /// <summary>
+        /// Returns the collection of local branches and tags which can be deleted.
+        /// </summary>
+        /// <returns></returns>
+        public IGitRef[] GetDeletableLocalRefs(string currentBranch)
+        {
+            return _localBranches.Where(b => !b.Name.Equals(currentBranch)).Union(_tags).ToArray();
+        }
+
+        /// <summary>
+        /// Returns the collection of local branches which can be renamed.
+        /// </summary>
+        /// <returns></returns>
+        public IGitRef[] GetRenameableLocalBranches()
+        {
+            return _localBranches.ToArray();
         }
     }
 }


### PR DESCRIPTION
Allow to rename and delete branches and tags from keyboard.
Actions:
* F2 - rename
* DEL - delete

If there is...
* no valid branch or tag to rename or delete the action is ignored
* a single branch or tag - the respective action dialog is launched
* multiple branches or tags then a quick select dialog is launched to specify the exact ref to perform action on.

Addresses #3503


Rename (F2)
![image](https://cloud.githubusercontent.com/assets/4403806/24825823/ddf2f240-1c6a-11e7-8932-68db13902c22.png)
Very long branch names/tags gets constrained to 100 symbols, to reduce the risk of not fitting on user's screen.

Delete (DEL)
![image](https://cloud.githubusercontent.com/assets/4403806/24825836/1c605b6c-1c6b-11e7-880c-0c84e4b94b9a.png)

The quick selector shows upto 8 items without scroll. This is again to reduce the risk of not fitting on user's monitor:
![image](https://cloud.githubusercontent.com/assets/4403806/24825861/a98ff7fe-1c6b-11e7-8b18-db149668f110.png)

