### PR TITLE
fix: Layout issues with FormRecentReposSettings

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
@@ -29,12 +29,17 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.FlowLayoutPanel flpnlControls;
+            System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+            this.Ok = new System.Windows.Forms.Button();
+            this.Abort = new System.Windows.Forms.Button();
             this._NO_TRANSLATE_maxRecentRepositories = new System.Windows.Forms.NumericUpDown();
             this.maxRecentRepositories = new System.Windows.Forms.Label();
             this.sortLessRecentRepos = new System.Windows.Forms.CheckBox();
             this.sortMostRecentRepos = new System.Windows.Forms.CheckBox();
             this.comboPanel = new System.Windows.Forms.Panel();
-            this.LessRecentLB = new System.Windows.Forms.ListBox();
+            this.LessRecentLB = new System.Windows.Forms.ListView();
+            this.chdrRepository1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.anchorToMostToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.anchorToLessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -42,62 +47,102 @@
             this.removeRecentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.panel3 = new System.Windows.Forms.Panel();
             this.label1 = new System.Windows.Forms.Label();
-            this.MostRecentLB = new System.Windows.Forms.ListBox();
+            this.MostRecentLB = new System.Windows.Forms.ListView();
+            this.chdrRepository = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.panel2 = new System.Windows.Forms.Panel();
             this.MostRecentLabel = new System.Windows.Forms.Label();
-            this.Abort = new System.Windows.Forms.Button();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.Ok = new System.Windows.Forms.Button();
             this.shorteningGB = new System.Windows.Forms.GroupBox();
             this.dontShortenRB = new System.Windows.Forms.RadioButton();
             this.middleDotRB = new System.Windows.Forms.RadioButton();
             this.mostSigDirRB = new System.Windows.Forms.RadioButton();
             this.comboMinWidthEdit = new System.Windows.Forms.NumericUpDown();
             this.comboMinWidthLabel = new System.Windows.Forms.Label();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.comboMinWidthNote = new System.Windows.Forms.Label();
+            flpnlControls = new System.Windows.Forms.FlowLayoutPanel();
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            flpnlControls.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_maxRecentRepositories)).BeginInit();
             this.comboPanel.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.panel3.SuspendLayout();
             this.panel2.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
             this.shorteningGB.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.comboMinWidthEdit)).BeginInit();
-            this.tableLayoutPanel1.SuspendLayout();
+            tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // flpnlControls
+            // 
+            flpnlControls.Controls.Add(this.Ok);
+            flpnlControls.Controls.Add(this.Abort);
+            flpnlControls.Dock = System.Windows.Forms.DockStyle.Bottom;
+            flpnlControls.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            flpnlControls.Location = new System.Drawing.Point(0, 327);
+            flpnlControls.Name = "flpnlControls";
+            flpnlControls.Size = new System.Drawing.Size(676, 34);
+            flpnlControls.TabIndex = 2;
+            flpnlControls.WrapContents = false;
+            // 
+            // Ok
+            // 
+            this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.Ok.AutoSize = true;
+            this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.Ok.Location = new System.Drawing.Point(549, 3);
+            this.Ok.Name = "Ok";
+            this.Ok.Size = new System.Drawing.Size(124, 25);
+            this.Ok.TabIndex = 0;
+            this.Ok.Text = "OK";
+            this.Ok.UseCompatibleTextRendering = true;
+            this.Ok.UseVisualStyleBackColor = true;
+            this.Ok.Click += new System.EventHandler(this.Ok_Click);
+            // 
+            // Abort
+            // 
+            this.Abort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.Abort.AutoSize = true;
+            this.Abort.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.Abort.Location = new System.Drawing.Point(468, 3);
+            this.Abort.Name = "Abort";
+            this.Abort.Size = new System.Drawing.Size(75, 25);
+            this.Abort.TabIndex = 1;
+            this.Abort.Text = "Cancel";
+            this.Abort.UseCompatibleTextRendering = true;
+            this.Abort.UseVisualStyleBackColor = true;
+            this.Abort.Click += new System.EventHandler(this.Abort_Click);
             // 
             // _NO_TRANSLATE_maxRecentRepositories
             // 
