### PR TITLE
Stretch stash file list rather than message

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -107,8 +107,8 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 3;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.Size = new System.Drawing.Size(280, 650);
             this.tableLayoutPanel2.TabIndex = 2;


### PR DESCRIPTION
Fixes #3564 .

Changes proposed in this pull request:
 - Stretch stash file list and auto-size stash message, rather than filling space with message
 
Screenshots before and after (if PR changes UI):
- Before
![before](https://cloud.githubusercontent.com/assets/28189926/25580034/297e9374-2e75-11e7-9182-b077a78bb63c.png)

- After
![after](https://cloud.githubusercontent.com/assets/28189926/25580037/2d96b040-2e75-11e7-815d-61368adf6733.png)

How did I test this code:
 - Manual

Has been tested on (remove any that don't apply):
 - GIT 2.10.1
 - Windows 10
