### PR TITLE
Encodings in fileviewer

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1499,7 +1499,7 @@ namespace GitCommands
                 addEncoding(new UnicodeEncoding());
                 addEncoding(new UTF7Encoding());
                 addEncoding(new UTF8Encoding(false));
-                addEncoding(Encoding.GetEncoding("CP852"));
+                addEncoding(Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
             }
             else
             {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1489,9 +1489,10 @@ namespace GitCommands
         private static void LoadEncodings()
         {
             Action<Encoding> addEncoding = delegate (Encoding e) { AvailableEncodings[e.HeaderName] = e; };
+            Action<string> addEncodingByName = delegate (string s) { try { addEncoding(Encoding.GetEncoding(s)); } catch { } };
 
-            string[] availableEncodings = GetString("AvailableEncodings", "").Split(';');
-            if (availableEncodings == null || availableEncodings.Length == 0 || string.IsNullOrWhiteSpace(availableEncodings[0]))
+            string availableEncodings = GetString("AvailableEncodings", "");
+            if (string.IsNullOrWhiteSpace(availableEncodings))
             {
                 // Default encoding set
                 addEncoding(Encoding.Default);
@@ -1504,16 +1505,17 @@ namespace GitCommands
             else
             {
                 var utf8 = new UTF8Encoding(false);
-                foreach(var encoding in availableEncodings)
+                foreach(var encodingName in availableEncodings.Split(';'))
                 {
                     // create utf-8 without BOM
-                    if (encoding == utf8.HeaderName)
+                    if (encodingName == utf8.HeaderName)
                         addEncoding(utf8);
                     // default encoding
-                    else if (encoding == "Default")
+                    else if (encodingName == "Default")
                         addEncoding(Encoding.Default);
+                    // add encoding by name
                     else
-                        addEncoding(Encoding.GetEncoding(encoding));
+                        addEncodingByName(encodingName);
                 }
             }
         }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1503,10 +1503,15 @@ namespace GitCommands
             }
             else
             {
+                var utf8 = new UTF8Encoding(false);
                 foreach(var encoding in availableEncodings)
                 {
-                    if (encoding.GetType() == typeof(UTF8Encoding))
-                        addEncoding(new UTF8Encoding(false));
+                    // create utf-8 without BOM
+                    if (encoding == utf8.HeaderName)
+                        addEncoding(utf8);
+                    // default encoding
+                    else if (encoding == "Default")
+                        addEncoding(Encoding.Default);
                     else
                         addEncoding(Encoding.GetEncoding(encoding));
                 }
@@ -1516,6 +1521,7 @@ namespace GitCommands
         private static void SaveEncodings()
         {
             string availableEncodings = AvailableEncodings.Values.Select(e => e.HeaderName).Join(";");
+            availableEncodings = availableEncodings.Replace(Encoding.Default.HeaderName, "Default");
             SetString("AvailableEncodings", availableEncodings);
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.Designer.cs
@@ -83,6 +83,7 @@
             this.ListAvailableEncodings.Location = new System.Drawing.Point(315, 23);
             this.ListAvailableEncodings.Name = "ListAvailableEncodings";
             this.ListAvailableEncodings.Size = new System.Drawing.Size(287, 252);
+            this.ListAvailableEncodings.Sorted = true;
             this.ListAvailableEncodings.TabIndex = 1;
             this.ListAvailableEncodings.SelectedValueChanged += new System.EventHandler(this.ListAvailableEncodings_SelectedValueChanged);
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.Designer.cs
@@ -1,0 +1,222 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog
+{
+    partial class FormAvailableEncodings
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.ListIncludedEncodings = new System.Windows.Forms.ListBox();
+            this.ListAvailableEncodings = new System.Windows.Forms.ListBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.ToRight = new System.Windows.Forms.Button();
+            this.ToLeft = new System.Windows.Forms.Button();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.ButtonOk = new System.Windows.Forms.Button();
+            this.ButtonCancel = new System.Windows.Forms.Button();
+            this.lSelectedEncodings = new System.Windows.Forms.Label();
+            this.lAvaolableEncodings = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.ListIncludedEncodings, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.ListAvailableEncodings, 2, 1);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 2, 2);
+            this.tableLayoutPanel1.Controls.Add(this.lSelectedEncodings, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lAvaolableEncodings, 2, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(605, 315);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // ListIncludedEncodings
+            // 
+            this.ListIncludedEncodings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ListIncludedEncodings.FormattingEnabled = true;
+            this.ListIncludedEncodings.Location = new System.Drawing.Point(3, 23);
+            this.ListIncludedEncodings.Name = "ListIncludedEncodings";
+            this.ListIncludedEncodings.Size = new System.Drawing.Size(266, 252);
+            this.ListIncludedEncodings.TabIndex = 0;
+            // 
+            // ListAvailableEncodings
+            // 
+            this.ListAvailableEncodings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ListAvailableEncodings.FormattingEnabled = true;
+            this.ListAvailableEncodings.Location = new System.Drawing.Point(315, 23);
+            this.ListAvailableEncodings.Name = "ListAvailableEncodings";
+            this.ListAvailableEncodings.Size = new System.Drawing.Size(287, 252);
+            this.ListAvailableEncodings.TabIndex = 1;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.ColumnCount = 1;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Controls.Add(this.ToRight, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.ToLeft, 0, 2);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(275, 23);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 4;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(34, 252);
+            this.tableLayoutPanel2.TabIndex = 2;
+            // 
+            // ToRight
+            // 
+            this.ToRight.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ToRight.Location = new System.Drawing.Point(3, 99);
+            this.ToRight.Name = "ToRight";
+            this.ToRight.Size = new System.Drawing.Size(28, 24);
+            this.ToRight.TabIndex = 0;
+            this.ToRight.Text = ">";
+            this.ToRight.UseVisualStyleBackColor = true;
+            this.ToRight.Click += new System.EventHandler(this.ToRight_Click);
+            // 
+            // ToLeft
+            // 
+            this.ToLeft.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ToLeft.Location = new System.Drawing.Point(3, 129);
+            this.ToLeft.Name = "ToLeft";
+            this.ToLeft.Size = new System.Drawing.Size(28, 24);
+            this.ToLeft.TabIndex = 1;
+            this.ToLeft.Text = "<";
+            this.ToLeft.UseVisualStyleBackColor = true;
+            this.ToLeft.Click += new System.EventHandler(this.ToLeft_Click);
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.ColumnCount = 3;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel3.Controls.Add(this.ButtonOk, 2, 0);
+            this.tableLayoutPanel3.Controls.Add(this.ButtonCancel, 1, 0);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(315, 281);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 1;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(287, 31);
+            this.tableLayoutPanel3.TabIndex = 3;
+            // 
+            // ButtonOk
+            // 
+            this.ButtonOk.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ButtonOk.Location = new System.Drawing.Point(193, 3);
+            this.ButtonOk.Name = "ButtonOk";
+            this.ButtonOk.Size = new System.Drawing.Size(91, 25);
+            this.ButtonOk.TabIndex = 0;
+            this.ButtonOk.Text = "OK";
+            this.ButtonOk.UseVisualStyleBackColor = true;
+            this.ButtonOk.Click += new System.EventHandler(this.ButtonOk_Click);
+            // 
+            // ButtonCancel
+            // 
+            this.ButtonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.ButtonCancel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ButtonCancel.Location = new System.Drawing.Point(98, 3);
+            this.ButtonCancel.Name = "ButtonCancel";
+            this.ButtonCancel.Size = new System.Drawing.Size(89, 25);
+            this.ButtonCancel.TabIndex = 1;
+            this.ButtonCancel.Text = "Cancel";
+            this.ButtonCancel.UseVisualStyleBackColor = true;
+            this.ButtonCancel.Click += new System.EventHandler(this.ButtonCancel_Click);
+            // 
+            // lSelectedEncodings
+            // 
+            this.lSelectedEncodings.AutoSize = true;
+            this.lSelectedEncodings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lSelectedEncodings.Location = new System.Drawing.Point(3, 0);
+            this.lSelectedEncodings.Name = "lSelectedEncodings";
+            this.lSelectedEncodings.Size = new System.Drawing.Size(266, 20);
+            this.lSelectedEncodings.TabIndex = 4;
+            this.lSelectedEncodings.Text = "Selected:";
+            this.lSelectedEncodings.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lAvaolableEncodings
+            // 
+            this.lAvaolableEncodings.AutoSize = true;
+            this.lAvaolableEncodings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lAvaolableEncodings.Location = new System.Drawing.Point(315, 0);
+            this.lAvaolableEncodings.Name = "lAvaolableEncodings";
+            this.lAvaolableEncodings.Size = new System.Drawing.Size(287, 20);
+            this.lAvaolableEncodings.TabIndex = 5;
+            this.lAvaolableEncodings.Text = "Available:";
+            this.lAvaolableEncodings.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // FormAvailableEncodings
+            // 
+            this.AcceptButton = this.ButtonOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.ButtonCancel;
+            this.ClientSize = new System.Drawing.Size(605, 315);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FormAvailableEncodings";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Configure available encodings";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.ListBox ListIncludedEncodings;
+        private System.Windows.Forms.ListBox ListAvailableEncodings;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Button ToRight;
+        private System.Windows.Forms.Button ToLeft;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+        private System.Windows.Forms.Button ButtonOk;
+        private System.Windows.Forms.Button ButtonCancel;
+        private System.Windows.Forms.Label lSelectedEncodings;
+        private System.Windows.Forms.Label lAvaolableEncodings;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.Designer.cs
@@ -74,6 +74,7 @@
             this.ListIncludedEncodings.Name = "ListIncludedEncodings";
             this.ListIncludedEncodings.Size = new System.Drawing.Size(266, 252);
             this.ListIncludedEncodings.TabIndex = 0;
+            this.ListIncludedEncodings.SelectedValueChanged += new System.EventHandler(this.ListIncludedEncodings_SelectedValueChanged);
             // 
             // ListAvailableEncodings
             // 
@@ -83,6 +84,7 @@
             this.ListAvailableEncodings.Name = "ListAvailableEncodings";
             this.ListAvailableEncodings.Size = new System.Drawing.Size(287, 252);
             this.ListAvailableEncodings.TabIndex = 1;
+            this.ListAvailableEncodings.SelectedValueChanged += new System.EventHandler(this.ListAvailableEncodings_SelectedValueChanged);
             // 
             // tableLayoutPanel2
             // 
@@ -104,6 +106,7 @@
             // ToRight
             // 
             this.ToRight.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ToRight.Enabled = false;
             this.ToRight.Location = new System.Drawing.Point(3, 99);
             this.ToRight.Name = "ToRight";
             this.ToRight.Size = new System.Drawing.Size(28, 24);
@@ -115,6 +118,7 @@
             // ToLeft
             // 
             this.ToLeft.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ToLeft.Enabled = false;
             this.ToLeft.Location = new System.Drawing.Point(3, 129);
             this.ToLeft.Name = "ToLeft";
             this.ToLeft.Size = new System.Drawing.Size(28, 24);

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -22,20 +22,39 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         private void LoadEncoding()
         {
             var includedEncoding = AppSettings.AvailableEncodings;
-            ListIncludedEncodings.Items.AddRange(includedEncoding.Values.ToArray());
-            ListIncludedEncodings.DisplayMember = "EncodingName";
+            ListIncludedEncodings.BeginUpdate();
+            try
+            {
+                ListIncludedEncodings.Items.AddRange(includedEncoding.Values.ToArray());
+                ListIncludedEncodings.DisplayMember = "EncodingName";
+            }
+            finally
+            {
+                ListIncludedEncodings.EndUpdate();
+            }
 
             var availableEncoding = System.Text.Encoding.GetEncodings()
                 .Select(ei => ei.GetEncoding())
-                .Where(e => !includedEncoding.ContainsKey(e.HeaderName)).ToList();
+                .Where(e => !includedEncoding.ContainsKey(e.HeaderName))
+                .ToList();
+            // If exists utf-8, then replace to utf-8 without BOM
             var utf8 = availableEncoding.Where(e => typeof(UTF8Encoding) == e.GetType()).FirstOrDefault();
             if (utf8 != null)
             {
                 availableEncoding.Remove(utf8);
                 availableEncoding.Add(new UTF8Encoding(false));
             }
-            ListAvailableEncodings.Items.AddRange(availableEncoding.OrderBy(e => e.HeaderName).ToArray());
-            ListAvailableEncodings.DisplayMember = "EncodingName";
+
+            ListAvailableEncodings.BeginUpdate();
+            try
+            {
+                ListAvailableEncodings.Items.AddRange(availableEncoding.ToArray());
+                ListAvailableEncodings.DisplayMember = "EncodingName";
+            }
+            finally
+            {
+                ListAvailableEncodings.EndUpdate();
+            }
         }
 
         private void ToLeft_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -1,0 +1,77 @@
+﻿using GitCommands;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs.SettingsDialog
+{
+    public partial class FormAvailableEncodings : GitModuleForm
+    {
+        public FormAvailableEncodings()
+        {
+            InitializeComponent();
+            Translate();
+            LoadEncoding();
+        }
+
+        private void LoadEncoding()
+        {
+            var includedEncoding = AppSettings.AvailableEncodings;
+            ListIncludedEncodings.Items.AddRange(includedEncoding.Values.ToArray());
+            ListIncludedEncodings.DisplayMember = "EncodingName";
+
+            var availableEncoding = System.Text.Encoding.GetEncodings()
+                .Select(ei => ei.GetEncoding())
+                .Where(e => !includedEncoding.ContainsKey(e.HeaderName)).ToList();
+            var utf8 = availableEncoding.Where(e => typeof(UTF8Encoding) == e.GetType()).FirstOrDefault();
+            if (utf8 != null)
+            {
+                availableEncoding.Remove(utf8);
+                availableEncoding.Add(new UTF8Encoding(false));
+            }
+            ListAvailableEncodings.Items.AddRange(availableEncoding.OrderBy(e => e.HeaderName).ToArray());
+            ListAvailableEncodings.DisplayMember = "EncodingName";
+        }
+
+        private void ToLeft_Click(object sender, EventArgs e)
+        {
+            if (ListAvailableEncodings.SelectedItem != null)
+            {
+                var indx = ListAvailableEncodings.SelectedIndex;
+                ListIncludedEncodings.Items.Add(ListAvailableEncodings.SelectedItem);
+                ListAvailableEncodings.Items.RemoveAt(indx);
+            }
+        }
+
+        private void ButtonOk_Click(object sender, EventArgs e)
+        {
+            AppSettings.AvailableEncodings.Clear();
+            foreach(Encoding encoding in ListIncludedEncodings.Items)
+            {
+                AppSettings.AvailableEncodings.Add(encoding.HeaderName, encoding);
+            }
+
+            DialogResult = DialogResult.OK;
+        }
+
+        private void ButtonCancel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+        }
+
+        private void ToRight_Click(object sender, EventArgs e)
+        {
+            if (ListIncludedEncodings.SelectedItem != null)
+            {
+                var indx = ListIncludedEncodings.SelectedIndex;
+                ListAvailableEncodings.Items.Add(ListIncludedEncodings.SelectedItem);
+                ListIncludedEncodings.Items.RemoveAt(indx);
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -73,5 +73,29 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 ListIncludedEncodings.Items.RemoveAt(indx);
             }
         }
+
+        private void ListIncludedEncodings_SelectedValueChanged(object sender, EventArgs e)
+        {
+            // Get selected encoding
+            var encoding = ListIncludedEncodings.SelectedItem as Encoding;
+            Type encodingType = null;
+            // Get type if exists
+            if (encoding != null)
+                encodingType = encoding.GetType();
+            // If selected encoding and encoding not default list
+            ToRight.Enabled = encoding != null && 
+                !(
+                    encodingType == typeof(ASCIIEncoding) ||
+                    encodingType == typeof(UnicodeEncoding) ||
+                    encodingType == typeof(UTF8Encoding) ||
+                    encodingType == typeof(UTF7Encoding) ||
+                    encoding == Encoding.Default
+                );
+        }
+
+        private void ListAvailableEncodings_SelectedValueChanged(object sender, EventArgs e)
+        {
+            ToLeft.Enabled = ListAvailableEncodings.SelectedItem != null;
+        }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -67,6 +67,7 @@
             this.globalAutoCrlfFalse = new System.Windows.Forms.RadioButton();
             this.globalAutoCrlfNotSet = new System.Windows.Forms.RadioButton();
             this.tableLayoutPanelGitConfig = new System.Windows.Forms.TableLayoutPanel();
+            this.ConfigureEncoding = new System.Windows.Forms.Button();
             this.InvalidGitPathGlobal.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.groupBoxLineEndings.SuspendLayout();
@@ -181,7 +182,7 @@
             this.DifftoolPath.Size = new System.Drawing.Size(897, 23);
             this.DifftoolPath.TabIndex = 10;
             // 
-            // GlobalDiffTool
+            // _NO_TRANSLATE_GlobalDiffTool
             // 
             this._NO_TRANSLATE_GlobalDiffTool.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this._NO_TRANSLATE_GlobalDiffTool.FormattingEnabled = true;
@@ -312,7 +313,7 @@
             this.BrowseMergeTool.UseVisualStyleBackColor = true;
             this.BrowseMergeTool.Click += new System.EventHandler(this.BrowseMergeTool_Click);
             // 
-            // GlobalMergeTool
+            // _NO_TRANSLATE_GlobalMergeTool
             // 
             this._NO_TRANSLATE_GlobalMergeTool.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this._NO_TRANSLATE_GlobalMergeTool.FormattingEnabled = true;
@@ -510,6 +511,7 @@
             this.tableLayoutPanelGitConfig.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanelGitConfig.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelGitConfig.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelGitConfig.Controls.Add(this.ConfigureEncoding, 2, 12);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label3, 0, 0);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label60, 0, 12);
             this.tableLayoutPanelGitConfig.Controls.Add(this.groupBoxLineEndings, 0, 11);
@@ -561,6 +563,17 @@
             this.tableLayoutPanelGitConfig.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanelGitConfig.Size = new System.Drawing.Size(1310, 778);
             this.tableLayoutPanelGitConfig.TabIndex = 81;
+            // 
+            // ConfigureEncoding
+            // 
+            this.ConfigureEncoding.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.ConfigureEncoding.Location = new System.Drawing.Point(537, 434);
+            this.ConfigureEncoding.Name = "ConfigureEncoding";
+            this.ConfigureEncoding.Size = new System.Drawing.Size(123, 25);
+            this.ConfigureEncoding.TabIndex = 81;
+            this.ConfigureEncoding.Text = "Configure";
+            this.ConfigureEncoding.UseVisualStyleBackColor = true;
+            this.ConfigureEncoding.Click += new System.EventHandler(this.ConfigureEncoding_Click);
             // 
             // GitConfigSettingsPage
             // 
@@ -623,5 +636,6 @@
         private System.Windows.Forms.RadioButton globalAutoCrlfNotSet;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelGitConfig;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelLineEndings;
+        private System.Windows.Forms.Button ConfigureEncoding;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -265,5 +265,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             CommitTemplatePath.Text = CommonLogic.SelectFile(".", "*.txt (*.txt)|*.txt", CommitTemplatePath.Text);
         }
+
+        private void ConfigureEncoding_Click(object sender, EventArgs e)
+        {
+            using (var encodingDlg = new FormAvailableEncodings())
+            {
+                if (encodingDlg.ShowDialog() == DialogResult.OK)
+                {
+                    Global_FilesEncoding.Items.Clear();
+                    CommonLogic.FillEncodings(Global_FilesEncoding);
+                }
+            }
+        }
     }
 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -71,11 +71,10 @@ namespace GitUI.Editor
 
             IsReadOnly = true;
 
