### PR TITLE
Add Clear List menu item into Recent Repositories items list. Fixes #1064.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -121,6 +121,8 @@ namespace GitUI.CommandsDialogs
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.recentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.clearRecentRepositoriesListToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+            this.clearRecentRepositoriesListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
             this.cloneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cloneSVNToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1212,7 +1214,9 @@ namespace GitUI.CommandsDialogs
             // recentToolStripMenuItem
             // 
             this.recentToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem2});
+            this.toolStripMenuItem2,
+            this.clearRecentRepositoriesListToolStripMenuItem,
+            this.clearRecentRepositoriesListMenuItem});
             this.recentToolStripMenuItem.Image = global::GitUI.Properties.Resources.RecentRepositories;
             this.recentToolStripMenuItem.Name = "recentToolStripMenuItem";
             this.recentToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
@@ -1221,8 +1225,20 @@ namespace GitUI.CommandsDialogs
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(83, 22);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(152, 22);
             this.toolStripMenuItem2.Text = "...";
+            // 
+            // clearRecentRepositoriesListToolStripMenuItem
+            // 
+            this.clearRecentRepositoriesListToolStripMenuItem.Name = "clearRecentRepositoriesListToolStripMenuItem";
+            this.clearRecentRepositoriesListToolStripMenuItem.Size = new System.Drawing.Size(149, 6);
+            // 
+            // clearRecentRepositoriesListMenuItem
+            // 
+            this.clearRecentRepositoriesListMenuItem.Name = "clearRecentRepositoriesListMenuItem";
+            this.clearRecentRepositoriesListMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.clearRecentRepositoriesListMenuItem.Text = "Clear List";
+            this.clearRecentRepositoriesListMenuItem.Click += new System.EventHandler(ClearRecentRepositoriesListClick);
             // 
             // toolStripSeparator12
             // 
@@ -2268,5 +2284,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem manageWorktreeToolStripMenuItem;
         private ToolStripMenuItem createWorktreeToolStripMenuItem;
         private ToolStripMenuItem toolStripMenuItemWorktrees;
+        private ToolStripMenuItem clearRecentRepositoriesListMenuItem;
+        private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1873,6 +1873,13 @@ namespace GitUI.CommandsDialogs
 
         private void FileToolStripMenuItemDropDownOpening(object sender, EventArgs e)
         {
+            if (Repositories.RepositoryHistory.Repositories.Count() == 0)
+            {
+                recentToolStripMenuItem.Enabled = false;
+                return;
+            }
+
+            recentToolStripMenuItem.Enabled = true;
             recentToolStripMenuItem.DropDownItems.Clear();
 
             foreach (var historyItem in Repositories.RepositoryHistory.Repositories)
@@ -1885,6 +1892,11 @@ namespace GitUI.CommandsDialogs
                 historyItemMenu.Width = 225;
                 recentToolStripMenuItem.DropDownItems.Add(historyItemMenu);
             }
+
+            // Re-add controls.
+            recentToolStripMenuItem.DropDownItems.Add(this.clearRecentRepositoriesListToolStripMenuItem);
+            TranslateItem(clearRecentRepositoriesListMenuItem.Name, clearRecentRepositoriesListMenuItem);
+            recentToolStripMenuItem.DropDownItems.Add(clearRecentRepositoriesListMenuItem);
         }
 
         private void ChangeWorkingDir(string path)
@@ -1916,6 +1928,16 @@ namespace GitUI.CommandsDialogs
                 return;
 
             ChangeWorkingDir(button.Text);
+        }
+
+        private void ClearRecentRepositoriesListClick(object sender, EventArgs e)
+        {
+            Repositories.RepositoryHistory.Repositories.Clear();
+            Repositories.SaveSettings();
+            // Force clear recent repositories list from dashboard.
+            if (this._dashboard != null) {
+                _dashboard.ShowRecentRepositories();
+            }
         }
 
         private void PluginSettingsToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #1064. This is almost five year old feature-request but I still find it useful to have.
I've kept this to minimum, nothing fancy.

Changes proposed in this pull request:
- _Clear List_ menu item was added into _Start_ > _Recent Repositories_;
- The _Recent Repositories_ menu item is disabled if the list is empty (VLC-like behavior).

Screenshots before and after (if PR changes UI):
**Before**
![0-before](https://cloud.githubusercontent.com/assets/12585988/25456365/6757d3c4-2adb-11e7-9c58-e623e83e98b0.png)

**After**
![1-after](https://cloud.githubusercontent.com/assets/12585988/25456377/6eb71044-2adb-11e7-93c8-30e76016609f.png)

![2-after](https://cloud.githubusercontent.com/assets/12585988/25456388/78fa0a84-2adb-11e7-91fb-6e19f9a48e8e.png)

How did I test this code:
 - Test scenario 1
1) Open several repositories to populate the list in _Recent Repositories_;
2) While dashboard is visible go to _Start_ > _Recent Repositories_ > _Clear List_;
3) Check that the _Recent Repositories_ list in the dashboard is cleared and _Recent Repositories_ menu item is disabled;
4) Close and reopen GitExtensions; Re-check step 3).

 - Test scenario 2
1) Open several repositories to populate the list in _Recent Repositories_;
2) While browser repository is visible > go to _Start_ > _Recent Repositories_ > _Clear List_;
3) Check that _Recent Repositories_ menu item is disabled.
4) Close and reopen GitExtensions; Re-check step 3) and that _Recent Repositories_ list in the dashboard is cleared.

Has been tested on (remove any that don't apply):
 - GIT 2.12.2.windows.1
 - Windows 10 x64
