### PR TITLE
Fix spelling in UI: "mergeconflict*" -> "merge conflict*"

### DIFF
--- a/GitPlugin/Connect.cs
+++ b/GitPlugin/Connect.cs
@@ -160,7 +160,7 @@ namespace GitPlugin
                     _gitPlugin.AddPopupCommand(mainMenuPopup, "CreateBranch",        "Create bra&nch", "Create new branch", 10, n++);
                     _gitPlugin.AddPopupCommand(mainMenuPopup, "Merge",               "&Merge", "merge", 18, n++);
                     _gitPlugin.AddPopupCommand(mainMenuPopup, "Rebase",              "R&ebase", "Rebase", 19, n++);
-                    _gitPlugin.AddPopupCommand(mainMenuPopup, "SolveMergeConflicts", "Sol&ve mergeconflicts", "Solve mergeconflicts", 0, n++);
+                    _gitPlugin.AddPopupCommand(mainMenuPopup, "SolveMergeConflicts", "Sol&ve merge conflicts", "Solve merge conflicts", 0, n++);
                     _gitPlugin.AddPopupCommand(mainMenuPopup, "CherryPick",          "Cherry &pick", "Cherry pick commit", 15, n++);
                 }
 

--- a/GitUI/CommandsDialogs/FormApplyPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.Designer.cs
@@ -212,7 +212,7 @@
             this.SolveMergeconflicts.Name = "SolveMergeconflicts";
             this.SolveMergeconflicts.Size = new System.Drawing.Size(125, 78);
             this.SolveMergeconflicts.TabIndex = 12;
-            this.SolveMergeconflicts.Text = "There are unresolved mergeconflicts\r\n";
+            this.SolveMergeconflicts.Text = "There are unresolved merge conflicts\r\n";
             this.SolveMergeconflicts.UseVisualStyleBackColor = false;
             this.SolveMergeconflicts.Visible = false;
             this.SolveMergeconflicts.Click += new System.EventHandler(this.SolveMergeconflicts_Click);

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -1699,7 +1699,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.runMergetoolToolStripMenuItem.Name = "runMergetoolToolStripMenuItem";
             this.runMergetoolToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.runMergetoolToolStripMenuItem.Text = "Solve mergeconflicts...";
+            this.runMergetoolToolStripMenuItem.Text = "Solve merge conflicts...";
             this.runMergetoolToolStripMenuItem.Click += new System.EventHandler(this.RunMergetoolToolStripMenuItemClick);
             // 
             // toolStripSeparator45

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1020,7 +1020,7 @@ namespace GitUI.CommandsDialogs
             this.SolveMergeconflicts.Name = "SolveMergeconflicts";
             this.SolveMergeconflicts.Size = new System.Drawing.Size(188, 42);
             this.SolveMergeconflicts.TabIndex = 0;
-            this.SolveMergeconflicts.Text = "There are unresolved mergeconflicts\r\n";
+            this.SolveMergeconflicts.Text = "There are unresolved merge conflicts\r\n";
             this.SolveMergeconflicts.UseVisualStyleBackColor = false;
             this.SolveMergeconflicts.Visible = false;
             this.SolveMergeconflicts.Click += new System.EventHandler(this.SolveMergeConflictsClick);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _enterCommitMessageHint = new TranslationString("Enter commit message");
 
         private readonly TranslationString _mergeConflicts =
-            new TranslationString("There are unresolved mergeconflicts, solve mergeconflicts before committing.");
+            new TranslationString("There are unresolved merge conflicts, solve merge conflicts before committing.");
 
         private readonly TranslationString _mergeConflictsCaption = new TranslationString("Merge conflicts");
 

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -390,7 +390,7 @@ namespace GitUI.CommandsDialogs
             this.SolveMergeconflicts.Name = "SolveMergeconflicts";
             this.SolveMergeconflicts.Size = new System.Drawing.Size(161, 49);
             this.SolveMergeconflicts.TabIndex = 19;
-            this.SolveMergeconflicts.Text = "There are unresolved mergeconflicts\r\n";
+            this.SolveMergeconflicts.Text = "There are unresolved merge conflicts\r\n";
             this.SolveMergeconflicts.UseVisualStyleBackColor = false;
             this.SolveMergeconflicts.Visible = false;
             this.SolveMergeconflicts.Click += new System.EventHandler(this.SolveMergeconflictsClick);

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -473,7 +473,7 @@
             this.Rescan.Name = "Rescan";
             this.Rescan.Size = new System.Drawing.Size(140, 25);
             this.Rescan.TabIndex = 5;
