### PR TITLE
Able to build the installer in Visual Studio 2017 MSBuild15 environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ UpgradeLog*.htm*
 packages/
 GitExtensions.*.sln.VisualState.xml
 GitExtensions.settings.backup
+vswhere*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ UpgradeLog*.htm*
 packages/
 GitExtensions.*.sln.VisualState.xml
 GitExtensions.settings.backup
-vswhere*.exe

--- a/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{BBE7B8AD-D175-4679-A614-38BFF28B0269}</ProjectGuid>
     <RootNamespace>GitExtensionsShellEx</RootNamespace>
     <Keyword>AtlProj</Keyword>
-    <VCTargetsPath Condition="'$(VCTargetsPath11)' != '' and '$(VSVersion)' == '' and $(VisualStudioVersion) == ''">$(VCTargetsPath11)</VCTargetsPath>
     <ProjectName>GitExtensionsShellEx</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Setup/BuildInstallers.VS2017.cmd
+++ b/Setup/BuildInstallers.VS2017.cmd
@@ -2,12 +2,19 @@
 
 cd /d "%~p0"
 
-IF NOT EXIST "%~p0\tools\vswhere1.0.62.exe" (
-    "%~p0\tools\curl.exe" -L -k -o %~p0\tools\vswhere1.0.62.exe https://github.com/Microsoft/vswhere/releases/download/1.0.62/vswhere.exe -L https://github.com > NUL
-    IF ERRORLEVEL 1 EXIT /B 1
+set subPathToVsWhere=Microsoft Visual Studio\Installer\vswhere.exe
+if exist "%ProgramFiles(x86)%" (
+    set vswhere="%ProgramFiles(x86)%\%subPathToVsWhere%"
+) else (
+    set vswhere="%ProgramFiles%\%subPathToVsWhere%"
 )
 
-for /f "usebackq tokens=1* delims=: " %%i in (`.\tools\vswhere1.0.62.exe -latest -requires Microsoft.Component.MSBuild`) do (
+if not exist %vswhere% (
+    echo "Failed to find vswhere.exe, make sure you have installed Visual Studio 15.2.26418.1 or a later version."
+    exit /B 1
+)
+
+for /f "usebackq tokens=1* delims=: " %%i in (`%vswhere% -latest -requires Microsoft.Component.MSBuild`) do (
   if /i "%%i"=="installationPath" set msbuild="%%j\MSBuild\15.0\Bin\MSBuild.exe"
 )
 

--- a/Setup/BuildInstallers.VS2017.cmd
+++ b/Setup/BuildInstallers.VS2017.cmd
@@ -1,0 +1,49 @@
+@echo off
+
+cd /d "%~p0"
+
+IF NOT EXIST "%~p0\tools\vswhere1.0.62.exe" (
+    "%~p0\tools\curl.exe" -L -k -o %~p0\tools\vswhere1.0.62.exe https://github.com/Microsoft/vswhere/releases/download/1.0.62/vswhere.exe -L https://github.com > NUL
+    IF ERRORLEVEL 1 EXIT /B 1
+)
+
+for /f "usebackq tokens=1* delims=: " %%i in (`.\tools\vswhere1.0.62.exe -latest -requires Microsoft.Component.MSBuild`) do (
+  if /i "%%i"=="installationPath" set msbuild="%%j\MSBuild\15.0\Bin\MSBuild.exe"
+)
+
+set project=..\GitExtensions.VS2015.sln
+set projectShellEx=..\GitExtensionsShellEx\GitExtensionsShellEx.vcxproj
+set projectSshAskPass=..\GitExtSshAskPass\SshAskPass.vcxproj
+set nuget=..\.nuget\nuget.exe
+set SkipShellExtRegistration=1
+set EnableNuGetPackageRestore=true
+
+set msbuildparams=/p:Configuration=Release /t:Rebuild /nologo /v:m
+
+%nuget% install ..\GitUI\packages.config -OutputDirectory ..\packages -Source https://nuget.org/api/v2/
+%nuget% install ..\GitExtensionsVSIX\packages.config -OutputDirectory ..\packages -Source https://nuget.org/api/v2/
+%nuget% install ..\Plugins\BackgroundFetch\packages.config -OutputDirectory ..\packages -Source https://nuget.org/api/v2/
+%nuget% install ..\Plugins\BuildServerIntegration\TeamCityIntegration\packages.config -OutputDirectory ..\packages -Source https://nuget.org/api/v2/
+%nuget% install packages.config -OutputDirectory ..\packages -Source https://nuget.org/api/v2/
+%nuget% install ..\Externals\conemu-inside\ConEmuWinForms\packages.config -OutputDirectory ..\packages -Source https://nuget.org/api/v2/
+
+%msbuild% %project% /p:Platform="Any CPU" %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+%msbuild% %projectShellEx% /p:Platform=Win32 %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+%msbuild% %projectShellEx% /p:Platform=x64 %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+%msbuild% %projectSshAskPass% /p:Platform=Win32 %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+
+call MakeInstallers.cmd
+IF ERRORLEVEL 1 EXIT /B 1
+
+%msbuild% %project% /p:Platform="Any CPU" /p:DefineConstants=__MonoCS__ %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+
+call MakeMonoArchive.cmd
+IF ERRORLEVEL 1 EXIT /B 1
+
+echo.
+pause


### PR DESCRIPTION
Changes proposed in this pull request:
 - Able to build the installer using msbuild15/vs2017

How did I test this code:
 - Run the buildinstaller.vs2017.cmd in the setup folder. 
 - Install the complete_setup with the explore integration ticked
 - Right click a repo and verify the gitextensions menu items are still working.
 - Push a branch to a repo of a new host e.g. bitbucket, make sure the openssh will ask for password

i'm not able to test the buildinstaller.vs2015.cmd, can someone verify that buildinstaller.vs2015.cmd is still working

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10 64-bit