### PR TITLE
handle worktrees with spaces in the path

### DIFF
--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -124,7 +124,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         private void CreateWorktree()
         {
             //https://git-scm.com/docs/git-worktree
-            var arguments = "worktree add " + WorktreeDirectory;
+            var arguments = "worktree add \"" + WorktreeDirectory + "\"";
             if (radioButtonCreateNewBranch.Checked)
             {
                 arguments += " -b " + textBoxNewBranchName.Text;
@@ -132,9 +132,9 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             else
             {
                 arguments += " " + ((GitRef)comboBoxBranches.SelectedItem).Name;
-
             }
-            UICommands.StartCommandLineProcessDialog("git", arguments);
+
+            UICommands.StartGitCommandProcessDialog(arguments);
             this.DialogResult = DialogResult.OK;
         }
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 var strings = current.Split(' ');
                 if (strings[0] == "worktree")
                 {
-                    currentWorktree = new WorkTree { Path = strings[1] };
+                    currentWorktree = new WorkTree { Path = current.Substring(9) };
                     currentWorktree.IsDeleted = !Directory.Exists(currentWorktree.Path);
                     _worktrees.Add(currentWorktree);
                 }


### PR DESCRIPTION
Fixes #3849

- Fix "Manage worktree" form
- Fix creation of the worktree when putting a space in the path

Has been tested on:
 - GIT 2.13 

