### PR TITLE
Create tag using the standard ProcessDialog.

### DIFF
--- a/GitCommands/Git/GitCheckoutBranchCmd.cs
+++ b/GitCommands/Git/GitCheckoutBranchCmd.cs
@@ -41,7 +41,7 @@ namespace GitCommands.Git
             return "checkout";
         }
 
-        public override IEnumerable<string> CollectArguments()
+        protected override IEnumerable<string> CollectArguments()
         {
             if (LocalChanges == LocalChangesAction.Merge)
                 yield return "--merge";

--- a/GitCommands/Git/GitCommand.cs
+++ b/GitCommands/Git/GitCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using GitUIPluginInterfaces;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GitCommands
@@ -9,19 +10,18 @@ namespace GitCommands
     /// here we can introduce methods which can operate on command structure
     /// instead of command string
     /// </summary>
-    public abstract class GitCommand
+    public abstract class GitCommand : IGitCommand
     {
         /// <summary>
         /// here commands should add theirs arguments
         /// </summary>
-        public abstract IEnumerable<string> CollectArguments();
+        protected abstract IEnumerable<string> CollectArguments();
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns>name of git command eg. push, pull</returns>
         public abstract string GitComandName();
-
 
         /// <summary>
         /// 
@@ -41,12 +41,21 @@ namespace GitCommands
         /// <returns>git command arguments as single line</returns>
         public virtual string ToLine()
         {
+            Validate();
             return GitComandName() + " " + CollectArguments().Join(" ");
         }
 
         public override string ToString()
         {
-            return ToLine();
+            return GitComandName() + " " + CollectArguments().Join(" ");
+        }
+
+        /// <summary>
+        /// Validates if the supplied arguments are correct
+        /// </summary>
+        public virtual void Validate()
+        {
+
         }
 
     }

--- a/GitCommands/Git/GitCreateTagCmd.cs
+++ b/GitCommands/Git/GitCreateTagCmd.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitCommands.Git
+{
+    public enum TagOperation
+    {
+        Lightweight = 0,
+        Annotate,
+        SignWithDefaultKey,
+        SignWithSpecificKey
+    };
+
+    public static class TagOperationExtensions
+    {
+        public static bool CanProvideMessage(this TagOperation operationType)
+        {
+            switch (operationType)
+            {
+                case TagOperation.Lightweight:
+                    return false;
+                case TagOperation.Annotate:
+                case TagOperation.SignWithDefaultKey:
+                case TagOperation.SignWithSpecificKey:
+                    return true;
+                default:
+                    throw new NotSupportedException("Invalid TagOperation: " + operationType);
+            }
+        }
+    }
+
+    public sealed class GitCreateTagArgs
+    {
+        public string Revision;
+        public string TagName;
+        public bool Force = false;
+        public TagOperation OperationType = TagOperation.Lightweight;
+        public string TagMessage = "";
+        public string SignKeyId = "";
+    }
+
+    public sealed class GitCreateTagCmd : GitCommand
+    {
+        public GitCreateTagArgs Args;
+        public string TagMessageFileName;
+
+        public GitCreateTagCmd(GitCreateTagArgs aArgs)
+        {
+            Args = aArgs;
+        }
+
+        public override string GitComandName()
+        {
+            return "tag";
+        }
+
+        protected override IEnumerable<string> CollectArguments()
+        {
+            if (Args.Force)
+            {
+                yield return "-f";
+            }
+
+            string operationArg;
+            if (GetArgumentForOperation(out operationArg))
+            {
+                yield return operationArg;
+            }
+
+            if (Args.OperationType.CanProvideMessage())
+            {
+                yield return "-F " + TagMessageFileName.Quote();
+            }
+
+            yield return Args.TagName.Trim().Quote();
+            yield return "--";
+            yield return Args.Revision.Quote();
+        }
+
+        private bool GetArgumentForOperation(out string operationArg)
+        {
+            switch (Args.OperationType)
+            {
+                /* Lightweight */
+                case TagOperation.Lightweight:
+                    operationArg = null;
+                    return false;
+
+                /* Annotate */
+                case TagOperation.Annotate:
+                    operationArg = "-a";
+                    return true;
+
+                /* Sign with default GPG */
+                case TagOperation.SignWithDefaultKey:
+                    operationArg = "-s";
+                    return true;
+
+                /* Sign with specific GPG */
+                case TagOperation.SignWithSpecificKey:
+                    operationArg = $"-u {Args.SignKeyId}";
+                    return true;
+
+                /* Error */
+                default:
+                    throw new NotSupportedException("Invalid TagOperation: " + Args.OperationType);
+            }
+        }
+
+        public override bool AccessesRemote()
+        {
+            return false;
+        }
+
+        public override bool ChangesRepoState()
+        {
+            return true;
+        }
+
+        public override void Validate()
+        {
+            if (string.IsNullOrEmpty(Args.Revision))
+            {
+                throw new ArgumentNullException("Args.Revision");
+            }
+
+            if (string.IsNullOrEmpty(Args.TagName))
+            {
+                throw new ArgumentNullException("Args.TagName");
+            }
+
+            if (Args.OperationType.CanProvideMessage() && TagMessageFileName.IsNullOrEmpty())
+            {
+                throw new ArgumentNullException("TagMessageFileName");
+            }
+
+            if (Args.OperationType == TagOperation.SignWithSpecificKey && string.IsNullOrEmpty(Args.SignKeyId))
+            {
+                throw new ArgumentNullException("Args.SignKeyId");
+            }
+        }
+    }
+}

--- a/GitCommands/Git/GitDeleteBranchCmd.cs
+++ b/GitCommands/Git/GitDeleteBranchCmd.cs
@@ -24,7 +24,7 @@ namespace GitCommands
             return "branch";
         }
 
