### PR TITLE
lowercase the patch file search filter

### DIFF
--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -126,7 +126,7 @@ namespace GitUI.CommandsDialogs
         {
             using (var dialog = new OpenFileDialog
                              {
-                                 Filter = _selectPatchFileFilter.Text + "|*.Patch",
+                                 Filter = _selectPatchFileFilter.Text + "|*.patch",
                                  InitialDirectory = initialDirectory,
                                  Title = _selectPatchFileCaption.Text
                              })

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs
         {
             using (var dialog = new OpenFileDialog
                              {
-                                 Filter = _patchFileFilterString.Text + "|*.Patch",
+                                 Filter = _patchFileFilterString.Text + "|*.patch",
                                  InitialDirectory = initialDirectory,
                                  Title = _patchFileFilterTitle.Text
                              })


### PR DESCRIPTION
Fixes #3867.

Should all the UI text be modified to read `*.patch` instead `*.Patch` too?

Has been tested on Ubuntu 16.04.