### PR TITLE
Refactor IGitItem

### DIFF
--- a/GitCommands/Git/GitItem.cs
+++ b/GitCommands/Git/GitItem.cs
@@ -2,42 +2,34 @@
 using System.Diagnostics;
 using GitUIPluginInterfaces;
 
-namespace GitCommands
+namespace GitCommands.Git
 {
     [DebuggerDisplay("GitItem( {FileName} )")]
     public class GitItem : IGitItem
     {
-        public GitItem(string mode, string itemType, string guid, string name)
+        public GitItem(string mode, string objectType, string guid, string name)
         {
             Mode = mode;
-            ItemType = itemType;
+            GitObjectType type;
+            Enum.TryParse(objectType, true, out type);
+            ObjectType = type;
             Guid = guid;
             FileName = Name = name;
         }
 
 
         public string Guid { get; }
-        public string ItemType { get; }
+        public GitObjectType ObjectType { get; }
         public string Name { get; }
         public string FileName { get; set; }
         public string Mode { get; }
-
-
-        public bool IsBlob
-        {
-            get { return ItemType == "blob"; }
-        }
-
-        public bool IsCommit
-        {
-            get { return ItemType == "commit"; }
-        }
-
-        public bool IsTree
-        {
-            get { return ItemType == "tree"; }
-        }
     }
 
+    public enum GitObjectType
+    {
+        None = 0,
+        Commit,
+        Tree,
+        Blob
     }
 }

--- a/GitCommands/Git/GitItem.cs
+++ b/GitCommands/Git/GitItem.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using GitUIPluginInterfaces;
 
@@ -7,16 +7,20 @@ namespace GitCommands
     [DebuggerDisplay("GitItem( {FileName} )")]
     public class GitItem : IGitItem
     {
-        internal const int MinimumStringLength = 53;
+        public GitItem(string mode, string itemType, string guid, string name)
+        {
+            Mode = mode;
+            ItemType = itemType;
+            Guid = guid;
+            FileName = Name = name;
+        }
 
-        public string Guid { get; set; }
-        public string CommitGuid { get; set; }
-        public string ItemType { get; set; }
-        public string Name { get; set; }
-        public string Author { get; set; }
-        public string Date { get; set; }
+
+        public string Guid { get; }
+        public string ItemType { get; }
+        public string Name { get; }
         public string FileName { get; set; }
-        public string Mode { get; set; }
+        public string Mode { get; }
 
 
         public bool IsBlob
@@ -33,55 +37,7 @@ namespace GitCommands
         {
             get { return ItemType == "tree"; }
         }
+    }
 
-
-        internal static GitItem CreateGitItemFromString(string itemsString)
-        {
-            if ((itemsString == null) || (itemsString.Length <= MinimumStringLength))
-                return null;
-
-            var guidStart = itemsString.IndexOf(' ', 7);
-
-            var item = new GitItem
-            {
-                Mode = itemsString.Substring(0, 6),
-                ItemType = itemsString.Substring(7, guidStart - 7),
-                Guid = itemsString.Substring(guidStart + 1, 40),
-                Name = itemsString.Substring(guidStart + 42).Trim()
-            };
-
-            item.FileName = item.Name;
-            return item;
-        }
-
-
-        public static List<GitItem> CreateGitItemsFromString(string tree)
-        {
-            var itemsStrings = tree.Split('\0', '\n');
-
-            var items = new List<GitItem>();
-
-            foreach (var itemsString in itemsStrings)
-            {
-                if (itemsString.Length <= 53)
-                    continue;
-
-                var item = CreateGitItemFromString(itemsString);
-
-                items.Add(item);
-            }
-
-            return items;
-        }
-
-        public static List<IGitItem> CreateIGitItemsFromString(string tree)
-        {
-            var items = new List<IGitItem>();
-
-            foreach (var item in CreateGitItemsFromString(tree))
-                items.Add(item);
-
-            return items;
-        }
     }
 }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -90,6 +90,7 @@ namespace GitCommands
         private readonly object _lock = new object();
         private readonly IIndexLockManager _indexLockManager;
         private static readonly IGitDirectoryResolver GitDirectoryResolverInstance = new GitDirectoryResolver();
+        private readonly IGitTreeParser _gitTreeParser = new GitTreeParser();
 
         public const string NoNewLineAtTheEnd = "\\ No newline at end of file";
         private const string DiffCommandWithStandardArgs = "diff --no-color ";
@@ -979,8 +980,7 @@ namespace GitCommands
         private IGitItem GetSubmoduleCommitHash(string filename, string refName)
         {
             string str = RunGitCmd("ls-tree " + refName + " \"" + filename + "\"");
-
-            return GitItem.CreateGitItemFromString(str);
+            return _gitTreeParser.ParseSingle(str);
         }
 
         public int? GetCommitCount(string parentHash, string childHash)
@@ -2817,7 +2817,7 @@ namespace GitCommands
             return tree.Split(new char[] { '\0', '\n' });
         }
 
