### PR TITLE
Restoring splitters based on SplitContainer size and font size.

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Settings\ConfigFileSettingsCache.cs" />
     <Compile Include="Settings\FileSettingsCache.cs" />
     <Compile Include="Settings\GitExtSettingsCache.cs" />
+    <Compile Include="Settings\MemorySettings.cs" />
+    <Compile Include="Settings\MemorySettingsCache.cs" />
     <Compile Include="Settings\RepoDistSettings.cs" />
     <Compile Include="Settings\Setting.cs" />
     <Compile Include="Settings\SettingsCache.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -878,24 +878,6 @@ namespace GitCommands
             set { SetBool("showfirstparent", value); }
         }
 
-        public static int CommitDialogDeviceDpi
-        {
-            get { return GetInt("commitdialogdevicedpi", 96); }
-            set { SetInt("commitdialogdevicedpi", value); }
-        }
-
-        public static int CommitDialogSplitter
-        {
-            get { return GetInt("commitdialogsplitter", -1); }
-            set { SetInt("commitdialogsplitter", value); }
-        }
-
-        public static int CommitDialogRightSplitter
-        {
-            get { return GetInt("commitdialogrightsplitter", -1); }
-            set { SetInt("commitdialogrightsplitter", value); }
-        }
-
         public static bool CommitDialogSelectionFilter
         {
             get { return GetBool("commitdialogselectionfilter", false); }
@@ -1584,7 +1566,7 @@ namespace GitCommands
 
     }
 
