### PR TITLE
fix: Recent repositories history size not respected

### DIFF
--- a/GitCommands/Repository/Repositories.cs
+++ b/GitCommands/Repository/Repositories.cs
@@ -14,7 +14,6 @@ namespace GitCommands.Repository
         private static Task<RepositoryHistory> _repositoryHistory;
         private static RepositoryHistory _remoteRepositoryHistory;
         private static BindingList<RepositoryCategory> _repositoryCategories;
-        private const int DefaultRepositoriesCount = 30;
 
         public static Task<RepositoryHistory> LoadRepositoryHistoryAsync()
         {
@@ -26,7 +25,7 @@ namespace GitCommands.Repository
 
         private static RepositoryHistory LoadRepositoryHistory()
         {
-            int size = AppSettings.GetInt("history size", DefaultRepositoriesCount);
+            int size = AppSettings.RecentRepositoriesHistorySize;
             object setting = AppSettings.GetString("history", null);
             if (setting == null)
             {
@@ -77,17 +76,19 @@ namespace GitCommands.Repository
             {
                 if (_repositoryHistory != null && _repositoryHistory.Status == TaskStatus.Running)
                     _repositoryHistory.Wait();
+
+                int size = AppSettings.RecentRepositoriesHistorySize;
                 if (_remoteRepositoryHistory == null)
                 {
                     object setting = AppSettings.GetString("history remote", null);
                     if (setting != null)
                     {
                         _remoteRepositoryHistory = DeserializeHistoryFromXml(setting.ToString());
-                        _remoteRepositoryHistory.MaxCount = DefaultRepositoriesCount;
+                        _remoteRepositoryHistory.MaxCount = size;
                     }
                 }
 
-                return _remoteRepositoryHistory ?? (_remoteRepositoryHistory = new RepositoryHistory(DefaultRepositoriesCount));
+                return _remoteRepositoryHistory ?? (_remoteRepositoryHistory = new RepositoryHistory(size));
             }
         }
 

--- a/GitCommands/Repository/RepositoryHistory.cs
+++ b/GitCommands/Repository/RepositoryHistory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Xml.Serialization;
 
 namespace GitCommands.Repository
 {
@@ -18,6 +19,8 @@ namespace GitCommands.Repository
 
 
         private int _maxCount;
+
+        [XmlIgnore]
         public int MaxCount
         {
             get

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1244,6 +1244,12 @@ namespace GitCommands
             set { SetInt("MaxMostRecentRepositories", value); }
         }
 
+        public static int RecentRepositoriesHistorySize
+        {
+            get { return GetInt("history size", 30); }
+            set { SetInt("history size", value); }
+        }
+
         public static int RecentReposComboMinWidth
         {
             get { return GetInt("RecentReposComboMinWidth", 0); }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
@@ -33,10 +33,17 @@
             System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
             this.Ok = new System.Windows.Forms.Button();
             this.Abort = new System.Windows.Forms.Button();
-            this._NO_TRANSLATE_maxRecentRepositories = new System.Windows.Forms.NumericUpDown();
+            this.comboMinWidthNote = new System.Windows.Forms.Label();
             this.maxRecentRepositories = new System.Windows.Forms.Label();
-            this.sortLessRecentRepos = new System.Windows.Forms.CheckBox();
+            this._NO_TRANSLATE_maxRecentRepositories = new System.Windows.Forms.NumericUpDown();
+            this.comboMinWidthEdit = new System.Windows.Forms.NumericUpDown();
             this.sortMostRecentRepos = new System.Windows.Forms.CheckBox();
+            this.comboMinWidthLabel = new System.Windows.Forms.Label();
+            this.sortLessRecentRepos = new System.Windows.Forms.CheckBox();
+            this.shorteningGB = new System.Windows.Forms.GroupBox();
+            this.dontShortenRB = new System.Windows.Forms.RadioButton();
+            this.middleDotRB = new System.Windows.Forms.RadioButton();
+            this.mostSigDirRB = new System.Windows.Forms.RadioButton();
             this.comboPanel = new System.Windows.Forms.Panel();
             this.LessRecentLB = new System.Windows.Forms.ListView();
             this.chdrRepository1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -51,24 +58,20 @@
             this.chdrRepository = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.panel2 = new System.Windows.Forms.Panel();
             this.MostRecentLabel = new System.Windows.Forms.Label();
-            this.shorteningGB = new System.Windows.Forms.GroupBox();
-            this.dontShortenRB = new System.Windows.Forms.RadioButton();
-            this.middleDotRB = new System.Windows.Forms.RadioButton();
-            this.mostSigDirRB = new System.Windows.Forms.RadioButton();
-            this.comboMinWidthEdit = new System.Windows.Forms.NumericUpDown();
-            this.comboMinWidthLabel = new System.Windows.Forms.Label();
-            this.comboMinWidthNote = new System.Windows.Forms.Label();
+            this.lblRecentRepositoriesHistorySize = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize = new System.Windows.Forms.NumericUpDown();
             flpnlControls = new System.Windows.Forms.FlowLayoutPanel();
             tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             flpnlControls.SuspendLayout();
+            tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_maxRecentRepositories)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.comboMinWidthEdit)).BeginInit();
+            this.shorteningGB.SuspendLayout();
             this.comboPanel.SuspendLayout();
             this.contextMenuStrip1.SuspendLayout();
             this.panel3.SuspendLayout();
             this.panel2.SuspendLayout();
-            this.shorteningGB.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.comboMinWidthEdit)).BeginInit();
-            tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_RecentRepositoriesHistorySize)).BeginInit();
             this.SuspendLayout();
             // 
             // flpnlControls
