### PR TITLE
Improve setting description in UI (issue #3499)

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -326,8 +326,7 @@
             this.chkShowGitStatusInToolbar.Name = "chkShowGitStatusInToolbar";
             this.chkShowGitStatusInToolbar.Size = new System.Drawing.Size(451, 17);
             this.chkShowGitStatusInToolbar.TabIndex = 1;
-            this.chkShowGitStatusInToolbar.Text = "Show repository status in browse dialog (number of changes in toolbar, restart re" +
-    "quired)";
+            this.chkShowGitStatusInToolbar.Text = "Show number of changed files on commit button (restart required)";
             this.chkShowGitStatusInToolbar.UseVisualStyleBackColor = true;
             // 
             // chkShowStashCountInBrowseWindow

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6875,7 +6875,7 @@ global settings.
         <target />
       </trans-unit>
       <trans-unit id="chkShowGitStatusInToolbar.Text">
-        <source>Show repository status in browse dialog (number of changes in toolbar, restart required)</source>
+        <source>Show number of changed files on commit button (restart required)</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowStashCountInBrowseWindow.Text">


### PR DESCRIPTION
Fixes #3499 .

Changes proposed in this pull request:
 - Changed the description of the first setting in the Git Extensions /Git Extensions page.
 
Screenshots before and after (if PR changes UI):
- Before: 
![image](https://cloud.githubusercontent.com/assets/834999/25626172/55f51bf6-2f67-11e7-9794-b9ef3113b8ef.png)
- After: 
![image](https://cloud.githubusercontent.com/assets/834999/25626186/5e4881d0-2f67-11e7-96d9-21ca0db47089.png)


How did I test this code:
 - I built the project and took the above screenshots.
 - I needed to change the English.xlf file for the change to actually appear in the UI.


Has been tested on:
 - GIT 2.10
 - Windows 10
