### PR TITLE
Applied the same behavior to FormFileHistory

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -560,8 +560,6 @@ namespace GitUI.CommandsDialogs
             // 
             // toolStripBranchFilterComboBox
             // 
-            this.toolStripBranchFilterComboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
-            this.toolStripBranchFilterComboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.toolStripBranchFilterComboBox.AutoSize = false;
             this.toolStripBranchFilterComboBox.DropDownWidth = 300;
             this.toolStripBranchFilterComboBox.Name = "toolStripBranchFilterComboBox";

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -313,6 +313,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripBranchFilterComboBox.Name = "toolStripBranchFilterComboBox";
             this.toolStripBranchFilterComboBox.Size = new System.Drawing.Size(150, 25);
+            this.toolStripBranchFilterComboBox.Click += new System.EventHandler(this.toolStripBranchFilterComboBox_Click);
             // 
             // toolStripBranchFilterDropDownButton
             // 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -496,5 +496,10 @@ namespace GitUI.CommandsDialogs
             }
             base.Dispose(disposing);
         }
+
+        private void toolStripBranchFilterComboBox_Click(object sender, EventArgs e)
+        {
+            toolStripBranchFilterComboBox.DroppedDown = true;
+        }
     }
 }


### PR DESCRIPTION
Fixes #4016 .

Changes proposed in this pull request:
 - Applied the same behavior to the FormFileHistory as requested by @RussKie 
 
Screenshots before and after (if PR changes UI):
-
![image](https://user-images.githubusercontent.com/2108835/30774079-c956d792-a0af-11e7-9851-02cecc13cfab.png)
