### PR TITLE
Fix strings in .git/info/exclude

### DIFF
--- a/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
@@ -60,10 +60,11 @@
             panel1.Controls.Add(this.lnkGitIgnorePatterns);
             panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             panel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            panel1.Location = new System.Drawing.Point(0, 385);
+            panel1.Location = new System.Drawing.Point(0, 479);
+            panel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             panel1.Name = "panel1";
-            panel1.Padding = new System.Windows.Forms.Padding(0, 0, 8, 4);
-            panel1.Size = new System.Drawing.Size(250, 38);
+            panel1.Padding = new System.Windows.Forms.Padding(0, 0, 10, 5);
+            panel1.Size = new System.Drawing.Size(267, 47);
             panel1.TabIndex = 5;
             // 
             // lnkGitIgnoreGenerate
@@ -71,14 +72,14 @@
             this.lnkGitIgnoreGenerate.AutoSize = true;
             this.lnkGitIgnoreGenerate.Dock = System.Windows.Forms.DockStyle.Right;
             this.lnkGitIgnoreGenerate.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(96, 2);
-            this.lnkGitIgnoreGenerate.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(14, 2);
+            this.lnkGitIgnoreGenerate.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.lnkGitIgnoreGenerate.Name = "lnkGitIgnoreGenerate";
             this.lnkGitIgnoreGenerate.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(143, 13);
+            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(239, 17);
             this.lnkGitIgnoreGenerate.TabIndex = 7;
             this.lnkGitIgnoreGenerate.TabStop = true;
-            this.lnkGitIgnoreGenerate.Text = "Generate a custom gitignore";
+            this.lnkGitIgnoreGenerate.Text = "Generate a custom ignore/ignoring file";
             this.lnkGitIgnoreGenerate.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnoreGenerate_LinkClicked);
             // 
             // lnkGitIgnorePatterns
@@ -86,14 +87,14 @@
             this.lnkGitIgnorePatterns.AutoSize = true;
             this.lnkGitIgnorePatterns.Dock = System.Windows.Forms.DockStyle.Right;
             this.lnkGitIgnorePatterns.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(119, 19);
-            this.lnkGitIgnorePatterns.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(64, 23);
+            this.lnkGitIgnorePatterns.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.lnkGitIgnorePatterns.Name = "lnkGitIgnorePatterns";
             this.lnkGitIgnorePatterns.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(120, 13);
+            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(189, 17);
             this.lnkGitIgnorePatterns.TabIndex = 6;
             this.lnkGitIgnorePatterns.TabStop = true;
-            this.lnkGitIgnorePatterns.Text = "More gitignore patterns";
+            this.lnkGitIgnorePatterns.Text = "More ignore/ignoring patterns";
             this.lnkGitIgnorePatterns.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnorePatterns_LinkClicked);
             // 
             // flowLayoutPanel2
@@ -102,9 +103,10 @@
             flowLayoutPanel2.Controls.Add(this.AddDefault);
             flowLayoutPanel2.Controls.Add(this.AddPattern);
             flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            flowLayoutPanel2.Location = new System.Drawing.Point(0, 391);
+            flowLayoutPanel2.Location = new System.Drawing.Point(0, 484);
+            flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             flowLayoutPanel2.Name = "flowLayoutPanel2";
-            flowLayoutPanel2.Size = new System.Drawing.Size(372, 32);
+            flowLayoutPanel2.Size = new System.Drawing.Size(510, 42);
             flowLayoutPanel2.TabIndex = 6;
             flowLayoutPanel2.WrapContents = false;
             // 
@@ -112,9 +114,10 @@
             // 
             this.AddDefault.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AddDefault.AutoSize = true;
-            this.AddDefault.Location = new System.Drawing.Point(3, 3);
+            this.AddDefault.Location = new System.Drawing.Point(4, 4);
+            this.AddDefault.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AddDefault.Name = "AddDefault";
-            this.AddDefault.Size = new System.Drawing.Size(160, 25);
+            this.AddDefault.Size = new System.Drawing.Size(200, 34);
             this.AddDefault.TabIndex = 2;
             this.AddDefault.Text = "Add default ignores";
             this.AddDefault.UseVisualStyleBackColor = true;
