### PR TITLE
Ask user for credentials if there were no credentials in IsolatedStorage

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -109,6 +109,7 @@ namespace GitUI.BuildServerIntegration
             lock (buildServerCredentialsLock)
             {
                 IBuildServerCredentials buildServerCredentials = new BuildServerCredentials { UseGuestAccess = true };
+                var foundInConfig = false;
 
                 const string CredentialsConfigName = "Credentials";
                 const string UseGuestAccessKey = "UseGuestAccess";
@@ -142,6 +143,7 @@ namespace GitUI.BuildServerIntegration
                                         true);
                                     buildServerCredentials.Username = section.GetValue(UsernameKey);
                                     buildServerCredentials.Password = section.GetValue(PasswordKey);
+                                    foundInConfig = true;
 
                                     if (useStoredCredentialsIfExisting)
                                     {
@@ -162,7 +164,7 @@ namespace GitUI.BuildServerIntegration
                     }
                 }
 
-                if (!useStoredCredentialsIfExisting)
+                if (!useStoredCredentialsIfExisting || !foundInConfig)
                 {
                     buildServerCredentials = ShowBuildServerCredentialsForm(buildServerAdapter.UniqueKey, buildServerCredentials);
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Ask user for credentials for CI if there were no credentials in IsolatedStorage


Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