@@ -111,9 +114,63 @@
             this.Abort.UseVisualStyleBackColor = true;
             this.Abort.Click += new System.EventHandler(this.Abort_Click);
             // 
+            // tableLayoutPanel1
+            // 
+            tableLayoutPanel1.AutoSize = true;
+            tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_RecentRepositoriesHistorySize, 1, 0);
+            tableLayoutPanel1.Controls.Add(this.lblRecentRepositoriesHistorySize, 0, 0);
+            tableLayoutPanel1.Controls.Add(this.comboMinWidthNote, 0, 6);
+            tableLayoutPanel1.Controls.Add(this.maxRecentRepositories, 0, 1);
+            tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_maxRecentRepositories, 1, 1);
+            tableLayoutPanel1.Controls.Add(this.comboMinWidthEdit, 1, 5);
+            tableLayoutPanel1.Controls.Add(this.sortMostRecentRepos, 0, 2);
+            tableLayoutPanel1.Controls.Add(this.comboMinWidthLabel, 0, 5);
+            tableLayoutPanel1.Controls.Add(this.sortLessRecentRepos, 0, 3);
+            tableLayoutPanel1.Controls.Add(this.shorteningGB, 0, 4);
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Left;
+            tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
+            tableLayoutPanel1.RowCount = 7;
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            tableLayoutPanel1.Size = new System.Drawing.Size(322, 327);
+            tableLayoutPanel1.TabIndex = 0;
+            // 
+            // comboMinWidthNote
+            // 
+            tableLayoutPanel1.SetColumnSpan(this.comboMinWidthNote, 2);
+            this.comboMinWidthNote.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.comboMinWidthNote.Location = new System.Drawing.Point(11, 246);
+            this.comboMinWidthNote.Name = "comboMinWidthNote";
+            this.comboMinWidthNote.Padding = new System.Windows.Forms.Padding(12, 0, 0, 0);
+            this.comboMinWidthNote.Size = new System.Drawing.Size(300, 73);
+            this.comboMinWidthNote.TabIndex = 9;
+            this.comboMinWidthNote.Text = "NB: The width of the columns helps to visualise how the repository name will be s" +
+    "hown in the combobox.";
+            // 
+            // maxRecentRepositories
+            // 
+            this.maxRecentRepositories.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.maxRecentRepositories.AutoSize = true;
+            this.maxRecentRepositories.Location = new System.Drawing.Point(11, 42);
+            this.maxRecentRepositories.Name = "maxRecentRepositories";
+            this.maxRecentRepositories.Size = new System.Drawing.Size(222, 13);
+            this.maxRecentRepositories.TabIndex = 2;
+            this.maxRecentRepositories.Text = "Maximum number of most recent repositories";
+            // 
             // _NO_TRANSLATE_maxRecentRepositories
             // 