-            this._NO_TRANSLATE_maxRecentRepositories.Location = new System.Drawing.Point(292, 11);
+            this._NO_TRANSLATE_maxRecentRepositories.Location = new System.Drawing.Point(250, 11);
             this._NO_TRANSLATE_maxRecentRepositories.Maximum = new decimal(new int[] {
             1000000,
             0,
             0,
             0});
             this._NO_TRANSLATE_maxRecentRepositories.Name = "_NO_TRANSLATE_maxRecentRepositories";
-            this._NO_TRANSLATE_maxRecentRepositories.Size = new System.Drawing.Size(61, 23);
-            this._NO_TRANSLATE_maxRecentRepositories.TabIndex = 0;
+            this._NO_TRANSLATE_maxRecentRepositories.Size = new System.Drawing.Size(61, 21);
+            this._NO_TRANSLATE_maxRecentRepositories.TabIndex = 1;
             this._NO_TRANSLATE_maxRecentRepositories.ValueChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
             // 
             // maxRecentRepositories
             // 
             this.maxRecentRepositories.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.maxRecentRepositories.AutoSize = true;
-            this.maxRecentRepositories.Location = new System.Drawing.Point(11, 14);
+            this.maxRecentRepositories.Location = new System.Drawing.Point(11, 15);
             this.maxRecentRepositories.Name = "maxRecentRepositories";
-            this.maxRecentRepositories.Size = new System.Drawing.Size(269, 16);
-            this.maxRecentRepositories.TabIndex = 57;
+            this.maxRecentRepositories.Size = new System.Drawing.Size(222, 13);
+            this.maxRecentRepositories.TabIndex = 0;
             this.maxRecentRepositories.Text = "Maximum number of most recent repositories";
             // 
             // sortLessRecentRepos
             // 
             this.sortLessRecentRepos.AutoSize = true;
             this.sortLessRecentRepos.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.sortLessRecentRepos.Location = new System.Drawing.Point(11, 66);
+            this.sortLessRecentRepos.Location = new System.Drawing.Point(11, 61);
             this.sortLessRecentRepos.Name = "sortLessRecentRepos";
             this.sortLessRecentRepos.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.sortLessRecentRepos.Size = new System.Drawing.Size(269, 20);
-            this.sortLessRecentRepos.TabIndex = 2;
+            this.sortLessRecentRepos.Size = new System.Drawing.Size(228, 17);
+            this.sortLessRecentRepos.TabIndex = 3;
             this.sortLessRecentRepos.Text = "Sort less recent repositories alphabetically";
             this.sortLessRecentRepos.UseVisualStyleBackColor = true;
             this.sortLessRecentRepos.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
@@ -106,11 +151,11 @@
             // 
             this.sortMostRecentRepos.AutoSize = true;
             this.sortMostRecentRepos.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.sortMostRecentRepos.Location = new System.Drawing.Point(11, 40);
+            this.sortMostRecentRepos.Location = new System.Drawing.Point(11, 38);
             this.sortMostRecentRepos.Name = "sortMostRecentRepos";
             this.sortMostRecentRepos.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.sortMostRecentRepos.Size = new System.Drawing.Size(275, 20);
-            this.sortMostRecentRepos.TabIndex = 1;
+            this.sortMostRecentRepos.Size = new System.Drawing.Size(233, 17);
+            this.sortMostRecentRepos.TabIndex = 2;
             this.sortMostRecentRepos.Text = "Sort most recent repositories alphabetically";
             this.sortMostRecentRepos.UseVisualStyleBackColor = true;
             this.sortMostRecentRepos.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
