### PR TITLE
Support any encoding for fileview

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1089,7 +1089,15 @@ namespace GitUI.CommandsDialogs
 
             OnStageAreaLoaded += stageAreaLoaded;
 
-            Module.ResetMixed("HEAD");
+            if (IsMergeCommit)
+            {
+                Staged.SelectAll();
+                Unstage(canUseUnstageAll: false);
+            }
+            else
+            {
+                Module.ResetMixed("HEAD");
+            }
             Initialize();
         }
 
@@ -1127,9 +1135,11 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void Unstage()
+        private void Unstage(bool canUseUnstageAll = true)
         {
-            if (Staged.GitItemStatuses.Count() > 10 && Staged.SelectedItems.Count() == Staged.GitItemStatuses.Count())
+            if (canUseUnstageAll && 
+                Staged.GitItemStatuses.Count() > 10 && 
+                Staged.SelectedItems.Count() == Staged.GitItemStatuses.Count())
             {
                 UnstageAllToolStripMenuItemClick(null, null);
                 return;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -803,6 +803,26 @@ namespace GitUI
             return SelectFiles(RegexForSelecting(selectionFilter));
         }
 
+        public void SelectAll()
+        {
+            try
+            {
+                SuspendLayout();
+
+                var items = AllItems;
+                int i = 0;
+                foreach (var item in items)
+                {
+                    FileStatusListView.Items[i].Selected = true;
+                    i++;
+                }
+            }
+            finally
+            {
+                ResumeLayout(true);
+            }
+        }
+
         private static Regex RegexForSelecting(string value)
         {
             return string.IsNullOrEmpty(value)


### PR DESCRIPTION
Changes proposed in this pull request:
-
Added support all available encodings .NET:
- in settings
- in file viewer
 
Screenshots before and after (if PR changes UI):
-
List of encodings
![encodings_before](https://cloud.githubusercontent.com/assets/838185/24830849/64af0eec-1c96-11e7-80e5-710846872704.png)

![encodings](https://cloud.githubusercontent.com/assets/838185/24830771/04cf03a2-1c95-11e7-8c6d-503121195c9f.png)

How did I test this code:
 - 
Manual testing: viewing files in different encodings

Has been tested on:
-
 - GIT 2.12.2
 - Windows 10
