### PR TITLE
Path utils refactor

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -420,7 +420,7 @@ namespace GitCommands
                 {
                     var commDir = RunGitCmdResult("rev-parse --git-common-dir");
                     _GitCommonDirectory = PathUtil.ToNativePath(commDir.StdOutput.Trim());
-                    if (!commDir.ExitedSuccessfully || _GitCommonDirectory == ".git" || !PathUtil.DirectoryExists(_GitCommonDirectory))
+                    if (!commDir.ExitedSuccessfully || _GitCommonDirectory == ".git" || !Directory.Exists(_GitCommonDirectory))
                     {
                         _GitCommonDirectory = GetGitDirectory();
                     }

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Git\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitTagController.cs" />
     <Compile Include="Logging\CommandLogEntry.cs" />
+    <Compile Include="PathEqualityComparer.cs" />
     <Compile Include="RemoteActionResult.cs" />
     <Compile Include="Remote\GitRemote.cs" />
     <Compile Include="Remote\GitRemoteController.cs" />

--- a/GitCommands/PathEqualityComparer.cs
+++ b/GitCommands/PathEqualityComparer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using GitCommands.Utils;
+
+namespace GitCommands
+{
+    public class PathEqualityComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string path1, string path2)
+        {
+            path1 = Path.GetFullPath(path1).TrimEnd('\\');
+            path2 = Path.GetFullPath(path2).TrimEnd('\\');
+            var comprasion = !EnvUtils.RunningOnWindows()
+                ? StringComparison.InvariantCulture
+                : StringComparison.InvariantCultureIgnoreCase;
+
+            return string.Compare(path1, path2, comprasion) == 0;
+        }
+
+        public int GetHashCode(string path)
+        {
+            path = Path.GetFullPath(path).TrimEnd('\\');
+            if (EnvUtils.RunningOnWindows())
+            {
+                path = path.ToLower();
+            }
+            return path.GetHashCode();
+        }
+    }
+}

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -188,52 +188,56 @@ namespace GitCommands
             return fi != null;
         }
                 
-        public static bool PathExists(string aPath)
+        public static bool TryFindFullPath(string fileName, out string fullPath)
         {
-            FileInfo fi = null;
             try
             {
-                fi = new FileInfo(aPath);
-            }
-            catch (ArgumentException) { }
-            catch (PathTooLongException) { }
-            catch (NotSupportedException) { }
-
-            return fi != null && fi.Exists;
-        }
-
-        public static bool TryFindFullPath(string aFileName, out string fullPath)
-        {
-            if (PathUtil.PathExists(aFileName))
-            {
-                fullPath = Path.GetFullPath(aFileName);
-                return true;
-            }
-
-            foreach (var path in PathUtil.GetEnvironmentValidPaths())
-            {
-                fullPath = Path.Combine(path, aFileName);
-                if (PathUtil.PathExists(fullPath))
+                if (File.Exists(fileName))
+                {
+                    fullPath = Path.GetFullPath(fileName);
                     return true;
-            }
+                }
 
+                foreach (var path in GetEnvironmentValidPaths())
+                {
+                    fullPath = Path.Combine(path, fileName);
+                    if (File.Exists(fullPath))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                // do nothing 
+            }
             fullPath = null;
             return false;
         }
 
         public static bool TryFindShellPath(string shell, out string shellPath)
         {
-            shellPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", shell);
-            if (PathUtil.PathExists(shellPath))
-                return true;
-
-            shellPath = Path.Combine(AppSettings.GitBinDir, shell);
-            if (PathUtil.PathExists(shellPath))
-                return true;
-
-            if (PathUtil.TryFindFullPath(shell, out shellPath))
-                return true;
-
+            try
+            {
+                shellPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", shell);
+                if (File.Exists(shellPath))
+                {
+                    return true;
+                }
+                shellPath = Path.Combine(AppSettings.GitBinDir, shell);
+                if (File.Exists(shellPath))
+                {
+                    return true;
+                }
+                if (TryFindFullPath(shell, out shellPath))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // do nothing 
+            }
             shellPath = null;
             return false;
         }

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -90,38 +90,6 @@ namespace GitCommands
             return true;
         }
 
-        public static bool Equal(string path1, string path2)
-        {
-            path1 = Path.GetFullPath(path1).TrimEnd('\\');
-            path2 = Path.GetFullPath(path2).TrimEnd('\\');
-            StringComparison comprasion = EnvUtils.RunningOnUnix()
-                                              ? StringComparison.InvariantCulture
-                                              : StringComparison.InvariantCultureIgnoreCase;
-
-            return String.Compare(path1, path2, comprasion) == 0;
-        }
-
-        private class PathEqualityComparer : IEqualityComparer<string>
-        {
-            public bool Equals(string path1, string path2)
-            {
-                return Equal(path1, path2);
-            }
-
-            public int GetHashCode(string path)
-            {
-                path = Path.GetFullPath(path).TrimEnd('\\');
-                if (!EnvUtils.RunningOnUnix())
-                    path = path.ToLower();
-                return path.GetHashCode();
-            }
-        }
-
-        public static IEqualityComparer<string> CreatePathEqualityComparer()
-        {
-            return new PathEqualityComparer();
-        }
-
         public static string GetRepositoryName(string repositoryUrl)
         {
             string name = "";

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -202,19 +202,6 @@ namespace GitCommands
             return fi != null && fi.Exists;
         }
 