-            this._NO_TRANSLATE_maxRecentRepositories.Location = new System.Drawing.Point(250, 11);
+            this._NO_TRANSLATE_maxRecentRepositories.Location = new System.Drawing.Point(250, 38);
             this._NO_TRANSLATE_maxRecentRepositories.Maximum = new decimal(new int[] {
             1000000,
             0,
@@ -121,44 +178,108 @@
             0});
             this._NO_TRANSLATE_maxRecentRepositories.Name = "_NO_TRANSLATE_maxRecentRepositories";
             this._NO_TRANSLATE_maxRecentRepositories.Size = new System.Drawing.Size(61, 21);
-            this._NO_TRANSLATE_maxRecentRepositories.TabIndex = 1;
+            this._NO_TRANSLATE_maxRecentRepositories.TabIndex = 3;
             this._NO_TRANSLATE_maxRecentRepositories.ValueChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
             // 
-            // maxRecentRepositories
+            // comboMinWidthEdit
             // 
-            this.maxRecentRepositories.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.maxRecentRepositories.AutoSize = true;
-            this.maxRecentRepositories.Location = new System.Drawing.Point(11, 15);
-            this.maxRecentRepositories.Name = "maxRecentRepositories";
-            this.maxRecentRepositories.Size = new System.Drawing.Size(222, 13);
-            this.maxRecentRepositories.TabIndex = 0;
-            this.maxRecentRepositories.Text = "Maximum number of most recent repositories";
-            // 
-            // sortLessRecentRepos
-            // 
-            this.sortLessRecentRepos.AutoSize = true;
-            this.sortLessRecentRepos.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.sortLessRecentRepos.Location = new System.Drawing.Point(11, 61);
-            this.sortLessRecentRepos.Name = "sortLessRecentRepos";
-            this.sortLessRecentRepos.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.sortLessRecentRepos.Size = new System.Drawing.Size(228, 17);
-            this.sortLessRecentRepos.TabIndex = 3;
-            this.sortLessRecentRepos.Text = "Sort less recent repositories alphabetically";
-            this.sortLessRecentRepos.UseVisualStyleBackColor = true;
-            this.sortLessRecentRepos.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
+            this.comboMinWidthEdit.Location = new System.Drawing.Point(250, 222);
+            this.comboMinWidthEdit.Maximum = new decimal(new int[] {
+            800,
+            0,
+            0,
+            0});
+            this.comboMinWidthEdit.Name = "comboMinWidthEdit";
+            this.comboMinWidthEdit.Size = new System.Drawing.Size(61, 21);
+            this.comboMinWidthEdit.TabIndex = 8;
+            this.comboMinWidthEdit.ValueChanged += new System.EventHandler(this.comboMinWidthEdit_ValueChanged);
             // 
             // sortMostRecentRepos
             // 
             this.sortMostRecentRepos.AutoSize = true;
             this.sortMostRecentRepos.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.sortMostRecentRepos.Location = new System.Drawing.Point(11, 38);
+            this.sortMostRecentRepos.Location = new System.Drawing.Point(11, 65);
             this.sortMostRecentRepos.Name = "sortMostRecentRepos";
             this.sortMostRecentRepos.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.sortMostRecentRepos.Size = new System.Drawing.Size(233, 17);
