### PR TITLE
Add a context menu command for copying the commit hash to the clipboard

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -34,6 +34,16 @@
             this.RevisionInfo = new System.Windows.Forms.RichTextBox();
             this.commitInfoContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyCommitInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyCommitHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyCommitSubjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyCommitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyAuthorNameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyAuthorEmailToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyAuthorDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyCommitterNameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyCommitterEmailToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyCommitDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.showContainedInBranchesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showContainedInBranchesRemoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -101,6 +111,7 @@
             // 
             this.commitInfoContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyCommitInfoToolStripMenuItem,
+            this.copyToolStripMenuItem,
             this.toolStripSeparator1,
             this.showContainedInBranchesToolStripMenuItem,
             this.showContainedInBranchesRemoteToolStripMenuItem,
@@ -110,14 +121,94 @@
             this.toolStripSeparator2,
             this.addNoteToolStripMenuItem});
             this.commitInfoContextMenuStrip.Name = "commitInfoContextMenuStrip";
-            this.commitInfoContextMenuStrip.Size = new System.Drawing.Size(454, 170);
+            this.commitInfoContextMenuStrip.Size = new System.Drawing.Size(454, 192);
             // 
             // copyCommitInfoToolStripMenuItem
             // 
             this.copyCommitInfoToolStripMenuItem.Name = "copyCommitInfoToolStripMenuItem";
             this.copyCommitInfoToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
-            this.copyCommitInfoToolStripMenuItem.Text = "Copy commit info";
+            this.copyCommitInfoToolStripMenuItem.Text = "Copy full commit info";
             this.copyCommitInfoToolStripMenuItem.Click += new System.EventHandler(this.copyCommitInfoToolStripMenuItem_Click);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyCommitHashToolStripMenuItem,
+            this.copyCommitSubjectToolStripMenuItem,
+            this.copyCommitMessageToolStripMenuItem,
+            this.copyAuthorNameToolStripMenuItem,
+            this.copyAuthorEmailToolStripMenuItem,
+            this.copyAuthorDateToolStripMenuItem,
+            this.copyCommitterNameToolStripMenuItem,
+            this.copyCommitterEmailToolStripMenuItem,
+            this.copyCommitDateToolStripMenuItem});
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
+            this.copyToolStripMenuItem.Text = "Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyCommitHashToolStripMenuItem_Click);
+            // 
+            // copyCommitHashToolStripMenuItem
+            // 
+            this.copyCommitHashToolStripMenuItem.Name = "copyCommitHashToolStripMenuItem";
+            this.copyCommitHashToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyCommitHashToolStripMenuItem.Text = "Commit hash";
+            this.copyCommitHashToolStripMenuItem.Click += new System.EventHandler(this.copyCommitHashToolStripMenuItem_Click);
+            // 
+            // copyCommitSubjectToolStripMenuItem
+            // 
+            this.copyCommitSubjectToolStripMenuItem.Name = "copyCommitSubjectToolStripMenuItem";
+            this.copyCommitSubjectToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyCommitSubjectToolStripMenuItem.Text = "Commit subject";
+            this.copyCommitSubjectToolStripMenuItem.Click += new System.EventHandler(this.copyCommitSubjectToolStripMenuItem_Click);
+            // 
+            // copyCommitMessageToolStripMenuItem
+            // 
+            this.copyCommitMessageToolStripMenuItem.Name = "copyCommitMessageToolStripMenuItem";
+            this.copyCommitMessageToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyCommitMessageToolStripMenuItem.Text = "Commit message";
+            this.copyCommitMessageToolStripMenuItem.Click += new System.EventHandler(this.copyCommitMessageToolStripMenuItem_Click);
+            // 
+            // copyAuthorNameToolStripMenuItem
+            // 
+            this.copyAuthorNameToolStripMenuItem.Name = "copyAuthorNameToolStripMenuItem";
+            this.copyAuthorNameToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyAuthorNameToolStripMenuItem.Text = "Author name";
+            this.copyAuthorNameToolStripMenuItem.Click += new System.EventHandler(this.copyAuthorNameToolStripMenuItem_Click);
+            // 
+            // copyAuthorEmailToolStripMenuItem
+            // 
+            this.copyAuthorEmailToolStripMenuItem.Name = "copyAuthorEmailToolStripMenuItem";
+            this.copyAuthorEmailToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyAuthorEmailToolStripMenuItem.Text = "Author e-mail";
+            this.copyAuthorEmailToolStripMenuItem.Click += new System.EventHandler(this.copyAuthorEmailToolStripMenuItem_Click);
+            // 
+            // copyAuthorDateToolStripMenuItem
+            // 
+            this.copyAuthorDateToolStripMenuItem.Name = "copyAuthorDateToolStripMenuItem";
+            this.copyAuthorDateToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyAuthorDateToolStripMenuItem.Text = "Author date";
+            this.copyAuthorDateToolStripMenuItem.Click += new System.EventHandler(this.copyAuthorDateToolStripMenuItem_Click);
+            // 
+            // copyCommitterNameToolStripMenuItem
+            // 
+            this.copyCommitterNameToolStripMenuItem.Name = "copyCommitterNameToolStripMenuItem";
+            this.copyCommitterNameToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyCommitterNameToolStripMenuItem.Text = "Committer name";
+            this.copyCommitterNameToolStripMenuItem.Click += new System.EventHandler(this.copyCommitterNameToolStripMenuItem_Click);
+            // 
+            // copyCommitterEmailToolStripMenuItem
+            // 
+            this.copyCommitterEmailToolStripMenuItem.Name = "copyCommitterEmailToolStripMenuItem";
+            this.copyCommitterEmailToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyCommitterEmailToolStripMenuItem.Text = "Committer e-mail";
+            this.copyCommitterEmailToolStripMenuItem.Click += new System.EventHandler(this.copyCommitterEmailToolStripMenuItem_Click);
+            // 
+            // copyCommitDateToolStripMenuItem
+            // 
+            this.copyCommitDateToolStripMenuItem.Name = "copyCommitDateToolStripMenuItem";
+            this.copyCommitDateToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copyCommitDateToolStripMenuItem.Text = "Commit date";
+            this.copyCommitDateToolStripMenuItem.Click += new System.EventHandler(this.copyCommitDateToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
@@ -218,5 +309,15 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem addNoteToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showMessagesOfAnnotatedTagsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyCommitHashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyAuthorNameToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyAuthorEmailToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyAuthorDateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyCommitterNameToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyCommitterEmailToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyCommitMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyCommitDateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyCommitSubjectToolStripMenuItem;
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -35,6 +35,8 @@
             this.commitInfoContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyCommitInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copySelectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copySelectionToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.copyCommitHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyCommitSubjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyCommitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -122,6 +124,7 @@
             this.addNoteToolStripMenuItem});
             this.commitInfoContextMenuStrip.Name = "commitInfoContextMenuStrip";
             this.commitInfoContextMenuStrip.Size = new System.Drawing.Size(454, 192);
