### PR TITLE
Feature 2868

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -936,6 +936,12 @@ namespace GitCommands
             set { SetBool("showdiffforallparents", value); }
         }
 
+        public static int DiffVerticalRulerPosition
+        {
+            get { return GetInt( "diffverticalrulerposition", 80 ); }
+            set { SetInt( "diffverticalrulerposition", value ); }
+        }
+
         public static string RecentWorkingDir
         {
             get { return GetString("RecentWorkingDir", null); }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -30,23 +30,26 @@
         {
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanelForDiffViewer = new System.Windows.Forms.TableLayoutPanel();
+            this.chkShowDiffForAllParents = new System.Windows.Forms.CheckBox();
+            this.chkOpenSubmoduleDiffInSeparateWindow = new System.Windows.Forms.CheckBox();
             this.chkRememberIgnoreWhiteSpacePreference = new System.Windows.Forms.CheckBox();
             this.chkRememberShowNonPrintingCharsPreference = new System.Windows.Forms.CheckBox();
             this.chkRememberShowEntireFilePreference = new System.Windows.Forms.CheckBox();
             this.chkRememberNumberOfContextLines = new System.Windows.Forms.CheckBox();
             this.chkOmitUninterestingDiff = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.VerticalRulerPosition = new System.Windows.Forms.NumericUpDown();
             this.tooltip = new System.Windows.Forms.ToolTip(this.components);
-            this.chkOpenSubmoduleDiffInSeparateWindow = new System.Windows.Forms.CheckBox();
-            this.chkShowDiffForAllParents = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanelForDiffViewer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.VerticalRulerPosition)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanelForDiffViewer
             // 
             this.tableLayoutPanelForDiffViewer.AutoSize = true;
-            this.tableLayoutPanelForDiffViewer.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanelForDiffViewer.ColumnCount = 1;
-            this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelForDiffViewer.ColumnCount = 2;
+            this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkShowDiffForAllParents, 0, 6);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkOpenSubmoduleDiffInSeparateWindow, 0, 5);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkRememberIgnoreWhiteSpacePreference, 0, 0);
@@ -54,19 +57,43 @@
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkRememberShowEntireFilePreference, 0, 2);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkRememberNumberOfContextLines, 0, 3);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkOmitUninterestingDiff, 0, 4);
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.label1, 0, 7);
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.VerticalRulerPosition, 1, 7);
             this.tableLayoutPanelForDiffViewer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanelForDiffViewer.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanelForDiffViewer.Name = "tableLayoutPanelForDiffViewer";
-            this.tableLayoutPanelForDiffViewer.RowCount = 7;
+            this.tableLayoutPanelForDiffViewer.RowCount = 9;
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanelForDiffViewer.Size = new System.Drawing.Size(1216, 464);
+            this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForDiffViewer.Size = new System.Drawing.Size(1132, 821);
             this.tableLayoutPanelForDiffViewer.TabIndex = 1;
+            // 
+            // chkShowDiffForAllParents
+            // 
+            this.chkShowDiffForAllParents.AutoSize = true;
+            this.chkShowDiffForAllParents.Location = new System.Drawing.Point(3, 141);
+            this.chkShowDiffForAllParents.Name = "chkShowDiffForAllParents";
+            this.chkShowDiffForAllParents.Size = new System.Drawing.Size(280, 17);
+            this.chkShowDiffForAllParents.TabIndex = 10;
+            this.chkShowDiffForAllParents.Text = "Show file differences for all parents in browse dialog.";
+            this.chkShowDiffForAllParents.UseVisualStyleBackColor = true;
+            // 
+            // chkOpenSubmoduleDiffInSeparateWindow
+            // 
+            this.chkOpenSubmoduleDiffInSeparateWindow.AutoSize = true;
+            this.chkOpenSubmoduleDiffInSeparateWindow.Location = new System.Drawing.Point(3, 118);
+            this.chkOpenSubmoduleDiffInSeparateWindow.Name = "chkOpenSubmoduleDiffInSeparateWindow";
+            this.chkOpenSubmoduleDiffInSeparateWindow.Size = new System.Drawing.Size(223, 17);
+            this.chkOpenSubmoduleDiffInSeparateWindow.TabIndex = 9;
+            this.chkOpenSubmoduleDiffInSeparateWindow.Text = "Open Submodule Diff in separate window";
+            this.chkOpenSubmoduleDiffInSeparateWindow.UseVisualStyleBackColor = true;
             // 
             // chkRememberIgnoreWhiteSpacePreference
             // 
