### PR TITLE
fix: Clicking Commit causes a crash

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -56,7 +56,6 @@
             this.TextBox.Size = new System.Drawing.Size(386, 336);
             this.TextBox.TabIndex = 1;
             this.TextBox.Text = "";
-            this.TextBox.SelectionChanged += new System.EventHandler(this.TextBox_SelectionChanged);
             this.TextBox.SizeChanged += new System.EventHandler(this.TextBoxSizeChanged);
             this.TextBox.TextChanged += new System.EventHandler(this.TextBoxTextChanged);
             this.TextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyDown);
@@ -98,7 +97,6 @@
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "EditNetSpell";
             this.Size = new System.Drawing.Size(386, 336);
-            this.Load += new System.EventHandler(this.EditNetSpellLoad);
             this.SpellCheckContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -34,7 +33,7 @@ namespace GitUI.SpellChecker
         private readonly TranslationString dictionaryText = new TranslationString("Dictionary");
         private readonly TranslationString markIllFormedLinesText = new TranslationString("Mark ill formed lines");
 
-        private readonly SpellCheckEditControl _customUnderlines;
+        private SpellCheckEditControl _customUnderlines;
         private Spelling _spelling;
         private static WordDictionary _wordDictionary;
 
@@ -63,15 +62,10 @@ namespace GitUI.SpellChecker
             InitializeComponent();
             Translate();
 
-            _customUnderlines = new SpellCheckEditControl(TextBox);
-
-            SpellCheckTimer.Enabled = false;
-
-            EnabledChanged += EditNetSpellEnabledChanged;
-
-            if(AppSettings.ProvideAutocompletion)
-              InitializeAutoCompleteWordsTask();
+            MistakeFont = new Font(TextBox.Font, FontStyle.Underline);
+            TextBoxFont = TextBox.Font;
         }
+
 
         public override string Text
         {
@@ -214,7 +208,7 @@ namespace GitUI.SpellChecker
             }
             set
             {
-               TextBox.SelectedText = value;
+                TextBox.SelectedText = value;
             }
         }
 
@@ -223,42 +217,52 @@ namespace GitUI.SpellChecker
             get
             {
                 return IsUICommandsInitialized ?
-                    Module.EffectiveSettings:
+                    Module.EffectiveSettings :
                     AppSettings.SettingsContainer;
             }
         }
+
 
         public void SelectAll()
         {
             TextBox.SelectAll();
         }
 
-        private void EditNetSpellLoad(object sender, EventArgs e)
+        protected override void OnRuntimeLoad(EventArgs e)
         {
-            MistakeFont = new Font(TextBox.Font, FontStyle.Underline);
-            TextBoxFont = TextBox.Font;
+            base.OnRuntimeLoad(e);
+
+            _customUnderlines = new SpellCheckEditControl(TextBox);
+            TextBox.SelectionChanged += TextBox_SelectionChanged;
+
+            SpellCheckTimer.Enabled = false;
+
+            EnabledChanged += EditNetSpellEnabledChanged;
+
             ShowWatermark();
 
             components = new Container();
-            _spelling =
-                new Spelling(components)
-                    {
-                        ShowDialog = false,
-                        IgnoreAllCapsWords = true,
-                        IgnoreWordsWithDigits = true
-                    };
+            _spelling = new Spelling(components)
+            {
+                ShowDialog = false,
+                IgnoreAllCapsWords = true,
+                IgnoreWordsWithDigits = true
+            };
 
-            if(AppSettings.ProvideAutocompletion)
+            if (AppSettings.ProvideAutocompletion)
+            {
+                InitializeAutoCompleteWordsTask();
                 _autoCompleteListTask.ContinueWith(
-                w =>
-                {
-                    _spelling.AddAutoCompleteWords(w.Result.Select(x => x.Word));
-                    w.Dispose();
-                },
+                    w =>
+                    {
+                        _spelling.AddAutoCompleteWords(w.Result.Select(x => x.Word));
+                        w.Dispose();
+                    },
                     _autoCompleteCancellationTokenSource.Token,
                     TaskContinuationOptions.NotOnCanceled,
                     TaskScheduler.FromCurrentSynchronizationContext()
                 );
+            }
             //
             // spelling
             //
@@ -283,9 +287,9 @@ namespace GitUI.SpellChecker
             {
                 _wordDictionary =
                     new WordDictionary(components)
-                        {
-                            DictionaryFile = dictionaryFile
-                        };
+                    {
+                        DictionaryFile = dictionaryFile
+                    };
             }
 
             _spelling.Dictionary = _wordDictionary;
@@ -508,23 +512,11 @@ namespace GitUI.SpellChecker
 
             var mi =
                 new ToolStripMenuItem(markIllFormedLinesText.Text)
-                    {
-                        Checked = AppSettings.MarkIllFormedLinesInCommitMsg
-                    };
+                {
+                    Checked = AppSettings.MarkIllFormedLinesInCommitMsg
+                };
             mi.Click += MarkIllFormedLinesInCommitMsgClick;
             SpellCheckContextMenu.Items.Add(mi);
-        }
-
-        private static string CultureCodeToString(string cultureCode)
-        {
-            try
-            {
-                return new CultureInfo(new CultureInfo(cultureCode.Replace('_', '-')).TwoLetterISOLanguageName).NativeName;
-            }
-            catch
-            {
-                return cultureCode;
-            }
         }
 
         private void RemoveWordClick(object sender, EventArgs e)