@@ -121,23 +166,35 @@
             this.comboPanel.Controls.Add(this.panel3);
             this.comboPanel.Controls.Add(this.MostRecentLB);
             this.comboPanel.Controls.Add(this.panel2);
-            this.comboPanel.Dock = System.Windows.Forms.DockStyle.Right;
-            this.comboPanel.Location = new System.Drawing.Point(394, 0);
+            this.comboPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.comboPanel.Location = new System.Drawing.Point(322, 0);
             this.comboPanel.Name = "comboPanel";
-            this.comboPanel.Size = new System.Drawing.Size(233, 449);
-            this.comboPanel.TabIndex = 60;
+            this.comboPanel.Size = new System.Drawing.Size(354, 327);
+            this.comboPanel.TabIndex = 1;
             // 
             // LessRecentLB
             // 
+            this.LessRecentLB.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chdrRepository1});
             this.LessRecentLB.ContextMenuStrip = this.contextMenuStrip1;
-            this.LessRecentLB.DisplayMember = "Caption";
             this.LessRecentLB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LessRecentLB.FormattingEnabled = true;
-            this.LessRecentLB.ItemHeight = 16;
-            this.LessRecentLB.Location = new System.Drawing.Point(0, 179);
+            this.LessRecentLB.GridLines = true;
+            this.LessRecentLB.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.LessRecentLB.HideSelection = false;
+            this.LessRecentLB.LabelWrap = false;
+            this.LessRecentLB.Location = new System.Drawing.Point(0, 162);
+            this.LessRecentLB.MultiSelect = false;
             this.LessRecentLB.Name = "LessRecentLB";
-            this.LessRecentLB.Size = new System.Drawing.Size(233, 270);
-            this.LessRecentLB.TabIndex = 6;
+            this.LessRecentLB.OwnerDraw = true;
+            this.LessRecentLB.Size = new System.Drawing.Size(354, 165);
+            this.LessRecentLB.TabIndex = 2;
+            this.LessRecentLB.UseCompatibleStateImageBehavior = false;
+            this.LessRecentLB.View = System.Windows.Forms.View.Details;
+            this.LessRecentLB.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.listView_DrawItem);
+            // 
+            // chdrRepository1
+            // 
+            this.chdrRepository1.Text = "Header";
             // 
             // contextMenuStrip1
             // 
@@ -147,34 +204,34 @@
             this.removeAnchorToolStripMenuItem,
             this.removeRecentToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(252, 92);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(258, 92);
             this.contextMenuStrip1.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip1_Opening);
             // 
             // anchorToMostToolStripMenuItem
             // 
             this.anchorToMostToolStripMenuItem.Name = "anchorToMostToolStripMenuItem";
-            this.anchorToMostToolStripMenuItem.Size = new System.Drawing.Size(251, 22);
+            this.anchorToMostToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
             this.anchorToMostToolStripMenuItem.Text = "Anchor to most recent repositories";
             this.anchorToMostToolStripMenuItem.Click += new System.EventHandler(this.anchorToMostToolStripMenuItem_Click);
             // 
             // anchorToLessToolStripMenuItem
             // 
             this.anchorToLessToolStripMenuItem.Name = "anchorToLessToolStripMenuItem";
-            this.anchorToLessToolStripMenuItem.Size = new System.Drawing.Size(251, 22);
+            this.anchorToLessToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
             this.anchorToLessToolStripMenuItem.Text = "Anchor to less recent repositories";
             this.anchorToLessToolStripMenuItem.Click += new System.EventHandler(this.anchorToLessToolStripMenuItem_Click);
             // 
             // removeAnchorToolStripMenuItem
             // 
             this.removeAnchorToolStripMenuItem.Name = "removeAnchorToolStripMenuItem";
