### PR TITLE
Hide CommitInfo panel for virtual commits

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -13,6 +13,7 @@ using GitCommands.Repository;
 using GitCommands.Settings;
 using Microsoft.Win32;
 using System.Linq;
+using GitCommands.Utils;
 
 namespace GitCommands
 {
@@ -322,7 +323,12 @@ namespace GitCommands
         public static readonly StringSetting ConEmuStyle = new StringSetting("ConEmuStyle", DetailedSettingsPath, "<Solarized Light>");
         public static readonly StringSetting ConEmuTerminal = new StringSetting("ConEmuTerminal", DetailedSettingsPath, "bash");
         public static readonly StringSetting ConEmuFontSize = new StringSetting("ConEmuFontSize", DetailedSettingsPath, "12");
-        public static readonly BoolNullableSetting ShowRevisionInfoNextToRevisionGrid = new BoolNullableSetting("ShowRevisionInfoNextToRevisionGrid", DetailedSettingsPath, false);
+
+        public static bool ShowRevisionInfoNextToRevisionGrid
+        {
+            get { return !EnvUtils.IsMonoRuntime() && DetailedSettingsPath.GetBool("ShowRevisionInfoNextToRevisionGrid", false); }
+            set { DetailedSettingsPath.SetBool("ShowRevisionInfoNextToRevisionGrid", !EnvUtils.IsMonoRuntime() && value); }
+        }
 
         public static bool ProvideAutocompletion
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -73,7 +73,7 @@
             this.chkShowRevisionInfoNextToRevisionGrid.Name = "chkShowRevisionInfoNextToRevisionGrid";
             this.chkShowRevisionInfoNextToRevisionGrid.Size = new System.Drawing.Size(1291, 17);
             this.chkShowRevisionInfoNextToRevisionGrid.TabIndex = 6;
-            this.chkShowRevisionInfoNextToRevisionGrid.Text = "Show revision details next to the revision list (restart required)";
+            this.chkShowRevisionInfoNextToRevisionGrid.Text = "Show revision details next to the revision list";
             this.chkShowRevisionInfoNextToRevisionGrid.UseVisualStyleBackColor = true;
             // 
             // ConEmuGB

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -1,12 +1,5 @@
 ﻿using GitCommands;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
+using GitCommands.Utils;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
@@ -25,13 +18,25 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             BindSettingsWithControls();
         }
 
+        protected override void SettingsToPage()
+        {
+            chkShowRevisionInfoNextToRevisionGrid.Checked = AppSettings.ShowRevisionInfoNextToRevisionGrid;
+            chkShowRevisionInfoNextToRevisionGrid.Visible = !EnvUtils.IsMonoRuntime();
+            base.SettingsToPage();
+        }
+
+        protected override void PageToSettings()
+        {
+            AppSettings.ShowRevisionInfoNextToRevisionGrid = chkShowRevisionInfoNextToRevisionGrid.Checked;
+            base.PageToSettings();
+        }
+
         private void BindSettingsWithControls()
         {
             AddSettingBinding(AppSettings.ShowConEmuTab, chkChowConsoleTab);
             AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);
             AddSettingBinding(AppSettings.ConEmuTerminal, cboTerminal);
             AddSettingBinding(AppSettings.ConEmuFontSize, cboFontSize);
-            AddSettingBinding(AppSettings.ShowRevisionInfoNextToRevisionGrid, chkShowRevisionInfoNextToRevisionGrid);
         }
 
         private void chkChowConsoleTab_CheckedChanged(object sender, System.EventArgs e)

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -323,19 +323,44 @@ namespace GitUI.CommitInfo
             }
         }
 
-        public void DisplayAvatarOnRight()
+        private void DisplayAvatarSetup(bool right)
         {
             tableLayout.SuspendLayout();
             this.tableLayout.ColumnStyles.Clear();
-            this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            tableLayout.SetColumn(gravatar1, 1);
-            tableLayout.SetColumn(_RevisionHeader, 0);
-            tableLayout.SetColumn(RevisionInfo, 0);
-            tableLayout.SetRowSpan(gravatar1, 1);
-            tableLayout.SetColumnSpan(RevisionInfo, 2);
+            int gravatarIndex, revInfoIndex, gravatarSpan, revInfoSpan;
+            if (right)
+            {
+                this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+                this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+                gravatarIndex = 1;
+                revInfoIndex = 0;
+                gravatarSpan = 1;
+                revInfoSpan = 2;
+            } else
+            {
+                this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+                this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+                gravatarIndex = 0;
+                revInfoIndex = 1;
+                gravatarSpan = 2;
+                revInfoSpan = 1;
+            }
+            tableLayout.SetColumn(gravatar1, gravatarIndex);
+            tableLayout.SetColumn(_RevisionHeader, revInfoIndex);
+            tableLayout.SetColumn(RevisionInfo, revInfoIndex);
+            tableLayout.SetRowSpan(gravatar1, gravatarSpan);
+            tableLayout.SetColumnSpan(RevisionInfo, revInfoSpan);
             tableLayout.ResumeLayout(true);
+        }
 
+        public void DisplayAvatarOnRight()
+        {
+            DisplayAvatarSetup(true);
+        }
+
+        public void DisplayAvatarOnLeft()
+        {
+            DisplayAvatarSetup(false);
         }
 
         private void updateText()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2731,7 +2731,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowRevisionInfoNextToRevisionGrid.Text">
-        <source>Show revision details next to the revision list (restart required)</source>
+        <source>Show revision details next to the revision list</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBoxConsoleSettings.Text">


### PR DESCRIPTION
It has no information for staged/unstaged, just blank
It _should_ later be used for commit without a popup as discussed in #4031 etc

Discussed in #4031

Changes proposed in this pull request:
 - Make sure the commit info panel is collapsed for artificial commits
 
Screenshots before and after (if PR changes UI):
- Only before - the blank window is removed for artificial commits with this PR
![image](https://user-images.githubusercontent.com/6248932/31969542-37a10664-b915-11e7-8e78-e4a98ff463bd.png)

How did I test this code:
 - Manual

Has been tested on (remove any that don't apply):
 - Windows 10
