### PR TITLE
Extract "File Tree" control from FormBrowse

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -63,30 +63,6 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabPage = new System.Windows.Forms.TabPage();
             this.RevisionInfo = new GitUI.CommitInfo.CommitInfo();
             this.TreeTabPage = new System.Windows.Forms.TabPage();
-            this.FileTreeSplitContainer = new System.Windows.Forms.SplitContainer();
-            this.GitTree = new System.Windows.Forms.TreeView();
-            this.FileTreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetToThisRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator30 = new System.Windows.Forms.ToolStripSeparator();
-            this.openSubmoduleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyFilenameToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileTreeOpenContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileTreeArchiveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileTreeCleanWorkingTreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator31 = new System.Windows.Forms.ToolStripSeparator();
-            this.fileHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.blameToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.findToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
-            this.editCheckedOutFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openFileWithToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openWithToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
-            this.expandAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.collapseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.FileText = new GitUI.Editor.FileViewer();
             this.DiffTabPage = new System.Windows.Forms.TabPage();
             this.DiffSplitContainer = new System.Windows.Forms.SplitContainer();
             this.DiffFiles = new GitUI.FileStatusList();
@@ -227,6 +203,7 @@ namespace GitUI.CommandsDialogs
             this.menuStrip1 = new GitUI.MenuStripEx();
             this.gitItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.fileTree = new GitUI.CommandsDialogs.RevisionFileTree();
             ((System.ComponentModel.ISupportInitialize)(this.toolPanel)).BeginInit();
             this.toolPanel.Panel1.SuspendLayout();
             this.toolPanel.Panel2.SuspendLayout();
@@ -242,11 +219,6 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabControl.SuspendLayout();
             this.CommitInfoTabPage.SuspendLayout();
             this.TreeTabPage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).BeginInit();
-            this.FileTreeSplitContainer.Panel1.SuspendLayout();
-            this.FileTreeSplitContainer.Panel2.SuspendLayout();
-            this.FileTreeSplitContainer.SuspendLayout();
-            this.FileTreeContextMenu.SuspendLayout();
             this.DiffTabPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.DiffSplitContainer)).BeginInit();
             this.DiffSplitContainer.Panel1.SuspendLayout();
@@ -707,7 +679,7 @@ namespace GitUI.CommandsDialogs
             // 
             // TreeTabPage
             // 
-            this.TreeTabPage.Controls.Add(this.FileTreeSplitContainer);
+            this.TreeTabPage.Controls.Add(this.fileTree);
             this.TreeTabPage.Location = new System.Drawing.Point(4, 28);
             this.TreeTabPage.Name = "TreeTabPage";
             this.TreeTabPage.Padding = new System.Windows.Forms.Padding(3);
@@ -715,221 +687,6 @@ namespace GitUI.CommandsDialogs
             this.TreeTabPage.TabIndex = 0;
             this.TreeTabPage.Text = "File tree";
             this.TreeTabPage.UseVisualStyleBackColor = true;
-            // 
-            // FileTreeSplitContainer
-            // 
-            this.FileTreeSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.FileTreeSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.FileTreeSplitContainer.Location = new System.Drawing.Point(3, 3);
-            this.FileTreeSplitContainer.Name = "FileTreeSplitContainer";
-            // 
-            // FileTreeSplitContainer.Panel1
-            // 
-            this.FileTreeSplitContainer.Panel1.Controls.Add(this.GitTree);
-            // 
-            // FileTreeSplitContainer.Panel2
-            // 
-            this.FileTreeSplitContainer.Panel2.Controls.Add(this.FileText);
-            this.FileTreeSplitContainer.Size = new System.Drawing.Size(909, 251);
-            this.FileTreeSplitContainer.SplitterDistance = 300;
-            this.FileTreeSplitContainer.TabIndex = 1;
-            // 
-            // GitTree
-            // 
-            this.GitTree.ContextMenuStrip = this.FileTreeContextMenu;
-            this.GitTree.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GitTree.HideSelection = false;
-            this.GitTree.Location = new System.Drawing.Point(0, 0);
-            this.GitTree.Name = "GitTree";
-            this.GitTree.Size = new System.Drawing.Size(300, 251);
-            this.GitTree.TabIndex = 0;
-            this.GitTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.GitTreeBeforeExpand);
-            this.GitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.GitTree_AfterSelect);
-            this.GitTree.DoubleClick += new System.EventHandler(this.GitTreeDoubleClick);
-            this.GitTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GitTreeKeyDown);
-            this.GitTree.MouseDown += new System.Windows.Forms.MouseEventHandler(this.GitTreeMouseDown);
-            // 
-            // FileTreeContextMenu
-            // 
-            this.FileTreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.saveAsToolStripMenuItem,
-            this.resetToThisRevisionToolStripMenuItem,
-            this.toolStripSeparator30,
-            this.openSubmoduleMenuItem,
-            this.copyFilenameToClipboardToolStripMenuItem,
-            this.fileTreeOpenContainingFolderToolStripMenuItem,
-            this.fileTreeArchiveToolStripMenuItem,
-            this.fileTreeCleanWorkingTreeToolStripMenuItem,
-            this.toolStripSeparator31,
-            this.fileHistoryToolStripMenuItem,
-            this.blameToolStripMenuItem1,
-            this.findToolStripMenuItem,
-            this.toolStripSeparator20,
-            this.editCheckedOutFileToolStripMenuItem,
-            this.openFileToolStripMenuItem,
-            this.openFileWithToolStripMenuItem,
-            this.openWithToolStripMenuItem,
-            this.toolStripSeparator18,
-            this.expandAllToolStripMenuItem,
-            this.collapseAllToolStripMenuItem});
-            this.FileTreeContextMenu.Name = "FileTreeContextMenu";
-            this.FileTreeContextMenu.Size = new System.Drawing.Size(297, 380);
-            this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
-            // 
-            // saveAsToolStripMenuItem
-            // 
-            this.saveAsToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconSaveAs;
-            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.saveAsToolStripMenuItem.Text = "Save as...";
-            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.SaveAsOnClick);
-            // 
-            // resetToThisRevisionToolStripMenuItem
-            // 
-            this.resetToThisRevisionToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetFileTo;
-            this.resetToThisRevisionToolStripMenuItem.Name = "resetToThisRevisionToolStripMenuItem";
-            this.resetToThisRevisionToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.resetToThisRevisionToolStripMenuItem.Text = "Reset to selected revision";
-            this.resetToThisRevisionToolStripMenuItem.Click += new System.EventHandler(this.ResetToThisRevisionOnClick);
-            // 
-            // toolStripSeparator30
-            // 
-            this.toolStripSeparator30.Name = "toolStripSeparator30";
-            this.toolStripSeparator30.Size = new System.Drawing.Size(293, 6);
-            // 
-            // openSubmoduleMenuItem
-            // 
-            this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Resources.IconFolderSubmodule;
-            this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
-            this.openSubmoduleMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openSubmoduleMenuItem.Text = "Open with Git Extensions";
-            this.openSubmoduleMenuItem.Click += new System.EventHandler(this.OpenSubmoduleMenuItemOnClick);
-            // 
-            // copyFilenameToClipboardToolStripMenuItem
-            // 
-            this.copyFilenameToClipboardToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
-            this.copyFilenameToClipboardToolStripMenuItem.Name = "copyFilenameToClipboardToolStripMenuItem";
-            this.copyFilenameToClipboardToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyFilenameToClipboardToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.copyFilenameToClipboardToolStripMenuItem.Text = "Copy full path";
-            this.copyFilenameToClipboardToolStripMenuItem.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem_Click);
-            // 
-            // fileTreeOpenContainingFolderToolStripMenuItem
-            // 
-            this.fileTreeOpenContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
-            this.fileTreeOpenContainingFolderToolStripMenuItem.Name = "fileTreeOpenContainingFolderToolStripMenuItem";
-            this.fileTreeOpenContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.fileTreeOpenContainingFolderToolStripMenuItem.Text = "Open containing folder";
-            this.fileTreeOpenContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.fileTreeOpenContainingFolderToolStripMenuItem_Click);
-            // 
-            // fileTreeArchiveToolStripMenuItem
-            // 
-            this.fileTreeArchiveToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconArchiveRevision;
-            this.fileTreeArchiveToolStripMenuItem.Name = "fileTreeArchiveToolStripMenuItem";
-            this.fileTreeArchiveToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.fileTreeArchiveToolStripMenuItem.Text = "Archive...";
-            this.fileTreeArchiveToolStripMenuItem.Click += new System.EventHandler(this.fileTreeArchiveToolStripMenuItem_Click);
-            // 
-            // fileTreeCleanWorkingTreeToolStripMenuItem
-            // 
-            this.fileTreeCleanWorkingTreeToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCleanupRepo;
-            this.fileTreeCleanWorkingTreeToolStripMenuItem.Name = "fileTreeCleanWorkingTreeToolStripMenuItem";
-            this.fileTreeCleanWorkingTreeToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.fileTreeCleanWorkingTreeToolStripMenuItem.Text = "Clean working directory...";
-            this.fileTreeCleanWorkingTreeToolStripMenuItem.Click += new System.EventHandler(this.fileTreeCleanWorkingTreeToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator31
-            // 
-            this.toolStripSeparator31.Name = "toolStripSeparator31";
-            this.toolStripSeparator31.Size = new System.Drawing.Size(293, 6);
-            // 
-            // fileHistoryToolStripMenuItem
-            // 
-            this.fileHistoryToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFileHistory;
-            this.fileHistoryToolStripMenuItem.Name = "fileHistoryToolStripMenuItem";
-            this.fileHistoryToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.fileHistoryToolStripMenuItem.Text = "File history";
-            this.fileHistoryToolStripMenuItem.Click += new System.EventHandler(this.fileHistoryItem_Click);
-            // 
-            // blameToolStripMenuItem1
-            // 
-            this.blameToolStripMenuItem1.Image = global::GitUI.Properties.Resources.IconBlame;
-            this.blameToolStripMenuItem1.Name = "blameToolStripMenuItem1";
-            this.blameToolStripMenuItem1.Size = new System.Drawing.Size(296, 22);
-            this.blameToolStripMenuItem1.Text = "Blame";
-            this.blameToolStripMenuItem1.Click += new System.EventHandler(this.blameMenuItem_Click);
-            // 
-            // findToolStripMenuItem
-            // 
-            this.findToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFind;
-            this.findToolStripMenuItem.Name = "findToolStripMenuItem";
-            this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.findToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.findToolStripMenuItem.Text = "Find";
-            this.findToolStripMenuItem.Click += new System.EventHandler(this.FindFileOnClick);
-            // 
-            // toolStripSeparator20
-            // 
-            this.toolStripSeparator20.Name = "toolStripSeparator20";
-            this.toolStripSeparator20.Size = new System.Drawing.Size(293, 6);
-            // 
-            // editCheckedOutFileToolStripMenuItem
-            // 
-            this.editCheckedOutFileToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconEditFile;
-            this.editCheckedOutFileToolStripMenuItem.Name = "editCheckedOutFileToolStripMenuItem";
-            this.editCheckedOutFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.editCheckedOutFileToolStripMenuItem.Text = "Edit working directory file";
-            this.editCheckedOutFileToolStripMenuItem.Click += new System.EventHandler(this.editCheckedOutFileToolStripMenuItem_Click);
-            // 
-            // openFileToolStripMenuItem
-            // 
-            this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
-            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openFileToolStripMenuItem.Text = "Open this revision (temp file)";
-            this.openFileToolStripMenuItem.Click += new System.EventHandler(this.OpenOnClick);
-            // 
-            // openFileWithToolStripMenuItem
-            // 
-            this.openFileWithToolStripMenuItem.Name = "openFileWithToolStripMenuItem";
-            this.openFileWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openFileWithToolStripMenuItem.Text = "Open this revision with... (temp file)";
-            this.openFileWithToolStripMenuItem.Click += new System.EventHandler(this.OpenWithOnClick);
-            // 
-            // openWithToolStripMenuItem
-            // 
-            this.openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
-            this.openWithToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openWithToolStripMenuItem.Text = "Open working directory file with...";
-            this.openWithToolStripMenuItem.Click += new System.EventHandler(this.openWithToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator18
-            // 
-            this.toolStripSeparator18.Name = "toolStripSeparator18";
-            this.toolStripSeparator18.Size = new System.Drawing.Size(293, 6);
-            // 
-            // expandAllToolStripMenuItem
-            // 
-            this.expandAllToolStripMenuItem.Name = "expandAllToolStripMenuItem";
-            this.expandAllToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.expandAllToolStripMenuItem.Text = "Expand all (takes a while on large trees)";
-            this.expandAllToolStripMenuItem.Click += new System.EventHandler(this.expandAllStripMenuItem_Click);
-            // 
-            // collapseAllToolStripMenuItem
-            // 
-            this.collapseAllToolStripMenuItem.Name = "collapseAllToolStripMenuItem";
-            this.collapseAllToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.collapseAllToolStripMenuItem.Text = "Collapse all";
-            this.collapseAllToolStripMenuItem.Click += new System.EventHandler(this.collapseAllToolStripMenuItem_Click);
-            // 
-            // FileText
-            // 
-            this.FileText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.FileText.Location = new System.Drawing.Point(0, 0);
-            this.FileText.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.FileText.Name = "FileText";
-            this.FileText.Size = new System.Drawing.Size(605, 251);
-            this.FileText.TabIndex = 0;
             // 
             // DiffTabPage
             // 
@@ -1256,20 +1013,20 @@ namespace GitUI.CommandsDialogs
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(152, 22);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(122, 22);
             this.toolStripMenuItem2.Text = "...";
             // 
             // clearRecentRepositoriesListToolStripMenuItem
             // 
             this.clearRecentRepositoriesListToolStripMenuItem.Name = "clearRecentRepositoriesListToolStripMenuItem";
-            this.clearRecentRepositoriesListToolStripMenuItem.Size = new System.Drawing.Size(149, 6);
+            this.clearRecentRepositoriesListToolStripMenuItem.Size = new System.Drawing.Size(119, 6);
             // 
             // clearRecentRepositoriesListMenuItem
             // 
             this.clearRecentRepositoriesListMenuItem.Name = "clearRecentRepositoriesListMenuItem";
-            this.clearRecentRepositoriesListMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.clearRecentRepositoriesListMenuItem.Size = new System.Drawing.Size(122, 22);
             this.clearRecentRepositoriesListMenuItem.Text = "Clear List";
-            this.clearRecentRepositoriesListMenuItem.Click += new System.EventHandler(ClearRecentRepositoriesListClick);
+            this.clearRecentRepositoriesListMenuItem.Click += new System.EventHandler(this.ClearRecentRepositoriesListClick);
             // 
             // toolStripSeparator12
             // 
@@ -2026,7 +1783,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator7,
             this.settingsToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
             this.toolsToolStripMenuItem.Text = "Tools";
             // 
             // commitcountPerUserToolStripMenuItem
@@ -2067,6 +1824,14 @@ namespace GitUI.CommandsDialogs
             this.menuStrip1.Size = new System.Drawing.Size(923, 24);
             this.menuStrip1.TabIndex = 3;
             // 
+            // fileTree
+            // 
+            this.fileTree.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fileTree.Location = new System.Drawing.Point(3, 3);
+            this.fileTree.Name = "fileTree";
+            this.fileTree.Size = new System.Drawing.Size(909, 251);
+            this.fileTree.TabIndex = 0;
+            // 
             // FormBrowse
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -2098,11 +1863,6 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabControl.ResumeLayout(false);
             this.CommitInfoTabPage.ResumeLayout(false);
             this.TreeTabPage.ResumeLayout(false);
-            this.FileTreeSplitContainer.Panel1.ResumeLayout(false);
-            this.FileTreeSplitContainer.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).EndInit();
-            this.FileTreeSplitContainer.ResumeLayout(false);
-            this.FileTreeContextMenu.ResumeLayout(false);
             this.DiffTabPage.ResumeLayout(false);
             this.DiffSplitContainer.Panel1.ResumeLayout(false);
             this.DiffSplitContainer.Panel2.ResumeLayout(false);
@@ -2122,8 +1882,6 @@ namespace GitUI.CommandsDialogs
         }
 
         #endregion
