### PR TITLE
Skip worktree feature

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1061,7 +1061,7 @@ namespace GitCommands
             return diffFiles;
         }
 
-        public static List<GitItemStatus> GetAssumeUnchangedFilesFromString(GitModule module, string lsString)
+        public static List<GitItemStatus> GetAssumeUnchangedFilesFromString(string lsString)
         {
             List<GitItemStatus> result = new List<GitItemStatus>();
             string[] lines = lsString.SplitLines();
@@ -1076,6 +1076,26 @@ namespace GitCommands
                 gitItemStatus.IsStaged = false;
                 gitItemStatus.IsAssumeUnchanged = true;
                 result.Add(gitItemStatus);
+            }
+
+            return result;
+        }
+
+        public static List<GitItemStatus> GetSkipWorktreeFilesFromString(string lsString)
+        {
+            List<GitItemStatus> result = new List<GitItemStatus>();
+            string[] lines = lsString.SplitLines();
+            foreach (string line in lines)
+            {
+                char statusCharacter = line[0];
+
+                string fileName = line.Substring(line.IndexOf(' ') + 1);
+                GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(fileName, statusCharacter);
+                if (gitItemStatus.IsSkipWorktree)
+                {
+                    gitItemStatus.IsStaged = false;
+                    result.Add(gitItemStatus);
+                }
             }
 
             return result;
@@ -1115,6 +1135,7 @@ namespace GitCommands
             gitItemStatus.IsNew = x == 'A' || x == '?' || x == '!';
             gitItemStatus.IsChanged = x == 'M';
             gitItemStatus.IsDeleted = x == 'D';
+            gitItemStatus.IsSkipWorktree = x == 'S';
             gitItemStatus.IsRenamed = false;
             gitItemStatus.IsTracked = x != '?' && x != '!' && x != ' ' || !gitItemStatus.IsNew;
             gitItemStatus.IsConflict = x == 'U';

--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -14,6 +14,7 @@ namespace GitCommands
             IsCopied = false;
             IsConflict = false;
             IsAssumeUnchanged = false;
+            IsSkipWorktree = false;
             IsNew = false;
             IsStaged = true;
             IsSubmodule = false;
@@ -35,6 +36,7 @@ namespace GitCommands
                 else if (IsConflict) return "Conflict";
                 else if (IsCopied) return "Copied";
                 else if (IsAssumeUnchanged) return "Unchanged";
+                else if (IsSkipWorktree) return "SkipWorktree";
                 else return "";
             }
         }
@@ -47,6 +49,7 @@ namespace GitCommands
         public bool IsCopied { get; set; }
         public bool IsConflict { get; set; }
         public bool IsAssumeUnchanged { get; set; }
+        public bool IsSkipWorktree { get; set; }
         public bool IsStaged { get; set; }
         public bool IsSubmodule { get; set; }
         public string RenameCopyPercentage { get; set; }

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -38,6 +38,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.addFileTogitignoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.skipWorktreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.doNotSkipWorktreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.assumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.doNotAssumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -82,6 +84,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.workingToolStripMenuItem = new System.Windows.Forms.ToolStripDropDownButton();
             this.showIgnoredFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showSkipWorktreeFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAssumeUnchangedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showUntrackedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
@@ -176,9 +179,9 @@ namespace GitUI.CommandsDialogs
             this.toolbarCommit.SuspendLayout();
             this.commitStatusStrip.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // UnstagedFileContext
-            // 
+            //
             this.UnstagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.resetChanges,
             this.resetPartOfFileToolStripMenuItem,
@@ -197,6 +200,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5,
             this.addFileTogitignoreToolStripMenuItem,
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem,
+            this.skipWorktreeToolStripMenuItem,
+            this.doNotSkipWorktreeToolStripMenuItem,
             this.assumeUnchangedToolStripMenuItem,
             this.doNotAssumeUnchangedToolStripMenuItem,
             this.toolStripSeparator4,
@@ -204,154 +209,169 @@ namespace GitUI.CommandsDialogs
             this.UnstagedFileContext.Name = "UnstagedFileContext";
             this.UnstagedFileContext.Size = new System.Drawing.Size(233, 370);
             this.UnstagedFileContext.Opening += UnstagedContextMenu_Opening;
-            // 
+            //
             // resetChanges
-            // 
+            //
             this.resetChanges.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.resetChanges.Name = "resetChanges";
             this.resetChanges.Size = new System.Drawing.Size(232, 22);
             this.resetChanges.Text = "Reset file or directory changes";
             this.resetChanges.Click += new System.EventHandler(this.ResetSoftClick);
-            // 
+            //
             // resetPartOfFileToolStripMenuItem
