### PR TITLE
Add Blame command to VS extension

### DIFF
--- a/GitExtensionsVSIX/GitExtCommandTable.cs
+++ b/GitExtensionsVSIX/GitExtCommandTable.cs
@@ -6,7 +6,7 @@
 namespace GitExtensionsVSIX
 {
     using System;
-    
+
     /// <summary>
     /// Helper class that exposes all GUIDs used across VS Package.
     /// </summary>
@@ -59,6 +59,7 @@ namespace GitExtensionsVSIX
         public const int gitExtBashCommand = 0x1116;
         public const int gitExtSettingsCommand = 0x1117;
         public const int gitExtAboutCommand = 0x1118;
+        public const int gitExtBlameCommand = 0x1119;
         public const int edit = 0x0001;
         public const int configure = 0x0002;
         public const int stash = 0x0003;

--- a/GitExtensionsVSIX/GitExtCommandTable.vsct
+++ b/GitExtensionsVSIX/GitExtCommandTable.vsct
@@ -200,6 +200,13 @@
                     <ButtonText>V&amp;iew changes</ButtonText>
                 </Strings>
             </Button>
+            <Button guid="guidGitExtensionsPackageCmdSet" id="gitExtBlameCommand" priority="0x0002" type="Button">
+                <Parent guid="guidGitExtensionsPackageCmdSet" id="gitExtMenuFindGroup" />
+                <Strings>
+                    <CommandName>GitExt.Blame</CommandName>
+                    <ButtonText>Blame</ButtonText>
+                </Strings>
+            </Button>
             <Button guid="guidGitExtensionsPackageCmdSet" id="gitExtFindFileCommand" priority="0x0003" type="Button">
                 <Parent guid="guidGitExtensionsPackageCmdSet" id="gitExtMenuFindGroup" />
                 <Icon guid="guidImages" id="find"/>
@@ -384,6 +391,7 @@
             <IDSymbol name="gitExtBashCommand" value="0x1116" />
             <IDSymbol name="gitExtSettingsCommand" value="0x1117" />
             <IDSymbol name="gitExtAboutCommand" value="0x1118" />
+            <IDSymbol name="gitExtBlameCommand" value="0x1119"/>
         </GuidSymbol>
 
         <GuidSymbol name="guidImages" value="{8bcce2c8-daec-4814-878e-e9c346d42f24}" >

--- a/GitExtensionsVSIX/GitExtCommands.cs
+++ b/GitExtensionsVSIX/GitExtCommands.cs
@@ -9,8 +9,6 @@ using GitPluginShared;
 using GitPluginShared.Commands;
 
 using Microsoft.VisualStudio.Shell;
-
-using Constants = EnvDTE.Constants;
 using static GitExtensionsVSIX.PackageIds;
 
 namespace GitExtensionsVSIX
@@ -73,6 +71,7 @@ namespace GitExtensionsVSIX
                 RegisterCommand("ApplyPatch", new ToolbarCommand<ApplyPatch>(), gitExtApplyPatchCommand);
                 RegisterCommand("FormatPatch", new ToolbarCommand<FormatPatch>(), gitExtFormatPatchCommand);
                 RegisterCommand("ViewChanges", new ToolbarCommand<ViewChanges>(), gitExtViewChangesCommand);
+                RegisterCommand("Blame", new ToolbarCommand<Blame>(), gitExtBlameCommand);
                 RegisterCommand("FindFile", new ToolbarCommand<FindFile>(), gitExtFindFileCommand);
                 RegisterCommand("SwitchBranch", new ToolbarCommand<SwitchBranch>(), gitExtCheckoutCommand);
                 RegisterCommand("CreateBranch", new ToolbarCommand<CreateBranch>(), gitExtCreateBranchCommand);

--- a/GitPluginShared/Commands/Blame.cs
+++ b/GitPluginShared/Commands/Blame.cs
@@ -1,0 +1,17 @@
+﻿using EnvDTE;
+
+namespace GitPluginShared.Commands
+{
+    public sealed class Blame : ItemCommandBase
+    {
+        protected override void OnExecute (SelectedItem item, string fileName, OutputWindowPane pane)
+        {
+            RunGitEx ("blame", fileName);
+        }
+
+        protected override CommandTarget SupportedTargets
+        {
+            get { return CommandTarget.File; }
+        }
+    }
+}

--- a/GitPluginShared/Commands/Blame.cs
+++ b/GitPluginShared/Commands/Blame.cs
@@ -6,7 +6,15 @@ namespace GitPluginShared.Commands
     {
         protected override void OnExecute (SelectedItem item, string fileName, OutputWindowPane pane)
         {
-            RunGitEx ("blame", fileName);
+            string[] arguments = null;
+
+            var textSelection = item.DTE.ActiveDocument.Selection as TextSelection;
+            if( textSelection != null )
+            {
+                arguments = new string[] { textSelection.CurrentLine.ToString() };
+            }
+
+            RunGitEx ("blame", fileName, arguments);
         }
 
         protected override CommandTarget SupportedTargets

--- a/GitPluginShared/Commands/CommandBase.cs
+++ b/GitPluginShared/Commands/CommandBase.cs
@@ -10,9 +10,9 @@ namespace GitPluginShared.Commands
 
         abstract public bool IsEnabled(DTE2 application);
 
-        protected static void RunGitEx(string command, string filename)
+        protected static void RunGitEx(string command, string filename, string[] arguments = null)
         {
-            GitCommands.RunGitEx(command, filename);
+            GitCommands.RunGitEx(command, filename, arguments);
         }
 
         public bool RunForSelection { get; set; }

--- a/GitPluginShared/Git/GitCommands.cs
+++ b/GitPluginShared/Git/GitCommands.cs
@@ -62,7 +62,7 @@ namespace GitPluginShared.Git
             };
         }
 