-    internal class AppSettingsPath : SettingsPath
+    public class AppSettingsPath : SettingsPath
     {
         public AppSettingsPath(string aPathName) : base(null, aPathName)
         {

--- a/GitCommands/Settings/ConfigFileSettingsCache.cs
+++ b/GitCommands/Settings/ConfigFileSettingsCache.cs
@@ -43,7 +43,6 @@ namespace GitCommands.Settings
 
         protected override void ClearImpl()
         {
-            base.ClearImpl();
             ReadSettings(SettingsFilePath);
         }
 

--- a/GitCommands/Settings/GitExtSettingsCache.cs
+++ b/GitCommands/Settings/GitExtSettingsCache.cs
@@ -37,7 +37,6 @@ namespace GitCommands.Settings
 
         protected override void ClearImpl()
         {
-            base.ClearImpl();
             EncodedNameMap.Clear();
         }
 

--- a/GitCommands/Settings/MemorySettings.cs
+++ b/GitCommands/Settings/MemorySettings.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitCommands.Settings
+{
+    public class MemorySettings : SettingsContainer<MemorySettings, MemorySettingsCache>
+    {
+        public MemorySettings()
+            : base(null, new MemorySettingsCache())
+        {
+
+        }
+    }
+}

--- a/GitCommands/Settings/MemorySettingsCache.cs
+++ b/GitCommands/Settings/MemorySettingsCache.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitCommands.Settings
+{
+    public class MemorySettingsCache : SettingsCache
+    {
+        private IDictionary<string, string> stringSettings = new Dictionary<string, string>();
+
+        protected override void LoadImpl()
+        {
+            //cached in memory, do nothing
+        }
+
+        protected override bool NeedRefresh()
+        {
+            return false;
+        }
+
+        protected override void SaveImpl()
+        {
+            //cached in memory, do nothing
+        }
+
+        protected override void SetValueImpl(string key, string value)
+        {
+            stringSettings[key] = value;
+        }
+
+        protected override string GetValueImpl(string key)
+        {
+            string value = null;
+            if (stringSettings.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+
+        protected override void ClearImpl()
+        {
+            stringSettings.Clear();
+        }
+    }
+}

--- a/GitCommands/Settings/SettingsCache.cs
+++ b/GitCommands/Settings/SettingsCache.cs
@@ -46,15 +46,15 @@ namespace GitCommands
         protected abstract void SetValueImpl(string key, string value);        
         protected abstract string GetValueImpl(string key);
         protected abstract bool NeedRefresh();
-
-        protected virtual void ClearImpl()
-        {
-            ByNameMap.Clear();
-        }
+        protected abstract void ClearImpl();
 
         private void Clear()
         {
-            LockedAction(ClearImpl);
+            LockedAction(() =>
+            {
+                ClearImpl();
+                ByNameMap.Clear();
+            });
         }
 
         public void Save()

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -31,6 +31,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private readonly TranslationString directoryIsNotAValidRepositoryOpenIt = new TranslationString("The selected item is not a valid git repository.\n\nDo you want to open it?");
         private readonly TranslationString _showCurrentBranch = new TranslationString("Show current branch");
         private bool initialized;
+        private SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("Dashboard"));
 
         public Dashboard()
         {
@@ -159,17 +160,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public void SaveSplitterPositions()
         {
-            try
-            {
-                Settings.Default.Dashboard_DeviceDpi = GetCurrentDeviceDpi();
-                Settings.Default.Dashboard_MainSplitContainer_SplitterDistance = mainSplitContainer.SplitterDistance;
-                Settings.Default.Dashboard_CommonSplitContainer_SplitterDistance = commonSplitContainer.SplitterDistance;
-                Settings.Default.Save();
-            }
-            catch (ConfigurationException)
-            {
-                //TODO: howto restore a corrupted config? Properties.Settings.Default.Reset() doesn't work.
-            }
+            _splitterManager.SaveSplitters();
         }
 
         public event EventHandler<GitModuleEventArgs> GitModuleChanged;
@@ -266,77 +257,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public void SetSplitterPositions()
         {
-            try
-            {
-                int deviceDpi = GetCurrentDeviceDpi();
-                int dashboardDpi = Settings.Default.Dashboard_DeviceDpi;
-                int mainSplitterDistance = Settings.Default.Dashboard_MainSplitContainer_SplitterDistance;
-                int commonSplitterDistance = Settings.Default.Dashboard_CommonSplitContainer_SplitterDistance;
-
-                float scaleFactor = 1.0f * deviceDpi / dashboardDpi;
-                mainSplitterDistance = (int)(scaleFactor * mainSplitterDistance);
-                commonSplitterDistance = (int)(scaleFactor * commonSplitterDistance);
-
-                SetSplitterDistance(
-                    commonSplitContainer,
-                    commonSplitterDistance,
-                    Math.Max(2, (int)(CommonActions.Height * 1.2)));
-
-                SetSplitterDistance(
-                    splitContainer7,
-                    0, // No settings property for this splitter. Will use default always.
-                    Math.Max(2, splitContainer7.Height - (DonateCategory.Height + 25)));
-
-                SetSplitterDistance(
-                    mainSplitContainer,
-                    mainSplitterDistance,
-                    315);
-            }
-            catch (ConfigurationException)
-            {
-                //TODO: howto restore a corrupted config? Properties.Settings.Default.Reset() doesn't work.
-            }
-        }
-
-        private void SetSplitterDistance(SplitContainer splitContainer, int value, int @default)
-        {
-            try
-            {
-                if (isValidSplit(splitContainer,value))
-                {
-                    splitContainer.SplitterDistance = value;
-                }
-                else if (isValidSplit(splitContainer, @default))
-                {
-                    splitContainer.SplitterDistance = @default;
-                }
-                else
-                {
-                    // Both the value and default are invalid.
-                    // Don't attempt to change the SplitterDistance
-                }
-            }
-            catch (SystemException)
-            {
-                // The attempt to set even the default value has failed.
-            }
-        }
-
-        /// <summary>
-        /// Determine whether a given splitter value would be permitted for a given SplitContainer
-        /// </summary>
-        /// <param name="splitcontainer">The SplitContainer to check</param>
-        /// <param name="value">The potential SplitterDistance to try </param>
-        /// <returns>true if it is expected that setting a SplitterDistance of value would succeed
-        /// </returns>
-        bool isValidSplit(SplitContainer splitcontainer, int value)
-        {
-            bool valid;
-            int limit = (splitcontainer.Orientation == Orientation.Horizontal)
-                ? splitcontainer.Height
-                : splitcontainer.Width;
-            valid = (value > splitcontainer.Panel1MinSize) && (value < limit - splitcontainer.Panel2MinSize);
-            return valid;
+            _splitterManager.AddSplitter(commonSplitContainer, "commonSplitContainer", Math.Max(2, (int)(CommonActions.Height * 1.2)));
+            _splitterManager.AddSplitter(splitContainer7, "splitContainer7", Math.Max(2, splitContainer7.Height - (DonateCategory.Height + 25)));
+            _splitterManager.AddSplitter(mainSplitContainer, "mainSplitContainer", 315);
+            _splitterManager.RestoreSplitters();
         }
 
         private void TranslateItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -717,7 +717,6 @@ namespace GitUI.CommandsDialogs
             // 
             // FileTreeSplitContainer
             // 
-            this.FileTreeSplitContainer.DataBindings.Add(new System.Windows.Forms.Binding("SplitterDistance", global::GitUI.Properties.Settings.Default, "FormBrowse_FileTreeSplitContainer_SplitterDistance", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.FileTreeSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.FileTreeSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.FileTreeSplitContainer.Location = new System.Drawing.Point(3, 3);
@@ -943,7 +942,6 @@ namespace GitUI.CommandsDialogs
             // 
             // DiffSplitContainer
             // 
-            this.DiffSplitContainer.DataBindings.Add(new System.Windows.Forms.Binding("SplitterDistance", global::GitUI.Properties.Settings.Default, "FormBrowse_DiffSplitContainer_SplitterDistance", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.DiffSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DiffSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.DiffSplitContainer.Location = new System.Drawing.Point(3, 3);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -167,6 +167,7 @@ namespace GitUI.CommandsDialogs
 #pragma warning disable 0414
         private readonly FormBrowseMenuCommands _formBrowseMenuCommands;
 #pragma warning restore 0414
+        private SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("FormBrowse"));
 
         /// <summary>
         /// For VS designer
@@ -290,7 +291,7 @@ namespace GitUI.CommandsDialogs
             if (AppSettings.ShowRevisionInfoNextToRevisionGrid.ValueOrDefault)
             {
                 RevisionInfo.Parent = RevisionsSplitContainer.Panel2;
-                RevisionsSplitContainer.SplitterDistance = RevisionsSplitContainer.Width - 500;
+                RevisionsSplitContainer.SplitterDistance = RevisionsSplitContainer.Width - 420;
                 RevisionInfo.DisplayAvatarOnRight();
                 CommitInfoTabControl.SuspendLayout();
                 CommitInfoTabControl.RemoveIfExists(CommitInfoTabPage);
@@ -2907,48 +2908,18 @@ namespace GitUI.CommandsDialogs
 
         protected void SetSplitterPositions()
         {
-            try
-            {
-                int deviceDpi = GetCurrentDeviceDpi();
-                int browseFormDpi = Properties.Settings.Default.FormBrowse_DeviceDpi;
-                int mainSplitContainerSplitterDistance = Properties.Settings.Default.FormBrowse_MainSplitContainer_SplitterDistance;
-                int fileTreeSplitContainerSplitterDistance = Properties.Settings.Default.FormBrowse_FileTreeSplitContainer_SplitterDistance;
-                int diffSplitContainerSplitterDistance = Properties.Settings.Default.FormBrowse_DiffSplitContainer_SplitterDistance;
-
-                float scaleFactor = 1.0f * deviceDpi / browseFormDpi;
-                mainSplitContainerSplitterDistance = (int)(scaleFactor * mainSplitContainerSplitterDistance);
-                fileTreeSplitContainerSplitterDistance = (int)(scaleFactor * fileTreeSplitContainerSplitterDistance);
-                diffSplitContainerSplitterDistance = (int)(scaleFactor * diffSplitContainerSplitterDistance);
-                if (Properties.Settings.Default.FormBrowse_RevisionsSplitContainer_SplitterDistance > 0)
-                {
-                    RevisionsSplitContainer.SplitterDistance = (int)(scaleFactor * Properties.Settings.Default.FormBrowse_RevisionsSplitContainer_SplitterDistance);
-                }
-
-                if (mainSplitContainerSplitterDistance != 0)
-                    MainSplitContainer.SplitterDistance = mainSplitContainerSplitterDistance;
-                FileTreeSplitContainer.SplitterDistance = fileTreeSplitContainerSplitterDistance;
-                DiffSplitContainer.SplitterDistance = diffSplitContainerSplitterDistance;
-            }
-            catch (ConfigurationException)
-            {
-            }
+            _splitterManager.AddSplitter(RevisionsSplitContainer, "RevisionsSplitContainer");
+            _splitterManager.AddSplitter(MainSplitContainer, "MainSplitContainer");
+            _splitterManager.AddSplitter(FileTreeSplitContainer, "FileTreeSplitContainer");
+            _splitterManager.AddSplitter(DiffSplitContainer, "DiffSplitContainer");
+            //hide status in order to restore splitters against the full height (the most common case)
+            statusStrip.Hide();
+            _splitterManager.RestoreSplitters();
         }
 
         protected void SaveSplitterPositions()
         {
-            try
-            {
-                Properties.Settings.Default.FormBrowse_DeviceDpi = GetCurrentDeviceDpi();
-                Properties.Settings.Default.FormBrowse_MainSplitContainer_SplitterDistance = MainSplitContainer.SplitterDistance;
-                Properties.Settings.Default.FormBrowse_FileTreeSplitContainer_SplitterDistance = FileTreeSplitContainer.SplitterDistance;
-                Properties.Settings.Default.FormBrowse_DiffSplitContainer_SplitterDistance = DiffSplitContainer.SplitterDistance;
-                Properties.Settings.Default.FormBrowse_RevisionsSplitContainer_SplitterDistance = RevisionsSplitContainer.SplitterDistance;
-                Properties.Settings.Default.Save();
-            }
-            catch (ConfigurationException)
-            {
-                //TODO: howto restore a corrupted config? Properties.Settings.Default.Reset() doesn't work.
-            }
+            _splitterManager.SaveSplitters();
         }
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1723,7 +1723,6 @@ namespace GitUI.CommandsDialogs
         private static void SaveApplicationSettings()
         {
             AppSettings.SaveSettings();
-            Properties.Settings.Default.Save();
         }
 
         private void SaveUserMenuPosition()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -135,6 +135,7 @@ namespace GitUI.CommandsDialogs
         private CancellationTokenSource _interactiveAddBashCloseWaitCts = new CancellationTokenSource();
         private string _userName = "";
         private string _userEmail = "";
+        private SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("CommitDialog"));
         /// <summary>
         /// For VS designer
         /// </summary>
@@ -244,16 +245,9 @@ namespace GitUI.CommandsDialogs
 
         private void FormCommit_Load(object sender, EventArgs e)
         {
-            int deviceDpi = GetCurrentDeviceDpi();
-            int commitDialogDpi = AppSettings.CommitDialogDeviceDpi;
-            int commitDialogSplitter = AppSettings.CommitDialogSplitter;
-            int commitDialogRightSplitter = AppSettings.CommitDialogRightSplitter;
-
-            float scaleFactor = 1.0f * deviceDpi / commitDialogDpi;
-            if (commitDialogSplitter != -1)
-                splitMain.SplitterDistance = (int)(scaleFactor * commitDialogSplitter);
-            if (commitDialogRightSplitter != -1)
-                splitRight.SplitterDistance = (int)(scaleFactor * commitDialogRightSplitter);
+            _splitterManager.AddSplitter(splitMain, "splitMain");
+            _splitterManager.AddSplitter(splitRight, "splitRight");
+            _splitterManager.RestoreSplitters();
 
             SetVisibilityOfSelectionFilter(AppSettings.CommitDialogSelectionFilter);
             Reset.Visible = AppSettings.ShowResetAllChanges;
@@ -279,9 +273,7 @@ namespace GitUI.CommandsDialogs
             if (CommitKind.Normal == _commitKind)
                 GitCommands.CommitHelper.SetCommitMessage(Module, Message.Text, Amend.Checked);
 
-            AppSettings.CommitDialogDeviceDpi = GetCurrentDeviceDpi();
-            AppSettings.CommitDialogSplitter = splitMain.SplitterDistance;
-            AppSettings.CommitDialogRightSplitter = splitRight.SplitterDistance;
+            _splitterManager.SaveSplitters();
             AppSettings.CommitDialogSelectionFilter = toolbarSelectionFilter.Visible;
         }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -290,6 +290,7 @@
     <Compile Include="Script\PowerShellHelper.cs" />
     <Compile Include="RepoHosts.cs" />
     <Compile Include="AutoCompletion\AutoCompleteWord.cs" />
+    <Compile Include="SplitterManager.cs" />
     <Compile Include="UserControls\BranchComboBox.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -18,7 +18,7 @@ namespace GitUI
             _designTimeFontSize = designTimeFontSize;
         }
 
-        public SplitterData AddSplitter(SplitContainer splitter, string settingName, int? defaultDistance = null)
+        public void AddSplitter(SplitContainer splitter, string settingName, int? defaultDistance = null)
         {
             var data = new SplitterData()
             {
@@ -28,8 +28,6 @@ namespace GitUI
                 DesignTimeFontSize = _designTimeFontSize
             };
             splitters.Add(data);
-
-            return data;
         }
 
         public void RestoreSplitters()
@@ -47,7 +45,7 @@ namespace GitUI
             splitters.ForEach(s => s.AdjustToCurrentFontSize());
         }
 
-        public class SplitterData
+        private class SplitterData
         {
             public SplitContainer Splitter;
             public string SettingName;

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -1,0 +1,192 @@
+﻿using GitUIPluginInterfaces;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GitUI
+{
+    public class SplitterManager
+    {
+        private readonly ISettingsSource _settings;
+        private readonly List<SplitterData> splitters = new List<SplitterData>();
+        private float _designTimeFontSize;
+
+        public SplitterManager(ISettingsSource settings, float designTimeFontSize = 8.25F)
+        {
+            _settings = settings;
+            _designTimeFontSize = designTimeFontSize;
+        }
+
+        public SplitterData AddSplitter(SplitContainer splitter, string settingName, int? defaultDistance = null)
+        {
+            var data = new SplitterData()
+            {
+                Splitter = splitter,
+                SettingName = settingName,
+                DefaultDistance = defaultDistance,
+                DesignTimeFontSize = _designTimeFontSize
+            };
+            splitters.Add(data);
+
+            return data;
+        }
+
+        public void RestoreSplitters()
+        {
+            splitters.ForEach(s => s.RestoreFromSettings(_settings));
+        }
+
+        public void SaveSplitters()
+        {
+            splitters.ForEach(s => s.SaveToSettings(_settings));
+        }
+
+        public void AdjustAccordingToFontSize()
+        {
+            splitters.ForEach(s => s.AdjustToCurrentFontSize());
+        }
+
+        public class SplitterData
+        {
+            public SplitContainer Splitter;
+            public string SettingName;
+            public int? DefaultDistance;
+            public float DesignTimeFontSize;
+            private string SizeSettingsKey => SettingName + "_Size";
+            private string DistanceSettingsKey => SettingName + "_Distance";
+            private string FontSizeSettingsKey => SettingName + "_FontSize";
+            private float? _latestFontSize;
+
+            private int SplitterSize
+            {
+                get
+                {
+                    return (Splitter.Orientation == Orientation.Horizontal)
+                       ? Splitter.Height
+                       : Splitter.Width;
+                }
+            }
+
+            public void RestoreFromSettings(ISettingsSource settings)
+            {
+                _latestFontSize = settings.GetFloat(FontSizeSettingsKey);
+                if (!_latestFontSize.HasValue)
+                {
+                    _latestFontSize = DesignTimeFontSize;
+                }
+
+                int? prevSize = settings.GetInt(SizeSettingsKey);
+                int? prevDistance = settings.GetInt(DistanceSettingsKey);
+
+                if (prevSize > 0 && prevDistance > 0)
+                {
+                    if (SplitterSize == prevSize)
+                    {
+                        SetSplitterDistance(prevDistance.Value);
+                    }
+                    else
+                    {
+                        if (Splitter.FixedPanel == FixedPanel.None)
+                        {
+                            SetSplitterDistance(1F * SplitterSize * prevDistance.Value / prevSize.Value);
+                        }
+
+                        if (Splitter.FixedPanel == FixedPanel.Panel1)
+                        {
+                            SetSplitterDistance(prevDistance.Value);
+                        }
+
+                        if (Splitter.FixedPanel == FixedPanel.Panel2)
+                        {
+                            int panel2PrevSize = prevSize.Value - prevDistance.Value;
+                            SetSplitterDistance(SplitterSize - panel2PrevSize);
+                        }
+                    }
+                }
+
+                AdjustToCurrentFontSize();
+            }
+
+            public void AdjustToCurrentFontSize()
+            {
+                if (_latestFontSize.Value != 0 && Splitter.Font.Size != 0)
+                {
+                    if (_latestFontSize.Value != Splitter.Font.Size)
+                    {
+                        float scaleFactor = CalculateScaleFactor();
+                        if (scaleFactor != 0)
+                        {
+                            if (Splitter.FixedPanel == FixedPanel.Panel1)
+                            {
+                                SetSplitterDistance(Splitter.SplitterDistance + Splitter.SplitterDistance * scaleFactor);
+                            }
+
+                            if (Splitter.FixedPanel == FixedPanel.Panel2)
+                            {
+                                int panel2Size = SplitterSize - Splitter.SplitterDistance;
+                                SetSplitterDistance(Splitter.SplitterDistance - panel2Size * scaleFactor);
+                            }
+                        }
+                    }
+                }
+
+                _latestFontSize = Splitter.Font.Size;
+            }
+
+            private float CalculateScaleFactor()
+            {
+                return 1F * Splitter.Font.Size / _latestFontSize.Value - 1;
+            }
+
+            public void SaveToSettings(ISettingsSource settings)
+            {
+                settings.SetInt(SizeSettingsKey, SplitterSize);
+                settings.SetInt(DistanceSettingsKey, Splitter.SplitterDistance);
+                settings.SetFloat(FontSizeSettingsKey, Splitter.Font.Size);
+            }
+
+            private void SetSplitterDistance(float distance)
+            {
+                try
+                {
+                    int intDistance = Convert.ToInt32(distance);
+
+                    if (IsValidSplitterDistance(intDistance))
+                    {
+                        Splitter.SplitterDistance = intDistance;
+                    }
+                    else if (DefaultDistance.HasValue && IsValidSplitterDistance(DefaultDistance.Value))
+                    {
+                        Splitter.SplitterDistance = DefaultDistance.Value;
+                    }
+                    else
+                    {
+                        // Both the value and default are invalid.
+                        // Don't attempt to change the SplitterDistance
+                        // Use designtime font size to adjust to the current font size
+                        _latestFontSize = DesignTimeFontSize;
+                    }
+                }
+                catch
+                {
+                    // The attempt to set even the default value has failed.
+                }
+            }
+
+            /// <summary>
+            /// Determine whether a given splitter distance value would be permitted for the Splitter
+            /// </summary>
+            /// <param name="distance">The potential SplitterDistance to try </param>
+            /// <returns>true if it is expected that setting a SplitterDistance of distance would succeed
+            /// </returns>
+            private bool IsValidSplitterDistance(int distance)
+            {
+                bool valid;
+                int limit = SplitterSize;
+                valid = (distance > Splitter.Panel1MinSize) && (distance < limit - Splitter.Panel2MinSize);
+                return valid;
+            }
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
@@ -50,6 +50,25 @@ namespace GitUIPluginInterfaces
             });
         }
 
+        public void SetFloat(string name, float? value)
+        {
+            SetValue<float?>(name, value, (float? b) => b.HasValue ? b.ToString() : null);
+        }
+
+        public float? GetFloat(string name)
+        {
+            return GetValue<float?>(name, null, x =>
+            {
+                float result;
+                if (float.TryParse(x, out result))
+                {
+                    return result;
+                }
+
+                return null;
+            });
+        }
+
         public DateTime GetDate(string name, DateTime defaultValue)
         {
             return GetDate(name) ?? defaultValue;

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -52,6 +52,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -61,6 +62,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SplitterManagerTest.cs" />
     <Compile Include="TranslationTest.cs" />
     <Compile Include="UserControls\AuthorEmailBasedRevisionHighlightingFixture.cs" />
     <Compile Include="UserControls\ConsoleEmulatorOutputControlFixture.cs" />
@@ -108,6 +110,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="UserControls\RevisionGridClasses\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />

--- a/UnitTests/GitUITests/SplitterManagerTest.cs
+++ b/UnitTests/GitUITests/SplitterManagerTest.cs
@@ -1,0 +1,304 @@
+﻿using GitCommands.Settings;
+using GitUI;
+using NUnit.Framework;
+using FluentAssertions;
+using System.Drawing;
+using System.Windows.Forms;
+using System;
+
+namespace GitUITests
+{
+    [TestFixture]
+    public class SplitterManagerTest
+    {
+        private MemorySettings _settings;
+        private const float _designTimeFontSize = 10;
+        private const int _designTimeSplitterWidth = 100;
+        private const int _designTimeSplitterDistance = 40;
+
+        [SetUp]
+        public void SetupTest()
+        {
+            _settings = new MemorySettings();
+        }
+
+        [Test]
+        public void ForNoFixedPanel_WhenWidthChanges_DistanceChangesEvenly()
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 100;
+            const int splitterDistance = 30;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                splitter.Width = 2 * splitterWidth;
+                splitManager.RestoreSplitters();
+                //assert
+                splitter.SplitterDistance.Should().Be(splitterDistance * 2);
+            }
+        }
+
+        [TestCase(100)]
+        [TestCase(-100)]
+        public void ForFixedPanel1_WhenWidthChanges_DistanceDoesNotChange(int deltaWidth)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 70;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                splitter.Width = splitterWidth + deltaWidth;
+                splitter.FixedPanel = FixedPanel.Panel1;
+                splitManager.RestoreSplitters();
+                //assert
+                splitter.SplitterDistance.Should().Be(splitterDistance);
+            }
+        }
+
+        [TestCase(100)]
+        [TestCase(-100)]
+        public void ForFixedPanel2_WhenWidthChanges_DistanceChangesAlong(int deltaWidth)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 130;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                int splitterNewWidth = splitterWidth + deltaWidth;
+                splitter.Width = splitterNewWidth;
+                splitter.FixedPanel = FixedPanel.Panel2;
+                splitManager.RestoreSplitters();
+                //assert splitter moved by the width delta
+                splitter.SplitterDistance.Should().Be(splitterDistance + deltaWidth);
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DistanceDoesNotChangeWhenGoesBelowPanel1MinSize(bool applyMinSize)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 120;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                const int splitterNewWidth = 180;
+                splitter.Width = splitterNewWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitter.FixedPanel = FixedPanel.Panel2;
+                if (applyMinSize)
+                {
+                    splitter.Panel1MinSize = 110;
+                }
+                splitManager.RestoreSplitters();
+                //assert
+                if (applyMinSize)
+                {
+                    splitter.SplitterDistance.Should().Be(splitterDistance);
+                }
+                else
+                {
+                    splitter.SplitterDistance.Should().Be(100);
+                }
+            }
+        }
+
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DistanceDoesNotChangeWhenGoesBelowPanel2MinSize(bool applyMinSize)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 120;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                const int splitterNewWidth = 180;
+                splitter.Width = splitterNewWidth;
+                splitter.FixedPanel = FixedPanel.None;
+                if (applyMinSize)
+                {
+                    splitter.Panel2MinSize = 110;
+                }
+                splitter.SplitterDistance = 60;
+                splitManager.RestoreSplitters();
+                //assert
+                if (applyMinSize)
+                {
+                    splitter.SplitterDistance.Should().Be(60);
+                }
+                else
+                {
+                    splitter.SplitterDistance.Should().Be(108);//decreased by 10%
+                }
+            }
+        }
+
+        [TestCase(2)]
+        [TestCase(-2)]
+        public void ForFixedPanel1_WhenFontChanges_Panel1WidthChangesAlong(int deltaFontSize)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 70;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                splitter.Width = splitterWidth;
+                splitter.Font = new Font(splitter.Font.FontFamily, _designTimeFontSize + deltaFontSize);
+                splitter.FixedPanel = FixedPanel.Panel1;
+                splitManager.RestoreSplitters();
+                //assert
+                float scaleFactor = 1F * (_designTimeFontSize + deltaFontSize) / _designTimeFontSize;
+                int expectedDistance = Convert.ToInt32(splitterDistance * scaleFactor);
+                splitter.SplitterDistance.Should().Be(expectedDistance);
+            }
+        }
+
+        [TestCase(2)]
+        [TestCase(-2)]
+        public void ForFixedPanel2_WhenFontChanges_Panel2WidthChangesAlong(int deltaFontSize)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 70;
+            int panel2Width = splitterWidth - splitterDistance;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                splitter.Width = splitterWidth;
+                splitter.Font = new Font(splitter.Font.FontFamily, _designTimeFontSize + deltaFontSize);
+                splitter.FixedPanel = FixedPanel.Panel2;
+                splitManager.RestoreSplitters();
+                //assert
+                float scaleFactor = 1F * (_designTimeFontSize + deltaFontSize) / _designTimeFontSize;
+                int expectedDistance = Convert.ToInt32(panel2Width * scaleFactor);
+                int newPanel2Width = splitter.Width - splitter.SplitterDistance;
+                newPanel2Width.Should().Be(expectedDistance);
+            }
+        }
+
+        [TestCase(2)]
+        [TestCase(-2)]
+        public void ForNoFixedPanel_WhenFontChanges_DistanceDoesNotChange(int deltaFontSize)
+        {
+            //arrange 
+            const string splitterName = "splitterName";
+            const int splitterWidth = 200;
+            const int splitterDistance = 70;
+            {
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitter.Width = splitterWidth;
+                splitter.SplitterDistance = splitterDistance;
+                splitManager.AddSplitter(splitter, splitterName);
+                splitManager.SaveSplitters();
+            }
+            {
+                //act
+                SplitterManager splitManager = new SplitterManager(_settings, _designTimeFontSize);
+                SplitContainer splitter = CreateVerticalSplitContainer();
+                splitManager.AddSplitter(splitter, splitterName);
+                splitter.Width = splitterWidth;
+                splitter.Font = new Font(splitter.Font.FontFamily, _designTimeFontSize + deltaFontSize);
+                splitter.FixedPanel = FixedPanel.None;
+                splitManager.RestoreSplitters();
+                //assert
+                splitter.SplitterDistance.Should().Be(splitterDistance);
+            }
+        }
+
+        private SplitContainer CreateVerticalSplitContainer()
+        {
+            SplitContainer splitter = new SplitContainer();
+            splitter.FixedPanel = FixedPanel.None;
+            splitter.Font = new Font(splitter.Font.FontFamily, _designTimeFontSize);
+            splitter.Orientation = Orientation.Vertical;
+            splitter.Width = _designTimeSplitterWidth;
+            splitter.SplitterDistance = _designTimeSplitterDistance;            
+
+            return splitter;
+        }
+    }
+}

