### PR TITLE
Fixed DiffView for Submodules with diff.mnemonicprefix=true

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -915,7 +915,7 @@ namespace GitCommands
 
                 if (line != null)
                 {
-                    var match = Regex.Match(line, @"diff --git a/(.+)\sb/(.+)");
+                    var match = Regex.Match(line, @"diff --git (?:a|i)/(.+)\s(?:b|w)/(.+)");
                     if (match.Groups.Count > 1)
                     {
                         status.Name = match.Groups[1].Value;

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -915,7 +915,7 @@ namespace GitCommands
 
                 if (line != null)
                 {
-                    var match = Regex.Match(line, @"diff --git (?:a|i)/(.+)\s(?:b|w)/(.+)");
+                    var match = Regex.Match(line, @"diff --git (?:a|i|c)/(.+)\s(?:b|w|i)/(.+)");
                     if (match.Groups.Count > 1)
                     {
                         status.Name = match.Groups[1].Value;


### PR DESCRIPTION
Fixes #3948

Changes proposed in this pull request:
 - modified the regular expression 

How did I test this code:
 - modified content of a submodule => diff view works fine
 - commited changed content of submodule => submodule is staged => diff view works fine
 - tested both with  diff.mnemonicprefix=[true|false]

Has been tested on (remove any that don't apply):
 - git version 2.13.3.windows.1
 - Windows 7 Enterprise SP1