-            this.sortMostRecentRepos.TabIndex = 2;
+            this.sortMostRecentRepos.TabIndex = 4;
             this.sortMostRecentRepos.Text = "Sort most recent repositories alphabetically";
             this.sortMostRecentRepos.UseVisualStyleBackColor = true;
             this.sortMostRecentRepos.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
+            // 
+            // comboMinWidthLabel
+            // 
+            this.comboMinWidthLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.comboMinWidthLabel.AutoSize = true;
+            this.comboMinWidthLabel.Location = new System.Drawing.Point(11, 226);
+            this.comboMinWidthLabel.Name = "comboMinWidthLabel";
+            this.comboMinWidthLabel.Size = new System.Drawing.Size(202, 13);
+            this.comboMinWidthLabel.TabIndex = 7;
+            this.comboMinWidthLabel.Text = "Combobox minimum width (0 = Autosize)";
+            // 
+            // sortLessRecentRepos
+            // 
+            this.sortLessRecentRepos.AutoSize = true;
+            this.sortLessRecentRepos.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.sortLessRecentRepos.Location = new System.Drawing.Point(11, 88);
+            this.sortLessRecentRepos.Name = "sortLessRecentRepos";
+            this.sortLessRecentRepos.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.sortLessRecentRepos.Size = new System.Drawing.Size(228, 17);
+            this.sortLessRecentRepos.TabIndex = 5;
+            this.sortLessRecentRepos.Text = "Sort less recent repositories alphabetically";
+            this.sortLessRecentRepos.UseVisualStyleBackColor = true;
+            this.sortLessRecentRepos.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
+            // 
+            // shorteningGB
+            // 
+            this.shorteningGB.AutoSize = true;
+            this.shorteningGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.shorteningGB.Controls.Add(this.dontShortenRB);
+            this.shorteningGB.Controls.Add(this.middleDotRB);
+            this.shorteningGB.Controls.Add(this.mostSigDirRB);
+            this.shorteningGB.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.shorteningGB.Location = new System.Drawing.Point(11, 111);
+            this.shorteningGB.Name = "shorteningGB";
+            this.shorteningGB.Size = new System.Drawing.Size(233, 105);
+            this.shorteningGB.TabIndex = 6;
+            this.shorteningGB.TabStop = false;
+            this.shorteningGB.Text = "Shortening strategy";
+            // 
+            // dontShortenRB
+            // 
+            this.dontShortenRB.AutoSize = true;
+            this.dontShortenRB.Location = new System.Drawing.Point(6, 22);
+            this.dontShortenRB.Name = "dontShortenRB";
+            this.dontShortenRB.Size = new System.Drawing.Size(103, 17);
+            this.dontShortenRB.TabIndex = 0;
+            this.dontShortenRB.TabStop = true;
+            this.dontShortenRB.Text = "Do not shorten  ";
+            this.dontShortenRB.UseVisualStyleBackColor = true;
+            this.dontShortenRB.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
+            // 
+            // middleDotRB
+            // 
+            this.middleDotRB.AutoSize = true;
+            this.middleDotRB.Location = new System.Drawing.Point(6, 68);
+            this.middleDotRB.Name = "middleDotRB";
+            this.middleDotRB.Size = new System.Drawing.Size(169, 17);
+            this.middleDotRB.TabIndex = 2;
+            this.middleDotRB.TabStop = true;
+            this.middleDotRB.Text = "Replace middle part with dots ";
+            this.middleDotRB.UseVisualStyleBackColor = true;
+            this.middleDotRB.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
+            // 
+            // mostSigDirRB
+            // 
+            this.mostSigDirRB.AutoSize = true;
+            this.mostSigDirRB.Location = new System.Drawing.Point(6, 45);
+            this.mostSigDirRB.Name = "mostSigDirRB";
+            this.mostSigDirRB.Size = new System.Drawing.Size(169, 17);
+            this.mostSigDirRB.TabIndex = 1;
+            this.mostSigDirRB.TabStop = true;
+            this.mostSigDirRB.Text = "The most significant directory ";
+            this.mostSigDirRB.UseVisualStyleBackColor = true;
+            this.mostSigDirRB.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
             // 
             // comboPanel
             // 