-            this.encodingToolStripComboBox.Items.AddRange(new Object[]
-                                                    {
-                                                        "Default (" + Encoding.Default.HeaderName + ")","DOS852", "ASCII",
-                                                        "Unicode", "UTF7", "UTF8", "UTF32"
-                                                    });
+            encodingToolStripComboBox.Items.AddRange(
+                AppSettings.AvailableEncodings.Values.Select(e => e.EncodingName).ToArray()
+                );
+
             _internalFileViewer.MouseMove += TextAreaMouseMove;
             _internalFileViewer.MouseLeave += TextAreaMouseLeave;
             _internalFileViewer.TextChanged += TextEditor_TextChanged;
@@ -267,20 +266,8 @@ namespace GitUI.Editor
 
         private void UpdateEncodingCombo()
         {
-            if (this.Encoding.GetType() == typeof(ASCIIEncoding))
-                this.encodingToolStripComboBox.Text = "ASCII";
-            else if (this.Encoding.GetType() == typeof(UnicodeEncoding))
-                this.encodingToolStripComboBox.Text = "Unicode";
-            else if (this.Encoding.GetType() == typeof(UTF7Encoding))
-                this.encodingToolStripComboBox.Text = "UTF7";
-            else if (this.Encoding.GetType() == typeof(UTF8Encoding))
-                this.encodingToolStripComboBox.Text = "UTF8";
-            else if (this.Encoding.GetType() == typeof(UTF32Encoding))
-                this.encodingToolStripComboBox.Text = "UTF32";
-            else if (this.Encoding == Encoding.Default)
-                this.encodingToolStripComboBox.Text = "Default (" + Encoding.Default.HeaderName + ")";
-            else if (this.Encoding == Encoding.GetEncoding("CP852"))
-                this.encodingToolStripComboBox.Text = "DOS852";
+            if (Encoding != null)
+            encodingToolStripComboBox.Text = Encoding.EncodingName;
         }
 
         public event EventHandler<EventArgs> ExtraDiffArgumentsChanged;