-            this.Rescan.Text = "Rescan mergeconflicts";
+            this.Rescan.Text = "Rescan merge conflicts";
             this.Rescan.UseVisualStyleBackColor = true;
             this.Rescan.Click += new System.EventHandler(this.Rescan_Click);
             // 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -19,11 +19,11 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString uskUseCustomMergeScript = new TranslationString("There is a custom merge script ({0}) for this file type." + Environment.NewLine + Environment.NewLine + "Do you want to use this custom merge script?");
         private readonly TranslationString uskUseCustomMergeScriptCaption = new TranslationString("Custom merge script");
         private readonly TranslationString fileUnchangedAfterMerge = new TranslationString("The file has not been modified by the merge. Usually this means that the file has been saved to the wrong location." + Environment.NewLine + Environment.NewLine + "The merge conflict will not be marked as solved. Please try again.");
-        private readonly TranslationString allConflictsResolved = new TranslationString("All mergeconflicts are resolved, you can commit." + Environment.NewLine + "Do you want to commit now?");
+        private readonly TranslationString allConflictsResolved = new TranslationString("All merge conflicts are resolved, you can commit." + Environment.NewLine + "Do you want to commit now?");
         private readonly TranslationString allConflictsResolvedCaption = new TranslationString("Commit");
         private readonly TranslationString fileIsBinary = new TranslationString("The selected file appears to be a binary file." + Environment.NewLine + "Are you sure you want to open this file in {0}?");
-        private readonly TranslationString askMergeConflictSolvedAfterCustomMergeScript = new TranslationString("The merge conflict need to be solved and the result must be saved as:" + Environment.NewLine + "{0}" + Environment.NewLine + Environment.NewLine + "Is the mergeconflict solved?");
-        private readonly TranslationString askMergeConflictSolved = new TranslationString("Is the mergeconflict solved?");
+        private readonly TranslationString askMergeConflictSolvedAfterCustomMergeScript = new TranslationString("The merge conflict need to be solved and the result must be saved as:" + Environment.NewLine + "{0}" + Environment.NewLine + Environment.NewLine + "Is the merge conflict solved?");
+        private readonly TranslationString askMergeConflictSolved = new TranslationString("Is the merge conflict solved?");
         private readonly TranslationString askMergeConflictSolvedCaption = new TranslationString("Conflict solved?");
         private readonly TranslationString noMergeTool = new TranslationString("There is no mergetool configured. Please go to settings and set a mergetool!");
         private readonly TranslationString stageFilename = new TranslationString("Stage {0}");

--- a/GitUI/CommandsDialogs/ResolveConflictsDialog/FormModifiedDeletedCreated.Designer.cs
+++ b/GitUI/CommandsDialogs/ResolveConflictsDialog/FormModifiedDeletedCreated.Designer.cs
@@ -169,7 +169,7 @@
             this.MinimizeBox = false;
             this.Name = "FormModifiedDeletedCreated";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Solve mergeconflict";