-            this.removeAnchorToolStripMenuItem.Size = new System.Drawing.Size(251, 22);
+            this.removeAnchorToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
             this.removeAnchorToolStripMenuItem.Text = "Remove anchor";
             this.removeAnchorToolStripMenuItem.Click += new System.EventHandler(this.removeAnchorToolStripMenuItem_Click);
             // 
             // removeRecentToolStripMenuItem
             // 
             this.removeRecentToolStripMenuItem.Name = "removeRecentToolStripMenuItem";
-            this.removeRecentToolStripMenuItem.Size = new System.Drawing.Size(251, 22);
+            this.removeRecentToolStripMenuItem.Size = new System.Drawing.Size(257, 22);
             this.removeRecentToolStripMenuItem.Text = "Remove from recent repositories";
             this.removeRecentToolStripMenuItem.Click += new System.EventHandler(this.removeRecentToolStripMenuItem_Click);
             // 
@@ -183,9 +240,9 @@
             this.panel3.AutoSize = true;
             this.panel3.Controls.Add(this.label1);
             this.panel3.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel3.Location = new System.Drawing.Point(0, 154);
+            this.panel3.Location = new System.Drawing.Point(0, 140);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(233, 25);
+            this.panel3.Size = new System.Drawing.Size(354, 22);
             this.panel3.TabIndex = 3;
             // 
             // label1
@@ -193,21 +250,33 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(3, 9);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(144, 16);
-            this.label1.TabIndex = 1;
+            this.label1.Size = new System.Drawing.Size(121, 13);
+            this.label1.TabIndex = 0;
             this.label1.Text = "Less recent repositories";
             // 
             // MostRecentLB
             // 
+            this.MostRecentLB.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chdrRepository});
             this.MostRecentLB.ContextMenuStrip = this.contextMenuStrip1;
-            this.MostRecentLB.DisplayMember = "Caption";
             this.MostRecentLB.Dock = System.Windows.Forms.DockStyle.Top;
-            this.MostRecentLB.FormattingEnabled = true;
-            this.MostRecentLB.ItemHeight = 16;
-            this.MostRecentLB.Location = new System.Drawing.Point(0, 22);
+            this.MostRecentLB.GridLines = true;
+            this.MostRecentLB.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.MostRecentLB.HideSelection = false;
+            this.MostRecentLB.LabelWrap = false;
+            this.MostRecentLB.Location = new System.Drawing.Point(0, 19);
+            this.MostRecentLB.MultiSelect = false;
             this.MostRecentLB.Name = "MostRecentLB";
-            this.MostRecentLB.Size = new System.Drawing.Size(233, 132);
-            this.MostRecentLB.TabIndex = 5;
+            this.MostRecentLB.OwnerDraw = true;
+            this.MostRecentLB.Size = new System.Drawing.Size(354, 121);
+            this.MostRecentLB.TabIndex = 0;
+            this.MostRecentLB.UseCompatibleStateImageBehavior = false;
+            this.MostRecentLB.View = System.Windows.Forms.View.Details;
+            this.MostRecentLB.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.listView_DrawItem);
+            // 
+            // chdrRepository
+            // 
+            this.chdrRepository.Text = "Header";
             // 
             // panel2
             // 
@@ -217,60 +286,17 @@
             this.panel2.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel2.Location = new System.Drawing.Point(0, 0);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(233, 22);
-            this.panel2.TabIndex = 1;
+            this.panel2.Size = new System.Drawing.Size(354, 19);
+            this.panel2.TabIndex = 0;
             // 
             // MostRecentLabel
             // 
             this.MostRecentLabel.AutoSize = true;
             this.MostRecentLabel.Location = new System.Drawing.Point(3, 6);
             this.MostRecentLabel.Name = "MostRecentLabel";
-            this.MostRecentLabel.Size = new System.Drawing.Size(146, 16);
+            this.MostRecentLabel.Size = new System.Drawing.Size(123, 13);
             this.MostRecentLabel.TabIndex = 0;
             this.MostRecentLabel.Text = "Most recent repositories";
