### PR TITLE
New option: Crop path to show un/staged file names in commit dialog

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -97,6 +97,12 @@ namespace GitCommands
             set { SetBool("RememberAmendCommitState", value); }
         }
 
+        public static bool CropPathToShowFileNamesInCommitDialog
+        {
+            get { return GetBool("CropPathToShowFileNamesInCommitDialog", false); }
+            set { SetBool("CropPathToShowFileNamesInCommitDialog", value); }
+        }
+
         public static void UsingContainer(RepoDistSettings aSettingsContainer, Action action)
         {
             SettingsContainer.LockedAction(() =>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -28,228 +28,241 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// </summary>
         private void InitializeComponent()
         {
-            this.groupBoxBehaviour = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanelBehaviour = new System.Windows.Forms.TableLayoutPanel();
-            this.cbRememberAmendCommitState = new System.Windows.Forms.CheckBox();
-            this.chkAutocomplete = new System.Windows.Forms.CheckBox();
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages = new System.Windows.Forms.NumericUpDown();
-            this.lblCommitDialogNumberOfPreviousMessages = new System.Windows.Forms.Label();
-            this.chkShowErrorsWhenStagingFiles = new System.Windows.Forms.CheckBox();
-            this.chkWriteCommitMessageInCommitWindow = new System.Windows.Forms.CheckBox();
-            this.grpAdditionalButtons = new System.Windows.Forms.GroupBox();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.chkShowCommitAndPush = new System.Windows.Forms.CheckBox();
-            this.chkShowResetUnstagedChanges = new System.Windows.Forms.CheckBox();
-            this.chkShowResetAllChanges = new System.Windows.Forms.CheckBox();
-            this.chkAddNewlineToCommitMessageWhenMissing = new System.Windows.Forms.CheckBox();
-            this.groupBoxBehaviour.SuspendLayout();
-            this.tableLayoutPanelBehaviour.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).BeginInit();
-            this.grpAdditionalButtons.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // groupBoxBehaviour
-            // 
-            this.groupBoxBehaviour.AutoSize = true;
-            this.groupBoxBehaviour.Controls.Add(this.tableLayoutPanelBehaviour);
-            this.groupBoxBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
-            this.groupBoxBehaviour.Location = new System.Drawing.Point(0, 0);
-            this.groupBoxBehaviour.Name = "groupBoxBehaviour";
-            this.groupBoxBehaviour.Size = new System.Drawing.Size(974, 270);
-            this.groupBoxBehaviour.TabIndex = 56;
-            this.groupBoxBehaviour.TabStop = false;
-            this.groupBoxBehaviour.Text = "Behaviour";
-            // 
-            // tableLayoutPanelBehaviour
-            // 
-            this.tableLayoutPanelBehaviour.AutoSize = true;
-            this.tableLayoutPanelBehaviour.ColumnCount = 2;
-            this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanelBehaviour.Controls.Add(this.cbRememberAmendCommitState, 0, 6);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.chkAutocomplete, 0, 0);
-            this.tableLayoutPanelBehaviour.Controls.Add(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages, 1, 4);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.lblCommitDialogNumberOfPreviousMessages, 0, 4);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.chkShowErrorsWhenStagingFiles, 0, 1);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.chkWriteCommitMessageInCommitWindow, 0, 3);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.grpAdditionalButtons, 0, 7);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.chkAddNewlineToCommitMessageWhenMissing, 0, 2);
-            this.tableLayoutPanelBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tableLayoutPanelBehaviour.Location = new System.Drawing.Point(3, 17);
-            this.tableLayoutPanelBehaviour.Name = "tableLayoutPanelBehaviour";
-            this.tableLayoutPanelBehaviour.RowCount = 8;
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelBehaviour.Size = new System.Drawing.Size(968, 250);
-            this.tableLayoutPanelBehaviour.TabIndex = 57;
-            // 
-            // cbRememberAmendCommitState
-            // 
-            this.cbRememberAmendCommitState.AutoSize = true;
-            this.cbRememberAmendCommitState.Location = new System.Drawing.Point(3, 135);
-            this.cbRememberAmendCommitState.Name = "cbRememberAmendCommitState";
-            this.cbRememberAmendCommitState.Size = new System.Drawing.Size(304, 17);
-            this.cbRememberAmendCommitState.TabIndex = 5;
-            this.cbRememberAmendCommitState.Text = "Remember \'Amend commit\' checkbox on commit form close";
-            this.cbRememberAmendCommitState.UseVisualStyleBackColor = true;
-            // 
-            // chkAutocomplete
-            // 
-            this.chkAutocomplete.AutoSize = true;
-            this.chkAutocomplete.Location = new System.Drawing.Point(3, 3);
-            this.chkAutocomplete.Name = "chkAutocomplete";
-            this.chkAutocomplete.Size = new System.Drawing.Size(220, 17);
-            this.chkAutocomplete.TabIndex = 0;
-            this.chkAutocomplete.Text = "Provide auto-completion in commit dialog";
-            this.chkAutocomplete.UseVisualStyleBackColor = true;
-            // 
-            // _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages
-            // 
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(313, 108);
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Maximum = new decimal(new int[] {
+			this.groupBoxBehaviour = new System.Windows.Forms.GroupBox();
+			this.tableLayoutPanelBehaviour = new System.Windows.Forms.TableLayoutPanel();
+			this.cbRememberAmendCommitState = new System.Windows.Forms.CheckBox();
+			this.chkAutocomplete = new System.Windows.Forms.CheckBox();
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages = new System.Windows.Forms.NumericUpDown();
+			this.lblCommitDialogNumberOfPreviousMessages = new System.Windows.Forms.Label();
+			this.chkShowErrorsWhenStagingFiles = new System.Windows.Forms.CheckBox();
+			this.chkWriteCommitMessageInCommitWindow = new System.Windows.Forms.CheckBox();
+			this.grpAdditionalButtons = new System.Windows.Forms.GroupBox();
+			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+			this.chkShowCommitAndPush = new System.Windows.Forms.CheckBox();
+			this.chkShowResetUnstagedChanges = new System.Windows.Forms.CheckBox();
+			this.chkShowResetAllChanges = new System.Windows.Forms.CheckBox();
+			this.chkAddNewlineToCommitMessageWhenMissing = new System.Windows.Forms.CheckBox();
+			this.cbCropPathToShowFileNamesInCommitDialog = new System.Windows.Forms.CheckBox();
+			this.groupBoxBehaviour.SuspendLayout();
+			this.tableLayoutPanelBehaviour.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).BeginInit();
+			this.grpAdditionalButtons.SuspendLayout();
+			this.flowLayoutPanel1.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// groupBoxBehaviour
+			// 
+			this.groupBoxBehaviour.AutoSize = true;
+			this.groupBoxBehaviour.Controls.Add(this.tableLayoutPanelBehaviour);
+			this.groupBoxBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
+			this.groupBoxBehaviour.Location = new System.Drawing.Point(0, 0);
+			this.groupBoxBehaviour.Name = "groupBoxBehaviour";
+			this.groupBoxBehaviour.Size = new System.Drawing.Size(1446, 293);
+			this.groupBoxBehaviour.TabIndex = 56;
+			this.groupBoxBehaviour.TabStop = false;
+			this.groupBoxBehaviour.Text = "Behaviour";
+			// 
+			// tableLayoutPanelBehaviour
+			// 
+			this.tableLayoutPanelBehaviour.AutoSize = true;
+			this.tableLayoutPanelBehaviour.ColumnCount = 2;
+			this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanelBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanelBehaviour.Controls.Add(this.cbRememberAmendCommitState, 0, 6);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.chkAutocomplete, 0, 0);
+			this.tableLayoutPanelBehaviour.Controls.Add(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages, 1, 4);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.lblCommitDialogNumberOfPreviousMessages, 0, 4);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.chkShowErrorsWhenStagingFiles, 0, 1);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.chkWriteCommitMessageInCommitWindow, 0, 3);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.grpAdditionalButtons, 0, 8);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.chkAddNewlineToCommitMessageWhenMissing, 0, 2);
+			this.tableLayoutPanelBehaviour.Controls.Add(this.cbCropPathToShowFileNamesInCommitDialog, 0, 7);
+			this.tableLayoutPanelBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
+			this.tableLayoutPanelBehaviour.Location = new System.Drawing.Point(3, 17);
+			this.tableLayoutPanelBehaviour.Name = "tableLayoutPanelBehaviour";
+			this.tableLayoutPanelBehaviour.RowCount = 9;
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanelBehaviour.Size = new System.Drawing.Size(1440, 273);
+			this.tableLayoutPanelBehaviour.TabIndex = 57;
+			// 
+			// cbRememberAmendCommitState
+			// 
+			this.cbRememberAmendCommitState.AutoSize = true;
+			this.cbRememberAmendCommitState.Location = new System.Drawing.Point(3, 135);
+			this.cbRememberAmendCommitState.Name = "cbRememberAmendCommitState";
+			this.cbRememberAmendCommitState.Size = new System.Drawing.Size(304, 17);
+			this.cbRememberAmendCommitState.TabIndex = 5;
+			this.cbRememberAmendCommitState.Text = "Remember \'Amend commit\' checkbox on commit form close";
+			this.cbRememberAmendCommitState.UseVisualStyleBackColor = true;
+			// 
+			// chkAutocomplete
+			// 
+			this.chkAutocomplete.AutoSize = true;
+			this.chkAutocomplete.Location = new System.Drawing.Point(3, 3);
+			this.chkAutocomplete.Name = "chkAutocomplete";
+			this.chkAutocomplete.Size = new System.Drawing.Size(220, 17);
+			this.chkAutocomplete.TabIndex = 0;
+			this.chkAutocomplete.Text = "Provide auto-completion in commit dialog";
+			this.chkAutocomplete.UseVisualStyleBackColor = true;
+			// 
+			// _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages
+			// 
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(313, 108);
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Maximum = new decimal(new int[] {
             999,
             0,
             0,
             0});
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Minimum = new decimal(new int[] {
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Name = "_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages";
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(123, 21);
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.TabIndex = 4;
-            this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = new decimal(new int[] {
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Name = "_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages";
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(123, 21);
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.TabIndex = 4;
+			this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            // 
-            // lblCommitDialogNumberOfPreviousMessages
-            // 
-            this.lblCommitDialogNumberOfPreviousMessages.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.lblCommitDialogNumberOfPreviousMessages.AutoSize = true;
-            this.lblCommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(3, 112);
-            this.lblCommitDialogNumberOfPreviousMessages.Name = "lblCommitDialogNumberOfPreviousMessages";
-            this.lblCommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(229, 13);
-            this.lblCommitDialogNumberOfPreviousMessages.TabIndex = 2;
-            this.lblCommitDialogNumberOfPreviousMessages.Text = "Number of previous messages in commit dialog";
-            // 
-            // chkShowErrorsWhenStagingFiles
-            // 
-            this.chkShowErrorsWhenStagingFiles.AutoSize = true;
-            this.chkShowErrorsWhenStagingFiles.Location = new System.Drawing.Point(3, 26);
-            this.chkShowErrorsWhenStagingFiles.Name = "chkShowErrorsWhenStagingFiles";
-            this.chkShowErrorsWhenStagingFiles.Size = new System.Drawing.Size(173, 17);
-            this.chkShowErrorsWhenStagingFiles.TabIndex = 1;
-            this.chkShowErrorsWhenStagingFiles.Text = "Show errors when staging files";
-            this.chkShowErrorsWhenStagingFiles.UseVisualStyleBackColor = true;
-            // 
-            // chkWriteCommitMessageInCommitWindow
-            // 
-            this.chkWriteCommitMessageInCommitWindow.AutoSize = true;
-            this.chkWriteCommitMessageInCommitWindow.Location = new System.Drawing.Point(3, 72);
-            this.chkWriteCommitMessageInCommitWindow.Name = "chkWriteCommitMessageInCommitWindow";
-            this.chkWriteCommitMessageInCommitWindow.Size = new System.Drawing.Size(298, 30);
-            this.chkWriteCommitMessageInCommitWindow.TabIndex = 3;
-            this.chkWriteCommitMessageInCommitWindow.Text = "Compose commit messages in Commit dialog\r\n(otherwise the message will be requeste" +
+			// 
+			// lblCommitDialogNumberOfPreviousMessages
+			// 
+			this.lblCommitDialogNumberOfPreviousMessages.Anchor = System.Windows.Forms.AnchorStyles.Left;
+			this.lblCommitDialogNumberOfPreviousMessages.AutoSize = true;
+			this.lblCommitDialogNumberOfPreviousMessages.Location = new System.Drawing.Point(3, 112);
+			this.lblCommitDialogNumberOfPreviousMessages.Name = "lblCommitDialogNumberOfPreviousMessages";
+			this.lblCommitDialogNumberOfPreviousMessages.Size = new System.Drawing.Size(229, 13);
+			this.lblCommitDialogNumberOfPreviousMessages.TabIndex = 2;
+			this.lblCommitDialogNumberOfPreviousMessages.Text = "Number of previous messages in commit dialog";
+			// 
+			// chkShowErrorsWhenStagingFiles
+			// 
+			this.chkShowErrorsWhenStagingFiles.AutoSize = true;
+			this.chkShowErrorsWhenStagingFiles.Location = new System.Drawing.Point(3, 26);
+			this.chkShowErrorsWhenStagingFiles.Name = "chkShowErrorsWhenStagingFiles";
+			this.chkShowErrorsWhenStagingFiles.Size = new System.Drawing.Size(173, 17);
+			this.chkShowErrorsWhenStagingFiles.TabIndex = 1;
+			this.chkShowErrorsWhenStagingFiles.Text = "Show errors when staging files";
+			this.chkShowErrorsWhenStagingFiles.UseVisualStyleBackColor = true;
+			// 
+			// chkWriteCommitMessageInCommitWindow
+			// 
+			this.chkWriteCommitMessageInCommitWindow.AutoSize = true;
+			this.chkWriteCommitMessageInCommitWindow.Location = new System.Drawing.Point(3, 72);
+			this.chkWriteCommitMessageInCommitWindow.Name = "chkWriteCommitMessageInCommitWindow";
+			this.chkWriteCommitMessageInCommitWindow.Size = new System.Drawing.Size(298, 30);
+			this.chkWriteCommitMessageInCommitWindow.TabIndex = 3;
+			this.chkWriteCommitMessageInCommitWindow.Text = "Compose commit messages in Commit dialog\r\n(otherwise the message will be requeste" +
     "d during commit)";
-            this.chkWriteCommitMessageInCommitWindow.UseVisualStyleBackColor = true;
+			this.chkWriteCommitMessageInCommitWindow.UseVisualStyleBackColor = true;
+			// 
+			// grpAdditionalButtons
+			// 
+			this.grpAdditionalButtons.AutoSize = true;
+			this.grpAdditionalButtons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.tableLayoutPanelBehaviour.SetColumnSpan(this.grpAdditionalButtons, 2);
+			this.grpAdditionalButtons.Controls.Add(this.flowLayoutPanel1);
+			this.grpAdditionalButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.grpAdditionalButtons.Location = new System.Drawing.Point(3, 181);
+			this.grpAdditionalButtons.Name = "grpAdditionalButtons";
+			this.grpAdditionalButtons.Size = new System.Drawing.Size(1434, 89);
+			this.grpAdditionalButtons.TabIndex = 6;
+			this.grpAdditionalButtons.TabStop = false;
+			this.grpAdditionalButtons.Text = "Show additional buttons in commit button area";
+			// 
+			// flowLayoutPanel1
+			// 
+			this.flowLayoutPanel1.AutoSize = true;
+			this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.flowLayoutPanel1.Controls.Add(this.chkShowCommitAndPush);
+			this.flowLayoutPanel1.Controls.Add(this.chkShowResetUnstagedChanges);
+			this.flowLayoutPanel1.Controls.Add(this.chkShowResetAllChanges);
+			this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+			this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 17);
+			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+			this.flowLayoutPanel1.Size = new System.Drawing.Size(1428, 69);
+			this.flowLayoutPanel1.TabIndex = 0;
+			// 
+			// chkShowCommitAndPush
+			// 
+			this.chkShowCommitAndPush.AutoSize = true;
+			this.chkShowCommitAndPush.Location = new System.Drawing.Point(3, 3);
+			this.chkShowCommitAndPush.Name = "chkShowCommitAndPush";
+			this.chkShowCommitAndPush.Size = new System.Drawing.Size(97, 17);
+			this.chkShowCommitAndPush.TabIndex = 0;
+			this.chkShowCommitAndPush.Text = "Commit && Push";
+			this.chkShowCommitAndPush.UseVisualStyleBackColor = true;
+			// 
+			// chkShowResetUnstagedChanges
+			// 
+			this.chkShowResetUnstagedChanges.AutoSize = true;
+			this.chkShowResetUnstagedChanges.Location = new System.Drawing.Point(3, 26);
+			this.chkShowResetUnstagedChanges.Name = "chkShowResetUnstagedChanges";
+			this.chkShowResetUnstagedChanges.Size = new System.Drawing.Size(148, 17);
+			this.chkShowResetUnstagedChanges.TabIndex = 1;
+			this.chkShowResetUnstagedChanges.Text = "Reset Unstaged Changes";
+			this.chkShowResetUnstagedChanges.UseVisualStyleBackColor = true;
+			// 
+			// chkShowResetAllChanges
+			// 
+			this.chkShowResetAllChanges.AutoSize = true;
+			this.chkShowResetAllChanges.Location = new System.Drawing.Point(3, 49);
+			this.chkShowResetAllChanges.Name = "chkShowResetAllChanges";
+			this.chkShowResetAllChanges.Size = new System.Drawing.Size(113, 17);
+			this.chkShowResetAllChanges.TabIndex = 2;
+			this.chkShowResetAllChanges.Text = "Reset All Changes";
+			this.chkShowResetAllChanges.UseVisualStyleBackColor = true;
+			// 
+			// chkAddNewlineToCommitMessageWhenMissing
+			// 
+			this.chkAddNewlineToCommitMessageWhenMissing.AutoSize = true;
+			this.chkAddNewlineToCommitMessageWhenMissing.Location = new System.Drawing.Point(3, 49);
+			this.chkAddNewlineToCommitMessageWhenMissing.Name = "chkAddNewlineToCommitMessageWhenMissing";
+			this.chkAddNewlineToCommitMessageWhenMissing.Size = new System.Drawing.Size(271, 17);
+			this.chkAddNewlineToCommitMessageWhenMissing.TabIndex = 2;
+			this.chkAddNewlineToCommitMessageWhenMissing.Text = "Ensure the second line of commit message is empty";
+			this.chkAddNewlineToCommitMessageWhenMissing.UseVisualStyleBackColor = true;
             // 
-            // grpAdditionalButtons
+            // cbCropPathToShowFileNamesInCommitDialog
             // 
-            this.grpAdditionalButtons.AutoSize = true;
-            this.grpAdditionalButtons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanelBehaviour.SetColumnSpan(this.grpAdditionalButtons, 2);
-            this.grpAdditionalButtons.Controls.Add(this.flowLayoutPanel1);
-            this.grpAdditionalButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpAdditionalButtons.Location = new System.Drawing.Point(3, 158);
-            this.grpAdditionalButtons.Name = "grpAdditionalButtons";
-            this.grpAdditionalButtons.Size = new System.Drawing.Size(962, 89);
-            this.grpAdditionalButtons.TabIndex = 6;
-            this.grpAdditionalButtons.TabStop = false;
-            this.grpAdditionalButtons.Text = "Show additional buttons in commit button area";
-            // 
-            // flowLayoutPanel1
-            // 
-            this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.flowLayoutPanel1.Controls.Add(this.chkShowCommitAndPush);
-            this.flowLayoutPanel1.Controls.Add(this.chkShowResetUnstagedChanges);
-            this.flowLayoutPanel1.Controls.Add(this.chkShowResetAllChanges);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 17);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(956, 69);
-            this.flowLayoutPanel1.TabIndex = 0;
-            // 
-            // chkShowCommitAndPush
-            // 
-            this.chkShowCommitAndPush.AutoSize = true;
-            this.chkShowCommitAndPush.Location = new System.Drawing.Point(3, 3);
-            this.chkShowCommitAndPush.Name = "chkShowCommitAndPush";
-            this.chkShowCommitAndPush.Size = new System.Drawing.Size(97, 17);
-            this.chkShowCommitAndPush.TabIndex = 0;
-            this.chkShowCommitAndPush.Text = "Commit && Push";
-            this.chkShowCommitAndPush.UseVisualStyleBackColor = true;
-            // 
-            // chkShowResetUnstagedChanges
-            // 
-            this.chkShowResetUnstagedChanges.AutoSize = true;
-            this.chkShowResetUnstagedChanges.Location = new System.Drawing.Point(3, 26);
-            this.chkShowResetUnstagedChanges.Name = "chkShowResetUnstagedChanges";
-            this.chkShowResetUnstagedChanges.Size = new System.Drawing.Size(148, 17);
-            this.chkShowResetUnstagedChanges.TabIndex = 1;
-            this.chkShowResetUnstagedChanges.Text = "Reset Unstaged Changes";
-            this.chkShowResetUnstagedChanges.UseVisualStyleBackColor = true;
-            // 
-            // chkShowResetAllChanges
-            // 
-            this.chkShowResetAllChanges.AutoSize = true;
-            this.chkShowResetAllChanges.Location = new System.Drawing.Point(3, 49);
-            this.chkShowResetAllChanges.Name = "chkShowResetAllChanges";
-            this.chkShowResetAllChanges.Size = new System.Drawing.Size(113, 17);
-            this.chkShowResetAllChanges.TabIndex = 2;
-            this.chkShowResetAllChanges.Text = "Reset All Changes";
-            this.chkShowResetAllChanges.UseVisualStyleBackColor = true;
-            // 
-            // chkAddNewlineToCommitMessageWhenMissing
-            // 
-            this.chkAddNewlineToCommitMessageWhenMissing.AutoSize = true;
-            this.chkAddNewlineToCommitMessageWhenMissing.Location = new System.Drawing.Point(3, 49);
-            this.chkAddNewlineToCommitMessageWhenMissing.Name = "chkAddNewlineToCommitMessageWhenMissing";
-            this.chkAddNewlineToCommitMessageWhenMissing.Size = new System.Drawing.Size(271, 17);
-            this.chkAddNewlineToCommitMessageWhenMissing.TabIndex = 2;
-            this.chkAddNewlineToCommitMessageWhenMissing.Text = "Ensure the second line of commit message is empty";
-            this.chkAddNewlineToCommitMessageWhenMissing.UseVisualStyleBackColor = true;
-            // 
-            // CommitDialogSettingsPage
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.AutoScroll = true;
-            this.Controls.Add(this.groupBoxBehaviour);
-            this.Name = "CommitDialogSettingsPage";
-            this.Size = new System.Drawing.Size(974, 452);
-            this.groupBoxBehaviour.ResumeLayout(false);
-            this.groupBoxBehaviour.PerformLayout();
-            this.tableLayoutPanelBehaviour.ResumeLayout(false);
-            this.tableLayoutPanelBehaviour.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).EndInit();
-            this.grpAdditionalButtons.ResumeLayout(false);
-            this.grpAdditionalButtons.PerformLayout();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+            this.cbCropPathToShowFileNamesInCommitDialog.AutoSize = true;
+			this.cbCropPathToShowFileNamesInCommitDialog.Location = new System.Drawing.Point(3, 158);
+			this.cbCropPathToShowFileNamesInCommitDialog.Name = "cbCropPathToShowFileNamesInCommitDialog";
+			this.cbCropPathToShowFileNamesInCommitDialog.Size = new System.Drawing.Size(294, 17);
+			this.cbCropPathToShowFileNamesInCommitDialog.TabIndex = 5;
+			this.cbCropPathToShowFileNamesInCommitDialog.Text = "Crop path to show un/staged file names in commit dialog";
+			this.cbCropPathToShowFileNamesInCommitDialog.UseVisualStyleBackColor = true;
+			// 
+			// CommitDialogSettingsPage
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+			this.AutoScroll = true;
+			this.Controls.Add(this.groupBoxBehaviour);
+			this.Name = "CommitDialogSettingsPage";
+			this.Size = new System.Drawing.Size(1446, 756);
+			this.groupBoxBehaviour.ResumeLayout(false);
+			this.groupBoxBehaviour.PerformLayout();
+			this.tableLayoutPanelBehaviour.ResumeLayout(false);
+			this.tableLayoutPanelBehaviour.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).EndInit();
+			this.grpAdditionalButtons.ResumeLayout(false);
+			this.grpAdditionalButtons.PerformLayout();
+			this.flowLayoutPanel1.ResumeLayout(false);
+			this.flowLayoutPanel1.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 
@@ -269,5 +282,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private System.Windows.Forms.CheckBox chkAddNewlineToCommitMessageWhenMissing;
         private System.Windows.Forms.CheckBox chkAutocomplete;
         private System.Windows.Forms.CheckBox cbRememberAmendCommitState;
