### PR TITLE
fix: Pull dialog help picture disappear

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -314,7 +314,6 @@
             // Merge
             // 
             this.Merge.AutoSize = true;
-            this.Merge.Checked = true;
             this.Merge.Image = global::GitUI.Properties.Resources.IconMerge;
             this.Merge.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.Merge.Location = new System.Drawing.Point(3, 3);


### PR DESCRIPTION
Help images for helpImageDisplayUserControl1 are set whenever merge options are changed - e.g. merge/rebase/don't merge.
The designer defaults to the first option (merge) after that the user settings are applied. If the user settings were set to 'merge' as well the change event would not be triggered and images would not be set.

The designer default is unset, now the change event is triggered as expected.

Fixes #3829