-            // 
-            // Abort
-            // 
-            this.Abort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.Abort.AutoSize = true;
-            this.Abort.Location = new System.Drawing.Point(316, 3);
-            this.Abort.Name = "Abort";
-            this.Abort.Size = new System.Drawing.Size(75, 28);
-            this.Abort.TabIndex = 8;
-            this.Abort.Text = "Cancel";
-            this.Abort.UseCompatibleTextRendering = true;
-            this.Abort.UseVisualStyleBackColor = true;
-            this.Abort.Click += new System.EventHandler(this.Abort_Click);
-            // 
-            // tableLayoutPanel2
-            // 
-            this.tableLayoutPanel2.ColumnCount = 4;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.Controls.Add(this.Abort, 2, 0);
-            this.tableLayoutPanel2.Controls.Add(this.Ok, 1, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 449);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 1;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(627, 34);
-            this.tableLayoutPanel2.TabIndex = 59;
-            // 
-            // Ok
-            // 
-            this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.Ok.AutoSize = true;
-            this.Ok.Location = new System.Drawing.Point(235, 3);
-            this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(75, 28);
-            this.Ok.TabIndex = 7;
-            this.Ok.Text = "OK";
-            this.Ok.UseCompatibleTextRendering = true;
-            this.Ok.UseVisualStyleBackColor = true;
-            this.Ok.Click += new System.EventHandler(this.Ok_Click);
             // 
             // shorteningGB
             // 
@@ -279,10 +305,11 @@
             this.shorteningGB.Controls.Add(this.dontShortenRB);
             this.shorteningGB.Controls.Add(this.middleDotRB);
             this.shorteningGB.Controls.Add(this.mostSigDirRB);
-            this.shorteningGB.Location = new System.Drawing.Point(11, 92);
+            this.shorteningGB.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.shorteningGB.Location = new System.Drawing.Point(11, 84);
             this.shorteningGB.Name = "shorteningGB";
-            this.shorteningGB.Size = new System.Drawing.Size(212, 110);
-            this.shorteningGB.TabIndex = 3;
+            this.shorteningGB.Size = new System.Drawing.Size(233, 105);
+            this.shorteningGB.TabIndex = 4;
             this.shorteningGB.TabStop = false;
             this.shorteningGB.Text = "Shortening strategy";
             // 
@@ -291,7 +318,7 @@
             this.dontShortenRB.AutoSize = true;
             this.dontShortenRB.Location = new System.Drawing.Point(6, 22);
             this.dontShortenRB.Name = "dontShortenRB";
-            this.dontShortenRB.Size = new System.Drawing.Size(118, 20);
+            this.dontShortenRB.Size = new System.Drawing.Size(103, 17);
             this.dontShortenRB.TabIndex = 0;
             this.dontShortenRB.TabStop = true;
             this.dontShortenRB.Text = "Do not shorten  ";
@@ -303,7 +330,7 @@
             this.middleDotRB.AutoSize = true;
             this.middleDotRB.Location = new System.Drawing.Point(6, 68);
             this.middleDotRB.Name = "middleDotRB";
-            this.middleDotRB.Size = new System.Drawing.Size(200, 20);
+            this.middleDotRB.Size = new System.Drawing.Size(169, 17);
             this.middleDotRB.TabIndex = 2;
             this.middleDotRB.TabStop = true;
             this.middleDotRB.Text = "Replace middle part with dots ";
@@ -315,7 +342,7 @@
             this.mostSigDirRB.AutoSize = true;
             this.mostSigDirRB.Location = new System.Drawing.Point(6, 45);
             this.mostSigDirRB.Name = "mostSigDirRB";
-            this.mostSigDirRB.Size = new System.Drawing.Size(199, 20);
+            this.mostSigDirRB.Size = new System.Drawing.Size(169, 17);
             this.mostSigDirRB.TabIndex = 1;
             this.mostSigDirRB.TabStop = true;
             this.mostSigDirRB.Text = "The most significant directory ";
