### PR TITLE
GitFlow Publish and Pull button can be used for all kind of branch

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -152,9 +152,9 @@ namespace GitFlow
             }
 
             btnFinish.Enabled = isThereABranch &&(branchType != Branch.support.ToString("G"));
-            btnPublish.Enabled = isThereABranch;
-            btnPull.Enabled = isThereABranch;
-            pnlPull.Enabled = (branchType == Branch.feature.ToString("G"));
+            btnPublish.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
+            btnPull.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
+            pnlPull.Enabled = (branchType != Branch.support.ToString("G"));
         }
 
         private void LoadBaseBranches()
@@ -205,17 +205,19 @@ namespace GitFlow
 
         private void btnPublish_Click(object sender, EventArgs e)
         {
-            RunCommand("flow feature publish " + cbBranches.SelectedValue);
+            var branchType = cbType.SelectedValue.ToString();
+            RunCommand(string.Format("flow {0} publish {1}", branchType, cbBranches.SelectedValue));
         }
 
         private void btnPull_Click(object sender, EventArgs e)
         {
-            RunCommand("flow feature pull " + cbRemote.SelectedValue + " " + cbBranches.SelectedValue);
+            var branchType = cbType.SelectedValue.ToString();
+            RunCommand(string.Format("flow {0} pull {1} {2}" + branchType, cbRemote.SelectedValue, cbBranches.SelectedValue));
         }
 
         private void btnFinish_Click(object sender, EventArgs e)
         {
-            RunCommand("flow " + cbManageType.SelectedValue + " finish " + cbBranches.SelectedValue);
+            RunCommand(string.Format("flow {0} finish {1}", cbManageType.SelectedValue, cbBranches.SelectedValue));
         }
 
         private bool RunCommand(string commandText)


### PR DESCRIPTION
Fixes #3830  .

Changes proposed in this pull request:
 - `git flow publish` and `git flow pull` command will use the branch type, not fixed to feature
 - related button and panel will be disabled when `support` branch is selected
 
 
How did I test this code:
 - Open GitFlow panel, select `support` branch -> Pull panel and Publish button are disabled
 - select other kind of branch, if branch exists the same panel will be enabled
 - Push `Publish` button and see the command execution log, it's not fixed to `feature publish` but depends on the branch type selected above.


Has been tested on (remove any that don't apply):
 - GIT 2.132.windows.1
 - Windows 7