@@ -982,22 +969,10 @@ namespace GitUI.Editor
             Encoding encod = null;
             if (string.IsNullOrEmpty(encodingToolStripComboBox.Text))
                 encod = Module.FilesEncoding;
-            else if (encodingToolStripComboBox.Text.StartsWith("Default", StringComparison.CurrentCultureIgnoreCase))
-                encod = Encoding.Default;
-            else if (encodingToolStripComboBox.Text.Equals("DOS852", StringComparison.CurrentCultureIgnoreCase))
-                encod = Encoding.GetEncoding("CP852");
-            else if (encodingToolStripComboBox.Text.Equals("ASCII", StringComparison.CurrentCultureIgnoreCase))
-                encod = new ASCIIEncoding();
-            else if (encodingToolStripComboBox.Text.Equals("Unicode", StringComparison.CurrentCultureIgnoreCase))
-                encod = new UnicodeEncoding();
-            else if (encodingToolStripComboBox.Text.Equals("UTF7", StringComparison.CurrentCultureIgnoreCase))
-                encod = new UTF7Encoding();
-            else if (encodingToolStripComboBox.Text.Equals("UTF8", StringComparison.CurrentCultureIgnoreCase))
-                encod = new UTF8Encoding(false);
-            else if (encodingToolStripComboBox.Text.Equals("UTF32", StringComparison.CurrentCultureIgnoreCase))
-                encod = new UTF32Encoding(true, false);
             else
