### PR TITLE
Cancelling checking if shell extension is registered crashes GitExtensions

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -266,32 +266,39 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             if (File.Exists(path))
             {
-                var pi = new ProcessStartInfo
+                try
                 {
-                    FileName = "regsvr32",
-                    Arguments = string.Format("\"{0}\"", path),
-                    Verb = "RunAs",
-                    UseShellExecute = true
-                };
-
-                var process = Process.Start(pi);
-                process.WaitForExit();
-
-                if (IntPtr.Size == 8)
-                {
-                    path = path.Replace(CommonLogic.GitExtensionsShellEx32Name, CommonLogic.GitExtensionsShellEx64Name);
-                    if (File.Exists(path))
+                    var pi = new ProcessStartInfo
                     {
-                        pi.Arguments = string.Format("\"{0}\"", path);
+                        FileName = "regsvr32",
+                        Arguments = string.Format("\"{0}\"", path),
+                        Verb = "RunAs",
+                        UseShellExecute = true
+                    };
 
-                        var process64 = Process.Start(pi);
-                        process64.WaitForExit();
-                    }
-                    else
+                    var process = Process.Start(pi);
+                    process.WaitForExit();
+
+                    if (IntPtr.Size == 8)
                     {
-                        MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx64Name));
+                        path = path.Replace(CommonLogic.GitExtensionsShellEx32Name, CommonLogic.GitExtensionsShellEx64Name);
+                        if (File.Exists(path))
+                        {
+                            pi.Arguments = string.Format("\"{0}\"", path);
+
+                            var process64 = Process.Start(pi);
+                            process64.WaitForExit();
+                        }
+                        else
+                        {
+                            MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx64Name));
+                        }
                     }
                 }
+                catch(System.ComponentModel.Win32Exception)
+                {
+                    // User cancel operation, continue;
+                }               
             }
             else
             {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 
 
Screenshots before and after (if PR changes UI):
-
-
-

How did I test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
