### PR TITLE
fix: NRE in EditNetSpell control

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -44,6 +44,7 @@
             // 
             this.SpellCheckTimer.Interval = 250;
             this.SpellCheckTimer.Tick += new System.EventHandler(this.SpellCheckTimerTick);
+            this.SpellCheckTimer.Enabled = false;
             // 
             // TextBox
             // 
@@ -56,7 +57,6 @@
             this.TextBox.Size = new System.Drawing.Size(386, 336);
             this.TextBox.TabIndex = 1;
             this.TextBox.Text = "";
-            this.TextBox.SizeChanged += new System.EventHandler(this.TextBoxSizeChanged);
             this.TextBox.TextChanged += new System.EventHandler(this.TextBoxTextChanged);
             this.TextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyDown);
             this.TextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TextBox_KeyPress);

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -235,8 +235,6 @@ namespace GitUI.SpellChecker
             _customUnderlines = new SpellCheckEditControl(TextBox);
             TextBox.SelectionChanged += TextBox_SelectionChanged;
 
-            SpellCheckTimer.Enabled = false;
-
             EnabledChanged += EditNetSpellEnabledChanged;
 
             ShowWatermark();
@@ -269,11 +267,12 @@ namespace GitUI.SpellChecker
             _spelling.ReplacedWord += SpellingReplacedWord;
             _spelling.DeletedWord += SpellingDeletedWord;
             _spelling.MisspelledWord += SpellingMisspelledWord;
-
             //
             // wordDictionary
             //
             LoadDictionary();
+
+            SpellCheckTimer.Enabled = true;
         }
 
         private void LoadDictionary()
@@ -605,11 +604,6 @@ namespace GitUI.SpellChecker
                 SpellCheckTimer.Interval = 250;
                 SpellCheckTimer.Enabled = true;
             }
-        }
-
-        private void TextBoxSizeChanged(object sender, EventArgs e)
-        {
-            SpellCheckTimer.Enabled = true;
         }
 
         private void TextBoxLeave(object sender, EventArgs e)


### PR DESCRIPTION
In some conditions the timer would fire before the form init completed, which would lead to NRE.

Relates to #3827 