### PR TITLE
Unable to filter file list in commit form

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -322,7 +322,7 @@ namespace GitUI.CommandsDialogs
 
         private bool AddToGitIgnore()
         {
-            if (Unstaged.Focused)
+            if (Unstaged.FileListFocused)
             {
                 AddFileTogitignoreToolStripMenuItemClick(this, null);
                 return true;
@@ -332,7 +332,7 @@ namespace GitUI.CommandsDialogs
 
         private bool DeleteSelectedFiles()
         {
-            if (Unstaged.Focused)
+            if (Unstaged.FileListFocused)
             {
                 DeleteFileToolStripMenuItemClick(this, null);
                 return true;
@@ -366,7 +366,7 @@ namespace GitUI.CommandsDialogs
 
         private bool ResetSelectedFiles()
         {
-            if (Unstaged.Focused || Staged.Focused)
+            if (Unstaged.FileListFocused || Staged.FileListFocused)
             {
                 ResetSoftClick(this, null);
                 return true;
@@ -382,7 +382,7 @@ namespace GitUI.CommandsDialogs
 
         private bool StageSelectedFile()
         {
-            if (Unstaged.Focused)
+            if (Unstaged.FileListFocused)
             {
                 StageClick(this, null);
                 return true;
@@ -398,7 +398,7 @@ namespace GitUI.CommandsDialogs
 
         private bool UnStageSelectedFile()
         {
-            if (Staged.Focused)
+            if (Staged.FileListFocused)
             {
                 UnstageFilesClick(this, null);
                 return true;
@@ -426,7 +426,7 @@ namespace GitUI.CommandsDialogs
 
         private bool StartFileHistoryDialog()
         {
-            if (Staged.Focused || Unstaged.Focused)
+            if (Staged.FileListFocused || Unstaged.FileListFocused)
             {
                 if (_currentFilesList.SelectedItem != null)
                 {

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -155,11 +155,11 @@ namespace GitUI
             }
         }
 
-        public override bool Focused
+        public bool FileListFocused
         {
             get
             {
-                return FileStatusListView.Focused || FilterComboBox.Focused;
+                return FileStatusListView.Focused;
             }
         }
 


### PR DESCRIPTION
Fixes #4062 

Changes proposed in this pull request:
 - Able to filter file list in the commit form even if the key word contains hotkeys such as `r`, `s`, `u` and `h`
 
How did I test this code:
 - Type `r`, `s`, `u` and `h` in the filtering textbox, the application is able to filter the list
 - As regression test, focus on the file list and try the hotkeys, the application is able to respond to the hotkeys.

Has been tested on (remove any that don't apply):
 - GIT 2.13
 - Windows 10