@@ -118,40 +145,48 @@
             this.chkOmitUninterestingDiff.Text = "Omit uninteresting changes from combined diff";
             this.chkOmitUninterestingDiff.UseVisualStyleBackColor = true;
             // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 168);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(144, 13);
+            this.label1.TabIndex = 12;
+            this.label1.Text = "Vertical ruler position [chars]";
+            // 
+            // VerticalRulerPosition
+            // 
+            this.VerticalRulerPosition.Location = new System.Drawing.Point(305, 164);
+            this.VerticalRulerPosition.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.VerticalRulerPosition.Name = "VerticalRulerPosition";
+            this.VerticalRulerPosition.Size = new System.Drawing.Size(120, 21);
+            this.VerticalRulerPosition.TabIndex = 11;
+            this.VerticalRulerPosition.Value = new decimal(new int[] {
+            80,
+            0,
+            0,
+            0});
+            // 
             // tooltip
             // 
             this.tooltip.AutoPopDelay = 30000;
             this.tooltip.InitialDelay = 500;
             this.tooltip.ReshowDelay = 100;
             // 
-            // chkOpenSubmoduleDiffInSeparateWindow
-            // 
-            this.chkOpenSubmoduleDiffInSeparateWindow.AutoSize = true;
-            this.chkOpenSubmoduleDiffInSeparateWindow.Location = new System.Drawing.Point(3, 118);
-            this.chkOpenSubmoduleDiffInSeparateWindow.Name = "chkOpenSubmoduleDiffInSeparateWindow";
-            this.chkOpenSubmoduleDiffInSeparateWindow.Size = new System.Drawing.Size(223, 17);
-            this.chkOpenSubmoduleDiffInSeparateWindow.TabIndex = 9;
-            this.chkOpenSubmoduleDiffInSeparateWindow.Text = "Open Submodule Diff in separate window";
-            this.chkOpenSubmoduleDiffInSeparateWindow.UseVisualStyleBackColor = true;
-            // 
-            // chkShowDiffForAllParents
-            // 
-            this.chkShowDiffForAllParents.AutoSize = true;
-            this.chkShowDiffForAllParents.Location = new System.Drawing.Point(3, 141);
-            this.chkShowDiffForAllParents.Name = "chkShowDiffForAllParents";
-            this.chkShowDiffForAllParents.Size = new System.Drawing.Size(280, 17);
-            this.chkShowDiffForAllParents.TabIndex = 10;
-            this.chkShowDiffForAllParents.Text = "Show file differences for all parents in browse dialog.";
-            this.chkShowDiffForAllParents.UseVisualStyleBackColor = true;
-            // 
             // DiffViewerSettingsPage
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.Controls.Add(this.tableLayoutPanelForDiffViewer);
             this.Name = "DiffViewerSettingsPage";
-            this.Size = new System.Drawing.Size(1216, 464);
+            this.Size = new System.Drawing.Size(1132, 821);
             this.tableLayoutPanelForDiffViewer.ResumeLayout(false);
             this.tableLayoutPanelForDiffViewer.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.VerticalRulerPosition)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -168,5 +203,7 @@
         private System.Windows.Forms.ToolTip tooltip;
         private System.Windows.Forms.CheckBox chkOpenSubmoduleDiffInSeparateWindow;
         private System.Windows.Forms.CheckBox chkShowDiffForAllParents;
+        private System.Windows.Forms.NumericUpDown VerticalRulerPosition;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -20,6 +20,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkRememberNumberOfContextLines.Checked = AppSettings.RememberNumberOfContextLines;
             chkOpenSubmoduleDiffInSeparateWindow.Checked = AppSettings.OpenSubmoduleDiffInSeparateWindow;
             chkShowDiffForAllParents.Checked = AppSettings.ShowDiffForAllParents;