@@ -324,69 +351,86 @@
             // 
             // comboMinWidthEdit
             // 
-            this.comboMinWidthEdit.Location = new System.Drawing.Point(292, 208);
+            this.comboMinWidthEdit.Location = new System.Drawing.Point(250, 195);
             this.comboMinWidthEdit.Maximum = new decimal(new int[] {
             800,
             0,
             0,
             0});
             this.comboMinWidthEdit.Name = "comboMinWidthEdit";
-            this.comboMinWidthEdit.Size = new System.Drawing.Size(61, 23);
-            this.comboMinWidthEdit.TabIndex = 4;
-            this.comboMinWidthEdit.ValueChanged += new System.EventHandler(this.numericUpDown1_ValueChanged);
+            this.comboMinWidthEdit.Size = new System.Drawing.Size(61, 21);
+            this.comboMinWidthEdit.TabIndex = 6;
+            this.comboMinWidthEdit.ValueChanged += new System.EventHandler(this.comboMinWidthEdit_ValueChanged);
             // 
             // comboMinWidthLabel
             // 
             this.comboMinWidthLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.comboMinWidthLabel.AutoSize = true;
-            this.comboMinWidthLabel.Location = new System.Drawing.Point(11, 211);
+            this.comboMinWidthLabel.Location = new System.Drawing.Point(11, 199);
             this.comboMinWidthLabel.Name = "comboMinWidthLabel";
-            this.comboMinWidthLabel.Size = new System.Drawing.Size(246, 16);
-            this.comboMinWidthLabel.TabIndex = 62;
+            this.comboMinWidthLabel.Size = new System.Drawing.Size(202, 13);
+            this.comboMinWidthLabel.TabIndex = 5;
             this.comboMinWidthLabel.Text = "Combobox minimum width (0 = Autosize)";
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.AutoSize = true;
-            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel1.ColumnCount = 3;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel1.Controls.Add(this.maxRecentRepositories, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_maxRecentRepositories, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.comboMinWidthEdit, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.sortMostRecentRepos, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.comboMinWidthLabel, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.sortLessRecentRepos, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.shorteningGB, 0, 3);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.MinimumSize = new System.Drawing.Size(0, 450);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
-            this.tableLayoutPanel1.RowCount = 6;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(394, 450);
-            this.tableLayoutPanel1.TabIndex = 63;
+            tableLayoutPanel1.AutoSize = true;
+            tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.Controls.Add(this.comboMinWidthNote, 0, 5);
+            tableLayoutPanel1.Controls.Add(this.maxRecentRepositories, 0, 0);
+            tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_maxRecentRepositories, 1, 0);
+            tableLayoutPanel1.Controls.Add(this.comboMinWidthEdit, 1, 4);
+            tableLayoutPanel1.Controls.Add(this.sortMostRecentRepos, 0, 1);
+            tableLayoutPanel1.Controls.Add(this.comboMinWidthLabel, 0, 4);
+            tableLayoutPanel1.Controls.Add(this.sortLessRecentRepos, 0, 2);
+            tableLayoutPanel1.Controls.Add(this.shorteningGB, 0, 3);
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Left;
+            tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
+            tableLayoutPanel1.RowCount = 6;
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            tableLayoutPanel1.Size = new System.Drawing.Size(322, 327);
+            tableLayoutPanel1.TabIndex = 0;
+            // 
+            // label2
+            // 
+            tableLayoutPanel1.SetColumnSpan(this.comboMinWidthNote, 2);
+            this.comboMinWidthNote.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.comboMinWidthNote.Location = new System.Drawing.Point(11, 219);
+            this.comboMinWidthNote.Name = "comboMinWidthNote";
+            this.comboMinWidthNote.Padding = new System.Windows.Forms.Padding(12, 0, 0, 0);
+            this.comboMinWidthNote.Size = new System.Drawing.Size(300, 100);
+            this.comboMinWidthNote.TabIndex = 7;
+            this.comboMinWidthNote.Text = "NB: The width of the columns helps to visualise how the repository name will be shown in the combobox.";
             // 
             // FormRecentReposSettings
             // 
