### PR TITLE
Enhance file tree control

### DIFF
--- a/GitCommands/FileAssociatedIconProvider.cs
+++ b/GitCommands/FileAssociatedIconProvider.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Concurrent;
+using System.Drawing;
+using System.IO;
+using System.IO.Abstractions;
+using GitCommands.Utils;
+
+namespace GitCommands
+{
+    public interface IFileAssociatedIconProvider
+    {
+        Icon Get(string fullPath);
+    }
+
+    public sealed class FileAssociatedIconProvider : IFileAssociatedIconProvider
+    {
+        private readonly IFileSystem _fileSystem;
+        private static readonly ConcurrentDictionary<string, Icon> LoadedFileIcons = new ConcurrentDictionary<string, Icon>(StringComparer.OrdinalIgnoreCase);
+
+        public FileAssociatedIconProvider(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public FileAssociatedIconProvider()
+            : this(new FileSystem())
+        {
+        }
+
+        // unit tests only
+        internal int CacheCount => LoadedFileIcons.Count;
+
+
+        public Icon Get(string fullPath)
+        {
+            if (EnvUtils.IsMonoRuntime())
+            {
+                // Mono does not support icon extraction
+                // https://github.com/mono/mono/blob/master/mcs/class/System.Drawing/System.Drawing/Icon.cs#L314
+                return null;
+            }
+
+            var extension = Path.GetExtension(fullPath);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                return null;
+            }
+
+            var icon = LoadedFileIcons.GetOrAdd(extension, ext =>
+            {
+                string tempFile = null;
+                try
+                {
+                    // if the file doesn't exist - create a blank temp file with the required extension
+                    // so we can call Icon.ExtractAssociatedIcon on it
+                    // this may have a slight overhead, however an alternative would be extracting
+                    // extensions from the registry and using p/invokes and WinAPI, which have 
+                    // significantly higher maintenance overhead.
+
+                    if (!_fileSystem.File.Exists(fullPath))
+                    {
+                        tempFile = CreateTempFile(Path.GetFileName(fullPath));
+                    }
+                    return Icon.ExtractAssociatedIcon(fullPath);
+                }
+                catch
+                {
+                    return null;
+                }
+                finally
+                {
+                    if (!string.IsNullOrEmpty(tempFile))
+                    {
+                        DeleteFile(tempFile);
+                    }
+                }
+            });
+            return icon;
+        }
+
+        private string CreateTempFile(string fileName)
+        {
+            var tempFile = Path.Combine(Path.GetTempPath(), fileName);
+            _fileSystem.File.WriteAllText(tempFile, string.Empty);
+            return tempFile;
+        }
+
+        private void DeleteFile(string path)
+        {
+            try
+            {
+                _fileSystem.File.Delete(path);
+            }
+            catch
+            {
+                // do nothing 
+            }
+        }
+
+        // unit tests only
+        internal void ResetCache()
+        {
+            LoadedFileIcons.Clear();
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -70,8 +70,9 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Abstractions">
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.144, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Abstractions.2.0.0.144\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
@@ -88,6 +89,7 @@
     <Compile Include="Core\SimpleStructured.cs" />
     <Compile Include="DateTimeUtils.cs" />
     <Compile Include="ExceptionUtils.cs" />
+    <Compile Include="FileAssociatedIconProvider.cs" />
     <Compile Include="FileHelper.cs" />
     <Compile Include="Git\AuthorEmailEqualityComparer.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />

--- a/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
@@ -88,11 +88,10 @@
             this.tvGitTree.Size = new System.Drawing.Size(300, 303);
             this.tvGitTree.TabIndex = 0;
             this.tvGitTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.tvGitTree_BeforeExpand);
+            this.tvGitTree.ItemDrag += new System.Windows.Forms.ItemDragEventHandler(this.tvGitTree_ItemDrag);
             this.tvGitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.tvGitTree_AfterSelect);
             this.tvGitTree.DoubleClick += new System.EventHandler(this.tvGitTree_DoubleClick);
             this.tvGitTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tvGitTree_KeyDown);
-            this.tvGitTree.MouseDown += new System.Windows.Forms.MouseEventHandler(this.tvGitTree_MouseDown);
-            this.tvGitTree.MouseMove += new System.Windows.Forms.MouseEventHandler(this.tvGitTree_MouseMove);
             // 
             // FileTreeContextMenu
             // 

