### PR TITLE
fix FormGitIgnore layout and scroll

### DIFF
--- a/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
@@ -29,45 +29,87 @@
         private void InitializeComponent()
         {
             System.Windows.Forms.Panel panel1;
-            System.Windows.Forms.Panel panel2;
+            System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormGitIgnore));
+            this.lnkGitIgnoreGenerate = new System.Windows.Forms.LinkLabel();
+            this.lnkGitIgnorePatterns = new System.Windows.Forms.LinkLabel();
             this.AddDefault = new System.Windows.Forms.Button();
             this.AddPattern = new System.Windows.Forms.Button();
             this.Save = new System.Windows.Forms.Button();
-            this.lnkGitIgnoreGenerate = new System.Windows.Forms.LinkLabel();
-            this.lnkGitIgnorePatterns = new System.Windows.Forms.LinkLabel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this._NO_TRANSLATE_GitIgnoreEdit = new GitUI.Editor.FileViewer();
             this.label1 = new System.Windows.Forms.TextBox();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnCancel = new System.Windows.Forms.Button();
             panel1 = new System.Windows.Forms.Panel();
-            panel2 = new System.Windows.Forms.Panel();
+            flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             panel1.SuspendLayout();
-            panel2.SuspendLayout();
+            flowLayoutPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // panel1
             // 
-            panel1.Controls.Add(this.AddDefault);
-            panel1.Controls.Add(this.AddPattern);
-            panel1.Controls.Add(this.Save);
+            panel1.Controls.Add(this.lnkGitIgnoreGenerate);
+            panel1.Controls.Add(this.lnkGitIgnorePatterns);
             panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            panel1.Location = new System.Drawing.Point(0, 530);
-            panel1.Margin = new System.Windows.Forms.Padding(4);
+            panel1.Location = new System.Drawing.Point(0, 375);
             panel1.Name = "panel1";
-            panel1.Size = new System.Drawing.Size(289, 119);
+            panel1.Padding = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            panel1.Size = new System.Drawing.Size(250, 48);
             panel1.TabIndex = 5;
+            // 
+            // lnkGitIgnoreGenerate
+            // 
+            this.lnkGitIgnoreGenerate.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lnkGitIgnoreGenerate.LinkColor = System.Drawing.SystemColors.HotTrack;
+            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(0, 17);
+            this.lnkGitIgnoreGenerate.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.lnkGitIgnoreGenerate.Name = "lnkGitIgnoreGenerate";
+            this.lnkGitIgnoreGenerate.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.lnkGitIgnoreGenerate.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(242, 17);
+            this.lnkGitIgnoreGenerate.TabIndex = 7;
+            this.lnkGitIgnoreGenerate.TabStop = true;
+            this.lnkGitIgnoreGenerate.Text = "Generate a custom gitignore";
+            this.lnkGitIgnoreGenerate.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnoreGenerate_LinkClicked);
+            // 
+            // lnkGitIgnorePatterns
+            // 
+            this.lnkGitIgnorePatterns.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lnkGitIgnorePatterns.LinkColor = System.Drawing.SystemColors.HotTrack;
+            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(0, 0);
+            this.lnkGitIgnorePatterns.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.lnkGitIgnorePatterns.Name = "lnkGitIgnorePatterns";
+            this.lnkGitIgnorePatterns.Padding = new System.Windows.Forms.Padding(0, 2, 0, 2);
+            this.lnkGitIgnorePatterns.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(242, 17);
+            this.lnkGitIgnorePatterns.TabIndex = 6;
+            this.lnkGitIgnorePatterns.TabStop = true;
+            this.lnkGitIgnorePatterns.Text = "More gitignore patterns";
+            this.lnkGitIgnorePatterns.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnorePatterns_LinkClicked);
+            // 
+            // flowLayoutPanel2
+            // 
+            flowLayoutPanel2.Controls.Add(this.AddDefault);
+            flowLayoutPanel2.Controls.Add(this.AddPattern);
+            flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
+            flowLayoutPanel2.Location = new System.Drawing.Point(0, 391);
+            flowLayoutPanel2.Name = "flowLayoutPanel2";
+            flowLayoutPanel2.Size = new System.Drawing.Size(372, 32);
+            flowLayoutPanel2.TabIndex = 6;
+            flowLayoutPanel2.WrapContents = false;
             // 
             // AddDefault
             // 
             this.AddDefault.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.AddDefault.Location = new System.Drawing.Point(85, 45);
-            this.AddDefault.Margin = new System.Windows.Forms.Padding(4);
+            this.AddDefault.Location = new System.Drawing.Point(3, 3);
             this.AddDefault.Name = "AddDefault";
