### PR TITLE
Add (and refactor) diff and merge tools

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -22,26 +22,25 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         [NotNull]
         private static string GetNotepadPP()
         {
-            string npp = MergeToolsHelper.FindFileInFolders("notepad++.exe", "Notepad++");
-            if (String.IsNullOrEmpty(npp))
-                npp = "notepad++";
-            else
-                npp = "\"" + npp + "\"";
-            npp = npp + " -multiInst -nosession";
-            return npp;
+            return GetEditorCommandLine("Notepad++", "notepad++.exe", " -multiInst -nosession", "notepad++");
         }
 
         [NotNull]
         private static string GetSublimeText3()
         {
-            string exec = MergeToolsHelper.FindFileInFolders("sublime_text.exe", "Sublime Text 3");
+            //http://stackoverflow.com/questions/8951275/git-config-core-editor-how-to-make-sublime-text-the-default-editor-for-git-on
+            return GetEditorCommandLine("SublimeText", "sublime_text.exe", " -w --multiinstance", "Sublime Text 3");
+        }
+
+        private static string GetEditorCommandLine(string editorName, string executableName, string commandLineParameter, params string[] installFolders)
+        {
+            string exec = MergeToolsHelper.FindFileInFolders(executableName, installFolders);
             if (String.IsNullOrEmpty(exec))
-                exec = "SublimeText";
+                exec = editorName;
             else
                 exec = "\"" + exec + "\"";
-            //http://stackoverflow.com/questions/8951275/git-config-core-editor-how-to-make-sublime-text-the-default-editor-for-git-on
-            exec = exec + " -w --multiinstance";
-            return exec;
+            return exec + commandLineParameter;
         }
+
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -16,6 +16,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 "notepad",
                 GetNotepadPP(),
                 GetSublimeText3(),
+                GetVsCode(),
             };
         }
 
@@ -23,6 +24,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private static string GetNotepadPP()
         {
             return GetEditorCommandLine("Notepad++", "notepad++.exe", " -multiInst -nosession", "notepad++");
+        }
+
+        [NotNull]
+        private static string GetVsCode()
+        {
+            return GetEditorCommandLine("Visual Studio Code", "code.exe", " --wait", "Microsoft VS Code");
         }
 
         [NotNull]

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -303,8 +303,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "";
                 case "winmerge":
                     return "\"" + exeFile + "\" -e -u -dl \"Original\" -dr \"Modified\" \"$MERGED\" \"$REMOTE\"";
-                case "vsdiffmerge":
-                    return "\"" + exeFile + "\" /m \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\" ";
             }
             return AutoConfigMergeToolCmd(mergeToolText, exeFile);
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.Win32;
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
     static class MergeToolsHelper
-    {     
+    {
         private static string GetGlobalSetting(ConfigFileSettingsSet settings, string setting)
         {
             return settings.GlobalSettings.GetValue(setting);
@@ -133,6 +133,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "winmergeu.exe";
                 case "vsdiffmerge":
                     return "vsdiffmerge.exe";
+                case "vscode":
+                    return "code.exe";
             }
             return null;
         }
@@ -144,7 +146,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             {
                 case "beyondcompare3":
                     string bcomppath = UnquoteString(GetGlobalSetting(settings, "difftool.beyondcompare3.path"));
-                    
+
                     exeName = "bcomp.exe";
 
                     return FindFileInFolders(exeName, bcomppath,
@@ -200,6 +202,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     string regvsdiffmergepath = GetVisualStudioPath() + "vsdiffmerge.exe";
                     exeName = "vsdiffmerge.exe";
                     return FindFileInFolders(exeName, vsdiffmergepath, regvsdiffmergepath);
+                case "vscode":
+                    exeName = "code.exe";
+                    string vscodepath = UnquoteString(GetGlobalSetting(settings, "difftool.vscode.path"));
+                    return FindFileInFolders(exeName, vscodepath, @"Microsoft VS Code");
             }
             exeName = difftoolText + ".exe";
             return GetFullPath(exeName);
@@ -228,6 +234,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "\"" + exeFile + "\" -e -u \"$LOCAL\" \"$REMOTE\"";
                 case "vsdiffmerge":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
+                case "vscode":
+                    return "\"" + exeFile + "\" --wait --diff \"$LOCAL\" \"$REMOTE\"";
             }
             return "";
         }