-        public static bool DirectoryExists(string aPath)
-        {
-            try
-            {
-                DirectoryInfo di = new DirectoryInfo(aPath);
-                return di.Exists;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
         public static bool TryFindFullPath(string aFileName, out string fullPath)
         {
             if (PathUtil.PathExists(aFileName))

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -702,7 +702,7 @@ namespace GitUI.CommandsDialogs
 
             if (File.Exists(AppSettings.Pageant))
             {
-                HashSet<string> files = new HashSet<string>(PathUtil.CreatePathEqualityComparer());
+                HashSet<string> files = new HashSet<string>(new PathEqualityComparer());
                 foreach (var remote in GetSelectedRemotes())
                 {
                     var sshKeyFile = Module.GetPuttyKeyFileForRemote(remote);

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Helpers\PathUtilTest.cs" />
     <Compile Include="Patch\PatchManagerTest.cs" />
     <Compile Include="Patch\PatchTest.cs" />
+    <Compile Include="PathEqualityComparerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Remote\GitRemoteControllerTests.cs" />
   </ItemGroup>

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -120,21 +120,6 @@ namespace GitCommandsTests.Helpers
         }
 
         [Test]
-        public void EqualTest()
-        {
-            if (Path.DirectorySeparatorChar == '\\')
-            {
-                Assert.AreEqual(PathUtil.Equal("C:\\Work\\GitExtensions\\", "C:/Work/GitExtensions/"), true);
-                Assert.AreEqual(PathUtil.Equal("\\\\my-pc\\Work\\GitExtensions\\", "//my-pc/Work/GitExtensions/"), true);
-            }
-            else
-            {
-                Assert.AreEqual(PathUtil.Equal("/Work/GitExtensions/", "/Work/GitExtensions/"), true);
-                Assert.AreEqual(PathUtil.Equal("//my-pc/Work/GitExtensions/", "//my-pc/Work/GitExtensions/"), true);
-            }
-        }
-
-        [Test]
         public void GetRepositoryNameTest()
         {
             Assert.AreEqual(PathUtil.GetRepositoryName("https://github.com/gitextensions/gitextensions.git"), "gitextensions");

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GitCommands;
 using NUnit.Framework;
 using System.IO;
+using FluentAssertions;
 using GitCommands.Utils;
 
 namespace GitCommandsTests.Helpers
@@ -66,6 +67,7 @@ namespace GitCommandsTests.Helpers
                 Assert.AreEqual("/Work/GitExtensions\\".EnsureTrailingPathSeparator(), "/Work/GitExtensions\\/");
             }
         }
+
         [Test]
         public void IsLocalFileTest()
         {
@@ -203,20 +205,18 @@ namespace GitCommandsTests.Helpers
             CollectionAssert.AreEqual(GetValidPaths().ToArray(), validEnvPaths.ToArray());
         }
 
-        [Test]
-        public void ExistingPathsTest()
+        [Platform(Include = "Win")]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("a:\\folder\\filename.txt")]
+        [TestCase("a:\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\filename.txt")]
+        [TestCase("file:////folder/filename.txt")]
+        [TestCaseSource(nameof(GetInvalidPaths))]
+        public void TryFindFullPath_not_throw_if_file_not_exist(string fileName)
         {
-            Assert.IsTrue(PathUtil.PathExists(GetType().Assembly.Location));
-        }
-
-        [Test]
-        public void NonExistingPathsTest()
-        {
-            GetInvalidPaths().ForEach((path) =>
-            {
-                Assert.IsFalse(PathUtil.PathExists(path));
-            });
-            Assert.IsFalse(PathUtil.PathExists("c:\\94fc5ae63a6c5ed7c110219ade20374ea4d237b9.xyz"));
+            string fullPath;
+            PathUtil.TryFindFullPath(fileName, out fullPath).Should().BeFalse();
         }
 
         private static IEnumerable<string> GetValidPaths()

--- a/UnitTests/GitCommandsTests/PathEqualityComparerTests.cs
+++ b/UnitTests/GitCommandsTests/PathEqualityComparerTests.cs
@@ -1,0 +1,35 @@
+﻿using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class PathEqualityComparerTests
+    {
+        private PathEqualityComparer _comparer;
+
+        [SetUp]
+        public void Setup()
+        {
+            _comparer = new PathEqualityComparer();
+        }
+
+
+        [Platform(Include = "Win")]
+        [TestCase("C:\\WORK\\GitExtensions\\", "C:/Work/GitExtensions/")]
+        [TestCase("\\\\my-pc\\Work\\GitExtensions\\", "//my-pc/WORK/GitExtensions/")]
+        public void Equals(string input, string expected)
+        {
+            Assert.AreEqual(_comparer.Equals(input, expected), true);
+        }
+
+        [Platform(Exclude = "Win")]
+        [TestCase("/Work/GitExtensions/", "/Work/GitExtensions/", true)]
+        [TestCase("/WORK/GitExtensions/", "/Work/GitExtensions/", false)]
+        [TestCase("//my-pc/Work/GitExtensions/", "//my-pc/Work/GitExtensions/", true)]
+        public void Equals_Mono(string input, string expected, bool isEqual)
+        {
+            Assert.AreEqual(_comparer.Equals(input, expected), isEqual);
+        }
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/gitextensions/gitextensions/pull/4032#issuecomment-333517989

* Deprecate PathUtil.DirectoryExists
* Deprecate PathUtil.PathExists
* Move PathEqualityComparer to outer scope