### PR TITLE
Try to find ssh.exe in git installation directory

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -48,6 +48,8 @@ namespace GitCommands
 
     public static class GitCommandHelpers
     {
+        private static readonly ISshPathLocator SshPathLocatorInstance = new SshPathLocator();
+
         public static void SetEnvironmentVariable(bool reload = false)
         {
             string path = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process);
@@ -122,7 +124,7 @@ namespace GitCommands
             }
         }
 
-	    public static ProcessStartInfo CreateProcessStartInfo(string fileName, string arguments, string workingDirectory, Encoding outputEncoding)
+        public static ProcessStartInfo CreateProcessStartInfo(string fileName, string arguments, string workingDirectory, Encoding outputEncoding)
         {
             return new ProcessStartInfo
             {
@@ -161,7 +163,7 @@ namespace GitCommands
             return startProcess;
         }
 
-	    public static bool UseSsh(string arguments)
+        public static bool UseSsh(string arguments)
         {
             var x = !Plink() && GetArgumentsRequiresSsh(arguments);
             return x || arguments.Contains("plink");
@@ -603,17 +605,9 @@ namespace GitCommands
 
         public static bool Plink()
         {
-            var sshString = GetSsh();
+            var sshString = SshPathLocatorInstance.Find(AppSettings.GitBinDir);
 
             return sshString.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
-        }
-
-        /// <summary>Gets the git SSH command; or "" if the environment variable is NOT set.</summary>
-        public static string GetSsh()
-        {
-            var ssh = Environment.GetEnvironmentVariable("GIT_SSH", EnvironmentVariableTarget.Process);
-
-            return ssh ?? "";
         }
 
         /// <summary>Pushes multiple sets of local branches to remote branches.</summary>

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Git\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDirectoryResolver.cs" />
     <Compile Include="Git\GitTagController.cs" />
+    <Compile Include="SshPathLocator.cs" />
     <Compile Include="Logging\CommandLogEntry.cs" />
     <Compile Include="PathEqualityComparer.cs" />
     <Compile Include="RemoteActionResult.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.IO.Abstractions;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
@@ -30,6 +31,7 @@ namespace GitCommands
         public static Version AppVersion { get { return Assembly.GetCallingAssembly().GetName().Version; } }
         public static string ProductVersion { get { return Application.ProductVersion; } }
         public static readonly string SettingsFileName = "GitExtensions.settings";
+        private static readonly ISshPathLocator SshPathLocatorInstance = new SshPathLocator();
 
         public static readonly Lazy<string> ApplicationDataPath;
         public static string SettingsFilePath { get { return Path.Combine(ApplicationDataPath.Value, SettingsFileName); } }
@@ -1195,7 +1197,7 @@ namespace GitCommands
             {
                 SettingsContainer.LockedAction(() =>
                 {
-                    SshPath = GitCommandHelpers.GetSsh();
+                    SshPath = SshPathLocatorInstance.Find(GitBinDir);
                     Repositories.SaveSettings();
 
                     SettingsContainer.Save();

--- a/GitCommands/SshPathLocator.cs
+++ b/GitCommands/SshPathLocator.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+
+namespace GitCommands
+{
+    public interface ISshPathLocator
+    {
+        string Find(string gitBinDirectory);
+    }
+
+    public sealed class SshPathLocator : ISshPathLocator
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly IEnvironmentAbstraction _environment;
+
+        public SshPathLocator(IFileSystem fileSystem, IEnvironmentAbstraction environment)
+        {
+            _fileSystem = fileSystem;
+            _environment = environment;
+        }
+        public SshPathLocator()
+            : this(new FileSystem(), new EnvironmentAbstraction())
+        {
+        }
+
+
+        /// <summary>
+        /// Gets the git SSH command;
+        /// If the environment variable is not set, will try to find ssh.exe in git installation directory;
+        /// If not found, will return "".
+        /// </summary>
+        public string Find(string gitBinDirectory)
+        {
+            var ssh = _environment.GetEnvironmentVariable("GIT_SSH", EnvironmentVariableTarget.Process);
+
+            if (string.IsNullOrEmpty(ssh))
+            {
+                ssh = GetSshFromGitDir(gitBinDirectory);
+            }
+
+            return ssh ?? "";
+        }
+
+        private string GetSshFromGitDir(string gitBinDirectory)
+        {
+            if (string.IsNullOrEmpty(gitBinDirectory))
+            {
+                return null;
+            }
+            try
+            {
+                var gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory);
+                if (gitDirInfo == null)
+                {
+                    return null;
+                }
+                return _fileSystem.Directory.EnumerateFiles(gitDirInfo.FullName, "ssh.exe", SearchOption.AllDirectories).FirstOrDefault();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+            
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -157,6 +157,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         #endregion
 
         private const string _putty = "PuTTY";
+        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
 
         /// <summary>
         /// TODO: remove this direct dependency to another SettingsPage later when possible
@@ -492,7 +493,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                                         _puttyConfigured.Text);
             }
 
-            var ssh = GitCommandHelpers.GetSsh();
+            var ssh = _sshPathLocator.Find(AppSettings.GitBinDir);
             RenderSettingSet(SshConfig, SshConfig_Fix, string.IsNullOrEmpty(ssh) ? _opensshUsed.Text : string.Format(_unknownSshClient.Text, ssh));
             return true;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -10,6 +10,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class SshSettingsPage : SettingsPageWithHeader
     {
+        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
 
         public SshSettingsPage()
         {
@@ -37,13 +38,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             PageantPath.Text = AppSettings.Pageant;
             AutostartPageant.Checked = AppSettings.AutoStartPageant;
 
-            if (string.IsNullOrEmpty(GitCommandHelpers.GetSsh()))
+            var sshPath = _sshPathLocator.Find(AppSettings.GitBinDir);
+            if (string.IsNullOrEmpty(sshPath))
                 OpenSSH.Checked = true;
             else if (GitCommandHelpers.Plink())
                 Putty.Checked = true;
             else
             {
-                OtherSsh.Text = GitCommandHelpers.GetSsh();
+                OtherSsh.Text = sshPath;
                 Other.Checked = true;
             }
 

--- a/Plugins/Gerrit/GerritUtil.cs
+++ b/Plugins/Gerrit/GerritUtil.cs
@@ -12,6 +12,8 @@ namespace Gerrit
 {
     internal static class GerritUtil
     {
+        private static readonly ISshPathLocator SshPathLocatorInstance = new SshPathLocator();
+
         public static string RunGerritCommand([NotNull] IWin32Window owner, [NotNull] IGitModule aModule, [NotNull] string command, [NotNull] string remote, byte[] stdIn)
         {
             var fetchUrl = GetFetchUrl(aModule, remote);
@@ -43,7 +45,7 @@ namespace Gerrit
 
             StartAgent(owner, aModule, remote);
 
-            var sshCmd = GitCommandHelpers.GetSsh();
+            var sshCmd = SshPathLocatorInstance.Find(AppSettings.GitBinDir);
             if (GitCommandHelpers.Plink())
             {
                 sshCmd = AppSettings.Plink;

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="PathEqualityComparerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Remote\GitRemoteControllerTests.cs" />
+    <Compile Include="SshPathLocatorTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/UnitTests/GitCommandsTests/SshPathLocatorTest.cs
+++ b/UnitTests/GitCommandsTests/SshPathLocatorTest.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using System.IO.Abstractions;
+using FluentAssertions;
+using GitCommands;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class SshPathLocatorTest
+    {
+        private IFileSystem _fileSystem;
+        private IEnvironmentAbstraction _environment;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fileSystem = Substitute.For<IFileSystem>();
+            _environment = Substitute.For<IEnvironmentAbstraction>();
+        }
+
+        [Test]
+        public void Find_should_return_GIT_SSH_environment_variable_if_set()
+        {
+            const string path = @"C:\somedir\ssh.exe";
+            _environment.GetEnvironmentVariable("GIT_SSH", EnvironmentVariableTarget.Process).Returns(path);
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(@"c:\someotherdir").Should().Be(path);
+        }
+
+        [Test]
+        public void Find_on_null_should_return_empty_string_if_no_GIT_SSH_is_set()
+        {
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(null).Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void Find_on_gitBinDir_having_no_parent_should_return_empty_string_if_no_GIT_SSH_is_set()
+        {
+            const string path = @"C:\";
+            var directoryBase = Substitute.For<DirectoryBase>();
+            directoryBase.GetParent(path).Returns((DirectoryInfoBase) null);
+            _fileSystem.Directory.Returns(directoryBase);
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(path).Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void File_system_access_throwing_should_return_empty_string()
+        {
+            const string path = @"C:\";
+            var directoryBase = Substitute.For<DirectoryBase>();
+            directoryBase.GetParent(path).Throws<Exception>();
+            _fileSystem.Directory.Returns(directoryBase);
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(path).Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void Find_on_gitBinDir_parent_throwing_should_return_empty_string()
+        {
+            const string path = @"C:\";
+            var directoryBase = Substitute.For<DirectoryBase>();
+            directoryBase.GetParent(path).Throws<Exception>();
+            _fileSystem.Directory.Returns(directoryBase);
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(path).Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void Find_on_gitBinDir_having_ssh_exe_in_parent_directory_childrens_should_return_first_ssh_exe_found()
+        {
+            var path = SetUpFileSystemWithSshExePathsAs("first", "second");
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(path).Should().Be("first");
+        }
+
+        [Test]
+        public void Find_on_gitBinDir_having_no_ssh_exe_in_parent_directory_childrens_should_return_empty_string()
+        {
+            var path = SetUpFileSystemWithSshExePathsAs();
+            var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
+            sshPathLocator.Find(path).Should().Be(string.Empty);
+        }
+
+        private string SetUpFileSystemWithSshExePathsAs(params string[] sshExePaths)
+        {
+            const string path = @"C:\somedir";
+            const string parentPath = @"C:\";
+            var gitDir = Substitute.For<DirectoryInfoBase>();
+            gitDir.FullName.Returns(parentPath);
+            var directoryBase = Substitute.For<DirectoryBase>();
+            directoryBase.GetParent(path).Returns(gitDir);
+            directoryBase.EnumerateFiles(parentPath, "ssh.exe", SearchOption.AllDirectories).Returns(sshExePaths);
+            _fileSystem.Directory.Returns(directoryBase);
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- GIT_SSH environment variable is not always set. As a result, ssh is not found,
resulting in various failures. On of them is that the gerrit plugin fails to
install the commit-msg hook, with a very unuseful message.
- Of course, there is still a possibility to set this environemnt variable, but
this is an extra step.
- The change adds a try to retrieve ssh.exe from git installation directory,
when no environment variable is found. 

How did I test this code:
 - Desktop with no GIT_SSH environment variable
 - putty or openSSH configured for SSH
 - Install Hook was failing (was not finding ssh.exe)
 - After PR, hook installs correctly.

Has been tested on (remove any that don't apply):
 - GIT 2.10.2, GIT 2.13.3
 - Windows 7 & Windows 10