-
-        private System.Windows.Forms.TreeView GitTree;
         private System.Windows.Forms.SplitContainer MainSplitContainer;
         private System.Windows.Forms.SplitContainer RevisionsSplitContainer;
         private System.Windows.Forms.TabControl CommitInfoTabControl;
@@ -2131,7 +1889,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.BindingSource gitRevisionBindingSource;
         private System.Windows.Forms.BindingSource gitItemBindingSource;
         private GitUI.RevisionGrid RevisionGrid;
-        private System.Windows.Forms.SplitContainer FileTreeSplitContainer;
         private ToolStripEx ToolStrip;
         private System.Windows.Forms.ToolStripButton toolStripButton1;
         private System.Windows.Forms.ToolStripSplitButton _NO_TRANSLATE_Workingdir;
@@ -2146,7 +1903,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.SplitContainer DiffSplitContainer;
         private FileStatusList DiffFiles;
         private System.Windows.Forms.ToolStripButton toolStripButtonPush;
-        private FileViewer FileText;
         private FileViewer DiffText;
         private System.Windows.Forms.TabPage CommitInfoTabPage;
         private CommitInfo.CommitInfo RevisionInfo;
@@ -2161,16 +1917,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ContextMenuStrip DiffContextMenu;
         private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator17;
-        private ContextMenuStrip FileTreeContextMenu;
-        private ToolStripMenuItem saveAsToolStripMenuItem;
-        private ToolStripMenuItem openSubmoduleMenuItem;
-        private ToolStripMenuItem resetToThisRevisionToolStripMenuItem;
-        private ToolStripMenuItem openFileToolStripMenuItem;
-        private ToolStripMenuItem openFileWithToolStripMenuItem;
-        private ToolStripMenuItem fileHistoryToolStripMenuItem;
-        private ToolStripMenuItem findToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator18;
-        private ToolStripMenuItem copyFilenameToClipboardToolStripMenuItem;
         private ToolStripMenuItem copyFilenameToClipboardToolStripMenuItem1;
         private ToolStripMenuItem saveAsToolStripMenuItem1;
         private ToolStripSeparator toolStripSeparator19;
@@ -2180,16 +1926,11 @@ namespace GitUI.CommandsDialogs
         private ToolStripDropDownButton toolStripRevisionFilterDropDownButton;
         private StatusStrip statusStrip;
         private ToolStripStatusLabel toolStripStatusLabel1;
-        private ToolStripMenuItem openWithToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator20;
-        private ToolStripSeparator toolStripSeparator30;
-        private ToolStripSeparator toolStripSeparator31;
         private ToolStripSeparator toolStripSeparator32;
         private ToolStripSeparator toolStripSeparator33;
         private ToolStripMenuItem fileHistoryDiffToolstripMenuItem;
         private ToolStripSplitButton branchSelect;
         private ToolStripButton toggleSplitViewLayout;
-        private ToolStripMenuItem editCheckedOutFileToolStripMenuItem;
         private SplitContainer toolPanel;
         private ToolStripEx UserMenuToolStrip;
         private ToolStripMenuItem fileToolStripMenuItem;
@@ -2271,9 +2012,6 @@ namespace GitUI.CommandsDialogs
         private MenuStripEx menuStrip1;
         private ToolStripMenuItem openContainingFolderToolStripMenuItem;
         private ToolStripMenuItem diffShowInFileTreeToolStripMenuItem;
-        private ToolStripMenuItem fileTreeOpenContainingFolderToolStripMenuItem;
-        private ToolStripMenuItem fileTreeArchiveToolStripMenuItem;
-        private ToolStripMenuItem fileTreeCleanWorkingTreeToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator21;
         private ToolStripSeparator toolStripSeparator25;
         private ToolStripSeparator toolStripSeparator22;
@@ -2284,10 +2022,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator24;
         private ToolStripMenuItem SvnFetchToolStripMenuItem;
         private ToolStripMenuItem blameToolStripMenuItem;
