### PR TITLE
IME Patch for Commit message EditBox

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -585,6 +585,9 @@ namespace GitUI.SpellChecker
 
         private void TextBoxTextChanged(object sender, EventArgs e)
         {
+            if (_customUnderlines.IsImeStartingComposition)
+                return;
+
             if (!_disableAutoCompleteTriggerOnTextUpdate)
             {
                 // Reset when timer is already running
@@ -916,6 +919,9 @@ namespace GitUI.SpellChecker
 
         private void UpdateOrShowAutoComplete (bool calledByUser)
         {
+            if (_customUnderlines.IsImeStartingComposition)
+                return;
+
             if (_autoCompleteListTask == null || !AppSettings.ProvideAutocompletion)
                 return;
 


### PR DESCRIPTION
Fixes #2301

Changes proposed in this pull request:
 - korean language ime patch.
 
Screenshots before and after (if PR changes UI):
- previous screenshot :
![Prev](http://rossheo.com/assets/gitextensions_ime_problem.png)
- after screenshot : 
![After](http://rossheo.com/assets/gitextensions_ime_problem_fixed.png)

How did I test this code:
 - typing korean ime.

Has been tested on (remove any that don't apply):
 - GIT 2.12.2
 - Windows 10