-        public static Process RunGitEx(string command, string filename)
+        public static Process RunGitEx(string command, string filename, string[] arguments = null)
         {
             if (!string.IsNullOrEmpty(filename))
             {
@@ -74,6 +74,11 @@ namespace GitPluginShared.Git
                 }
 
                 command += " \"" + filename + "\"";
+            }
+
+            if (arguments != null && arguments.Length > 0)
+            {
+                command += " " + string.Join(" ", arguments);
             }
 
             string path = GetGitExRegValue("InstallDir");

--- a/GitPluginShared/GitPluginShared.csproj
+++ b/GitPluginShared/GitPluginShared.csproj
@@ -86,6 +86,7 @@
     </Compile>
     <Compile Include="Commands\About.cs" />
     <Compile Include="Commands\ApplyPatch.cs" />
+    <Compile Include="Commands\Blame.cs" />
     <Compile Include="Commands\Browse.cs" />
     <Compile Include="Commands\Cherry.cs" />
     <Compile Include="Commands\Clone.cs" />

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -7,17 +7,17 @@ namespace GitUI.CommandsDialogs
     {
         private FormBlame()
             : this(null)
-        {         
+        {
         }
 
         private FormBlame(GitUICommands aCommands)
             : base(aCommands)
         {
             InitializeComponent();
-            Translate();        
+            Translate();
         }
 
-        public FormBlame(GitUICommands aCommands, string fileName, GitRevision revision) : this(aCommands)
+        public FormBlame(GitUICommands aCommands, string fileName, GitRevision revision, int? initialLine = null) : this(aCommands)
         {
             if (string.IsNullOrEmpty(fileName))
                 return;
@@ -26,7 +26,7 @@ namespace GitUI.CommandsDialogs
             if (revision == null)
                 revision = Module.GetRevision("Head");
 
-            blameControl1.LoadBlame(revision, null, fileName, null, null, Module.FilesEncoding);
+            blameControl1.LoadBlame(revision, null, fileName, null, null, Module.FilesEncoding, initialLine);
         }
 
         public string FileName { get; set; }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1690,11 +1690,11 @@ namespace GitUI
             return StartBlameDialog(owner, fileName, null);
         }
 
-        private bool StartBlameDialog(IWin32Window owner, string fileName, GitRevision revision)
+        private bool StartBlameDialog(IWin32Window owner, string fileName, GitRevision revision, int? initialLine = null)
         {
             return DoActionOnRepo(owner, true, false, PreBlame, PostBlame, () =>
                 {
-                    using (var frm = new FormBlame(this, fileName, revision))
+                    using (var frm = new FormBlame(this, fileName, revision, initialLine))
                         frm.ShowDialog(owner);
 
                     return true;
@@ -1702,9 +1702,9 @@ namespace GitUI
             );
         }
 
-        public bool StartBlameDialog(string fileName)
+        public bool StartBlameDialog(string fileName, int? initialLine = null)
         {
-            return StartBlameDialog(null, fileName, null);
+            return StartBlameDialog(null, fileName, null, initialLine);
         }
 
         private bool StartBlameDialog(string fileName, GitRevision revision)
@@ -2098,7 +2098,18 @@ namespace GitUI
             // Remove working directory from filename. This is to prevent filenames that are too
             // long while there is room left when the workingdir was not in the path.
             string filenameFromBlame = args[2].Replace(Module.WorkingDir, "").ToPosixPath();
-            StartBlameDialog(filenameFromBlame);
+
+            int? initialLine = null;
+            if( args.Length >= 4 )
+            {
+                int temp;
+                if( int.TryParse( args[3], out temp ) )
+                {
+                    initialLine = temp;
+                }
+            }
+
+            StartBlameDialog(filenameFromBlame, initialLine);
         }
 
         private void RunMergeToolOrConflictCommand(Dictionary<string, string> arguments)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -191,7 +191,7 @@ namespace GitUI.Blame
         
         private AsyncLoader blameLoader = new AsyncLoader();
 
-        public void LoadBlame(GitRevision revision, List<string> children, string fileName, RevisionGrid revGrid, Control controlToMask, Encoding encoding)
+        public void LoadBlame(GitRevision revision, List<string> children, string fileName, RevisionGrid revGrid, Control controlToMask, Encoding encoding, int? initialLine = null)
         {
             //refresh only when something changed
             string guid = revision.Guid;
@@ -203,7 +203,7 @@ namespace GitUI.Blame
 
             var scrollpos = BlameFile.ScrollPos;
 
-            int line = 0;
+            int line = initialLine.GetValueOrDefault( 0 );
             if (_clickedBlameLine.CommitGuid == guid)
                 line = _clickedBlameLine.OriginLineNumber;
             _revGrid = revGrid;


### PR DESCRIPTION
Fixes #2839.

Changes proposed in this pull request:
 - the Blame control can be started at the specified line
 - commands can be started with additional arguments
 - the Blame command is added to VS extension
 
Has been tested on
 - GIT 2.10.1
 - Windows 10
