### PR TITLE
Show the icon for relevant scripts

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -472,6 +472,7 @@
             this.inMenuCheckBox.TabIndex = 9;
             this.inMenuCheckBox.Text = "Add to revision grid context menu";
             this.inMenuCheckBox.UseVisualStyleBackColor = true;
+            this.inMenuCheckBox.CheckedChanged += new System.EventHandler( this.inMenuCheckBox_CheckedChanged );
             this.inMenuCheckBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
             // 
             // scriptIsPowerShell

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -262,6 +262,8 @@ Current Branch:
                 moveDownButton.Enabled = false;
                 ClearScriptDetails();
             }
+
+            UpdateIconVisibility();
         }
 
         private void ScriptInfoEdit_Validating(object sender, System.ComponentModel.CancelEventArgs e)
@@ -309,25 +311,15 @@ Current Branch:
 
         private void scriptEvent_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (scriptEvent.Text == ScriptEvent.ShowInUserMenuBar.ToString())
-            {
-                /*
-                string icon_name = IconName;
-                if (ScriptList.RowCount > 0)
-                {
-                    ScriptInfo scriptInfo = ScriptList.SelectedRows[0].DataBoundItem as ScriptInfo;
-                    icon_name = scriptInfo.Icon;
-                }*/
+            UpdateIconVisibility();
+        }
 
-                sbtn_icon.Visible = true;
-                lbl_icon.Visible = true;
-            }
-            else
-            {
-                //not a menubar item, so hide the text label and dropdown button
-                sbtn_icon.Visible = false;
-                lbl_icon.Visible = false;
-            }
+        private void UpdateIconVisibility()
+        {
+            bool showIcon = scriptEvent.Text == ScriptEvent.ShowInUserMenuBar.ToString() || inMenuCheckBox.Checked;
+
+            sbtn_icon.Visible = showIcon;
+            lbl_icon.Visible = showIcon;
         }
 
         private void buttonShowArgumentsHelp_Click(object sender, EventArgs e)
@@ -346,6 +338,11 @@ Current Branch:
                 ((RichTextBox)sender).Paste(DataFormats.GetFormat(DataFormats.UnicodeText));
                 e.Handled = true;
             }
+        }
+
+        private void inMenuCheckBox_CheckedChanged( object sender, EventArgs e )
+        {
+            UpdateIconVisibility();
         }
     }
 }


### PR DESCRIPTION
Currently the button for setting an icon for a script is only visible when the *OnEvent* is set to *ShowInUserMenuBar*. However, the icon is also visible when placed in the context menu of the revision grid, but the setting button is not visible for such scripts.

Changes proposed in this pull request:
 - The button for script icon is visible for scripts which are to be shown in the user menu bar OR in the revision grid context menu
 
Has been tested on (remove any that don't apply):
 - GIT 2.13
 - Windows 10
