### PR TITLE
Fix a spelling mistake in code (FilePreabmle -> FilePreamble).

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -507,7 +507,7 @@ namespace GitUI.CommandsDialogs
             if (!_currentItemStaged && _currentItem.IsNew)
                 patch = PatchManager.GetSelectedLinesAsNewPatch(Module, _currentItem.Name,
                     SelectedDiff.GetText(), SelectedDiff.GetSelectionPosition(),
-                    SelectedDiff.GetSelectionLength(), SelectedDiff.Encoding, false, SelectedDiff.FilePreabmle);
+                    SelectedDiff.GetSelectionLength(), SelectedDiff.Encoding, false, SelectedDiff.FilePreamble);
             else
                 patch = PatchManager.GetSelectedLinesAsPatch(Module, SelectedDiff.GetText(),
                     SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
@@ -587,7 +587,7 @@ namespace GitUI.CommandsDialogs
             else if (_currentItem.IsNew)
                 patch = PatchManager.GetSelectedLinesAsNewPatch(Module, _currentItem.Name,
                     SelectedDiff.GetText(), SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
-                    SelectedDiff.Encoding, true, SelectedDiff.FilePreabmle);
+                    SelectedDiff.Encoding, true, SelectedDiff.FilePreamble);
             else
                 patch = PatchManager.GetResetUnstagedLinesAsPatch(Module, SelectedDiff.GetText(),
                     SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -180,7 +180,7 @@ namespace GitUI.Editor
         }
 
         [Browsable(false)]
-        public byte[] FilePreabmle { get; private set; }
+        public byte[] FilePreamble { get; private set; }
 
         private void WorkingDirChanged(object sender, GitUICommandsChangedEventArgs e)
         {
@@ -480,7 +480,7 @@ namespace GitUI.Editor
 
         private void ViewItem(string fileName, Func<Image> getImage, Func<string> getFileText, Func<string> getSubmoduleText)
         {
-            FilePreabmle = null;
+            FilePreamble = null;
 
             string fullPath = Path.GetFullPath(Path.Combine(Module.WorkingDir, fileName));
 
@@ -603,7 +603,7 @@ namespace GitUI.Editor
                 using (var reader = new StreamReader(path, Module.FilesEncoding))
                 {
                     var content = reader.ReadToEnd();
-                    FilePreabmle = reader.CurrentEncoding.GetPreamble();
+                    FilePreamble = reader.CurrentEncoding.GetPreamble();
                     return content;
                 }
             }


### PR DESCRIPTION
Fixes #
- Only renamed a Property, did not change the code semantically.

I don't know if these kinds of commits are welcome in this project. I am planning on fixing 'real issues' too in the future, I'm just new to GitExtensions yet!

PS: I used Resharper, so it was a 'clean rename' for sure!