### PR TITLE
Typo fix for deleting stale remote-tracking branches

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -85,7 +85,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _pruneBranchesCaption = new TranslationString("Pull was rejected");
         private readonly TranslationString _pruneBranchesMainInstruction = new TranslationString("Remote branch no longer exist");
         private readonly TranslationString _pruneBranchesBranch =
-            new TranslationString("Do you want deletes all stale remote-tracking branches?");
+            new TranslationString("Do you want to delete all stale remote-tracking branches?");
         private readonly TranslationString _pruneBranchesButtons = new TranslationString("Deletes stale branches|Cancel");
 
         private readonly TranslationString _pruneFromCaption = new TranslationString("Prune remote branches from {0}");

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -6388,7 +6388,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>Chcete smazat všechny zastaralé vzdálené větve?</target>
         
       </trans-unit>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -6441,7 +6441,7 @@ Wilt u doorgaan?</target>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>Wilt u alle vertakkingen welke vervallen externe vertakkingen volgt verwijderen?</target>
         
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5133,7 +5133,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target />
       </trans-unit>
       <trans-unit id="_pruneBranchesButtons.Text">

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -6437,7 +6437,7 @@ Voulez-vous continuer? </target>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>Voulez-vous effacer les vieilles branches distantes suivies?</target>
         
       </trans-unit>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -6462,7 +6462,7 @@ Wollen Sie trotzdem fortfahren?</target>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>Wollen Sie alle stale remote-tracking Branches löschen ?</target>
         
       </trans-unit>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -6067,7 +6067,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesButtons.Text">

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -6275,7 +6275,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>全ての古いリモート追跡ブランチを削除しますか？</target>
         
       </trans-unit>

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -6144,7 +6144,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>모든 Stale 원격-트래킹 브랜치를 삭제 하시겠습니까?</target>
         
       </trans-unit>

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -6376,7 +6376,7 @@ Chcesz kontynuować?</target>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>Chcesz usunąć wszystkie przestarzałe, śledzone zdalne gałęzie?</target>
         
       </trans-unit>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -6299,7 +6299,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesButtons.Text">

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -4560,7 +4560,7 @@ Do you want to continue?</source>
 
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
 
       </trans-unit>
       <trans-unit id="_pruneBranchesButtons.Text">

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -5255,7 +5255,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesButtons.Text">

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -6398,7 +6398,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>Вы хотите удалить все устаревшие ветки отслеживания?</target>
         
       </trans-unit>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -6313,7 +6313,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>你想删除所有过时的远程跟踪分支？</target>
         
       </trans-unit>

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -6381,7 +6381,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>¿Quiere borrar todas las ramas de seguimiento remotas obsoletas?</target>
         
       </trans-unit>

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -6193,7 +6193,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>你想刪除所有陳年的遠端branches嗎?</target>
         
       </trans-unit>

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -6446,7 +6446,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="_pruneBranchesBranch.Text">
-        <source>Do you want deletes all stale remote-tracking branches?</source>
+        <source>Do you want to delete all stale remote-tracking branches?</source>
         <target>[Ḓǿ ẏǿŭ ẇȧƞŧ ḓḗŀḗŧḗş ȧŀŀ şŧȧŀḗ řḗḿǿŧḗ-ŧřȧƈķīƞɠ ƀřȧƞƈħḗş? ΰϵ ϖ鶱ς ǲ]</target>
         
       </trans-unit>


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
Fix typo in warning message

How did I test this code:
Compile and test on local machine

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
