### PR TITLE
fix: Remove duplicate resource reference

### DIFF
--- a/GitUI/BuildServerIntegration/BuildInfoDrawingLogic.cs
+++ b/GitUI/BuildServerIntegration/BuildInfoDrawingLogic.cs
@@ -28,7 +28,7 @@ namespace GitUI.BuildServerIntegration
                         buildStatusImage = Resources.BuildCancelled;
                         break;
                     case BuildInfo.BuildStatus.InProgress:
-                        buildStatusImage = Resources.Icon_77;
+                        buildStatusImage = Resources.Settings;
                         break;
                     case BuildInfo.BuildStatus.Unstable:
                         buildStatusImage = Resources.IconMixed;

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -563,7 +563,7 @@ namespace GitUI.CommandsDialogs
             // toolStripBranchFilterDropDownButton
             // 
             this.toolStripBranchFilterDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripBranchFilterDropDownButton.Image = global::GitUI.Properties.Resources.Icon_77;
+            this.toolStripBranchFilterDropDownButton.Image = global::GitUI.Properties.Resources.Settings;
             this.toolStripBranchFilterDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripBranchFilterDropDownButton.Name = "toolStripBranchFilterDropDownButton";
             this.toolStripBranchFilterDropDownButton.Size = new System.Drawing.Size(29, 22);
@@ -599,7 +599,7 @@ namespace GitUI.CommandsDialogs
             // toolStripRevisionFilterDropDownButton
             // 
             this.toolStripRevisionFilterDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripRevisionFilterDropDownButton.Image = global::GitUI.Properties.Resources.Icon_77;
+            this.toolStripRevisionFilterDropDownButton.Image = global::GitUI.Properties.Resources.Settings;
             this.toolStripRevisionFilterDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripRevisionFilterDropDownButton.Name = "toolStripRevisionFilterDropDownButton";
             this.toolStripRevisionFilterDropDownButton.Size = new System.Drawing.Size(29, 22);

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -722,16 +722,6 @@ namespace GitUI.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
-        internal static System.Drawing.Bitmap Icon_77 {
-            get {
-                object obj = ResourceManager.GetObject("Icon_77", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
         internal static System.Drawing.Bitmap Icon_82 {
             get {
                 object obj = ResourceManager.GetObject("Icon_82", resourceCulture);

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -211,9 +211,6 @@
   <data name="TranslateProgress" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>../Resources/Icons/53.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="Icon_77" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>../Resources/Icons/77.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="pageant" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>../Resources/Icons/pageant.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>


### PR DESCRIPTION
77.png was referenced under both "Settings" and "Icon_77".