+            this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.AutoSize = true;
-            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ClientSize = new System.Drawing.Size(627, 483);
-            this.Controls.Add(this.tableLayoutPanel1);
+            this.CancelButton = this.Abort;
+            this.ClientSize = new System.Drawing.Size(684, 361);
             this.Controls.Add(this.comboPanel);
-            this.Controls.Add(this.tableLayoutPanel2);
+            this.Controls.Add(tableLayoutPanel1);
+            this.Controls.Add(flpnlControls);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(700, 400);
             this.Name = "FormRecentReposSettings";
+            this.Padding = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Recent repositories settings";
+            flpnlControls.ResumeLayout(false);
+            flpnlControls.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_maxRecentRepositories)).EndInit();
             this.comboPanel.ResumeLayout(false);
             this.comboPanel.PerformLayout();
@@ -395,13 +439,11 @@
             this.panel3.PerformLayout();
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
             this.shorteningGB.ResumeLayout(false);
             this.shorteningGB.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.comboMinWidthEdit)).EndInit();
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
+            tableLayoutPanel1.ResumeLayout(false);
+            tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -414,13 +456,11 @@
         private System.Windows.Forms.CheckBox sortLessRecentRepos;
         private System.Windows.Forms.CheckBox sortMostRecentRepos;
         private System.Windows.Forms.Panel comboPanel;
-        private System.Windows.Forms.ListBox LessRecentLB;
-        private System.Windows.Forms.ListBox MostRecentLB;
+        private System.Windows.Forms.ListView LessRecentLB;
+        private System.Windows.Forms.ListView MostRecentLB;
         private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Label MostRecentLabel;
         protected System.Windows.Forms.Button Abort;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-        protected System.Windows.Forms.Button Ok;
         private System.Windows.Forms.GroupBox shorteningGB;
         private System.Windows.Forms.RadioButton mostSigDirRB;
         private System.Windows.Forms.RadioButton middleDotRB;
@@ -434,6 +474,9 @@
         private System.Windows.Forms.ToolStripMenuItem removeAnchorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem removeRecentToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem anchorToLessToolStripMenuItem;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Button Ok;
+        private System.Windows.Forms.ColumnHeader chdrRepository;
+        private System.Windows.Forms.ColumnHeader chdrRepository1;
+        private System.Windows.Forms.Label comboMinWidthNote;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -1,23 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Repository;
-using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
 {
     public partial class FormRecentReposSettings : GitExtensionsForm
     {
-        private readonly int ComboWidth;
-        private readonly int FormWidth;
-
         public FormRecentReposSettings()
+            : base(true)
         {
             InitializeComponent();
-            FormWidth = Width;
-            ComboWidth = comboPanel.Width;
             Translate();
             LoadSettings();
             RefreshRepos();
@@ -31,7 +27,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             sortLessRecentRepos.Checked = AppSettings.SortLessRecentRepos;
             _NO_TRANSLATE_maxRecentRepositories.Value = AppSettings.MaxMostRecentRepositories;
             comboMinWidthEdit.Value = AppSettings.RecentReposComboMinWidth;
-
         }
 
         private void SaveSettings()
@@ -93,19 +88,25 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
 
             foreach (RecentRepoInfo repo in mostRecentRepos)
-                MostRecentLB.Items.Add(repo);
+                MostRecentLB.Items.Add(new ListViewItem(repo.Caption) { Tag = repo, ToolTipText = repo.Caption });
 
             foreach (RecentRepoInfo repo in lessRecentRepos)
-                LessRecentLB.Items.Add(repo);
+                LessRecentLB.Items.Add(new ListViewItem(repo.Caption) { Tag = repo, ToolTipText = repo.Caption });
         }
 
         private void SetComboWidth()
         {
             if (comboMinWidthEdit.Value == 0)
-                comboPanel.Width = ComboWidth;
+            {
+                MostRecentLB.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+                LessRecentLB.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+            }
             else
-                comboPanel.Width = (int)comboMinWidthEdit.Value + 30;
-            this.Width = FormWidth + comboPanel.Width - ComboWidth;
+            {
+                int width = Math.Max(30, (int)comboMinWidthEdit.Value);
+                MostRecentLB.Columns[0].Width = width;
+                LessRecentLB.Columns[0].Width = width;
+            }
         }
 
         private void sortMostRecentRepos_CheckedChanged(object sender, EventArgs e)
@@ -113,10 +114,21 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             RefreshRepos();
         }
 
