### PR TITLE
Add Reword functionality in Advanced menu 

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7592,6 +7592,10 @@ If this is a central repository (bare repository without a working directory):
         <source>Revert commit</source>
         <target />
       </trans-unit>
+      <trans-unit id="rewordCommitToolStripMenuItem.Text">
+        <source>Reword commit</source>
+        <target />
+      </trans-unit>
       <trans-unit id="runScriptToolStripMenuItem.Text">
         <source>Run script</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -122,6 +122,7 @@ namespace GitUI
             this.cherryPickCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.archiveRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.manipulateCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.rewordCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fixupCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.squashCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -583,13 +584,14 @@ namespace GitUI
             // 
             this.manipulateCommitToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.editCommitToolStripMenuItem,
+            this.rewordCommitToolStripMenuItem,
             this.fixupCommitToolStripMenuItem,
             this.squashCommitToolStripMenuItem,
             this.getHelpOnHowToUseTheseFeaturesToolStripMenuItem});
             this.manipulateCommitToolStripMenuItem.Name = "manipulateCommitToolStripMenuItem";
             this.manipulateCommitToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
             this.manipulateCommitToolStripMenuItem.Text = "Advanced";
-            // 
+            //
             // fixupCommitToolStripMenuItem
             // 
             this.fixupCommitToolStripMenuItem.Name = "fixupCommitToolStripMenuItem";
@@ -798,6 +800,13 @@ namespace GitUI
             this.editCommitToolStripMenuItem.Text = "Edit commit";
             this.editCommitToolStripMenuItem.Click += new System.EventHandler(this.editCommitToolStripMenuItem_Click);
             // 
+            // rewordCommitToolStripMenuItem
+            //
+            this.rewordCommitToolStripMenuItem.Name = "rewordCommitToolStripMenuItem";
+            this.rewordCommitToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
+            this.rewordCommitToolStripMenuItem.Text = "Reword commit";
+            this.rewordCommitToolStripMenuItem.Click += new System.EventHandler(this.rewordCommitToolStripMenuItem_Click);
+            // 
             // RevisionGrid
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -868,6 +877,7 @@ namespace GitUI
         private System.Windows.Forms.Button CloneRepository;
         private System.Windows.Forms.ToolStripMenuItem showMergeCommitsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem manipulateCommitToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem rewordCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fixupCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem squashCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem renameBranchToolStripMenuItem;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3359,15 +3359,25 @@ namespace GitUI
 
         private void editCommitToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            launchRebase("e");
+        }
+
+        private void rewordCommitToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            launchRebase("r");
+        }
+
+        private void launchRebase(string command)
+        {
             if (LatestSelectedRevision == null)
                 return;
 
-            String rebaseCmd = GitCommandHelpers.RebaseCmd(LatestSelectedRevision.ParentGuids[0], 
+            String rebaseCmd = GitCommandHelpers.RebaseCmd(LatestSelectedRevision.ParentGuids[0],
                 interactive: true, preserveMerges: false, autosquash: false, autostash: true);
 
             using (var formProcess = new FormProcess(null, rebaseCmd, Module.WorkingDir, null, true))
             {
-                formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", "sed -i -re '0,/pick/s//e/'");
+                formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", String.Format("sed -i -re '0,/pick/s//{0}/'", command));
                 formProcess.ShowDialog(this);
             }
         }


### PR DESCRIPTION
Add Reword functionality in Advanced menu.
By clicking it, it will :
- launch a git rebase interactive on one of the commit parent.
- replace automatically the first "pick" by "r".

![image](https://cloud.githubusercontent.com/assets/3659358/25307763/2a1f4776-27a7-11e7-8e6f-d18d698de4f6.png)