-        private ToolStripMenuItem blameToolStripMenuItem1;
-        private ToolStripMenuItem expandAllToolStripMenuItem;
         private ToolStripMenuItem findInDiffToolStripMenuItem;        
-        private ToolStripMenuItem collapseAllToolStripMenuItem;
         private ToolStripSplitButton toolStripButtonLevelUp;
         private ToolStripSplitButton toolStripButtonPull;
         private ToolStripMenuItem mergeToolStripMenuItem;
@@ -2331,5 +2066,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem toolStripMenuItemWorktrees;
         private ToolStripMenuItem clearRecentRepositoriesListMenuItem;
         private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
+        private RevisionFileTree fileTree;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1,21 +1,15 @@
-using GitUI.UserControls.RevisionGridClasses;
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Configuration;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-
 using ConEmu.WinForms;
-
 using GitCommands;
 using GitCommands.Repository;
 using GitCommands.Utils;
@@ -27,6 +21,7 @@ using GitUI.Plugin;
 using GitUI.Properties;
 using GitUI.Script;
 using GitUI.UserControls;
+using GitUI.UserControls.RevisionGridClasses;
 using GitUIPluginInterfaces;
 using Microsoft.Win32;
 using ResourceManager;
@@ -101,12 +96,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _updateCurrentSubmodule =
             new TranslationString("Update current submodule");
 
-        private readonly TranslationString _nodeNotFoundNextAvailableParentSelected =
-            new TranslationString("Node not found. The next available parent node will be selected.");
-
-        private readonly TranslationString _nodeNotFoundSelectionNotChanged =
-            new TranslationString("Node not found. File tree selection was not changed.");
-
         private readonly TranslationString _diffNoSelection =
             new TranslationString("Diff (no selection)");
 
@@ -129,13 +118,6 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Pull - rebase");
         private readonly TranslationString _pullOpenDialog =
             new TranslationString("Open pull dialog");
-
-        private readonly TranslationString _resetFileCaption =
-            new TranslationString("Reset");
-        private readonly TranslationString _resetFileText =
-            new TranslationString("Are you sure you want to reset this file or directory?");
-        private readonly TranslationString _resetFileError =
-            new TranslationString("Exactly one revision must be selected. Abort.");
 
         private readonly TranslationString _buildReportTabCaption =
             new TranslationString("Build Report");
@@ -165,7 +147,7 @@ namespace GitUI.CommandsDialogs
 #pragma warning disable 0414
         private readonly FormBrowseMenuCommands _formBrowseMenuCommands;
 #pragma warning restore 0414
-        private SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("FormBrowse"));
+        private readonly SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("FormBrowse"));
 
         /// <summary>
         /// For VS designer
@@ -234,13 +216,6 @@ namespace GitUI.CommandsDialogs
             _filterRevisionsHelper.SetFilter(filter);
             DiffText.SetFileLoader(getNextPatchFile);
 
-            GitTree.ImageList = new ImageList();
-            GitTree.ImageList.Images.Add(Properties.Resources.New); //File
-            GitTree.ImageList.Images.Add(Properties.Resources.Folder); //Folder
-            GitTree.ImageList.Images.Add(Properties.Resources.IconFolderSubmodule); //Submodule
-
-            GitTree.MouseDown += GitTree_MouseDown;
-            GitTree.MouseMove += GitTree_MouseMove;
 
             this.HotkeysEnabled = true;
             this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
@@ -394,21 +369,6 @@ namespace GitUI.CommandsDialogs
                 _dashboard.SaveSplitterPositions();
                 _dashboard.Visible = false;
             }
-        }
-
-        private void GitTree_AfterSelect(object sender, TreeViewEventArgs e)
-        {
-            var item = e.Node.Tag as GitItem;
-            if (item == null)
-                return;
-
-            if (item.IsBlob)
-                FileText.ViewGitItem(item.FileName, item.Guid);
-            else if (item.IsCommit)
-                FileText.ViewText(item.FileName,
-                    LocalizationHelpers.GetSubmoduleText(Module, item.FileName, item.Guid));
-            else
-                FileText.ViewText("", "");
         }
 
         private void BrowseLoad(object sender, EventArgs e)
@@ -1082,80 +1042,14 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.IndexWatcher.Reset();
         }
 
-        //store strings to not keep references to nodes
-        private readonly Stack<string> lastSelectedNodes = new Stack<string>();
-
         private void FillFileTree()
         {
-            if (CommitInfoTabControl.SelectedTab != TreeTabPage)
+            if (CommitInfoTabControl.SelectedTab != TreeTabPage || _selectedRevisionUpdatedTargets.HasFlag(UpdateTargets.FileTree))
+            {
                 return;
-
-            if (_selectedRevisionUpdatedTargets.HasFlag(UpdateTargets.FileTree))
-                return;
-
+            }
             _selectedRevisionUpdatedTargets |= UpdateTargets.FileTree;
-
-            try
-            {
-                GitTree.SuspendLayout();
-                // Save state only when there is selected node
-                if (GitTree.SelectedNode != null)
-                {
-                    TreeNode node = GitTree.SelectedNode;
-                    FileText.SaveCurrentScrollPos();
-                    lastSelectedNodes.Clear();
-                    while (node != null)
-                    {
-                        lastSelectedNodes.Push(node.Text);
-                        node = node.Parent;
-                    }
-                }
-
-                // Refresh tree
-                GitTree.Nodes.Clear();
-                //restore selected file and scroll position when new selection is done
-                if (RevisionGrid.GetSelectedRevisions().Count > 0)
-                {
-                    LoadInTree(RevisionGrid.GetSelectedRevisions()[0].SubItems, GitTree.Nodes);
-                    //GitTree.Sort();
-                    TreeNode lastMatchedNode = null;
-                    // Load state
-                    var currenNodes = GitTree.Nodes;
-                    TreeNode matchedNode = null;
-                    while (lastSelectedNodes.Count > 0 && currenNodes != null)
-                    {
-                        var next = lastSelectedNodes.Pop();
-                        foreach (TreeNode node in currenNodes)
-                        {
-                            if (node.Text != next && next.Length != 40)
-                                continue;
-
-                            node.Expand();
-                            matchedNode = node;
-                            break;
-                        }
-                        if (matchedNode == null)
-                            currenNodes = null;
-                        else
-                        {
-                            lastMatchedNode = matchedNode;
-                            currenNodes = matchedNode.Nodes;
-                        }
-                    }
-                    //if there is no exact match, don't restore scroll position
-                    if (lastMatchedNode != matchedNode)
-                        FileText.ResetCurrentScrollPos();
-                    GitTree.SelectedNode = lastMatchedNode;
-                }
-                if (GitTree.SelectedNode == null)
-                {
-                    FileText.ViewText("", "");
-                }
-            }
-            finally
-            {
-                GitTree.ResumeLayout();
-            }
+            fileTree.LoadRevision(RevisionGrid.GetSelectedRevisions().FirstOrDefault());
         }
 
         private void FillDiff()
@@ -1243,192 +1137,6 @@ namespace GitUI.CommandsDialogs
             BuildReportTabPageExtension.FillBuildReport(revision);
         }
 