-        public IList<IGitItem> GetTree(string id, bool full)
+        public IEnumerable<IGitItem> GetTree(string id, bool full)
         {
             string args = "-z";
             if (full)
@@ -2834,7 +2834,7 @@ namespace GitCommands
                 tree = this.RunCmd(AppSettings.GitCommand, "ls-tree " + args + " \"" + id + "\"", SystemEncoding);
             }
 
-            return GitItem.CreateIGitItemsFromString(tree);
+            return _gitTreeParser.Parse(tree);
         }
 
         public GitBlame Blame(string filename, string from, Encoding encoding)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -980,7 +980,7 @@ namespace GitCommands
         {
             string str = RunGitCmd("ls-tree " + refName + " \"" + filename + "\"");
 
-            return GitItem.CreateGitItemFromString(this, str);
+            return GitItem.CreateGitItemFromString(str);
         }
 
         public int? GetCommitCount(string parentHash, string childHash)
@@ -2834,7 +2834,7 @@ namespace GitCommands
                 tree = this.RunCmd(AppSettings.GitCommand, "ls-tree " + args + " \"" + id + "\"", SystemEncoding);
             }
 
-            return GitItem.CreateIGitItemsFromString(this, tree);
+            return GitItem.CreateIGitItemsFromString(tree);
         }
 
         public GitBlame Blame(string filename, string from, Encoding encoding)

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -10,7 +10,6 @@ namespace GitCommands
     {
         private readonly string _mergeSettingName;
         private readonly string _remoteSettingName;
-        private IList<IGitItem> _subItems;
        
         /// <summary>"refs/tags/"</summary>
         public static readonly string RefsTagsPrefix = "refs/tags/";
@@ -151,11 +150,6 @@ namespace GitCommands
 
         public string Guid { get; private set; }
         public string Name { get; private set; }
-
-        public IEnumerable<IGitItem> SubItems
-        {
-            get { return _subItems ?? (_subItems = Module.GetTree(Guid, false)); }
-        }
 
         #endregion
 

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -22,7 +22,6 @@ namespace GitCommands
         public static readonly Regex Sha1HashShortRegex = new Regex(string.Format(@"\b{0}\b", Sha1HashShortPattern), RegexOptions.Compiled);
 
         public string[] ParentGuids;
-        private IList<IGitItem> _subItems;
         private readonly List<IGitRef> _refs = new List<IGitRef>();
         public readonly GitModule Module;
         private BuildInfo _buildStatus;
@@ -65,11 +64,6 @@ namespace GitCommands
 
         public string Guid { get; set; }
         public string Name { get; set; }
-
-        public IEnumerable<IGitItem> SubItems
-        {
-            get { return _subItems ?? (_subItems = Module.GetTree(TreeGuid, false)); }
-        }
 
         #endregion
 

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using GitUIPluginInterfaces;
+
+namespace GitCommands.Git
+{
+    public interface IGitTreeParser
+    {
+        IEnumerable<IGitItem> Parse(string tree);
+        GitItem ParseSingle(string rawItem);
+    }
+
+    public sealed class GitTreeParser : IGitTreeParser
+    {
+        internal static readonly int MinimumStringLength = 53;
+
+
+        public IEnumerable<IGitItem> Parse(string tree)
+        {
+            if (string.IsNullOrWhiteSpace(tree))
+            {
+                return Enumerable.Empty<IGitItem>();
+            }
+            var items = tree.Split('\0', '\n');
+            return items.Select(ParseSingle).Where(item => item != null);
+        }
+
+        public GitItem ParseSingle(string rawItem)
+        {
+            if (rawItem == null || rawItem.Length <= MinimumStringLength)
+            {
+                return null;
+            }
+
+            var guidStart = rawItem.IndexOf(' ', 7);
+            var mode = rawItem.Substring(0, 6);
+            var itemType = rawItem.Substring(7, guidStart - 7);
+            var guid = rawItem.Substring(guidStart + 1, 40);
+            var name = rawItem.Substring(guidStart + 42).Trim();
+
+            var item = new GitItem(mode, itemType, guid, name);
+            return item;
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -94,6 +94,7 @@
     <Compile Include="FileAssociatedIconProvider.cs" />
     <Compile Include="FileHelper.cs" />
     <Compile Include="FullPathResolver.cs" />
+    <Compile Include="GitRevisionInfoProvider.cs" />
     <Compile Include="Git\AuthorEmailEqualityComparer.cs" />
     <Compile Include="Git\FileDeleteException.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Git\GitTagController.cs" />
     <Compile Include="SshPathLocator.cs" />
     <Compile Include="Git\IndexLockManager.cs" />
+    <Compile Include="Git\GitTreeParser.cs" />
     <Compile Include="Logging\CommandLogEntry.cs" />
     <Compile Include="PathEqualityComparer.cs" />
     <Compile Include="RemoteActionResult.cs" />

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GitUIPluginInterfaces;
+
+namespace GitCommands
+{
+    public interface IGitRevisionInfoProvider
+    {
+        /// <summary>
+        /// Loads children item for the given <paramref name="item"/>.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>The item's children.</returns>
+        IEnumerable<IGitItem> LoadChildren(IGitItem item);
+    }
+
+    public sealed class GitRevisionInfoProvider : IGitRevisionInfoProvider
+    {
+        private readonly IGitModule _module;
+
+        public GitRevisionInfoProvider(IGitModule module)
+        {
+            _module = module;
+        }
+
+        /// <summary>
+        /// Loads children item for the given <paramref name="item"/>.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>The item's children.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="item"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><see cref="IGitItem.Guid"/> is not supplied.</exception>
+        public IEnumerable<IGitItem> LoadChildren(IGitItem item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+            if (string.IsNullOrWhiteSpace(item.Guid))
+            {
+                throw new ArgumentException("Item must have a valid identifier", nameof(item.Guid));
+            }
+
+            var subItems = _module.GetTree(item.Guid, false);
+            foreach (var subItem in subItems.OfType<GitItem>())
+            {
+                subItem.FileName = Path.Combine((item as GitItem)?.FileName ?? string.Empty, subItem.FileName ?? string.Empty);
+            }
+            return subItems;
+        }
+    }
+}

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -43,7 +43,7 @@ namespace GitCommands
                 throw new ArgumentException("Item must have a valid identifier", nameof(item.Guid));
             }
 
-            var subItems = _module.GetTree(item.Guid, false);
+            var subItems = _module.GetTree(item.Guid, false).ToList();
             foreach (var subItem in subItems.OfType<GitItem>())
             {
                 subItem.FileName = Path.Combine((item as GitItem)?.FileName ?? string.Empty, subItem.FileName ?? string.Empty);

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using GitCommands.Git;
 using GitUIPluginInterfaces;
 
 namespace GitCommands

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
@@ -1,5 +1,6 @@
 ﻿using GitCommands;
 using System.IO;
+using GitCommands.Git;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
 {

--- a/GitUI/CommandsDialogs/BrowseDialog/GitFileTreeComparer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitFileTreeComparer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using GitCommands;
+using GitCommands.Git;
 using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
@@ -23,9 +24,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 return -1;
             }
 
-            if ((xGitItem.IsTree || xGitItem.IsCommit) && yGitItem.IsBlob)
+            if ((xGitItem.ObjectType == GitObjectType.Tree || xGitItem.ObjectType == GitObjectType.Commit) && yGitItem.ObjectType == GitObjectType.Blob)
                 return -1;
-            if (xGitItem.IsBlob && (yGitItem.IsTree || yGitItem.IsCommit))
+            if (xGitItem.ObjectType == GitObjectType.Blob && (yGitItem.ObjectType == GitObjectType.Tree || yGitItem.ObjectType == GitObjectType.Commit))
                 return 1;
             return xGitItem.Name.CompareTo(yGitItem.Name);
         }

--- a/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Forms;
+using GitCommands.Git;
 
 namespace GitUI.CommandsDialogs
 {
@@ -73,7 +74,7 @@ namespace GitUI.CommandsDialogs
             // 
             // gitItemBindingSource
             // 
-            this.gitItemBindingSource.DataSource = typeof(GitCommands.GitItem);
+            this.gitItemBindingSource.DataSource = typeof(GitItem);
             // 
             // splitContainer1
             // 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs
+﻿using GitCommands.Git;
+
+namespace GitUI.CommandsDialogs
 {
     partial class FormResolveConflicts
     {
@@ -299,7 +301,7 @@
             // 
             // gitItemBindingSource
             // 
-            this.gitItemBindingSource.DataSource = typeof(GitCommands.GitItem);
+            this.gitItemBindingSource.DataSource = typeof(GitItem);
             // 
             // tableLayoutPanel1
             // 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -77,7 +77,6 @@
             this.dateDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.fileNameDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.modeDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.subItemsBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
@@ -89,7 +88,6 @@
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.subItemsBindingSource)).BeginInit();
             this.tableLayoutPanel4.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel5.SuspendLayout();
@@ -543,11 +541,6 @@
             this.modeDataGridViewTextBoxColumn.Name = "modeDataGridViewTextBoxColumn";
             this.modeDataGridViewTextBoxColumn.ReadOnly = true;
             // 
-            // subItemsBindingSource
-            // 
-            this.subItemsBindingSource.DataMember = "SubItems";
-            this.subItemsBindingSource.DataSource = this.gitItemBindingSource;
-            // 
             // tableLayoutPanel4
             // 
             this.tableLayoutPanel4.ColumnCount = 2;
@@ -623,7 +616,6 @@
             this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 20);
             this.gotoUserManualControl1.TabIndex = 2;
             // 
-            // 
             // FormResolveConflicts
             // 
             this.AcceptButton = this.merge;
@@ -645,7 +637,6 @@
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.subItemsBindingSource)).EndInit();
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -701,7 +692,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.Button merge;
         private System.Windows.Forms.PictureBox pictureBox1;
-        private System.Windows.Forms.BindingSource subItemsBindingSource;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripMenuItem fileHistoryToolStripMenuItem;
         private System.Windows.Forms.DataGridViewTextBoxColumn FileName;

--- a/GitUI/CommandsDialogs/FormResolveConflicts.resx
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.resx
@@ -121,12 +121,9 @@
     <value>True</value>
   </metadata>
   <metadata name="ConflictedFilesContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>307, 17</value>
+    <value>186, 17</value>
   </metadata>
   <metadata name="gitItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="subItemsBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>495, 17</value>
   </metadata>
 </root>

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -44,7 +44,9 @@ namespace GitUI.CommandsDialogs
             GotFocus += (s, e) => tvGitTree.Focus();
             Load += (s, e) =>
             {
-                _revisionFileTreeController = new RevisionFileTreeController(Module, new FileAssociatedIconProvider());
+                _revisionFileTreeController = new RevisionFileTreeController(Module, 
+                                                                             new GitRevisionInfoProvider(Module), 
+                                                                             new FileAssociatedIconProvider());
             };
         }
 
