### PR TITLE
#3892 - Raised the previous messages limit from 10 to 999

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     partial class CommitDialogSettingsPage
     {
@@ -114,7 +114,7 @@
             // 
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(313, 108);
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Maximum = new decimal(new int[] {
-            10,
+            999,
             0,
             0,
             0});


### PR DESCRIPTION
Fixes #3892 .

Changes proposed in this pull request:
 - Change maximum commit message preview from 10 to 999
 
Screenshots before and after (if PR changes UI):
- None needed

How did I test this code:
 - Tested with value set to 100 and it displayed nicely. 999 works as well but it is significantly slower

Has been tested on (remove any that don't apply):
 - Git version 2.7.0.windows.1
 - Windows 10 and above
