### PR TITLE
Fix for issue #3759:

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -601,12 +601,21 @@ namespace GitUI.Editor
             if (File.Exists(path))
             {
                 // StreamReader disposes of 'fileStream'.
+                // see: https://msdn.microsoft.com/library/ms182334.aspx
                 var fileStream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using (var reader = new StreamReader(fileStream, Module.FilesEncoding))
+                try
                 {
-                    var content = reader.ReadToEnd();
-                    FilePreamble = reader.CurrentEncoding.GetPreamble();
-                    return content;
+                    using (var reader = new StreamReader(fileStream, Module.FilesEncoding))
+                    {
+                        fileStream = null;
+                        var content = reader.ReadToEnd();
+                        FilePreamble = reader.CurrentEncoding.GetPreamble();
+                        return content;
+                    }
+                }
+                finally
+                {
+                    fileStream?.Dispose();
                 }
             }
             else

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -600,7 +600,9 @@ namespace GitUI.Editor
 
             if (File.Exists(path))
             {
-                using (var reader = new StreamReader(path, Module.FilesEncoding))
+                // StreamReader disposes of 'fileStream'.
+                var fileStream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using (var reader = new StreamReader(fileStream, Module.FilesEncoding))
                 {
                     var content = reader.ReadToEnd();
                     FilePreamble = reader.CurrentEncoding.GetPreamble();


### PR DESCRIPTION
Issue: [Exception shown instead of error message for locked file in commit dialog](https://github.com/gitextensions/gitextensions/issues/3759)

Using **FileShare.ReadWrite** lets us read the file even if it's locked.

Yes the locker program(s) might write to the file and the file content shown might become outdated but then the user presses 'Refresh'. It's still a better UX than 'not reading' the file content and 'not showing' it, right?
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/12460850/27308464-f4bf03f2-554e-11e7-8b33-18a830307283.png)


How did I test this code:
 - Added a .dwg file to one my repos, and opened it in AutoCAD which always puts a write-lock on opened files. Then I checked the same file in the commit dialog.

Has been tested on (remove any that don't apply):
 - GIT 2.13.0
 - Windows 7