@@ -124,9 +127,10 @@
             // 
             this.AddPattern.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AddPattern.AutoSize = true;
-            this.AddPattern.Location = new System.Drawing.Point(169, 3);
+            this.AddPattern.Location = new System.Drawing.Point(212, 4);
+            this.AddPattern.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.AddPattern.Name = "AddPattern";
-            this.AddPattern.Size = new System.Drawing.Size(160, 25);
+            this.AddPattern.Size = new System.Drawing.Size(200, 34);
             this.AddPattern.TabIndex = 3;
             this.AddPattern.Text = "Add pattern";
             this.AddPattern.UseVisualStyleBackColor = true;
@@ -138,9 +142,10 @@
             this.Save.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.Save.Image = global::GitUI.Properties.Resources.IconSave;
             this.Save.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.Save.Location = new System.Drawing.Point(463, 3);
+            this.Save.Location = new System.Drawing.Point(578, 4);
+            this.Save.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Save.Name = "Save";
-            this.Save.Size = new System.Drawing.Size(160, 25);
+            this.Save.Size = new System.Drawing.Size(200, 34);
             this.Save.TabIndex = 1;
             this.Save.Text = "Save";
             this.Save.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -151,7 +156,8 @@
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.Location = new System.Drawing.Point(4, 4);
+            this.splitContainer1.Location = new System.Drawing.Point(5, 5);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -165,8 +171,9 @@
             this.splitContainer1.Panel2.Controls.Add(this.label1);
             this.splitContainer1.Panel2.Controls.Add(panel1);
             this.splitContainer1.Panel2MinSize = 250;
-            this.splitContainer1.Size = new System.Drawing.Size(626, 423);
-            this.splitContainer1.SplitterDistance = 372;
+            this.splitContainer1.Size = new System.Drawing.Size(782, 526);
+            this.splitContainer1.SplitterDistance = 510;
+            this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 0;
             // 
             // _NO_TRANSLATE_GitIgnoreEdit
@@ -176,9 +183,9 @@
             this._NO_TRANSLATE_GitIgnoreEdit.Dock = System.Windows.Forms.DockStyle.Fill;
             this._NO_TRANSLATE_GitIgnoreEdit.IsReadOnly = false;
             this._NO_TRANSLATE_GitIgnoreEdit.Location = new System.Drawing.Point(0, 0);
-            this._NO_TRANSLATE_GitIgnoreEdit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this._NO_TRANSLATE_GitIgnoreEdit.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this._NO_TRANSLATE_GitIgnoreEdit.Name = "_NO_TRANSLATE_GitIgnoreEdit";
-            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(372, 391);
+            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(510, 484);
             this._NO_TRANSLATE_GitIgnoreEdit.TabIndex = 0;
             // 
             // label1
@@ -186,10 +193,11 @@
             this.label1.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label1.Location = new System.Drawing.Point(0, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.label1.Multiline = true;
             this.label1.Name = "label1";
             this.label1.ReadOnly = true;
-            this.label1.Size = new System.Drawing.Size(250, 385);
+            this.label1.Size = new System.Drawing.Size(267, 479);
             this.label1.TabIndex = 4;
             this.label1.Text = resources.GetString("label1.Text");
             this.label1.WordWrap = false;
@@ -201,18 +209,20 @@
             this.flowLayoutPanel1.Controls.Add(this.btnCancel);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 427);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(5, 531);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(626, 31);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(782, 42);
             this.flowLayoutPanel1.TabIndex = 1;
             // 
             // btnCancel
             // 
             this.btnCancel.AutoSize = true;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(382, 3);
+            this.btnCancel.Location = new System.Drawing.Point(476, 4);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 25);
+            this.btnCancel.Size = new System.Drawing.Size(94, 34);
             this.btnCancel.TabIndex = 2;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -220,15 +230,16 @@
             // 
             // FormGitIgnore
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(634, 462);
+            this.ClientSize = new System.Drawing.Size(792, 578);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.flowLayoutPanel1);
-            this.MinimumSize = new System.Drawing.Size(650, 500);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.MinimumSize = new System.Drawing.Size(808, 613);
             this.Name = "FormGitIgnore";
