### PR TITLE
fix: NRE in EditNetSpell control

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -57,7 +57,6 @@
             this.TextBox.Size = new System.Drawing.Size(386, 336);
             this.TextBox.TabIndex = 1;
             this.TextBox.Text = "";
-            this.TextBox.TextChanged += new System.EventHandler(this.TextBoxTextChanged);
             this.TextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyDown);
             this.TextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TextBox_KeyPress);
             this.TextBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.TextBox_KeyUp);

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -234,6 +234,7 @@ namespace GitUI.SpellChecker
 
             _customUnderlines = new SpellCheckEditControl(TextBox);
             TextBox.SelectionChanged += TextBox_SelectionChanged;
+            TextBox.TextChanged += TextBoxTextChanged;
 
             EnabledChanged += EditNetSpellEnabledChanged;
 


### PR DESCRIPTION
In some conditions attempts to init the EditNetSpell.Watermark causes NRE.
Change to Watermark triggers TextChanged event may fire before EditNetSpell finished initialising.
Wire TextChanged event to fire only after the initialisation has finished.

Fixes #3827.

Has been tested on (remove any that don't apply):
- Windows 10, Ubuntu 17