-            // 
+            //
             this.resetPartOfFileToolStripMenuItem.Name = "resetPartOfFileToolStripMenuItem";
             this.resetPartOfFileToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.resetPartOfFileToolStripMenuItem.Text = "Reset chunk of file";
             this.resetPartOfFileToolStripMenuItem.Click += new System.EventHandler(this.ResetPartOfFileToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator12
-            // 
+            //
             this.toolStripSeparator12.Name = "toolStripSeparator12";
             this.toolStripSeparator12.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // openToolStripMenuItem
-            // 
+            //
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
-            // 
+            //
             // openWithToolStripMenuItem
-            // 
+            //
             this.openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
             this.openWithToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.openWithToolStripMenuItem.Text = "Open with...";
             this.openWithToolStripMenuItem.Click += new System.EventHandler(this.OpenWithToolStripMenuItemClick);
-            // 
+            //
             // openWithDifftoolToolStripMenuItem
-            // 
+            //
             this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconDiffTool;
             this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             this.openWithDifftoolToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
             this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.OpenWithDifftoolToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator9
-            // 
+            //
             this.toolStripSeparator9.Name = "toolStripSeparator9";
             this.toolStripSeparator9.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // filenameToClipboardToolStripMenuItem
-            // 
+            //
             this.filenameToClipboardToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
             this.filenameToClipboardToolStripMenuItem.Name = "filenameToClipboardToolStripMenuItem";
             this.filenameToClipboardToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.filenameToClipboardToolStripMenuItem.Text = "Copy full path";
             this.filenameToClipboardToolStripMenuItem.Click += new System.EventHandler(this.FilenameToClipboardToolStripMenuItemClick);
-            // 
+            //
             // openContainingFolderToolStripMenuItem
-            // 
+            //
             this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
             this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.openContainingFolderToolStripMenuItem.Text = "Open containing folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
-            // 
+            //
             // toolStripSeparator8
-            // 
+            //
             this.toolStripSeparator8.Name = "toolStripSeparator8";
             this.toolStripSeparator8.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // viewFileHistoryToolStripItem
-            // 
+            //
             this.viewFileHistoryToolStripItem.Image = global::GitUI.Properties.Resources.IconFileHistory;
             this.viewFileHistoryToolStripItem.Name = "viewFileHistoryToolStripItem";
             this.viewFileHistoryToolStripItem.Size = new System.Drawing.Size(232, 22);
             this.viewFileHistoryToolStripItem.Text = "View file history";
             this.viewFileHistoryToolStripItem.Click += new System.EventHandler(this.ViewFileHistoryMenuItem_Click);
-            // 
+            //
             // toolStripSeparator7
-            // 
+            //
             this.toolStripSeparator7.Name = "toolStripSeparator7";
             this.toolStripSeparator7.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // editFileToolStripMenuItem
-            // 
+            //
             this.editFileToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconEditFile;
             this.editFileToolStripMenuItem.Name = "editFileToolStripMenuItem";
             this.editFileToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.editFileToolStripMenuItem.Text = "Edit file";
             this.editFileToolStripMenuItem.Click += new System.EventHandler(this.editFileToolStripMenuItem_Click);
-            // 
+            //
             // deleteFileToolStripMenuItem
-            // 
+            //
             this.deleteFileToolStripMenuItem.Name = "deleteFileToolStripMenuItem";
             this.deleteFileToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.deleteFileToolStripMenuItem.Text = "Delete file";
             this.deleteFileToolStripMenuItem.Click += new System.EventHandler(this.DeleteFileToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator5
-            // 
+            //
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // addFileTogitignoreToolStripMenuItem
-            // 
+            //
             this.addFileTogitignoreToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconAddToGitIgnore;
             this.addFileTogitignoreToolStripMenuItem.Name = "addFileTogitignoreToolStripMenuItem";
             this.addFileTogitignoreToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.addFileTogitignoreToolStripMenuItem.Text = "Add file to .gitignore";
             this.addFileTogitignoreToolStripMenuItem.Click += new System.EventHandler(this.AddFileTogitignoreToolStripMenuItemClick);
-            // 
+            //
             // addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem
-            // 
+            //
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconAddToGitIgnore;
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Name = "addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem";
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Text = "Add file to .git/info/exclude";
             this.addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem.Click += new System.EventHandler(this.AddFileToGitInfoExcludeToolStripMenuItemClick);
-            // 
+            //
+            // skipWorktreeToolStripMenuItem
+            //
+            this.skipWorktreeToolStripMenuItem.Name = "skipWorktreeToolStripMenuItem";
+            this.skipWorktreeToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.skipWorktreeToolStripMenuItem.Text = "Skip worktree";
+            this.skipWorktreeToolStripMenuItem.Click += new System.EventHandler(this.SkipWorktreeToolStripMenuItemClick);
+            //
+            // doNotSkipWorktreeToolStripMenuItem
+            //
+            this.doNotSkipWorktreeToolStripMenuItem.Name = "doNotSkipWorktreeToolStripMenuItem";
+            this.doNotSkipWorktreeToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.doNotSkipWorktreeToolStripMenuItem.Text = "Do not skip worktree";
+            this.doNotSkipWorktreeToolStripMenuItem.Visible = false;
+            this.doNotSkipWorktreeToolStripMenuItem.Click += new System.EventHandler(this.DoNotSkipWorktreeToolStripMenuItemClick);
+            //
             // assumeUnchangedToolStripMenuItem
-            // 
+            //
             this.assumeUnchangedToolStripMenuItem.Name = "assumeUnchangedToolStripMenuItem";
             this.assumeUnchangedToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.assumeUnchangedToolStripMenuItem.Text = "Assume unchanged";
             this.assumeUnchangedToolStripMenuItem.Click += new System.EventHandler(this.AssumeUnchangedToolStripMenuItemClick);
-            // 
+            //
             // doNotAssumeUnchangedToolStripMenuItem
-            // 
+            //
             this.doNotAssumeUnchangedToolStripMenuItem.Name = "doNotAssumeUnchangedToolStripMenuItem";
             this.doNotAssumeUnchangedToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.doNotAssumeUnchangedToolStripMenuItem.Text = "Do not assume unchanged";
             this.doNotAssumeUnchangedToolStripMenuItem.Visible = false;
             this.doNotAssumeUnchangedToolStripMenuItem.Click += new System.EventHandler(this.DoNotAssumeUnchangedToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator4
-            // 
+            //
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // interactiveAddtoolStripMenuItem
-            // 
+            //
             this.interactiveAddtoolStripMenuItem.Name = "interactiveAddtoolStripMenuItem";
             this.interactiveAddtoolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.interactiveAddtoolStripMenuItem.Text = "Interactive Add";
             this.interactiveAddtoolStripMenuItem.Click += new System.EventHandler(this.toolStripMenuItem4_Click);
-            // 
+            //
             // StageInSuperproject
-            // 
+            //
             this.StageInSuperproject.AutoSize = true;
             this.StageInSuperproject.Location = new System.Drawing.Point(2, 130);
             this.StageInSuperproject.Margin = new System.Windows.Forms.Padding(2);
@@ -362,9 +382,9 @@ namespace GitUI.CommandsDialogs
             this.fileTooltip.SetToolTip(this.StageInSuperproject, "Stage current submodule in superproject after commit");
             this.StageInSuperproject.UseVisualStyleBackColor = true;
             this.StageInSuperproject.CheckedChanged += new System.EventHandler(this.StageInSuperproject_CheckedChanged);
-            // 
+            //
             // StagedFileContext
-            // 
+            //
             this.StagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.stagedResetChanges,
             this.stagedFileHistoryToolStripMenuItem6,
@@ -380,87 +400,87 @@ namespace GitUI.CommandsDialogs
             this.StagedFileContext.Name = "StagedFileContext";
             this.StagedFileContext.Size = new System.Drawing.Size(233, 198);
             this.StagedFileContext.Opening += StagedFileContext_Opening;
-            // 
+            //
             // stagedResetChanges
-            // 
+            //
             this.stagedResetChanges.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.stagedResetChanges.Name = "stagedResetChanges";
             this.stagedResetChanges.Size = new System.Drawing.Size(232, 22);
             this.stagedResetChanges.Text = "Reset file or directory changes";
             this.stagedResetChanges.Click += new System.EventHandler(this.ResetSoftClick);
-            // 
+            //
             // stagedFileHistoryToolStripMenuItem6
-            // 
+            //
             this.stagedFileHistoryToolStripMenuItem6.Image = global::GitUI.Properties.Resources.IconFileHistory;
             this.stagedFileHistoryToolStripMenuItem6.Name = "stagedFileHistoryToolStripMenuItem6";
             this.stagedFileHistoryToolStripMenuItem6.Size = new System.Drawing.Size(232, 22);
             this.stagedFileHistoryToolStripMenuItem6.Text = "View file history";
             this.stagedFileHistoryToolStripMenuItem6.Click += new System.EventHandler(this.ViewFileHistoryMenuItem_Click);
-            // 
+            //
             // stagedToolStripSeparator14
-            // 
+            //
             this.stagedToolStripSeparator14.Name = "stagedToolStripSeparator14";
             this.stagedToolStripSeparator14.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // stagedOpenToolStripMenuItem7
-            // 
+            //
             this.stagedOpenToolStripMenuItem7.Name = "stagedOpenToolStripMenuItem7";
             this.stagedOpenToolStripMenuItem7.Size = new System.Drawing.Size(232, 22);
             this.stagedOpenToolStripMenuItem7.Text = "Open";
             this.stagedOpenToolStripMenuItem7.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
-            // 
+            //
             // stagedOpenWithToolStripMenuItem8
-            // 
+            //
             this.stagedOpenWithToolStripMenuItem8.Name = "stagedOpenWithToolStripMenuItem8";
             this.stagedOpenWithToolStripMenuItem8.Size = new System.Drawing.Size(232, 22);
             this.stagedOpenWithToolStripMenuItem8.Text = "Open with...";
             this.stagedOpenWithToolStripMenuItem8.Click += new System.EventHandler(this.OpenWithToolStripMenuItemClick);
-            // 
+            //
             // stagedOpenDifftoolToolStripMenuItem9
-            // 
+            //
             this.stagedOpenDifftoolToolStripMenuItem9.Image = global::GitUI.Properties.Resources.IconDiffTool;
             this.stagedOpenDifftoolToolStripMenuItem9.Name = "stagedOpenDifftoolToolStripMenuItem9";
             this.stagedOpenDifftoolToolStripMenuItem9.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.stagedOpenDifftoolToolStripMenuItem9.Size = new System.Drawing.Size(232, 22);
             this.stagedOpenDifftoolToolStripMenuItem9.Text = "Open with difftool";
             this.stagedOpenDifftoolToolStripMenuItem9.Click += new System.EventHandler(this.stagedOpenDifftoolToolStripMenuItem9_Click);
-            // 
+            //
             // stagedToolStripSeparator18
-            // 
+            //
             this.stagedToolStripSeparator18.Name = "stagedToolStripSeparator18";
             this.stagedToolStripSeparator18.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // stagedCopyPathToolStripMenuItem14
-            // 
+            //
             this.stagedCopyPathToolStripMenuItem14.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
             this.stagedCopyPathToolStripMenuItem14.Name = "stagedCopyPathToolStripMenuItem14";
             this.stagedCopyPathToolStripMenuItem14.Size = new System.Drawing.Size(232, 22);
             this.stagedCopyPathToolStripMenuItem14.Text = "Copy full path";
             this.stagedCopyPathToolStripMenuItem14.Click += new System.EventHandler(this.FilenameToClipboardToolStripMenuItemClick);
-            // 
+            //
             // stagedOpenFolderToolStripMenuItem10
-            // 
+            //
             this.stagedOpenFolderToolStripMenuItem10.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
             this.stagedOpenFolderToolStripMenuItem10.Name = "stagedOpenFolderToolStripMenuItem10";
             this.stagedOpenFolderToolStripMenuItem10.Size = new System.Drawing.Size(232, 22);
             this.stagedOpenFolderToolStripMenuItem10.Text = "Open containing folder";
             this.stagedOpenFolderToolStripMenuItem10.Click += new System.EventHandler(this.openFolderToolStripMenuItem10_Click);
-            // 
+            //
             // stagedToolStripSeparator17
-            // 
+            //
             this.stagedToolStripSeparator17.Name = "stagedToolStripSeparator17";
             this.stagedToolStripSeparator17.Size = new System.Drawing.Size(229, 6);
-            // 
+            //
             // stagedEditFileToolStripMenuItem11
-            // 
+            //
             this.stagedEditFileToolStripMenuItem11.Image = global::GitUI.Properties.Resources.IconEditFile;
             this.stagedEditFileToolStripMenuItem11.Name = "stagedEditFileToolStripMenuItem11";
             this.stagedEditFileToolStripMenuItem11.Size = new System.Drawing.Size(232, 22);
             this.stagedEditFileToolStripMenuItem11.Text = "Edit file";
             this.stagedEditFileToolStripMenuItem11.Click += new System.EventHandler(this.editFileToolStripMenuItem_Click);
-            // 
+            //
             // UnstagedSubmoduleContext
-            // 
+            //
             this.UnstagedSubmoduleContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.commitSubmoduleChanges,
             this.resetSubmoduleChanges,
@@ -478,111 +498,111 @@ namespace GitUI.CommandsDialogs
             this.UnstagedSubmoduleContext.Name = "UnstagedSubmoduleContext";
             this.UnstagedSubmoduleContext.Size = new System.Drawing.Size(229, 264);
             this.UnstagedSubmoduleContext.Opening += UnstagedContextMenu_Opening;
-            // 
+            //
             // commitSubmoduleChanges
-            // 
+            //
             this.commitSubmoduleChanges.Image = global::GitUI.Properties.Resources.IconDirtySubmodules;
             this.commitSubmoduleChanges.Name = "commitSubmoduleChanges";
             this.commitSubmoduleChanges.Size = new System.Drawing.Size(228, 22);
             this.commitSubmoduleChanges.Text = "Commit submodule changes";
             this.commitSubmoduleChanges.Click += new System.EventHandler(this.commitSubmoduleChanges_Click);
-            // 
+            //
             // resetSubmoduleChanges
-            // 
+            //
             this.resetSubmoduleChanges.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.resetSubmoduleChanges.Name = "resetSubmoduleChanges";
             this.resetSubmoduleChanges.Size = new System.Drawing.Size(228, 22);
             this.resetSubmoduleChanges.Text = "Reset submodule changes";
             this.resetSubmoduleChanges.Click += new System.EventHandler(this.resetSubmoduleChanges_Click);
-            // 
+            //
             // stashSubmoduleChangesToolStripMenuItem
-            // 
+            //
             this.stashSubmoduleChangesToolStripMenuItem.Image = global::GitUI.Properties.Resources.stash;
             this.stashSubmoduleChangesToolStripMenuItem.Name = "stashSubmoduleChangesToolStripMenuItem";
             this.stashSubmoduleChangesToolStripMenuItem.Size = new System.Drawing.Size(228, 22);
             this.stashSubmoduleChangesToolStripMenuItem.Text = "Stash submodule changes";
             this.stashSubmoduleChangesToolStripMenuItem.Click += new System.EventHandler(this.stashSubmoduleChangesToolStripMenuItem_Click);
-            // 
+            //
             // updateSubmoduleMenuItem
-            // 
+            //
             this.updateSubmoduleMenuItem.Image = global::GitUI.Properties.Resources.IconSubmodulesUpdate;
             this.updateSubmoduleMenuItem.Name = "updateSubmoduleMenuItem";
             this.updateSubmoduleMenuItem.Size = new System.Drawing.Size(228, 22);
             this.updateSubmoduleMenuItem.Tag = "1";
             this.updateSubmoduleMenuItem.Text = "Update submodule";
             this.updateSubmoduleMenuItem.Click += new System.EventHandler(this.updateSubmoduleMenuItem_Click);
-            // 
+            //
             // toolStripSeparator13
-            // 
+            //
             this.toolStripSeparator13.Name = "toolStripSeparator13";
             this.toolStripSeparator13.Size = new System.Drawing.Size(225, 6);
             this.toolStripSeparator13.Tag = "1";
-            // 
+            //
             // submoduleSummaryMenuItem
-            // 
+            //
             this.submoduleSummaryMenuItem.Name = "submoduleSummaryMenuItem";
             this.submoduleSummaryMenuItem.Size = new System.Drawing.Size(228, 22);
             this.submoduleSummaryMenuItem.Text = "View summary";
             this.submoduleSummaryMenuItem.Click += new System.EventHandler(this.submoduleSummaryMenuItem_Click);
-            // 
+            //
             // viewHistoryMenuItem
-            // 
+            //
             this.viewHistoryMenuItem.Image = global::GitUI.Properties.Resources.IconFileHistory;
             this.viewHistoryMenuItem.Name = "viewHistoryMenuItem";
             this.viewHistoryMenuItem.Size = new System.Drawing.Size(228, 22);
             this.viewHistoryMenuItem.Text = "View history";
             this.viewHistoryMenuItem.Click += new System.EventHandler(this.viewHistoryMenuItem_Click);
-            // 
+            //
             // toolStripSeparator15
-            // 
+            //
             this.toolStripSeparator15.Name = "toolStripSeparator15";
             this.toolStripSeparator15.Size = new System.Drawing.Size(225, 6);
-            // 
+            //
             // openSubmoduleMenuItem
-            // 
+            //
             this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Resources.gitex;
             this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
             this.openSubmoduleMenuItem.Size = new System.Drawing.Size(228, 22);
             this.openSubmoduleMenuItem.Tag = "1";
             this.openSubmoduleMenuItem.Text = "Open with Git Extensions";
             this.openSubmoduleMenuItem.Click += new System.EventHandler(this.openSubmoduleMenuItem_Click);
-            // 
+            //
             // openFolderMenuItem
-            // 
+            //
             this.openFolderMenuItem.Image = global::GitUI.Properties.Resources.IconFolderSubmodule;
             this.openFolderMenuItem.Name = "openFolderMenuItem";
             this.openFolderMenuItem.Size = new System.Drawing.Size(228, 22);
             this.openFolderMenuItem.Text = "Open containing folder";
             this.openFolderMenuItem.Click += new System.EventHandler(this.openFolderMenuItem_Click);
-            // 
+            //
             // openDiffMenuItem
-            // 
+            //
             this.openDiffMenuItem.Image = global::GitUI.Properties.Resources.IconDiffTool;
             this.openDiffMenuItem.Name = "openDiffMenuItem";
             this.openDiffMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.openDiffMenuItem.Size = new System.Drawing.Size(228, 22);
             this.openDiffMenuItem.Text = "Open with difftool";
             this.openDiffMenuItem.Click += new System.EventHandler(this.openDiffMenuItem_Click);
-            // 
+            //
             // toolStripSeparator16
-            // 
+            //
             this.toolStripSeparator16.Name = "toolStripSeparator16";
             this.toolStripSeparator16.Size = new System.Drawing.Size(225, 6);
-            // 
+            //
             // copyFolderNameMenuItem
-            // 
+            //
             this.copyFolderNameMenuItem.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
             this.copyFolderNameMenuItem.Name = "copyFolderNameMenuItem";
             this.copyFolderNameMenuItem.Size = new System.Drawing.Size(228, 22);
             this.copyFolderNameMenuItem.Text = "Copy folder name";
             this.copyFolderNameMenuItem.Click += new System.EventHandler(this.copyFolderNameMenuItem_Click);
-            // 
+            //
             // gitItemStatusBindingSource
-            // 
+            //
             this.gitItemStatusBindingSource.DataSource = typeof(GitCommands.GitItemStatus);
-            // 
+            //
             // Cancel
-            // 
+            //
             this.Cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.Cancel.Location = new System.Drawing.Point(134, 167);
             this.Cancel.Name = "Cancel";
@@ -591,41 +611,41 @@ namespace GitUI.CommandsDialogs
             this.Cancel.TabStop = false;
             this.Cancel.Text = "Cancel";
             this.Cancel.UseVisualStyleBackColor = true;
-            // 
+            //
             // splitMain
-            // 
+            //
             this.splitMain.BackColor = System.Drawing.SystemColors.Control;
             this.splitMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitMain.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitMain.Location = new System.Drawing.Point(0, 0);
             this.splitMain.Name = "splitMain";
-            // 
+            //
             // splitMain.Panel1
-            // 
+            //
             this.splitMain.Panel1.Controls.Add(this.splitLeft);
             this.splitMain.Panel1.Controls.Add(this.Ok);
-            // 
+            //
             // splitMain.Panel2
-            // 
+            //
             this.splitMain.Panel2.Controls.Add(this.splitRight);
             this.splitMain.Size = new System.Drawing.Size(918, 622);
             this.splitMain.SplitterDistance = 397;
             this.splitMain.TabIndex = 0;
             this.splitMain.TabStop = false;
-            // 
+            //
             // splitLeft
-            // 
+            //
             this.splitLeft.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitLeft.Location = new System.Drawing.Point(0, 0);
             this.splitLeft.Name = "splitLeft";
             this.splitLeft.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
+            //
             // splitLeft.Panel1
-            // 
+            //
             this.splitLeft.Panel1.Controls.Add(this.toolStripContainer1);
-            // 
+            //
             // splitLeft.Panel2
-            // 
+            //
             this.splitLeft.Panel2.Controls.Add(this.LoadingStaged);
             this.splitLeft.Panel2.Controls.Add(this.Staged);
             this.splitLeft.Panel2.Controls.Add(this.Cancel);
@@ -634,12 +654,12 @@ namespace GitUI.CommandsDialogs
             this.splitLeft.SplitterDistance = 274;
             this.splitLeft.TabIndex = 3;
             this.splitLeft.TabStop = false;
-            // 
+            //
             // toolStripContainer1
-            // 
-            // 
+            //
+            //
             // toolStripContainer1.ContentPanel
-            // 
+            //
             this.toolStripContainer1.ContentPanel.Controls.Add(this.Loading);
             this.toolStripContainer1.ContentPanel.Controls.Add(this.Unstaged);
             this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(397, 249);
@@ -648,14 +668,14 @@ namespace GitUI.CommandsDialogs
             this.toolStripContainer1.Name = "toolStripContainer1";
             this.toolStripContainer1.Size = new System.Drawing.Size(397, 274);
             this.toolStripContainer1.TabIndex = 13;
-            // 
+            //
             // toolStripContainer1.TopToolStripPanel
-            // 
+            //
             this.toolStripContainer1.TopToolStripPanel.Controls.Add(this.toolbarUnstaged);
             this.toolStripContainer1.TopToolStripPanel.Controls.Add(this.toolbarSelectionFilter);
-            // 
+            //
             // Loading
-            // 
+            //
             this.Loading.BackColor = System.Drawing.SystemColors.AppWorkspace;
             this.Loading.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
             this.Loading.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -665,9 +685,9 @@ namespace GitUI.CommandsDialogs
             this.Loading.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.Loading.TabIndex = 11;
             this.Loading.TabStop = false;
-            // 
+            //
             // Unstaged
-            // 
+            //
             this.Unstaged.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Unstaged.FilterVisible = false;
             this.Unstaged.Location = new System.Drawing.Point(0, 0);
@@ -680,9 +700,9 @@ namespace GitUI.CommandsDialogs
             this.Unstaged.DataSourceChanged += new System.EventHandler(this.Staged_DataSourceChanged);
             this.Unstaged.DoubleClick += new System.EventHandler(this.Unstaged_DoubleClick);
             this.Unstaged.Enter += new System.EventHandler(this.Unstaged_Enter);
-            // 
+            //
             // toolbarUnstaged
-            // 
+            //
             this.toolbarUnstaged.AutoSize = false;
             this.toolbarUnstaged.BackColor = System.Drawing.SystemColors.Control;
             this.toolbarUnstaged.ClickThrough = true;
@@ -700,9 +720,9 @@ namespace GitUI.CommandsDialogs
             this.toolbarUnstaged.Size = new System.Drawing.Size(397, 25);
             this.toolbarUnstaged.Stretch = true;
             this.toolbarUnstaged.TabIndex = 12;
-            // 
+            //
             // toolRefreshItem
-            // 
+            //
             this.toolRefreshItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.toolRefreshItem.Image = global::GitUI.Properties.Resources.arrow_refresh;
             this.toolRefreshItem.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -710,17 +730,18 @@ namespace GitUI.CommandsDialogs
             this.toolRefreshItem.Size = new System.Drawing.Size(23, 20);
             this.toolRefreshItem.Text = "Refresh";
             this.toolRefreshItem.Click += new System.EventHandler(this.RescanChangesToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator6
-            // 
+            //
             this.toolStripSeparator6.Name = "toolStripSeparator6";
             this.toolStripSeparator6.Size = new System.Drawing.Size(6, 23);
-            // 
+            //
             // workingToolStripMenuItem
-            // 
+            //
             this.workingToolStripMenuItem.AutoToolTip = false;
             this.workingToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showIgnoredFilesToolStripMenuItem,
+            this.showSkipWorktreeFilesToolStripMenuItem,
             this.showAssumeUnchangedFilesToolStripMenuItem,
             this.showUntrackedFilesToolStripMenuItem,
             this.toolStripSeparator3,
@@ -738,117 +759,124 @@ namespace GitUI.CommandsDialogs
             this.workingToolStripMenuItem.Name = "workingToolStripMenuItem";
             this.workingToolStripMenuItem.Size = new System.Drawing.Size(178, 20);
             this.workingToolStripMenuItem.Text = "Working directory changes";
-            // 
+            //
             // showIgnoredFilesToolStripMenuItem
-            // 
+            //
             this.showIgnoredFilesToolStripMenuItem.Name = "showIgnoredFilesToolStripMenuItem";
             this.showIgnoredFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.showIgnoredFilesToolStripMenuItem.Text = "Show ignored files";
             this.showIgnoredFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowIgnoredFilesToolStripMenuItemClick);
-            // 
+            //
+            // showSkipWorktreeFilesToolStripMenuItem
+            //
+            this.showSkipWorktreeFilesToolStripMenuItem.Name = "showSkipWorktreeFilesToolStripMenuItem";
+            this.showSkipWorktreeFilesToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.showSkipWorktreeFilesToolStripMenuItem.Text = "Show skip-worktree files";
+            this.showSkipWorktreeFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowSkipWorktreeFilesToolStripMenuItemClick);
+            //
             // showAssumeUnchangedFilesToolStripMenuItem
-            // 
+            //
             this.showAssumeUnchangedFilesToolStripMenuItem.Name = "showAssumeUnchangedFilesToolStripMenuItem";
             this.showAssumeUnchangedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.showAssumeUnchangedFilesToolStripMenuItem.Text = "Show assumed-unchanged files";
             this.showAssumeUnchangedFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowAssumeUnchangedFilesToolStripMenuItemClick);
-            // 
+            //
             // showUntrackedFilesToolStripMenuItem
-            // 
+            //
             this.showUntrackedFilesToolStripMenuItem.Checked = true;
             this.showUntrackedFilesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showUntrackedFilesToolStripMenuItem.Name = "showUntrackedFilesToolStripMenuItem";
             this.showUntrackedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.showUntrackedFilesToolStripMenuItem.Text = "Show untracked files";
             this.showUntrackedFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowUntrackedFilesToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator3
-            // 
+            //
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(239, 6);
-            // 
+            //
             // deleteSelectedFilesToolStripMenuItem
-            // 
+            //
             this.deleteSelectedFilesToolStripMenuItem.Name = "deleteSelectedFilesToolStripMenuItem";
             this.deleteSelectedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.deleteSelectedFilesToolStripMenuItem.Text = "Delete selected files";
             this.deleteSelectedFilesToolStripMenuItem.Click += new System.EventHandler(this.DeleteSelectedFilesToolStripMenuItemClick);
-            // 
+            //
             // resetSelectedFilesToolStripMenuItem
-            // 
+            //
             this.resetSelectedFilesToolStripMenuItem.Name = "resetSelectedFilesToolStripMenuItem";
             this.resetSelectedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.resetSelectedFilesToolStripMenuItem.Text = "Reset selected files";
             this.resetSelectedFilesToolStripMenuItem.Click += new System.EventHandler(this.ResetSelectedFilesToolStripMenuItemClick);
-            // 
+            //
             // resetUnstagedChangesToolStripMenuItem
-            // 
+            //
             this.resetUnstagedChangesToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.resetUnstagedChangesToolStripMenuItem.Name = "resetUnstagedChangesToolStripMenuItem";
             this.resetUnstagedChangesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.resetUnstagedChangesToolStripMenuItem.Text = "Reset unstaged changes";
             this.resetUnstagedChangesToolStripMenuItem.Click += new System.EventHandler(this.resetUnstagedChangesToolStripMenuItem_Click);
-            // 
+            //
             // resetAlltrackedChangesToolStripMenuItem
-            // 
+            //
             this.resetAlltrackedChangesToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.resetAlltrackedChangesToolStripMenuItem.Name = "resetAlltrackedChangesToolStripMenuItem";
             this.resetAlltrackedChangesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.resetAlltrackedChangesToolStripMenuItem.Text = "Reset all (tracked) changes";
             this.resetAlltrackedChangesToolStripMenuItem.Click += new System.EventHandler(this.ResetAlltrackedChangesToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator1
-            // 
+            //
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(239, 6);
-            // 
+            //
             // editGitIgnoreToolStripMenuItem
-            // 
+            //
             this.editGitIgnoreToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconEditGitIgnore;
             this.editGitIgnoreToolStripMenuItem.Name = "editGitIgnoreToolStripMenuItem";
             this.editGitIgnoreToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.editGitIgnoreToolStripMenuItem.Text = "Edit ignored files";
             this.editGitIgnoreToolStripMenuItem.Click += new System.EventHandler(this.EditGitIgnoreToolStripMenuItemClick);
-            // 
+            //
             // editLocallyIgnoredFilesToolStripMenuItem
-            // 
+            //
             this.editLocallyIgnoredFilesToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconEditGitIgnore;
             this.editLocallyIgnoredFilesToolStripMenuItem.Name = "editLocallyIgnoredFilesToolStripMenuItem";
             this.editLocallyIgnoredFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.editLocallyIgnoredFilesToolStripMenuItem.Text = "Edit locally ignored files";
             this.editLocallyIgnoredFilesToolStripMenuItem.Click += new System.EventHandler(this.EditGitInfoExcludeToolStripMenuItemClick);
-            // 
+            //
             // deleteAllUntrackedFilesToolStripMenuItem
-            // 
+            //
             this.deleteAllUntrackedFilesToolStripMenuItem.Name = "deleteAllUntrackedFilesToolStripMenuItem";
             this.deleteAllUntrackedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.deleteAllUntrackedFilesToolStripMenuItem.Text = "Delete all untracked files";
             this.deleteAllUntrackedFilesToolStripMenuItem.Click += new System.EventHandler(this.DeleteAllUntrackedFilesToolStripMenuItemClick);
-            // 
+            //
             // toolStripMenuItem2
-            // 
+            //
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
             this.toolStripMenuItem2.Size = new System.Drawing.Size(239, 6);
-            // 
+            //
             // selectionFilterToolStripMenuItem
-            // 
+            //
             this.selectionFilterToolStripMenuItem.CheckOnClick = true;
             this.selectionFilterToolStripMenuItem.Name = "selectionFilterToolStripMenuItem";
             this.selectionFilterToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.selectionFilterToolStripMenuItem.Text = "Selection filter";
             this.selectionFilterToolStripMenuItem.CheckedChanged += new System.EventHandler(this.ToogleShowSelectionFilter);
-            // 
+            //
             // toolStripProgressBar1
-            // 
+            //
             this.toolStripProgressBar1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStripProgressBar1.Margin = new System.Windows.Forms.Padding(0);
             this.toolStripProgressBar1.Name = "toolStripProgressBar1";
             this.toolStripProgressBar1.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.toolStripProgressBar1.Size = new System.Drawing.Size(150, 27);
             this.toolStripProgressBar1.Visible = false;
-            // 
+            //
             // toolbarSelectionFilter
-            // 
+            //
             this.toolbarSelectionFilter.ClickThrough = true;
             this.toolbarSelectionFilter.Dock = System.Windows.Forms.DockStyle.None;
             this.toolbarSelectionFilter.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -859,22 +887,22 @@ namespace GitUI.CommandsDialogs
             this.toolbarSelectionFilter.Size = new System.Drawing.Size(219, 25);
             this.toolbarSelectionFilter.TabIndex = 13;
             this.toolbarSelectionFilter.Visible = false;
-            // 
+            //
             // toolStripLabel1
-            // 
+            //
             this.toolStripLabel1.Name = "toolStripLabel1";
             this.toolStripLabel1.Size = new System.Drawing.Size(84, 22);
             this.toolStripLabel1.Text = "Selection Filter";
-            // 
+            //
             // selectionFilter
-            // 
+            //
             this.selectionFilter.Name = "selectionFilter";
             this.selectionFilter.Size = new System.Drawing.Size(121, 25);
             this.selectionFilter.SelectedIndexChanged += new System.EventHandler(this.FilterIndexChanged);
             this.selectionFilter.TextChanged += new System.EventHandler(this.FilterChanged);
-            // 
+            //
             // LoadingStaged
-            // 
+            //
             this.LoadingStaged.BackColor = System.Drawing.SystemColors.AppWorkspace;
             this.LoadingStaged.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
             this.LoadingStaged.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -884,9 +912,9 @@ namespace GitUI.CommandsDialogs
             this.LoadingStaged.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.LoadingStaged.TabIndex = 17;
             this.LoadingStaged.TabStop = false;
-            // 
+            //
             // Staged
-            // 
+            //
             this.Staged.ContextMenuStrip = this.StagedFileContext;
             this.Staged.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Staged.FilterVisible = false;
@@ -900,9 +928,9 @@ namespace GitUI.CommandsDialogs
             this.Staged.DataSourceChanged += new System.EventHandler(this.Staged_DataSourceChanged);
             this.Staged.DoubleClick += new System.EventHandler(this.Staged_DoubleClick);
             this.Staged.Enter += new System.EventHandler(this.Staged_Enter);
-            // 
+            //
             // toolbarStaged
-            // 
+            //
             this.toolbarStaged.AutoSize = false;
             this.toolbarStaged.BackColor = System.Drawing.SystemColors.Control;
             this.toolbarStaged.ClickThrough = true;
@@ -920,9 +948,9 @@ namespace GitUI.CommandsDialogs
             this.toolbarStaged.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
             this.toolbarStaged.Size = new System.Drawing.Size(397, 28);
             this.toolbarStaged.TabIndex = 13;
-            // 
+            //
             // toolStageAllItem
-            // 
+            //
             this.toolStageAllItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStageAllItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.toolStageAllItem.Image = global::GitUI.Properties.Resources.IconStageAll;
@@ -931,15 +959,15 @@ namespace GitUI.CommandsDialogs
             this.toolStageAllItem.Size = new System.Drawing.Size(23, 23);
             this.toolStageAllItem.Text = "Stage All";
             this.toolStageAllItem.Click += new System.EventHandler(this.StageAllToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator10
-            // 
+            //
             this.toolStripSeparator10.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStripSeparator10.Name = "toolStripSeparator10";
             this.toolStripSeparator10.Size = new System.Drawing.Size(6, 26);
-            // 
+            //
             // toolStageItem
-            // 
+            //
             this.toolStageItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStageItem.AutoToolTip = false;
             this.toolStageItem.Image = global::GitUI.Properties.Resources.IconStage;
@@ -949,9 +977,9 @@ namespace GitUI.CommandsDialogs
             this.toolStageItem.Text = "&Stage";
             this.toolStageItem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.toolStageItem.Click += new System.EventHandler(this.StageClick);
-            // 
+            //
             // toolUnstageAllItem
-            // 
+            //
             this.toolUnstageAllItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.toolUnstageAllItem.Image = global::GitUI.Properties.Resources.IconUnstageAll;
             this.toolUnstageAllItem.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -959,14 +987,14 @@ namespace GitUI.CommandsDialogs
             this.toolUnstageAllItem.Size = new System.Drawing.Size(23, 23);
             this.toolUnstageAllItem.Text = "Unstage All";
             this.toolUnstageAllItem.Click += new System.EventHandler(this.UnstageAllToolStripMenuItemClick);
-            // 
+            //
             // toolStripSeparator11
-            // 
+            //
             this.toolStripSeparator11.Name = "toolStripSeparator11";
             this.toolStripSeparator11.Size = new System.Drawing.Size(6, 26);
-            // 
+            //
             // toolUnstageItem
-            // 
+            //
             this.toolUnstageItem.AutoToolTip = false;
             this.toolUnstageItem.Image = global::GitUI.Properties.Resources.IconUnstage;
             this.toolUnstageItem.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -975,41 +1003,41 @@ namespace GitUI.CommandsDialogs
             this.toolUnstageItem.Text = "&Unstage";
             this.toolUnstageItem.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.toolUnstageItem.Click += new System.EventHandler(this.UnstageFilesClick);
-            // 
+            //
             // Ok
-            // 
+            //
             this.Ok.Location = new System.Drawing.Point(334, 10);
             this.Ok.Name = "Ok";
             this.Ok.Size = new System.Drawing.Size(75, 23);
             this.Ok.TabIndex = 2;
             this.Ok.Text = "Commit";
             this.Ok.UseVisualStyleBackColor = true;
-            // 
+            //
             // splitRight
-            // 
+            //
             this.splitRight.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitRight.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.splitRight.Location = new System.Drawing.Point(0, 0);
             this.splitRight.Name = "splitRight";
             this.splitRight.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
+            //
             // splitRight.Panel1
-            // 
+            //
             this.splitRight.Panel1.Controls.Add(this.llShowPreview);
             this.splitRight.Panel1.Controls.Add(this.SolveMergeconflicts);
             this.splitRight.Panel1.Controls.Add(this.SelectedDiff);
-            // 
+            //
             // splitRight.Panel2
-            // 
+            //
             this.splitRight.Panel2.Controls.Add(this.tableLayoutPanel1);
             this.splitRight.Panel2MinSize = 145;
             this.splitRight.Size = new System.Drawing.Size(517, 622);
             this.splitRight.SplitterDistance = 426;
             this.splitRight.TabIndex = 0;
             this.splitRight.TabStop = false;
-            // 
+            //
             // llShowPreview
-            // 
+            //
             this.llShowPreview.AutoSize = true;
             this.llShowPreview.Location = new System.Drawing.Point(43, 23);
             this.llShowPreview.Name = "llShowPreview";
@@ -1019,9 +1047,9 @@ namespace GitUI.CommandsDialogs
             this.llShowPreview.Text = "This file is over 5 MB. Click to show preview";
             this.llShowPreview.Visible = false;
             this.llShowPreview.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llShowPreview_LinkClicked);
-            // 
+            //
             // SolveMergeconflicts
-            // 
+            //
             this.SolveMergeconflicts.BackColor = System.Drawing.Color.SeaShell;
             this.SolveMergeconflicts.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.SolveMergeconflicts.Image = global::GitUI.Properties.Resources.IconSolveMerge;
@@ -1034,9 +1062,9 @@ namespace GitUI.CommandsDialogs
             this.SolveMergeconflicts.UseVisualStyleBackColor = false;
             this.SolveMergeconflicts.Visible = false;
             this.SolveMergeconflicts.Click += new System.EventHandler(this.SolveMergeConflictsClick);
-            // 
+            //
             // SelectedDiff
-            // 
+            //
             this.SelectedDiff.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SelectedDiff.Location = new System.Drawing.Point(0, 0);
             this.SelectedDiff.Margin = new System.Windows.Forms.Padding(2, 3, 3, 3);
@@ -1045,9 +1073,9 @@ namespace GitUI.CommandsDialogs
             this.SelectedDiff.TabIndex = 0;
             this.SelectedDiff.TabStop = false;
             this.SelectedDiff.ContextMenuOpening += new System.ComponentModel.CancelEventHandler(this.SelectedDiff_ContextMenuOpening);
-            // 
+            //
             // tableLayoutPanel1
-            // 
+            //
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -1062,18 +1090,18 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(517, 192);
             this.tableLayoutPanel1.TabIndex = 8;
-            // 
+            //
             // panel1
-            // 
+            //
             this.panel1.Controls.Add(this.Message);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel1.Location = new System.Drawing.Point(178, 31);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(336, 158);
             this.panel1.TabIndex = 7;
-            // 
+            //
             // Message
-            // 
+            //
             this.Message.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Message.Location = new System.Drawing.Point(0, 0);
             this.Message.Margin = new System.Windows.Forms.Padding(0);
@@ -1085,9 +1113,9 @@ namespace GitUI.CommandsDialogs
             this.Message.Enter += new System.EventHandler(this.Message_Enter);
             this.Message.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Message_KeyDown);
             this.Message.KeyUp += new System.Windows.Forms.KeyEventHandler(this.Message_KeyUp);
-            // 
+            //
             // flowCommitButtons
-            // 
+            //
             this.flowCommitButtons.AutoSize = true;
             this.flowCommitButtons.Controls.Add(this.Commit);
             this.flowCommitButtons.Controls.Add(this.CommitAndPush);
@@ -1104,9 +1132,9 @@ namespace GitUI.CommandsDialogs
             this.flowCommitButtons.Size = new System.Drawing.Size(175, 192);
             this.flowCommitButtons.TabIndex = 1;
             this.flowCommitButtons.WrapContents = false;
-            // 
+            //
             // Commit
-            // 
+            //
             this.Commit.Image = global::GitUI.Properties.Resources.IconClean;
             this.Commit.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.Commit.Location = new System.Drawing.Point(1, 3);
@@ -1118,9 +1146,9 @@ namespace GitUI.CommandsDialogs
             this.Commit.Text = "&Commit";
             this.Commit.UseVisualStyleBackColor = true;
             this.Commit.Click += new System.EventHandler(this.CommitClick);
-            // 
+            //
             // CommitAndPush
-            // 
+            //
             this.CommitAndPush.Image = global::GitUI.Properties.Resources.ArrowUp;
             this.CommitAndPush.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.CommitAndPush.Location = new System.Drawing.Point(1, 35);
@@ -1132,9 +1160,9 @@ namespace GitUI.CommandsDialogs
             this.CommitAndPush.Text = "C&ommit && push";
             this.CommitAndPush.UseVisualStyleBackColor = true;
             this.CommitAndPush.Click += new System.EventHandler(this.CommitAndPush_Click);
-            // 
+            //
             // Reset
-            // 
+            //
             this.Reset.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.Reset.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.Reset.Location = new System.Drawing.Point(1, 67);
@@ -1146,9 +1174,9 @@ namespace GitUI.CommandsDialogs
             this.Reset.Text = "Reset all changes";
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.ResetClick);
-            // 
+            //
             // ResetUnStaged