+            VerticalRulerPosition.Value = AppSettings.DiffVerticalRulerPosition;
         }
 
         protected override void PageToSettings()
@@ -31,6 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RememberNumberOfContextLines = chkRememberNumberOfContextLines.Checked;
             AppSettings.OpenSubmoduleDiffInSeparateWindow = chkOpenSubmoduleDiffInSeparateWindow.Checked;
             AppSettings.ShowDiffForAllParents = chkShowDiffForAllParents.Checked;
+            AppSettings.DiffVerticalRulerPosition = (int) VerticalRulerPosition.Value;
         }
 
         public static SettingsPageReference GetPageReference()

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -101,13 +101,13 @@ namespace GitUI.Editor
 
         void FileViewer_GitUICommandsSourceSet(object sender, GitUICommandsSourceEventArgs e)
         {
-            UICommandsSource.GitUICommandsChanged += WorkingDirChanged;
-            WorkingDirChanged(UICommandsSource, null);
+            UICommandsSource.GitUICommandsChanged += UICommandsSourceChanged;
+            UICommandsSourceChanged(UICommandsSource, null);
         }
 
         protected override void DisposeUICommandsSource()
         {
-            UICommandsSource.GitUICommandsChanged -= WorkingDirChanged;
+            UICommandsSource.GitUICommandsChanged -= UICommandsSourceChanged;
             base.DisposeUICommandsSource();
         }
 
@@ -182,7 +182,7 @@ namespace GitUI.Editor
         [Browsable(false)]
         public byte[] FilePreamble { get; private set; }
 
-        private void WorkingDirChanged(object sender, GitUICommandsChangedEventArgs e)
+        private void UICommandsSourceChanged(object sender, GitUICommandsChangedEventArgs e)
         {
             this.Encoding = null;
         }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -184,7 +184,19 @@ namespace GitUI.Editor
 
         private void UICommandsSourceChanged(object sender, GitUICommandsChangedEventArgs e)
         {
+            if(e?.OldCommands != null)
+                e.OldCommands.PostSettings -= UICommands_PostSettings;
+
+            var commandSource = sender as IGitUICommandsSource;
+            if( commandSource?.UICommands != null)
+                commandSource.UICommands.PostSettings += UICommands_PostSettings;
+
             this.Encoding = null;
+        }
+
+        private void UICommands_PostSettings( object sender, GitUIPluginInterfaces.GitUIPostActionEventArgs e )
+        {
+            _internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition;
         }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -32,6 +32,8 @@ namespace GitUI.Editor
             TextEditor.ActiveTextAreaControl.TextArea.DoubleClick += ActiveTextAreaControlDoubleClick;
 
             _lineNumbersControl = new DiffViewerLineNumberCtrl(TextEditor.ActiveTextAreaControl.TextArea);
+
+            VRulerPosition = GitCommands.AppSettings.DiffVerticalRulerPosition;
         }
 
         public new Font Font
@@ -262,6 +264,18 @@ namespace GitUI.Editor
             set
             {
                 TextEditor.ShowTabs = value;
+            }
+        }
+
+        public int VRulerPosition
+        {
+            get
+            {
+                return TextEditor.VRulerRow;
+            }
+            set
+            {
+                TextEditor.VRulerRow = value;
             }
         }
 

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -45,6 +45,7 @@ namespace GitUI.Editor
         bool ShowEOLMarkers { get; set; }
         bool ShowSpaces { get; set; }
         bool ShowTabs { get; set; }
+        int VRulerPosition { get; set; }
         bool IsReadOnly { get; set; }
         bool Visible { get; set; }
 


### PR DESCRIPTION
Implements #2868

Changes proposed in this pull request:
 - Add DiffVerticalRulerPosition to settings and to Diff page
 - Expose VRulerPosition in IFileViewer interface
 
How did I test this code:
 - after changing the settings file viewer is updated

Has been tested on (remove any that don't apply):
 - Windows 10 and above
