### PR TITLE
Introduce auto complete for words starting with dot.

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -296,6 +296,8 @@
     <Compile Include="RepoHosts.cs" />
     <Compile Include="AutoCompletion\AutoCompleteWord.cs" />
     <Compile Include="SplitterManager.cs" />
+    <Compile Include="SpellChecker\SpellCheckerHelper.cs" />
+    <Compile Include="SpellChecker\WordAtCursorExtractor.cs" />
     <Compile Include="UserControls\BranchComboBox.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -52,6 +52,8 @@ namespace GitUI.SpellChecker
                                                                              { Keys.Home, "{HOME}" }
                                                                      };
 
+        private readonly IWordAtCursorExtractor _wordAtCursorExtractor;
+
         public Font TextBoxFont { get; set; }
 
         public EventHandler TextAssigned;
@@ -64,6 +66,8 @@ namespace GitUI.SpellChecker
 
             MistakeFont = new Font(TextBox.Font, FontStyle.Underline);
             TextBoxFont = TextBox.Font;
+
+            _wordAtCursorExtractor = new WordAtCursorExtractor();
         }
 
 
@@ -619,6 +623,7 @@ namespace GitUI.SpellChecker
         }
 
         private bool skipSelectionUndo = false;
+
         private void UndoHighlighting()
         {
             if (!skipSelectionUndo)
@@ -867,22 +872,10 @@ namespace GitUI.SpellChecker
 
         private string GetWordAtCursor()
         {
-            if (TextBox.Text.Length > TextBox.SelectionStart && IsSeparatorChar(TextBox.Text[TextBox.SelectionStart]))
+            if (TextBox.Text.Length > TextBox.SelectionStart && TextBox.Text[TextBox.SelectionStart].IsSeparator())
                 return null;
 
-            var sb = new StringBuilder();
-
-            int i = TextBox.SelectionStart - 1;
-
-            while (i >= 0 && !IsSeparatorChar(TextBox.Text[i]))
-                sb.Insert(0, TextBox.Text[i--]);
-
-            return sb.ToString();
-        }
-
-        private bool IsSeparatorChar(char c)
-        {
-            return char.IsWhiteSpace(c) || c == '.';
+            return _wordAtCursorExtractor.Extract(TextBox.Text, TextBox.SelectionStart - 1);
         }
 
         private void CloseAutoComplete()

--- a/GitUI/SpellChecker/SpellCheckerHelper.cs
+++ b/GitUI/SpellChecker/SpellCheckerHelper.cs
@@ -1,0 +1,10 @@
+﻿namespace GitUI.SpellChecker
+{
+    internal static class SpellCheckerHelper
+    {
+        public static bool IsSeparator(this char c)
+        {
+            return !char.IsLetterOrDigit(c);
+        }
+    }
+}

--- a/GitUI/SpellChecker/WordAtCursorExtractor.cs
+++ b/GitUI/SpellChecker/WordAtCursorExtractor.cs
@@ -32,7 +32,12 @@ namespace GitUI.SpellChecker
 
         private static bool IsLeadingChar(string text, int cursor)
         {
-            return cursor == 0 || text[cursor - 1].IsSeparator();
+            return cursor == 0 || IsSeparatorExceptClosingBrackets(text[cursor - 1]);
+        }
+
+        private static bool IsSeparatorExceptClosingBrackets(char c)
+        {
+            return c != ')' && c != ']' && c.IsSeparator();
         }
     }
 

