### PR TITLE
Fix crash when pushing with no remote configured

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -610,16 +610,20 @@ namespace GitUI.CommandsDialogs
             if (!string.IsNullOrEmpty(_NO_TRANSLATE_Branch.Text))
                 RemoteBranch.Items.Add(_NO_TRANSLATE_Branch.Text);
 
-            foreach (var head in GetRemoteBranches(_selectedRemote.Name))
-                if (_NO_TRANSLATE_Branch.Text != head.LocalName)
-                    RemoteBranch.Items.Add(head.LocalName);
+            if (_selectedRemote != null)
+            {
+                foreach (var head in GetRemoteBranches(_selectedRemote.Name))
+                    if (_NO_TRANSLATE_Branch.Text != head.LocalName)
+                        RemoteBranch.Items.Add(head.LocalName);
 
-            var remoteBranchesSet = GetRemoteBranches(_selectedRemote.Name).ToHashSet(b => b.LocalName);
-            var onlyLocalBranches = GetLocalBranches().Where(b => !remoteBranchesSet.Contains(b.LocalName));
+                var remoteBranchesSet = GetRemoteBranches(_selectedRemote.Name).ToHashSet(b => b.LocalName);
+                var onlyLocalBranches = GetLocalBranches().Where(b => !remoteBranchesSet.Contains(b.LocalName));
 
-            foreach (var head in onlyLocalBranches)
-                if (_NO_TRANSLATE_Branch.Text != head.LocalName)
-                    RemoteBranch.Items.Add(head.LocalName);
+
+                foreach (var head in onlyLocalBranches)
+                    if (_NO_TRANSLATE_Branch.Text != head.LocalName)
+                        RemoteBranch.Items.Add(head.LocalName);
+            }
 
             ComboBoxHelper.ResizeComboBoxDropDownWidth(RemoteBranch, AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
         }


### PR DESCRIPTION
Fixes #3794  .

Changes proposed in this pull request:
 - Fixed crash when pushing with no remote configured
 
How did I test this code:
 - Create a new repo locally without adding any remote
 - Make a commit and try to push

Has been tested on (remove any that don't apply):
 - GIT 2.12.2
 - Windows 10