### PR TITLE
Allow cherry-picking multiple commits from FormBrowse menu

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1647,14 +1647,9 @@ namespace GitUI.CommandsDialogs
 
         private void CherryPickToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var revisions = RevisionGrid.GetSelectedRevisions();
-            if (revisions.Count != 1)
-            {
-                MessageBox.Show("Select exactly one revision.");
-                return;
-            }
+            var revisions = RevisionGrid.GetSelectedRevisions(System.DirectoryServices.SortDirection.Descending);
 
-            UICommands.StartCherryPickDialog(this, revisions.First());
+            UICommands.StartCherryPickDialog(this, revisions);
         }
 
         private void MergeBranchToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
The ability to do so from the RevisionGrid context menu has been added in commit b3e79447928051cfb3494c9c0ef1a1d0ecde56a8.

A followup fix for #2396.

Changes proposed in this pull request:
 - Cherry-picking uses the same code regardless of whether it is run from the `RevisionGrid` context menu or `FormBrowse` window menu.
 
How did I test this code:
 - Selected some commits from a different branch (not necessarily in chronological order)
 - Clicked *Commands* - *Cherry pick...*
 - The Cherry-pick form appeared sequentially for each of the selected commits (this time in chronological order)

Has been tested on
 - GIT 2.13
 - Windows 10
