### PR TITLE
Remove "(slow!)" for showing stageged/unstaged as commits in Settings

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -356,7 +356,7 @@
             this.chkShowCurrentChangesInRevisionGraph.Name = "chkShowCurrentChangesInRevisionGraph";
             this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(337, 17);
             this.chkShowCurrentChangesInRevisionGraph.TabIndex = 2;
-            this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes in revision graph (slow!)";
+            this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes in revision graph";
             this.chkShowCurrentChangesInRevisionGraph.UseVisualStyleBackColor = true;
             // 
             // label12

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -9023,8 +9023,8 @@ měnit globální nastavení.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Zobrazit změny provedené v pracovní složce v grafu revizí (pomalé!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Zobrazit změny provedené v pracovní složce v grafu revizí</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -9112,8 +9112,8 @@ te kunnen wijzigen.</target>
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Laat wijzigingen in werk directory zien in de revisie grafiek (langzaam!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Laat wijzigingen in werk directory zien in de revisie grafiek</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7257,7 +7257,7 @@ global settings.
         <target />
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
+        <source>Show current working directory changes in revision graph</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -9110,8 +9110,8 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Afficher les changements actuels du répertoire de travail dans le graphe des révisions (lent !)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Afficher les changements actuels du répertoire de travail dans le graphe des révisions</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -9145,8 +9145,8 @@ können.</target>
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Änderungen im Arbeitsverzeichnis im Revisions-Graphen darstellen (langsam!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Änderungen im Arbeitsverzeichnis im Revisions-Graphen darstellen</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -8527,7 +8527,7 @@ globali.</target>
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
+        <source>Show current working directory changes in revision graph</source>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -8891,8 +8891,8 @@ Git の 正しいパスを入力してください。</target>
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>作業ディレクトリの変更をリビジョングラフ上に表示する (動作は遅くなります)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>作業ディレクトリの変更をリビジョングラフ上に表示する</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -8670,7 +8670,7 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
+        <source>Show current working directory changes in revision graph</source>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -9008,8 +9008,8 @@ zmieniać globalne ustawienia.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Pokaż zmiany bieżącego katalogu roboczego na wykresie rewizji (wolne!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Pokaż zmiany bieżącego katalogu roboczego na wykresie rewizji</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -8871,7 +8871,7 @@ configurações globais.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
+        <source>Show current working directory changes in revision graph</source>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -6514,7 +6514,7 @@ global settings.
 
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
+        <source>Show current working directory changes in revision graph</source>
 
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -7431,7 +7431,7 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
+        <source>Show current working directory changes in revision graph</source>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -9031,8 +9031,8 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Показывать текущие изменения в списке коммитов (медленно!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Показывать текущие изменения в списке коммитов</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -8924,8 +8924,8 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>在版本图里显示工作目录的改变(慢!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>在版本图里显示工作目录的改变</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -9000,8 +9000,8 @@ la configuración global.</target>
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>Mostrar cambios del directorio de trabajo actual en el gráfico de revisiones (lento)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>Mostrar cambios del directorio de trabajo actual en el gráfico de revisiones</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -8764,8 +8764,8 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>在版本圖上顯示當前工作目錄的變更(慢!)</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>在版本圖上顯示當前工作目錄的變更</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -9122,8 +9122,8 @@ global settings.
         
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph (slow!)</source>
-        <target>[Şħǿẇ ƈŭřřḗƞŧ ẇǿřķīƞɠ ḓīřḗƈŧǿřẏ ƈħȧƞɠḗş īƞ řḗṽīşīǿƞ ɠřȧƥħ (şŀǿẇ!) ſϖſϰ ıςϖϐ]</target>
+        <source>Show current working directory changes in revision graph</source>
+        <target>[Şħǿẇ ƈŭřřḗƞŧ ẇǿřķīƞɠ ḓīřḗƈŧǿřẏ ƈħȧƞɠḗş īƞ řḗṽīşīǿƞ ɠřȧƥħ ſϖſϰ ıςϖϐ]</target>
         
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">


### PR DESCRIPTION
Also changed all translations
No change in Transifex, the translated files could be uploaded
Original: Show current working directory changes in revision graph (slow!)

The setting is slower when switching tabs etc because git commands are not cached, but nothing going on in the background
The text should be changed, this is temporary change until the functionality has settled (will the commit move completely to Browse)
Suggestion: Show staged and unstaged as artificial commits in revision graph

A later step is to enable this functionality by default

Discussed in #4031

Changes proposed in this pull request:
 - Rewording in setting
 - 
 - 
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/31877538-2abf95ee-b7d7-11e7-992f-2850abef7460.png)

How did I test this code:
 - View

Has been tested on (remove any that don't apply):
 - GIT 2.14
 - Windows 7 and Win10