### PR TITLE
fix: NRE when trying to push

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -525,6 +525,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this._NO_TRANSLATE_Remotes.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this._NO_TRANSLATE_Remotes.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this._NO_TRANSLATE_Remotes.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._NO_TRANSLATE_Remotes.FormattingEnabled = true;
             this._NO_TRANSLATE_Remotes.Location = new System.Drawing.Point(128, 19);
             this._NO_TRANSLATE_Remotes.Name = "_NO_TRANSLATE_Remotes";


### PR DESCRIPTION
An attempt to push when no remote defined would result in NRE.
Check for remotes before pushing. If no remotes available, show an error message and a prompt to
configure remotes.

Fixes #3862.

Screenshots before and after (if PR changes UI):
Before:
![image](https://user-images.githubusercontent.com/4403806/29701819-778cf1c2-89b1-11e7-9856-eb624b11fe04.png)

After:
![image](https://user-images.githubusercontent.com/4403806/29738657-3db045c4-8a6c-11e7-84c5-7cdc86604585.png)


Has been tested on (remove any that don't apply):
 - Windows 10 and above
- Ubuntu 17.04