+        private System.Windows.Forms.CheckBox cbCropPathToShowFileNamesInCommitDialog;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
@@ -22,6 +22,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowResetAllChanges.Checked = AppSettings.ShowResetAllChanges;
             chkAutocomplete.Checked = AppSettings.ProvideAutocompletion;
             cbRememberAmendCommitState.Checked = AppSettings.RememberAmendCommitState;
+            cbCropPathToShowFileNamesInCommitDialog.Checked = AppSettings.CropPathToShowFileNamesInCommitDialog;
         }
 
         protected override void PageToSettings()
@@ -35,6 +36,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowResetAllChanges = chkShowResetAllChanges.Checked;
             AppSettings.ProvideAutocompletion = chkAutocomplete.Checked;
             AppSettings.RememberAmendCommitState = cbRememberAmendCommitState.Checked;
+            AppSettings.CropPathToShowFileNamesInCommitDialog = cbCropPathToShowFileNamesInCommitDialog.Checked;
         }
     }
 }

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -831,6 +831,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Zajistěte, aby druhá řádka zprávy odevzdání byla prázdná</target>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -831,6 +831,10 @@ Zorg dat git (Git voor Windows of cygwin) is geïnstalleerd of stel het pad hand
         <target>Vergeet de 'Wijzig commit' checkbox niet bij het sluiten van de commit form</target>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Controleer dat de twee regel van het bericht leeg is</target>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -670,6 +670,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         <target />
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target />

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -835,6 +835,10 @@ Veuillez vous assurez que git (Git for Windows ou cygwin) est installé ou rense
         <target>Mémoriser l'état de la case à cocher 'Rectifier le commit' lors de la fermeture du formulaire de commit</target>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Assurez-vous que la 2ème ligne du message de commit soit vide</target>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -835,6 +835,10 @@ Stellen Sie sicher, dadd git (Git für Windows oder cygwin) installiert wurde od
         <target>Speichere 'Commit anpassen' Einstellung beim Schließen des Commit Dialogs.</target>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Stellen Sie sicher, dass die zweite Zeile der Commit Nachricht leer ist</target>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -812,6 +812,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -818,6 +818,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>コミットメッセージの2行目が空行であることを保証</target>

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -815,6 +815,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -832,6 +832,10 @@ Upewnij się, czy jest zainstalowany git (Git dla Windows lub cygwin) lub ustal 
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Upewnij się, czy druga linia wiadomości zatwierdzenia jest pusta</target>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -830,6 +830,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Certifique-se que a segunda linha da mensagem de commit esteja vazia</target>

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -699,6 +699,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -832,6 +832,11 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        <target>Обрезать путь чтобы показывать имя файла в окне комита</target>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Убедитесь что вторая строка сообщение коммита пустая</target>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -832,6 +832,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>确保提交信息第二行是空的</target>

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -832,6 +832,10 @@ Por favor asegúrese que git (Git for Windows o cygwin) está instalado o config
         <target>Recordar casilla 'Arreglar commit' al cerrar la ventana de commit</target>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>Asegúrese de que la segunda línea del mensaje de commit esté vacía</target>

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -817,6 +817,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -833,6 +833,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target>[Řḗḿḗḿƀḗř 'Ȧḿḗƞḓ ƈǿḿḿīŧ' ƈħḗƈķƀǿẋ ǿƞ ƈǿḿḿīŧ ƒǿřḿ ƈŀǿşḗ ǋϕ衋ϰΐϖǈſ]</target>
         
       </trans-unit>