@@ -260,6 +268,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "winmergeu.exe";
                 case "vsdiffmerge":
                     return "vsdiffmerge.exe";
+                case "vscode":
+                    return "vscode.exe";
             }
             return null;
         }
@@ -332,6 +342,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     string regvsdiffmergepath = GetVisualStudioPath() + "vsdiffmerge.exe";
                     exeName = "vsdiffmerge.exe";
                     return FindFileInFolders(exeName, vsdiffmergepath, regvsdiffmergepath);
+                case "vscode":
+                    exeName = "code.exe";
+                    string vscodepath = UnquoteString(GetGlobalSetting(settings, "mergetool.vscode.path"));
+                    return FindFileInFolders(exeName, vscodepath, @"Microsoft VS Code");
             }
             exeName = mergeToolText + ".exe";
             return GetFullPath(exeName);
@@ -375,6 +389,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                         command = command.Replace("/", "-");
 
                     return String.Format(command, exeFile);
+                case "vscode":
+                    return "\"" + exeFile + "\" --wait \"$MERGED\" ";
                 case "vsdiffmerge":
                     return "\"" + exeFile + "\" /m \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"";
             }
@@ -404,6 +420,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         private static string GetVisualStudioPath()
         {
+            //%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
             var vsVersionNumber = new string[] { "2020", "2019", "2018", "2017" };
             var vsVersionType = new string[] { "Professional", "Community" };
             string pathFormat = @"Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\";

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -186,17 +186,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     if (String.IsNullOrEmpty(difftoolPath))
                     {
                         exeName = "TortoiseMerge.exe";
-                        difftoolPath = FindFileInFolders(exeName, @"TortoiseGit\bin\");
-                        if (String.IsNullOrEmpty(difftoolPath))
-                            difftoolPath = FindFileInFolders(exeName, @"TortoiseSVN\bin\");
+                        difftoolPath = FindFileInFolders(exeName, @"TortoiseGit\bin\", @"TortoiseSVN\bin\");
                     }
                     return difftoolPath;
                 case "winmerge":
                     exeName = "winmergeu.exe";
                     string winmergepath = UnquoteString(GetGlobalSetting(settings, "difftool.winmerge.path"));
-
-                    return FindFileInFolders("winmergeu.exe", winmergepath,
-                                                          @"WinMerge\");
+                    return FindFileInFolders(exeName, winmergepath, @"WinMerge\");
                 case "vsdiffmerge":
                     string vsdiffmergepath = UnquoteString(GetGlobalSetting(settings, "difftool.vsdiffmerge.path"));
                     string regvsdiffmergepath = GetVisualStudioPath() + "vsdiffmerge.exe";
@@ -327,9 +323,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     if (string.IsNullOrEmpty(path))
                     {
                         exeName = "TortoiseMerge.exe";
-                        path = FindFileInFolders(exeName, @"TortoiseGit\bin\");
-                        if (string.IsNullOrEmpty(path))
-                            path = FindFileInFolders(exeName, @"TortoiseSVN\bin\");
+                        path = FindFileInFolders(exeName, @"TortoiseGit\bin\", @"TortoiseSVN\bin\");
                     }
                     return path;
                 case "winmerge":

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -148,25 +148,20 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             switch (diffTool)
             {
                 case "beyondcompare3":
-                    string bcomppath = UnquoteString(GetGlobalSetting(settings, "difftool.beyondcompare3.path"));
-                    return FindFileInFolders(exeName, bcomppath,
+                    return FindDiffToolFullPath(settings, exeName, "difftool.beyondcompare3.path",
                                                           @"Beyond Compare 3 (x86)\",
                                                           @"Beyond Compare 3\");
                 case "beyondcompare4":
-                    string bcomppath4 = UnquoteString(GetGlobalSetting(settings, "difftool.beyondcompare4.path"));
-                    return FindFileInFolders(exeName, bcomppath4,
+                    return FindDiffToolFullPath(settings, exeName, "difftool.beyondcompare4.path",
                                                           @"Beyond Compare 4 (x86)\",
                                                           @"Beyond Compare 4\");
                 case "kdiff3":
-                    string kdiff3path = UnquoteString(GetGlobalSetting(settings, "difftool.kdiff3.path"));
                     string regkdiff3path = GetRegistryValue(Registry.LocalMachine, "SOFTWARE\\KDiff3", "") + "\\kdiff3.exe";
-                    return FindFileInFolders(exeName, kdiff3path, @"KDiff3\", regkdiff3path);
+                    return FindDiffToolFullPath(settings, exeName, "difftool.kdiff3.path", @"KDiff3\", regkdiff3path);
                 case "p4merge":
-                    string p4mergepath = UnquoteString(GetGlobalSetting(settings, "difftool.p4merge.path"));
-                    return FindFileInFolders(exeName, p4mergepath, @"Perforce\");
+                    return FindDiffToolFullPath(settings, exeName, "difftool.p4merge.path", @"Perforce\");
                 case "meld":
-                    string difftoolMeldPath = UnquoteString(GetGlobalSetting(settings, "difftool.meld.path"));
-                    return FindFileInFolders(exeName, difftoolMeldPath, @"Meld\", @"Meld (x86)\");
+                    return FindDiffToolFullPath(settings, exeName, "difftool.meld.path", @"Meld\", @"Meld (x86)\");
                 case "semanticdiff":
                     string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                     folder = Path.Combine(folder, @"PlasticSCM4\semanticmerge\");
@@ -181,18 +176,23 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     }
                     return difftoolPath;
                 case "winmerge":
-                    string winmergepath = UnquoteString(GetGlobalSetting(settings, "difftool.winmerge.path"));
-                    return FindFileInFolders(exeName, winmergepath, @"WinMerge\");
+                    return FindDiffToolFullPath(settings, exeName, "difftool.winmerge.path", @"WinMerge\");
                 case "vsdiffmerge":
-                    string vsdiffmergepath = UnquoteString(GetGlobalSetting(settings, "difftool.vsdiffmerge.path"));
-                    string regvsdiffmergepath = GetVisualStudioPath() + exeName;
-                    return FindFileInFolders(exeName, vsdiffmergepath, regvsdiffmergepath);
+                    return FindDiffToolFullPath(settings, exeName, "difftool.vsdiffmerge.path", GetVsDiffMergePath());
                 case "vscode":
-                    string vscodepath = UnquoteString(GetGlobalSetting(settings, "difftool.vscode.path"));
-                    return FindFileInFolders(exeName, vscodepath, @"Microsoft VS Code");
+                    return FindDiffToolFullPath(settings, exeName, "difftool.vscode.path", @"Microsoft VS Code");
             }
             exeName = difftoolText + ".exe";
             return GetFullPath(exeName);
+        }
+
+        private static string FindDiffToolFullPath(ConfigFileSettingsSet settings, string exeName, string settingsKey, params string[] pathToSearch)
+        {
+            string exePathFromSettings = UnquoteString(GetGlobalSetting(settings, settingsKey));
+            var paths = new string[pathToSearch.Length + 1];
+            paths[0] = exePathFromSettings;
+            Array.Copy(pathToSearch, 0, paths, 1, pathToSearch.Length);
+            return FindFileInFolders(exeName, paths);
         }
 
         public static string DiffToolCmdSuggest(string diffToolText, string exeFile)
@@ -252,30 +252,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                                                         @"Araxis 6.5\Araxis Merge\",
                                                         @"Araxis\Araxis Merge v6.5\");
                 case "beyondcompare3":
-                    string bcomppath = UnquoteString(GetGlobalSetting(settings, "mergetool.beyondcompare3.path"));
-
-                    return FindFileInFolders(exeName, bcomppath, @"Beyond Compare 3 (x86)\",
-                                                                 @"Beyond Compare 3\");
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.beyondcompare3.path",
+                        @"Beyond Compare 3 (x86)\",
+                        @"Beyond Compare 3\");
                 case "beyondcompare4":
-                    string bcomppath4 = UnquoteString(GetGlobalSetting(settings, "mergetool.beyondcompare4.path"));
-
-                    return FindFileInFolders(exeName, bcomppath4, @"Beyond Compare 4 (x86)\",
-                                                                  @"Beyond Compare 4\");
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.beyondcompare4.path",
+                        @"Beyond Compare 4 (x86)\",
+                        @"Beyond Compare 4\");
                 case "diffmerge":
                     return FindFileInFolders(exeName, @"SourceGear\Common\DiffMerge\", @"SourceGear\DiffMerge\");
                 case "kdiff3":
-                    string kdiff3path = UnquoteString(GetGlobalSetting(settings, "mergetool.kdiff3.path"));
                     string regkdiff3path = GetRegistryValue(Registry.LocalMachine, "SOFTWARE\\KDiff3", "");
                     if (regkdiff3path != "")
                         regkdiff3path += "\\" + exeName;
-
-                    return FindFileInFolders(exeName, kdiff3path, @"KDiff3\", regkdiff3path);
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.kdiff3.path", @"KDiff3\", regkdiff3path);
                 case "meld":
-                    string mergetoolMeldPath = UnquoteString(GetGlobalSetting(settings, "mergetool.meld.path"));
-                    return FindFileInFolders(exeName, mergetoolMeldPath, @"Meld\", @"Meld (x86)\");
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.meld.path", @"Meld\", @"Meld (x86)\");
                 case "p4merge":
-                    string p4mergepath = UnquoteString(GetGlobalSetting(settings, "mergetool.p4merge.path"));
-                    return FindFileInFolders(exeName, p4mergepath, @"Perforce\");
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.p4merge.path", @"Perforce\");
                 case "semanticmerge":
                     string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                     folder = Path.Combine(folder, @"PlasticSCM4\semanticmerge\");
@@ -290,16 +284,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     }
                     return path;
                 case "winmerge":
-                    string winmergepath = UnquoteString(GetGlobalSetting(settings, "mergetool.winmerge.path"));
-
-                    return FindFileInFolders(exeName, winmergepath, @"WinMerge\");
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.winmerge.path", @"WinMerge\");
                 case "vsdiffmerge":
-                    string vsdiffmergepath = UnquoteString(GetGlobalSetting(settings, "mergetool.vsdiffmerge.path"));
-                    string regvsdiffmergepath = GetVisualStudioPath() + exeName;
-                    return FindFileInFolders(exeName, vsdiffmergepath, regvsdiffmergepath);
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.vsdiffmerge.path", GetVsDiffMergePath());
                 case "vscode":
-                    string vscodepath = UnquoteString(GetGlobalSetting(settings, "mergetool.vscode.path"));
-                    return FindFileInFolders(exeName, vscodepath, @"Microsoft VS Code");
+                    return FindDiffToolFullPath(settings, exeName, "mergetool.vscode.path", @"Microsoft VS Code");
             }
             exeName = mergeToolText + ".exe";
             return GetFullPath(exeName);
@@ -372,11 +361,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             return value ?? string.Empty;
         }
 
-        private static string GetVisualStudioPath()
+        private static string GetVsDiffMergePath()
         {
             //%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
             var vsVersionNumber = new string[] { "2020", "2019", "2018", "2017" };
             var vsVersionType = new string[] { "Professional", "Community" };
+            const string exeName = "vsDiffMerge.exe";
             string pathFormat = @"Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\";
 
             foreach (var number in vsVersionNumber)
@@ -384,7 +374,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 foreach (var type in vsVersionType)
                 {
                     var vsPath = string.Format(pathFormat, number, type);
-                    string path = FindFileInFolders("vsDiffMerge.exe", vsPath);
+                    string path = FindFileInFolders(exeName, vsPath);
 
                     if (!string.IsNullOrEmpty(path))
                     {
@@ -405,7 +395,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                         var path = localMachineKey.GetValue("InstallDir") as string;
                         if (!string.IsNullOrEmpty(path))
                         {
-                            return path;
+                            return Path.Combine(path, exeName);
                         }
                     }
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -119,6 +119,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "bcomp.exe";
                 case "beyondcompare4":
                     return "bcomp.exe";
+                case "diffmerge":
+                    return "DiffMerge.exe";
                 case "kdiff3":
                     return "kdiff3.exe";
                 case "meld":
@@ -202,6 +204,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
                 case "beyondcompare4":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
+                case "diffmerge":
+                    return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
                 case "kdiff3":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\"";
                 case "meld":
@@ -225,33 +229,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public static string GetMergeToolExeFile(string mergeToolText)
         {
             string mergeTool = mergeToolText.ToLowerInvariant();
+            var exeName = GetDiffToolExeFile(mergeTool);
+            if (exeName != null)
+                return exeName;
 
             switch (mergeTool)
             {
-                case "araxis":
-                    return "Compare.exe";
-                case "beyondcompare3":
-                    return "bcomp.exe";
-                case "beyondcompare4":
-                    return "bcomp.exe";
-                case "diffmerge":
-                    return "DiffMerge.exe";
-                case "kdiff3":
-                    return "kdiff3.exe";
-                case "meld":
-                    return "meld.exe";
-                case "p4merge":
-                    return "p4merge.exe";
-                case "semanticmerge":
-                    return "semanticmergetool.exe";
                 case "tortoisemerge":
                     return "TortoiseMerge.exe";
-                case "winmerge":
-                    return "winmergeu.exe";
-                case "vsdiffmerge":
-                    return "vsdiffmerge.exe";
-                case "vscode":
-                    return "vscode.exe";
             }
             return null;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -369,7 +369,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             //%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
             var vsVersionNumber = new string[] { "2020", "2019", "2018", "2017" };
-            var vsVersionType = new string[] { "Professional", "Community" };
+            var vsVersionType = new string[] { "Entreprise", "Professional", "Community"};
             string pathFormat = @"Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\";
 
             foreach (var number in vsVersionNumber)

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -404,6 +404,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         private static string GetVisualStudioPath()
         {
+            var vsVersionNumber = new string[] { "2020", "2019", "2018", "2017" };
+            var vsVersionType = new string[] { "Professional", "Community" };
+            string pathFormat = @"Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\";
+
+            foreach (var number in vsVersionNumber)
+            {
+                foreach (var type in vsVersionType)
+                {
+                    var vsPath = string.Format(pathFormat, number, type);
+                    string path = FindFileInFolders("vsDiffMerge.exe", vsPath);
+
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        return path;
+                    }
+                }
+            }
+
             var vsVersions = new string[] { "14.0", "12.0", "11.0" };
 
             foreach (var version in vsVersions)

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -367,25 +367,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 return exeName;
             }
 
-            //%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
-            var vsVersionNumber = new string[] { "2020", "2019", "2018", "2017" };
-            var vsVersionType = new string[] { "Entreprise", "Professional", "Community"};
-            string pathFormat = @"Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\";
-
-            foreach (var number in vsVersionNumber)
-            {
-                foreach (var type in vsVersionType)
-                {
-                    var vsPath = string.Format(pathFormat, number, type);
-                    string path = FindFileInFolders(exeName, vsPath);
-
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        return path;
-                    }
-                }
-            }
-
             var vsVersions = new string[] { "14.0", "12.0", "11.0" };
 
             foreach (var version in vsVersions)

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -142,41 +142,30 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public static string FindDiffToolFullPath(ConfigFileSettingsSet settings, string difftoolText, out string exeName)
         {
             string diffTool = difftoolText.ToLowerInvariant();
+            exeName = GetDiffToolExeFile(difftoolText);
             switch (diffTool)
             {
                 case "beyondcompare3":
                     string bcomppath = UnquoteString(GetGlobalSetting(settings, "difftool.beyondcompare3.path"));
-
-                    exeName = "bcomp.exe";
-
                     return FindFileInFolders(exeName, bcomppath,
                                                           @"Beyond Compare 3 (x86)\",
                                                           @"Beyond Compare 3\");
                 case "beyondcompare4":
                     string bcomppath4 = UnquoteString(GetGlobalSetting(settings, "difftool.beyondcompare4.path"));
-
-                    exeName = "bcomp.exe";
-
                     return FindFileInFolders(exeName, bcomppath4,
                                                           @"Beyond Compare 4 (x86)\",
                                                           @"Beyond Compare 4\");
                 case "kdiff3":
                     string kdiff3path = UnquoteString(GetGlobalSetting(settings, "difftool.kdiff3.path"));
                     string regkdiff3path = GetRegistryValue(Registry.LocalMachine, "SOFTWARE\\KDiff3", "") + "\\kdiff3.exe";
-
-                    exeName = "kdiff3.exe";
-
                     return FindFileInFolders(exeName, kdiff3path, @"KDiff3\", regkdiff3path);
                 case "p4merge":
                     string p4mergepath = UnquoteString(GetGlobalSetting(settings, "difftool.p4merge.path"));
-                    exeName = "p4merge.exe";
                     return FindFileInFolders(exeName, p4mergepath, @"Perforce\");
                 case "meld":
                     string difftoolMeldPath = UnquoteString(GetGlobalSetting(settings, "difftool.meld.path"));
-                    exeName = "meld.exe";
                     return FindFileInFolders(exeName, difftoolMeldPath, @"Meld\", @"Meld (x86)\");
                 case "semanticdiff":
-                    exeName = "semanticmergetool.exe";
                     string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                     folder = Path.Combine(folder, @"PlasticSCM4\semanticmerge\");
                     return FindFileInFolders(exeName, folder);
@@ -190,16 +179,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     }
                     return difftoolPath;
                 case "winmerge":
-                    exeName = "winmergeu.exe";
                     string winmergepath = UnquoteString(GetGlobalSetting(settings, "difftool.winmerge.path"));
                     return FindFileInFolders(exeName, winmergepath, @"WinMerge\");
                 case "vsdiffmerge":
                     string vsdiffmergepath = UnquoteString(GetGlobalSetting(settings, "difftool.vsdiffmerge.path"));
-                    string regvsdiffmergepath = GetVisualStudioPath() + "vsdiffmerge.exe";
-                    exeName = "vsdiffmerge.exe";
+                    string regvsdiffmergepath = GetVisualStudioPath() + exeName;
                     return FindFileInFolders(exeName, vsdiffmergepath, regvsdiffmergepath);
                 case "vscode":
-                    exeName = "code.exe";
                     string vscodepath = UnquoteString(GetGlobalSetting(settings, "difftool.vscode.path"));
                     return FindFileInFolders(exeName, vscodepath, @"Microsoft VS Code");
             }
@@ -273,31 +259,26 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public static string FindMergeToolFullPath(ConfigFileSettingsSet settings, string mergeToolText, out string exeName)
         {
             string mergeTool = mergeToolText.ToLowerInvariant();
-
+            exeName = GetMergeToolExeFile(mergeToolText);
             switch (mergeTool)
             {
                 case "araxis":
-                    exeName = "Compare.exe";
                     return FindFileInFolders(exeName, @"Araxis\Araxis Merge\",
                                                         @"Araxis 6.5\Araxis Merge\",
                                                         @"Araxis\Araxis Merge v6.5\");
                 case "beyondcompare3":
                     string bcomppath = UnquoteString(GetGlobalSetting(settings, "mergetool.beyondcompare3.path"));
 
-                    exeName = "bcomp.exe";
                     return FindFileInFolders(exeName, bcomppath, @"Beyond Compare 3 (x86)\",
                                                                  @"Beyond Compare 3\");
                 case "beyondcompare4":
                     string bcomppath4 = UnquoteString(GetGlobalSetting(settings, "mergetool.beyondcompare4.path"));
 
-                    exeName = "bcomp.exe";
                     return FindFileInFolders(exeName, bcomppath4, @"Beyond Compare 4 (x86)\",
                                                                   @"Beyond Compare 4\");
                 case "diffmerge":
-                    exeName = "DiffMerge.exe";
                     return FindFileInFolders(exeName, @"SourceGear\Common\DiffMerge\", @"SourceGear\DiffMerge\");
                 case "kdiff3":
-                    exeName = "kdiff3.exe";
                     string kdiff3path = UnquoteString(GetGlobalSetting(settings, "mergetool.kdiff3.path"));
                     string regkdiff3path = GetRegistryValue(Registry.LocalMachine, "SOFTWARE\\KDiff3", "");
                     if (regkdiff3path != "")
@@ -306,14 +287,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return FindFileInFolders(exeName, kdiff3path, @"KDiff3\", regkdiff3path);
                 case "meld":
                     string mergetoolMeldPath = UnquoteString(GetGlobalSetting(settings, "mergetool.meld.path"));
-                    exeName = "meld.exe";
                     return FindFileInFolders(exeName, mergetoolMeldPath, @"Meld\", @"Meld (x86)\");
                 case "p4merge":
                     string p4mergepath = UnquoteString(GetGlobalSetting(settings, "mergetool.p4merge.path"));
-                    exeName = "p4merge.exe";
                     return FindFileInFolders(exeName, p4mergepath, @"Perforce\");
                 case "semanticmerge":
-                    exeName = "semanticmergetool.exe";
                     string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                     folder = Path.Combine(folder, @"PlasticSCM4\semanticmerge\");
                     return FindFileInFolders(exeName, folder);
@@ -329,15 +307,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 case "winmerge":
                     string winmergepath = UnquoteString(GetGlobalSetting(settings, "mergetool.winmerge.path"));
 
-                    exeName = "winmergeu.exe";
                     return FindFileInFolders(exeName, winmergepath, @"WinMerge\");
                 case "vsdiffmerge":
                     string vsdiffmergepath = UnquoteString(GetGlobalSetting(settings, "mergetool.vsdiffmerge.path"));
-                    string regvsdiffmergepath = GetVisualStudioPath() + "vsdiffmerge.exe";
-                    exeName = "vsdiffmerge.exe";
+                    string regvsdiffmergepath = GetVisualStudioPath() + exeName;
                     return FindFileInFolders(exeName, vsdiffmergepath, regvsdiffmergepath);
                 case "vscode":
-                    exeName = "code.exe";
                     string vscodepath = UnquoteString(GetGlobalSetting(settings, "mergetool.vscode.path"));
                     return FindFileInFolders(exeName, vscodepath, @"Microsoft VS Code");
             }

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -361,10 +361,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         private static string GetVsDiffMergePath()
         {
+            const string exeName = "vsDiffMerge.exe";
+            if (!EnvUtils.RunningOnWindows())
+            {
+                return exeName;
+            }
+
             //%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
             var vsVersionNumber = new string[] { "2020", "2019", "2018", "2017" };
             var vsVersionType = new string[] { "Professional", "Community" };
-            const string exeName = "vsDiffMerge.exe";
             string pathFormat = @"Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\";
 
             foreach (var number in vsVersionNumber)
@@ -398,7 +403,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     }
                 }
             }
-            return string.Empty;
+            return exeName;
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -9,6 +9,7 @@ using GitCommands.Config;
 using GitCommands.Utils;
 using Microsoft.Win32;
 using ResourceManager;
+using System.Linq;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
@@ -333,6 +334,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             SaveAndRescan_Click(null, null);
         }
 
+        private readonly string[] AutoConfigMergeTools = new[] { "p4merge", "TortoiseMerge", "meld", "beyondcompare3", "beyondcompare4", "diffmerge", "semanticmerge", "vscode", "vsdiffmerge" };
         private void MergeToolFix_Click(object sender, EventArgs e)
         {
             if (string.IsNullOrEmpty(CommonLogic.GetGlobalMergeTool()))
@@ -355,7 +357,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 CheckSettingsLogic.SolveMergeToolPathForKDiff();
             }
-            else if (CommonLogic.IsMergeTool("p4merge") || CommonLogic.IsMergeTool("TortoiseMerge") || CommonLogic.IsMergeTool("meld"))
+            else if (AutoConfigMergeTools.Any(tool => CommonLogic.IsMergeTool(tool)))
             {
                 CheckSettingsLogic.AutoConfigMergeToolCmd();
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -216,6 +216,7 @@
             "vimdiff",
             "winmerge",
             "xxdiff",
+            "vscode",
             "vsdiffmerge"});
             this._NO_TRANSLATE_GlobalDiffTool.Location = new System.Drawing.Point(192, 265);
             this._NO_TRANSLATE_GlobalDiffTool.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -348,6 +349,7 @@
             "p4merge",
             "semanticmerge",
             "TortoiseMerge",
+            "vscode",
             "vsdiffmerge"});
             this._NO_TRANSLATE_GlobalMergeTool.Location = new System.Drawing.Point(192, 109);
             this._NO_TRANSLATE_GlobalMergeTool.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -202,6 +202,7 @@
             "beyondcompare3",
             "beyondcompare4",
             "diffuse",
+            "diffmerge",
             "ecmerge",
             "emerge",
             "gvimdiff",


### PR DESCRIPTION
Changes proposed in this pull request:
 - Add Visual Studio Code as Editor (because it add highlighting on rebase interactive file), Diff and Merge tools
 - Fix the way to get 'vsdiffmerge.exe' with VS>=2017 because Microsoft changed the way to find VisualStudio path making it harder :( (should work for the default install and for the future ;) )
 - Add missing config as diff tool for 'DiffMerge'
 - multiple refactoring to remove a lot of code duplication 
 
PS: The review should be a lot easier if done reading diffs of commits one by one....

Has been tested on:
 - GIT 2.13.2 (but should be of no importance)
 - Windows 10 and above