--- a/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
@@ -31,7 +31,6 @@
             this.components = new System.ComponentModel.Container();
             this.FileTreeSplitContainer = new System.Windows.Forms.SplitContainer();
             this.tvGitTree = new System.Windows.Forms.TreeView();
-            this.FileText = new GitUI.Editor.FileViewer();
             this.FileTreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetToThisRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -53,17 +52,19 @@
             this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
             this.expandAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.collapseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.FileText = new GitUI.Editor.FileViewer();
             ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).BeginInit();
             this.FileTreeSplitContainer.Panel1.SuspendLayout();
             this.FileTreeSplitContainer.Panel2.SuspendLayout();
             this.FileTreeSplitContainer.SuspendLayout();
             this.FileTreeContextMenu.SuspendLayout();
             this.SuspendLayout();
+            // 
             // FileTreeSplitContainer
             // 
             this.FileTreeSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.FileTreeSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.FileTreeSplitContainer.Location = new System.Drawing.Point(3, 3);
+            this.FileTreeSplitContainer.Location = new System.Drawing.Point(0, 0);
             this.FileTreeSplitContainer.Name = "FileTreeSplitContainer";
             // 
             // FileTreeSplitContainer.Panel1
@@ -73,49 +74,49 @@
             // FileTreeSplitContainer.Panel2
             // 
             this.FileTreeSplitContainer.Panel2.Controls.Add(this.FileText);
-            this.FileTreeSplitContainer.Size = new System.Drawing.Size(909, 251);
+            this.FileTreeSplitContainer.Size = new System.Drawing.Size(793, 303);
             this.FileTreeSplitContainer.SplitterDistance = 300;
             this.FileTreeSplitContainer.TabIndex = 1;
             // 
-            // GitTree
+            // tvGitTree
             // 
             this.tvGitTree.ContextMenuStrip = this.FileTreeContextMenu;
             this.tvGitTree.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tvGitTree.HideSelection = false;
             this.tvGitTree.Location = new System.Drawing.Point(0, 0);
             this.tvGitTree.Name = "tvGitTree";
-            this.tvGitTree.Size = new System.Drawing.Size(300, 251);
+            this.tvGitTree.Size = new System.Drawing.Size(300, 303);
             this.tvGitTree.TabIndex = 0;
-            this.tvGitTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.GitTree_BeforeExpand);
-            this.tvGitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.GitTree_AfterSelect);
-            this.tvGitTree.DoubleClick += new System.EventHandler(this.GitTree_DoubleClick);
-            this.tvGitTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GitTree_KeyDown);
-            this.tvGitTree.MouseDown += new System.Windows.Forms.MouseEventHandler(this.GitTree_MouseDown);
-            this.tvGitTree.MouseMove += new System.Windows.Forms.MouseEventHandler(this.GitTree_MouseMove);
+            this.tvGitTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.tvGitTree_BeforeExpand);
+            this.tvGitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.tvGitTree_AfterSelect);
+            this.tvGitTree.DoubleClick += new System.EventHandler(this.tvGitTree_DoubleClick);
+            this.tvGitTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tvGitTree_KeyDown);
+            this.tvGitTree.MouseDown += new System.Windows.Forms.MouseEventHandler(this.tvGitTree_MouseDown);
+            this.tvGitTree.MouseMove += new System.Windows.Forms.MouseEventHandler(this.tvGitTree_MouseMove);
             // 
             // FileTreeContextMenu
             // 
             this.FileTreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.saveAsToolStripMenuItem,