-            this.AddDefault.Size = new System.Drawing.Size(200, 31);
+            this.AddDefault.Size = new System.Drawing.Size(160, 25);
             this.AddDefault.TabIndex = 2;
             this.AddDefault.Text = "Add default ignores";
             this.AddDefault.UseVisualStyleBackColor = true;
@@ -76,10 +118,9 @@
             // AddPattern
             // 
             this.AddPattern.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.AddPattern.Location = new System.Drawing.Point(85, 6);
-            this.AddPattern.Margin = new System.Windows.Forms.Padding(4);
+            this.AddPattern.Location = new System.Drawing.Point(169, 3);
             this.AddPattern.Name = "AddPattern";
-            this.AddPattern.Size = new System.Drawing.Size(200, 31);
+            this.AddPattern.Size = new System.Drawing.Size(160, 25);
             this.AddPattern.TabIndex = 3;
             this.AddPattern.Text = "Add pattern";
             this.AddPattern.UseVisualStyleBackColor = true;
@@ -87,122 +128,117 @@
             // 
             // Save
             // 
-            this.Save.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.Save.Location = new System.Drawing.Point(85, 83);
-            this.Save.Margin = new System.Windows.Forms.Padding(4);
+            this.Save.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.Save.Image = global::GitUI.Properties.Resources.IconSave;
+            this.Save.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.Save.Location = new System.Drawing.Point(463, 3);
             this.Save.Name = "Save";
-            this.Save.Size = new System.Drawing.Size(200, 31);
+            this.Save.Size = new System.Drawing.Size(160, 25);
             this.Save.TabIndex = 1;
             this.Save.Text = "Save";
+            this.Save.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.Save.UseVisualStyleBackColor = true;
             this.Save.Click += new System.EventHandler(this.SaveClick);
-            // 
-            // panel2
-            // 
-            panel2.Controls.Add(this.lnkGitIgnoreGenerate);
-            panel2.Controls.Add(this.lnkGitIgnorePatterns);
-            panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            panel2.Location = new System.Drawing.Point(0, 474);
-            panel2.Margin = new System.Windows.Forms.Padding(4);
-            panel2.Name = "panel2";
-            panel2.Size = new System.Drawing.Size(289, 56);
-            panel2.TabIndex = 7;
-            // 
-            // lnkGitIgnoreGenerate
-            // 
-            this.lnkGitIgnoreGenerate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lnkGitIgnoreGenerate.AutoSize = true;
-            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(0, 28);
-            this.lnkGitIgnoreGenerate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lnkGitIgnoreGenerate.Name = "lnkGitIgnoreGenerate";
-            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(181, 17);
-            this.lnkGitIgnoreGenerate.TabIndex = 7;
-            this.lnkGitIgnoreGenerate.TabStop = true;
-            this.lnkGitIgnoreGenerate.Text = "Generate a custom gitignore";
-            this.lnkGitIgnoreGenerate.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnoreGenerate_LinkClicked);
-            // 
-            // lnkGitIgnorePatterns
-            // 
-            this.lnkGitIgnorePatterns.AutoSize = true;
-            this.lnkGitIgnorePatterns.Dock = System.Windows.Forms.DockStyle.Left;
-            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(0, 0);
-            this.lnkGitIgnorePatterns.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lnkGitIgnorePatterns.Name = "lnkGitIgnorePatterns";
-            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(150, 17);
-            this.lnkGitIgnorePatterns.TabIndex = 6;
-            this.lnkGitIgnorePatterns.TabStop = true;
-            this.lnkGitIgnorePatterns.Text = "More gitignore patterns";
-            this.lnkGitIgnorePatterns.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnorePatterns_LinkClicked);
             // 
             // splitContainer1
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
+            this.splitContainer1.Location = new System.Drawing.Point(4, 4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
             // 
             this.splitContainer1.Panel1.Controls.Add(this._NO_TRANSLATE_GitIgnoreEdit);
+            this.splitContainer1.Panel1.Controls.Add(flowLayoutPanel2);
+            this.splitContainer1.Panel1MinSize = 250;
             // 
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.label1);
-            this.splitContainer1.Panel2.Controls.Add(panel2);
             this.splitContainer1.Panel2.Controls.Add(panel1);
-            this.splitContainer1.Size = new System.Drawing.Size(792, 649);
-            this.splitContainer1.SplitterDistance = 498;
-            this.splitContainer1.SplitterWidth = 5;
+            this.splitContainer1.Panel2MinSize = 250;
+            this.splitContainer1.Size = new System.Drawing.Size(626, 423);
+            this.splitContainer1.SplitterDistance = 372;
             this.splitContainer1.TabIndex = 0;
             // 
             // _NO_TRANSLATE_GitIgnoreEdit
             // 