-        public void fileHistoryItem_Click(object sender, EventArgs e)
-        {
-            var item = GitTree.SelectedNode.Tag as GitItem;
-
-            if (item == null)
-                return;
-
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count == 0 || GitRevision.IsArtificial(revisions[0].Guid))
-                UICommands.StartFileHistoryDialog(this, item.FileName);
-            else
-                UICommands.StartFileHistoryDialog(this, item.FileName, revisions[0], false, false);
-        }
-
-        private void blameMenuItem_Click(object sender, EventArgs e)
-        {
-            var item = GitTree.SelectedNode.Tag as GitItem;
-
-            if (item == null)
-                return;
-
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count == 0 || GitRevision.IsArtificial(revisions[0].Guid))
-                UICommands.StartFileHistoryDialog(this, item.FileName, null, false, true);
-            else
-                UICommands.StartFileHistoryDialog(this, item.FileName, revisions[0], true, true);
-        }
-
-        public void FindFileOnClick(object sender, EventArgs e)
-        {
-            string selectedItem;
-            using (var searchWindow = new SearchWindow<string>(FindFileMatches)
-            {
-                Owner = this
-            })
-            {
-                searchWindow.ShowDialog(this);
-                selectedItem = searchWindow.SelectedItem;
-            }
-            if (string.IsNullOrEmpty(selectedItem))
-            {
-                return;
-            }
-
-            string[] items = selectedItem.Split(new[] { '/' });
-            TreeNodeCollection nodes = GitTree.Nodes;
-
-            for (int i = 0; i < items.Length - 1; i++)
-            {
-                TreeNode selectedNode = Find(nodes, items[i]);
-
-                if (selectedNode == null)
-                {
-                    return; //Item does not exist in the tree
-                }
-
-                selectedNode.Expand();
-                nodes = selectedNode.Nodes;
-            }
-
-            var lastItem = Find(nodes, items[items.Length - 1]);
-            if (lastItem != null)
-            {
-                GitTree.SelectedNode = lastItem;
-            }
-        }
-
-        private static TreeNode Find(TreeNodeCollection nodes, string label)
-        {
-            for (int i = 0; i < nodes.Count; i++)
-            {
-                if (nodes[i].Text == label)
-                {
-                    return nodes[i];
-                }
-            }
-            return null;
-        }
-
-        private IList<string> FindFileMatches(string name)
-        {
-            var candidates = Module.GetFullTree(RevisionGrid.GetSelectedRevisions()[0].TreeGuid);
-
-            string nameAsLower = name.ToLower();
-
-            return candidates.Where(fileName => fileName.ToLower().Contains(nameAsLower)).ToList();
-        }
-
-        private string SaveSelectedItemToTempFile()
-        {
-            var gitItem = GitTree.SelectedNode.Tag as GitItem;
-            if (gitItem == null || !gitItem.IsBlob)
-                return null;
-
-            var fileName = gitItem.FileName;
-            if (fileName.Contains("\\") && fileName.LastIndexOf("\\") < fileName.Length)
-                fileName = fileName.Substring(fileName.LastIndexOf('\\') + 1);
-            if (fileName.Contains("/") && fileName.LastIndexOf("/") < fileName.Length)
-                fileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
-
-            fileName = (Path.GetTempPath() + fileName).ToNativePath();
-            Module.SaveBlobAs(fileName, gitItem.Guid);
-            return fileName;
-        }
-
-        public void OpenWithOnClick(object sender, EventArgs e)
-        {
-            var fileName = SaveSelectedItemToTempFile();
-            if (fileName != null)
-                OsShellUtil.OpenAs(fileName);
-        }
-
-        public void OpenOnClick(object sender, EventArgs e)
-        {
-            try
-            {
-                var fileName = SaveSelectedItemToTempFile();
-                if (fileName != null)
-                    Process.Start(fileName);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message);
-            }
-        }
-
-        private void FileTreeContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            var gitItem = (GitTree.SelectedNode != null) ? GitTree.SelectedNode.Tag as GitItem : null;
-            var enableItems = gitItem != null && gitItem.IsBlob;
-
-            if (gitItem != null && gitItem.IsCommit)
-            {
-                openSubmoduleMenuItem.Visible = true;
-                if (!openSubmoduleMenuItem.Font.Bold)
-                {
-                    openSubmoduleMenuItem.Font = new Font(openSubmoduleMenuItem.Font, FontStyle.Bold);
-                }
-            }
-            else
-            {
-                openSubmoduleMenuItem.Visible = false;
-            }
-
-            saveAsToolStripMenuItem.Visible = enableItems;
-            openFileToolStripMenuItem.Visible = enableItems;
-            openFileWithToolStripMenuItem.Visible = enableItems;
-            openWithToolStripMenuItem.Visible = enableItems;
-            copyFilenameToClipboardToolStripMenuItem.Visible = gitItem != null && FormBrowseUtil.IsFileOrDirectory(FormBrowseUtil.GetFullPathFromGitItem(Module, gitItem));
-            editCheckedOutFileToolStripMenuItem.Visible = enableItems;
-        }
-
-        protected void LoadInTree(IEnumerable<IGitItem> items, TreeNodeCollection node)
-        {
-            var sortedItems = items.OrderBy(gi => gi, new GitFileTreeComparer());
-
-            foreach (var item in sortedItems)
-            {
-                var subNode = node.Add(item.Name);
-                subNode.Tag = item;
-
-                var gitItem = item as GitItem;
-
-                if (gitItem == null)
-                    subNode.Nodes.Add(new TreeNode());
-                else
-                {
-                    if (gitItem.IsTree)
-                    {
-                        subNode.ImageIndex = 1;
-                        subNode.SelectedImageIndex = 1;
-                        subNode.Nodes.Add(new TreeNode());
-                    }
-                    else
-                        if (gitItem.IsCommit)
-                    {
-                        subNode.ImageIndex = 2;
-                        subNode.SelectedImageIndex = 2;
-                        subNode.Text = item.Name + " (Submodule)";
-                    }
-                }
-            }
-        }
-
         [Flags]
         internal enum UpdateTargets
         {
@@ -1484,39 +1192,6 @@ namespace GitUI.CommandsDialogs
         private void CheckoutToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartCheckoutRevisionDialog(this);
-        }
-
-        private void GitTreeDoubleClick(object sender, EventArgs e)
-        {
-            OnItemActivated();
-        }
-
-        private void OnItemActivated()
-        {
-            if (GitTree.SelectedNode == null || !(GitTree.SelectedNode.Tag is IGitItem))
-                return;
-
-            var item = GitTree.SelectedNode.Tag as GitItem;
-            if (item == null)
-                return;
-
-            if (item.IsBlob)
-            {
-                UICommands.StartFileHistoryDialog(this, item.FileName, null);
-            }
-            else if (item.IsCommit)
-            {
-                SpawnCommitBrowser(item);
-            }
-        }
-
-        private void SpawnCommitBrowser(GitItem item)
-        {
-            Process process = new Process();
-            process.StartInfo.FileName = Application.ExecutablePath;
-            process.StartInfo.Arguments = "browse";
-            process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, item.FileName.EnsureTrailingPathSeparator());
-            process.Start();
         }
 
         private void CloneToolStripMenuItemClick(object sender, EventArgs e)
@@ -1687,7 +1362,7 @@ namespace GitUI.CommandsDialogs
             this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
             RevisionGrid.ReloadHotkeys();
             RevisionGrid.ReloadTranslation();
-            FileText.ReloadHotkeys();
+            fileTree.ReloadHotkeys();
             DiffText.ReloadHotkeys();
         }
 
@@ -2056,12 +1731,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void GitTreeMouseDown(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right)
-                GitTree.SelectedNode = GitTree.GetNodeAt(e.X, e.Y);
-        }
-
         private void UserManualToolStripMenuItemClick(object sender, EventArgs e)
         {
             try
@@ -2228,78 +1897,6 @@ namespace GitUI.CommandsDialogs
             CommitToolStripMenuItemClick(sender, e);
         }
 
-        public void OpenSubmoduleMenuItemOnClick(object sender, EventArgs e)
-        {
-            var item = GitTree.SelectedNode.Tag as GitItem;
-
-            if (item.IsCommit)
-            {
-                SpawnCommitBrowser(item);
-            }
-        }
-
-        public void SaveAsOnClick(object sender, EventArgs e)
-        {
-            var item = GitTree.SelectedNode.Tag as GitItem;
-
-            if (item == null)
-                return;
-            if (!item.IsBlob)
-                return;
-
-            var fullName = Path.Combine(Module.WorkingDir, item.FileName);
-            using (var fileDialog =
-                new SaveFileDialog
-                {
-                    InitialDirectory = Path.GetDirectoryName(fullName),
-                    FileName = Path.GetFileName(fullName),
-                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
-                    AddExtension = true
-                })
-            {
-                fileDialog.Filter =
-                    _saveFileFilterCurrentFormat.Text + " (*." +
-                    GitCommandHelpers.GetFileExtension(fileDialog.FileName) + ")|*." +
-                    GitCommandHelpers.GetFileExtension(fileDialog.FileName) +
-                    "|" + _saveFileFilterAllFiles.Text + " (*.*)|*.*";
-
-                if (fileDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    Module.SaveBlobAs(fileDialog.FileName, item.Guid);
-                }
-            }
-        }
-
-        private void ResetToThisRevisionOnClick(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (!revisions.Any() || revisions.Count != 1)
-            {
-                MessageBox.Show(_resetFileError.Text, _resetFileCaption.Text);
-                return;
-            }
-
-            if (MessageBox.Show(_resetFileText.Text, _resetFileCaption.Text, MessageBoxButtons.OKCancel)
-                == System.Windows.Forms.DialogResult.OK)
-            {
-                var item = GitTree.SelectedNode.Tag as GitItem;
-                var files = new List<string> { item.FileName };
-                Module.CheckoutFiles(files, revisions.First().Guid, false);
-            }
-        }
-
-        private void GitTreeBeforeExpand(object sender, TreeViewCancelEventArgs e)
-        {
-            if (e.Node.IsExpanded)
-                return;
-
-            var item = (IGitItem)e.Node.Tag;
-
-            e.Node.Nodes.Clear();
-            LoadInTree(item.SubItems, e.Node.Nodes);
-        }
-
         private void CreateBranchToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartCreateBranchDialog(this, RevisionGrid.GetSelectedRevisions().FirstOrDefault());
@@ -2318,16 +1915,6 @@ namespace GitUI.CommandsDialogs
         private void editgitattributesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UICommands.StartEditGitAttributesDialog(this);
-        }
-
-        private void copyFilenameToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var gitItem = GitTree.SelectedNode.Tag as GitItem;
-            if (gitItem == null)
-                return;
-
-            var fileName = Path.Combine(Module.WorkingDir, (gitItem).FileName);
-            Clipboard.SetText(fileName.ToNativePath());
         }
 
         private void copyFilenameToClipboardToolStripMenuItem1_Click(object sender, EventArgs e)
@@ -2423,18 +2010,6 @@ namespace GitUI.CommandsDialogs
         private void toolStripStatusLabel1_Click(object sender, EventArgs e)
         {
             statusStrip.Hide();
-        }
-
-        private void openWithToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var item = GitTree.SelectedNode.Tag;
-
-            var gitItem = item as GitItem;
-            if (gitItem == null || !(gitItem).IsBlob)
-                return;
-
-            var fileName = Path.Combine(Module.WorkingDir, (gitItem).FileName);
-            OsShellUtil.OpenAs(fileName.ToNativePath());
         }
 
         private void pluginsToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
@@ -2583,8 +2158,8 @@ namespace GitUI.CommandsDialogs
         {
             CommitInfoTabControl.SelectedTab = TreeTabPage;
             EnabledSplitViewLayout(true);
-            GitTree.Focus();
-            FindFileOnClick(null, null);
+
+            fileTree.InvokeFindFileDialog();
         }
 
         private void QuickFetch()
@@ -2602,7 +2177,7 @@ namespace GitUI.CommandsDialogs
                 case Commands.GitGitK: Module.RunGitK(); break;
                 case Commands.FocusRevisionGrid: RevisionGrid.Focus(); break;
                 case Commands.FocusCommitInfo: CommitInfoTabControl.SelectedTab = CommitInfoTabPage; break;
-                case Commands.FocusFileTree: CommitInfoTabControl.SelectedTab = TreeTabPage; GitTree.Focus(); break;
+                case Commands.FocusFileTree: CommitInfoTabControl.SelectedTab = TreeTabPage; fileTree.Focus(); break;
                 case Commands.FocusDiff: CommitInfoTabControl.SelectedTab = DiffTabPage; DiffFiles.Focus(); break;
                 case Commands.Commit: CommitToolStripMenuItemClick(null, null); break;
                 case Commands.AddNotes: AddNotes(); break;
@@ -2640,72 +2215,6 @@ namespace GitUI.CommandsDialogs
             else
                 MainSplitContainer.SplitterDistance = MainSplitContainer.Height;
         }
