### PR TITLE
CA2202 CA2213 suppression

### DIFF
--- a/GitCommands/Repository/Repositories.cs
+++ b/GitCommands/Repository/Repositories.cs
@@ -155,22 +155,21 @@ namespace GitCommands.Repository
         private static BindingList<RepositoryCategory> DeserializeRepositories(string xml)
         {
             BindingList<RepositoryCategory> repositories = null;
+            StringReader stringReader = null;
             try
             {
                 var serializer = new XmlSerializer(typeof(BindingList<RepositoryCategory>));
-                using (var stringReader = new StringReader(xml))
+                stringReader = new StringReader(xml);
+                using (var xmlReader = new XmlTextReader(stringReader))
                 {
-                    using (var xmlReader = new XmlTextReader(stringReader))
+                    var repos = serializer.Deserialize(xmlReader) as BindingList<RepositoryCategory>;
+                    if (repos != null)
                     {
-                        var repos = serializer.Deserialize(xmlReader) as BindingList<RepositoryCategory>;
-                        if (repos != null)
+                        repositories = new BindingList<RepositoryCategory>();
+                        foreach (var repositoryCategory in repos.Where(r => r.CategoryType == RepositoryCategoryType.Repositories))
                         {
-                            repositories = new BindingList<RepositoryCategory>();
-                            foreach (var repositoryCategory in repos.Where(r => r.CategoryType == RepositoryCategoryType.Repositories))
-                            {
-                                repositoryCategory.SetIcon();
-                                repositories.Add(repositoryCategory);
-                            }
+                            repositoryCategory.SetIcon();
+                            repositories.Add(repositoryCategory);
                         }
                     }
                 }
@@ -178,6 +177,13 @@ namespace GitCommands.Repository
             catch (Exception ex)
             {
                 Trace.WriteLine(ex.Message);
+            }
+            finally
+            {
+                if (stringReader != null)
+                {
+                    stringReader.Dispose();
+                }
             }
             return repositories;
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2685,7 +2685,10 @@ namespace GitUI.CommandsDialogs
                     _interactiveAddBashCloseWaitCts.Dispose();
                     _interactiveAddBashCloseWaitCts = null;
                 }
-                components?.Dispose();
+                if (components != null)
+                {
+                    components.Dispose();
+                }
             }
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Seen when working with #4031 
Visual Studio (at least 2017) raises 2 warnings for me.
One is correct, the other incorrectly detected.
Rather change them then to go and check that the warning is not in my changes every time.

Changes proposed in this pull request:
 - Code refactoring
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Debugger, manual test

Has been tested on (remove any that don't apply):
 - GIT 2.14
 - Windows 10
