### PR TITLE
Include recently added System.IO.Abstractions in setup package

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -76,6 +76,9 @@
       <Component Id="Gravatar.dll" Guid="*">
         <File Source="..\Gravatar\bin\Release\Gravatar.dll" />
       </Component>
+      <Component Id="System.IO.Abstractions.dll" Guid="*">
+        <File Source="..\Gravatar\bin\Release\System.IO.Abstractions.dll" />
+      </Component>
       <Component Id="GitCommands.dll" Guid="*">
         <File Source="..\GitCommands\bin\Release\GitCommands.dll" />
       </Component>
@@ -633,6 +636,7 @@
       <ComponentRef Id="PSTaskDialog.dll" />
       <ComponentRef Id="Microsoft.WindowsAPICodePack.dll" />
       <ComponentRef Id="Microsoft.WindowsAPICodePack.Shell.dll" />
+      <ComponentRef Id="System.IO.Abstractions.dll" />
       <ComponentRef Id="System.Reactive.Core.dll" />
       <ComponentRef Id="System.Reactive.Interfaces.dll" />
       <ComponentRef Id="System.Reactive.Linq.dll" />


### PR DESCRIPTION
Got a crash after installing latest master branch build. It turns out System.IO.Abstractions.dll was missing from setup package. It's been recently added as a dependency for Gravatar.