-            this.Padding = new System.Windows.Forms.Padding(4);
+            this.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit .gitignore";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormGitIgnoreFormClosing);
@@ -238,6 +249,7 @@
             flowLayoutPanel2.ResumeLayout(false);
             flowLayoutPanel2.PerformLayout();
             this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);
             this.splitContainer1.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();

--- a/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
@@ -64,7 +64,7 @@
             panel1.Margin = new System.Windows.Forms.Padding(4);
             panel1.Name = "panel1";
             panel1.Padding = new System.Windows.Forms.Padding(0, 0, 10, 5);
-            panel1.Size = new System.Drawing.Size(268, 47);
+            panel1.Size = new System.Drawing.Size(269, 47);
             panel1.TabIndex = 5;
             // 
             // lnkGitIgnoreGenerate
@@ -72,14 +72,14 @@
             this.lnkGitIgnoreGenerate.AutoSize = true;
             this.lnkGitIgnoreGenerate.Dock = System.Windows.Forms.DockStyle.Right;
             this.lnkGitIgnoreGenerate.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(9, 2);
+            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(30, 2);
             this.lnkGitIgnoreGenerate.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.lnkGitIgnoreGenerate.Name = "lnkGitIgnoreGenerate";
             this.lnkGitIgnoreGenerate.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(245, 17);
+            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(225, 17);
             this.lnkGitIgnoreGenerate.TabIndex = 7;
             this.lnkGitIgnoreGenerate.TabStop = true;
-            this.lnkGitIgnoreGenerate.Text = "Generate a custom ignores/ignoring file";
+            this.lnkGitIgnoreGenerate.Text = "Generate a custom ignore file for git";
             this.lnkGitIgnoreGenerate.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnoreGenerate_LinkClicked);
             // 
             // lnkGitIgnorePatterns
@@ -87,14 +87,14 @@
             this.lnkGitIgnorePatterns.AutoSize = true;
             this.lnkGitIgnorePatterns.Dock = System.Windows.Forms.DockStyle.Right;
             this.lnkGitIgnorePatterns.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(59, 23);
+            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(98, 23);
             this.lnkGitIgnorePatterns.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.lnkGitIgnorePatterns.Name = "lnkGitIgnorePatterns";
             this.lnkGitIgnorePatterns.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(195, 17);
+            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(157, 17);
             this.lnkGitIgnorePatterns.TabIndex = 6;
             this.lnkGitIgnorePatterns.TabStop = true;
-            this.lnkGitIgnorePatterns.Text = "More ignores/ignoring patterns";
+            this.lnkGitIgnorePatterns.Text = "Example ignore patterns";
             this.lnkGitIgnorePatterns.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnorePatterns_LinkClicked);
             // 
             // flowLayoutPanel2
@@ -106,7 +106,7 @@
             flowLayoutPanel2.Location = new System.Drawing.Point(0, 484);
             flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(4);
             flowLayoutPanel2.Name = "flowLayoutPanel2";
-            flowLayoutPanel2.Size = new System.Drawing.Size(509, 42);
+            flowLayoutPanel2.Size = new System.Drawing.Size(508, 42);
             flowLayoutPanel2.TabIndex = 6;
             flowLayoutPanel2.WrapContents = false;
             // 
@@ -172,7 +172,7 @@
             this.splitContainer1.Panel2.Controls.Add(panel1);
             this.splitContainer1.Panel2MinSize = 250;
             this.splitContainer1.Size = new System.Drawing.Size(782, 526);
-            this.splitContainer1.SplitterDistance = 509;
+            this.splitContainer1.SplitterDistance = 508;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 0;
             // 
@@ -185,7 +185,7 @@
             this._NO_TRANSLATE_GitIgnoreEdit.Location = new System.Drawing.Point(0, 0);
             this._NO_TRANSLATE_GitIgnoreEdit.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this._NO_TRANSLATE_GitIgnoreEdit.Name = "_NO_TRANSLATE_GitIgnoreEdit";
-            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(509, 484);
+            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(508, 484);
             this._NO_TRANSLATE_GitIgnoreEdit.TabIndex = 0;
             // 
             // label1