@@ -647,11 +639,9 @@ namespace GitUI.SpellChecker
             IsUndoInProgress = false;
         }
 
-
-
         private void TextBox_KeyDown(object sender, KeyEventArgs e)
         {
-            if (!e.Alt && !e.Control && !e.Shift && _keysToSendToAutoComplete.ContainsKey (e.KeyCode) && AutoComplete.Visible)
+            if (!e.Alt && !e.Control && !e.Shift && _keysToSendToAutoComplete.ContainsKey(e.KeyCode) && AutoComplete.Visible)
             {
 
                 if (e.KeyCode == Keys.Up && AutoComplete.SelectedIndex == 0)
@@ -671,7 +661,7 @@ namespace GitUI.SpellChecker
             }
 
             // handle paste from clipboard (Ctrl+V, Shift+Ins)
-            if((e.Control && e.KeyCode == Keys.V) || (e.Shift && e.KeyCode == Keys.Insert))
+            if ((e.Control && e.KeyCode == Keys.V) || (e.Shift && e.KeyCode == Keys.Insert))
             {
                 PasteTextFromClipboard();
                 e.Handled = true;
@@ -708,8 +698,8 @@ namespace GitUI.SpellChecker
         {
             UpdateOrShowAutoComplete(false);
 
-            if (SelectionChanged != null)
-                SelectionChanged(sender, e);
+            var handler = SelectionChanged;
+            handler?.Invoke(sender, e);
         }
 
         private void ShowWatermark()
@@ -734,7 +724,7 @@ namespace GitUI.SpellChecker
             }
         }
 
-         private void TextBox_LostFocus(object sender, EventArgs e)
+        private void TextBox_LostFocus(object sender, EventArgs e)
         {
             ShowWatermark();
         }
@@ -786,7 +776,7 @@ namespace GitUI.SpellChecker
             TextBox.SelectionLength = 0;
             TextBox.SelectionStart = oldPos;
             //restore old color only if oldPos doesn't intersects with colored selection
-            if(restoreColor)
+            if (restoreColor)
                 TextBox.SelectionColor = oldColor;
             //undoes all recent selections while ctrl-z pressed
             skipSelectionUndo = true;
@@ -818,7 +808,7 @@ namespace GitUI.SpellChecker
                 InitializeAutoCompleteWordsTask();
         }
 
-        private void InitializeAutoCompleteWordsTask ()
+        private void InitializeAutoCompleteWordsTask()
         {
             CancelAutoComplete();
             _autoCompleteCancellationTokenSource = new CancellationTokenSource();
@@ -855,12 +845,12 @@ namespace GitUI.SpellChecker
                     }, _autoCompleteCancellationTokenSource.Token);
         }
 
-        public void AddAutoCompleteProvider (IAutoCompleteProvider autoCompleteProvider)
+        public void AddAutoCompleteProvider(IAutoCompleteProvider autoCompleteProvider)
         {
             _autoCompleteProviders.Add(autoCompleteProvider);
         }
 