-        public override IEnumerable<string> CollectArguments()
+        protected override IEnumerable<string> CollectArguments()
         {
             yield return force ? "-D" : "-d";
 

--- a/GitCommands/Git/GitTagController.cs
+++ b/GitCommands/Git/GitTagController.cs
@@ -2,37 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
+using System.Windows.Forms;
 
 namespace GitCommands.Git
 {
-    public enum TagOperation
-    {
-        Lightweight = 0,
-        Annotate,
-        SignWithDefaultKey,
-        SignWithSpecificKey 
-    };
-
-    public static class TagOperationExtensions
-    {
-        public static bool CanProvideMessage(this TagOperation operationType)
-        {
-            switch (operationType)
-            {
-                case TagOperation.Lightweight:
-                    return false;
-                case TagOperation.Annotate:
-                case TagOperation.SignWithDefaultKey:
-                case TagOperation.SignWithSpecificKey:
-                    return true;
-                default:
-                    throw new NotSupportedException("Invalid TagOperation: " + operationType);
-            }
-        }
-    }
-
     public interface IGitTagController
     {
         /// <summary>
@@ -44,24 +20,27 @@ namespace GitCommands.Git
         /// <param name="operationType">The operation to perform on the tag  (Lightweight, Annotate, Sign with defaul key, Sign with specific key)</param>
         /// <param name="tagMessage">Tag Message</param>
         /// <param name="keyId">Specific Key ID to be used instead of default one</param>
-        /// <returns>Output string from RunGitCmd.</returns>
-        string CreateTag(string revision, string tagName, bool force, TagOperation operationType = TagOperation.Lightweight, string tagMessage = "", string keyId = "");
+        /// <returns>True if create tag command succeeded, False otherwise</returns>
+        bool CreateTag(GitCreateTagArgs args, IWin32Window parentForm);
     }
 
 
     public class GitTagController : IGitTagController
     {
+        private IGitUICommands _uiCommands;
         private IGitModule _module;
+        private IFileSystem _fileSystem;
 
-        public GitTagController(IGitModule module)
+        public GitTagController(IGitUICommands uiCommands, IGitModule module, IFileSystem fileSystem)
         {
-            if(module == null)
-            {
-                throw new ArgumentNullException("module");
-            }
-
             _module = module;
+            _uiCommands = uiCommands;
+            _fileSystem = fileSystem;
         }
+
+        public GitTagController(IGitUICommands uiCommands, IGitModule module)
+            : this(uiCommands, module, new FileSystem())
+        { }
 
         /// <summary>
         /// Create the Tag depending on input parameter.
@@ -73,67 +52,16 @@ namespace GitCommands.Git
         /// <param name="tagMessage">Tag Message</param>
         /// <param name="keyId">Specific Key ID to be used instead of default one</param>
         /// <returns>Output string from RunGitCmd.</returns>
-        public string CreateTag(string revision, string inputTagName, bool force, TagOperation operationType = TagOperation.Lightweight, string tagMessage = "", string keyId = "")
+        public bool CreateTag(GitCreateTagArgs args, IWin32Window parentForm)
         {
-            if (string.IsNullOrEmpty(revision))
+            GitCreateTagCmd createTagCmd = new GitCreateTagCmd(args);
+            if (args.OperationType.CanProvideMessage())
             {
-                throw new ArgumentNullException("revision");
+                createTagCmd.TagMessageFileName = Path.Combine(_module.GetGitDirectory(), "TAGMESSAGE");
+                _fileSystem.File.WriteAllText(createTagCmd.TagMessageFileName, args.TagMessage);
             }
 
-            if (string.IsNullOrEmpty(inputTagName))
-            {
-                throw new ArgumentNullException("tagName");
-            }
-
-            string tagMessageFileName = Path.Combine(_module.GetGitDirectory(), "TAGMESSAGE");
-
-            if (operationType.CanProvideMessage())
-            {
-                File.WriteAllText(tagMessageFileName, tagMessage);
-            }
-
-            string tagName = inputTagName.Trim();
-            string forced = force ? "-f" : "";
-
-            string tagSwitch = "";
-
-            switch (operationType)
-            {
-                /* Lightweight */
-                case TagOperation.Lightweight:
-                    /* tagSwitch is already ok */
-                    break;
-
-                /* Annotate */
-                case TagOperation.Annotate:
-                    tagSwitch = "-a";
-                    break;
-
-                /* Sign with default GPG */
-                case TagOperation.SignWithDefaultKey:
-                    tagSwitch = "-s";
-                    break;
-
-                /* Sign with specific GPG */
-                case TagOperation.SignWithSpecificKey:
-                    if(string.IsNullOrEmpty(keyId))
-                    {
-                        throw new ArgumentNullException("keyId");
-                    }
-                    tagSwitch = $"-u {keyId}";
-                    break;
-                    
-                /* Error */
-                default:
-                    throw new NotSupportedException("Invalid TagOperation: " + operationType);
-            }
-
-            if (operationType.CanProvideMessage())
-            {
-                tagSwitch = tagSwitch + " -F " + tagMessageFileName.Quote();
-            }
-
-            return _module.RunGitCmd($"tag {forced} {tagSwitch} \"{tagName}\" -- \"{revision}\"");
+            return _uiCommands.StartCommandLineProcessDialog(createTagCmd, parentForm);
         }
     }
 }

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -70,6 +70,9 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Abstractions">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.144\lib\net40\System.IO.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
@@ -89,6 +92,7 @@
     <Compile Include="Git\AuthorEmailEqualityComparer.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />
     <Compile Include="Git\GitBranchNameOptions.cs" />
+    <Compile Include="Git\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitTagController.cs" />
     <Compile Include="Logging\CommandLogEntry.cs" />
     <Compile Include="RemoteActionResult.cs" />

--- a/GitCommands/packages.config
+++ b/GitCommands/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="SmartFormat.NET" version="2.0.0.0" targetFramework="net461" />
+  <package id="System.IO.Abstractions" version="2.0.0.144" targetFramework="net461" />
 </packages>

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -66,23 +66,26 @@ namespace GitUI.CommandsDialogs
 
         private string CreateTag()
         {
-            string revision = commitPickerSmallControl1.SelectedCommitHash;
+            GitCreateTagArgs createTagArgs = new GitCreateTagArgs();
+            createTagArgs.Revision = commitPickerSmallControl1.SelectedCommitHash;
 
-            if (revision.IsNullOrEmpty())
+            if (createTagArgs.Revision.IsNullOrEmpty())
             {
                 MessageBox.Show(this, _noRevisionSelected.Text, _messageCaption.Text);
                 return string.Empty;
             }
 
-            IGitTagController _gitTagController = new GitTagController(Module);
-            var s = _gitTagController.CreateTag(revision, textBoxTagName.Text, ForceTag.Checked, GetSelectedOperation(annotate.SelectedIndex), tagMessage.Text, textBoxGpgKey.Text);
-            if (!string.IsNullOrEmpty(s))
-            {
-                MessageBox.Show(this, s, _messageCaption.Text);
-            }
+            createTagArgs.TagName = textBoxTagName.Text;
+            createTagArgs.Force = ForceTag.Checked;
+            createTagArgs.OperationType = GetSelectedOperation(annotate.SelectedIndex);
+            createTagArgs.TagMessage = tagMessage.Text;
+            createTagArgs.SignKeyId = textBoxGpgKey.Text;
 
-            if (s.Contains("fatal:"))
+            IGitTagController _gitTagController = new GitTagController(UICommands, Module);
+            if (!_gitTagController.CreateTag(createTagArgs, this))
+            {
                 return string.Empty;
+            }
 
             DialogResult = DialogResult.OK;
             return textBoxTagName.Text;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -250,11 +250,14 @@ namespace GitUI.CommandsDialogs
                 return 0;
             }
             var currentTag = 0;
-            IGitTagController _gitTagController = new GitTagController(Module);
+            IGitTagController _gitTagController = new GitTagController(UICommands, Module);
             foreach (var lostObject in selectedLostObjects)
             {
                 currentTag++;
-                _gitTagController.CreateTag(lostObject.Hash, $"{RestoredObjectsTagPrefix}{currentTag}", false);
+                GitCreateTagArgs createTagArgs = new GitCreateTagArgs();
+                createTagArgs.Revision = lostObject.Hash;
+                createTagArgs.TagName = $"{RestoredObjectsTagPrefix}{currentTag}";
+                _gitTagController.CreateTag(createTagArgs, this);
             }
 
             return currentTag;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -242,7 +242,7 @@ namespace GitUI
             return StartBatchFileProcessDialog(null, batchFile);
         }
 
