### PR TITLE
Use GitExt icon for menu items that open a new instance for Submodule

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
@@ -143,7 +143,7 @@
             // 
             // openSubmoduleMenuItem
             // 
-            this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Resources.IconFolderSubmodule;
+            this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Resources.gitex;
             this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
             this.openSubmoduleMenuItem.Size = new System.Drawing.Size(296, 22);
             this.openSubmoduleMenuItem.Text = "Open with Git Extensions";

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -90,7 +90,7 @@ namespace GitUI
                 Name = "openSubmoduleMenuItem",
                 Tag = "1",
                 Text = "Open with Git Extensions",
-                Image = Resources.IconFolderSubmodule
+                Image = Resources.gitex
             };
             _openSubmoduleMenuItem.Click += (s, ea) => { OpenSubmodule(); };
         }


### PR DESCRIPTION
Use GitExt icon for menu items that open a new instance for Submodule Status

This was used for an icon recently added in Commit form

Seen as part of #4031 .

Changes proposed in this pull request:
 - Consistently use GitExt icon to open new Browse window
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/31861594-7c163756-b730-11e7-82b9-6390b2754307.png)

- ![image](https://user-images.githubusercontent.com/6248932/31861588-68a63298-b730-11e7-8a2e-35c3806d69d6.png)

How did I test this code:
 - open UI

Has been tested on (remove any that don't apply):
 - GIT 2.14 (not Git related)
 - Windows 7 and Win10