-            // 
+            //
             this.ResetUnStaged.Image = global::GitUI.Properties.Resources.IconResetWorkingDirChanges;
             this.ResetUnStaged.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.ResetUnStaged.Location = new System.Drawing.Point(1, 99);
@@ -1161,9 +1189,9 @@ namespace GitUI.CommandsDialogs
             this.ResetUnStaged.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.ResetUnStaged.UseVisualStyleBackColor = true;
             this.ResetUnStaged.Click += new System.EventHandler(this.ResetUnStagedClick);
-            // 
+            //
             // Amend
-            // 
+            //
             this.Amend.AutoSize = true;
             this.Amend.Location = new System.Drawing.Point(3, 152);
             this.Amend.Name = "Amend";
@@ -1172,9 +1200,9 @@ namespace GitUI.CommandsDialogs
             this.Amend.Text = "&Amend Commit";
             this.Amend.UseVisualStyleBackColor = true;
             this.Amend.CheckedChanged += new System.EventHandler(this.Amend_CheckedChanged);
-            // 
+            //
             // toolbarCommit
-            // 
+            //
             this.toolbarCommit.AutoSize = false;
             this.toolbarCommit.BackColor = System.Drawing.SystemColors.Control;
             this.toolbarCommit.ClickThrough = true;
@@ -1191,9 +1219,9 @@ namespace GitUI.CommandsDialogs
             this.toolbarCommit.Size = new System.Drawing.Size(342, 28);
             this.toolbarCommit.Stretch = true;
             this.toolbarCommit.TabIndex = 5;
