### PR TITLE
Reload file viewer hotkeys when the settings form is closed

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1685,6 +1685,8 @@ namespace GitUI.CommandsDialogs
             this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
             RevisionGrid.ReloadHotkeys();
             RevisionGrid.ReloadTranslation();
+            FileText.ReloadHotkeys();
+            DiffText.ReloadHotkeys();
         }
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -189,8 +189,13 @@ namespace GitUI.Editor
 
         protected override void OnRuntimeLoad(EventArgs e)
         {
-            this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
+            ReloadHotkeys();
             Font = AppSettings.DiffFont;
+        }
+
+        public void ReloadHotkeys()
+        {
+            this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
         }
 
         void ContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)


### PR DESCRIPTION
Fixes #3933.

Changes proposed in this pull request:
 - the hotkeys for the diff viewer and file viewer in the _Browse_ dialog are reloaded each time the _Settings_ form is closed (similarly to the revision grid).
 
Has been tested on (remove any that don't apply):
 - GIT 2.13.2
 - Windows 10
