### PR TITLE
Fix a crash after clicking on "Browse..."

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -52,6 +52,20 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             directories.AddRange(Repositories.RepositoryHistory.Repositories.Select(r => r.Path));
 
+            if (directories.Count == 0)
+            {
+                if (AppSettings.RecentWorkingDir.IsNotNullOrWhitespace())
+                {
+                    directories.Add(PathUtil.EnsureTrailingPathSeparator(AppSettings.RecentWorkingDir));
+                }
+
+                string homeDir = GitCommandHelpers.GetHomeDir();
+                if (homeDir.IsNotNullOrWhitespace())
+                {
+                    directories.Add(PathUtil.EnsureTrailingPathSeparator(homeDir));
+                }
+            }
+            
             return directories.Distinct().ToList();
         }
 
@@ -107,8 +121,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void _NO_TRANSLATE_Directory_TextChanged(object sender, EventArgs e)
         {
-            DirectoryInfo currentDirectory = new DirectoryInfo(_NO_TRANSLATE_Directory.Text);
-            folderGoUpbutton.Enabled = (currentDirectory.Parent != null);
+            try
+            {
+                DirectoryInfo currentDirectory = new DirectoryInfo(_NO_TRANSLATE_Directory.Text);
+                folderGoUpbutton.Enabled = currentDirectory.Exists && currentDirectory.Parent != null;
+            }
+            catch (Exception)
+            {
+                folderGoUpbutton.Enabled = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Having a clean repository history, when trying to Browse a local git repository, GitExtension will crash if "directories" list is empty.
This fix will add two directory (recent working dir and git home dir) to the list to avoid the crash.

Fixes #3817  .

Changes proposed in this pull request:
 - add two directory to avoid using an empty list
 

How did I test this code:
 - repeat the steps inside the issue, it will not crash