+            this.commitInfoContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.commitInfoContextMenuStrip_Opening);
             // 
             // copyCommitInfoToolStripMenuItem
             // 
@@ -133,6 +136,8 @@
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copySelectionToolStripMenuItem,
+            this.copySelectionToolStripSeparator,
             this.copyCommitHashToolStripMenuItem,
             this.copyCommitSubjectToolStripMenuItem,
             this.copyCommitMessageToolStripMenuItem,
@@ -146,6 +151,18 @@
             this.copyToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
             this.copyToolStripMenuItem.Text = "Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyCommitHashToolStripMenuItem_Click);
+            // 
+            // copySelectionToolStripMenuItem
+            // 
+            this.copySelectionToolStripMenuItem.Name = "copySelectionToolStripMenuItem";
+            this.copySelectionToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.copySelectionToolStripMenuItem.Text = "Selection";
+            this.copySelectionToolStripMenuItem.Click += new System.EventHandler(this.copySelectionToolStripMenuItem_Click);
+            // 
+            // copySelectionToolStripSeparator
+            // 
+            this.copySelectionToolStripSeparator.Name = "copySelectionToolStripSeparator";
+            this.copySelectionToolStripSeparator.Size = new System.Drawing.Size(166, 6);
             // 
             // copyCommitHashToolStripMenuItem
             // 
@@ -319,5 +336,7 @@
         private System.Windows.Forms.ToolStripMenuItem copyCommitMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyCommitDateToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyCommitSubjectToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copySelectionToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator copySelectionToolStripSeparator;
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -566,6 +566,11 @@ namespace GitUI.CommitInfo
             ReloadCommitInfo();
         }
 
+        private void copySelectionToolStripMenuItem_Click( object sender, EventArgs e )
+        {
+            Clipboard.SetText(SelectedText);
+        }
+
         private void copyCommitHashToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Clipboard.SetText(_revision.Guid);
@@ -673,6 +678,23 @@ namespace GitUI.CommitInfo
         {
             // Cache desired size for commit header
             _headerResize = e.NewRectangle;
+        }
+        /// <summary>
+        /// Gets the selected text from both the header and the info panel
+        /// </summary>
+        private string SelectedText
+        {
+            get
+            {
+                var selectedText = string.Join( Environment.NewLine, _RevisionHeader.SelectedText, RevisionInfo.SelectedText );
+
+                return string.IsNullOrWhiteSpace( selectedText ) ? string.Empty : selectedText;
+            }
+        }
+
+        private void commitInfoContextMenuStrip_Opening( object sender, CancelEventArgs e )
+        {
+            copySelectionToolStripMenuItem.Enabled = SelectedText.Length > 0;
         }
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -566,6 +566,51 @@ namespace GitUI.CommitInfo
             ReloadCommitInfo();
         }
 
+        private void copyCommitHashToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.Guid);
+        }
+
+        private void copyCommitSubjectToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.Subject);
+        }
+
+        private void copyCommitMessageToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.Body);
+        }
+
+        private void copyAuthorNameToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.Author);
+        }
+
+        private void copyAuthorEmailToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.AuthorEmail);
+        }
+
+        private void copyAuthorDateToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.AuthorDate.ToString());
+        }
+
+        private void copyCommitterNameToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.Committer);
+        }
+
+        private void copyCommitterEmailToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.CommitterEmail);
+        }
+
+        private void copyCommitDateToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Clipboard.SetText(_revision.CommitDate.ToString());
+        }
+
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var commitInfo = string.Empty;


### PR DESCRIPTION
Fixes #3505.
Since the commit info is displayed in a `RichTextBox`, I couldn't simply add a copy button. Therefore I've added a context menu command.

Changes proposed in this pull request:
 - a *Copy commit hash* context menu command has been added
 - the command for copying the commit info was renamed to *Copy **full** commit info* to better differentiate it from the first command
 
Screenshots before and after (if PR changes UI):
Before:
![obrazek](https://cloud.githubusercontent.com/assets/11479798/25277126/bd176e60-269d-11e7-9d59-5244e6f36265.png)

After:
![obrazek](https://cloud.githubusercontent.com/assets/11479798/25277079/8f8e02ba-269d-11e7-93df-568175401472.png)

Has been tested on (remove any that don't apply):
 - GIT 2.10.1
 - Windows 10
