### PR TITLE
FileHistory: Icons for menu

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -117,6 +117,7 @@ namespace GitUI.CommandsDialogs
             // 
             // openWithDifftoolToolStripMenuItem
             // 
+            this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconDiffTool;
             this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             this.openWithDifftoolToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(339, 22);
@@ -132,6 +133,7 @@ namespace GitUI.CommandsDialogs
             // 
             // saveAsToolStripMenuItem
             // 
+            this.saveAsToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconSaveAs;
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
             this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(339, 22);
             this.saveAsToolStripMenuItem.Text = "Save as";
@@ -160,6 +162,7 @@ namespace GitUI.CommandsDialogs
             // 
             // revertCommitToolStripMenuItem
             // 
+            this.revertCommitToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconRevertCommit;
             this.revertCommitToolStripMenuItem.Name = "revertCommitToolStripMenuItem";
             this.revertCommitToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.revertCommitToolStripMenuItem.Text = "Revert commit";
@@ -167,6 +170,7 @@ namespace GitUI.CommandsDialogs
             // 
             // cherryPickThisCommitToolStripMenuItem
             // 
+            this.cherryPickThisCommitToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCherryPick;
             this.cherryPickThisCommitToolStripMenuItem.Name = "cherryPickThisCommitToolStripMenuItem";
             this.cherryPickThisCommitToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.cherryPickThisCommitToolStripMenuItem.Text = "Cherry pick commit";


### PR DESCRIPTION
Some relevant icons were missing in FileHistory menu

Related to #4031 

Changes proposed in this pull request:
 - Add some relevant icons
 
Screenshots before and after (if PR changes UI):
- Add icons
![image](https://user-images.githubusercontent.com/6248932/31917542-6ea44936-b858-11e7-8937-4fdd207ac773.png)

How did I test this code:
 - View FileHistory menu

Has been tested on (remove any that don't apply):
 - GIT 2.14 (not Git related)
 - Windows 10
