### PR TITLE
Improve setting description in UI (English and Spanish) (issue #3499)

### DIFF
--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -8515,7 +8515,7 @@ měnit globální nastavení.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Zobrazit stav repozitáře v dialogu procházení (počet změn v panelu nástrojů, požaduje restart)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -8522,7 +8522,7 @@ te kunnen wijzigen.</target>
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Toon opslagplaats status in dialoog (aantal wijzigingen, herstart vereist)</target>
 
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6875,7 +6875,7 @@ global settings.
         <target />
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowStashCountInBrowseWindow.Text">

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -8563,7 +8563,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Afficher le statut du dépôt dans la fenêtre parcourir (number of changes in toolbar, restart required)</target>
 
       </trans-unit>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -8555,7 +8555,7 @@ können.</target>
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Zeige Repository Status im Durchsuchen Dialog (Anzahl der Änderungen in der Toolbar, Neustart erforderlich)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -8043,7 +8043,7 @@ globali.</target>
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Mostra stato del repository nella finestra Sfoglia (numero di cambiamenti nella barra degli strumenti, richiesto riavvio)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -8409,7 +8409,7 @@ Git の 正しいパスを入力してください。</target>
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>リポジトリの状態 (変更の数) を表示する (再起動が必要)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -8188,7 +8188,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>브라우저 창에서 저장소 상태 보여주기 (툴바에 변경된 숫자 표기, 재시작 필요)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -8531,7 +8531,7 @@ zmieniać globalne ustawienia.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Pokaż status repozytorium w oknie przeglądania (ilość zmian na pasku narzędzi, wymagany restart)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -8090,7 +8090,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
 
       </trans-unit>
       <trans-unit id="chkShowStashCountInBrowseWindow.Text">

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -6520,7 +6520,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
 
       </trans-unit>
       <trans-unit id="chkShowStashCountInBrowseWindow.Text">

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -6950,7 +6950,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
 
       </trans-unit>
       <trans-unit id="chkShowStashCountInBrowseWindow.Text">

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -8574,7 +8574,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>Отображать статус репозитория в диалоге обзора (количество изменений на панели инструментов, необходим перезапуск)</target>
 
       </trans-unit>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -8447,7 +8447,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>在浏览对话框中显示档案库的状态（在工具栏上会产生一些变化，需要重新启动）</target>
 
       </trans-unit>

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -8498,8 +8498,8 @@ la configuración global.</target>
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
-        <target>Mostrar el estado del repositorio en la ventana de búsqueda (número de cambios en la barra de herramientas, requiere reiniciar)</target>
+        <source>Show number of changed files on commit button (restart required)</source>
+        <target>Mostrar el número de archivos modificados en el botón de commit (requiere reiniciar)</target>
 
       </trans-unit>
       <trans-unit id="chkShowStashCountInBrowseWindow.Text">

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -8280,7 +8280,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>在瀏覽對話框中顯示版本庫的狀態（在工具欄上會產生一些變化，需要重新啟動）</target>
 
       </trans-unit>

--- a/GitUI/Translation/en_pseudo.Plugins.xlf
+++ b/GitUI/Translation/en_pseudo.Plugins.xlf
@@ -8518,7 +8518,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>[Şħǿẇ řḗƥǿşīŧǿřẏ şŧȧŧŭş īƞ ƀřǿẇşḗ ḓīȧŀǿɠ (ƞŭḿƀḗř ǿƒ ƈħȧƞɠḗş īƞ ŧǿǿŀƀȧř, řḗşŧȧřŧ řḗɋŭīřḗḓ) 衋ϱǅΰ 靐ΐϱςϐǋςΐϵ]</target>
 
       </trans-unit>

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -8562,7 +8562,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target>[Şħǿẇ řḗƥǿşīŧǿřẏ şŧȧŧŭş īƞ ƀřǿẇşḗ ḓīȧŀǿɠ (ƞŭḿƀḗř ǿƒ ƈħȧƞɠḗş īƞ ŧǿǿŀƀȧř, řḗşŧȧřŧ řḗɋŭīřḗḓ) ϑıǋǲ ϵϰǋǲϖ靐衋ſϱ]</target>
 
       </trans-unit>


### PR DESCRIPTION
Fixes #3499 .

Changes proposed in this pull request:
 - Changed the description of the first setting in the Git Extensions /Git Extensions page.
 
Screenshots before and after (if PR changes UI):
- Before: 
![image](https://cloud.githubusercontent.com/assets/834999/25596205/be01272c-2ed0-11e7-80ac-8298de417405.png)

- After: 
![image](https://cloud.githubusercontent.com/assets/834999/25596223/ceecea4e-2ed0-11e7-80ed-2cb4ca805360.png)



How did I test this code:
 - I built the project and took the above screenshots.
 - I'd like a review on the Spanish translation I provided, and need help with translation for all other languages.

Has been tested on (remove any that don't apply):
 - GIT 2.10
 - Windows 10
