### PR TITLE
GitDirectory location depends on the repository kind.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -389,6 +389,47 @@ namespace GitCommands
                    Directory.Exists(dirPath + "refs");
         }
 
+        /// <summary>
+        /// Asks git to resolve the given relativePath
+        /// git special folders are located in different directories depending on the kind of repo: submodule, worktree, main
+        /// See https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-pathltpathgt
+        /// </summary>
+        /// <param name="relativePath">A path relative to the .git directory</param>
+        /// <returns></returns>
+        public string ResolveGitInternalPath(string relativePath)
+        {
+            string gitPath = RunGitCmd("rev-parse --git-path " + relativePath.Quote());
+            string systemPath = PathUtil.ToNativePath(gitPath.Trim());
+            if (systemPath.StartsWith(".git\\"))
+            {
+                systemPath = Path.Combine(GetGitDirectory(), systemPath.Substring(".git\\".Length));
+            }
+            return systemPath;
+        }
+
+        private string _GitCommonDirectory;
+        /// <summary>
+        /// Returns git common directory
+        /// https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-common-dir
+        /// </summary>
+        public string GitCommonDirectory
+        {
+            get
+            {
+                if (_GitCommonDirectory == null)
+                {
+                    _GitCommonDirectory = PathUtil.ToNativePath(RunGitCmd("rev-parse --git-common-dir").Trim());
+                    if (_GitCommonDirectory == ".git")
+                    {
+                        _GitCommonDirectory = GetGitDirectory();
+                    }
+
+                }
+
+                return _GitCommonDirectory;
+            }
+        }
+
         /// <summary>Gets the ".git" directory path.</summary>
         public string GetGitDirectory()
         {

--- a/GitCommands/Settings/ConfigFileSettings.cs
+++ b/GitCommands/Settings/ConfigFileSettings.cs
@@ -30,7 +30,7 @@ namespace GitCommands.Settings
         private static ConfigFileSettings CreateLocal(GitModule aModule, ConfigFileSettings aLowerPriority, bool allowCache = true)
         {
             return new ConfigFileSettings(aLowerPriority,
-                ConfigFileSettingsCache.Create(Path.Combine(aModule.GetGitDirectory(), "config"), true, allowCache));
+                ConfigFileSettingsCache.Create(Path.Combine(aModule.GitCommonDirectory, "config"), true, allowCache));
         }
 
         public static ConfigFileSettings CreateGlobal(bool allowCache = true)

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -30,7 +30,7 @@ namespace GitCommands.Settings
         {
             //if (aModule.IsBareRepository()
             return new RepoDistSettings(aLowerPriority,
-                GitExtSettingsCache.Create(Path.Combine(aModule.GetGitDirectory(), AppSettings.SettingsFileName), allowCache));
+                GitExtSettingsCache.Create(Path.Combine(aModule.GitCommonDirectory, AppSettings.SettingsFileName), allowCache));
         }
 
         public static RepoDistSettings CreateLocal(GitModule aModule, bool allowCache = true)

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs
                 }
                 else
                 {
-                    return Path.Combine(Module.GetGitDirectory(), "info", "exclude");
+                    return Path.Combine(Module.ResolveGitInternalPath("info"), "exclude");
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1755,7 +1755,7 @@ namespace GitUI.CommandsDialogs
 
         private void EditLocalGitConfigToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var fileName = Path.Combine(Module.GetGitDirectory(), "config");
+            var fileName = Path.Combine(Module.ResolveGitInternalPath("config"));
             UICommands.StartFileEditorDialog(fileName, true);
         }
 

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -92,7 +92,7 @@ namespace GitUI.CommandsDialogs
                 }
                 else
                 {
-                    return Path.Combine(Module.GetGitDirectory(), "info", "exclude");
+                    return Path.Combine(Module.ResolveGitInternalPath("info"), "exclude");
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -137,7 +137,7 @@ namespace GitUI.CommandsDialogs
             if (aCommands != null)
             {
                 // Detect by presence of the shallow file, not 100% sure it's the best way, but it's created upon shallow cloning and removed upon unshallowing
-                bool isRepoShallow = File.Exists(Path.Combine(aCommands.Module.GetGitDirectory(), "shallow"));
+                bool isRepoShallow = File.Exists(aCommands.Module.ResolveGitInternalPath("shallow"));
                 if (isRepoShallow)
                     Unshallow.Visible = true;
             }

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -130,7 +130,7 @@ namespace GitUI.CommandsDialogs
         [NotNull]
         public FileInfo GetPathToSparseCheckoutFile()
         {
-            return new FileInfo(Path.Combine(Path.Combine(_gitcommands.GitModule.GetGitDirectory(), "info"), "sparse-checkout"));
+            return new FileInfo(Path.Combine(_gitcommands.GitModule.ResolveGitInternalPath("info"), "sparse-checkout"));
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGridClasses/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGridClasses/IndexWatcher.cs
@@ -59,16 +59,16 @@ namespace GitUI.UserControls.RevisionGridClasses
             {
                 try
                 {
-                    enabled = GitCommands.AppSettings.UseFastChecks;
+                    enabled = AppSettings.UseFastChecks;
 
-                    Path = Module.GetGitDirectory();
+                    _gitDirPath = Module.GetGitDirectory();
 
-                    GitIndexWatcher.Path = Path;
+                    GitIndexWatcher.Path = _gitDirPath;
                     GitIndexWatcher.Filter = "index";
                     GitIndexWatcher.IncludeSubdirectories = false;
                     GitIndexWatcher.EnableRaisingEvents = enabled;
 
-                    RefsWatcher.Path = System.IO.Path.Combine(Path, "refs");
+                    RefsWatcher.Path = Path.Combine(Module.GitCommonDirectory, "refs");
                     RefsWatcher.IncludeSubdirectories = true;
                     RefsWatcher.EnableRaisingEvents = enabled;
                 }
@@ -87,7 +87,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 if (!enabled)
                     return true;
 
-                if (Path != Module.GetGitDirectory())
+                if (_gitDirPath != Module.GetGitDirectory())
                     return true;
 
                 return indexChanged;
@@ -103,7 +103,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         }
 
         private bool enabled;
-        private string Path;
+        private string _gitDirPath;
         private FileSystemWatcher GitIndexWatcher { get; set; }
         private FileSystemWatcher RefsWatcher { get; set; }
 
@@ -126,8 +126,8 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         private void RefreshWatcher()
         {
-            if (Path != Module.GetGitDirectory() ||
-                enabled != GitCommands.AppSettings.UseFastChecks)
+            if (_gitDirPath != Module.GetGitDirectory() ||
+                enabled != AppSettings.UseFastChecks)
                 SetFileSystemWatcher();
         }
 

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -65,7 +65,7 @@ namespace FindLargeFiles
                         curGitObject.Commit.Add(commit);
                     }
                 }