+      <trans-unit id="cbCropPathToShowFileNmesInCommitDialog.Text">
+        <source>Crop path to show un/staged file names in commit dialog</source>
+        
+      </trans-unit>
       <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
         <source>Ensure the second line of commit message is empty</source>
         <target>[Ḗƞşŭřḗ ŧħḗ şḗƈǿƞḓ ŀīƞḗ ǿƒ ƈǿḿḿīŧ ḿḗşşȧɠḗ īş ḗḿƥŧẏ 鶱ıς衋ΰǋ ςϱſ]</target>


### PR DESCRIPTION
Feature.

Changes proposed in this pull request:
- option can show files list to show file name if full path doesn't fit to window. Ex.:
was:
"GitUI\CommandsDialogs\SettingsDialog\Pages\Com"
will:
"GitUI\CommandsDi...\CommitDialogSettingsPage.cs"
 
Screenshots before and after (if PR changes UI):
- before:
![gitextensions_crop_path_before](https://user-images.githubusercontent.com/2765902/31352404-5ce69f04-ad37-11e7-9877-80e6ee81652b.png)
- after:
![gitextensions_crop_path_after](https://user-images.githubusercontent.com/2765902/31352427-69b1d028-ad37-11e7-9541-549422c5aa8f.png)

How did I test this code:
- run multiple times with various width and changed files

Has been tested on (remove any that don't apply):
- Windows 10