@@ -298,119 +419,37 @@
             this.MostRecentLabel.TabIndex = 0;
             this.MostRecentLabel.Text = "Most recent repositories";
             // 
-            // shorteningGB
+            // lblRecentRepositoriesHistorySize
             // 
-            this.shorteningGB.AutoSize = true;
-            this.shorteningGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.shorteningGB.Controls.Add(this.dontShortenRB);
-            this.shorteningGB.Controls.Add(this.middleDotRB);
-            this.shorteningGB.Controls.Add(this.mostSigDirRB);
-            this.shorteningGB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.shorteningGB.Location = new System.Drawing.Point(11, 84);
-            this.shorteningGB.Name = "shorteningGB";
-            this.shorteningGB.Size = new System.Drawing.Size(233, 105);
-            this.shorteningGB.TabIndex = 4;
-            this.shorteningGB.TabStop = false;
-            this.shorteningGB.Text = "Shortening strategy";
+            this.lblRecentRepositoriesHistorySize.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblRecentRepositoriesHistorySize.AutoSize = true;
+            this.lblRecentRepositoriesHistorySize.Location = new System.Drawing.Point(11, 15);
+            this.lblRecentRepositoriesHistorySize.Name = "lblRecentRepositoriesHistorySize";
+            this.lblRecentRepositoriesHistorySize.Size = new System.Drawing.Size(157, 13);
+            this.lblRecentRepositoriesHistorySize.TabIndex = 0;
+            this.lblRecentRepositoriesHistorySize.Text = "Recent repositories history size";
             // 
-            // dontShortenRB
+            // _NO_TRANSLATE_RecentRepositoriesHistorySize
             // 