-
-        private void editCheckedOutFileToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var item = GitTree.SelectedNode.Tag;
-
-            var gitItem = item as GitItem;
-            if (gitItem == null || !gitItem.IsBlob)
-                return;
-
-            var fileName = Path.Combine(Module.WorkingDir, (gitItem).FileName);
-            UICommands.StartFileEditorDialog(fileName);
-        }
-
-        #region Git file tree drag-drop
-        private Rectangle gitTreeDragBoxFromMouseDown;
-
-        private void GitTree_MouseDown(object sender, MouseEventArgs e)
-        {
-            //DRAG
-            if (e.Button == MouseButtons.Left)
-            {
-                // Remember the point where the mouse down occurred.
-                // The DragSize indicates the size that the mouse can move
-                // before a drag event should be started.
-                Size dragSize = SystemInformation.DragSize;
-
-                // Create a rectangle using the DragSize, with the mouse position being
-                // at the center of the rectangle.
-                gitTreeDragBoxFromMouseDown = new Rectangle(new Point(e.X - (dragSize.Width / 2),
-                                                                e.Y - (dragSize.Height / 2)),
-                                                                dragSize);
-            }
-        }
-
-        void GitTree_MouseMove(object sender, MouseEventArgs e)
-        {
-            TreeView gitTree = (TreeView)sender;
-
-            //DRAG
-            // If the mouse moves outside the rectangle, start the drag.
-            if (gitTreeDragBoxFromMouseDown != Rectangle.Empty &&
-                !gitTreeDragBoxFromMouseDown.Contains(e.X, e.Y))
-            {
-                StringCollection fileList = new StringCollection();
-
-                //foreach (GitItemStatus item in SelectedItems)
-                if (gitTree.SelectedNode != null)
-                {
-                    GitItem item = gitTree.SelectedNode.Tag as GitItem;
-                    if (item != null)
-                    {
-                        string fileName = Path.Combine(Module.WorkingDir, item.FileName);
-
-                        fileList.Add(fileName.ToNativePath());
-                    }
-
-                    DataObject obj = new DataObject();
-                    obj.SetFileDropList(fileList);
-
-                    // Proceed with the drag and drop, passing in the list item.
-                    DoDragDrop(obj, DragDropEffects.Copy);
-                    gitTreeDragBoxFromMouseDown = Rectangle.Empty;
-                }
-            }
-        }
-        #endregion
 
         private int getNextIdx(int curIdx, int maxIdx, bool searchBackward)
         {
@@ -2768,112 +2277,11 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        /// <summary>
-        /// TODO: move logic to other source file?
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void diffShowInFileTreeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var diffGitItemStatus = DiffFiles.SelectedItems.First();
-
-            ExecuteCommand((int)Commands.FocusFileTree); // switch to view (and fills the first level of file tree data model if not already done)
-
-            var currentNodes = GitTree.Nodes;
-            TreeNode foundNode = null;
-            bool isIncompleteMatch = false;
-            var pathParts = UtilGetPathParts(diffGitItemStatus.Name);
-            for (int i = 0; i < pathParts.Length; i++)
-            {
-                string pathPart = pathParts[i];
-                string diffPathPart = pathPart.ToNativePath();
-
-                var currentFoundNode = currentNodes.Cast<TreeNode>().FirstOrDefault(a =>
-                {
-                    var treeGitItem = a.Tag as GitItem;
-                    if (treeGitItem != null)
-                    {
-                        // TODO: what about case(in)sensitive handling?
-                        return treeGitItem.Name == diffPathPart;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                });
-
-                if (currentFoundNode == null)
-                {
-                    isIncompleteMatch = true;
-                    break;
-                }
-
-                foundNode = currentFoundNode;
-
-                if (i < pathParts.Length - 1) // if not the last path part...
-                {
-                    foundNode.Expand(); // load more data
-
-                    if (currentFoundNode.Nodes == null)
-                    {
-                        isIncompleteMatch = true;
-                        break;
-                    }
-
-                    currentNodes = currentFoundNode.Nodes;
-                }
-            }
-
-            if (foundNode != null)
-            {
-                if (isIncompleteMatch)
-                {
-                    MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text);
-                }
-
-                GitTree.SelectedNode = foundNode;
-                GitTree.SelectedNode.EnsureVisible();
-            }
-            else
-            {
-                MessageBox.Show(_nodeNotFoundSelectionNotChanged.Text);
-            }
-        }
-
-        private string[] UtilGetPathParts(string path)
-        {
-            return path.Split('/');
-        }
-
-        private void fileTreeOpenContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var gitItem = GitTree.SelectedNode.Tag as GitItem;
-            if (gitItem == null)
-            {
-                return;
-            }
-
-            var filePath = FormBrowseUtil.GetFullPathFromGitItem(Module, gitItem);
-            FormBrowseUtil.ShowFileOrFolderInFileExplorer(filePath);
-        }
-
-        private void fileTreeArchiveToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            if (selectedRevisions.Count != 1)
-            {
-                MessageBox.Show("Select exactly one revision.");
-                return;
-            }
-
-            var gitItem = (GitItem)GitTree.SelectedNode.Tag;
-            UICommands.StartArchiveDialog(this, selectedRevisions.First(), null, gitItem.FileName);
-        }
-
-        private void fileTreeCleanWorkingTreeToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var gitItem = (GitItem)GitTree.SelectedNode.Tag;
-            UICommands.StartCleanupRepositoryDialog(this, gitItem.FileName + "/"); // the trailing / marks a directory
+            // switch to view (and fills the first level of file tree data model if not already done)
+            ExecuteCommand((int)Commands.FocusFileTree);
+            fileTree.ExpandToFile(DiffFiles.SelectedItems.First().Name);
         }
 
         private void DiffContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
@@ -2923,8 +2331,8 @@ namespace GitUI.CommandsDialogs
         {
             _splitterManager.AddSplitter(RevisionsSplitContainer, "RevisionsSplitContainer");
             _splitterManager.AddSplitter(MainSplitContainer, "MainSplitContainer");
-            _splitterManager.AddSplitter(FileTreeSplitContainer, "FileTreeSplitContainer");
             _splitterManager.AddSplitter(DiffSplitContainer, "DiffSplitContainer");
+            fileTree.Init(_splitterManager);
             //hide status in order to restore splitters against the full height (the most common case)
             statusStrip.Hide();
             _splitterManager.RestoreSplitters();
@@ -2968,16 +2376,6 @@ namespace GitUI.CommandsDialogs
         private void SvnFetchToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UICommands.StartSvnFetchDialog(this);
-        }
-
-        private void expandAllStripMenuItem_Click(object sender, EventArgs e)
-        {
-            GitTree.ExpandAll();
-        }
-
-        private void collapseAllToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            GitTree.CollapseAll();
         }
 
         private void DiffFiles_DataSourceChanged(object sender, EventArgs e)
@@ -3712,18 +3110,6 @@ namespace GitUI.CommandsDialogs
         private void cherryPickSelectedDiffFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
             DiffText.CherryPickAllChanges();