--- a/GitUI/SpellChecker/WordAtCursorExtractor.cs
+++ b/GitUI/SpellChecker/WordAtCursorExtractor.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+
+namespace GitUI.SpellChecker
+{
+    internal class WordAtCursorExtractor : IWordAtCursorExtractor
+    {
+        public string Extract(string text, int cursor)
+        {
+            if (cursor < 0)
+                return string.Empty;
+
+            var sb = new StringBuilder();
+
+            while (cursor >= 0)
+            {
+                if (text[cursor].IsSeparator() && !IsDot(text[cursor]))
+                    break;
+
+                if (IsDot(text[cursor]) && !IsLeadingChar(text, cursor))
+                    break;
+
+                sb.Insert(0, text[cursor--]);
+            }
+
+            return sb.ToString();
+        }
+
+        private static bool IsDot(char c)
+        {
+            return c == '.';
+        }
+
+        private static bool IsLeadingChar(string text, int cursor)
+        {
+            return cursor == 0 || text[cursor - 1].IsSeparator();
+        }
+    }
+
+    internal interface IWordAtCursorExtractor
+    {
+        string Extract(string text, int cursor);
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -63,6 +63,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SpellChecker\WordAtCursorExtractorTests.cs" />
     <Compile Include="SplitterManagerTest.cs" />
     <Compile Include="TranslationTest.cs" />
     <Compile Include="UserControls\AuthorEmailBasedRevisionHighlightingFixture.cs" />

--- a/UnitTests/GitUITests/SpellChecker/WordAtCursorExtractorTests.cs
+++ b/UnitTests/GitUITests/SpellChecker/WordAtCursorExtractorTests.cs
@@ -20,8 +20,10 @@ namespace GitUITests.SpellChecker
         [TestCase("Add,git", ExpectedResult = "git")]
         [TestCase("Add (.git", ExpectedResult = ".git")]
         [TestCase("Introduce Tes", ExpectedResult = "Tes")]
-        [TestCase("Add).git", ExpectedResult = ".git")]
-        [TestCase("[Add].git", ExpectedResult = ".git")]
+        [TestCase("Add).git", ExpectedResult = "git")]
+        [TestCase("[Add].git", ExpectedResult = "git")]
+        [TestCase("Introduce .babeljs]", ExpectedResult = "")]
+        [TestCase("func().otherFun", ExpectedResult = "otherFun")]
         public string ExtractsMeaningfulWord(string text)
         {
             return _wordAtCursorExtractor.Extract(text, text.Length - 1);

--- a/UnitTests/GitUITests/SpellChecker/WordAtCursorExtractorTests.cs
+++ b/UnitTests/GitUITests/SpellChecker/WordAtCursorExtractorTests.cs
@@ -1,0 +1,30 @@
+﻿using GitUI.SpellChecker;
+using NUnit.Framework;
+
+namespace GitUITests.SpellChecker
+{
+    [TestFixture]
+    public class WordAtCursorExtractorTests
+    {
+        private WordAtCursorExtractor _wordAtCursorExtractor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _wordAtCursorExtractor = new WordAtCursorExtractor();
+        }
+
+        [TestCase(".git", ExpectedResult = ".git")]
+        [TestCase("Add .g", ExpectedResult = ".g")]
+        [TestCase("Add.g", ExpectedResult = "g")]
+        [TestCase("Add,git", ExpectedResult = "git")]
+        [TestCase("Add (.git", ExpectedResult = ".git")]
+        [TestCase("Introduce Tes", ExpectedResult = "Tes")]
+        [TestCase("Add).git", ExpectedResult = ".git")]
+        [TestCase("[Add].git", ExpectedResult = ".git")]
+        public string ExtractsMeaningfulWord(string text)
+        {
+            return _wordAtCursorExtractor.Extract(text, text.Length - 1);
+        }
+    }
+}


### PR DESCRIPTION
Fixes # 3760.

Changes proposed in this pull request:
 - GetWordAtCursor() includes dot into a word if the dot is leading.
 
Screenshots before and after (if PR changes UI):
before: 
![image](https://user-images.githubusercontent.com/1637680/31251165-bc3bddf8-aa25-11e7-8524-07820fc67501.png)
after:
![image](https://user-images.githubusercontent.com/1637680/31251149-b10acd5e-aa25-11e7-8717-42a48a018cd6.png)

How did I test this code:
I tested it manually.

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