-            // 
+            //
             // commitMessageToolStripMenuItem
-            // 
+            //
             this.commitMessageToolStripMenuItem.AutoToolTip = false;
             this.commitMessageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem1,
@@ -1205,21 +1233,21 @@ namespace GitUI.CommandsDialogs
             this.commitMessageToolStripMenuItem.Text = "Commit &message";
             this.commitMessageToolStripMenuItem.DropDownOpening += new System.EventHandler(this.CommitMessageToolStripMenuItemDropDownOpening);
             this.commitMessageToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.CommitMessageToolStripMenuItemDropDownItemClicked);
-            // 
+            //
             // toolStripMenuItem1
-            // 
+            //
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
             this.toolStripMenuItem1.Size = new System.Drawing.Size(287, 6);
-            // 
+            //
             // generateListOfChangesInSubmodulesChangesToolStripMenuItem
-            // 
+            //
             this.generateListOfChangesInSubmodulesChangesToolStripMenuItem.Name = "generateListOfChangesInSubmodulesChangesToolStripMenuItem";
             this.generateListOfChangesInSubmodulesChangesToolStripMenuItem.Size = new System.Drawing.Size(290, 22);
             this.generateListOfChangesInSubmodulesChangesToolStripMenuItem.Text = "Generate a list of changes in submodules";
             this.generateListOfChangesInSubmodulesChangesToolStripMenuItem.Click += new System.EventHandler(this.generateListOfChangesInSubmodulesChangesToolStripMenuItem_Click);