@@ -122,6 +124,7 @@ namespace GitUI.CommandsDialogs
         public void LoadRevision(GitRevision revision)
         {
             _revision = revision;
+            _revisionFileTreeController.ResetCache();
 
             try
             {
@@ -144,7 +147,7 @@ namespace GitUI.CommandsDialogs
                 //restore selected file and scroll position when new selection is done
                 if (_revision != null)
                 {
-                    _revisionFileTreeController.LoadItemsInTreeView(_revision.SubItems, tvGitTree.Nodes, tvGitTree.ImageList.Images);
+                    _revisionFileTreeController.LoadChildren(_revision, tvGitTree.Nodes, tvGitTree.ImageList.Images);
                     //GitTree.Sort();
                     TreeNode lastMatchedNode = null;
                     // Load state
@@ -282,7 +285,7 @@ namespace GitUI.CommandsDialogs
             }
 
             e.Node.Nodes.Clear();
-            _revisionFileTreeController.LoadItemsInTreeView(item.SubItems, e.Node.Nodes, tvGitTree.ImageList.Images);
+            _revisionFileTreeController.LoadChildren(item, e.Node.Nodes, tvGitTree.ImageList.Images);
         }
 
         private void tvGitTree_DoubleClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitUI.CommandsDialogs.BrowseDialog;
 using ResourceManager;
 
@@ -44,8 +45,8 @@ namespace GitUI.CommandsDialogs
             GotFocus += (s, e) => tvGitTree.Focus();
             Load += (s, e) =>
             {
-                _revisionFileTreeController = new RevisionFileTreeController(Module, 
-                                                                             new GitRevisionInfoProvider(Module), 
+                _revisionFileTreeController = new RevisionFileTreeController(Module,
+                                                                             new GitRevisionInfoProvider(Module),
                                                                              new FileAssociatedIconProvider());
             };
         }
@@ -210,20 +211,25 @@ namespace GitUI.CommandsDialogs
             if (item == null)
                 return;
 
-            if (item.IsBlob)
+            switch (item.ObjectType)
             {
-                UICommands.StartFileHistoryDialog(this, item.FileName, null);
-            }
-            else if (item.IsCommit)
-            {
-                SpawnCommitBrowser(item);
+                case GitObjectType.Blob:
+                    {
+                        UICommands.StartFileHistoryDialog(this, item.FileName, null);
+                        break;
+                    }
+                case GitObjectType.Commit:
+                    {
+                        SpawnCommitBrowser(item);
+                        break;
+                    }
             }
         }
 
         private string SaveSelectedItemToTempFile()
         {
             var gitItem = tvGitTree.SelectedNode.Tag as GitItem;
-            if (gitItem == null || !gitItem.IsBlob || string.IsNullOrWhiteSpace(gitItem.FileName))
+            if (gitItem == null || gitItem.ObjectType != GitObjectType.Blob || string.IsNullOrWhiteSpace(gitItem.FileName))
             {
                 return null;
             }
@@ -257,18 +263,24 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (item.IsBlob)
+            switch (item.ObjectType)
             {
-                FileText.ViewGitItem(item.FileName, item.Guid);
-            }
-            else if (item.IsCommit)
-            {
-                FileText.ViewText(item.FileName, LocalizationHelpers.GetSubmoduleText(Module, item.FileName, item.Guid));
-            }
-            else
-            {
-                FileText.ViewText("", "");
-                e.Node.Toggle();
+                case GitObjectType.Blob:
+                    {
+                        FileText.ViewGitItem(item.FileName, item.Guid);
+                        break;
+                    }
+                case GitObjectType.Commit:
+                    {
+                        FileText.ViewText(item.FileName, LocalizationHelpers.GetSubmoduleText(Module, item.FileName, item.Guid));
+                        break;
+                    }
+                default:
+                    {
+                        FileText.ViewText("", "");
+                        e.Node.Toggle();
+                        break;
+                    }
             }
         }
 
