### PR TITLE
fix: Help in Branch dialog exception

### DIFF
--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -1,10 +1,7 @@
 ﻿namespace GitUI
 {
     using System.Diagnostics;
-    using System.Text.RegularExpressions;
     using System.Windows.Forms;
-
-    using Microsoft.Win32;
 #if !__MonoCS__
     using Microsoft.WindowsAPICodePack.Dialogs;
 #endif
@@ -37,13 +34,9 @@
         /// </summary>
         public static void OpenUrlInDefaultBrowser(string url)
         {
-            // Process.Start(url); / does not work with anchors: http://stackoverflow.com/questions/2404449/process-starturl-with-anchor-in-the-url
-            var openSubKey = Registry.ClassesRoot.OpenSubKey(@"\http\shell\open\command\");
-            if (openSubKey != null)
+            if (!string.IsNullOrWhiteSpace(url))
             {
-                var browserRegistryString  = openSubKey.GetValue("").ToString();
-                var defaultBrowserPath = Regex.Match(browserRegistryString, @"(\"".*?\"")").Captures[0].ToString();
-                Process.Start(defaultBrowserPath, url);
+                Process.Start(url);
             }
         }
 


### PR DESCRIPTION
In a rare case when the user's browser of choice points to non-existent executable attempts to launch the help will result in Win32Exception "the system cannot find the file specified".
The old implementation was also looking at the now-defunct registry key to determine the browser of choice.
Since Win8 the registry key containing the user's choice is encrypted and thus no longer usable by thrid-party applications.

The code is simplified to launch the help URL via `Process.Start`.

Fixes #3011


Has been tested on (remove any that don't apply):
 - Windows 10 and above
 - Ubuntu 17.04