@@ -197,7 +197,7 @@
             this.label1.Multiline = true;
             this.label1.Name = "label1";
             this.label1.ReadOnly = true;
-            this.label1.Size = new System.Drawing.Size(268, 479);
+            this.label1.Size = new System.Drawing.Size(269, 479);
             this.label1.TabIndex = 4;
             this.label1.Text = resources.GetString("label1.Text");
             this.label1.WordWrap = false;

--- a/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
@@ -61,10 +61,10 @@
             panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             panel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             panel1.Location = new System.Drawing.Point(0, 479);
-            panel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            panel1.Margin = new System.Windows.Forms.Padding(4);
             panel1.Name = "panel1";
             panel1.Padding = new System.Windows.Forms.Padding(0, 0, 10, 5);
-            panel1.Size = new System.Drawing.Size(267, 47);
+            panel1.Size = new System.Drawing.Size(268, 47);
             panel1.TabIndex = 5;
             // 
             // lnkGitIgnoreGenerate
@@ -72,14 +72,14 @@
             this.lnkGitIgnoreGenerate.AutoSize = true;
             this.lnkGitIgnoreGenerate.Dock = System.Windows.Forms.DockStyle.Right;
             this.lnkGitIgnoreGenerate.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(14, 2);
+            this.lnkGitIgnoreGenerate.Location = new System.Drawing.Point(9, 2);
             this.lnkGitIgnoreGenerate.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.lnkGitIgnoreGenerate.Name = "lnkGitIgnoreGenerate";
             this.lnkGitIgnoreGenerate.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(239, 17);
+            this.lnkGitIgnoreGenerate.Size = new System.Drawing.Size(245, 17);
             this.lnkGitIgnoreGenerate.TabIndex = 7;
             this.lnkGitIgnoreGenerate.TabStop = true;
-            this.lnkGitIgnoreGenerate.Text = "Generate a custom ignore/ignoring file";
+            this.lnkGitIgnoreGenerate.Text = "Generate a custom ignores/ignoring file";
             this.lnkGitIgnoreGenerate.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnoreGenerate_LinkClicked);
             // 
             // lnkGitIgnorePatterns
@@ -87,14 +87,14 @@
             this.lnkGitIgnorePatterns.AutoSize = true;
             this.lnkGitIgnorePatterns.Dock = System.Windows.Forms.DockStyle.Right;
             this.lnkGitIgnorePatterns.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(64, 23);
+            this.lnkGitIgnorePatterns.Location = new System.Drawing.Point(59, 23);
             this.lnkGitIgnorePatterns.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this.lnkGitIgnorePatterns.Name = "lnkGitIgnorePatterns";
             this.lnkGitIgnorePatterns.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(189, 17);
+            this.lnkGitIgnorePatterns.Size = new System.Drawing.Size(195, 17);
             this.lnkGitIgnorePatterns.TabIndex = 6;
             this.lnkGitIgnorePatterns.TabStop = true;
-            this.lnkGitIgnorePatterns.Text = "More ignore/ignoring patterns";
+            this.lnkGitIgnorePatterns.Text = "More ignores/ignoring patterns";
             this.lnkGitIgnorePatterns.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkGitIgnorePatterns_LinkClicked);
             // 
             // flowLayoutPanel2
@@ -104,9 +104,9 @@
             flowLayoutPanel2.Controls.Add(this.AddPattern);
             flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
             flowLayoutPanel2.Location = new System.Drawing.Point(0, 484);
-            flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(4);
             flowLayoutPanel2.Name = "flowLayoutPanel2";
-            flowLayoutPanel2.Size = new System.Drawing.Size(510, 42);
+            flowLayoutPanel2.Size = new System.Drawing.Size(509, 42);
             flowLayoutPanel2.TabIndex = 6;
             flowLayoutPanel2.WrapContents = false;
             // 
@@ -115,7 +115,7 @@
             this.AddDefault.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AddDefault.AutoSize = true;
             this.AddDefault.Location = new System.Drawing.Point(4, 4);