-        private void numericUpDown1_ValueChanged(object sender, EventArgs e)
+        private void comboMinWidthEdit_ValueChanged(object sender, EventArgs e)
         {
-            SetComboWidth();
-            RefreshRepos();
+            try
+            {
+                MostRecentLB.BeginUpdate();
+                LessRecentLB.BeginUpdate();
+
+                SetComboWidth();
+                RefreshRepos();
+            }
+            finally
+            {
+                MostRecentLB.EndUpdate();
+                LessRecentLB.EndUpdate();
+            }
         }
 
         private void Ok_Click(object sender, EventArgs e)
@@ -147,13 +159,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private bool GetSelectedRepo(object sender, out RecentRepoInfo repo)
         {
             if (sender is ContextMenuStrip)
-                sender = (sender as ContextMenuStrip).SourceControl;
+                sender = ((ContextMenuStrip)sender).SourceControl;
             else if (sender is ToolStripItem)
-                return GetSelectedRepo((sender as ToolStripItem).Owner, out repo);
+                return GetSelectedRepo(((ToolStripItem)sender).Owner, out repo);
             else
                 sender = null;
 
-            ListBox lb;
+            ListView lb;
             if (sender == MostRecentLB)
                 lb = MostRecentLB;
             else if (sender == LessRecentLB)
@@ -161,11 +173,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             else
                 lb = null;
 
-            if (lb != null)
-                repo = (RecentRepoInfo)lb.SelectedItem;
-            else
-                repo = null;
-
+            repo = null;
+            if (lb?.SelectedItems.Count > 0)
+            {
+                repo = lb.SelectedItems[0].Tag as RecentRepoInfo;
+            }
             return repo != null;
         }
 
@@ -213,6 +225,17 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
         }
 
+        private void listView_DrawItem(object sender, DrawListViewItemEventArgs e)
+        {
+            var listView = (ListView)sender;
 
+            var rowBounds = e.Bounds;
+            int leftMargin = e.Item.GetBounds(ItemBoundsPortion.Label).Left;
+            var bounds = new Rectangle(leftMargin, rowBounds.Top, rowBounds.Width - leftMargin, rowBounds.Height);
+
+            e.Graphics.FillRectangle(SystemBrushes.Window, bounds);
+            TextRenderer.DrawText(e.Graphics, e.Item.Text, listView.Font, bounds, SystemColors.ControlText,
+                                  TextFormatFlags.Left | TextFormatFlags.SingleLine | TextFormatFlags.GlyphOverhangPadding | TextFormatFlags.VerticalCenter);
+        }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.resx
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.resx
@@ -117,8 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="flpnlControls.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="tableLayoutPanel1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>32</value>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5345,6 +5345,10 @@ Nothing to rebase.</source>
         <source>Sort most recent repositories alphabetically</source>
         <target />
       </trans-unit>
+      <trans-unit id="comboMinWidthNote.Text">
+        <source>NB: The width of the columns helps to visualise how the repository name will be shown in the combobox.</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="FormRemotes" source-language="en">


### PR DESCRIPTION
The existing layout prevented the dialog from being resized to accommodate for longer repository names.
Also fix tab stops and set dialog results.