-        protected override bool ProcessCmdKey (ref Message msg, Keys keyData)
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
             if (AutoComplete.Visible)
             {
@@ -880,7 +870,7 @@ namespace GitUI.SpellChecker
             return base.ProcessCmdKey(ref msg, keyData);
         }
 
-        private string GetWordAtCursor ()
+        private string GetWordAtCursor()
         {
             if (TextBox.Text.Length > TextBox.SelectionStart && IsSeparatorChar(TextBox.Text[TextBox.SelectionStart]))
                 return null;
@@ -895,20 +885,20 @@ namespace GitUI.SpellChecker
             return sb.ToString();
         }
 
-        private bool IsSeparatorChar (char c)
+        private bool IsSeparatorChar(char c)
         {
             return char.IsWhiteSpace(c) || c == '.';
         }
 
-        private void CloseAutoComplete ()
+        private void CloseAutoComplete()
         {
             AutoComplete.Hide();
             _autoCompleteWasUserActivated = false;
         }
 
-        private void AcceptAutoComplete (AutoCompleteWord completionWord = null)
+        private void AcceptAutoComplete(AutoCompleteWord completionWord = null)
         {
-            completionWord = completionWord ?? (AutoCompleteWord) AutoComplete.SelectedItem;
+            completionWord = completionWord ?? (AutoCompleteWord)AutoComplete.SelectedItem;
 
             var word = GetWordAtCursor();
 
@@ -922,7 +912,7 @@ namespace GitUI.SpellChecker
             CloseAutoComplete();
         }
 
-        private void UpdateOrShowAutoComplete (bool calledByUser)
+        private void UpdateOrShowAutoComplete(bool calledByUser)
         {
             if (IsDisposed)
             {
@@ -1017,20 +1007,20 @@ namespace GitUI.SpellChecker
             TextBox.Focus();
         }
 
-        private Point GetCursorPosition ()
+        private Point GetCursorPosition()
         {
             var cursorPos = TextBox.GetPositionFromCharIndex(TextBox.SelectionStart);
-            cursorPos.Y += (int) Math.Ceiling(TextBox.Font.GetHeight());
+            cursorPos.Y += (int)Math.Ceiling(TextBox.Font.GetHeight());
             cursorPos.X += 2;
             return cursorPos;
         }
 
-        private void AutoComplete_Click (object sender, EventArgs e)
+        private void AutoComplete_Click(object sender, EventArgs e)
         {
             AcceptAutoComplete();
         }
 
-        private void AutoCompleteTimer_Tick (object sender, EventArgs e)
+        private void AutoCompleteTimer_Tick(object sender, EventArgs e)
         {
             if (!_customUnderlines.IsImeStartingComposition)
             {
@@ -1039,14 +1029,14 @@ namespace GitUI.SpellChecker
             }
         }
 
-        public void CancelAutoComplete ()
+        public void CancelAutoComplete()
         {
             _autoCompleteCancellationTokenSource.Cancel();
             AutoCompleteToolTipTimer.Stop();
             AutoCompleteTimer.Stop();
         }
 
-        private void AutoCompleteToolTipTimer_Tick (object sender, EventArgs e)
+        private void AutoCompleteToolTipTimer_Tick(object sender, EventArgs e)
         {
             AutoCompleteToolTip.Hide(TextBox);
         }
@@ -1065,7 +1055,7 @@ namespace GitUI.SpellChecker
                 _customUnderlines.Dispose();
                 if (components != null)
                     components.Dispose();
-                if (_autoCompleteListTask != null &&_autoCompleteListTask.Status == TaskStatus.Canceled)
+                if (_autoCompleteListTask != null && _autoCompleteListTask.Status == TaskStatus.Canceled)
                 {
                     _autoCompleteListTask.Dispose();
                 }


### PR DESCRIPTION
In some circumstances SpellCheckEditControl could be initialised and start raising events before EditNetSpell control completed instantiation sequence. This would lead to NRE.

The initialisation sequence adjusted to initialise SpellCheckEditControl after EditNetSpell control has loaded.

Fixes #3827

Has been tested on (remove any that don't apply):
- Windows 10