-            this.AddDefault.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AddDefault.Margin = new System.Windows.Forms.Padding(4);
             this.AddDefault.Name = "AddDefault";
             this.AddDefault.Size = new System.Drawing.Size(200, 34);
             this.AddDefault.TabIndex = 2;
@@ -128,7 +128,7 @@
             this.AddPattern.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AddPattern.AutoSize = true;
             this.AddPattern.Location = new System.Drawing.Point(212, 4);
-            this.AddPattern.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AddPattern.Margin = new System.Windows.Forms.Padding(4);
             this.AddPattern.Name = "AddPattern";
             this.AddPattern.Size = new System.Drawing.Size(200, 34);
             this.AddPattern.TabIndex = 3;
@@ -143,7 +143,7 @@
             this.Save.Image = global::GitUI.Properties.Resources.IconSave;
             this.Save.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.Save.Location = new System.Drawing.Point(578, 4);
-            this.Save.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Save.Margin = new System.Windows.Forms.Padding(4);
             this.Save.Name = "Save";
             this.Save.Size = new System.Drawing.Size(200, 34);
             this.Save.TabIndex = 1;
@@ -157,7 +157,7 @@
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.splitContainer1.Location = new System.Drawing.Point(5, 5);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -172,7 +172,7 @@
             this.splitContainer1.Panel2.Controls.Add(panel1);
             this.splitContainer1.Panel2MinSize = 250;
             this.splitContainer1.Size = new System.Drawing.Size(782, 526);
-            this.splitContainer1.SplitterDistance = 510;
+            this.splitContainer1.SplitterDistance = 509;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 0;
             // 
@@ -185,7 +185,7 @@
             this._NO_TRANSLATE_GitIgnoreEdit.Location = new System.Drawing.Point(0, 0);
             this._NO_TRANSLATE_GitIgnoreEdit.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
             this._NO_TRANSLATE_GitIgnoreEdit.Name = "_NO_TRANSLATE_GitIgnoreEdit";
-            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(510, 484);
+            this._NO_TRANSLATE_GitIgnoreEdit.Size = new System.Drawing.Size(509, 484);
             this._NO_TRANSLATE_GitIgnoreEdit.TabIndex = 0;
             // 
             // label1
@@ -193,11 +193,11 @@
             this.label1.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label1.Location = new System.Drawing.Point(0, 0);
-            this.label1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.label1.Margin = new System.Windows.Forms.Padding(5);
             this.label1.Multiline = true;
             this.label1.Name = "label1";
             this.label1.ReadOnly = true;
-            this.label1.Size = new System.Drawing.Size(267, 479);
+            this.label1.Size = new System.Drawing.Size(268, 479);
             this.label1.TabIndex = 4;
             this.label1.Text = resources.GetString("label1.Text");
             this.label1.WordWrap = false;
@@ -210,7 +210,7 @@
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(5, 531);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(782, 42);
             this.flowLayoutPanel1.TabIndex = 1;
@@ -220,7 +220,7 @@
             this.btnCancel.AutoSize = true;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.Location = new System.Drawing.Point(476, 4);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(94, 34);
             this.btnCancel.TabIndex = 2;
@@ -236,10 +236,10 @@
             this.ClientSize = new System.Drawing.Size(792, 578);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.flowLayoutPanel1);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MinimumSize = new System.Drawing.Size(808, 613);
             this.Name = "FormGitIgnore";
-            this.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.Padding = new System.Windows.Forms.Padding(5);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Edit .gitignore";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormGitIgnoreFormClosing);

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -4,31 +4,20 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitUI.CommandsDialogs.GitIgnoreDialog;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormGitIgnore : GitModuleForm
     {
-        private readonly TranslationString _editLocalExcludeTitle =
-            new TranslationString("Edit .git/info/exclude");
-
-        private readonly TranslationString _gitignoreOnlyInWorkingDirSupported =
-            new TranslationString(".gitignore is only supported when there is a working directory.");
         private readonly TranslationString _gitignoreOnlyInWorkingDirSupportedCaption =
             new TranslationString("No working directory");
 
-        private readonly TranslationString _cannotAccessGitignore =
-            new TranslationString("Failed to save .gitignore." + Environment.NewLine + "Check if file is accessible.");
-        private readonly TranslationString _cannotAccessGitignoreCaption =
-            new TranslationString("Failed to save .gitignore");
-
-        private readonly TranslationString _saveFileQuestion =
-            new TranslationString("Save changes to .gitignore?");
         private readonly TranslationString _saveFileQuestionCaption =
             new TranslationString("Save changes?");
 
-        private bool _localExclude;
+        private readonly bool _localExclude;
         private string _originalGitIgnoreFileContent = string.Empty;
 
         #region default patterns
@@ -67,6 +56,9 @@ namespace GitUI.CommandsDialogs
             "#Nuget packages folder",
             "packages/"
         };