-                string objectsPackDirectory = _gitCommands.GetGitDirectory() + "objects/pack/";
+                string objectsPackDirectory = _gitCommands.ResolveGitInternalPath("objects/pack/");
                 if (Directory.Exists(objectsPackDirectory))
                 {
                     var packFiles = Directory.GetFiles(objectsPackDirectory, "pack-*.idx");

--- a/Plugins/Gerrit/GerritPlugin.cs
+++ b/Plugins/Gerrit/GerritPlugin.cs
@@ -84,20 +84,20 @@ namespace Gerrit
 
             _installCommitMsgMenuItem.Visible =
                 showGerritItems &&
-                !HaveValidCommitMsgHook(e.GitModule.GetGitDirectory());
+                !HaveValidCommitMsgHook(e.GitModule);
         }
 
-        private bool HaveValidCommitMsgHook(string gitDirectory)
+        private bool HaveValidCommitMsgHook(IGitModule gitModule)
         {
-            return HaveValidCommitMsgHook(gitDirectory, false);
+            return HaveValidCommitMsgHook(gitModule, false);
         }
 
-        private bool HaveValidCommitMsgHook([NotNull] string gitDirectory, bool force)
+        private bool HaveValidCommitMsgHook([NotNull] IGitModule gitModule, bool force)
         {
-            if (gitDirectory == null)
+            if (gitModule == null)
                 throw new ArgumentNullException("gitDirectory");
 
-            string path = Path.Combine(gitDirectory, "hooks", "commit-msg");
+            string path = Path.Combine(gitModule.ResolveGitInternalPath("hooks"), "commit-msg");
 
             if (!File.Exists(path))
                 return false;
@@ -280,8 +280,7 @@ namespace Gerrit
                 return;
 
             string path = Path.Combine(
-                _gitUiCommands.GitModule.GetGitDirectory(),
-                "hooks",
+                _gitUiCommands.GitModule.ResolveGitInternalPath("hooks"),
                 "commit-msg"
             );
 
@@ -312,7 +311,7 @@ namespace Gerrit
 
                 // Update the cache.
 
-                HaveValidCommitMsgHook(_gitUiCommands.GitModule.GetGitDirectory(), true);
+                HaveValidCommitMsgHook(_gitUiCommands.GitModule, true);
             }
         }
 

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -63,6 +63,15 @@ namespace GitUIPluginInterfaces
         /// <summary>Gets the ".git" directory path.</summary>
         string GetGitDirectory();
 
+        /// <summary>
+        /// Asks git to resolve the given relativePath
+        /// git special folders are located in different directories depending on the kind of repo: submodule, worktree, main
+        /// See https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-pathltpathgt
+        /// </summary>
+        /// <param name="relativePath">A path relative to the .git directory</param>
+        /// <returns></returns>
+        string ResolveGitInternalPath(string relativePath);
+
         /// <summary>Indicates whether the specified directory contains a git repository.</summary>
         bool IsValidGitWorkingDir();
 


### PR DESCRIPTION
For worktrees .git subfolders are spread between $GIT_DIR and $GIT_COMMON_DIR

How did I test this code:
 I worked with submodules and worktrees
 
Has been tested on (remove any that don't apply):
 - GIT 2.13
 - Windows 10
