### PR TITLE
FormOpenDirectory: Add a button to go (easily) to the parent directory

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
@@ -28,10 +28,13 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.label1 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_Directory = new System.Windows.Forms.ComboBox();
             this.Load = new System.Windows.Forms.Button();
             this.folderBrowserButton1 = new GitUI.UserControls.FolderBrowserButton();
+            this.folderGoUpbutton = new System.Windows.Forms.Button();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // label1
@@ -52,8 +55,9 @@
             this._NO_TRANSLATE_Directory.FormattingEnabled = true;
             this._NO_TRANSLATE_Directory.Location = new System.Drawing.Point(85, 10);
             this._NO_TRANSLATE_Directory.Name = "_NO_TRANSLATE_Directory";
-            this._NO_TRANSLATE_Directory.Size = new System.Drawing.Size(343, 21);
+            this._NO_TRANSLATE_Directory.Size = new System.Drawing.Size(360, 21);
             this._NO_TRANSLATE_Directory.TabIndex = 1;
+            this._NO_TRANSLATE_Directory.TextChanged += new System.EventHandler(this._NO_TRANSLATE_Directory_TextChanged);
             this._NO_TRANSLATE_Directory.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.DirectoryKeyPress);
             // 
             // Load
@@ -61,7 +65,7 @@
             this.Load.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Load.Image = global::GitUI.Properties.Resources.IconRepoOpen;
             this.Load.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.Load.Location = new System.Drawing.Point(410, 45);
+            this.Load.Location = new System.Drawing.Point(443, 45);
             this.Load.Name = "Load";
             this.Load.Size = new System.Drawing.Size(134, 25);
             this.Load.TabIndex = 3;
@@ -74,18 +78,37 @@
             this.folderBrowserButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.folderBrowserButton1.AutoSize = true;
             this.folderBrowserButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.folderBrowserButton1.Location = new System.Drawing.Point(444, 8);
+            this.folderBrowserButton1.Location = new System.Drawing.Point(477, 8);
             this.folderBrowserButton1.Name = "folderBrowserButton1";
             this.folderBrowserButton1.PathShowingControl = this._NO_TRANSLATE_Directory;
             this.folderBrowserButton1.Size = new System.Drawing.Size(100, 25);
             this.folderBrowserButton1.TabIndex = 4;
+            // 
+            // folderGoUpbutton
+            // 
+            this.folderGoUpbutton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.folderGoUpbutton.Image = global::GitUI.Properties.Resources.levelUp;
+            this.folderGoUpbutton.Location = new System.Drawing.Point(448, 8);
+            this.folderGoUpbutton.Name = "folderGoUpbutton";
+            this.folderGoUpbutton.Size = new System.Drawing.Size(26, 25);
+            this.folderGoUpbutton.TabIndex = 5;
+            this.toolTip1.SetToolTip(this.folderGoUpbutton, "Go to parent directory...");
+            this.folderGoUpbutton.UseVisualStyleBackColor = true;
+            this.folderGoUpbutton.Click += new System.EventHandler(this.folderGoUpbutton_Click);
+            // 
+            // toolTip1
+            // 
+            this.toolTip1.AutomaticDelay = 0;
+            this.toolTip1.ShowAlways = true;
+            this.toolTip1.ToolTipTitle = "Help";
             // 
             // FormOpenDirectory
             // 
             this.AcceptButton = this.Load;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(548, 81);
+            this.ClientSize = new System.Drawing.Size(581, 81);
+            this.Controls.Add(this.folderGoUpbutton);
             this.Controls.Add(this.folderBrowserButton1);
             this.Controls.Add(this.Load);
             this.Controls.Add(this._NO_TRANSLATE_Directory);
@@ -109,5 +132,7 @@
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_Directory;
         private new System.Windows.Forms.Button Load;
         private UserControls.FolderBrowserButton folderBrowserButton1;
+        private System.Windows.Forms.Button folderGoUpbutton;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -86,5 +86,29 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 LoadClick(null, null);
             }
         }
+
+        private void folderGoUpbutton_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                DirectoryInfo currentDirectory = new DirectoryInfo(_NO_TRANSLATE_Directory.Text);
+                if (currentDirectory.Parent == null)
+                    return;
+                string parentPath = currentDirectory.Parent.FullName.TrimEnd('\\');
+                _NO_TRANSLATE_Directory.Text = parentPath;
+                _NO_TRANSLATE_Directory.Focus();
+                _NO_TRANSLATE_Directory.Select(_NO_TRANSLATE_Directory.Text.Length, 0);
+                SendKeys.Send(@"\");
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void _NO_TRANSLATE_Directory_TextChanged(object sender, EventArgs e)
+        {
+            DirectoryInfo currentDirectory = new DirectoryInfo(_NO_TRANSLATE_Directory.Text);
+            folderGoUpbutton.Enabled = (currentDirectory.Parent != null);
+        }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.resx
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Most of the time the path selected when opening the form is the one of the current open repository.
It could be very convenient to be able to go to the parent directory that has a high probability to contains
a lot of git repostories (and open the "AutoComplete" list that show the available folders to select one of them easily).