+
+        private IGitIgnoreDialogModel _dialogModel;
+
         #endregion
 
         public FormGitIgnore(GitUICommands aCommands, bool localExclude)
@@ -76,25 +68,22 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             Translate();
 
-            if (localExclude)
-            {
-                Text = _editLocalExcludeTitle.Text;
-            }
+            _dialogModel = CreateGitIgnoreDialogModel(localExclude);
+
+            Text = _dialogModel.FormCaption;
+        }
+
+        private IGitIgnoreDialogModel CreateGitIgnoreDialogModel(bool localExclude)
+        {
+            if(localExclude)
+                return new GitLocalExcludeModel(Module);
+
+            return new GitIgnoreModel(Module);
         }
 
         private string ExcludeFile
         {
-            get
-            {
-                if (!_localExclude)
-                {
-                    return Path.Combine(Module.WorkingDir, ".gitignore");
-                }
-                else
-                {
-                    return Path.Combine(Module.ResolveGitInternalPath("info"), "exclude");
-                }
-            }
+            get { return _dialogModel.ExcludeFile; }
         }
 
 
@@ -157,8 +146,8 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _cannotAccessGitignore.Text + Environment.NewLine + ex.Message,
-                    _cannotAccessGitignoreCaption.Text);
+                MessageBox.Show(this, _dialogModel.CannotAccessFile + Environment.NewLine + ex.Message,
+                    _dialogModel.CannotAccessFileCaption);
                 return false;
             }
         }
