### PR TITLE
GitCommands: Avoid creating a fake remote ref on fetch

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1601,26 +1601,19 @@ namespace GitCommands
             if (localBranch != null)
                 localBranch = localBranch.Replace(" ", "");
 
-            string remoteBranchArguments;
+            string branchArguments = "";
 
-            if (string.IsNullOrEmpty(remoteBranch))
-                remoteBranchArguments = "";
-            else
+            if (!string.IsNullOrEmpty(remoteBranch))
             {
                 if (remoteBranch.StartsWith("+"))
                     remoteBranch = remoteBranch.Remove(0, 1);
-                remoteBranchArguments = "+" + FormatBranchName(remoteBranch);
+                branchArguments = " +" + FormatBranchName(remoteBranch);
+
+                var remoteUrl = GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
+
+                if (!string.IsNullOrEmpty(localBranch))
+                    branchArguments += ":" + GitCommandHelpers.GetFullBranchName(localBranch);
             }
-
-            string localBranchArguments;
-            var remoteUrl = GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
-
-            if (PathIsUrl(remote) && !string.IsNullOrEmpty(localBranch) && string.IsNullOrEmpty(remoteUrl))
-                localBranchArguments = ":" + GitCommandHelpers.GetFullBranchName(localBranch);
-            else if (string.IsNullOrEmpty(localBranch) || PathIsUrl(remote) || string.IsNullOrEmpty(remoteUrl))
-                localBranchArguments = "";
-            else
-                localBranchArguments = ":" + "refs/remotes/" + remote.Trim() + "/" + localBranch;
 
             string arguments = fetchTags == true ? " --tags" : fetchTags == false ? " --no-tags" : "";
 
@@ -1629,7 +1622,7 @@ namespace GitCommands
             if (isUnshallow)
                 arguments += " --unshallow";
 
-            return "\"" + remote.Trim() + "\" " + remoteBranchArguments + localBranchArguments + arguments + pruneArguments;
+            return "\"" + remote.Trim() + "\"" + branchArguments + arguments + pruneArguments;
         }
 
         public string GetRebaseDir()

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -149,7 +149,6 @@ namespace GitUI.CommandsDialogs
         private void Init(string defaultRemote)
         {
             _branch = Module.GetSelectedBranch();
-            localBranch.Text = _branch;
             BindRemotesDropDown(defaultRemote);
         }
 
@@ -841,6 +840,7 @@ namespace GitUI.CommandsDialogs
         private void FetchCheckedChanged(object sender, EventArgs e)
         {
             localBranch.Enabled = true;
+            localBranch.Text = string.Empty;
             helpImageDisplayUserControl1.Image1 = Resources.HelpPullFetch;
             helpImageDisplayUserControl1.IsOnHoverShowImage2 = false;
             AllTags.Enabled = true;

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -62,13 +62,13 @@ namespace GitCommandsTests.Git
         public void TestFetchArguments()
         {
             GitModule module = new GitModule(null);
-            { // Using a registered remote creates a local branch (FIXME: Change that)
+            { // Specifying a remote and a local branch creates a local branch
                 var fetchCmd = module.FetchCmd("origin", "some-branch", "local");
-                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/remotes/origin/local --no-tags", fetchCmd);
+                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
             }
             {
                 var fetchCmd = module.FetchCmd("origin", "some-branch", "local", true);
-                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/remotes/origin/local --tags", fetchCmd);
+                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/heads/local --tags", fetchCmd);
             }
             { // Using a URL as remote and passing a local branch creates the branch
                 var fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", "local");
@@ -77,6 +77,10 @@ namespace GitCommandsTests.Git
             { // Using a URL as remote and not passing a local branch
                 var fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", null);
                 Assert.AreEqual("fetch --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+            }
+            { // No remote branch -> No local branch
+                var fetchCmd = module.FetchCmd("origin", "", "local");
+                Assert.AreEqual("fetch --progress \"origin\" --no-tags", fetchCmd);
             }
             { // Pull doesn't accept a local branch ever
                 var fetchCmd = module.PullCmd("origin", "some-branch", false);


### PR DESCRIPTION
This was done for pull in d7dbd16e45ad3512ccd1921f6575ae560ef49fc2.

The same should be done for fetch. Unless the user specifies a local
branch, there is no point in creating one.