-                encod = Module.FilesEncoding;
+                encod = AppSettings.AvailableEncodings.Values
+                      .Where(en => en.EncodingName == encodingToolStripComboBox.Text)
+                      .FirstOrDefault() ?? Module.FilesEncoding;
             if (!encod.Equals(this.Encoding))
             {
                 this.Encoding = encod;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -68,12 +68,19 @@ namespace GitUI.Editor
             showNonprintableCharactersToolStripMenuItem.Checked = AppSettings.ShowNonPrintingChars;
             ToggleNonPrintingChars(AppSettings.ShowNonPrintingChars);
 
-
             IsReadOnly = true;
+            var encodingList = AppSettings.AvailableEncodings.Values.Select(e => e.EncodingName).ToList();
+            var defaultEncodingName = Encoding.Default.EncodingName;
 
-            encodingToolStripComboBox.Items.AddRange(
-                AppSettings.AvailableEncodings.Values.Select(e => e.EncodingName).ToArray()
-                );
+            for (int i = 0; i < encodingList.Count; i++)
+            {
+                if (string.Compare(encodingList[i], defaultEncodingName, true) == 0)
+                {
+                    encodingList[i] = "Default (" + Encoding.Default.HeaderName + ")";
+                    break;
+                }
+            }
+            encodingToolStripComboBox.Items.AddRange(encodingList.ToArray());
 
             _internalFileViewer.MouseMove += TextAreaMouseMove;
             _internalFileViewer.MouseLeave += TextAreaMouseLeave;
@@ -177,7 +184,6 @@ namespace GitUI.Editor
             this.Encoding = null;
         }
 