-        }
-
-        private void GitTreeKeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Return)
-            {
-                if (GitTree.SelectedNode != null)
-                {
-                    OnItemActivated();
-                    e.Handled = true;
-                }
-            }
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
@@ -1,0 +1,321 @@
+﻿namespace GitUI.CommandsDialogs
+{
+    partial class RevisionFileTree
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.FileTreeSplitContainer = new System.Windows.Forms.SplitContainer();
+            this.tvGitTree = new System.Windows.Forms.TreeView();
+            this.FileText = new GitUI.Editor.FileViewer();
+            this.FileTreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetToThisRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator30 = new System.Windows.Forms.ToolStripSeparator();
+            this.openSubmoduleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyFilenameToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileTreeOpenContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileTreeArchiveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileTreeCleanWorkingTreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator31 = new System.Windows.Forms.ToolStripSeparator();
+            this.fileHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.blameToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.findToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
+            this.editCheckedOutFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openFileWithToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openWithToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
+            this.expandAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.collapseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).BeginInit();
+            this.FileTreeSplitContainer.Panel1.SuspendLayout();
+            this.FileTreeSplitContainer.Panel2.SuspendLayout();
+            this.FileTreeSplitContainer.SuspendLayout();
+            this.FileTreeContextMenu.SuspendLayout();
+            this.SuspendLayout();
+            // FileTreeSplitContainer
+            // 
+            this.FileTreeSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.FileTreeSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.FileTreeSplitContainer.Location = new System.Drawing.Point(3, 3);
+            this.FileTreeSplitContainer.Name = "FileTreeSplitContainer";
+            // 
+            // FileTreeSplitContainer.Panel1
+            // 
+            this.FileTreeSplitContainer.Panel1.Controls.Add(this.tvGitTree);
+            // 
+            // FileTreeSplitContainer.Panel2
+            // 
+            this.FileTreeSplitContainer.Panel2.Controls.Add(this.FileText);
+            this.FileTreeSplitContainer.Size = new System.Drawing.Size(909, 251);
+            this.FileTreeSplitContainer.SplitterDistance = 300;
+            this.FileTreeSplitContainer.TabIndex = 1;
+            // 
+            // GitTree
+            // 
+            this.tvGitTree.ContextMenuStrip = this.FileTreeContextMenu;
+            this.tvGitTree.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tvGitTree.HideSelection = false;
+            this.tvGitTree.Location = new System.Drawing.Point(0, 0);
+            this.tvGitTree.Name = "tvGitTree";
+            this.tvGitTree.Size = new System.Drawing.Size(300, 251);
+            this.tvGitTree.TabIndex = 0;
+            this.tvGitTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.GitTree_BeforeExpand);
+            this.tvGitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.GitTree_AfterSelect);
+            this.tvGitTree.DoubleClick += new System.EventHandler(this.GitTree_DoubleClick);
+            this.tvGitTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GitTree_KeyDown);
+            this.tvGitTree.MouseDown += new System.Windows.Forms.MouseEventHandler(this.GitTree_MouseDown);
+            this.tvGitTree.MouseMove += new System.Windows.Forms.MouseEventHandler(this.GitTree_MouseMove);
+            // 
+            // FileTreeContextMenu
+            // 
+            this.FileTreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+                this.saveAsToolStripMenuItem,
+                this.resetToThisRevisionToolStripMenuItem,
+                this.toolStripSeparator30,
+                this.openSubmoduleMenuItem,
+                this.copyFilenameToClipboardToolStripMenuItem,
+                this.fileTreeOpenContainingFolderToolStripMenuItem,
+                this.fileTreeArchiveToolStripMenuItem,
+                this.fileTreeCleanWorkingTreeToolStripMenuItem,
+                this.toolStripSeparator31,
+                this.fileHistoryToolStripMenuItem,
+                this.blameToolStripMenuItem1,
+                this.findToolStripMenuItem,
+                this.toolStripSeparator20,
+                this.editCheckedOutFileToolStripMenuItem,
+                this.openFileToolStripMenuItem,
+                this.openFileWithToolStripMenuItem,
+                this.openWithToolStripMenuItem,
+                this.toolStripSeparator18,
+                this.expandAllToolStripMenuItem,
+                this.collapseAllToolStripMenuItem});
+            this.FileTreeContextMenu.Name = "FileTreeContextMenu";
+            this.FileTreeContextMenu.Size = new System.Drawing.Size(297, 380);
+            this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
+            // 
+            // saveAsToolStripMenuItem
+            // 
+            this.saveAsToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconSaveAs;
+            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.saveAsToolStripMenuItem.Text = "Save as...";
+            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
+            // 
+            // resetToThisRevisionToolStripMenuItem
+            // 
+            this.resetToThisRevisionToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetFileTo;
+            this.resetToThisRevisionToolStripMenuItem.Name = "resetToThisRevisionToolStripMenuItem";
+            this.resetToThisRevisionToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.resetToThisRevisionToolStripMenuItem.Text = "Reset to selected revision";
+            this.resetToThisRevisionToolStripMenuItem.Click += new System.EventHandler(this.resetToThisRevisionToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator30
+            // 
+            this.toolStripSeparator30.Name = "toolStripSeparator30";
+            this.toolStripSeparator30.Size = new System.Drawing.Size(293, 6);
+            // 
+            // openSubmoduleMenuItem
+            // 
+            this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Resources.IconFolderSubmodule;
+            this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
+            this.openSubmoduleMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.openSubmoduleMenuItem.Text = "Open with Git Extensions";
+            this.openSubmoduleMenuItem.Click += new System.EventHandler(this.openSubmoduleMenuItem_Click);
+            // 
+            // copyFilenameToClipboardToolStripMenuItem
+            // 
+            this.copyFilenameToClipboardToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
+            this.copyFilenameToClipboardToolStripMenuItem.Name = "copyFilenameToClipboardToolStripMenuItem";
+            this.copyFilenameToClipboardToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this.copyFilenameToClipboardToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.copyFilenameToClipboardToolStripMenuItem.Text = "Copy full path";
+            this.copyFilenameToClipboardToolStripMenuItem.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem_Click);
+            // 
+            // fileTreeOpenContainingFolderToolStripMenuItem
+            // 
+            this.fileTreeOpenContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
+            this.fileTreeOpenContainingFolderToolStripMenuItem.Name = "fileTreeOpenContainingFolderToolStripMenuItem";
+            this.fileTreeOpenContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.fileTreeOpenContainingFolderToolStripMenuItem.Text = "Open containing folder";
+            this.fileTreeOpenContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.fileTreeOpenContainingFolderToolStripMenuItem_Click);
+            // 
+            // fileTreeArchiveToolStripMenuItem
+            // 
+            this.fileTreeArchiveToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconArchiveRevision;
+            this.fileTreeArchiveToolStripMenuItem.Name = "fileTreeArchiveToolStripMenuItem";
+            this.fileTreeArchiveToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.fileTreeArchiveToolStripMenuItem.Text = "Archive...";
+            this.fileTreeArchiveToolStripMenuItem.Click += new System.EventHandler(this.fileTreeArchiveToolStripMenuItem_Click);
+            // 
+            // fileTreeCleanWorkingTreeToolStripMenuItem
+            // 
+            this.fileTreeCleanWorkingTreeToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCleanupRepo;
+            this.fileTreeCleanWorkingTreeToolStripMenuItem.Name = "fileTreeCleanWorkingTreeToolStripMenuItem";
+            this.fileTreeCleanWorkingTreeToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.fileTreeCleanWorkingTreeToolStripMenuItem.Text = "Clean working directory...";
+            this.fileTreeCleanWorkingTreeToolStripMenuItem.Click += new System.EventHandler(this.fileTreeCleanWorkingTreeToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator31
+            // 
+            this.toolStripSeparator31.Name = "toolStripSeparator31";
+            this.toolStripSeparator31.Size = new System.Drawing.Size(293, 6);
+            // 
+            // fileHistoryToolStripMenuItem
+            // 
+            this.fileHistoryToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFileHistory;
+            this.fileHistoryToolStripMenuItem.Name = "fileHistoryToolStripMenuItem";
+            this.fileHistoryToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.fileHistoryToolStripMenuItem.Text = "File history";
+            this.fileHistoryToolStripMenuItem.Click += new System.EventHandler(this.fileHistoryItem_Click);
+            // 
+            // blameToolStripMenuItem1
+            // 
+            this.blameToolStripMenuItem1.Image = global::GitUI.Properties.Resources.IconBlame;
+            this.blameToolStripMenuItem1.Name = "blameToolStripMenuItem1";
+            this.blameToolStripMenuItem1.Size = new System.Drawing.Size(296, 22);
+            this.blameToolStripMenuItem1.Text = "Blame";
+            this.blameToolStripMenuItem1.Click += new System.EventHandler(this.blameMenuItem_Click);
+            // 
+            // findToolStripMenuItem
+            // 
+            this.findToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFind;
+            this.findToolStripMenuItem.Name = "findToolStripMenuItem";
+            this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
+            this.findToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.findToolStripMenuItem.Text = "Find";
+            this.findToolStripMenuItem.Click += new System.EventHandler(this.findToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator20
+            // 
+            this.toolStripSeparator20.Name = "toolStripSeparator20";
+            this.toolStripSeparator20.Size = new System.Drawing.Size(293, 6);
+            // 
+            // editCheckedOutFileToolStripMenuItem
+            // 
+            this.editCheckedOutFileToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconEditFile;
+            this.editCheckedOutFileToolStripMenuItem.Name = "editCheckedOutFileToolStripMenuItem";
+            this.editCheckedOutFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.editCheckedOutFileToolStripMenuItem.Text = "Edit working directory file";
+            this.editCheckedOutFileToolStripMenuItem.Click += new System.EventHandler(this.editCheckedOutFileToolStripMenuItem_Click);
+            // 
+            // openFileToolStripMenuItem
+            // 
+            this.openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
+            this.openFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.openFileToolStripMenuItem.Text = "Open this revision (temp file)";
+            this.openFileToolStripMenuItem.Click += new System.EventHandler(this.openFileToolStripMenuItem_Click);
+            // 
+            // openFileWithToolStripMenuItem
+            // 
+            this.openFileWithToolStripMenuItem.Name = "openFileWithToolStripMenuItem";
+            this.openFileWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.openFileWithToolStripMenuItem.Text = "Open this revision with... (temp file)";
+            this.openFileWithToolStripMenuItem.Click += new System.EventHandler(this.openFileWithToolStripMenuItem_Click);
+            // 
+            // openWithToolStripMenuItem
+            // 
+            this.openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
+            this.openWithToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+            this.openWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.openWithToolStripMenuItem.Text = "Open working directory file with...";
+            this.openWithToolStripMenuItem.Click += new System.EventHandler(this.openWithToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator18
+            // 
+            this.toolStripSeparator18.Name = "toolStripSeparator18";
+            this.toolStripSeparator18.Size = new System.Drawing.Size(293, 6);
+            // 
+            // expandAllToolStripMenuItem
+            // 
+            this.expandAllToolStripMenuItem.Name = "expandAllToolStripMenuItem";
+            this.expandAllToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.expandAllToolStripMenuItem.Text = "Expand all (takes a while on large trees)";
+            this.expandAllToolStripMenuItem.Click += new System.EventHandler(this.expandAllStripMenuItem_Click);
+            // 
+            // collapseAllToolStripMenuItem
+            // 
+            this.collapseAllToolStripMenuItem.Name = "collapseAllToolStripMenuItem";
+            this.collapseAllToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.collapseAllToolStripMenuItem.Text = "Collapse all";
+            this.collapseAllToolStripMenuItem.Click += new System.EventHandler(this.collapseAllToolStripMenuItem_Click);
+            // 
+            // FileText
+            // 
+            this.FileText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.FileText.Location = new System.Drawing.Point(0, 0);
+            this.FileText.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.FileText.Name = "FileText";
+            this.FileText.Size = new System.Drawing.Size(605, 251);
+            this.FileText.TabIndex = 0;
+            //             // 
+            // FileTreeControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.FileTreeSplitContainer);
+            this.Name = "FileTreeControl";
+            this.Size = new System.Drawing.Size(793, 303);
+            this.FileTreeSplitContainer.Panel1.ResumeLayout(false);
+            this.FileTreeSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).EndInit();
+            this.FileTreeSplitContainer.ResumeLayout(false);
+            this.FileTreeContextMenu.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.SplitContainer FileTreeSplitContainer;
+        private System.Windows.Forms.TreeView tvGitTree;
+        private Editor.FileViewer FileText;
+        private System.Windows.Forms.ContextMenuStrip FileTreeContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetToThisRevisionToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator30;
+        private System.Windows.Forms.ToolStripMenuItem openSubmoduleMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyFilenameToClipboardToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem fileTreeOpenContainingFolderToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem fileTreeArchiveToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem fileTreeCleanWorkingTreeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator31;
+        private System.Windows.Forms.ToolStripMenuItem fileHistoryToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem blameToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem findToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator20;
+        private System.Windows.Forms.ToolStripMenuItem editCheckedOutFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openFileWithToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator18;
+        private System.Windows.Forms.ToolStripMenuItem expandAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem collapseAllToolStripMenuItem;
+    }
+}

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -1,0 +1,604 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitUI.CommandsDialogs.BrowseDialog;
+using GitUIPluginInterfaces;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs
+{
+    public partial class RevisionFileTree : GitModuleControl
+    {
+        private readonly TranslationString _resetFileCaption = new TranslationString("Reset");
+        private readonly TranslationString _resetFileText = new TranslationString("Are you sure you want to reset this file or directory?");
+        private readonly TranslationString _saveFileFilterCurrentFormat = new TranslationString("Current format");
+        private readonly TranslationString _saveFileFilterAllFiles = new TranslationString("All files");
+        private readonly TranslationString _nodeNotFoundNextAvailableParentSelected = new TranslationString("Node not found. The next available parent node will be selected.");
+        private readonly TranslationString _nodeNotFoundSelectionNotChanged = new TranslationString("Node not found. File tree selection was not changed.");
+
+        //store strings to not keep references to nodes
+        private readonly Stack<string> _lastSelectedNodes = new Stack<string>();
+        private Rectangle _gitTreeDragBoxFromMouseDown;
+        private GitRevision _revision;
+
+
+        public RevisionFileTree()
+        {
+            InitializeComponent();
+            Translate();
+
+            tvGitTree.ImageList = new ImageList();
+            tvGitTree.ImageList.Images.Add(Properties.Resources.New); //File
+            tvGitTree.ImageList.Images.Add(Properties.Resources.Folder); //Folder
+            tvGitTree.ImageList.Images.Add(Properties.Resources.IconFolderSubmodule); //Submodule
+
+            GotFocus += (s, e) => tvGitTree.Focus();
+        }
+
+
+        public void ExpandToFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return;
+            }
+
+            var pathParts = filePath.Split('/');
+
+            var currentNodes = tvGitTree.Nodes;
+            TreeNode foundNode = null;
+            bool isIncompleteMatch = false;
+            for (int i = 0; i < pathParts.Length; i++)
+            {
+                string pathPart = pathParts[i];
+                string diffPathPart = pathPart.ToNativePath();
+
+                var currentFoundNode = currentNodes.Cast<TreeNode>().FirstOrDefault(a =>
+                {
+                    var treeGitItem = a.Tag as GitItem;
+                    if (treeGitItem != null)
+                    {
+                        // TODO: what about case(in)sensitive handling?
+                        return treeGitItem.Name == diffPathPart;
+                    }
+                    return false;
+                });
+
+                if (currentFoundNode == null)
+                {
+                    isIncompleteMatch = true;
+                    break;
+                }
+
+                foundNode = currentFoundNode;
+
+                if (i < pathParts.Length - 1) // if not the last path part...
+                {
+                    foundNode.Expand(); // load more data
+                    currentNodes = currentFoundNode.Nodes;
+                }
+            }
+
+            if (foundNode != null)
+            {
+                if (isIncompleteMatch)
+                {
+                    MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text);
+                }
+
+                tvGitTree.SelectedNode = foundNode;
+                tvGitTree.SelectedNode.EnsureVisible();
+            }
+            else
+            {
+                MessageBox.Show(_nodeNotFoundSelectionNotChanged.Text);
+            }
+        }
+
+        public void Init(SplitterManager splitterManager)
+        {
+            splitterManager.AddSplitter(FileTreeSplitContainer, "FileTreeSplitContainer");
+        }
+
+        public void InvokeFindFileDialog()
+        {
+            tvGitTree.Focus();
+            findToolStripMenuItem_Click(null, null);
+        }
+
+        public void LoadRevision(GitRevision revision)
+        {
+            _revision = revision;
+
+            try
+            {
+                tvGitTree.SuspendLayout();
+                // Save state only when there is selected node
+                if (tvGitTree.SelectedNode != null)
+                {
+                    var node = tvGitTree.SelectedNode;
+                    FileText.SaveCurrentScrollPos();
+                    _lastSelectedNodes.Clear();
+                    while (node != null)
+                    {
+                        _lastSelectedNodes.Push(node.Text);
+                        node = node.Parent;
+                    }
+                }
+
+                // Refresh tree
+                tvGitTree.Nodes.Clear();
+                //restore selected file and scroll position when new selection is done
+                if (_revision != null)
+                {
+                    LoadInTree(_revision.SubItems, tvGitTree.Nodes);
+                    //GitTree.Sort();
+                    TreeNode lastMatchedNode = null;
+                    // Load state
+                    var currenNodes = tvGitTree.Nodes;
+                    TreeNode matchedNode = null;
+                    while (_lastSelectedNodes.Count > 0 && currenNodes != null)
+                    {
+                        var next = _lastSelectedNodes.Pop();
+                        foreach (TreeNode node in currenNodes)
+                        {
+                            if (node.Text != next && next.Length != 40)
+                                continue;
+
+                            node.Expand();
+                            matchedNode = node;
+                            break;
+                        }
+                        if (matchedNode == null)
+                            currenNodes = null;
+                        else
+                        {
+                            lastMatchedNode = matchedNode;
+                            currenNodes = matchedNode.Nodes;
+                        }
+                    }
+                    //if there is no exact match, don't restore scroll position
+                    if (lastMatchedNode != matchedNode)
+                        FileText.ResetCurrentScrollPos();
+                    tvGitTree.SelectedNode = lastMatchedNode;
+                }
+                if (tvGitTree.SelectedNode == null)
+                {
+                    FileText.ViewText("", "");
+                }
+            }
+            finally
+            {
+                tvGitTree.ResumeLayout();
+            }
+        }
+
+        public void ReloadHotkeys()
+        {
+            FileText.ReloadHotkeys();
+        }
+
+
+        private static TreeNode Find(TreeNodeCollection nodes, string label)
+        {
+            for (var i = 0; i < nodes.Count; i++)
+            {
+                if (nodes[i].Text == label)
+                {
+                    return nodes[i];
+                }
+            }
+            return null;
+        }
+
+        private IList<string> FindFileMatches(string name)
+        {
+            var candidates = Module.GetFullTree(_revision.TreeGuid);
+
+            var nameAsLower = name.ToLower();
+
+            return candidates.Where(fileName => fileName.ToLower().Contains(nameAsLower)).ToList();
+        }
+
+        private void LoadInTree(IEnumerable<IGitItem> items, TreeNodeCollection node)
+        {
+            var sortedItems = items.OrderBy(gi => gi, new GitFileTreeComparer());
+
+            foreach (var item in sortedItems)
+            {
+                var subNode = node.Add(item.Name);
+                subNode.Tag = item;
+
+                var gitItem = item as GitItem;
+                if (gitItem == null)
+                {
+                    subNode.Nodes.Add(new TreeNode());
+                }
+                else
+                {
+                    if (gitItem.IsTree)
+                    {
+                        subNode.ImageIndex = 1;
+                        subNode.SelectedImageIndex = 1;
+                        subNode.Nodes.Add(new TreeNode());
+                    }
+                    else
+                    if (gitItem.IsCommit)
+                    {
+                        subNode.ImageIndex = 2;
+                        subNode.SelectedImageIndex = 2;
+                        subNode.Text = $@"{item.Name} (Submodule)";
+                    }
+                }
+            }
+        }
+
+        private void OnItemActivated()
+        {
+            var item = tvGitTree.SelectedNode?.Tag as GitItem;
+            if (item == null)
+                return;
+
+            if (item.IsBlob)
+            {
+                UICommands.StartFileHistoryDialog(this, item.FileName, null);
+            }
+            else if (item.IsCommit)
+            {
+                SpawnCommitBrowser(item);
+            }
+        }
+
+        private string SaveSelectedItemToTempFile()
+        {
+            var gitItem = tvGitTree.SelectedNode.Tag as GitItem;
+            if (gitItem == null || !gitItem.IsBlob || string.IsNullOrWhiteSpace(gitItem.FileName))
+            {
+                return null;
+            }
+
+            var fileName = gitItem.FileName;
+            if (fileName.Contains("\\") && fileName.LastIndexOf("\\", StringComparison.Ordinal) < fileName.Length)
+                fileName = fileName.Substring(fileName.LastIndexOf('\\') + 1);
+            if (fileName.Contains("/") && fileName.LastIndexOf("/", StringComparison.Ordinal) < fileName.Length)
+                fileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
+
+            fileName = (Path.GetTempPath() + fileName).ToNativePath();
+            Module.SaveBlobAs(fileName, gitItem.Guid);
+            return fileName;
+        }
+
+        private void SpawnCommitBrowser(GitItem item)
+        {
+            var process = new Process();
+            process.StartInfo.FileName = Application.ExecutablePath;
+            process.StartInfo.Arguments = "browse";
+            process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, item.FileName.EnsureTrailingPathSeparator());
+            process.Start();
+        }
+
+
+        private void GitTree_AfterSelect(object sender, TreeViewEventArgs e)
+        {
+            var item = e.Node.Tag as GitItem;
+            if (item == null)
+                return;
+
+            if (item.IsBlob)
+                FileText.ViewGitItem(item.FileName, item.Guid);
+            else if (item.IsCommit)
+                FileText.ViewText(item.FileName, LocalizationHelpers.GetSubmoduleText(Module, item.FileName, item.Guid));
+            else
+                FileText.ViewText("", "");
+        }
+
+        private void GitTree_BeforeExpand(object sender, TreeViewCancelEventArgs e)
+        {
+            if (e.Node.IsExpanded)
+                return;
+
+            var item = (IGitItem)e.Node.Tag;
+
+            e.Node.Nodes.Clear();
+            LoadInTree(item.SubItems, e.Node.Nodes);
+        }
+
+        private void GitTree_DoubleClick(object sender, EventArgs e)
+        {
+            OnItemActivated();
+        }
+
+        private void GitTree_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Return)
+            {
+                if (tvGitTree.SelectedNode != null)
+                {
+                    OnItemActivated();
+                    e.Handled = true;
+                }
+            }
+        }
+
+        private void GitTree_MouseDown(object sender, MouseEventArgs e)
+        {
+            //DRAG
+            if (e.Button == MouseButtons.Left)
+            {
+                // Remember the point where the mouse down occurred.
+                // The DragSize indicates the size that the mouse can move
+                // before a drag event should be started.
+                var dragSize = SystemInformation.DragSize;
+
+                // Create a rectangle using the DragSize, with the mouse position being
+                // at the center of the rectangle.
+                _gitTreeDragBoxFromMouseDown = new Rectangle(new Point(e.X - dragSize.Width / 2, e.Y - dragSize.Height / 2), dragSize);
+            }
+            else if (e.Button == MouseButtons.Right)
+            {
+                tvGitTree.SelectedNode = tvGitTree.GetNodeAt(e.X, e.Y);
+            }
+        }
+
+        private void GitTree_MouseMove(object sender, MouseEventArgs e)
+        {
+            var gitTree = (TreeView)sender;
+
+            //DRAG
+            // If the mouse moves outside the rectangle, start the drag.
+            if (_gitTreeDragBoxFromMouseDown != Rectangle.Empty &&
+                !_gitTreeDragBoxFromMouseDown.Contains(e.X, e.Y))
+            {
+                var fileList = new StringCollection();
+
+                //foreach (GitItemStatus item in SelectedItems)
+                if (gitTree.SelectedNode != null)
+                {
+                    var item = gitTree.SelectedNode.Tag as GitItem;
+                    if (item != null)
+                    {
+                        var fileName = Path.Combine(Module.WorkingDir, item.FileName);
+
+                        fileList.Add(fileName.ToNativePath());
+                    }
+
+                    var obj = new DataObject();
+                    obj.SetFileDropList(fileList);
+
+                    // Proceed with the drag and drop, passing in the list item.
+                    DoDragDrop(obj, DragDropEffects.Copy);
+                    _gitTreeDragBoxFromMouseDown = Rectangle.Empty;
+                }
+            }
+        }
+
+
+        private void blameMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = tvGitTree.SelectedNode.Tag as GitItem;
+
+            if (item == null)
+                return;
+
+            if (GitRevision.IsArtificial(_revision.Guid))
+                UICommands.StartFileHistoryDialog(this, item.FileName, null, false, true);
+            else
+                UICommands.StartFileHistoryDialog(this, item.FileName, _revision, true, true);
+        }
+
+        private void collapseAllToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            tvGitTree.CollapseAll();
+        }
+
+        private void copyFilenameToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var gitItem = tvGitTree.SelectedNode.Tag as GitItem;
+            if (gitItem == null)
+                return;
+
+            var fileName = Path.Combine(Module.WorkingDir, gitItem.FileName);
+            Clipboard.SetText(fileName.ToNativePath());
+        }
+
+        private void fileHistoryItem_Click(object sender, EventArgs e)
+        {
+            var item = tvGitTree.SelectedNode.Tag as GitItem;
+            if (item == null)
+                return;
+
+            if (GitRevision.IsArtificial(_revision.Guid))
+                UICommands.StartFileHistoryDialog(this, item.FileName);
+            else
+                UICommands.StartFileHistoryDialog(this, item.FileName, _revision, false, false);
+        }
+
+        private void findToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            string selectedItem;
+            using (var searchWindow = new SearchWindow<string>(FindFileMatches) { Owner = FindForm() })
+            {
+                searchWindow.ShowDialog(this);
+                selectedItem = searchWindow.SelectedItem;
+            }
+            if (string.IsNullOrEmpty(selectedItem))
+            {
+                return;
+            }
+
+            var items = selectedItem.Split('/');
+            var nodes = tvGitTree.Nodes;
+
+            for (var i = 0; i < items.Length - 1; i++)
+            {
+                var selectedNode = Find(nodes, items[i]);
+                if (selectedNode == null)
+                {
+                    return; //Item does not exist in the tree
+                }
+
+                selectedNode.Expand();
+                nodes = selectedNode.Nodes;
+            }
+
+            var lastItem = Find(nodes, items[items.Length - 1]);
+            if (lastItem != null)
+            {
+                tvGitTree.SelectedNode = lastItem;
+            }
+        }
+
+        private void editCheckedOutFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = tvGitTree.SelectedNode.Tag;
+
+            var gitItem = item as GitItem;
+            if (gitItem == null || !gitItem.IsBlob)
+                return;
+
+            var fileName = Path.Combine(Module.WorkingDir, gitItem.FileName);
+            UICommands.StartFileEditorDialog(fileName);
+        }
+
+        private void expandAllStripMenuItem_Click(object sender, EventArgs e)
+        {
+            tvGitTree.ExpandAll();
+        }
+
+        private void fileTreeArchiveToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var gitItem = (GitItem)tvGitTree.SelectedNode.Tag;
+            UICommands.StartArchiveDialog(this, _revision, null, gitItem.FileName);
+        }
+
+        private void fileTreeCleanWorkingTreeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var gitItem = (GitItem)tvGitTree.SelectedNode.Tag;
+            UICommands.StartCleanupRepositoryDialog(this, gitItem.FileName + "/"); // the trailing / marks a directory
+        }
+
+        private void FileTreeContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            var gitItem = tvGitTree.SelectedNode?.Tag as GitItem;
+            var enableItems = gitItem != null && gitItem.IsBlob;
+
+            if (gitItem != null && gitItem.IsCommit)
+            {
+                openSubmoduleMenuItem.Visible = true;
+                if (!openSubmoduleMenuItem.Font.Bold)
+                {
+                    openSubmoduleMenuItem.Font = new Font(openSubmoduleMenuItem.Font, FontStyle.Bold);
+                }
+            }
+            else
+            {
+                openSubmoduleMenuItem.Visible = false;
+            }
+
+            saveAsToolStripMenuItem.Visible = enableItems;
+            openFileToolStripMenuItem.Visible = enableItems;
+            openFileWithToolStripMenuItem.Visible = enableItems;
+            openWithToolStripMenuItem.Visible = enableItems;
+            copyFilenameToClipboardToolStripMenuItem.Visible = gitItem != null && FormBrowseUtil.IsFileOrDirectory(FormBrowseUtil.GetFullPathFromGitItem(Module, gitItem));
+            editCheckedOutFileToolStripMenuItem.Visible = enableItems;
+        }
+
+        private void fileTreeOpenContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var gitItem = tvGitTree.SelectedNode.Tag as GitItem;
+            if (gitItem == null)
+            {
+                return;
+            }
+
+            var filePath = FormBrowseUtil.GetFullPathFromGitItem(Module, gitItem);
+            FormBrowseUtil.ShowFileOrFolderInFileExplorer(filePath);
+        }
+
+        private void openFileWithToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var fileName = SaveSelectedItemToTempFile();
+            if (fileName != null)
+                OsShellUtil.OpenAs(fileName);
+        }
+
+        private void openFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                var fileName = SaveSelectedItemToTempFile();
+                if (fileName != null)
+                    Process.Start(fileName);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message);
+            }
+        }
+
+        private void openSubmoduleMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = tvGitTree.SelectedNode.Tag as GitItem;
+            if (item != null && item.IsCommit)
+            {
+                SpawnCommitBrowser(item);
+            }
+        }
+
+        private void openWithToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = tvGitTree.SelectedNode.Tag;
+
+            var gitItem = item as GitItem;
+            if (gitItem == null || !gitItem.IsBlob)
+                return;
+
+            var fileName = Path.Combine(Module.WorkingDir, gitItem.FileName);
+            OsShellUtil.OpenAs(fileName.ToNativePath());
+        }
+
+        private void resetToThisRevisionToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (DialogResult.OK == MessageBox.Show(_resetFileText.Text, _resetFileCaption.Text, MessageBoxButtons.OKCancel))
+            {
+                var item = tvGitTree.SelectedNode.Tag as GitItem;
+                var files = new List<string> { item.FileName };
+                Module.CheckoutFiles(files, _revision.Guid, false);
+            }
+        }
+
+        private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = tvGitTree.SelectedNode.Tag as GitItem;
+            if (item == null || !item.IsBlob)
+            {
+                return;
+            }
+
+            var fullName = Path.Combine(Module.WorkingDir, item.FileName);
+            using (var fileDialog =
+                new SaveFileDialog
+                {
+                    InitialDirectory = Path.GetDirectoryName(fullName),
+                    FileName = Path.GetFileName(fullName),
+                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                    AddExtension = true
+                })
+            {
+                var extension = GitCommandHelpers.GetFileExtension(fileDialog.FileName);
+
+                fileDialog.Filter = $@"{_saveFileFilterCurrentFormat.Text}(*.{extension})|*.{extension }| {_saveFileFilterAllFiles.Text} (*.*)|*.*";
+                if (fileDialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    Module.SaveBlobAs(fileDialog.FileName, item.Guid);
+                }
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/RevisionFileTree.resx
+++ b/GitUI/CommandsDialogs/RevisionFileTree.resx
@@ -117,37 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolPanel.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="UserMenuToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>126, 56</value>
-  </metadata>
-  <metadata name="ToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>251, 17</value>
-  </metadata>
-  <metadata name="DiffContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>860, 17</value>
-  </metadata>
-  <metadata name="FilterToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="FileTreeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="TreeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>711, 17</value>
-  </metadata>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
-  </metadata>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>136, 17</value>
-  </metadata>
-  <metadata name="gitItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>542, 17</value>
-  </metadata>
-  <metadata name="gitRevisionBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>352, 17</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>217</value>
   </metadata>
 </root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -137,6 +137,12 @@
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommand.cs" />
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommandsBase.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\CommitTemplateManager.cs" />
+    <Compile Include="CommandsDialogs\RevisionFileTree.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\RevisionFileTree.Designer.cs">
+      <DependentUpon>RevisionFileTree.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\FormCompareToBranch.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1090,6 +1096,9 @@
     <EmbeddedResource Include="CommandsDialogs\BrowseDialog\FormUpdates.resx">
       <DependentUpon>FormUpdates.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\RevisionFileTree.resx">
+      <DependentUpon>RevisionFileTree.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\FormCompareToBranch.resx">
       <DependentUpon>FormCompareToBranch.cs</DependentUpon>


### PR DESCRIPTION
No functional changes.

Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/30772844-b9fc935c-a0a7-11e7-8b9a-4ed2c1741a35.png)
![image](https://user-images.githubusercontent.com/4403806/30772862-296a0ca6-a0a8-11e7-934d-b7dd14c3fae8.png)


Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10
