### PR TITLE
fix: Incorrect selection of inactive remotes

### DIFF
--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -135,7 +135,8 @@ Inactive remote is completely invisible to git.");
                 // default fallback - if the preselection didn't work select the first available one
                 if (Remotes.SelectedIndices.Count < 1)
                 {
-                    Remotes.Items[0].Selected = true;
+                    var group = _lvgEnabled.Items.Count > 0 ? _lvgEnabled : _lvgDisabled;
+                    group.Items[0].Selected = true;
                 }
                 Remotes.Select();
             }


### PR DESCRIPTION
The remotes management screen will now select the first available active remote. If none active, the first inactive remote is selected.

Fixes #3861