@@ -403,7 +415,7 @@ namespace GitUI.CommandsDialogs
             var item = tvGitTree.SelectedNode.Tag;
 
             var gitItem = item as GitItem;
-            if (gitItem == null || !gitItem.IsBlob)
+            if (gitItem == null || gitItem.ObjectType != GitObjectType.Blob)
                 return;
 
             var fileName = Path.Combine(Module.WorkingDir, gitItem.FileName);
@@ -430,9 +442,9 @@ namespace GitUI.CommandsDialogs
         private void FileTreeContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             var gitItem = tvGitTree.SelectedNode?.Tag as GitItem;
-            var enableItems = gitItem != null && gitItem.IsBlob;
+            var enableItems = gitItem != null && gitItem.ObjectType == GitObjectType.Blob;
 
-            if (gitItem != null && gitItem.IsCommit)
+            if (gitItem != null && gitItem.ObjectType == GitObjectType.Commit)
             {
                 openSubmoduleMenuItem.Visible = true;
                 if (!openSubmoduleMenuItem.Font.Bold)
@@ -489,7 +501,7 @@ namespace GitUI.CommandsDialogs
         private void openSubmoduleMenuItem_Click(object sender, EventArgs e)
         {
             var item = tvGitTree.SelectedNode.Tag as GitItem;
-            if (item != null && item.IsCommit)
+            if (item != null && item.ObjectType == GitObjectType.Commit)
             {
                 SpawnCommitBrowser(item);
             }
@@ -500,7 +512,7 @@ namespace GitUI.CommandsDialogs
             var item = tvGitTree.SelectedNode.Tag;
 
             var gitItem = item as GitItem;
-            if (gitItem == null || !gitItem.IsBlob)
+            if (gitItem == null || gitItem.ObjectType != GitObjectType.Blob)
                 return;
 
             var fileName = Path.Combine(Module.WorkingDir, gitItem.FileName);
@@ -525,7 +537,7 @@ namespace GitUI.CommandsDialogs
         private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var item = tvGitTree.SelectedNode.Tag as GitItem;
-            if (item == null || !item.IsBlob)
+            if (item == null || item.ObjectType != GitObjectType.Blob)
             {
                 return;
             }

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUIPluginInterfaces;
 
@@ -103,37 +104,39 @@ namespace GitUI.CommandsDialogs
                     continue;
                 }
 
-                if (gitItem.IsTree)
+                switch (gitItem.ObjectType)
                 {
-                    subNode.ImageIndex = subNode.SelectedImageIndex = TreeNodeImages.Folder;
-                    subNode.Nodes.Add(new TreeNode());
-                    continue;
-                }
-
-                if (gitItem.IsCommit)
-                {
-                    subNode.ImageIndex = subNode.SelectedImageIndex = TreeNodeImages.Submodule;
-                    subNode.Text = $@"{childItem.Name} (Submodule)";
-                    continue;
-                }
-
-                if (gitItem.IsBlob)
-                {
-                    var extension = Path.GetExtension(gitItem.FileName);
-                    if (string.IsNullOrWhiteSpace(extension))
-                    {
-                        continue;
-                    }
-                    if (!imageCollection.ContainsKey(extension))
-                    {
-                        var fileIcon = _iconProvider.Get(_module.WorkingDir, gitItem.FileName);
-                        if (fileIcon == null)
+                    case GitObjectType.Tree:
                         {
-                            continue;
+                            subNode.ImageIndex = subNode.SelectedImageIndex = TreeNodeImages.Folder;
+                            subNode.Nodes.Add(new TreeNode());
+                            break;
                         }
-                        imageCollection.Add(extension, fileIcon);
-                    }
-                    subNode.ImageKey = subNode.SelectedImageKey = extension;
+                    case GitObjectType.Commit:
+                        {
+                            subNode.ImageIndex = subNode.SelectedImageIndex = TreeNodeImages.Submodule;
+                            subNode.Text = $@"{childItem.Name} (Submodule)";
+                            break;
+                        }
+                    case GitObjectType.Blob:
+                        {
+                            var extension = Path.GetExtension(gitItem.FileName);
+                            if (string.IsNullOrWhiteSpace(extension))
+                            {
+                                continue;
+                            }
+                            if (!imageCollection.ContainsKey(extension))
+                            {
+                                var fileIcon = _iconProvider.Get(_module.WorkingDir, gitItem.FileName);
+                                if (fileIcon == null)
+                                {
+                                    continue;
+                                }
+                                imageCollection.Add(extension, fileIcon);
+                            }
+                            subNode.ImageKey = subNode.SelectedImageKey = extension;
+                            break;
+                        }
                 }
             }
         }

