### PR TITLE
Convert relative path command line argument to absolute path

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -147,6 +147,9 @@ namespace GitExtensions
                     workingDir = GitModule.FindGitWorkingDir(workingDir);
                 }
 
+                if (Directory.Exists(workingDir))
+                    workingDir = Path.GetFullPath(workingDir);
+
                 //Do not add this working directory to the recent repositories. It is a nice feature, but it
                 //also increases the startup time
                 //if (Module.ValidWorkingDir())


### PR DESCRIPTION
fix for #3947
When run `browse` command from command line with relative path as argument gitextensions show that relative path in recent repositories list. 
Relative path may be meaningless (e.g. `.\..\..`).

Changes proposed in this pull request:
 - convert relative path to absolute at the moment of parsing arguments