-            // 
+            //
             // toolStripMenuItem3
-            // 
+            //
             this.toolStripMenuItem3.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStripMenuItem3.AutoToolTip = false;
             this.toolStripMenuItem3.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -1235,83 +1263,83 @@ namespace GitUI.CommandsDialogs
             this.toolStripMenuItem3.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.toolStripMenuItem3.Size = new System.Drawing.Size(62, 23);
             this.toolStripMenuItem3.Text = "Options";
-            // 
+            //
             // closeDialogAfterEachCommitToolStripMenuItem
-            // 
+            //
             this.closeDialogAfterEachCommitToolStripMenuItem.Name = "closeDialogAfterEachCommitToolStripMenuItem";
             this.closeDialogAfterEachCommitToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
             this.closeDialogAfterEachCommitToolStripMenuItem.Text = "Close dialog after each commit";
             this.closeDialogAfterEachCommitToolStripMenuItem.Click += new System.EventHandler(this.closeDialogAfterEachCommitToolStripMenuItem_Click);
-            // 
+            //
             // closeDialogAfterAllFilesCommittedToolStripMenuItem
-            // 
+            //
             this.closeDialogAfterAllFilesCommittedToolStripMenuItem.Name = "closeDialogAfterAllFilesCommittedToolStripMenuItem";
             this.closeDialogAfterAllFilesCommittedToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
             this.closeDialogAfterAllFilesCommittedToolStripMenuItem.Text = "Close dialog when all changes are committed";
             this.closeDialogAfterAllFilesCommittedToolStripMenuItem.Click += new System.EventHandler(this.closeDialogAfterAllFilesCommittedToolStripMenuItem_Click);
