### PR TITLE
Added toolStripFileExplorer to complete the feature-request

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -44,6 +44,7 @@ namespace GitUI.CommandsDialogs
             this.setNextPullActionAsDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripButtonPush = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripFileExplorer = new System.Windows.Forms.ToolStripButton();
             this.GitBash = new System.Windows.Forms.ToolStripButton();
             this.EditSettings = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
@@ -311,6 +312,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripButtonPull,
             this.toolStripButtonPush,
             this.toolStripSeparator2,
+            this.toolStripFileExplorer,
             this.GitBash,
             this.EditSettings,
             this.toolStripSeparator5,
@@ -527,6 +529,17 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            // 
+            // toolStripFileExplorer
+            // 
+            this.toolStripFileExplorer.CheckOnClick = true;
+            this.toolStripFileExplorer.Enabled = false;
+            this.toolStripFileExplorer.Image = global::GitUI.Properties.Resources.Folder;
+            this.toolStripFileExplorer.ImageTransparentColor = System.Drawing.Color.Gray;
+            this.toolStripFileExplorer.Name = "toolStripFileExplorer";
+            this.toolStripFileExplorer.Size = new System.Drawing.Size(23, 22);
+            this.toolStripFileExplorer.ToolTipText = "File Explorer";
+            this.toolStripFileExplorer.Click += new System.EventHandler(this.ToolStripFileExplorerClick);
             // 
             // GitBash
             // 
@@ -2330,5 +2343,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem toolStripMenuItemWorktrees;
         private ToolStripMenuItem clearRecentRepositoriesListMenuItem;
         private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
+        private ToolStripButton toolStripFileExplorer;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -539,7 +539,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripFileExplorer.Name = "toolStripFileExplorer";
             this.toolStripFileExplorer.Size = new System.Drawing.Size(23, 22);
             this.toolStripFileExplorer.ToolTipText = "File Explorer";
-            this.toolStripFileExplorer.Click += new System.EventHandler(this.ToolStripFileExplorerClick);
+            this.toolStripFileExplorer.Click += new System.EventHandler(this.FileExplorerToolStripMenuItemClick);
             // 
             // GitBash
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -571,6 +571,7 @@ namespace GitUI.CommandsDialogs
             dashboardToolStripMenuItem.Visible = !validWorkingDir;
             repositoryToolStripMenuItem.Visible = validWorkingDir;
             commandsToolStripMenuItem.Visible = validWorkingDir;
+            toolStripFileExplorer.Enabled = validWorkingDir;
             if (validWorkingDir)
             {
                 refreshToolStripMenuItem.ShortcutKeys = Keys.F5;
@@ -1900,6 +1901,18 @@ namespace GitUI.CommandsDialogs
         private void ToolStripButtonPushClick(object sender, EventArgs e)
         {
             PushToolStripMenuItemClick(sender, e);
+        }
+
+        private void ToolStripFileExplorerClick(object sender, EventArgs e)
+        {
+            try
+            {
+                Process.Start(Module.WorkingDir);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message);
+            }
         }
 
         private void ManageSubmodulesToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1903,18 +1903,6 @@ namespace GitUI.CommandsDialogs
             PushToolStripMenuItemClick(sender, e);
         }
 
-        private void ToolStripFileExplorerClick(object sender, EventArgs e)
-        {
-            try
-            {
-                Process.Start(Module.WorkingDir);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message);
-            }
-        }
-
         private void ManageSubmodulesToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartSubmodulesDialog(this);


### PR DESCRIPTION
Fixes #3585  .

Changes proposed in this pull request:
 - Add a "File Explorer" shortcut in the toolbar (next to "Git bash")
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/2108835/30751308-8f42d818-9feb-11e7-9772-99294f773f6e.png)

**How did I test this code:**
 - Make sure the button appears correctly
 - If it is a valid working directory, the file explorer is enabled and behaves as expected
 - If it is not a valid working directory, the file explorer button is disabled