### PR TITLE
Set the OK button as accept button so we can use Enter key to confirm the merge

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -419,6 +419,7 @@
             // 
             // FormMergeBranch
             // 
+            this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSize = true;


### PR DESCRIPTION
Fixes #3782, I believe the accept button was removed inadvertently.

Changes proposed in this pull request:
 - Added back the ability to confirm the merge form using Enter key

How did I test this code:
 - Open the merge form and type the Enter key

Has been tested on (remove any that don't apply):
 - Git 2.12.2
 - Windows 10