-            // 
+            //
             // refreshDialogOnFormFocusToolStripMenuItem
-            // 
+            //
             this.refreshDialogOnFormFocusToolStripMenuItem.Name = "refreshDialogOnFormFocusToolStripMenuItem";
             this.refreshDialogOnFormFocusToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
             this.refreshDialogOnFormFocusToolStripMenuItem.Text = "Refresh dialog on form focus";
             this.refreshDialogOnFormFocusToolStripMenuItem.Click += new System.EventHandler(this.refreshDialogOnFormFocusToolStripMenuItem_Click);
-            // 
+            //
             // toolStripSeparator2
-            // 
+            //
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(311, 6);
-            // 
+            //
             // signOffToolStripMenuItem
-            // 
+            //
             this.signOffToolStripMenuItem.Name = "signOffToolStripMenuItem";
             this.signOffToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
             this.signOffToolStripMenuItem.Text = "Sign-off commit";
             this.signOffToolStripMenuItem.Click += new System.EventHandler(this.signOffToolStripMenuItem_Click);
-            // 
+            //
             // toolAuthorLabelItem
-            // 
+            //
             this.toolAuthorLabelItem.Enabled = false;
             this.toolAuthorLabelItem.Name = "toolAuthorLabelItem";
             this.toolAuthorLabelItem.Size = new System.Drawing.Size(314, 22);
             this.toolAuthorLabelItem.Text = "Author: (Format: \"name <mail>\")";
             this.toolAuthorLabelItem.Click += new System.EventHandler(this.toolAuthorLabelItem_Click);