-            this._NO_TRANSLATE_GitIgnoreEdit.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this._NO_TRANSLATE_GitIgnoreEdit.AutoScroll = true;
+            this._NO_TRANSLATE_GitIgnoreEdit.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this._NO_TRANSLATE_GitIgnoreEdit.Dock = System.Windows.Forms.DockStyle.Fill;
             this._NO_TRANSLATE_GitIgnoreEdit.IsReadOnly = false;
             this._NO_TRANSLATE_GitIgnoreEdit.Location = new System.Drawing.Point(0, 0);
-            this._NO_TRANSLATE_GitIgnoreEdit.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this._NO_TRANSLATE_GitIgnoreEdit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this._NO_TRANSLATE_GitIgnoreEdit.Name = "_NO_TRANSLATE_GitIgnoreEdit";
-            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(498, 649);
+            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(372, 391);
             this._NO_TRANSLATE_GitIgnoreEdit.TabIndex = 0;
             // 
             // label1
             // 
+            this.label1.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label1.Location = new System.Drawing.Point(0, 0);
-            this.label1.Margin = new System.Windows.Forms.Padding(5);
             this.label1.Multiline = true;
             this.label1.Name = "label1";
             this.label1.ReadOnly = true;
-            this.label1.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.label1.Size = new System.Drawing.Size(289, 474);
+            this.label1.Size = new System.Drawing.Size(250, 375);
             this.label1.TabIndex = 4;
             this.label1.Text = resources.GetString("label1.Text");
             this.label1.WordWrap = false;
             // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.Controls.Add(this.Save);
+            this.flowLayoutPanel1.Controls.Add(this.btnCancel);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 427);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(626, 31);
+            this.flowLayoutPanel1.TabIndex = 1;
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.AutoSize = true;
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(382, 3);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 25);
+            this.btnCancel.TabIndex = 2;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseCompatibleTextRendering = true;
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
             // FormGitIgnore
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(792, 649);
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(634, 462);
             this.Controls.Add(this.splitContainer1);
-            this.Margin = new System.Windows.Forms.Padding(4);
+            this.Controls.Add(this.flowLayoutPanel1);
+            this.MinimumSize = new System.Drawing.Size(650, 500);
             this.Name = "FormGitIgnore";
+            this.Padding = new System.Windows.Forms.Padding(4);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit .gitignore";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormGitIgnoreFormClosing);
             this.Load += new System.EventHandler(this.FormGitIgnoreLoad);
             panel1.ResumeLayout(false);
-            panel2.ResumeLayout(false);
-            panel2.PerformLayout();
+            flowLayoutPanel2.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
             this.splitContainer1.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -216,5 +252,7 @@
         private System.Windows.Forms.Button AddPattern;
         private System.Windows.Forms.LinkLabel lnkGitIgnorePatterns;
         private System.Windows.Forms.LinkLabel lnkGitIgnoreGenerate;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.Button btnCancel;
     }
 }

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -95,12 +95,25 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+
         protected override void OnRuntimeLoad(EventArgs e)
         {
             base.OnRuntimeLoad(e);
             LoadGitIgnore();
             _NO_TRANSLATE_GitIgnoreEdit.TextLoaded += GitIgnoreFileLoaded;
         }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.Escape)
+            {
+                DialogResult = DialogResult.Cancel;
+                Close();
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
 
         private void LoadGitIgnore()
         {
@@ -221,6 +234,11 @@ namespace GitUI.CommandsDialogs
         private void lnkGitIgnoreGenerate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start(@"https://www.gitignore.io/");
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            Close();
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormGitIgnore.resx
+++ b/GitUI/CommandsDialogs/FormGitIgnore.resx
@@ -120,7 +120,7 @@
   <metadata name="panel1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="panel2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="flowLayoutPanel2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
   <data name="label1.Text" xml:space="preserve">


### PR DESCRIPTION
* GitIgnore form now has scrollbars when editing the list of ignores.
* Form layout update

<img width="592" alt="screen shot 2017-05-13 at 8 49 53 am" src="https://cloud.githubusercontent.com/assets/4403806/26019524/27691a3a-37b9-11e7-9d18-6413a5bc042c.png">
<img width="765" alt="screen shot 2017-05-13 at 8 50 47 am" src="https://cloud.githubusercontent.com/assets/4403806/26019531/3ef78eb6-37b9-11e7-9e63-bcab4842e002.png">