-
         protected override void OnRuntimeLoad(EventArgs e)
         {
             this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
@@ -238,6 +244,7 @@ namespace GitUI.Editor
         protected virtual void OnRequestDiffView(EventArgs args)
         {
             var handler = RequestDiffView;
+
             if (handler != null)
             {
                 handler(this, args);
@@ -287,7 +294,6 @@ namespace GitUI.Editor
             copyPatchToolStripMenuItem.Visible = visible;
         }
 
-
         private void OnExtraDiffArgumentsChanged()
         {
             if (ExtraDiffArgumentsChanged != null)
@@ -297,6 +303,7 @@ namespace GitUI.Editor
         public string GetExtraDiffArguments()
         {
             var diffArguments = new StringBuilder();
+
             if (IgnoreWhitespaceChanges)
                 diffArguments.Append(" --ignore-space-change");
 
@@ -327,7 +334,6 @@ namespace GitUI.Editor
                 fileviewerToolbar != null)
                 fileviewerToolbar.Visible = false;
         }
-
 
         public void SaveCurrentScrollPos()
         {
@@ -472,7 +478,9 @@ namespace GitUI.Editor
         private void ViewItem(string fileName, Func<Image> getImage, Func<string> getFileText, Func<string> getSubmoduleText)
         {
             FilePreabmle = null;
+
             string fullPath = Path.GetFullPath(Path.Combine(Module.WorkingDir, fileName));
+
             if (fileName.EndsWith("/") || Directory.Exists(fullPath))
             {
                 if (GitModule.IsValidGitWorkingDir(fullPath))
@@ -501,7 +509,6 @@ namespace GitUI.Editor
                                     {
                                         PictureBox.SizeMode = PictureBoxSizeMode.CenterImage;
                                     }
-
                                 }
                                 PictureBox.Image = image;
                             });
@@ -515,7 +522,6 @@ namespace GitUI.Editor
                 _async.Load(getFileText, text => ViewText(fileName, text));
             }
         }