-                this.resetToThisRevisionToolStripMenuItem,
-                this.toolStripSeparator30,
-                this.openSubmoduleMenuItem,
-                this.copyFilenameToClipboardToolStripMenuItem,
-                this.fileTreeOpenContainingFolderToolStripMenuItem,
-                this.fileTreeArchiveToolStripMenuItem,
-                this.fileTreeCleanWorkingTreeToolStripMenuItem,
-                this.toolStripSeparator31,
-                this.fileHistoryToolStripMenuItem,
-                this.blameToolStripMenuItem1,
-                this.findToolStripMenuItem,
-                this.toolStripSeparator20,
-                this.editCheckedOutFileToolStripMenuItem,
-                this.openFileToolStripMenuItem,
-                this.openFileWithToolStripMenuItem,
-                this.openWithToolStripMenuItem,
-                this.toolStripSeparator18,
-                this.expandAllToolStripMenuItem,
-                this.collapseAllToolStripMenuItem});
+            this.saveAsToolStripMenuItem,
+            this.resetToThisRevisionToolStripMenuItem,
+            this.toolStripSeparator30,
+            this.openSubmoduleMenuItem,
+            this.copyFilenameToClipboardToolStripMenuItem,
+            this.fileTreeOpenContainingFolderToolStripMenuItem,
+            this.fileTreeArchiveToolStripMenuItem,
+            this.fileTreeCleanWorkingTreeToolStripMenuItem,
+            this.toolStripSeparator31,
+            this.fileHistoryToolStripMenuItem,
+            this.blameToolStripMenuItem1,
+            this.findToolStripMenuItem,
+            this.toolStripSeparator20,
+            this.editCheckedOutFileToolStripMenuItem,
+            this.openFileToolStripMenuItem,
+            this.openFileWithToolStripMenuItem,
+            this.openWithToolStripMenuItem,
+            this.toolStripSeparator18,
+            this.expandAllToolStripMenuItem,
+            this.collapseAllToolStripMenuItem});
             this.FileTreeContextMenu.Name = "FileTreeContextMenu";
             this.FileTreeContextMenu.Size = new System.Drawing.Size(297, 380);
             this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
@@ -272,15 +273,15 @@
             this.FileText.Location = new System.Drawing.Point(0, 0);
             this.FileText.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.FileText.Name = "FileText";
-            this.FileText.Size = new System.Drawing.Size(605, 251);
+            this.FileText.Size = new System.Drawing.Size(489, 303);
             this.FileText.TabIndex = 0;
-            //             // 
-            // FileTreeControl
+            // 
+            // RevisionFileTree
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.FileTreeSplitContainer);
-            this.Name = "FileTreeControl";
+            this.Name = "RevisionFileTree";
             this.Size = new System.Drawing.Size(793, 303);
             this.FileTreeSplitContainer.Panel1.ResumeLayout(false);
             this.FileTreeSplitContainer.Panel2.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -284,7 +284,7 @@ namespace GitUI.CommandsDialogs
         }
 
 
-        private void GitTree_AfterSelect(object sender, TreeViewEventArgs e)
+        private void tvGitTree_AfterSelect(object sender, TreeViewEventArgs e)
         {
             var item = e.Node.Tag as GitItem;
             if (item == null)
@@ -298,7 +298,7 @@ namespace GitUI.CommandsDialogs
                 FileText.ViewText("", "");
         }
 
-        private void GitTree_BeforeExpand(object sender, TreeViewCancelEventArgs e)
+        private void tvGitTree_BeforeExpand(object sender, TreeViewCancelEventArgs e)
         {
             if (e.Node.IsExpanded)
                 return;
@@ -309,12 +309,12 @@ namespace GitUI.CommandsDialogs
             LoadInTree(item.SubItems, e.Node.Nodes);
         }
 
-        private void GitTree_DoubleClick(object sender, EventArgs e)
+        private void tvGitTree_DoubleClick(object sender, EventArgs e)
         {
             OnItemActivated();
         }
 