@@ -167,7 +156,7 @@ namespace GitUI.CommandsDialogs
         {
             if (HasUnsavedChanges())
             {
-                switch (MessageBox.Show(this, _saveFileQuestion.Text, _saveFileQuestionCaption.Text,
+                switch (MessageBox.Show(this, _dialogModel.SaveFileQuestion, _saveFileQuestionCaption.Text,
                                     MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question))
                 {
                     case DialogResult.Yes:
@@ -188,7 +177,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.IsBareRepository())
                 return;
-            MessageBox.Show(this, _gitignoreOnlyInWorkingDirSupported.Text, _gitignoreOnlyInWorkingDirSupportedCaption.Text);
+            MessageBox.Show(this, _dialogModel.FileOnlyInWorkingDirSupported, _gitignoreOnlyInWorkingDirSupportedCaption.Text);
             Close();
         }
 

--- a/GitUI/CommandsDialogs/GitIgnoreDialog/GitIgnoreModel.cs
+++ b/GitUI/CommandsDialogs/GitIgnoreDialog/GitIgnoreModel.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.IO;
+using GitCommands;
+using GitUIPluginInterfaces;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.GitIgnoreDialog
+{
+    public class GitIgnoreModel : Translate, IGitIgnoreDialogModel
+    {
+        private readonly TranslationString _editGitignoreTitle =
+            new TranslationString("Edit .gitignore");
+
+        private readonly TranslationString _gitignoreOnlyInWorkingDirSupported =
+            new TranslationString(".gitignore is only supported when there is a working directory.");
+
+        private readonly TranslationString _cannotAccessGitignore =
+            new TranslationString("Failed to save .gitignore." + Environment.NewLine + "Check if file is accessible.");
+
+        private readonly TranslationString _cannotAccessGitignoreCaption =
+            new TranslationString("Failed to save .gitignore");
+
+        private readonly TranslationString _saveFileQuestion =
+            new TranslationString("Save changes to .gitignore?");
+
+        private readonly IGitModule _module;
+
+        public GitIgnoreModel(IGitModule module)
+        {
+            _module = module;
+
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
+
+        public string FormCaption
+        {
+            get { return _editGitignoreTitle.Text; }
+        }
+
+        public string ExcludeFile
+        {
+            get { return Path.Combine(_module.WorkingDir, ".gitignore"); }
+        }
+
+        public string FileOnlyInWorkingDirSupported
+        {
+            get { return _gitignoreOnlyInWorkingDirSupported.Text; }
+        }
+
+        public string CannotAccessFile
+        {
+            get { return _cannotAccessGitignore.Text; }
+        }
+
+        public string CannotAccessFileCaption
+        {
+            get { return _cannotAccessGitignoreCaption.Text; }
+        }
+
+        public string SaveFileQuestion
+        {
+            get { return _saveFileQuestion.Text; }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/GitIgnoreDialog/GitLocalExcludeModel.cs
+++ b/GitUI/CommandsDialogs/GitIgnoreDialog/GitLocalExcludeModel.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+using GitCommands;
+using GitUIPluginInterfaces;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.GitIgnoreDialog
+{
+    public class GitLocalExcludeModel : Translate, IGitIgnoreDialogModel
+    {
+        private readonly TranslationString _editLocalExcludeTitle =
+            new TranslationString("Edit .git/info/exclude");
+
+        private readonly TranslationString _localExcludeOnlyInWorkingDirSupported =
+            new TranslationString(".git/info/exclude is only supported when there is a working directory.");
+
+        private readonly TranslationString _cannotAccessLocalExclude =
+            new TranslationString("Failed to save .git/info/exclude." + Environment.NewLine +
+                                  "Check if file is accessible.");
+
+        private readonly TranslationString _cannotAccessLocalExcludeCaption =
+            new TranslationString("Failed to save .git/info/exclude");
+
+        private readonly TranslationString _saveFileQuestion =
+            new TranslationString("Save changes to .git/info/exclude?");
+
+        private readonly IGitModule _module;
+
+        public GitLocalExcludeModel(IGitModule module)
+        {
+            _module = module;
+
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
+
+        public string FormCaption
+        {
+            get { return _editLocalExcludeTitle.Text; }
+        }
+
+        public string ExcludeFile
+        {
+            get { return Path.Combine(_module.ResolveGitInternalPath("info"), "exclude"); }
+        }
+
+        public string FileOnlyInWorkingDirSupported
+        {
+            get { return _localExcludeOnlyInWorkingDirSupported.Text; }
+        }
+
+        public string CannotAccessFile
+        {
+            get { return _cannotAccessLocalExclude.Text; }
+        }
+
+        public string CannotAccessFileCaption
+        {
+            get { return _cannotAccessLocalExcludeCaption.Text; }
+        }
+
+        public string SaveFileQuestion
+        {
+            get { return _saveFileQuestion.Text; }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/GitIgnoreDialog/IGitIgnoreDialogModel.cs
+++ b/GitUI/CommandsDialogs/GitIgnoreDialog/IGitIgnoreDialogModel.cs
@@ -1,0 +1,12 @@
+﻿namespace GitUI.CommandsDialogs.GitIgnoreDialog
+{
+    public interface IGitIgnoreDialogModel
+    {
+        string FormCaption { get; }
+        string ExcludeFile { get; }
+        string FileOnlyInWorkingDirSupported { get; }
+        string CannotAccessFile { get; }
+        string CannotAccessFileCaption { get; }
+        string SaveFileQuestion { get; }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -137,6 +137,9 @@
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommand.cs" />
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommandsBase.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\CommitTemplateManager.cs" />
+    <Compile Include="CommandsDialogs\GitIgnoreDialog\GitIgnoreModel.cs" />
+    <Compile Include="CommandsDialogs\GitIgnoreDialog\GitLocalExcludeModel.cs" />
+    <Compile Include="CommandsDialogs\GitIgnoreDialog\IGitIgnoreDialogModel.cs" />
     <Compile Include="CommandsDialogs\RevisionFileTree.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -5624,10 +5624,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -5624,14 +5624,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Vytvořit uživatelský gitignore</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Více výrazů .gitignore</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -5663,10 +5663,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -5663,14 +5663,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Genereer een aangepaste gitignore</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Meer gitignore expressies</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4531,11 +4531,11 @@ _ReSharper*/</source>
         <target />
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
+        <source>Generate a custom ignores/ignoring file</source>
         <target />
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
+        <source>More ignores/ignoring patterns</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4531,11 +4531,11 @@ _ReSharper*/</source>
         <target />
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
         <target />
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -5667,14 +5667,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Générer un .gitignore personalisé</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Plus de modèles gitignore</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -5667,10 +5667,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -5685,14 +5685,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Angepasste gitignore erzeugen</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Mehr gitignore-Muster</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -5685,10 +5685,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -5373,12 +5373,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -5373,10 +5373,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -5521,13 +5521,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>さらなるパターン</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -5521,10 +5521,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -5436,10 +5436,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -5436,13 +5436,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>추가 gitignore 패턴</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -5610,10 +5610,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -5610,14 +5610,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Utwórz własny gitignore</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Więcej wzorców gitignore</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -5576,14 +5576,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Gerar gitignore customizado</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Mais modelos do gitignore</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -5576,10 +5576,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -4057,9 +4057,11 @@ obj/
 _ReSharper*/</source>
 
       </trans-unit>
+      <trans-unit id="lnkGitIgnoreGenerate.Text">
+        <source>Generate a custom ignores/ignoring file</source>
+      </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -4058,10 +4058,10 @@ _ReSharper*/</source>
 
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -4636,12 +4636,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -4636,10 +4636,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -5635,14 +5635,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Создавать пользовательский gitignore</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Коллекция шаблонов игнорирования</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -5635,10 +5635,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -5565,13 +5565,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>更多 gitignore 模板</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -5565,10 +5565,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -5615,10 +5615,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -5615,14 +5615,10 @@ _ReSharper*/</target>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>Generar un gitignore personalizado</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>Más patrones gitignore</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -5470,13 +5470,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>更多.gitignore的範例patterns</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -5470,10 +5470,10 @@ _ReSharper*/</source>
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -5670,14 +5670,10 @@ _ŘḗŞħȧřƥḗř*/ ıϖẛϰǈϑǈ ǅſſſǈΐϕΰςſǋ靐 靐ǈϰ ΰ鶱�
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom gitignore</source>
-        <target>[Ɠḗƞḗřȧŧḗ ȧ ƈŭşŧǿḿ ɠīŧīɠƞǿřḗ ς靐ſ靐ǅϰẛ衋 ǋ]</target>
-        
+        <source>Generate a custom ignores/ignoring file</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More gitignore patterns</source>
-        <target>[Ḿǿřḗ ɠīŧīɠƞǿřḗ ƥȧŧŧḗřƞş ϑǅϵǋ 衋ϵǋϰΐǋ]</target>
-        
+        <source>More ignores/ignoring patterns</source>
       </trans-unit>
     </body>
   </file>

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -5670,10 +5670,10 @@ _ŘḗŞħȧřƥḗř*/ ıϖẛϰǈϑǈ ǅſſſǈΐϕΰςſǋ靐 靐ǈϰ ΰ鶱�
         
       </trans-unit>
       <trans-unit id="lnkGitIgnoreGenerate.Text">
-        <source>Generate a custom ignores/ignoring file</source>
+        <source>Generate a custom ignore file for git</source>
       </trans-unit>
       <trans-unit id="lnkGitIgnorePatterns.Text">
-        <source>More ignores/ignoring patterns</source>
+        <source>Example ignore patterns</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Fixes #3860.

Changes proposed in this pull request:
 - Introduce `GitIgnoreModel` and `GitLocalExcludeModel` to use polymorphism instead of `if` checks.
 - Extract strings from `FormGitIgnore` to those files.
 - Change resources for the links.
 - This fix loses some of translated strings, since they are moved to other files.
 
Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/1637680/31316373-98d5f518-ac34-11e7-9f2e-7ee9e7b9edef.png)

- after (updated image)
![image](https://user-images.githubusercontent.com/1637680/31319174-3cc93342-ac67-11e7-9d0b-916850372981.png)


How did I test this code:
I have tested it manually.

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
