### PR TITLE
Fixed plugin loading issue due to lower version of newton json dll was missing

### DIFF
--- a/GitExtensions/app.config
+++ b/GitExtensions/app.config
@@ -33,7 +33,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Additional fix to #3704 #3771

Changes proposed in this pull request:
 - Fixed NewtonSoft.Json.Dll v6 and v8 could not be found issue when loading the TFS plugin
 
How did I test this code:
 - No, I didn't test TFS, hope someone using TFS can test it
 - I just made sure the exception is gone during debugging