-
 
         private bool IsBinaryFile(string fileName)
         {
@@ -583,6 +589,7 @@ namespace GitUI.Editor
         private string GetFileText(string fileName)
         {
             string path;
+
             if (File.Exists(fileName))
                 path = fileName;
             else
@@ -627,6 +634,7 @@ namespace GitUI.Editor
         }
 
         private bool patchHighlighting;
+
         private void ResetForDiff()
         {
             Reset(true, true);
@@ -702,6 +710,7 @@ namespace GitUI.Editor
         private void CopyToolStripMenuItemClick(object sender, EventArgs e)
         {
             string code = _internalFileViewer.GetSelectedText();
+
             if (string.IsNullOrEmpty(code))
                 return;
 
@@ -730,9 +739,10 @@ namespace GitUI.Editor
         private string RemovePrefix(string line)
         {
             var isCombinedDiff = DiffHighlightService.IsCombinedDiff(_internalFileViewer.GetText());
-            var specials = isCombinedDiff ? new[]{"  ", "++", "+ ", " +", "--", "- ", " -"}
-                : new[]{ " ", "-", "+" };
-            if(string.IsNullOrWhiteSpace(line))
+            var specials = isCombinedDiff ? new[] { "  ", "++", "+ ", " +", "--", "- ", " -" }
+                : new[] { " ", "-", "+" };
+
+            if (string.IsNullOrWhiteSpace(line))
             {
                 return line;
             }
@@ -746,6 +756,7 @@ namespace GitUI.Editor
         private void CopyPatchToolStripMenuItemClick(object sender, EventArgs e)
         {
             var selectedText = _internalFileViewer.GetSelectedText();
+
             if (!string.IsNullOrEmpty(selectedText))
             {
                 Clipboard.SetText(selectedText);
@@ -753,6 +764,7 @@ namespace GitUI.Editor
             }
 
             var text = _internalFileViewer.GetText();
+
             if (!text.IsNullOrEmpty())
                 Clipboard.SetText(text);
         }
@@ -800,6 +812,7 @@ namespace GitUI.Editor
         private void NextChangeButtonClick(object sender, EventArgs e)
         {
             Focus();
+
             var firstVisibleLine = _internalFileViewer.LineAtCaret;
             var totalNumberOfLines = _internalFileViewer.TotalNumberOfLines;
             var emptyLineCheck = false;
@@ -807,6 +820,7 @@ namespace GitUI.Editor
             for (var line = firstVisibleLine + 1; line < totalNumberOfLines; line++)
             {
                 var lineContent = _internalFileViewer.GetLineText(line);
+
                 if (IsDiffLine(_internalFileViewer.GetText(), lineContent))
                 {
                     if (emptyLineCheck)
@@ -829,13 +843,14 @@ namespace GitUI.Editor
         private static bool IsDiffLine(string wholeText, string lineContent)
         {
             var isCombinedDiff = DiffHighlightService.IsCombinedDiff(wholeText);
-            return lineContent.StartsWithAny(isCombinedDiff ? new[] {"+", "-", " +", " -"}
-                : new[] {"+", "-"});
+            return lineContent.StartsWithAny(isCombinedDiff ? new[] { "+", "-", " +", " -" }
+                : new[] { "+", "-" });
         }
 
         private void PreviousChangeButtonClick(object sender, EventArgs e)
         {
             Focus();
+
             var firstVisibleLine = _internalFileViewer.LineAtCaret;
             var emptyLineCheck = false;
             //go to the top of change block
@@ -846,6 +861,7 @@ namespace GitUI.Editor
             for (var line = firstVisibleLine; line > 0; line--)
             {
                 var lineContent = _internalFileViewer.GetLineText(line);
+
                 if (lineContent.StartsWithAny(new string[] { "+", "-" })
                     && !lineContent.StartsWithAny(new string[] { "++", "--" }))
                 {
@@ -960,15 +976,19 @@ namespace GitUI.Editor
             return (_internalFileViewer.GetText() != null && _internalFileViewer.GetText().Contains("@@"));
         }
 
-        public void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader){
+        public void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader)
+        {
             _internalFileViewer.SetFileLoader(fileLoader);
         }
 
         private void encodingToolStripComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             Encoding encod = null;
+
             if (string.IsNullOrEmpty(encodingToolStripComboBox.Text))
                 encod = Module.FilesEncoding;
+            else if (encodingToolStripComboBox.Text.StartsWith("Default", StringComparison.CurrentCultureIgnoreCase))
+                encod = Encoding.Default;
             else
                 encod = AppSettings.AvailableEncodings.Values
                       .Where(en => en.EncodingName == encodingToolStripComboBox.Text)
@@ -1004,6 +1024,7 @@ namespace GitUI.Editor
         {
             string code = _internalFileViewer.GetSelectedText();
             bool noSelection = false;
+
             if (string.IsNullOrEmpty(code))
             {
                 code = _internalFileViewer.GetText();
@@ -1015,9 +1036,11 @@ namespace GitUI.Editor
                 //add artificail space if selected text is not starting from line begining, it will be removed later
                 int pos = noSelection ? 0 : _internalFileViewer.GetSelectionPosition();
                 string fileText = _internalFileViewer.GetText();
+
                 if (pos > 0)
                     if (fileText[pos - 1] != '\n')
                         code = " " + code;
+
                 IEnumerable<string> lines = code.Split('\n');
                 lines = lines.Where(s => s.Length == 0 || s[0] != startChar || (s.Length > 2 && s[1] == s[0] && s[2] == s[0]));
                 int hpos = fileText.IndexOf("\n@@");
@@ -1067,6 +1090,7 @@ namespace GitUI.Editor
             if (patch != null && patch.Length > 0)
             {
                 string output = Module.RunGitCmd(args, null, patch);
+
                 if (!string.IsNullOrEmpty(output))
                 {
                     if (!MergeConflictHandler.HandleMergeConflicts(UICommands, this, false, false))

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -267,7 +267,7 @@ namespace GitUI.Editor
         private void UpdateEncodingCombo()
         {
             if (Encoding != null)
-            encodingToolStripComboBox.Text = Encoding.EncodingName;
+                encodingToolStripComboBox.Text = Encoding.EncodingName;
         }
 
         public event EventHandler<EventArgs> ExtraDiffArgumentsChanged;

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -180,6 +180,12 @@
     <Compile Include="CommandsDialogs\RepoHosting\ViewPullRequestsForm.Designer.cs">
       <DependentUpon>ViewPullRequestsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\FormAvailableEncodings.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\FormAvailableEncodings.Designer.cs">
+      <DependentUpon>FormAvailableEncodings.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\DiffViewerSettingsPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1102,6 +1108,9 @@
     <EmbeddedResource Include="CommandsDialogs\RepoHosting\ViewPullRequestsForm.resx">
       <DependentUpon>ViewPullRequestsForm.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\SettingsDialog\FormAvailableEncodings.resx">
+      <DependentUpon>FormAvailableEncodings.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\DiffViewerSettingsPage.resx">
       <DependentUpon>DiffViewerSettingsPage.cs</DependentUpon>


### PR DESCRIPTION
Changes proposed in this pull request:
 - 
Create new form for choosing encoding.
Added support all available encodings .NET in file viewer.
 
Screenshots after:
-

![settings](https://cloud.githubusercontent.com/assets/838185/24839200/c59a1954-1d5e-11e7-8336-c58fb9c8d183.png)

![configureencodings](https://cloud.githubusercontent.com/assets/838185/24839201/c59a8056-1d5e-11e7-875e-bcfd5fe6be79.png)

Has been tested on:
 - Git 2.12 
 - Windows 10