-            // 
+            //
             // toolAuthor
-            // 
+            //
             this.toolAuthor.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.toolAuthor.Name = "toolAuthor";
             this.toolAuthor.Size = new System.Drawing.Size(230, 23);
             this.toolAuthor.Leave += new System.EventHandler(this.toolAuthor_Leave);
             this.toolAuthor.TextChanged += new System.EventHandler(this.toolAuthor_TextChanged);
-            // 
+            //
             // noVerifyToolStripMenuItem
-            // 
+            //
             this.noVerifyToolStripMenuItem.CheckOnClick = true;
             this.noVerifyToolStripMenuItem.Name = "noVerifyToolStripMenuItem";
             this.noVerifyToolStripMenuItem.Size = new System.Drawing.Size(314, 22);
             this.noVerifyToolStripMenuItem.Text = "No verify";
-            // 
+            //
             // commitTemplatesToolStripMenuItem
-            // 
+            //
             this.commitTemplatesToolStripMenuItem.Image = global::GitUI.Properties.Resources.CommitTemplates;
             this.commitTemplatesToolStripMenuItem.Name = "commitTemplatesToolStripMenuItem";
             this.commitTemplatesToolStripMenuItem.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.commitTemplatesToolStripMenuItem.Size = new System.Drawing.Size(135, 20);
             this.commitTemplatesToolStripMenuItem.Text = "Commit &templates";
             this.commitTemplatesToolStripMenuItem.DropDownOpening += new System.EventHandler(this.commitTemplatesToolStripMenuItem_DropDownOpening);