-            this.dontShortenRB.AutoSize = true;
-            this.dontShortenRB.Location = new System.Drawing.Point(6, 22);
-            this.dontShortenRB.Name = "dontShortenRB";
-            this.dontShortenRB.Size = new System.Drawing.Size(103, 17);
-            this.dontShortenRB.TabIndex = 0;
-            this.dontShortenRB.TabStop = true;
-            this.dontShortenRB.Text = "Do not shorten  ";
-            this.dontShortenRB.UseVisualStyleBackColor = true;
-            this.dontShortenRB.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
-            // 
-            // middleDotRB
-            // 
-            this.middleDotRB.AutoSize = true;
-            this.middleDotRB.Location = new System.Drawing.Point(6, 68);
-            this.middleDotRB.Name = "middleDotRB";
-            this.middleDotRB.Size = new System.Drawing.Size(169, 17);
-            this.middleDotRB.TabIndex = 2;
-            this.middleDotRB.TabStop = true;
-            this.middleDotRB.Text = "Replace middle part with dots ";
-            this.middleDotRB.UseVisualStyleBackColor = true;
-            this.middleDotRB.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
-            // 
-            // mostSigDirRB
-            // 
-            this.mostSigDirRB.AutoSize = true;
-            this.mostSigDirRB.Location = new System.Drawing.Point(6, 45);
-            this.mostSigDirRB.Name = "mostSigDirRB";
-            this.mostSigDirRB.Size = new System.Drawing.Size(169, 17);
-            this.mostSigDirRB.TabIndex = 1;
-            this.mostSigDirRB.TabStop = true;
-            this.mostSigDirRB.Text = "The most significant directory ";
-            this.mostSigDirRB.UseVisualStyleBackColor = true;
-            this.mostSigDirRB.CheckedChanged += new System.EventHandler(this.sortMostRecentRepos_CheckedChanged);
-            // 
-            // comboMinWidthEdit
-            // 
-            this.comboMinWidthEdit.Location = new System.Drawing.Point(250, 195);
-            this.comboMinWidthEdit.Maximum = new decimal(new int[] {
-            800,
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.Location = new System.Drawing.Point(250, 11);
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.Maximum = new decimal(new int[] {
+            999,
             0,
             0,
             0});
-            this.comboMinWidthEdit.Name = "comboMinWidthEdit";
-            this.comboMinWidthEdit.Size = new System.Drawing.Size(61, 21);
-            this.comboMinWidthEdit.TabIndex = 6;
-            this.comboMinWidthEdit.ValueChanged += new System.EventHandler(this.comboMinWidthEdit_ValueChanged);
-            // 
-            // comboMinWidthLabel
-            // 
-            this.comboMinWidthLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.comboMinWidthLabel.AutoSize = true;
-            this.comboMinWidthLabel.Location = new System.Drawing.Point(11, 199);
-            this.comboMinWidthLabel.Name = "comboMinWidthLabel";
-            this.comboMinWidthLabel.Size = new System.Drawing.Size(202, 13);
-            this.comboMinWidthLabel.TabIndex = 5;
-            this.comboMinWidthLabel.Text = "Combobox minimum width (0 = Autosize)";
-            // 
-            // tableLayoutPanel1
-            // 
-            tableLayoutPanel1.AutoSize = true;
-            tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            tableLayoutPanel1.ColumnCount = 2;
-            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            tableLayoutPanel1.Controls.Add(this.comboMinWidthNote, 0, 5);
-            tableLayoutPanel1.Controls.Add(this.maxRecentRepositories, 0, 0);
-            tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_maxRecentRepositories, 1, 0);
-            tableLayoutPanel1.Controls.Add(this.comboMinWidthEdit, 1, 4);
-            tableLayoutPanel1.Controls.Add(this.sortMostRecentRepos, 0, 1);
-            tableLayoutPanel1.Controls.Add(this.comboMinWidthLabel, 0, 4);
-            tableLayoutPanel1.Controls.Add(this.sortLessRecentRepos, 0, 2);
-            tableLayoutPanel1.Controls.Add(this.shorteningGB, 0, 3);
-            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Left;
-            tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            tableLayoutPanel1.Name = "tableLayoutPanel1";
-            tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
-            tableLayoutPanel1.RowCount = 6;
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            tableLayoutPanel1.Size = new System.Drawing.Size(322, 327);
-            tableLayoutPanel1.TabIndex = 0;
-            // 
-            // label2
-            // 
-            tableLayoutPanel1.SetColumnSpan(this.comboMinWidthNote, 2);
-            this.comboMinWidthNote.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.comboMinWidthNote.Location = new System.Drawing.Point(11, 219);
-            this.comboMinWidthNote.Name = "comboMinWidthNote";
-            this.comboMinWidthNote.Padding = new System.Windows.Forms.Padding(12, 0, 0, 0);
-            this.comboMinWidthNote.Size = new System.Drawing.Size(300, 100);
-            this.comboMinWidthNote.TabIndex = 7;
-            this.comboMinWidthNote.Text = "NB: The width of the columns helps to visualise how the repository name will be shown in the combobox.";
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.Minimum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.Name = "_NO_TRANSLATE_RecentRepositoriesHistorySize";
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.Size = new System.Drawing.Size(61, 21);
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.TabIndex = 1;
+            this._NO_TRANSLATE_RecentRepositoriesHistorySize.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
             // 
             // FormRecentReposSettings
             // 
@@ -431,7 +470,12 @@
             this.Text = "Recent repositories settings";
             flpnlControls.ResumeLayout(false);
             flpnlControls.PerformLayout();
+            tableLayoutPanel1.ResumeLayout(false);
+            tableLayoutPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_maxRecentRepositories)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.comboMinWidthEdit)).EndInit();
+            this.shorteningGB.ResumeLayout(false);
+            this.shorteningGB.PerformLayout();
             this.comboPanel.ResumeLayout(false);
             this.comboPanel.PerformLayout();
             this.contextMenuStrip1.ResumeLayout(false);