-        private void GitTree_KeyDown(object sender, KeyEventArgs e)
+        private void tvGitTree_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Return)
             {
@@ -326,7 +326,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void GitTree_MouseDown(object sender, MouseEventArgs e)
+        private void tvGitTree_MouseDown(object sender, MouseEventArgs e)
         {
             //DRAG
             if (e.Button == MouseButtons.Left)
@@ -346,7 +346,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void GitTree_MouseMove(object sender, MouseEventArgs e)
+        private void tvGitTree_MouseMove(object sender, MouseEventArgs e)
         {
             var gitTree = (TreeView)sender;
 

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -287,22 +287,36 @@ namespace GitUI.CommandsDialogs
         {
             var item = e.Node.Tag as GitItem;
             if (item == null)
+            {
                 return;
+            }
 
             if (item.IsBlob)
+            {
                 FileText.ViewGitItem(item.FileName, item.Guid);
+            }
             else if (item.IsCommit)
+            {
                 FileText.ViewText(item.FileName, LocalizationHelpers.GetSubmoduleText(Module, item.FileName, item.Guid));
+            }
             else
+            {
                 FileText.ViewText("", "");
+                e.Node.Toggle();
+            }
         }
 
         private void tvGitTree_BeforeExpand(object sender, TreeViewCancelEventArgs e)
         {
             if (e.Node.IsExpanded)
+            {
                 return;
-
-            var item = (IGitItem)e.Node.Tag;
+            }
+            var item = e.Node.Tag as GitItem;
+            if (item == null)
+            {
+                return;
+            }
 
             e.Node.Nodes.Clear();
             LoadInTree(item.SubItems, e.Node.Nodes);

--- a/UnitTests/GitCommandsTests/FileAssociatedIconProviderTests.cs
+++ b/UnitTests/GitCommandsTests/FileAssociatedIconProviderTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using System.IO.Abstractions;
+using FluentAssertions;
+using GitCommands;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class FileAssociatedIconProviderTests
+    {
+        private FileBase _file;
+        private IFileSystem _fileSystem;
+        private FileAssociatedIconProvider _iconProvider;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _file = Substitute.For<FileBase>();
+            _fileSystem = Substitute.For<IFileSystem>();
+            _fileSystem.File.Returns(_file);
+            _iconProvider = new FileAssociatedIconProvider(_fileSystem);
+            _iconProvider.ResetCache();
+        }
+
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("aaaa")]
+        [Platform(Include = "Mono")]
+        public void Get_should_always_return_null_under_mono(string fullPath)
+        {
+            _iconProvider.Get(fullPath).Should().BeNull();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [Platform(Exclude = "Mono")]
+        public void Get_should_return_null_if_path_null_or_empty(string fullPath)
+        {
+            _iconProvider.Get(fullPath).Should().BeNull();
+        }
+
+        [Test]
+        [Platform(Exclude = "Mono")]
+        public void Get_should_return_null_for_extensionless_file()
+        {
+            _iconProvider.Get(@"c:\file").Should().BeNull();
+        }
+
+        [Test]
+        [Platform(Exclude = "Mono")]
+        public void Get_if_file_does_not_exist_create_temp()
+        {
+            const string file = @"c:\file.txt";
+            _file.Exists(file).Returns(false);
+
+            _iconProvider.Get(file).Should().BeNull();
+
+            var tempPath = Path.Combine(Path.GetTempPath(), "file.txt");
+            _file.Received(1).WriteAllText(tempPath, string.Empty);
+        }
+
+        [Test]
+        [Platform(Exclude = "Mono")]
+        public void Get_if_temp_file_cant_be_delete_ignore()
+        {
+            _file.Exists(Arg.Any<string>()).Returns(false);
+            _file.When(x => x.Delete(Arg.Any<string>()))
+                .Do(x =>
+                {
+                    throw new DivideByZeroException("boom");
+                });
+
+            _iconProvider.Get(@"c:\file.txt").Should().BeNull();
+
+            var tempPath = Path.Combine(Path.GetTempPath(), "file.txt");
+            _file.Received(1).WriteAllText(tempPath, string.Empty);
+        }
+
+        [Test]
+        [Platform(Exclude = "Mono")]
+        public void Get_should_add_entry_for_extension_once()
+        {
+            _iconProvider = new FileAssociatedIconProvider(); // use real file system
+            _iconProvider.ResetCache();
+
+            var tempFile = Path.GetTempFileName();
+
+            _iconProvider.CacheCount.Should().Be(0);
+            _iconProvider.Get(tempFile);
+            _iconProvider.Get(tempFile);
+            _iconProvider.Get(tempFile);
+            _iconProvider.Get(tempFile);
+            _iconProvider.CacheCount.Should().Be(1);
+
+            try
+            {
+                File.Delete(tempFile);
+            }
+            catch
+            {
+                // do nothing
+            }
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -52,8 +52,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Abstractions">
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.144, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Abstractions.2.0.0.144\lib\net40\System.IO.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
@@ -66,6 +67,7 @@
   <ItemGroup>
     <Compile Include="CommitInformationTest.cs" />
     <Compile Include="Config\ConfigFileTest.cs" />
+    <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="GitExtLinks\GitExtLinksTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />

--- a/UnitTests/GitCommandsTests/packages.config
+++ b/UnitTests/GitCommandsTests/packages.config
@@ -3,4 +3,5 @@
   <package id="FluentAssertions" version="4.19.3" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="System.IO.Abstractions" version="2.0.0.144" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Changes proposed in this pull request:
 - Optimise revision file drag-out and drop
 - Expand "File Tree" folders on click
 

Has been tested on (remove any that don't apply):
 - GIT 2.13 and above
 - Windows 10
 - Ubuntu 17.04