-            // 
+            //
             // createBranchToolStripButton
-            // 
+            //
             this.createBranchToolStripButton.Image = global::GitUI.Properties.Resources.IconBranchCreate;
             this.createBranchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.createBranchToolStripButton.Name = "createBranchToolStripButton";
             this.createBranchToolStripButton.Size = new System.Drawing.Size(101, 20);
             this.createBranchToolStripButton.Text = "Create branch";
             this.createBranchToolStripButton.Click += new System.EventHandler(this.createBranchToolStripButton_Click);
-            // 
+            //
             // commitStatusStrip
-            // 
+            //
             this.commitStatusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.commitAuthorStatus,
             this.commitStagedCountLabel,
@@ -1327,9 +1355,9 @@ namespace GitUI.CommandsDialogs
             this.commitStatusStrip.ShowItemToolTips = true;
             this.commitStatusStrip.Size = new System.Drawing.Size(918, 22);
             this.commitStatusStrip.TabIndex = 13;
-            // 
+            //
             // commitAuthorStatus
-            // 
+            //
             this.commitAuthorStatus.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.commitAuthorStatus.IsLink = true;
             this.commitAuthorStatus.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
@@ -1339,57 +1367,57 @@ namespace GitUI.CommandsDialogs
             this.commitAuthorStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.commitAuthorStatus.ToolTipText = "Click to change author information.";
             this.commitAuthorStatus.Click += new System.EventHandler(this.commitCommitter_Click);
-            // 
+            //
             // commitStagedCountLabel
-            // 
+            //
             this.commitStagedCountLabel.Name = "commitStagedCountLabel";
             this.commitStagedCountLabel.Size = new System.Drawing.Size(43, 17);
             this.commitStagedCountLabel.Text = "Staged";
-            // 
+            //
             // commitStagedCount
-            // 
+            //
             this.commitStagedCount.AutoSize = false;
             this.commitStagedCount.Name = "commitStagedCount";
             this.commitStagedCount.Size = new System.Drawing.Size(40, 17);
             this.commitStagedCount.Text = "0";
             this.commitStagedCount.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
             // commitCursorLineLabel
-            // 
+            //
             this.commitCursorLineLabel.Name = "commitCursorLineLabel";
             this.commitCursorLineLabel.Size = new System.Drawing.Size(20, 17);
             this.commitCursorLineLabel.Text = "Ln";
-            // 
+            //
             // commitCursorLine
-            // 
+            //
             this.commitCursorLine.AutoSize = false;
             this.commitCursorLine.Name = "commitCursorLine";
             this.commitCursorLine.Size = new System.Drawing.Size(40, 17);
             this.commitCursorLine.Text = "0";
             this.commitCursorLine.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
             // commitCursorColumnLabel
-            // 
+            //
             this.commitCursorColumnLabel.Name = "commitCursorColumnLabel";
             this.commitCursorColumnLabel.Size = new System.Drawing.Size(25, 17);
             this.commitCursorColumnLabel.Text = "Col";
-            // 
+            //
             // commitCursorColumn
-            // 
+            //
             this.commitCursorColumn.AutoSize = false;
             this.commitCursorColumn.Name = "commitCursorColumn";
             this.commitCursorColumn.Size = new System.Drawing.Size(40, 17);
             this.commitCursorColumn.Text = "0";
             this.commitCursorColumn.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
             // commitEndPadding
-            // 
+            //
             this.commitEndPadding.AutoSize = false;
             this.commitEndPadding.Name = "commitEndPadding";
             this.commitEndPadding.Size = new System.Drawing.Size(1, 17);
-            // 
+            //
             // FormCommit
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.Cancel;
@@ -1467,6 +1495,8 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem assumeUnchangedToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem doNotAssumeUnchangedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem skipWorktreeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem doNotSkipWorktreeToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
@@ -1490,6 +1520,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripDropDownButton workingToolStripMenuItem;
         private ToolStripMenuItem showIgnoredFilesToolStripMenuItem;
         private ToolStripMenuItem showAssumeUnchangedFilesToolStripMenuItem;
+        private ToolStripMenuItem showSkipWorktreeFilesToolStripMenuItem;
         private ToolStripMenuItem showUntrackedFilesToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem deleteSelectedFilesToolStripMenuItem;


### PR DESCRIPTION
Add the 'skip-worktree' feature next to the 'assume-unchanged' one in the commit form.

Works quite similary to the existing 'assume-unchanged' one.

In fact, the person that made the PR for 'assume-unchanged' do not really understand the differences or didn't know that 'skip-worktree' exists (To understand the differences, see: https://stackoverflow.com/a/13631525/717372 ). Consequently, proposing this feature in the commit form *make no sense* :(

'Assume-unchanged' should only be used for big files *that don't change* and that is costly to get status.
'Skip-Worktree' should be used for files the developer knows they have changed but don't want to commit and so don't want to see them in the unchanged file list.

'Assume-unchanged' is for files that don't change, so can't appear in the unstaged list, so can't be assume-unchanged :(

It make a lot more sense to had it in 'file tree' contextual menu (but that's not the goal of this PR focus on 'skip-worktree' feature)

Also:
- Display/hide the items in the contextual menu when intended.
- Add tooltips to understand the difference  between 'skip-worktree' and 'assume-unchanged'


Has been tested on (remove any that don't apply):
 - GIT 2.13
 - Windows 10