+            this.Text = "Solve merge conflict";
             this.Load += new System.EventHandler(this.FormModifiedDeletedCreated_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -116,7 +116,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             new TranslationString("There is a difftool configured: {0}");
 
         private readonly TranslationString _configureMergeTool =
-            new TranslationString("You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).");
+            new TranslationString("You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).");
 
         private readonly TranslationString _kdiffAsMergeConfiguredButNotFound =
             new TranslationString("KDiff3 is configured as mergetool, but the path to kdiff.exe is not configured.");

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -416,7 +416,7 @@ Při získávání větve bude tato akce provedena bez varování.</target>
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Musíte nastavit nástroj na rozdíly, abyste mohli řešit konflikty sloučení (např. kdiff3).</target>
         
       </trans-unit>
@@ -2159,7 +2159,7 @@ Budete moci odesílat. {2}</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Existují nevyřešené konflikty sloučení
 </target>
@@ -3177,7 +3177,7 @@ Chcete akci přerušit a odstranit ji ze seznamu repozitářů?</target>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Vyřešit konflikty sloučení...</target>
         
       </trans-unit>
@@ -3930,7 +3930,7 @@ gitex.cmd / gitex (umístěný ve stejné složce jako GitExtensions.exe):</targ
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Existují nevyřešené konflikty sloučení</target>
         
@@ -4066,7 +4066,7 @@ Chcete pokračovat?</target>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Existují nevyřešené konflikty sloučení. Před odevzdáním je musíte vyřešit.</target>
         
       </trans-unit>
@@ -6153,7 +6153,7 @@ Tato úprava je také provedena na stromě společného předka.</target>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="cs">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Vyřešit konflikt sloučení</target>
         
       </trans-unit>
@@ -6855,7 +6855,7 @@ Opravdu chcete odeslat tuto větev?</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Existují nevyřešené konflikty sloučení</target>
         
@@ -7548,7 +7548,7 @@ Hodnota byla změněna na prázdnou.</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Znovu skenovat konflikty sloučení</target>
         
       </trans-unit>
@@ -7676,7 +7676,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Všechny konflikty sloučení jsou vyřešené.Nyní můžete provést odevzdání.
 Chcete provést odevzdání?</target>
@@ -7688,7 +7688,7 @@ Chcete provést odevzdání?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>Je tento konflikt sloučení vyřešený?</target>
         
       </trans-unit>
@@ -7696,7 +7696,7 @@ Chcete provést odevzdání?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Konflikt sloučení musí být vyřešen a výsledek musí být uložen jako:
 {0}
 

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -415,7 +415,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Stel een merge tool in om merge conflicten op te lossen (bijvoorbeeld kidff3).</target>
         
       </trans-unit>
@@ -2176,7 +2176,7 @@ U heeft rechten om commits te verzenden. {2}
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Er zijn niet opgeloste conflicten</target>
         
@@ -3198,7 +3198,7 @@ Wilt u teruggaan naar het dashboard en het item verwijderen uit de 'recent geope
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Samenvoeg conflicten oplossen...</target>
         
       </trans-unit>
@@ -3963,7 +3963,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Er zijn niet opgeloste samenvoeg conflicten</target>
         
@@ -4099,7 +4099,7 @@ Weet u zeker dat u wilt doorgaan?</target>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Er zijn niet opgeloste samenvoeg conflicten. Deze moeten opgelost worden voordat u een commit kunt maken.</target>
         
       </trans-unit>
@@ -6201,7 +6201,7 @@ De aanpassingen worden ook in gemeenschappelijke oorspronkelijke vertakking uitg
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="nl">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Samenvoeg conflicten oplossen</target>
         
       </trans-unit>
@@ -6913,7 +6913,7 @@ Weet u zeker dat u deze vertakking wilt verzenden?</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Er zijn niet opgeloste conflicten</target>
         
@@ -7633,7 +7633,7 @@ De waarde is teruggezet naar een lege waarde.</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Verversen</target>
         
       </trans-unit>
@@ -7761,7 +7761,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Alle samenvoeg conflicten zijn opgelost, u kunt nu committen.
 Wilt u nu committen?</target>
@@ -7773,7 +7773,7 @@ Wilt u nu committen?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>Is het samenvoeg conflict opgelost?</target>
         
       </trans-unit>
@@ -7781,7 +7781,7 @@ Wilt u nu committen?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Het samenvoeg conflict moet worden opgelost en het resultaat moet worden opgeslagen als: 
 {0} 
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -338,7 +338,7 @@ This action will be performed without warning while checking out branch.</source
         <target />
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target />
       </trans-unit>
       <trans-unit id="_customMergeToolXConfigured.Text">
@@ -1758,7 +1758,7 @@ You will have push access. {2}</source>
         <target />
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target />
       </trans-unit>
@@ -2579,7 +2579,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         <target />
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target />
       </trans-unit>
       <trans-unit id="saveAsToolStripMenuItem.Text">
@@ -3196,7 +3196,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target />
       </trans-unit>
@@ -3299,7 +3299,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target />
       </trans-unit>
       <trans-unit id="_mergeConflictsCaption.Text">
@@ -4947,7 +4947,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target />
       </trans-unit>
       <trans-unit id="Abort.Text">
@@ -5512,7 +5512,7 @@ Are you sure you want to push this branch?</source>
         <target />
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target />
       </trans-unit>
@@ -6089,7 +6089,7 @@ Value has been reset to empty value.</source>
         <target />
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target />
       </trans-unit>
       <trans-unit id="Reset.Text">
@@ -6190,7 +6190,7 @@ This action cannot be made undone.</source>
         <target />
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target />
       </trans-unit>
@@ -6199,14 +6199,14 @@ Do you want to commit now?</source>
         <target />
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target />
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedAfterCustomMergeScript.Text">
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target />
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedCaption.Text">

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -416,7 +416,7 @@ Cette action sera effectuée sans avertissement durant le chargement d'une branc
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Vous devez configurer un outils de fusion pour résoudre les conflits de fusion (kdiff3 par exemple).
 </target>
         
@@ -2178,7 +2178,7 @@ Vous aurez les droits de pousser. {2}</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Il y a des conflits de fusion non résolus</target>
         
@@ -3200,7 +3200,7 @@ Voulez vous abandonner et le retirer de la liste des dépôts récents?</target>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Résoudre les conflits de fusion...</target>
         
       </trans-unit>
@@ -3967,7 +3967,7 @@ gitex.cmd / gitex (situé dans le même répertoire que GitExtensions.exe) :</ta
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Il y a des conflits de fusion non résolus</target>
         
@@ -4103,7 +4103,7 @@ Voulez-vous continuer?</target>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Il y a des conflits de fusion non résolus, résolvez les avant un commit</target>
         
       </trans-unit>
@@ -6200,7 +6200,7 @@ Cet ajustement est également fait à l'arbre de l'ancêtre commun.  </target>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="fr">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Résoudre le conflit de fusion</target>
         
       </trans-unit>
@@ -6911,7 +6911,7 @@ Voulez-vous vraiment pousser cette branche ?
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Il y a des conflits de fusion non résolus</target>
         
@@ -7632,7 +7632,7 @@ fichiers et/ou répertoires</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Rescanner les conflits de fusion</target>
         
       </trans-unit>
@@ -7762,7 +7762,7 @@ Cette action ne peut être annulée.</target>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Tous les conflits de fusion sont résolus, vous pouvez commiter.
 Voulez-vous commiter maintenant?</target>
@@ -7774,7 +7774,7 @@ Voulez-vous commiter maintenant?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>Est-ce que le conflit de fusion est résolu?</target>
         
       </trans-unit>
@@ -7782,7 +7782,7 @@ Voulez-vous commiter maintenant?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Le conflit de fusion doit être résolu et le résultat doit être enregistré comme :
 {0}
 

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -416,7 +416,7 @@ Diese Aktion wird dann ohne Warnung beim Auschecken eines Branch angewendet.</ta
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Sie müssen ein Merge-Werkzeug konfigurieren, um Konflikte beim Zusammenführen aufzulösen (zum Beispiel KDiff3).</target>
         
       </trans-unit>
@@ -2178,7 +2178,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Es liegen nicht gelöste Merge-Konflikte vor.
 </target>
@@ -3203,7 +3203,7 @@ Wollen Sie abbrechen und es von der Liste der zuletzt verwendeten Repositorys st
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Merge-Konflikte auflösen...</target>
         
       </trans-unit>
@@ -3971,7 +3971,7 @@ gitex.cmd / gitex (befinden sich im gleichen Ordner wie GitExtensions.exe):</tar
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Es liegen ungelöste Mergekonflikte vor
 
@@ -4116,7 +4116,7 @@ Wollen Sie trotzdem fortfahren?</target>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Es liegen unaufgelöste Merge-Konflikte vor. Lösen Sie die Merge-Konflikte auf bevor Sie committen.</target>
         
       </trans-unit>
@@ -6223,7 +6223,7 @@ auf den gemeinsamen Vorfahrenbaum angewendet.</target>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="de">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Merge-Konflikt lösen</target>
         
       </trans-unit>
@@ -6935,7 +6935,7 @@ Sind Sie sich sicher, dass Sie diesen Branch pushen wollen?</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Es liegen unaufgelöste Mergekonflikte vor
 </target>
@@ -7655,7 +7655,7 @@ Wert wurde mit leerem Wert ersetzt.</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Merge-Konflikte neu prüfen</target>
         
       </trans-unit>
@@ -7790,7 +7790,7 @@ Diese Aktion kann nicht rückgängig gemacht werden.</target>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Alle Merge-Konflikte wurden gelöst, Sie können nun committen.
 Wollen Sie nun committen?</target>
@@ -7802,7 +7802,7 @@ Wollen Sie nun committen?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>Ist der Merge-Konflikt behoben?</target>
         
       </trans-unit>
@@ -7810,7 +7810,7 @@ Wollen Sie nun committen?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Der Merge-Konflikt muss aufgelöst und das Resultat gespeichert werden als:
 {0}
 

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -409,7 +409,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Devi configurare lo strumento di merge per risolvere i conflitti delle fusioni (kdiff3 ad esempio).</target>
         
       </trans-unit>
@@ -2107,7 +2107,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Ci sono conflitti di merge non risolti</target>
         
@@ -3076,7 +3076,7 @@ Vuoi rimuoverlo dalla lista dei repository recenti?</target>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Risolvi conflitti di merge...</target>
         
       </trans-unit>
@@ -3810,7 +3810,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Ci sono conflitti di merge non risolti</target>
         
@@ -3934,7 +3934,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Ci sono conflitti di merge non risolti, risolvili prima di farne il commit</target>
         
       </trans-unit>
@@ -5851,7 +5851,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="it">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Risolvi conflitti di merge</target>
         
       </trans-unit>
@@ -6504,7 +6504,7 @@ Sei sicuro di volerne effettuare il push?</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Ci sono conflitti di merge non risolti</target>
         
@@ -7147,7 +7147,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Ricontrolla conflitti di merge</target>
         
       </trans-unit>
@@ -7252,7 +7252,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Tutti i conflitti di merge sono stati risolti, si può farne il commit.
 Vuoi farlo ora?</target>
@@ -7264,7 +7264,7 @@ Vuoi farlo ora?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>E' stato risolto il conflitto?</target>
         
       </trans-unit>
@@ -7272,7 +7272,7 @@ Vuoi farlo ora?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Il conflitto di merge deve essere risolto e il risultato sarà salvato come:
 {0}
 

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -411,7 +411,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>競合の解決をするため、KDiff3などのマージツールを設定する必要があります。</target>
         
       </trans-unit>
@@ -2137,7 +2137,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>未解決のmergeconflictsがあります。</target>
         
@@ -3142,7 +3142,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>競合の解決...</target>
         
       </trans-unit>
@@ -3879,7 +3879,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>解決されていない競合があります</target>
         
@@ -4014,7 +4014,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>未解決の競合があります。コミット前に競合を解決してください。</target>
         
       </trans-unit>
@@ -6047,7 +6047,7 @@ subtree
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="ja">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>競合の解決</target>
         
       </trans-unit>
@@ -6735,7 +6735,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>未解決の競合があります。</target>
         
@@ -7423,7 +7423,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>競合の再調査</target>
         
       </trans-unit>
@@ -7553,7 +7553,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>すべての競合を解決するとコミットできます。
 今すぐコミットしますか？</target>
@@ -7565,7 +7565,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>競合は解決しましたか？</target>
         
       </trans-unit>
@@ -7573,7 +7573,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>マージの競合を快活する必要があり、結果は次のように保存する必要があります:
 {0}
 

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -408,7 +408,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>파일머지/충돌처리 툴 또는 외부 프로그램을 설정하세요. (kdiff3, bc3, etc...)</target>
         
       </trans-unit>
@@ -2120,7 +2120,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>미해결된 충돌파일이 존재합니다</target>
         
@@ -3102,7 +3102,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         
       </trans-unit>
       <trans-unit id="saveAsToolStripMenuItem.Text">
@@ -3825,7 +3825,7 @@ gitex.cmd / gitex (GitExtensions.ex 와 같은 폴더에 있음)</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>미해결된 충돌파일이 존재합니다</target>
         
@@ -3960,7 +3960,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>머지충돌 파일이 존재합니다. 커밋 하기전에 충돌 파일을 정리하세요.</target>
         
       </trans-unit>
@@ -5923,7 +5923,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="ko">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>머지 충돌파일 처리</target>
         
       </trans-unit>
@@ -6598,7 +6598,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>미해결된 충돌파일이 존재합니다</target>
         
@@ -7275,7 +7275,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         
       </trans-unit>
       <trans-unit id="Reset.Text">
@@ -7396,7 +7396,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>모든 머지충돌이 해결되어 커밋이 가능합니다.
 수정사항을 지금 커밋 할까요?</target>
@@ -7408,7 +7408,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>충돌파일이 처리되었습니까?</target>
         
       </trans-unit>
@@ -7416,7 +7416,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedCaption.Text">

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -416,7 +416,7 @@ Ta akcja będzie wykonywana bez ostrzeżenia podczas przełączania gałęzi.</t
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Musisz skonfigurować narzędzie scalania (przykładowo kdiff3), aby móc rozwiązywać konflikty scalania.</target>
         
       </trans-unit>
@@ -2157,7 +2157,7 @@ Będziesz mieć uprawnienia wysyłania. {2}</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Istnieją nierozwiązane konflikty scalania
 </target>
@@ -3173,7 +3173,7 @@ Chcesz przerwać, i usunąć go z listy ostatnich repozytoriów?</target>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Rozwiąż konflikty scalania...</target>
         
       </trans-unit>
@@ -3923,7 +3923,7 @@ gitex.cmd / gitex (umieszczone w tym samym folderze, co GitExtensions.exe):</tar
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Istnieją nierozwiązane konflikty scalania
 </target>
@@ -4060,7 +4060,7 @@ Chcesz kontynuować?</target>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Istnieją nierozwiązane konflikty scalania, rozwiąż je przed zatwierdzeniem.</target>
         
       </trans-unit>
@@ -6138,7 +6138,7 @@ poziomie. Dostosowanie jest również wykonywane do zwyczajnego drzewa przodka.<
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="pl">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Rozwiąż konflikt scalania</target>
         
       </trans-unit>
@@ -6840,7 +6840,7 @@ Na pewno chcesz wysłać tę gałąź?</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Istnieją nierozwiązane konflikty scalania
 </target>
@@ -7529,7 +7529,7 @@ Przywrócono do pustej wartości.</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Przeskanuj konflikty scalania</target>
         
       </trans-unit>
@@ -7659,7 +7659,7 @@ Ta czynność nie może zostać cofnięta.</target>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Wszystkie konflikty scalania zostały rozwiązane, możesz zatwierdzić.
 Chcesz teraz zatwierdzić?</target>
@@ -7671,7 +7671,7 @@ Chcesz teraz zatwierdzić?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>Czy konflikt scalania został rozwiązany?</target>
         
       </trans-unit>
@@ -7679,7 +7679,7 @@ Chcesz teraz zatwierdzić?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Konflikt scalania musi zostać rozwiązany, a wynik musi zostać zapisany jako:
 {0}
 

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -416,7 +416,7 @@ Esta ação será executada sem aviso enquanto estiver indo para um branch.</tar
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Você precisa configurar uma ferramenta de merge para solucionar conflitos de merge (kdiff3 por exemplo).</target>
         
       </trans-unit>
@@ -2166,7 +2166,7 @@ Você poderá realizar push. {2}</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Existem conflitos de merge não resolvidos
 </target>
@@ -3189,7 +3189,7 @@ Quer interromper e removê-lo da lista de repositórios recentes?</target>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Solucionar conflitos de merge...</target>
         
       </trans-unit>
@@ -3947,7 +3947,7 @@ gitex.cmd / gitex (localizado na mesma pasta do GitExtensions.exe):</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Existem conflitos de merge não resolvidos
 </target>
@@ -4084,7 +4084,7 @@ Quer continuar?</target>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Há conflitos de merge não resolvidos, resolva conflitos de merge antes de commitar.</target>
         
       </trans-unit>
@@ -6075,7 +6075,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="pt-BR">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Solucionar conflito de merge</target>
         
       </trans-unit>
@@ -6749,7 +6749,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Existem conflitos de merge não resolvidos
 </target>
@@ -7440,7 +7440,7 @@ Valor foi restaurado para vazio.</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         
       </trans-unit>
       <trans-unit id="Reset.Text">
@@ -7565,7 +7565,7 @@ Esta ação não poderá ser desfeita.</target>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Todos os conflitos de merge estão resolvidos, você pode commitar.
 Quer commitar agora?</target>
@@ -7577,7 +7577,7 @@ Quer commitar agora?</target>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>O conflito de merge está solucionado?</target>
         
       </trans-unit>
@@ -7585,7 +7585,7 @@ Quer commitar agora?</target>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>O conflito de merge precisa ser solucionado e o resultado deve ser salvo como:
 {0}
 

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -269,7 +269,7 @@ This action will be performed without warning while checking out branch.</source
 
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
 
       </trans-unit>
       <trans-unit id="_customMergeToolXConfigured.Text">
@@ -1577,7 +1577,7 @@ You will have push access. {2}</source>
 
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
 
       </trans-unit>
@@ -2334,7 +2334,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
 
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
 
       </trans-unit>
       <trans-unit id="saveAsToolStripMenuItem.Text">
@@ -2856,7 +2856,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
 
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
 
       </trans-unit>
@@ -2959,7 +2959,7 @@ Do you want to continue?</source>
 
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
 
       </trans-unit>
       <trans-unit id="_mergeConflictsCaption.Text">
@@ -4382,7 +4382,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
 
       </trans-unit>
       <trans-unit id="Abort.Text">
@@ -4879,7 +4879,7 @@ Are you sure you want to push this branch?</source>
 
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
 
       </trans-unit>
@@ -5352,7 +5352,7 @@ Value has been reset to empty value.</source>
 
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
 
       </trans-unit>
       <trans-unit id="Reset.Text">
@@ -5453,7 +5453,7 @@ This action cannot be made undone.</source>
 
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
 
       </trans-unit>
@@ -5462,14 +5462,14 @@ Do you want to commit now?</source>
 
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
 
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedAfterCustomMergeScript.Text">
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
 
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedCaption.Text">

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -350,7 +350,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         
       </trans-unit>
       <trans-unit id="_customMergeToolXConfigured.Text">
@@ -1820,7 +1820,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         
       </trans-unit>
@@ -2652,7 +2652,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         
       </trans-unit>
       <trans-unit id="saveAsToolStripMenuItem.Text">
@@ -3278,7 +3278,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         
       </trans-unit>
@@ -3383,7 +3383,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflictsCaption.Text">
@@ -5066,7 +5066,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="ro">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         
       </trans-unit>
       <trans-unit id="Abort.Text">
@@ -5643,7 +5643,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         
       </trans-unit>
@@ -6237,7 +6237,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         
       </trans-unit>
       <trans-unit id="Reset.Text">
@@ -6338,7 +6338,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         
       </trans-unit>
@@ -6347,14 +6347,14 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedAfterCustomMergeScript.Text">
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolvedCaption.Text">

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -416,7 +416,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Необходимо настроить инструмент слияния для решения конфликтов (например, kdiff3).</target>
         
       </trans-unit>
@@ -2167,7 +2167,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Неразрешенные конфликты</target>
         
@@ -3186,7 +3186,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Разрешить конфликты...</target>
         
       </trans-unit>
@@ -3938,7 +3938,7 @@ gitex.cmd / gitex (находится в той же папке, что и GitEx
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Есть неразрешенные конфликты</target>
         
@@ -4073,7 +4073,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Есть конфликты слияния, решите их перед коммитом.</target>
         
       </trans-unit>
@@ -6161,7 +6161,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="ru">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Разрешить конфликт слияния</target>
         
       </trans-unit>
@@ -6862,7 +6862,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Неразрешенные конфликты</target>
         
@@ -7553,7 +7553,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Пересканировать конфликты</target>
         
       </trans-unit>
@@ -7684,7 +7684,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Все конфликты были разрешены, вы можете зафиксировать изменения.
 Хотите зафиксировать сейчас?</target>
@@ -7696,7 +7696,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>Конфликт разрешен?</target>
         
       </trans-unit>
@@ -7704,7 +7704,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>Конфликт должен быть разрешен, и результат должен быть сохранен как:
 {0}
 

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -416,7 +416,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>您应该配置合并工具，以解决合并冲突项（例如kdiff3）。</target>
         
       </trans-unit>
@@ -2153,7 +2153,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>有未解决的合并冲突</target>
         
@@ -3161,7 +3161,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>解决合并冲突...</target>
         
       </trans-unit>
@@ -3898,7 +3898,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>有未解决的合并冲突</target>
         
@@ -4034,7 +4034,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>有未解决的合并冲突，提交之前要先结果合并冲突。</target>
         
       </trans-unit>
@@ -6077,7 +6077,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="zh-Hans">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>解决合并冲突</target>
         
       </trans-unit>
@@ -6774,7 +6774,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>有未解决的合并错误</target>
         
@@ -7461,7 +7461,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>重新扫描合并冲突</target>
         
       </trans-unit>
@@ -7591,7 +7591,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>所有合并冲突都解决了，你可以提交了。
 你想现在提交吗？</target>
@@ -7603,7 +7603,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>合并冲突解决了吗？</target>
         
       </trans-unit>
@@ -7611,7 +7611,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>合并冲突需要解决，必须将结果保存为：
 {0}
 

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -416,7 +416,7 @@ Esta acción se realizará sin preguntar al hacer checkout de una rama.</target>
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>Necesita configurar la herramienta de fusión para resolver conflictos de fusión (kdiff3 por ejemplo).</target>
         
       </trans-unit>
@@ -2162,7 +2162,7 @@ Tendrá acceso para hacer Push. {2}</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Hay conflictos de fusión sin resolver</target>
         
@@ -3178,7 +3178,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>Resolver conflictos de fusión...</target>
         
       </trans-unit>
@@ -3928,7 +3928,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Hay conflictos de fusión sin resolver</target>
         
@@ -4065,7 +4065,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>Hay conflictos de fusión sin resolver, solucionar conflictos antes de realizar el commit.</target>
         
       </trans-unit>
@@ -6144,7 +6144,7 @@ al árbol ancestro común.</target>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="es">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>Resolver conflicto de fusión</target>
         
       </trans-unit>
@@ -6841,7 +6841,7 @@ el remoto. ¿Está seguro de que desea hacer Push con esta rama?</target>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>Hay conflictos sin resolver</target>
         
@@ -7529,7 +7529,7 @@ El valor se ha restablecido a un valor vacío.</target>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>Volver a examinar conflictos</target>
         
       </trans-unit>
@@ -7659,7 +7659,7 @@ Esta acción no se puede deshacer.</target>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>Todos los conflictos de fusión se resolvieron, puede hacer commit. 
 ¿Quiere hacer commit ahora?</target>
@@ -7671,7 +7671,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>¿Está resuelto el conflicto?</target>
         
       </trans-unit>
@@ -7679,7 +7679,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>El conflicto de fusión necesita ser solucionado y el resultado guardado como:
 {0}
 

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -411,7 +411,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>建議設定merge工具(如KDiff3)，以解決merge衝突</target>
         
       </trans-unit>
@@ -2124,7 +2124,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>有未解決的合併衝突</target>
         
@@ -3113,7 +3113,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>解決合併衝突...</target>
         
       </trans-unit>
@@ -3849,7 +3849,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>有未解決的合併衝突</target>
         
@@ -3978,7 +3978,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>有未解決的合併衝突，提交之前要先結果合併衝突。 </target>
         
       </trans-unit>
@@ -5965,7 +5965,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en" target-language="zh-Hant">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>解決合併衝突</target>
         
       </trans-unit>
@@ -6647,7 +6647,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>有未解決的合併錯誤</target>
         
@@ -7331,7 +7331,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>重新掃描合併衝突</target>
         
       </trans-unit>
@@ -7454,7 +7454,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>所有合併衝突都解決了，你可以提交了。 
 你想現在提交嗎？ </target>
@@ -7466,7 +7466,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>合併衝突解決了嗎？ </target>
         
       </trans-unit>
@@ -7474,7 +7474,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>合併衝突需要解決，結果要儲存為:
 {0}
 

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -416,7 +416,7 @@ This action will be performed without warning while checking out branch.</source
         
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve mergeconflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
         <target>[Ẏǿŭ ƞḗḗḓ ŧǿ ƈǿƞƒīɠŭřḗ ḿḗřɠḗ ŧǿǿŀ īƞ ǿřḓḗř ŧǿ şǿŀṽḗ ḿḗřɠḗƈǿƞƒŀīƈŧş (ķḓīƒƒ3 ƒǿř ḗẋȧḿƥŀḗ). 鶱ẛϰ ϕǲϰϕ ſ鶱 ϱϖ]</target>
         
       </trans-unit>
@@ -2176,7 +2176,7 @@ You will have push access. {2}</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>[Ŧħḗřḗ ȧřḗ ŭƞřḗşǿŀṽḗḓ ḿḗřɠḗƈǿƞƒŀīƈŧş
  ΰςǋϑϰ ϖς靐]</target>
@@ -3201,7 +3201,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         
       </trans-unit>
       <trans-unit id="runMergetoolToolStripMenuItem.Text">
-        <source>Solve mergeconflicts...</source>
+        <source>Solve merge conflicts...</source>
         <target>[Şǿŀṽḗ ḿḗřɠḗƈǿƞƒŀīƈŧş... ΰΐϖΰ衋 ςϐẛϐϑ]</target>
         
       </trans-unit>
@@ -3968,7 +3968,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>[Ŧħḗřḗ ȧřḗ ŭƞřḗşǿŀṽḗḓ ḿḗřɠḗƈǿƞƒŀīƈŧş
  靐ΰϵϑı ſϵǋ]</target>
@@ -4105,7 +4105,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_mergeConflicts.Text">
-        <source>There are unresolved mergeconflicts, solve mergeconflicts before committing.</source>
+        <source>There are unresolved merge conflicts, solve merge conflicts before committing.</source>
         <target>[Ŧħḗřḗ ȧřḗ ŭƞřḗşǿŀṽḗḓ ḿḗřɠḗƈǿƞƒŀīƈŧş, şǿŀṽḗ ḿḗřɠḗƈǿƞƒŀīƈŧş ƀḗƒǿřḗ ƈǿḿḿīŧŧīƞɠ. ẛǅϕẛǈ 靐靐ǋ ıς]</target>
         
       </trans-unit>
@@ -6208,7 +6208,7 @@ ancestor tree.</source>
   <file datatype="plaintext" original="FormModifiedDeletedCreated" source-language="en">
     <body>
       <trans-unit id="$this.Text">
-        <source>Solve mergeconflict</source>
+        <source>Solve merge conflict</source>
         <target>[Şǿŀṽḗ ḿḗřɠḗƈǿƞƒŀīƈŧ 鶱ϖΰǋ鶱 ϵſıẛẛ]</target>
         
       </trans-unit>
@@ -6918,7 +6918,7 @@ Are you sure you want to push this branch?</source>
         
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
-        <source>There are unresolved mergeconflicts
+        <source>There are unresolved merge conflicts
 </source>
         <target>[Ŧħḗřḗ ȧřḗ ŭƞřḗşǿŀṽḗḓ ḿḗřɠḗƈǿƞƒŀīƈŧş
  ϰǈǲǋϖ ϐϑ靐]</target>
@@ -7639,7 +7639,7 @@ Value has been reset to empty value.</source>
         
       </trans-unit>
       <trans-unit id="Rescan.Text">
-        <source>Rescan mergeconflicts</source>
+        <source>Rescan merge conflicts</source>
         <target>[Řḗşƈȧƞ ḿḗřɠḗƈǿƞƒŀīƈŧş ΐ衋衋衋ſǈ ϑſǈ]</target>
         
       </trans-unit>
@@ -7769,7 +7769,7 @@ This action cannot be made undone.</source>
         
       </trans-unit>
       <trans-unit id="allConflictsResolved.Text">
-        <source>All mergeconflicts are resolved, you can commit.
+        <source>All merge conflicts are resolved, you can commit.
 Do you want to commit now?</source>
         <target>[Ȧŀŀ ḿḗřɠḗƈǿƞƒŀīƈŧş ȧřḗ řḗşǿŀṽḗḓ, ẏǿŭ ƈȧƞ ƈǿḿḿīŧ.
 Ḓǿ ẏǿŭ ẇȧƞŧ ŧǿ ƈǿḿḿīŧ ƞǿẇ? 鶱ϖΐ ǈǋΰΐΰϰϰ衋]</target>
@@ -7781,7 +7781,7 @@ Do you want to commit now?</source>
         
       </trans-unit>
       <trans-unit id="askMergeConflictSolved.Text">
-        <source>Is the mergeconflict solved?</source>
+        <source>Is the merge conflict solved?</source>
         <target>[Īş ŧħḗ ḿḗřɠḗƈǿƞƒŀīƈŧ şǿŀṽḗḓ? 衋ǋ ϱ鶱ı 靐ςſ衋]</target>
         
       </trans-unit>
@@ -7789,7 +7789,7 @@ Do you want to commit now?</source>
         <source>The merge conflict need to be solved and the result must be saved as:
 {0}
 
-Is the mergeconflict solved?</source>
+Is the merge conflict solved?</source>
         <target>[Ŧħḗ ḿḗřɠḗ ƈǿƞƒŀīƈŧ ƞḗḗḓ ŧǿ ƀḗ şǿŀṽḗḓ ȧƞḓ ŧħḗ řḗşŭŀŧ ḿŭşŧ ƀḗ şȧṽḗḓ ȧş:
 {0}
 


### PR DESCRIPTION
I am not a native English speaker, but I believe 'mergeconflict' is not an English word (even GitHub underlines it). I think it should be 'merge conflict' in UI strings and localized strings.

Changes proposed in this pull request:
- updated all .xlf files in GitUI/Translation
- updated all the occurrences I've found in the code, except:
  1: the command name in GitUICommands (and related occurrences)
  2: in ChangeLog.md.
 
How did I test this code:
 - Ran a 'Build solution' in VS2015: No build errors. No generated files changed (so I probably did not miss any UI string)
 
Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