-        public bool StartCommandLineProcessDialog(GitCommand cmd, IWin32Window parentForm)
+        public bool StartCommandLineProcessDialog(IGitCommand cmd, IWin32Window parentForm)
         {
             bool executed;
 

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -86,6 +86,7 @@
     <Compile Include="IBrowseRepo.cs" />
     <Compile Include="IConfigFileSettings.cs" />
     <Compile Include="IConfigSection.cs" />
+    <Compile Include="IGitCommand.cs" />
     <Compile Include="IGitItem.cs" />
     <Compile Include="IGitPluginForRepository.cs" />
     <Compile Include="IGitModule.cs" />

--- a/Plugins/GitUIPluginInterfaces/IGitCommand.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitCommand.cs
@@ -1,0 +1,23 @@
+﻿namespace GitUIPluginInterfaces
+{
+    public interface IGitCommand
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns>if command accesses remote repository</returns>
+        bool AccessesRemote();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns>true if repo state changes after executing this command</returns>
+        bool ChangesRepoState();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns>git command arguments as single line</returns>
+        string ToLine();
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Windows.Forms;
 
 namespace GitUIPluginInterfaces
 {
@@ -110,6 +111,7 @@ namespace GitUIPluginInterfaces
         ILockableNotifier RepoChangedNotifier { get; }
 
         bool StartCommandLineProcessDialog(object ownerForm, string command, string arguments);
+        bool StartCommandLineProcessDialog(IGitCommand cmd, IWin32Window parentForm);
         bool StartCommandLineProcessDialog(string command, string arguments);
         bool StartBatchFileProcessDialog(object ownerForm, string batchFile);
         bool StartBatchFileProcessDialog(string batchFile);

--- a/UnitTests/GitCommandsTests/Git/GitCheckoutBranchCmdTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCheckoutBranchCmdTest.cs
@@ -53,30 +53,30 @@ namespace GitCommandsTests.Git
         {
             GitCheckoutBranchCmd cmd = GetInstance(true);
 
-            IEnumerable<string> whenMergeChangesOnly = new List<string> { "--merge", "\"branchName\"" };
-            IEnumerable<string> whenMergeChangesWithRemoteNewBranchCreate = new List<string> { "--merge", "-b \"newBranchName\"", "\"branchName\"" };
-            IEnumerable<string> whenMergeChangesWithRemoteNewBranchReset = new List<string> { "--merge", "-B \"newBranchName\"", "\"branchName\"" };
+            IEnumerable<string> whenMergeChangesOnly = new List<string> { "checkout", "--merge", "\"branchName\"" };
+            IEnumerable<string> whenMergeChangesWithRemoteNewBranchCreate = new List<string> { "checkout", "--merge", "-b \"newBranchName\"", "\"branchName\"" };
+            IEnumerable<string> whenMergeChangesWithRemoteNewBranchReset = new List<string> { "checkout", "--merge", "-B \"newBranchName\"", "\"branchName\"" };
 
-            IEnumerable<string> whenResetChangesOnly = new List<string> { "--force", "\"branchName\"" };
-            IEnumerable<string> whenResetChangesWithRemoteNewBranchCreate = new List<string> { "--force", "-b \"newBranchName\"", "\"branchName\"" };
-            IEnumerable<string> whenResetChangesWithRemoteNewBranchReset = new List<string> { "--force", "-B \"newBranchName\"", "\"branchName\"" };
+            IEnumerable<string> whenResetChangesOnly = new List<string> { "checkout", "--force", "\"branchName\"" };
+            IEnumerable<string> whenResetChangesWithRemoteNewBranchCreate = new List<string> { "checkout", "--force", "-b \"newBranchName\"", "\"branchName\"" };
+            IEnumerable<string> whenResetChangesWithRemoteNewBranchReset = new List<string> { "checkout", "--force", "-B \"newBranchName\"", "\"branchName\"" };
 
             //Merge
             {
                 cmd.LocalChanges = LocalChangesAction.Merge;
                 cmd.Remote = false;
 
-                Assert.IsTrue(cmd.CollectArguments().SequenceEqual(whenMergeChangesOnly));
+                Assert.AreEqual(cmd.ToLine(), whenMergeChangesOnly.Join(" "));
 
                 cmd.NewBranchAction = GitCheckoutBranchCmd.NewBranch.Create;
                 cmd.Remote = true;
                 cmd.NewBranchName = "newBranchName";
 
-                Assert.IsTrue(cmd.CollectArguments().SequenceEqual(whenMergeChangesWithRemoteNewBranchCreate));
+                Assert.AreEqual(cmd.ToLine(), whenMergeChangesWithRemoteNewBranchCreate.Join(" "));
 
                 cmd.NewBranchAction = GitCheckoutBranchCmd.NewBranch.Reset;
 
-                Assert.IsTrue(cmd.CollectArguments().SequenceEqual(whenMergeChangesWithRemoteNewBranchReset));
+                Assert.AreEqual(cmd.ToLine(), whenMergeChangesWithRemoteNewBranchReset.Join(" "));
             }
 
             //Reset
@@ -84,17 +84,17 @@ namespace GitCommandsTests.Git
                 cmd.LocalChanges = LocalChangesAction.Reset;
                 cmd.Remote = false;
 
-                Assert.IsTrue(cmd.CollectArguments().SequenceEqual(whenResetChangesOnly));
+                Assert.AreEqual(cmd.ToLine(), whenResetChangesOnly.Join(" "));
 
                 cmd.NewBranchAction = GitCheckoutBranchCmd.NewBranch.Create;
                 cmd.Remote = true;
                 cmd.NewBranchName = "newBranchName";
 
-                Assert.IsTrue(cmd.CollectArguments().SequenceEqual(whenResetChangesWithRemoteNewBranchCreate));
+                Assert.AreEqual(cmd.ToLine(), whenResetChangesWithRemoteNewBranchCreate.Join(" "));
 
                 cmd.NewBranchAction = GitCheckoutBranchCmd.NewBranch.Reset;
 
-                Assert.IsTrue(cmd.CollectArguments().SequenceEqual(whenResetChangesWithRemoteNewBranchReset));
+                Assert.AreEqual(cmd.ToLine(), whenResetChangesWithRemoteNewBranchReset.Join(" "));
             }
 
         }

--- a/UnitTests/GitCommandsTests/Git/GitTagControllerTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitTagControllerTest.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.IO.Abstractions;
 using TestMethod = NUnit.Framework.TestAttribute;
 
 namespace GitExtensionsTest.GitCommands.Git
@@ -17,51 +18,90 @@ namespace GitExtensionsTest.GitCommands.Git
         private string WorkingDir = TestContext.CurrentContext.TestDirectory;
         private IGitModule _module;
         private IGitTagController _controller;
+        private IGitUICommands _uiCommands;
+        private IFileSystem _fileSystem;
 
         [SetUp]
         public void Setup()
         {
             _module = Substitute.For<IGitModule>();
+            _uiCommands = Substitute.For<IGitUICommands>();
             _module.GetGitDirectory().Returns(x => WorkingDir);
+            _fileSystem = Substitute.For<IFileSystem>();
+            _fileSystem.File.Returns(Substitute.For<FileBase>());
 
-            _controller = new GitTagController(_module);
+            _controller = new GitTagController(_uiCommands, _module, _fileSystem);
+        }
+
+        private GitCreateTagArgs CreateDefaultArgs()
+        {
+            GitCreateTagArgs args = new GitCreateTagArgs();
+            args.Revision = Revision;
+            args.TagName = TagName;
+            args.TagMessage = TagMessage;
+            args.SignKeyId = KeyId;
+
+            return args;
+        }
+
+        private GitCreateTagCmd CreateDefaultCommand()
+        {
+            GitCreateTagCmd cmd = new GitCreateTagCmd(CreateDefaultArgs());
+            cmd.TagMessageFileName = Path.Combine(WorkingDir, "TAGMESSAGE");
+            return cmd;
         }
 
         [TestCase(true)]
         [TestCase(false)]
         public void Tag_sign_with_default_gpg(bool force)
         {
-            var result = _controller.CreateTag(Revision, TagName, force, TagOperation.SignWithDefaultKey, TagMessage);
+            GitCreateTagCmd cmd = CreateDefaultCommand();
+            cmd.Args.Force = force;
+            cmd.Args.OperationType = TagOperation.SignWithDefaultKey;
 
-            _module.Received(1).RunGitCmd($"tag {(force ? "-f" : "")} -s -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\" \"{TagName}\" -- \"{Revision}\"");
+            string cmdLine = cmd.ToLine();
+
+            string expectedCmdLine = $"tag{(force ? " -f" : "")} -s -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\" \"{TagName}\" -- \"{Revision}\"";
+            Assert.AreEqual(expectedCmdLine, cmdLine);
         }
 
         [TestMethod]
         [ExpectedException(typeof (ArgumentNullException))]
         public void Tag_name_null()
         {
-            var result = _controller.CreateTag(Revision, null, true, TagOperation.SignWithDefaultKey, TagMessage);
+            GitCreateTagCmd cmd = CreateDefaultCommand();
+            cmd.Args.TagName = null;
+            cmd.Validate();
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void Tag_revision_null()
         {
-            var result = _controller.CreateTag(null, TagName, true);
+            GitCreateTagCmd cmd = CreateDefaultCommand();
+            cmd.Args.Revision = null;
+            cmd.Validate();
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void Tag_key_id_null()
         {
-            var result = _controller.CreateTag(Revision, TagName, true, TagOperation.SignWithSpecificKey, TagMessage, null);
+            GitCreateTagCmd cmd = CreateDefaultCommand();
+            cmd.Args.OperationType = TagOperation.SignWithSpecificKey;
+            cmd.Args.SignKeyId = null;
+
+            cmd.Validate();
         }
 
         [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
         public void Tag_operation_not_supported()
         {
-            var result = _controller.CreateTag(Revision, TagName, true, (TagOperation) 10, TagMessage, null);
+            GitCreateTagCmd cmd = CreateDefaultCommand();
+            cmd.Args.OperationType = (TagOperation)10;
+
+            cmd.ToLine();
         }
 
         [TestCase(TagOperation.Lightweight)]
@@ -70,7 +110,11 @@ namespace GitExtensionsTest.GitCommands.Git
         [TestCase(TagOperation.SignWithSpecificKey)]
         public void Tag_supported_operation(TagOperation operation)
         {
-            var result = _controller.CreateTag(Revision, TagName, true, operation, TagMessage, KeyId);
+            GitCreateTagCmd cmd = CreateDefaultCommand();
+            cmd.Args.OperationType = operation;
+            cmd.Args.Force = true;
+
+            string actualCmdLine = cmd.ToLine();
 
             string switches = "";
 
@@ -79,17 +123,78 @@ namespace GitExtensionsTest.GitCommands.Git
                 case TagOperation.Lightweight:
                     break;
                 case TagOperation.Annotate:
-                    switches = $"-a -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\"";
+                    switches = $" -a -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\"";
                     break;
                 case TagOperation.SignWithDefaultKey:
-                    switches = $"-s -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\"";
+                    switches = $" -s -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\"";
                     break;
                 case TagOperation.SignWithSpecificKey:
-                    switches = $"-u {KeyId} -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\"";
+                    switches = $" -u {KeyId} -F \"{Path.Combine(WorkingDir, "TAGMESSAGE")}\"";
                     break;
             }
 
-            _module.Received(1).RunGitCmd($"tag -f {switches} \"{TagName}\" -- \"{Revision}\"");
+            string expectedCmdLine = $"tag -f{switches} \"{TagName}\" -- \"{Revision}\"";
+
+            Assert.AreEqual(expectedCmdLine, actualCmdLine);
         }
+
+        [TestMethod]
+        public void CreateTagWithMessageAssignsTagMessageFile()
+        {
+            GitCreateTagArgs args = CreateDefaultArgs();
+            args.OperationType = TagOperation.Annotate;
+
+            _uiCommands.StartCommandLineProcessDialog(Arg.Do<IGitCommand>(
+                cmd =>
+                {
+                    GitCreateTagCmd createTagCmd = cmd as GitCreateTagCmd;
+                    Assert.AreEqual(Path.Combine(WorkingDir, "TAGMESSAGE"), createTagCmd.TagMessageFileName);
+                }
+                ), null);
+
+            _controller.CreateTag(args, null);
+            _uiCommands.Received(1).StartCommandLineProcessDialog(Arg.Any<IGitCommand>(), null);
+        }
+
+        [TestMethod]
+        public void CreateTagUsesGivenArgs()
+        {
+            GitCreateTagArgs args = CreateDefaultArgs();
+
+            _uiCommands.StartCommandLineProcessDialog(Arg.Do<IGitCommand>(
+                cmd =>
+                {
+                    GitCreateTagCmd createTagCmd = cmd as GitCreateTagCmd;
+                    Assert.AreEqual(args, createTagCmd.Args);
+                }
+                ), null);
+
+            _controller.CreateTag(args, null);
+            _uiCommands.Received(1).StartCommandLineProcessDialog(Arg.Any<IGitCommand>(), null);
+        }
+
+        [TestMethod]
+        public void CreateTagWithMessageWritesTagMessageFile()
+        {
+            GitCreateTagArgs args = CreateDefaultArgs();
+            args.OperationType = TagOperation.Annotate;
+
+            _controller.CreateTag(args, null);
+            var tagMagPath = Path.Combine(WorkingDir, "TAGMESSAGE");
+            _fileSystem.File.Received(1).WriteAllText(tagMagPath, TagMessage);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CreateTagReturnsCmdResult(bool expectedCmdResult)
+        {
+            GitCreateTagArgs args = CreateDefaultArgs();
+            args.OperationType = TagOperation.Annotate;
+            _uiCommands.StartCommandLineProcessDialog(Arg.Any<IGitCommand>(), null).Returns(expectedCmdResult);
+
+            bool actualCmdResult = _controller.CreateTag(args, null);
+            Assert.AreEqual(expectedCmdResult, actualCmdResult);
+        }
+
     }
 }

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -13,7 +13,7 @@
     <RestorePackages>true</RestorePackages>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TestProjectType>UnitTest</TestProjectType>    
+    <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,6 +52,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Abstractions">
+      <HintPath>..\..\packages\System.IO.Abstractions.2.0.0.144\lib\net40\System.IO.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
The ProcessDialog provides to the user a full command, output (warnings especially) and error messages.
It returns also the exit code, so FormCreateTag does not have to parse the output for execution status.
The parsing got obsolete after the recent changes.