@@ -439,11 +483,7 @@
             this.panel3.PerformLayout();
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
-            this.shorteningGB.ResumeLayout(false);
-            this.shorteningGB.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.comboMinWidthEdit)).EndInit();
-            tableLayoutPanel1.ResumeLayout(false);
-            tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_RecentRepositoriesHistorySize)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -478,5 +518,7 @@
         private System.Windows.Forms.ColumnHeader chdrRepository;
         private System.Windows.Forms.ColumnHeader chdrRepository1;
         private System.Windows.Forms.Label comboMinWidthNote;
+        private System.Windows.Forms.NumericUpDown _NO_TRANSLATE_RecentRepositoriesHistorySize;
+        private System.Windows.Forms.Label lblRecentRepositoriesHistorySize;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -20,13 +20,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             SetComboWidth();
         }
 
+
         private void LoadSettings()
         {
             SetShorteningStrategy(AppSettings.ShorteningRecentRepoPathStrategy);
             sortMostRecentRepos.Checked = AppSettings.SortMostRecentRepos;
             sortLessRecentRepos.Checked = AppSettings.SortLessRecentRepos;
-            _NO_TRANSLATE_maxRecentRepositories.Value = AppSettings.MaxMostRecentRepositories;
             comboMinWidthEdit.Value = AppSettings.RecentReposComboMinWidth;
+            SetNumericUpDownValue(_NO_TRANSLATE_maxRecentRepositories, AppSettings.MaxMostRecentRepositories);
+            SetNumericUpDownValue(_NO_TRANSLATE_RecentRepositoriesHistorySize, AppSettings.RecentRepositoriesHistorySize);
         }
 
         private void SaveSettings()
@@ -36,6 +38,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             AppSettings.SortLessRecentRepos = sortLessRecentRepos.Checked;
             AppSettings.MaxMostRecentRepositories = (int)_NO_TRANSLATE_maxRecentRepositories.Value;
             AppSettings.RecentReposComboMinWidth = (int)comboMinWidthEdit.Value;
+
+            var mustResizeRepositriesHistory = AppSettings.RecentRepositoriesHistorySize != (int)_NO_TRANSLATE_RecentRepositoriesHistorySize.Value;
+            AppSettings.RecentRepositoriesHistorySize = (int)_NO_TRANSLATE_RecentRepositoriesHistorySize.Value;
+            if (mustResizeRepositriesHistory)
+            {
+                Repositories.RepositoryHistory.MaxCount = AppSettings.RecentRepositoriesHistorySize;
+            }
         }
 
         private string GetShorteningStrategy()
@@ -107,6 +116,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 MostRecentLB.Columns[0].Width = width;
                 LessRecentLB.Columns[0].Width = width;
             }
+        }
+
+        private static void SetNumericUpDownValue(NumericUpDown control, int value)
+        {
+            control.Value = Math.Min(Math.Max(control.Minimum, value), control.Maximum);
         }
 
         private void sortMostRecentRepos_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.resx
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.resx
@@ -120,11 +120,11 @@
   <metadata name="flpnlControls.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="tableLayoutPanel1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
+  </metadata>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>32</value>


### PR DESCRIPTION
Recent repositories history size is set to 30 without any ability to change. The "recent repositories settings" form provides the ability to set "Maximum number of most recent repositories" which does
not have any effect on the history size and it is not used anywhere else.

The fix deprecates "MaxMostRecentRepositories" setting and consolidates the use of "history size" setting.

Fixes #3908
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/29995758-323d7450-9034-11e7-82ce-6c642ae7ce0a.png)
![image](https://user-images.githubusercontent.com/4403806/29995760-40932c84-9034-11e7-83ca-b6744585416b.png)


Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10 and above