--- a/Plugins/GitUIPluginInterfaces/IGitItem.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitItem.cs
@@ -1,12 +1,8 @@
-﻿using System.Collections.Generic;
-
-namespace GitUIPluginInterfaces
+﻿namespace GitUIPluginInterfaces
 {
     public interface IGitItem
     {
         string Guid { get; }
         string Name { get; }
-
-        IEnumerable<IGitItem> SubItems { get; }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -13,7 +13,7 @@ namespace GitUIPluginInterfaces
         string AddRemote(string remoteName, string path);
         IList<IGitRef> GetRefs(bool tags = true, bool branches = true);
         IEnumerable<string> GetSettings(string setting);
-        IList<IGitItem> GetTree(string id, bool full);
+        IEnumerable<IGitItem> GetTree(string id, bool full);
 
         /// <summary>
         /// Removes the registered remote by running <c>git remote rm</c> command.

--- a/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
@@ -34,13 +34,13 @@ namespace GitCommandsTests.Git
             item.Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
             item.Mode.Should().Be("100644");
             item.Name.Should().Be(".gitignore");
-            item.ItemType.Should().Be("blob");
+            item.ObjectType.Should().Be(GitObjectType.Blob);
 
             item = (GitItem)items[8];
             item.Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
             item.Mode.Should().Be("040000");
             item.Name.Should().Be("Bin");
-            item.ItemType.Should().Be("tree");
+            item.ObjectType.Should().Be(GitObjectType.Tree);
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace GitCommandsTests.Git
             item.Guid.Should().Be("25d7b5d771e84982a3dfd8bd537531d8fb45d491");
             item.Mode.Should().Be("100644");
             item.Name.Should().Be(".editorconfig");
-            item.ItemType.Should().Be("blob");
+            item.ObjectType.Should().Be(GitObjectType.Blob);
         }
 
 

--- a/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Git;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public class GitTreeParserTests
+    {
+        private IGitTreeParser _parser;
+
+        [SetUp]
+        public void Setup()
+        {
+            _parser = new GitTreeParser();
+        }
+
+
+        [Test]
+        public void Parse_should_return_empty_if_null()
+        {
+            _parser.Parse(null).Should().BeEmpty();
+        }
+
+        [Test]
+        public void Parse_should_return_the_list()
+        {
+            var items = _parser.Parse(GetLsTreeOutput()).ToList();
+
+            items.Count.Should().Be(10);
+            var item = (GitItem)items[3];
+            item.Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
+            item.Mode.Should().Be("100644");
+            item.Name.Should().Be(".gitignore");
+            item.ItemType.Should().Be("blob");
+
+            item = (GitItem)items[8];
+            item.Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
+            item.Mode.Should().Be("040000");
+            item.Name.Should().Be("Bin");
+            item.ItemType.Should().Be("tree");
+        }
+
+        [Test]
+        public void ParseSingle_should_return_null_for_null()
+        {
+            _parser.ParseSingle(null).Should().BeNull();
+        }
+
+        [Test]
+        public void ParseSingle_should_return_null_if_input_shorter_than_required()
+        {
+            _parser.ParseSingle("").Should().BeNull();
+            _parser.ParseSingle(new string('c', GitTreeParser.MinimumStringLength - 1)).Should().BeNull();
+        }
+
+        [Test]
+        public void ParseSingle_should_return_GitItem()
+        {
+            const string s = "100644 blob 25d7b5d771e84982a3dfd8bd537531d8fb45d491    .editorconfig";
+            var item = _parser.ParseSingle(s);
+
+            item.Guid.Should().Be("25d7b5d771e84982a3dfd8bd537531d8fb45d491");
+            item.Mode.Should().Be("100644");
+            item.Name.Should().Be(".editorconfig");
+            item.ItemType.Should().Be("blob");
+        }
+
+
+        private static string GetLsTreeOutput()
+        {
+            return string.Concat("100644 blob 25d7b5d771e84982a3dfd8bd537531d8fb45d491	.editorconfig", "\n",
+                "100644 blob bf29d31ff93be092ce746849e8db0984d4a83231	.gitattributes", "\0",
+                "040000 tree 93185d6bd18327f5a23bc34e7eb75e66ec0ef2d1	.github", "\n",
+                "100644 blob 46cccae116d2e5a1a2f818b0b31adde4ab3800a9	.gitignore", "\0",
+                "100644 blob e55070b6c781e278bc68fc1b2525f56318d18244	.gitmodules", "\n",
+                "100644 blob 1a569e3aa555e8cdf14dcc29f9bf4edf9aa465eb	.mailmap", "\n",
+                "040000 tree 5c1f6ae123f16e2bee1c5a064cf293c11250d98f	.nuget", "\n",
+                "100644 blob 1e53ed8f6759a92d4596af6a99ef04f1554bfd57	.travis.yml", "\0",
+                "040000 tree 58d57013ed2ef925fc1b3f6fe72ead258c522e75	Bin", "\0",
+                "040000 tree 0c7cce8981b980d03431f65b9b54c680a467fa2e	Build");
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Git\IndexLockManagerTests.cs" />
     <Compile Include="Git\GitDirectoryResolverTests.cs" />
     <Compile Include="Git\GitTagControllerTest.cs" />
+    <Compile Include="Git\GitTreeParserTests.cs" />
     <Compile Include="Helpers\FileInfoExtensions.cs" />
     <Compile Include="Helpers\FileInfoExtensionsTest.cs" />
     <Compile Include="Helpers\PathUtilTest.cs" />

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
     <Compile Include="GitExtLinks\GitExtLinksTests.cs" />
+    <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
     <Compile Include="Git\GitBlameTest.cs" />

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -51,7 +51,7 @@ namespace GitCommandsTests
 
             var children = _provider.LoadChildren(item);
 
-            children.Should().BeSameAs(items);
+            children.Should().BeEquivalentTo(items);
             _module.Received(1).GetTree(guid, false);
         }
 
@@ -59,14 +59,14 @@ namespace GitCommandsTests
         public void LoadChildren_should_return_shallow_tree_for_GitItem_with_updated_FileName()
         {
             var guid = Guid.NewGuid().ToString("N");
-            var item = new GitItem { Guid = guid, FileName = "folder" };
+            var item = new GitItem("", "", guid, "folder");
 
-            var items = new[] { Substitute.For<IGitItem>(), new GitItem { FileName = "file2" }, new GitItem { FileName = "file3" } };
+            var items = new[] { Substitute.For<IGitItem>(), new GitItem("", "", "", "file2"), new GitItem("", "", "", "file3") };
             _module.GetTree(guid, false).Returns(items);
 
             var children = _provider.LoadChildren(item);
 
-            children.Should().BeSameAs(items);
+            children.Should().BeEquivalentTo(items);
             ((GitItem)items[1]).FileName.Should().Be(Path.Combine(item.FileName, "file2"));
             ((GitItem)items[2]).FileName.Should().Be(Path.Combine(item.FileName, "file3"));
             _module.Received(1).GetTree(guid, false);

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using FluentAssertions;
 using GitCommands;
+using GitCommands.Git;
 using GitUIPluginInterfaces;
 using NSubstitute;
 using NUnit.Framework;

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using GitCommands;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class GitRevisionInfoProviderTests
+    {
+        private IGitModule _module;
+        private GitRevisionInfoProvider _provider;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _module = Substitute.For<IGitModule>();
+            _provider = new GitRevisionInfoProvider(_module);
+        }
+
+        [Test]
+        public void LoadChildren_should_throw_if_null()
+        {
+            ((Action)(() => _provider.LoadChildren(null))).ShouldThrow<ArgumentNullException>();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void LoadChildren_should_throw_if_guid_not_supplied(string guid)
+        {
+            var item = Substitute.For<IGitItem>();
+            item.Guid.Returns(guid);
+
+            ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void LoadChildren_should_return_shallow_tree_for_non_GitItem()
+        {
+            var guid = Guid.NewGuid().ToString("N");
+            var item = Substitute.For<IGitItem>();
+            item.Guid.Returns(guid);
+
+            var items = new[] { Substitute.For<IGitItem>(), Substitute.For<IGitItem>(), Substitute.For<IGitItem>() };
+            _module.GetTree(guid, false).Returns(items);
+
+            var children = _provider.LoadChildren(item);
+
+            children.Should().BeSameAs(items);
+            _module.Received(1).GetTree(guid, false);
+        }
+
+        [Test]
+        public void LoadChildren_should_return_shallow_tree_for_GitItem_with_updated_FileName()
+        {
+            var guid = Guid.NewGuid().ToString("N");
+            var item = new GitItem { Guid = guid, FileName = "folder" };
+
+            var items = new[] { Substitute.For<IGitItem>(), new GitItem { FileName = "file2" }, new GitItem { FileName = "file3" } };
+            _module.GetTree(guid, false).Returns(items);
+
+            var children = _provider.LoadChildren(item);
+
+            children.Should().BeSameAs(items);
+            ((GitItem)items[1]).FileName.Should().Be(Path.Combine(item.FileName, "file2"));
+            ((GitItem)items[2]).FileName.Should().Be(Path.Combine(item.FileName, "file3"));
+            _module.Received(1).GetTree(guid, false);
+        }
+    }
+}

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -16,6 +16,7 @@ namespace GitUITests.CommandsDialogs
     {
         private IGitModule _module;
         private IFileAssociatedIconProvider _iconProvider;
+        private IGitRevisionInfoProvider _revisionInfoProvider;
         private RevisionFileTreeController _controller;
         private TreeNode _rootNode;
         private ImageList _imageList;
@@ -25,8 +26,9 @@ namespace GitUITests.CommandsDialogs
         public void Setup()
         {
             _module = Substitute.For<IGitModule>();
+            _revisionInfoProvider = Substitute.For<IGitRevisionInfoProvider>();
             _iconProvider = Substitute.For<IFileAssociatedIconProvider>();
-            _controller = new RevisionFileTreeController(_module, _iconProvider);
+            _controller = new RevisionFileTreeController(_module, _revisionInfoProvider, _iconProvider);
 
              _rootNode = new TreeNode();
              _imageList = new ImageList();
@@ -41,11 +43,25 @@ namespace GitUITests.CommandsDialogs
 
 
         [Test]
+        public void LoadItemsInTreeView_should_not_add_nods_if_no_children()
+        {
+            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(x =>null);
+
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+
+            _rootNode.Nodes.Count.Should().Be(0);
+            _imageList.Images.Count.Should().Be(0);
+        }
+
+        [Test]
         public void LoadItemsInTreeView_should_add_all_none_GitItem_items_with_1st_level_nodes()
         {
             var items = new IGitItem[] { new MockGitItem("file1"), new MockGitItem("file2") };
+            var item = new MockGitItem("folder");
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -62,8 +78,10 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsTree_as_folders()
         {
             var items = new[] { CreateGitItem("file1", true, false, false), CreateGitItem("file2", true, false, false) };
+            var item = new GitItem { Name =  "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -80,8 +98,10 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsCommit_as_submodue()
         {
             var items = new[] { CreateGitItem("file1", false, true, false), CreateGitItem("file2", false, true, false) };
+            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -98,8 +118,10 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsBlob_as_file()
         {
             var items = new[] { CreateGitItem("file1", false, false, true), CreateGitItem("file2", false, false, true) };
+            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -113,8 +135,10 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_not_load_icons_for_file_without_extension()
         {
             var items = new[] { CreateGitItem("file1.", false, false, true), CreateGitItem("file2", false, false, true) };
+            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -132,8 +156,10 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_not_add_icons_for_file_if_none_provided()
         {
             var items = new[] { CreateGitItem("file1.foo", false, false, true), CreateGitItem("file2.txt", false, false, true) };
+            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -151,10 +177,12 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_icon_for_file_extension_only_once()
         {
             var items = new[] { CreateGitItem("file1.txt", false, false, true), CreateGitItem("file2.txt", false, false, true) };
+            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            _revisionInfoProvider.LoadChildren(item).Returns(items);
             var image = Resources.cow_head;
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(image);
 
-            _controller.LoadItemsInTreeView(items, _rootNode.Nodes, _imageList.Images);
+            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -171,7 +199,7 @@ namespace GitUITests.CommandsDialogs
 
         private IGitItem CreateGitItem(string name, bool isTree, bool isCommit, bool isBlol)
         {
-            var item = new GitItem(new GitModule(""))
+            var item = new GitItem
             {
                 Name = name,
                 FileName = isBlol ? name : "",

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Windows.Forms;
 using FluentAssertions;
 using GitCommands;
+using GitCommands.Git;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
 using GitUIPluginInterfaces;

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -45,7 +45,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_not_add_nods_if_no_children()
         {
-            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(x =>null);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -78,7 +78,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsTree_as_folders()
         {
             var items = new[] { CreateGitItem("file1", true, false, false), CreateGitItem("file2", true, false, false) };
-            var item = new GitItem { Name =  "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -98,7 +98,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsCommit_as_submodue()
         {
             var items = new[] { CreateGitItem("file1", false, true, false), CreateGitItem("file2", false, true, false) };
-            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -118,7 +118,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsBlob_as_file()
         {
             var items = new[] { CreateGitItem("file1", false, false, true), CreateGitItem("file2", false, false, true) };
-            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -135,7 +135,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_not_load_icons_for_file_without_extension()
         {
             var items = new[] { CreateGitItem("file1.", false, false, true), CreateGitItem("file2", false, false, true) };
-            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -156,7 +156,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_not_add_icons_for_file_if_none_provided()
         {
             var items = new[] { CreateGitItem("file1.foo", false, false, true), CreateGitItem("file2.txt", false, false, true) };
-            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -177,7 +177,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_icon_for_file_extension_only_once()
         {
             var items = new[] { CreateGitItem("file1.txt", false, false, true), CreateGitItem("file2.txt", false, false, true) };
-            var item = new GitItem { Name = "folder", Guid = System.Guid.NewGuid().ToString("N") };
+            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
             var image = Resources.cow_head;
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(image);
@@ -199,12 +199,7 @@ namespace GitUITests.CommandsDialogs
 
         private IGitItem CreateGitItem(string name, bool isTree, bool isCommit, bool isBlol)
         {
-            var item = new GitItem
-            {
-                Name = name,
-                FileName = isBlol ? name : "",
-                ItemType = isTree ? "tree" : isBlol ? "blob" : isCommit ? "commit" : "",
-            };
+            var item = new GitItem("", isTree ? "tree" : isBlol ? "blob" : isCommit ? "commit" : "", "", name);
             return item;
         }
 


### PR DESCRIPTION
* Remove `SubItems` property as it was only used by GitItem class in a single use-case in RevisionFileTree control. All other implementations of the interface had no use for this property.
* Functionality of loading item's children moved to `GitRevisionInfoProvider`.
* The `RevisionFileTreeController` maintains the cache of retrieved items' children for a given revision.
* Remove redundant properties
* Extract raw data parsing to `GitTreeParser`
* Convert `IsBlob`/`IsTree`/`IsCommit` to enum