--- a/UnitTests/GitUITests/SplitterManagerTest.cs
+++ b/UnitTests/GitUITests/SplitterManagerTest.cs
@@ -220,8 +220,8 @@ namespace GitUITests
                 splitManager.RestoreSplitters();
                 //assert
                 float scaleFactor = 1F * (_designTimeFontSize + deltaFontSize) / _designTimeFontSize;
-                int expectedDistance = Convert.ToInt32(splitterDistance * scaleFactor);
-                splitter.SplitterDistance.Should().Be(expectedDistance);
+                int expectedPanel1Width = Convert.ToInt32(splitterDistance * scaleFactor);
+                splitter.SplitterDistance.Should().Be(expectedPanel1Width);
             }
         }
 
@@ -253,9 +253,9 @@ namespace GitUITests
                 splitManager.RestoreSplitters();
                 //assert
                 float scaleFactor = 1F * (_designTimeFontSize + deltaFontSize) / _designTimeFontSize;
-                int expectedDistance = Convert.ToInt32(panel2Width * scaleFactor);
+                int expectedPanel2Width = Convert.ToInt32(panel2Width * scaleFactor);
                 int newPanel2Width = splitter.Width - splitter.SplitterDistance;
-                newPanel2Width.Should().Be(expectedDistance);
+                newPanel2Width.Should().Be(expectedPanel2Width);
             }
         }
 


### PR DESCRIPTION
The current restoring algorithm based on DeviceDPI does not work if font size or window size changes.
Every time the GitExt starts, the MainSplitContainer.SplitterDistance increases by 12 due to statusStrip being shown. Connecting with remote desktop decreases my screen size and all the splitters are messed up.

Proposed changes:

Currently window size and position are scaled to the current DPI. That means the window size will change if the current DPI differs from the stored one. After that splitter position will be scaled based on the new window size and the current font size. The scaling algorithm respects FixedPanel property:
 - When splitter size differs from the stored one then resizes the non fixed panel or both if there is no fixed panel.
 - When splitter font size differs from the stored one then scales only the fixed panel - if exists.

