### PR TITLE
Fix commit messages that are displayed incorrectly

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3218,13 +3218,13 @@ namespace GitCommands
             return ReEncodeStringFromLossless(s, LogOutputEncoding);
         }
 
-        //there is a bug: git does not recode commit message when format is given
+        //there was a bug: Git before v1.8.4 did not recode commit message when format is given
         //Lossless encoding is used, because LogOutputEncoding might not be lossless and not recoded
         //characters could be replaced by replacement character while reencoding to LogOutputEncoding
         public string ReEncodeCommitMessage(string s, string toEncodingName)
         {
 
-            bool isABug = true;
+            bool isABug = !GitCommandHelpers.VersionInUse.LogFormatRecodesCommitMessage;
 
             Encoding encoding;
             try
@@ -3240,7 +3240,7 @@ namespace GitCommands
                     else
                         encoding = Encoding.GetEncoding(toEncodingName);
                 }
-                else//if bug will be fixed, git should recode commit message to LogOutputEncoding
+                else//bug is fixed in Git v1.8.4, Git recodes commit message to LogOutputEncoding
                     encoding = LogOutputEncoding;
 
             }

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -9,6 +9,7 @@ namespace GitCommands
         private static readonly GitVersion v1_7_1 = new GitVersion("1.7.1");
         private static readonly GitVersion v1_7_7 = new GitVersion("1.7.7");
         private static readonly GitVersion v1_7_11 = new GitVersion("1.7.11");
+        private static readonly GitVersion v1_8_4 = new GitVersion("1.8.4");
         private static readonly GitVersion v1_8_5 = new GitVersion("1.8.5");
         private static readonly GitVersion v2_0_1 = new GitVersion("2.0.1");
         private static readonly GitVersion v2_5_1 = new GitVersion("2.5.1");
@@ -39,6 +40,11 @@ namespace GitCommands
         public bool FetchCanAskForProgress
         {
             get { return this >= v1_7_1; }
+        }
+
+        public bool LogFormatRecodesCommitMessage
+        {
+            get { return this >= v1_8_4; }
         }
 
         public bool PushCanAskForProgress


### PR DESCRIPTION
GitExtensions recodes commit messages that differ from
`i18n.logOutputEncoding` as Git before v1.8.4 did not do this because of a
a bug. Since v1.8.4 (see commit [ecaee80 (pretty: --format output should honor logOutputEncoding, 2013-06-26)](https://github.com/git/git/commit/ecaee80) in Git repository) Git does not
have this issue anymore, but GitExtensions still relies on its buggy
behaviour.

Today we know the version of Git with no bug. Let's rely on this
knowledge.

Fixes #3707.

Changes proposed in this pull request:
 - Test Git version. If its version >= 1.8.4 then do not recode commit message as Git already does it
 
Screenshots before and after (if PR changes UI):
- screenshots the same as attached in #3707:
before:
When `git config i18n.logOutputEncoding = Windows-1251`
![ge-encoding-bug-logoutputencoding-non-utf-8](https://cloud.githubusercontent.com/assets/1183752/26179351/eb4163e4-3b6b-11e7-81c1-4dbcf2ef6abb.png)
When `git config i18n.logOutputEncoding = UTF-8`
![ge-encoding-bug-logoutputencoding-utf-8](https://cloud.githubusercontent.com/assets/1183752/26179352/eb45fbca-3b6b-11e7-8865-10919ab48bc5.png)

after:
![ge-encoding-bug-fixed](https://cloud.githubusercontent.com/assets/1183752/26179774/45e0f2a4-3b6e-11e7-9376-577f56f35664.png)

How did I test this code:
 -  Manually, "with eyes"

Has been tested on:
 - Git 2.5.1
 - Windows 7
