### PR TITLE
Upgrade to KDiff3 0.9.98 32-Bit

### DIFF
--- a/Setup/DownloadExternals.cmd
+++ b/Setup/DownloadExternals.cmd
@@ -9,7 +9,7 @@ IF NOT EXIST "%~p0\cache\Git-2.12.2-32-bit.exe" (
     IF ERRORLEVEL 1 EXIT /B 1
 )
 
-IF NOT EXIST "%~p0\cache\KDiff3-32bit-Setup_0.9.97.exe" (
-    "%~p0\tools\curl.exe" -L -k -o %~p0\cache\KDiff3-32bit-Setup_0.9.97.exe http://sourceforge.net/projects/kdiff3/files/kdiff3/0.9.97/KDiff3-32bit-Setup_0.9.97.exe/download -L http://sourceforge.net/ > NUL
+IF NOT EXIST "%~p0\cache\KDiff3-32bit-Setup_0.9.98-3.exe" (
+    "%~p0\tools\curl.exe" -L -k -o %~p0\cache\KDiff3-32bit-Setup_0.9.98-3.exe https://sourceforge.net/projects/kdiff3/files/kdiff3/0.9.98/KDiff3-32bit-Setup_0.9.98-3.exe/download
     IF ERRORLEVEL 1 EXIT /B 1
 )

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -898,7 +898,7 @@
             </Feature>
         </Feature>
         <?if $(var.IncludeRequiredSoftware) = 1 ?>
-        <Binary Id="KDiff" SourceFile="cache\KDiff3-32bit-Setup_0.9.97.exe" />
+        <Binary Id="KDiff" SourceFile="cache\KDiff3-32bit-Setup_0.9.98-3.exe" />
         <CustomAction Id="InstallKDiff" Impersonate="no" BinaryKey="KDiff" Execute="deferred" ExeCommand="" Return="ignore" />
         <Binary Id="Git" SourceFile="cache\Git-2.12.2-32-bit.exe" />
         <CustomAction Id="InstallGit" Impersonate="no" BinaryKey="Git" Execute="deferred" ExeCommand="/COMPONENTS=&quot;assoc,assoc_sh&quot;" Return="ignore" />

--- a/Setup/UI/RequiredSoftwareDlg.wxs
+++ b/Setup/UI/RequiredSoftwareDlg.wxs
@@ -18,7 +18,7 @@
         <Control Id="GitDescription" Type="Text" Height="46" Width="238" X="25" Y="86" Text="Git for Windows is the native version of Git that powers Git Extensions. You must have a version of Git installed for Git Extensions to function properly." />
         <Control Id="GitCheckBox" Type="CheckBox" Height="20" Width="78" X="274" Y="87" Text="Install Git" Property="INSTALLGIT" CheckBoxValue="1" />
 
-        <Control Id="KDiffTitle" Type="Text" Height="15" Width="200" X="15" Y="136" Text="{\WixUI_Font_Title}KDiff3 32bit 0.9.97" />
+        <Control Id="KDiffTitle" Type="Text" Height="15" Width="200" X="15" Y="136" Text="{\WixUI_Font_Title}KDiff3 32bit 0.9.98" />
         <Control Id="KDiffDescription" Type="Text" Height="46" Width="238" X="25" Y="152" Text="KDiff is a diff/merge tool that Git Extensions calls upon when it encounters a merge conflict. If you already have a diff/merge tool that works with Git then you don't need to install this." />
         <Control Id="KDiffCheckBox" Type="CheckBox" Height="20" Width="78" X="274" Y="154" Text="Install KDiff" Property="INSTALLKDIFF3" CheckBoxValue="1" />
       </Dialog>


### PR DESCRIPTION
Fixes: #3784.

Changes proposed in this pull request:
 - Upgrade to KDiff3 0.9.98
 - Removed ` -L http://sourceforge.net/ > NUL` from Setup/DownloadExternals.cmd which seems silly. It just downloads SourceForge's home page and pipes it to NUL...

How did I test this code:
 - I ran Setup/DownloadExternals.cmd
 - I tried to run Setup/BuildInstallers.VS2015.cmd. But it failed since I don't have the VS2015 SDK installed locally and it's a huge install... Hopefully the AppVeyor CI will be enough.

Has been tested on (remove any that don't apply):
 - Windows 10

cc @pmiossec