### PR TITLE
Fixed superproject, stash and pull ToolStripSplitButton closing issue

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -400,6 +400,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSplitStash.Size = new System.Drawing.Size(32, 22);
             this.toolStripSplitStash.ToolTipText = "Stash changes";
             this.toolStripSplitStash.ButtonClick += new System.EventHandler(this.ToolStripSplitStashButtonClick);
+            this.toolStripSplitStash.DropDownOpened += new System.EventHandler(this.toolStripSplitStash_DropDownOpened);
             // 
             // stashChangesToolStripMenuItem
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2168,6 +2168,7 @@ namespace GitUI.CommandsDialogs
                 RefreshWorkingDirCombo();
             };
 
+            PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         public void SetWorkingDir(string path)
@@ -2481,6 +2482,7 @@ namespace GitUI.CommandsDialogs
                     break;
             }
 
+            PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         void BranchSelectToolStripItem_Click(object sender, EventArgs e)
@@ -3335,9 +3337,44 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        private void PreventToolStripSplitButtonClosing(ToolStripSplitButton control)
+        {
+            if (control == null || toolStripBranchFilterComboBox.Focused || toolStripRevisionFilterTextBox.Focused)
+            {
+                return;
+            }
+
+            control.Tag = this.FindFocusedControl();
+            control.DropDownClosed += ToolStripSplitButtonDropDownClosed;
+            toolStripBranchFilterComboBox.Focus();
+        }
+
+        private void ToolStripSplitButtonDropDownClosed(object sender, EventArgs e)
+        {
+            var control = sender as ToolStripSplitButton;
+
+            if (control == null)
+            {
+                return;
+            }
+
+            control.DropDownClosed -= ToolStripSplitButtonDropDownClosed;
+
+            var controlToFocus = control.Tag as Control;
+
+            if (controlToFocus == null)
+            {
+                return;
+            }
+
+            controlToFocus.Focus();
+            control.Tag = null;
+        }
+
         private void toolStripButtonLevelUp_DropDownOpening(object sender, EventArgs e)
         {
             LoadSubmodulesIntoDropDownMenu();
+            PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         private void RemoveSubmoduleButtons()
@@ -3675,6 +3712,7 @@ namespace GitUI.CommandsDialogs
         private void toolStripButtonPull_DropDownOpened(object sender, EventArgs e)
         {
             setNextPullActionAsDefaultToolStripMenuItem.Checked = Settings.SetNextPullActionAsDefault;
+            PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         private void FormBrowse_Activated(object sender, EventArgs e)
@@ -3931,6 +3969,11 @@ namespace GitUI.CommandsDialogs
                 var newModule = new GitModule(formCreateWorktree.WorktreeDirectory);
                 SetGitModule(this, new GitModuleEventArgs(newModule));
             }
+        }
+
+        private void toolStripSplitStash_DropDownOpened(object sender, EventArgs e)
+        {
+            PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
     }
 }


### PR DESCRIPTION
Fixes #3832

Changes proposed in this pull request:
 - Avoid `ToolStripSplitButton` menu to close unexpectedly
 
How did I test this code:
 - Click on `Superproject`, `Stash` of `Pull` button (the small black triangle)
 - Move the mouse 1 pixel out of the button or the left or on the right of the button
 - The context menu that just opened should close
 - The fix prevent the menu to close in such situation

Has been tested on (remove any that don't apply):
 - Windows 10 Pro
