### PR TITLE
Commit: Do not show menu items irrelevant for submodules

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -378,6 +378,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripMenuItem11});
             this.StagedFileContext.Name = "UnstagedFileContext";
             this.StagedFileContext.Size = new System.Drawing.Size(233, 198);
+            this.StagedFileContext.Opening += StagedFileContext_Opening;
             // 
             // stagedResetChanges
             // 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1311,6 +1311,21 @@ namespace GitUI.CommandsDialogs
                 Message.Focus();
         }
 
+        private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            bool isFile = false;
+            foreach(GitItemStatus item in Staged.SelectedItems)
+            {
+                if (!item.IsSubmodule) { isFile = true; }
+            }
+            this.stagedToolStripSeparator14.Visible = isFile;
+            this.stagedEditFileToolStripMenuItem11.Visible = isFile;
+            this.stagedOpenDifftoolToolStripMenuItem9.Visible = isFile;
+            this.stagedOpenToolStripMenuItem7.Visible = isFile;
+            this.stagedToolStripSeparator17.Visible = isFile;
+            this.stagedOpenWithToolStripMenuItem8.Visible = isFile;
+        }
+
         void Unstaged_DoubleClick(object sender, EventArgs e)
         {
             _currentFilesList = Unstaged;


### PR DESCRIPTION
Seen in #4031 .

Changes proposed in this pull request:
 - The menu items for FormCommit Staged submodules has several irrelevant options that has odd or no effect. If no file is displayed, those options are not displayed.
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/31862667-e6f5b68a-b741-11e7-9db8-5583a62e2647.png)

- 
![image](https://user-images.githubusercontent.com/6248932/31862674-0aa875c2-b742-11e7-9e18-65516a926db2.png)


How did I test this code:
 - Stage changes to a submodule
 - View menu alternatives

Has been tested on (remove any that don't apply):
 - GIT 2.14 (not Git related)
 - Windows 7 and Win10
