### PR TITLE
FileStatusList had useless horizontal scrollbar

### DIFF
--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -62,14 +62,7 @@ namespace GitUI
 
             if (truncatePathMethod.Equals("fileNameOnly"))
             {
-                name = name.TrimEnd(AppSettings.PosixPathSeparator);
-                var fileName = Path.GetFileName(name);
-                var oldFileName = Path.GetFileName(oldName);
-                
-                if (fileName.Equals(oldFileName))
-                    oldFileName = null;
-
-                return fileName.Combine(" ", oldFileName.AddParenthesesNE());
+                return FormatTextForFileNameOnly(name, oldName);
             }
 
             if ((!truncatePathMethod.Equals("compact", StringComparison.OrdinalIgnoreCase) || !EnvUtils.RunningOnWindows()) &&
@@ -93,6 +86,18 @@ namespace GitUI
             }
 
             return result;
+        }
+
+        public static string FormatTextForFileNameOnly(string name, string oldName)
+        {
+            name = name.TrimEnd(AppSettings.PosixPathSeparator);
+            var fileName = Path.GetFileName(name);
+            var oldFileName = Path.GetFileName(oldName);
+
+            if (fileName.Equals(oldFileName))
+                oldFileName = null;
+
+            return fileName.Combine(" ", oldFileName.AddParenthesesNE());
         }
 
         private static string FormatString(string name, string oldName, int step, bool isNameTruncated)


### PR DESCRIPTION
Useless horizontal scrollbar has been removed in FileStatusList control for compact, trimstart and fileNameOnly modes.
 
Has been tested on (remove any that don't apply):
 - Windows 10

P.S. You can notice that in fileNameOnly mode all list-items are processed the same way as in OnDraw method. I tested 100k items and they took only 65 ms on mobile i5 in debug. So it should be ok if I'm right.