### PR TITLE
Extract "Revision Diff" control from FormBrowse

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -64,35 +64,10 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabPage = new System.Windows.Forms.TabPage();
             this.RevisionInfo = new GitUI.CommitInfo.CommitInfo();
             this.TreeTabPage = new System.Windows.Forms.TabPage();
+            this.fileTree = new GitUI.CommandsDialogs.RevisionFileTree();
             this.DiffTabPage = new System.Windows.Forms.TabPage();
-            this.DiffSplitContainer = new System.Windows.Forms.SplitContainer();
-            this.DiffFiles = new GitUI.FileStatusList();
-            this.DiffContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.bLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.parentOfALocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.parentOfBLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveAsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetFileToToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetFileToFirstToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetFileToSecondToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetFileToSelectedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetFileToParentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.cherryPickSelectedDiffFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator32 = new System.Windows.Forms.ToolStripSeparator();
-            this.copyFilenameToClipboardToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.openContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.diffShowInFileTreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator33 = new System.Windows.Forms.ToolStripSeparator();
-            this.fileHistoryDiffToolstripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.blameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.findInDiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.DiffText = new GitUI.Editor.FileViewer();
+            this.revisionDiff = new GitUI.CommandsDialogs.RevisionDiff();
             this.FilterToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.TreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -204,7 +179,6 @@ namespace GitUI.CommandsDialogs
             this.menuStrip1 = new GitUI.MenuStripEx();
             this.gitItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.fileTree = new GitUI.CommandsDialogs.RevisionFileTree();
             ((System.ComponentModel.ISupportInitialize)(this.toolPanel)).BeginInit();
             this.toolPanel.Panel1.SuspendLayout();
             this.toolPanel.Panel2.SuspendLayout();
@@ -221,12 +195,6 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabPage.SuspendLayout();
             this.TreeTabPage.SuspendLayout();
             this.DiffTabPage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.DiffSplitContainer)).BeginInit();
-            this.DiffSplitContainer.Panel1.SuspendLayout();
-            this.DiffSplitContainer.Panel2.SuspendLayout();
-            this.DiffSplitContainer.SuspendLayout();
-            this.DiffContextMenu.SuspendLayout();
-            this.TreeContextMenu.SuspendLayout();
             this.statusStrip.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gitItemBindingSource)).BeginInit();
@@ -699,9 +667,17 @@ namespace GitUI.CommandsDialogs
             this.TreeTabPage.Text = "File tree";
             this.TreeTabPage.UseVisualStyleBackColor = true;
             // 
+            // fileTree
+            // 
+            this.fileTree.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fileTree.Location = new System.Drawing.Point(3, 3);
+            this.fileTree.Name = "fileTree";
+            this.fileTree.Size = new System.Drawing.Size(909, 251);
+            this.fileTree.TabIndex = 0;
+            // 
             // DiffTabPage
             // 
-            this.DiffTabPage.Controls.Add(this.DiffSplitContainer);
+            this.DiffTabPage.Controls.Add(this.revisionDiff);
             this.DiffTabPage.Location = new System.Drawing.Point(4, 28);
             this.DiffTabPage.Name = "DiffTabPage";
             this.DiffTabPage.Padding = new System.Windows.Forms.Padding(3);
@@ -710,233 +686,13 @@ namespace GitUI.CommandsDialogs
             this.DiffTabPage.Text = "Diff";
             this.DiffTabPage.UseVisualStyleBackColor = true;
             // 
-            // DiffSplitContainer
+            // revisionDiff
             // 
-            this.DiffSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DiffSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.DiffSplitContainer.Location = new System.Drawing.Point(3, 3);
-            this.DiffSplitContainer.Name = "DiffSplitContainer";
-            // 
-            // DiffSplitContainer.Panel1
-            // 
-            this.DiffSplitContainer.Panel1.Controls.Add(this.DiffFiles);
-            // 
-            // DiffSplitContainer.Panel2
-            // 
-            this.DiffSplitContainer.Panel2.Controls.Add(this.DiffText);
-            this.DiffSplitContainer.Size = new System.Drawing.Size(909, 251);
-            this.DiffSplitContainer.SplitterDistance = 300;
-            this.DiffSplitContainer.TabIndex = 0;
-            // 
-            // DiffFiles
-            // 
-            this.DiffFiles.ContextMenuStrip = this.DiffContextMenu;
-            this.DiffFiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DiffFiles.FilterVisible = false;
-            this.DiffFiles.Location = new System.Drawing.Point(0, 0);
-            this.DiffFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.DiffFiles.Name = "DiffFiles";
-            this.DiffFiles.Size = new System.Drawing.Size(300, 251);
-            this.DiffFiles.TabIndex = 1;
-            this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFilesSelectedIndexChanged);
-            this.DiffFiles.DataSourceChanged += new System.EventHandler(this.DiffFiles_DataSourceChanged);
-            this.DiffFiles.DoubleClick += new System.EventHandler(this.DiffFilesDoubleClick);
-            // 
-            // DiffContextMenu
-            // 
-            this.DiffContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openWithDifftoolToolStripMenuItem,
-            this.saveAsToolStripMenuItem1,
-            this.resetFileToToolStripMenuItem,
-            this.cherryPickSelectedDiffFileToolStripMenuItem,
-            this.toolStripSeparator32,
-            this.copyFilenameToClipboardToolStripMenuItem1,
-            this.openContainingFolderToolStripMenuItem,
-            this.diffShowInFileTreeToolStripMenuItem,
-            this.toolStripSeparator33,
-            this.fileHistoryDiffToolstripMenuItem,
-            this.blameToolStripMenuItem,
-            this.findInDiffToolStripMenuItem});
-            this.DiffContextMenu.Name = "DiffContextMenu";
-            this.DiffContextMenu.Size = new System.Drawing.Size(211, 236);
-            this.DiffContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.DiffContextMenu_Opening);
-            // 
-            // openWithDifftoolToolStripMenuItem
-            // 
-            this.openWithDifftoolToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.aBToolStripMenuItem,
-            this.aLocalToolStripMenuItem,
-            this.bLocalToolStripMenuItem,
-            this.parentOfALocalToolStripMenuItem,
-            this.parentOfBLocalToolStripMenuItem});
-            this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconDiffTool;
-            this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
-            this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
-            this.openWithDifftoolToolStripMenuItem.DropDownOpening += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_DropDownOpening);
-            // 
-            // aBToolStripMenuItem
-            // 
-            this.aBToolStripMenuItem.Name = "aBToolStripMenuItem";
-            this.aBToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.aBToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
-            this.aBToolStripMenuItem.Text = "A <--> B";
-            this.aBToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
-            // 
-            // aLocalToolStripMenuItem
-            // 
-            this.aLocalToolStripMenuItem.Name = "aLocalToolStripMenuItem";
-            this.aLocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
-            this.aLocalToolStripMenuItem.Text = "A <--> Working directory";
-            this.aLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
-            // 
-            // bLocalToolStripMenuItem
-            // 
-            this.bLocalToolStripMenuItem.Name = "bLocalToolStripMenuItem";
-            this.bLocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
-            this.bLocalToolStripMenuItem.Text = "B <--> Working directory";
-            this.bLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
-            // 
-            // parentOfALocalToolStripMenuItem
-            // 
-            this.parentOfALocalToolStripMenuItem.Name = "parentOfALocalToolStripMenuItem";
-            this.parentOfALocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
-            this.parentOfALocalToolStripMenuItem.Text = "A\'s parent <--> Working directory";
-            this.parentOfALocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
-            // 
-            // parentOfBLocalToolStripMenuItem
-            // 
-            this.parentOfBLocalToolStripMenuItem.Name = "parentOfBLocalToolStripMenuItem";
-            this.parentOfBLocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
-            this.parentOfBLocalToolStripMenuItem.Text = "B\'s parent <--> Working directory";
-            this.parentOfBLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
-            // 
-            // saveAsToolStripMenuItem1
-            // 
-            this.saveAsToolStripMenuItem1.Image = global::GitUI.Properties.Resources.IconSaveAs;
-            this.saveAsToolStripMenuItem1.Name = "saveAsToolStripMenuItem1";
-            this.saveAsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveAsToolStripMenuItem1.Size = new System.Drawing.Size(210, 22);
-            this.saveAsToolStripMenuItem1.Text = "Save (B) as...";
-            this.saveAsToolStripMenuItem1.Click += new System.EventHandler(this.saveAsToolStripMenuItem1_Click);
-            // 
-            // resetFileToToolStripMenuItem
-            // 
-            this.resetFileToToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.resetFileToFirstToolStripMenuItem,
-            this.resetFileToSecondToolStripMenuItem,
-            this.resetFileToSelectedToolStripMenuItem,
-            this.resetFileToParentToolStripMenuItem});
-            this.resetFileToToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetFileTo;
-            this.resetFileToToolStripMenuItem.Name = "resetFileToToolStripMenuItem";
-            this.resetFileToToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.resetFileToToolStripMenuItem.Text = "Reset file(s) to";
-            this.resetFileToToolStripMenuItem.DropDownOpening += new System.EventHandler(this.resetFileToToolStripMenuItem_DropDownOpening);
-            // 
-            // resetFileToFirstToolStripMenuItem
-            // 
-            this.resetFileToFirstToolStripMenuItem.Name = "resetFileToFirstToolStripMenuItem";
-            this.resetFileToFirstToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.resetFileToFirstToolStripMenuItem.Text = "First";
-            this.resetFileToFirstToolStripMenuItem.Click += new System.EventHandler(this.resetFileToFirstToolStripMenuItem_Click);
-            // 
-            // resetFileToSecondToolStripMenuItem
-            // 
-            this.resetFileToSecondToolStripMenuItem.Name = "resetFileToSecondToolStripMenuItem";
-            this.resetFileToSecondToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.resetFileToSecondToolStripMenuItem.Text = "Second";
-            this.resetFileToSecondToolStripMenuItem.Click += new System.EventHandler(this.resetFileToSecondToolStripMenuItem_Click);
-            // 
-            // resetFileToSelectedToolStripMenuItem
-            // 
-            this.resetFileToSelectedToolStripMenuItem.Name = "resetFileToSelectedToolStripMenuItem";
-            this.resetFileToSelectedToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.resetFileToSelectedToolStripMenuItem.Text = "Selected";
-            this.resetFileToSelectedToolStripMenuItem.Click += new System.EventHandler(this.resetFileToSelectedToolStripMenuItem_Click);
-            // 
-            // resetFileToParentToolStripMenuItem
-            // 
-            this.resetFileToParentToolStripMenuItem.Name = "resetFileToParentToolStripMenuItem";
-            this.resetFileToParentToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.resetFileToParentToolStripMenuItem.Text = "Parent";
-            this.resetFileToParentToolStripMenuItem.Click += new System.EventHandler(this.resetFileToParentToolStripMenuItem_Click);
-            // 
-            // cherryPickSelectedDiffFileToolStripMenuItem
-            // 
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCherryPick;
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Name = "cherryPickSelectedDiffFileToolStripMenuItem";
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Text = "Cherry pick file\'s changes";
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Click += new System.EventHandler(this.cherryPickSelectedDiffFileToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator32
-            // 
-            this.toolStripSeparator32.Name = "toolStripSeparator32";
-            this.toolStripSeparator32.Size = new System.Drawing.Size(207, 6);
-            // 
-            // copyFilenameToClipboardToolStripMenuItem1
-            // 
-            this.copyFilenameToClipboardToolStripMenuItem1.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
-            this.copyFilenameToClipboardToolStripMenuItem1.Name = "copyFilenameToClipboardToolStripMenuItem1";
-            this.copyFilenameToClipboardToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyFilenameToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(210, 22);
-            this.copyFilenameToClipboardToolStripMenuItem1.Text = "Copy full path(s)";
-            this.copyFilenameToClipboardToolStripMenuItem1.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem1_Click);
-            // 
-            // openContainingFolderToolStripMenuItem
-            // 
-            this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
-            this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
-            this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.openContainingFolderToolStripMenuItem.Text = "Open containing folder(s)";
-            this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
-            // 
-            // diffShowInFileTreeToolStripMenuItem
-            // 
-            this.diffShowInFileTreeToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFileTree;
-            this.diffShowInFileTreeToolStripMenuItem.Name = "diffShowInFileTreeToolStripMenuItem";
-            this.diffShowInFileTreeToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.diffShowInFileTreeToolStripMenuItem.Text = "Show in File tree";
-            this.diffShowInFileTreeToolStripMenuItem.Click += new System.EventHandler(this.diffShowInFileTreeToolStripMenuItem_Click);
-            // 
-            // toolStripSeparator33
-            // 
-            this.toolStripSeparator33.Name = "toolStripSeparator33";
-            this.toolStripSeparator33.Size = new System.Drawing.Size(207, 6);
-            // 
-            // fileHistoryDiffToolstripMenuItem
-            // 
-            this.fileHistoryDiffToolstripMenuItem.Image = global::GitUI.Properties.Resources.IconFileHistory;
-            this.fileHistoryDiffToolstripMenuItem.Name = "fileHistoryDiffToolstripMenuItem";
-            this.fileHistoryDiffToolstripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.fileHistoryDiffToolstripMenuItem.Text = "File history";
-            this.fileHistoryDiffToolstripMenuItem.Click += new System.EventHandler(this.fileHistoryDiffToolstripMenuItem_Click);
-            // 
-            // blameToolStripMenuItem
-            // 
-            this.blameToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBlame;
-            this.blameToolStripMenuItem.Name = "blameToolStripMenuItem";
-            this.blameToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.blameToolStripMenuItem.Text = "Blame";
-            this.blameToolStripMenuItem.Click += new System.EventHandler(this.blameToolStripMenuItem_Click);
-            // 
-            // findInDiffToolStripMenuItem
-            // 
-            this.findInDiffToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFind;
-            this.findInDiffToolStripMenuItem.Name = "findInDiffToolStripMenuItem";
-            this.findInDiffToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.findInDiffToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.findInDiffToolStripMenuItem.Text = "Find";
-            this.findInDiffToolStripMenuItem.Click += new System.EventHandler(this.findInDiffToolStripMenuItem_Click);
-            // 
-            // DiffText
-            // 
-            this.DiffText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DiffText.Location = new System.Drawing.Point(0, 0);
-            this.DiffText.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.DiffText.Name = "DiffText";
-            this.DiffText.Size = new System.Drawing.Size(605, 251);
-            this.DiffText.TabIndex = 0;
+            this.revisionDiff.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.revisionDiff.Location = new System.Drawing.Point(3, 3);
+            this.revisionDiff.Name = "revisionDiff";
+            this.revisionDiff.Size = new System.Drawing.Size(909, 251);
+            this.revisionDiff.TabIndex = 0;
             // 
             // FilterToolTip
             // 
@@ -946,19 +702,6 @@ namespace GitUI.CommandsDialogs
             this.FilterToolTip.ToolTipTitle = "RegEx";
             this.FilterToolTip.UseAnimation = false;
             this.FilterToolTip.UseFading = false;
-            // 
-            // TreeContextMenu
-            // 
-            this.TreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.saveToolStripMenuItem});
-            this.TreeContextMenu.Name = "TreeContextMenu";
-            this.TreeContextMenu.Size = new System.Drawing.Size(99, 26);
-            // 
-            // saveToolStripMenuItem
-            // 
-            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(98, 22);
-            this.saveToolStripMenuItem.Text = "Save";
             // 
             // statusStrip
             // 
@@ -1835,14 +1578,6 @@ namespace GitUI.CommandsDialogs
             this.menuStrip1.Size = new System.Drawing.Size(923, 24);
             this.menuStrip1.TabIndex = 3;
             // 
-            // fileTree
-            // 
-            this.fileTree.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.fileTree.Location = new System.Drawing.Point(3, 3);
-            this.fileTree.Name = "fileTree";
-            this.fileTree.Size = new System.Drawing.Size(909, 251);
-            this.fileTree.TabIndex = 0;
-            // 
             // FormBrowse
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1875,12 +1610,6 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabPage.ResumeLayout(false);
             this.TreeTabPage.ResumeLayout(false);
             this.DiffTabPage.ResumeLayout(false);
-            this.DiffSplitContainer.Panel1.ResumeLayout(false);
-            this.DiffSplitContainer.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.DiffSplitContainer)).EndInit();
-            this.DiffSplitContainer.ResumeLayout(false);
-            this.DiffContextMenu.ResumeLayout(false);
-            this.TreeContextMenu.ResumeLayout(false);
             this.statusStrip.ResumeLayout(false);
             this.statusStrip.PerformLayout();
             this.menuStrip1.ResumeLayout(false);
@@ -1911,10 +1640,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripTextBox toolStripRevisionFilterTextBox;
         private System.Windows.Forms.TabPage DiffTabPage;
-        private System.Windows.Forms.SplitContainer DiffSplitContainer;
-        private FileStatusList DiffFiles;
         private System.Windows.Forms.ToolStripButton toolStripButtonPush;
-        private FileViewer DiffText;
         private System.Windows.Forms.TabPage CommitInfoTabPage;
         private CommitInfo.CommitInfo RevisionInfo;
         private System.Windows.Forms.ToolStripLabel toolStripRevisionFilterLabel;
@@ -1923,13 +1649,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem stashPopToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
         private System.Windows.Forms.ToolStripMenuItem viewStashToolStripMenuItem;
-        private System.Windows.Forms.ContextMenuStrip TreeContextMenu;
-        private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
-        private System.Windows.Forms.ContextMenuStrip DiffContextMenu;
-        private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator17;
-        private ToolStripMenuItem copyFilenameToClipboardToolStripMenuItem1;
-        private ToolStripMenuItem saveAsToolStripMenuItem1;
         private ToolStripSeparator toolStripSeparator19;
         private ToolStripLabel toolStripLabel1;
         private ToolStripComboBox toolStripBranchFilterComboBox;
@@ -1937,9 +1657,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripDropDownButton toolStripRevisionFilterDropDownButton;
         private StatusStrip statusStrip;
         private ToolStripStatusLabel toolStripStatusLabel1;
-        private ToolStripSeparator toolStripSeparator32;
-        private ToolStripSeparator toolStripSeparator33;
-        private ToolStripMenuItem fileHistoryDiffToolstripMenuItem;
         private ToolStripSplitButton branchSelect;
         private ToolStripButton toggleSplitViewLayout;
         private SplitContainer toolPanel;
@@ -2021,8 +1738,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem donateToolStripMenuItem;
         private ToolStripMenuItem aboutToolStripMenuItem;
         private MenuStripEx menuStrip1;
-        private ToolStripMenuItem openContainingFolderToolStripMenuItem;
-        private ToolStripMenuItem diffShowInFileTreeToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator21;
         private ToolStripSeparator toolStripSeparator25;
         private ToolStripSeparator toolStripSeparator22;
@@ -2032,8 +1747,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem SvnDcommitToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator24;
         private ToolStripMenuItem SvnFetchToolStripMenuItem;
-        private ToolStripMenuItem blameToolStripMenuItem;
-        private ToolStripMenuItem findInDiffToolStripMenuItem;        
         private ToolStripSplitButton toolStripButtonLevelUp;
         private ToolStripSplitButton toolStripButtonPull;
         private ToolStripMenuItem mergeToolStripMenuItem;
@@ -2043,17 +1756,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator14;
         private ToolStripMenuItem setNextPullActionAsDefaultToolStripMenuItem;
         private ToolStripMenuItem fetchAllToolStripMenuItem;
-        private ToolStripMenuItem resetFileToToolStripMenuItem;
-        private ToolStripMenuItem resetFileToFirstToolStripMenuItem;
-        private ToolStripMenuItem resetFileToParentToolStripMenuItem;
-        private ToolStripMenuItem resetFileToSecondToolStripMenuItem;
-        private ToolStripMenuItem resetFileToSelectedToolStripMenuItem;
         private ToolStripMenuItem resetToolStripMenuItem;        
-        private ToolStripMenuItem aBToolStripMenuItem;
-        private ToolStripMenuItem aLocalToolStripMenuItem;
-        private ToolStripMenuItem bLocalToolStripMenuItem;
-        private ToolStripMenuItem parentOfALocalToolStripMenuItem;
-        private ToolStripMenuItem parentOfBLocalToolStripMenuItem;        
         private ToolStripMenuItem reportAnIssueToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator41;
         private ToolStripSeparator toolStripSeparator42;
@@ -2065,7 +1768,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem commitcountPerUserToolStripMenuItem;
         private ToolStripMenuItem gitcommandLogToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator7;
-        private ToolStripMenuItem cherryPickSelectedDiffFileToolStripMenuItem;
         private ToolStripMenuItem menuitemSparse;
         private ToolStripButton ShowFirstParent;
         private ToolTip FilterToolTip;
@@ -2079,5 +1781,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
         private ToolStripButton toolStripFileExplorer;
         private RevisionFileTree fileTree;
+        private RevisionDiff revisionDiff;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,11 +62,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _superprojectModuleFormat =
             new TranslationString("Superproject: {0}");
 
-        private readonly TranslationString _saveFileFilterCurrentFormat =
-            new TranslationString("Current format");
-        private readonly TranslationString _saveFileFilterAllFiles =
-            new TranslationString("All files");
-
         private readonly TranslationString _indexLockCantDelete =
             new TranslationString("Failed to delete index.lock.");
         private readonly TranslationString _indexLockNotFound =
@@ -95,18 +89,6 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _updateCurrentSubmodule =
             new TranslationString("Update current submodule");
-
-        private readonly TranslationString _diffNoSelection =
-            new TranslationString("Diff (no selection)");
-
-        private readonly TranslationString _diffParentWithSelection =
-            new TranslationString("Diff (A: parent --> B: selection)");
-
-        private readonly TranslationString _diffTwoSelected =
-            new TranslationString("Diff (A: first --> B: second)");
-
-        private readonly TranslationString _diffNotSupported =
-            new TranslationString("Diff (not supported)");
 
         private readonly TranslationString _pullFetch =
             new TranslationString("Pull - fetch");
@@ -177,8 +159,6 @@ namespace GitUI.CommandsDialogs
                 CommitInfoTabControl.TabPages[1].ImageIndex = 1;
                 CommitInfoTabControl.TabPages[2].ImageIndex = 2;
             }
-            DiffFiles.FilterVisible = true;
-            DiffFiles.DescribeRevision = DescribeRevision;
             RevisionGrid.UICommandsSource = this;
             Repositories.LoadRepositoryHistoryAsync();
             Task.Factory.StartNew(PluginLoader.Load)
@@ -187,6 +167,7 @@ namespace GitUI.CommandsDialogs
             _filterRevisionsHelper = new FilterRevisionsHelper(toolStripRevisionFilterTextBox, toolStripRevisionFilterDropDownButton, RevisionGrid, toolStripRevisionFilterLabel, ShowFirstParent, form: this);
             _filterBranchHelper = new FilterBranchHelper(toolStripBranchFilterComboBox, toolStripBranchFilterDropDownButton, RevisionGrid);
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
+            revisionDiff.Bind(RevisionGrid, fileTree);
 
             Translate();
             LayoutRevisionInfo();
@@ -214,9 +195,7 @@ namespace GitUI.CommandsDialogs
             }
 
             RevisionGrid.SelectionChanged += RevisionGridSelectionChanged;
-            DiffText.ExtraDiffArgumentsChanged += DiffTextExtraDiffArgumentsChanged;
             _filterRevisionsHelper.SetFilter(filter);
-            DiffText.SetFileLoader(getNextPatchFile);
 
 
             this.HotkeysEnabled = true;
@@ -248,17 +227,6 @@ namespace GitUI.CommandsDialogs
 
             FillTerminalTab();
             ManageWorktreeSupport();
-        }
-
-        private string DescribeRevision(string sha1)
-        {
-            var revision = RevisionGrid.GetRevision(sha1);
-            if (revision == null)
-            {
-                return sha1.ShortenTo(8);
-            }
-
-            return RevisionGrid.DescribeRevision(revision);
         }
 
         private void LayoutRevisionInfo()
@@ -312,28 +280,16 @@ namespace GitUI.CommandsDialogs
             this.InvokeAsync(RefreshRevisions);
         }
 
-        private string _oldRevision;
-        private GitItemStatus _oldDiffItem;
         private void RefreshRevisions()
         {
-            if (RevisionGrid.IsDisposed || DiffFiles.IsDisposed || IsDisposed || Disposing)
+            if (RevisionGrid.IsDisposed || IsDisposed || Disposing)
             {
                 return;
             }
 
             if (_dashboard == null || !_dashboard.Visible)
             {
-                var revisions = RevisionGrid.GetSelectedRevisions();
-                if (revisions.Count != 0)
-                {
-                    _oldRevision = revisions[0].Guid;
-                    _oldDiffItem = DiffFiles.SelectedItem;
-                }
-                else
-                {
-                    _oldRevision = null;
-                    _oldDiffItem = null;
-                }
+                revisionDiff.ForceRefreshRevisions();
                 RevisionGrid.ForceRefreshRevisions();
                 InternalInitialize(true);
             }
@@ -597,7 +553,6 @@ namespace GitUI.CommandsDialogs
                 ShowRevisions();
             RefreshWorkingDirCombo();
             Text = GenerateWindowTitle(Module.WorkingDir, validWorkingDir, branchSelect.Text);
-            DiffText.Font = Settings.DiffFont;
             UpdateJumplist(validWorkingDir);
 
             OnActivate();
@@ -1069,40 +1024,7 @@ namespace GitUI.CommandsDialogs
 
             _selectedRevisionUpdatedTargets |= UpdateTargets.DiffList;
 
-            var revisions = RevisionGrid.GetSelectedRevisions();
-
-            DiffText.SaveCurrentScrollPos();
-
-            DiffFiles.SetDiffs(revisions);
-            if (_oldDiffItem != null && revisions.Count > 0 && revisions[0].Guid == _oldRevision)
-            {
-                DiffFiles.SelectedItem = _oldDiffItem;
-                _oldDiffItem = null;
-                _oldRevision = null;
-            }
-
-            switch (revisions.Count)
-            {
-                case 0:
-                    DiffTabPage.Text = _diffNoSelection.Text;
-                    break;
-
-                case 1: // diff "parent" --> "selected revision"
-                    var revision = revisions[0];
-                    if (revision != null && revision.ParentGuids != null && revision.ParentGuids.Length != 0)
-                        DiffTabPage.Text = _diffParentWithSelection.Text;
-                    break;
-
-                case 2: // diff "first clicked revision" --> "second clicked revision"
-                    bool artificialRevSelected = revisions[0].IsArtificial() || revisions[1].IsArtificial();
-                    if (!artificialRevSelected)
-                        DiffTabPage.Text = _diffTwoSelected.Text;
-                    break;
-
-                default: // more than 2 revisions selected => no diff
-                    DiffTabPage.Text = _diffNotSupported.Text;
-                    break;
-            }
+            DiffTabPage.Text = revisionDiff.GetTabText();
         }
 
         private void FillCommitInfo()
@@ -1366,7 +1288,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.ReloadHotkeys();
             RevisionGrid.ReloadTranslation();
             fileTree.ReloadHotkeys();
-            DiffText.ReloadHotkeys();
+            revisionDiff.ReloadHotkeys();
         }
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)
@@ -1511,70 +1433,9 @@ namespace GitUI.CommandsDialogs
             FillTerminalTab();
         }
 
-        private void DiffFilesSelectedIndexChanged(object sender, EventArgs e)
-        {
-            ShowSelectedFileDiff();
-        }
-
-        private void ShowSelectedFileDiff()
-        {
-            if (DiffFiles.SelectedItem == null)
-            {
-                DiffText.ViewPatch("");
-                return;
-            }
-
-            IList<GitRevision> items = RevisionGrid.GetSelectedRevisions();
-            if (items.Count() == 1)
-            {
-                items.Add(new GitRevision(Module, DiffFiles.SelectedItemParent));
-
-                if (!string.IsNullOrWhiteSpace(DiffFiles.SelectedItemParent)
-                    && DiffFiles.SelectedItemParent == DiffFiles.CombinedDiff.Text)
-                {
-                    var diffOfConflict = Module.GetCombinedDiffContent(items.First(), DiffFiles.SelectedItem.Name,
-                        DiffText.GetExtraDiffArguments(), DiffText.Encoding);
-
-                    if (string.IsNullOrWhiteSpace(diffOfConflict))
-                    {
-                        diffOfConflict = Strings.GetUninterestingDiffOmitted();
-                    }
-
-                    DiffText.ViewPatch(diffOfConflict);
-                    return;
-                }
-            }
-            DiffText.ViewChanges(items, DiffFiles.SelectedItem, String.Empty);
-        }
-
         private void ChangelogToolStripMenuItemClick(object sender, EventArgs e)
         {
             using (var frm = new FormChangeLog()) frm.ShowDialog(this);
-        }
-
-        private void DiffFilesDoubleClick(object sender, EventArgs e)
-        {
-            if (DiffFiles.SelectedItem == null)
-                return;
-
-            if (AppSettings.OpenSubmoduleDiffInSeparateWindow && DiffFiles.SelectedItem.IsSubmodule)
-            {
-                var submoduleName = DiffFiles.SelectedItem.Name;
-                DiffFiles.SelectedItem.SubmoduleStatus.ContinueWith(
-                    (t) =>
-                    {
-                        Process process = new Process();
-                        process.StartInfo.FileName = Application.ExecutablePath;
-                        process.StartInfo.Arguments = "browse -commit=" + t.Result.Commit;
-                        process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, submoduleName.EnsureTrailingPathSeparator());
-                        process.Start();
-                    });
-            }
-            else
-            {
-
-                UICommands.StartFileHistoryDialog(this, (DiffFiles.SelectedItem).Name);
-            }
         }
 
         private void ToolStripButtonPushClick(object sender, EventArgs e)
@@ -1745,44 +1606,9 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void DiffTextExtraDiffArgumentsChanged(object sender, EventArgs e)
-        {
-            ShowSelectedFileDiff();
-        }
-
         private void CleanupToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartCleanupRepositoryDialog(this);
-        }
-
-        private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            if (DiffFiles.SelectedItem == null)
-                return;
-
-            GitUIExtensions.DiffWithRevisionKind diffKind;
-
-            if (sender == aLocalToolStripMenuItem)
-                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffALocal;
-            else if (sender == bLocalToolStripMenuItem)
-                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffBLocal;
-            else if (sender == parentOfALocalToolStripMenuItem)
-                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffAParentLocal;
-            else if (sender == parentOfBLocalToolStripMenuItem)
-                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffBParentLocal;
-            else
-            {
-                Debug.Assert(sender == aBToolStripMenuItem, "Not implemented DiffWithRevisionKind: " + sender);
-                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffAB;
-            }
-
-            foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
-            {
-                GitItemStatus selectedItem = itemWithParent.Item;
-                string parentGuid = RevisionGrid.GetSelectedRevisions().Count() == 1 ? itemWithParent.ParentGuid : null;
-
-                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
-            }
         }
 
         private void AddWorkingdirDropDownItem(Repository repo, string caption)
@@ -1920,11 +1746,6 @@ namespace GitUI.CommandsDialogs
             UICommands.StartEditGitAttributesDialog(this);
         }
 
-        private void copyFilenameToClipboardToolStripMenuItem1_Click(object sender, EventArgs e)
-        {
-            CopyFullPathToClipboard(DiffFiles, Module);
-        }
-
         public static void CopyFullPathToClipboard(FileStatusList diffFiles, GitModule module)
         {
             if (!diffFiles.SelectedItems.Any())
@@ -1975,41 +1796,6 @@ namespace GitUI.CommandsDialogs
             });
         }
 
-        private void saveAsToolStripMenuItem1_Click(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count == 0)
-                return;
-
-            if (DiffFiles.SelectedItem == null)
-                return;
-
-            GitItemStatus item = DiffFiles.SelectedItem;
-
-            var fullName = Path.Combine(Module.WorkingDir, item.Name);
-            using (var fileDialog =
-                new SaveFileDialog
-                {
-                    InitialDirectory = Path.GetDirectoryName(fullName),
-                    FileName = Path.GetFileName(fullName),
-                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
-                    AddExtension = true
-                })
-            {
-                fileDialog.Filter =
-                    _saveFileFilterCurrentFormat.Text + " (*." +
-                    fileDialog.DefaultExt + ")|*." +
-                    fileDialog.DefaultExt +
-                    "|" + _saveFileFilterAllFiles.Text + " (*.*)|*.*";
-
-                if (fileDialog.ShowDialog(this) == DialogResult.OK)
-                {
-                    Module.SaveBlobAs(fileDialog.FileName, string.Format("{0}:\"{1}\"", revisions[0].Guid, item.Name));
-                }
-            }
-        }
-
         private void toolStripStatusLabel1_Click(object sender, EventArgs e)
         {
             statusStrip.Hide();
@@ -2024,36 +1810,6 @@ namespace GitUI.CommandsDialogs
         {
             using (var frm = new FormBisect(RevisionGrid)) frm.ShowDialog(this);
             UICommands.RepoChangedNotifier.Notify();
-        }
-
-        private void fileHistoryDiffToolstripMenuItem_Click(object sender, EventArgs e)
-        {
-            GitItemStatus item = DiffFiles.SelectedItem;
-
-            if (item.IsTracked)
-            {
-                IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-                if (revisions.Count == 0 || GitRevision.IsArtificial(revisions[0].Guid))
-                    UICommands.StartFileHistoryDialog(this, item.Name);
-                else
-                    UICommands.StartFileHistoryDialog(this, item.Name, revisions[0], false);
-            }
-        }
-
-        private void blameToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            GitItemStatus item = DiffFiles.SelectedItem;
-
-            if (item.IsTracked)
-            {
-                IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-                if (revisions.Count == 0 || GitRevision.IsArtificial(revisions[0].Guid))
-                    UICommands.StartFileHistoryDialog(this, item.Name, null, false, true);
-                else
-                    UICommands.StartFileHistoryDialog(this, item.Name, revisions[0], true, true);
-            }
         }
 
         private void CurrentBranchDropDownOpening(object sender, EventArgs e)
@@ -2181,7 +1937,7 @@ namespace GitUI.CommandsDialogs
                 case Commands.FocusRevisionGrid: RevisionGrid.Focus(); break;
                 case Commands.FocusCommitInfo: CommitInfoTabControl.SelectedTab = CommitInfoTabPage; break;
                 case Commands.FocusFileTree: CommitInfoTabControl.SelectedTab = TreeTabPage; fileTree.Focus(); break;
-                case Commands.FocusDiff: CommitInfoTabControl.SelectedTab = DiffTabPage; DiffFiles.Focus(); break;
+                case Commands.FocusDiff: CommitInfoTabControl.SelectedTab = DiffTabPage; revisionDiff.Focus(); break;
                 case Commands.Commit: CommitToolStripMenuItemClick(null, null); break;
                 case Commands.AddNotes: AddNotes(); break;
                 case Commands.FindFileInSelectedCommit: FindFileInSelectedCommit(); break;
@@ -2219,54 +1975,6 @@ namespace GitUI.CommandsDialogs
                 MainSplitContainer.SplitterDistance = MainSplitContainer.Height;
         }
 
-        private int getNextIdx(int curIdx, int maxIdx, bool searchBackward)
-        {
-            if (searchBackward)
-            {
-                if (curIdx == 0)
-                {
-                    curIdx = maxIdx;
-                }
-                else
-                {
-                    curIdx--;
-                }
-            }
-            else
-            {
-                if (curIdx == maxIdx)
-                {
-                    curIdx = 0;
-                }
-                else
-                {
-                    curIdx++;
-                }
-            }
-            return curIdx;
-        }
-
-        private Tuple<int, string> getNextPatchFile(bool searchBackward)
-        {
-            var revisions = RevisionGrid.GetSelectedRevisions();
-            if (revisions.Count == 0)
-                return null;
-            int idx = DiffFiles.SelectedIndex;
-            if (idx == -1)
-                return new Tuple<int, string>(idx, null);
-
-            idx = getNextIdx(idx, DiffFiles.GitItemStatuses.Count() - 1, searchBackward);
-            DiffFiles.SetSelectedIndex(idx, notify: false);
-            return new Tuple<int, string>(idx, DiffText.GetSelectedPatch(RevisionGrid, DiffFiles.SelectedItem));
-        }
-
-        //
-        // diff context menu
-        //
-        private void openContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            OpenContainingFolder(DiffFiles, Module);
-        }
 
         public static void OpenContainingFolder(FileStatusList diffFiles, GitModule module)
         {
@@ -2280,62 +1988,12 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void diffShowInFileTreeToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            // switch to view (and fills the first level of file tree data model if not already done)
-            ExecuteCommand((int)Commands.FocusFileTree);
-            fileTree.ExpandToFile(DiffFiles.SelectedItems.First().Name);
-        }
-
-        private void DiffContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            bool artificialRevSelected;
-
-            IList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
-
-            if (selectedRevisions.Count == 0)
-                artificialRevSelected = false;
-            else
-                artificialRevSelected = selectedRevisions[0].IsArtificial();
-            if (selectedRevisions.Count > 1)
-                artificialRevSelected = artificialRevSelected || selectedRevisions[selectedRevisions.Count - 1].IsArtificial();
-
-            // disable items that need exactly one selected item
-            bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
-            var isCombinedDiff = isExactlyOneItemSelected &&
-                DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
-            var isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item == DiffFiles.CombinedDiff.Text);
-            var enabled = isExactlyOneItemSelected && !isCombinedDiff;
-            openWithDifftoolToolStripMenuItem.Enabled = !isAnyCombinedDiff;
-            saveAsToolStripMenuItem1.Enabled = enabled;
-            cherryPickSelectedDiffFileToolStripMenuItem.Enabled = enabled;
-            diffShowInFileTreeToolStripMenuItem.Enabled = isExactlyOneItemSelected;
-            fileHistoryDiffToolstripMenuItem.Enabled = isExactlyOneItemSelected;
-            blameToolStripMenuItem.Enabled = isExactlyOneItemSelected;
-            resetFileToToolStripMenuItem.Enabled = !isCombinedDiff;
-
-            // openContainingFolderToolStripMenuItem.Enabled or not
-            {
-                openContainingFolderToolStripMenuItem.Enabled = false;
-
-                foreach (var item in DiffFiles.SelectedItems)
-                {
-                    string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
-                    if (FormBrowseUtil.FileOrParentDirectoryExists(filePath))
-                    {
-                        openContainingFolderToolStripMenuItem.Enabled = true;
-                        break;
-                    }
-                }
-            }
-        }
-
         protected void SetSplitterPositions()
         {
             _splitterManager.AddSplitter(RevisionsSplitContainer, "RevisionsSplitContainer");
             _splitterManager.AddSplitter(MainSplitContainer, "MainSplitContainer");
-            _splitterManager.AddSplitter(DiffSplitContainer, "DiffSplitContainer");
-            fileTree.Init(_splitterManager);
+            revisionDiff.InitSplitterManager(_splitterManager);
+            fileTree.InitSplitterManager(_splitterManager);
             //hide status in order to restore splitters against the full height (the most common case)
             statusStrip.Hide();
             _splitterManager.RestoreSplitters();
@@ -2381,12 +2039,6 @@ namespace GitUI.CommandsDialogs
             UICommands.StartSvnFetchDialog(this);
         }
 
-        private void DiffFiles_DataSourceChanged(object sender, EventArgs e)
-        {
-            if (DiffFiles.GitItemStatuses == null || !DiffFiles.GitItemStatuses.Any())
-                DiffText.ViewPatch(String.Empty);
-        }
-
         public override void AddTranslationItems(ITranslation translation)
         {
             base.AddTranslationItems(translation);
@@ -2399,39 +2051,6 @@ namespace GitUI.CommandsDialogs
             base.TranslateItems(translation);
             TranslationUtils.TranslateItemsFromFields(Name, _filterRevisionsHelper, translation);
             TranslationUtils.TranslateItemsFromFields(Name, _filterBranchHelper, translation);
-        }
-
-        private void findInDiffToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-
-            var candidates = DiffFiles.GitItemStatuses;
-
-            Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
-            {
-
-                string nameAsLower = name.ToLower();
-
-                return candidates.Where(item =>
-                {
-                    return item.Name != null && item.Name.ToLower().Contains(nameAsLower)
-                        || item.OldName != null && item.OldName.ToLower().Contains(nameAsLower);
-                }
-                    ).ToList();
-            };
-
-            GitItemStatus selectedItem;
-            using (var searchWindow = new SearchWindow<GitItemStatus>(FindDiffFilesMatches)
-            {
-                Owner = this
-            })
-            {
-                searchWindow.ShowDialog(this);
-                selectedItem = searchWindow.SelectedItem;
-            }
-            if (selectedItem != null)
-            {
-                DiffFiles.SelectedItem = selectedItem;
-            }
         }
 
         private void dontSetAsDefaultToolStripMenuItem_Click(object sender, EventArgs e)
@@ -2548,129 +2167,6 @@ namespace GitUI.CommandsDialogs
                 Module.LastPullActionToFormPullAction();
 
             Settings.SetNextPullActionAsDefault = false;
-        }
-
-        private void resetFileToToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-            int selectedRevsCount = revisions.Count;
-
-            if (selectedRevsCount == 1)
-            {
-                resetFileToSelectedToolStripMenuItem.Visible = true;
-                TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
-                resetFileToSelectedToolStripMenuItem.Text += " (" + RevisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
-
-                if (revisions[0].HasParent())
-                {
-                    resetFileToParentToolStripMenuItem.Visible = true;
-                    TranslateItem(resetFileToParentToolStripMenuItem.Name, resetFileToParentToolStripMenuItem);
-                    GitRevision parentRev = RevisionGrid.GetRevision(revisions[0].ParentGuids[0]);
-                    if (parentRev != null)
-                    {
-                        resetFileToParentToolStripMenuItem.Text += " (" + RevisionGrid.DescribeRevision(parentRev).ShortenTo(50) + ")";
-                    }
-                }
-                else
-                {
-                    resetFileToParentToolStripMenuItem.Visible = false;
-                }
-            }
-            else
-            {
-                resetFileToSelectedToolStripMenuItem.Visible = false;
-                resetFileToParentToolStripMenuItem.Visible = false;
-            }
-
-            if (selectedRevsCount == 2)
-            {
-                resetFileToFirstToolStripMenuItem.Visible = true;
-                TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
-                resetFileToFirstToolStripMenuItem.Text += " (" + RevisionGrid.DescribeRevision(revisions[1]).ShortenTo(50) + ")";
-
-                resetFileToSecondToolStripMenuItem.Visible = true;
-                TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
-                resetFileToSecondToolStripMenuItem.Text += " (" + RevisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
-            }
-            else
-            {
-                resetFileToFirstToolStripMenuItem.Visible = false;
-                resetFileToSecondToolStripMenuItem.Visible = false;
-            }
-        }
-
-        private void ResetSelectedItemsTo(string revision, bool actsAsChild)
-        {
-            var selectedItems = DiffFiles.SelectedItems;
-            IEnumerable<GitItemStatus> itemsToCheckout;
-            if (actsAsChild)
-            {
-                var deletedItems = selectedItems.Where(item => item.IsDeleted);
-                Module.RemoveFiles(deletedItems.Select(item => item.Name), false);
-                itemsToCheckout = selectedItems.Where(item => !item.IsDeleted);
-            }
-            else //acts as parent
-            {
-                //if file is new to the parent, it has to be removed
-                var addedItems = selectedItems.Where(item => item.IsNew);
-                Module.RemoveFiles(addedItems.Select(item => item.Name), false);
-                itemsToCheckout = selectedItems.Where(item => !item.IsNew);
-            }
-
-            Module.CheckoutFiles(itemsToCheckout.Select(item => item.Name), revision, false);
-        }
-
-        private void resetFileToFirstToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count != 2 || !DiffFiles.SelectedItems.Any())
-            {
-                return;
-            }
-
-            ResetSelectedItemsTo(revisions[1].Guid, false);
-        }
-
-        private void resetFileToSecondToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count != 2 || !DiffFiles.SelectedItems.Any())
-            {
-                return;
-            }
-
-            ResetSelectedItemsTo(revisions[0].Guid, true);
-        }
-
-        private void resetFileToParentToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count != 1 || !DiffFiles.SelectedItems.Any())
-            {
-                return;
-            }
-
-            if (!revisions[0].HasParent())
-            {
-                throw new ApplicationException("This menu should be disabled for revisions that don't have a parent.");
-            }
-
-            ResetSelectedItemsTo(revisions[0].ParentGuids[0], false);
-        }
-
-        private void resetFileToSelectedToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count != 1 || !DiffFiles.SelectedItems.Any())
-            {
-                return;
-            }
-
-            ResetSelectedItemsTo(revisions[0].Guid, true);
         }
 
         private void _NO_TRANSLATE_Workingdir_MouseUp(object sender, MouseEventArgs e)
@@ -3029,65 +2525,6 @@ namespace GitUI.CommandsDialogs
                 toolStripButtonLevelUp.ShowDropDown();
         }
 
-        private void openWithDifftoolToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
-        {
-            bool artificialRevSelected = false;
-            bool enableDiffDropDown = true;
-            bool showParentItems = false;
-
-            IList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions();
-
-            if (revisions.Count > 0)
-            {
-                artificialRevSelected = revisions[0].IsArtificial();
-
-                if (revisions.Count == 2)
-                {
-                    artificialRevSelected = artificialRevSelected || revisions[revisions.Count - 1].IsArtificial();
-                    showParentItems = true;
-                }
-                else
-                    enableDiffDropDown = revisions.Count == 1;
-            }
-
-            aBToolStripMenuItem.Enabled = enableDiffDropDown;
-            bLocalToolStripMenuItem.Enabled = enableDiffDropDown;
-            aLocalToolStripMenuItem.Enabled = enableDiffDropDown;
-            parentOfALocalToolStripMenuItem.Enabled = enableDiffDropDown;
-            parentOfBLocalToolStripMenuItem.Enabled = enableDiffDropDown;
-
-            parentOfALocalToolStripMenuItem.Visible = showParentItems;
-            parentOfBLocalToolStripMenuItem.Visible = showParentItems;
-
-            if (!enableDiffDropDown)
-                return;
-            //enable *<->Local items only when local file exists
-            foreach (var item in DiffFiles.SelectedItems)
-            {
-                string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
-                if (File.Exists(filePath))
-                {
-                    bLocalToolStripMenuItem.Enabled = !artificialRevSelected;
-                    aLocalToolStripMenuItem.Enabled = !artificialRevSelected;
-                    parentOfALocalToolStripMenuItem.Enabled = !artificialRevSelected;
-                    parentOfBLocalToolStripMenuItem.Enabled = !artificialRevSelected;
-                    return;
-                }
-            }
-        }
-
-        private string GetMonoVersion()
-        {
-            Type type = Type.GetType("Mono.Runtime");
-            if (type != null)
-            {
-                MethodInfo displayName = type.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
-                if (displayName != null)
-                    return (string)displayName.Invoke(null, null);
-            }
-            return null;
-        }
-
         private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Process.Start(@"https://github.com/gitextensions/gitextensions/issues/new");
@@ -3108,11 +2545,6 @@ namespace GitUI.CommandsDialogs
         private void FormBrowse_Activated(object sender, EventArgs e)
         {
             this.InvokeAsync(OnActivate);
-        }
-
-        private void cherryPickSelectedDiffFileToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            DiffText.CherryPickAllChanges();
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/RevisionDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.Designer.cs
@@ -1,0 +1,347 @@
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs
+{
+    partial class RevisionDiff
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.DiffSplitContainer = new System.Windows.Forms.SplitContainer();
+            this.DiffFiles = new GitUI.FileStatusList();
+            this.DiffContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.bLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.parentOfALocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.parentOfBLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveAsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetFileToToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetFileToFirstToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetFileToSecondToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetFileToSelectedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetFileToParentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cherryPickSelectedDiffFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator32 = new System.Windows.Forms.ToolStripSeparator();
+            this.copyFilenameToClipboardToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.openContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.diffShowInFileTreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator33 = new System.Windows.Forms.ToolStripSeparator();
+            this.fileHistoryDiffToolstripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.blameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.findInDiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.DiffText = new GitUI.Editor.FileViewer();
+            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.DiffSplitContainer)).BeginInit();
+            this.DiffSplitContainer.Panel1.SuspendLayout();
+            this.DiffSplitContainer.Panel2.SuspendLayout();
+            this.DiffSplitContainer.SuspendLayout();
+            this.DiffContextMenu.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // DiffSplitContainer
+            // 
+            this.DiffSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DiffSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.DiffSplitContainer.Location = new System.Drawing.Point(0, 0);
+            this.DiffSplitContainer.Name = "DiffSplitContainer";
+            // 
+            // DiffSplitContainer.Panel1
+            // 
+            this.DiffSplitContainer.Panel1.Controls.Add(this.DiffFiles);
+            // 
+            // DiffSplitContainer.Panel2
+            // 
+            this.DiffSplitContainer.Panel2.Controls.Add(this.DiffText);
+            this.DiffSplitContainer.Size = new System.Drawing.Size(729, 360);
+            this.DiffSplitContainer.SplitterDistance = 300;
+            this.DiffSplitContainer.TabIndex = 0;
+            // 
+            // DiffFiles
+            // 
+            this.DiffFiles.ContextMenuStrip = this.DiffContextMenu;
+            this.DiffFiles.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DiffFiles.FilterVisible = false;
+            this.DiffFiles.Location = new System.Drawing.Point(0, 0);
+            this.DiffFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.DiffFiles.Name = "DiffFiles";
+            this.DiffFiles.Size = new System.Drawing.Size(300, 360);
+            this.DiffFiles.TabIndex = 1;
+            this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFiles_SelectedIndexChanged);
+            this.DiffFiles.DataSourceChanged += new System.EventHandler(this.DiffFiles_DataSourceChanged);
+            this.DiffFiles.DoubleClick += new System.EventHandler(this.DiffFiles_DoubleClick);
+            // 
+            // DiffContextMenu
+            // 
+            this.DiffContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.openWithDifftoolToolStripMenuItem,
+            this.saveAsToolStripMenuItem1,
+            this.resetFileToToolStripMenuItem,
+            this.cherryPickSelectedDiffFileToolStripMenuItem,
+            this.toolStripSeparator32,
+            this.copyFilenameToClipboardToolStripMenuItem1,
+            this.openContainingFolderToolStripMenuItem,
+            this.diffShowInFileTreeToolStripMenuItem,
+            this.toolStripSeparator33,
+            this.fileHistoryDiffToolstripMenuItem,
+            this.blameToolStripMenuItem,
+            this.findInDiffToolStripMenuItem});
+            this.DiffContextMenu.Name = "DiffContextMenu";
+            this.DiffContextMenu.Size = new System.Drawing.Size(211, 236);
+            this.DiffContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.DiffContextMenu_Opening);
+            // 
+            // openWithDifftoolToolStripMenuItem
+            // 
+            this.openWithDifftoolToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.aBToolStripMenuItem,
+            this.aLocalToolStripMenuItem,
+            this.bLocalToolStripMenuItem,
+            this.parentOfALocalToolStripMenuItem,
+            this.parentOfBLocalToolStripMenuItem});
+            this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconDiffTool;
+            this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
+            this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
+            this.openWithDifftoolToolStripMenuItem.DropDownOpening += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_DropDownOpening);
+            // 
+            // aBToolStripMenuItem
+            // 
+            this.aBToolStripMenuItem.Name = "aBToolStripMenuItem";
+            this.aBToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
+            this.aBToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
+            this.aBToolStripMenuItem.Text = "A <--> B";
+            this.aBToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            // 
+            // aLocalToolStripMenuItem
+            // 
+            this.aLocalToolStripMenuItem.Name = "aLocalToolStripMenuItem";
+            this.aLocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
+            this.aLocalToolStripMenuItem.Text = "A <--> Working directory";
+            this.aLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            // 
+            // bLocalToolStripMenuItem
+            // 
+            this.bLocalToolStripMenuItem.Name = "bLocalToolStripMenuItem";
+            this.bLocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
+            this.bLocalToolStripMenuItem.Text = "B <--> Working directory";
+            this.bLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            // 
+            // parentOfALocalToolStripMenuItem
+            // 
+            this.parentOfALocalToolStripMenuItem.Name = "parentOfALocalToolStripMenuItem";
+            this.parentOfALocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
+            this.parentOfALocalToolStripMenuItem.Text = "A\'s parent <--> Working directory";
+            this.parentOfALocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            // 
+            // parentOfBLocalToolStripMenuItem
+            // 
+            this.parentOfBLocalToolStripMenuItem.Name = "parentOfBLocalToolStripMenuItem";
+            this.parentOfBLocalToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
+            this.parentOfBLocalToolStripMenuItem.Text = "B\'s parent <--> Working directory";
+            this.parentOfBLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            // 
+            // saveAsToolStripMenuItem1
+            // 
+            this.saveAsToolStripMenuItem1.Image = global::GitUI.Properties.Resources.IconSaveAs;
+            this.saveAsToolStripMenuItem1.Name = "saveAsToolStripMenuItem1";
+            this.saveAsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.saveAsToolStripMenuItem1.Size = new System.Drawing.Size(210, 22);
+            this.saveAsToolStripMenuItem1.Text = "Save (B) as...";
+            this.saveAsToolStripMenuItem1.Click += new System.EventHandler(this.saveAsToolStripMenuItem1_Click);
+            // 
+            // resetFileToToolStripMenuItem
+            // 
+            this.resetFileToToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.resetFileToFirstToolStripMenuItem,
+            this.resetFileToSecondToolStripMenuItem,
+            this.resetFileToSelectedToolStripMenuItem,
+            this.resetFileToParentToolStripMenuItem});
+            this.resetFileToToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetFileTo;
+            this.resetFileToToolStripMenuItem.Name = "resetFileToToolStripMenuItem";
+            this.resetFileToToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.resetFileToToolStripMenuItem.Text = "Reset file(s) to";
+            this.resetFileToToolStripMenuItem.DropDownOpening += new System.EventHandler(this.resetFileToToolStripMenuItem_DropDownOpening);
+            // 
+            // resetFileToFirstToolStripMenuItem
+            // 
+            this.resetFileToFirstToolStripMenuItem.Name = "resetFileToFirstToolStripMenuItem";
+            this.resetFileToFirstToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.resetFileToFirstToolStripMenuItem.Text = "First";
+            this.resetFileToFirstToolStripMenuItem.Click += new System.EventHandler(this.resetFileToFirstToolStripMenuItem_Click);
+            // 
+            // resetFileToSecondToolStripMenuItem
+            // 
+            this.resetFileToSecondToolStripMenuItem.Name = "resetFileToSecondToolStripMenuItem";
+            this.resetFileToSecondToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.resetFileToSecondToolStripMenuItem.Text = "Second";
+            this.resetFileToSecondToolStripMenuItem.Click += new System.EventHandler(this.resetFileToSecondToolStripMenuItem_Click);
+            // 
+            // resetFileToSelectedToolStripMenuItem
+            // 
+            this.resetFileToSelectedToolStripMenuItem.Name = "resetFileToSelectedToolStripMenuItem";
+            this.resetFileToSelectedToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.resetFileToSelectedToolStripMenuItem.Text = "Selected";
+            this.resetFileToSelectedToolStripMenuItem.Click += new System.EventHandler(this.resetFileToSelectedToolStripMenuItem_Click);
+            // 
+            // resetFileToParentToolStripMenuItem
+            // 
+            this.resetFileToParentToolStripMenuItem.Name = "resetFileToParentToolStripMenuItem";
+            this.resetFileToParentToolStripMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.resetFileToParentToolStripMenuItem.Text = "Parent";
+            this.resetFileToParentToolStripMenuItem.Click += new System.EventHandler(this.resetFileToParentToolStripMenuItem_Click);
+            // 
+            // cherryPickSelectedDiffFileToolStripMenuItem
+            // 
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCherryPick;
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Name = "cherryPickSelectedDiffFileToolStripMenuItem";
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Text = "Cherry pick file\'s changes";
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Click += new System.EventHandler(this.cherryPickSelectedDiffFileToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator32
+            // 
+            this.toolStripSeparator32.Name = "toolStripSeparator32";
+            this.toolStripSeparator32.Size = new System.Drawing.Size(207, 6);
+            // 
+            // copyFilenameToClipboardToolStripMenuItem1
+            // 
+            this.copyFilenameToClipboardToolStripMenuItem1.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
+            this.copyFilenameToClipboardToolStripMenuItem1.Name = "copyFilenameToClipboardToolStripMenuItem1";
+            this.copyFilenameToClipboardToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this.copyFilenameToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(210, 22);
+            this.copyFilenameToClipboardToolStripMenuItem1.Text = "Copy full path(s)";
+            this.copyFilenameToClipboardToolStripMenuItem1.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem1_Click);
+            // 
+            // openContainingFolderToolStripMenuItem
+            // 
+            this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
+            this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
+            this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.openContainingFolderToolStripMenuItem.Text = "Open containing folder(s)";
+            this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
+            // 
+            // diffShowInFileTreeToolStripMenuItem
+            // 
+            this.diffShowInFileTreeToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFileTree;
+            this.diffShowInFileTreeToolStripMenuItem.Name = "diffShowInFileTreeToolStripMenuItem";
+            this.diffShowInFileTreeToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.diffShowInFileTreeToolStripMenuItem.Text = "Show in File tree";
+            this.diffShowInFileTreeToolStripMenuItem.Click += new System.EventHandler(this.diffShowInFileTreeToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator33
+            // 
+            this.toolStripSeparator33.Name = "toolStripSeparator33";
+            this.toolStripSeparator33.Size = new System.Drawing.Size(207, 6);
+            // 
+            // fileHistoryDiffToolstripMenuItem
+            // 
+            this.fileHistoryDiffToolstripMenuItem.Image = global::GitUI.Properties.Resources.IconFileHistory;
+            this.fileHistoryDiffToolstripMenuItem.Name = "fileHistoryDiffToolstripMenuItem";
+            this.fileHistoryDiffToolstripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.fileHistoryDiffToolstripMenuItem.Text = "File history";
+            this.fileHistoryDiffToolstripMenuItem.Click += new System.EventHandler(this.fileHistoryDiffToolstripMenuItem_Click);
+            // 
+            // blameToolStripMenuItem
+            // 
+            this.blameToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconBlame;
+            this.blameToolStripMenuItem.Name = "blameToolStripMenuItem";
+            this.blameToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.blameToolStripMenuItem.Text = "Blame";
+            this.blameToolStripMenuItem.Click += new System.EventHandler(this.blameToolStripMenuItem_Click);
+            // 
+            // findInDiffToolStripMenuItem
+            // 
+            this.findInDiffToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconFind;
+            this.findInDiffToolStripMenuItem.Name = "findInDiffToolStripMenuItem";
+            this.findInDiffToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
+            this.findInDiffToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+            this.findInDiffToolStripMenuItem.Text = "Find";
+            this.findInDiffToolStripMenuItem.Click += new System.EventHandler(this.findInDiffToolStripMenuItem_Click);
+            // 
+            // DiffText
+            // 
+            this.DiffText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DiffText.Location = new System.Drawing.Point(0, 0);
+            this.DiffText.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.DiffText.Name = "DiffText";
+            this.DiffText.Size = new System.Drawing.Size(425, 360);
+            this.DiffText.TabIndex = 0;
+            this.DiffText.ExtraDiffArgumentsChanged += new System.EventHandler<System.EventArgs>(this.DiffText_ExtraDiffArgumentsChanged);
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(98, 22);
+            this.saveToolStripMenuItem.Text = "Save";
+            // 
+            // RevisionDiff
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.DiffSplitContainer);
+            this.Name = "RevisionDiff";
+            this.Size = new System.Drawing.Size(729, 360);
+            this.DiffSplitContainer.Panel1.ResumeLayout(false);
+            this.DiffSplitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.DiffSplitContainer)).EndInit();
+            this.DiffSplitContainer.ResumeLayout(false);
+            this.DiffContextMenu.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private ToolStripMenuItem resetFileToParentToolStripMenuItem;
+        private ToolStripMenuItem resetFileToSelectedToolStripMenuItem;
+        private ToolStripMenuItem resetFileToSecondToolStripMenuItem;
+        private ToolStripMenuItem resetFileToFirstToolStripMenuItem;
+        private ToolStripMenuItem parentOfALocalToolStripMenuItem;
+        private ToolStripMenuItem parentOfBLocalToolStripMenuItem;
+        private ToolStripMenuItem bLocalToolStripMenuItem;
+        private ToolStripMenuItem aLocalToolStripMenuItem;
+        private ToolStripMenuItem aBToolStripMenuItem;
+        private ToolStripMenuItem findInDiffToolStripMenuItem;
+        private ToolStripMenuItem blameToolStripMenuItem;
+        private ToolStripMenuItem fileHistoryDiffToolstripMenuItem;
+        private ToolStripSeparator toolStripSeparator33;
+        private ToolStripMenuItem diffShowInFileTreeToolStripMenuItem;
+        private ToolStripMenuItem openContainingFolderToolStripMenuItem;
+        private ToolStripMenuItem copyFilenameToClipboardToolStripMenuItem1;
+        private ToolStripMenuItem cherryPickSelectedDiffFileToolStripMenuItem;
+        private ToolStripMenuItem resetFileToToolStripMenuItem;
+        private ToolStripMenuItem saveAsToolStripMenuItem1;
+        private ToolStripSeparator toolStripSeparator32;
+        private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
+        private System.Windows.Forms.SplitContainer DiffSplitContainer;
+        private System.Windows.Forms.ContextMenuStrip DiffContextMenu;
+        private FileStatusList DiffFiles;
+        private Editor.FileViewer DiffText;
+    }
+}

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -1,0 +1,607 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitUI.CommandsDialogs.BrowseDialog;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs
+{
+    public partial class RevisionDiff : GitModuleControl
+    {
+        private readonly TranslationString _saveFileFilterCurrentFormat = new TranslationString("Current format");
+        private readonly TranslationString _saveFileFilterAllFiles = new TranslationString("All files");
+        private readonly TranslationString _diffNoSelection = new TranslationString("Diff (no selection)");
+        private readonly TranslationString _diffParentWithSelection = new TranslationString("Diff (A: parent --> B: selection)");
+        private readonly TranslationString _diffTwoSelected = new TranslationString("Diff (A: first --> B: second)");
+        private readonly TranslationString _diffNotSupported = new TranslationString("Diff (not supported)");
+
+        private RevisionGrid _revisionGrid;
+        private RevisionFileTree _revisionFileTree;
+        private string _oldRevision;
+        private GitItemStatus _oldDiffItem;
+
+
+        public RevisionDiff()
+        {
+            InitializeComponent();
+            Translate();
+
+            DiffFiles.FilterVisible = true;
+            DiffFiles.DescribeRevision = DescribeRevision;
+            DiffText.SetFileLoader(GetNextPatchFile);
+            DiffText.Font = AppSettings.DiffFont;
+
+            GotFocus += (s, e) => DiffFiles.Focus();
+        }
+
+
+        public void ForceRefreshRevisions()
+        {
+            var revisions = _revisionGrid.GetSelectedRevisions();
+            if (revisions.Count != 0)
+            {
+                _oldRevision = revisions[0].Guid;
+                _oldDiffItem = DiffFiles.SelectedItem;
+            }
+            else
+            {
+                _oldRevision = null;
+                _oldDiffItem = null;
+            }
+        }
+
+        public string GetTabText()
+        {
+            var revisions = _revisionGrid.GetSelectedRevisions();
+
+            DiffText.SaveCurrentScrollPos();
+            DiffFiles.SetDiffs(revisions);
+            if (_oldDiffItem != null && revisions.Count > 0 && revisions[0].Guid == _oldRevision)
+            {
+                DiffFiles.SelectedItem = _oldDiffItem;
+                _oldDiffItem = null;
+                _oldRevision = null;
+            }
+
+            switch (revisions.Count)
+            {
+                case 0:
+                    return _diffNoSelection.Text;
+
+                case 1: // diff "parent" --> "selected revision"
+                    var revision = revisions[0];
+                    if (revision != null && revision.ParentGuids != null && revision.ParentGuids.Length != 0)
+                        return _diffParentWithSelection.Text;
+                    break;
+
+                case 2: // diff "first clicked revision" --> "second clicked revision"
+                    bool artificialRevSelected = revisions[0].IsArtificial() || revisions[1].IsArtificial();
+                    if (!artificialRevSelected)
+                        return _diffTwoSelected.Text;
+                    break;
+
+            }
+            return _diffNotSupported.Text;
+        }
+
+        public void Bind(RevisionGrid revisionGrid, RevisionFileTree revisionFileTree)
+        {
+            _revisionGrid = revisionGrid;
+            _revisionFileTree = revisionFileTree;
+        }
+
+        public void InitSplitterManager(SplitterManager splitterManager)
+        {
+            splitterManager.AddSplitter(DiffSplitContainer, "DiffSplitContainer");
+        }
+
+        public void ReloadHotkeys()
+        {
+            DiffText.ReloadHotkeys();
+        }
+
+
+        private string DescribeRevision(string sha1)
+        {
+            var revision = _revisionGrid.GetRevision(sha1);
+            if (revision == null)
+            {
+                return sha1.ShortenTo(8);
+            }
+
+            return _revisionGrid.DescribeRevision(revision);
+        }
+
+        private static int GetNextIdx(int curIdx, int maxIdx, bool searchBackward)
+        {
+            if (searchBackward)
+            {
+                if (curIdx == 0)
+                {
+                    curIdx = maxIdx;
+                }
+                else
+                {
+                    curIdx--;
+                }
+            }
+            else
+            {
+                if (curIdx == maxIdx)
+                {
+                    curIdx = 0;
+                }
+                else
+                {
+                    curIdx++;
+                }
+            }
+            return curIdx;
+        }
+
+        private Tuple<int, string> GetNextPatchFile(bool searchBackward)
+        {
+            var revisions = _revisionGrid.GetSelectedRevisions();
+            if (revisions.Count == 0)
+                return null;
+            int idx = DiffFiles.SelectedIndex;
+            if (idx == -1)
+                return new Tuple<int, string>(idx, null);
+
+            idx = GetNextIdx(idx, DiffFiles.GitItemStatuses.Count() - 1, searchBackward);
+            DiffFiles.SetSelectedIndex(idx, notify: false);
+            return new Tuple<int, string>(idx, GetSelectedPatch(revisions, DiffFiles.SelectedItem));
+        }
+
+        private string GetSelectedPatch(IList<GitRevision> revisions, GitItemStatus file)
+        {
+            string firstRevision = revisions.Count > 0 ? revisions[0].Guid : null;
+            string secondRevision = revisions.Count == 2 ? revisions[1].Guid : null;
+            return DiffText.GetSelectedPatch(firstRevision, secondRevision, file);
+        }
+
+        private void ResetSelectedItemsTo(string revision, bool actsAsChild)
+        {
+            var selectedItems = DiffFiles.SelectedItems;
+            IEnumerable<GitItemStatus> itemsToCheckout;
+            if (actsAsChild)
+            {
+                var deletedItems = selectedItems.Where(item => item.IsDeleted);
+                Module.RemoveFiles(deletedItems.Select(item => item.Name), false);
+                itemsToCheckout = selectedItems.Where(item => !item.IsDeleted);
+            }
+            else //acts as parent
+            {
+                //if file is new to the parent, it has to be removed
+                var addedItems = selectedItems.Where(item => item.IsNew);
+                Module.RemoveFiles(addedItems.Select(item => item.Name), false);
+                itemsToCheckout = selectedItems.Where(item => !item.IsNew);
+            }
+
+            Module.CheckoutFiles(itemsToCheckout.Select(item => item.Name), revision, false);
+        }
+
+        private void ShowSelectedFileDiff()
+        {
+            if (DiffFiles.SelectedItem == null)
+            {
+                DiffText.ViewPatch("");
+                return;
+            }
+
+            var items = _revisionGrid.GetSelectedRevisions();
+            if (items.Count() == 1)
+            {
+                items.Add(new GitRevision(Module, DiffFiles.SelectedItemParent));
+
+                if (!string.IsNullOrWhiteSpace(DiffFiles.SelectedItemParent)
+                    && DiffFiles.SelectedItemParent == DiffFiles.CombinedDiff.Text)
+                {
+                    var diffOfConflict = Module.GetCombinedDiffContent(items.First(), DiffFiles.SelectedItem.Name,
+                        DiffText.GetExtraDiffArguments(), DiffText.Encoding);
+
+                    if (string.IsNullOrWhiteSpace(diffOfConflict))
+                    {
+                        diffOfConflict = Strings.GetUninterestingDiffOmitted();
+                    }
+
+                    DiffText.ViewPatch(diffOfConflict);
+                    return;
+                }
+            }
+            DiffText.ViewChanges(items, DiffFiles.SelectedItem, String.Empty);
+        }
+
+
+        private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ShowSelectedFileDiff();
+        }
+
+        private void DiffFiles_DoubleClick(object sender, EventArgs e)
+        {
+            if (DiffFiles.SelectedItem == null)
+                return;
+
+            if (AppSettings.OpenSubmoduleDiffInSeparateWindow && DiffFiles.SelectedItem.IsSubmodule)
+            {
+                var submoduleName = DiffFiles.SelectedItem.Name;
+                DiffFiles.SelectedItem.SubmoduleStatus.ContinueWith(
+                    (t) =>
+                    {
+                        Process process = new Process();
+                        process.StartInfo.FileName = Application.ExecutablePath;
+                        process.StartInfo.Arguments = "browse -commit=" + t.Result.Commit;
+                        process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, submoduleName.EnsureTrailingPathSeparator());
+                        process.Start();
+                    });
+            }
+            else
+            {
+
+                UICommands.StartFileHistoryDialog(this, (DiffFiles.SelectedItem).Name);
+            }
+        }
+
+        private void DiffFiles_DataSourceChanged(object sender, EventArgs e)
+        {
+            if (DiffFiles.GitItemStatuses == null || !DiffFiles.GitItemStatuses.Any())
+                DiffText.ViewPatch(String.Empty);
+        }
+
+        private void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        {
+            ShowSelectedFileDiff();
+        }
+
+        private void diffShowInFileTreeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            // switch to view (and fills the first level of file tree data model if not already done)
+            (FindForm() as FormBrowse)?.ExecuteCommand(FormBrowse.Commands.FocusFileTree);
+            _revisionFileTree.ExpandToFile(DiffFiles.SelectedItems.First().Name);
+        }
+
+        private void DiffContextMenu_Opening(object sender, CancelEventArgs e)
+        {
+            bool artificialRevSelected;
+
+            IList<GitRevision> selectedRevisions = _revisionGrid.GetSelectedRevisions();
+
+            if (selectedRevisions.Count == 0)
+                artificialRevSelected = false;
+            else
+                artificialRevSelected = selectedRevisions[0].IsArtificial();
+            if (selectedRevisions.Count > 1)
+                artificialRevSelected = artificialRevSelected || selectedRevisions[selectedRevisions.Count - 1].IsArtificial();
+
+            // disable items that need exactly one selected item
+            bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
+            var isCombinedDiff = isExactlyOneItemSelected &&
+                DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
+            var isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item == DiffFiles.CombinedDiff.Text);
+            var enabled = isExactlyOneItemSelected && !isCombinedDiff;
+            openWithDifftoolToolStripMenuItem.Enabled = !isAnyCombinedDiff;
+            saveAsToolStripMenuItem1.Enabled = enabled;
+            cherryPickSelectedDiffFileToolStripMenuItem.Enabled = enabled;
+            diffShowInFileTreeToolStripMenuItem.Enabled = isExactlyOneItemSelected;
+            fileHistoryDiffToolstripMenuItem.Enabled = isExactlyOneItemSelected;
+            blameToolStripMenuItem.Enabled = isExactlyOneItemSelected;
+            resetFileToToolStripMenuItem.Enabled = !isCombinedDiff;
+
+            // openContainingFolderToolStripMenuItem.Enabled or not
+            {
+                openContainingFolderToolStripMenuItem.Enabled = false;
+
+                foreach (var item in DiffFiles.SelectedItems)
+                {
+                    string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                    if (FormBrowseUtil.FileOrParentDirectoryExists(filePath))
+                    {
+                        openContainingFolderToolStripMenuItem.Enabled = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        //
+        // diff context menu
+        //
+        private void blameToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            GitItemStatus item = DiffFiles.SelectedItem;
+
+            if (item.IsTracked)
+            {
+                IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+                if (revisions.Count == 0 || GitRevision.IsArtificial(revisions[0].Guid))
+                    UICommands.StartFileHistoryDialog(this, item.Name, null, false, true);
+                else
+                    UICommands.StartFileHistoryDialog(this, item.Name, revisions[0], true, true);
+            }
+        }
+
+        private void cherryPickSelectedDiffFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DiffText.CherryPickAllChanges();
+        }
+
+        private void copyFilenameToClipboardToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            FormBrowse.CopyFullPathToClipboard(DiffFiles, Module);
+        }
+
+        private void findInDiffToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+
+            var candidates = DiffFiles.GitItemStatuses;
+
+            Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
+            {
+
+                string nameAsLower = name.ToLower();
+
+                return candidates.Where(item =>
+                {
+                    return item.Name != null && item.Name.ToLower().Contains(nameAsLower)
+                        || item.OldName != null && item.OldName.ToLower().Contains(nameAsLower);
+                }
+                    ).ToList();
+            };
+
+            GitItemStatus selectedItem;
+            using (var searchWindow = new SearchWindow<GitItemStatus>(FindDiffFilesMatches)
+            {
+                Owner = FindForm()
+            })
+            {
+                searchWindow.ShowDialog(this);
+                selectedItem = searchWindow.SelectedItem;
+            }
+            if (selectedItem != null)
+            {
+                DiffFiles.SelectedItem = selectedItem;
+            }
+        }
+
+        private void fileHistoryDiffToolstripMenuItem_Click(object sender, EventArgs e)
+        {
+            GitItemStatus item = DiffFiles.SelectedItem;
+
+            if (item.IsTracked)
+            {
+                IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+                if (revisions.Count == 0 || GitRevision.IsArtificial(revisions[0].Guid))
+                    UICommands.StartFileHistoryDialog(this, item.Name);
+                else
+                    UICommands.StartFileHistoryDialog(this, item.Name, revisions[0], false);
+            }
+        }
+
+        private void openContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FormBrowse.OpenContainingFolder(DiffFiles, Module);
+        }
+
+        private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (DiffFiles.SelectedItem == null)
+                return;
+
+            GitUIExtensions.DiffWithRevisionKind diffKind;
+
+            if (sender == aLocalToolStripMenuItem)
+                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffALocal;
+            else if (sender == bLocalToolStripMenuItem)
+                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffBLocal;
+            else if (sender == parentOfALocalToolStripMenuItem)
+                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffAParentLocal;
+            else if (sender == parentOfBLocalToolStripMenuItem)
+                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffBParentLocal;
+            else
+            {
+                Debug.Assert(sender == aBToolStripMenuItem, "Not implemented DiffWithRevisionKind: " + sender);
+                diffKind = GitUIExtensions.DiffWithRevisionKind.DiffAB;
+            }
+
+            foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
+            {
+                GitItemStatus selectedItem = itemWithParent.Item;
+                string parentGuid = _revisionGrid.GetSelectedRevisions().Count() == 1 ? itemWithParent.ParentGuid : null;
+
+                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+            }
+        }
+
+        private void openWithDifftoolToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
+        {
+            bool artificialRevSelected = false;
+            bool enableDiffDropDown = true;
+            bool showParentItems = false;
+
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count > 0)
+            {
+                artificialRevSelected = revisions[0].IsArtificial();
+
+                if (revisions.Count == 2)
+                {
+                    artificialRevSelected = artificialRevSelected || revisions[revisions.Count - 1].IsArtificial();
+                    showParentItems = true;
+                }
+                else
+                    enableDiffDropDown = revisions.Count == 1;
+            }
+
+            aBToolStripMenuItem.Enabled = enableDiffDropDown;
+            bLocalToolStripMenuItem.Enabled = enableDiffDropDown;
+            aLocalToolStripMenuItem.Enabled = enableDiffDropDown;
+            parentOfALocalToolStripMenuItem.Enabled = enableDiffDropDown;
+            parentOfBLocalToolStripMenuItem.Enabled = enableDiffDropDown;
+
+            parentOfALocalToolStripMenuItem.Visible = showParentItems;
+            parentOfBLocalToolStripMenuItem.Visible = showParentItems;
+
+            if (!enableDiffDropDown)
+                return;
+            //enable *<->Local items only when local file exists
+            foreach (var item in DiffFiles.SelectedItems)
+            {
+                string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                if (File.Exists(filePath))
+                {
+                    bLocalToolStripMenuItem.Enabled = !artificialRevSelected;
+                    aLocalToolStripMenuItem.Enabled = !artificialRevSelected;
+                    parentOfALocalToolStripMenuItem.Enabled = !artificialRevSelected;
+                    parentOfBLocalToolStripMenuItem.Enabled = !artificialRevSelected;
+                    return;
+                }
+            }
+        }
+
+        private void resetFileToFirstToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count != 2 || !DiffFiles.SelectedItems.Any())
+            {
+                return;
+            }
+
+            ResetSelectedItemsTo(revisions[1].Guid, false);
+        }
+
+        private void resetFileToParentToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count != 1 || !DiffFiles.SelectedItems.Any())
+            {
+                return;
+            }
+
+            if (!revisions[0].HasParent())
+            {
+                throw new ApplicationException("This menu should be disabled for revisions that don't have a parent.");
+            }
+
+            ResetSelectedItemsTo(revisions[0].ParentGuids[0], false);
+        }
+
+        private void resetFileToSecondToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count != 2 || !DiffFiles.SelectedItems.Any())
+            {
+                return;
+            }
+
+            ResetSelectedItemsTo(revisions[0].Guid, true);
+        }
+
+        private void resetFileToSelectedToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count != 1 || !DiffFiles.SelectedItems.Any())
+            {
+                return;
+            }
+
+            ResetSelectedItemsTo(revisions[0].Guid, true);
+        }
+
+        private void resetFileToToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
+        {
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+            int selectedRevsCount = revisions.Count;
+
+            if (selectedRevsCount == 1)
+            {
+                resetFileToSelectedToolStripMenuItem.Visible = true;
+                TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
+                resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+
+                if (revisions[0].HasParent())
+                {
+                    resetFileToParentToolStripMenuItem.Visible = true;
+                    TranslateItem(resetFileToParentToolStripMenuItem.Name, resetFileToParentToolStripMenuItem);
+                    GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].ParentGuids[0]);
+                    if (parentRev != null)
+                    {
+                        resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev).ShortenTo(50) + ")";
+                    }
+                }
+                else
+                {
+                    resetFileToParentToolStripMenuItem.Visible = false;
+                }
+            }
+            else
+            {
+                resetFileToSelectedToolStripMenuItem.Visible = false;
+                resetFileToParentToolStripMenuItem.Visible = false;
+            }
+
+            if (selectedRevsCount == 2)
+            {
+                resetFileToFirstToolStripMenuItem.Visible = true;
+                TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
+                resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1]).ShortenTo(50) + ")";
+
+                resetFileToSecondToolStripMenuItem.Visible = true;
+                TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
+                resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+            }
+            else
+            {
+                resetFileToFirstToolStripMenuItem.Visible = false;
+                resetFileToSecondToolStripMenuItem.Visible = false;
+            }
+        }
+
+        private void saveAsToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            IList<GitRevision> revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count == 0)
+                return;
+
+            if (DiffFiles.SelectedItem == null)
+                return;
+
+            GitItemStatus item = DiffFiles.SelectedItem;
+
+            var fullName = Path.Combine(Module.WorkingDir, item.Name);
+            using (var fileDialog =
+                new SaveFileDialog
+                {
+                    InitialDirectory = Path.GetDirectoryName(fullName),
+                    FileName = Path.GetFileName(fullName),
+                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                    AddExtension = true
+                })
+            {
+                fileDialog.Filter =
+                    _saveFileFilterCurrentFormat.Text + " (*." +
+                    fileDialog.DefaultExt + ")|*." +
+                    fileDialog.DefaultExt +
+                    "|" + _saveFileFilterAllFiles.Text + " (*.*)|*.*";
+
+                if (fileDialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    Module.SaveBlobAs(fileDialog.FileName, string.Format("{0}:\"{1}\"", revisions[0].Guid, item.Name));
+                }
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/RevisionDiff.resx
+++ b/GitUI/CommandsDialogs/RevisionDiff.resx
@@ -117,31 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolPanel.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="UserMenuToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 17</value>
-  </metadata>
-  <metadata name="ToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>251, 17</value>
-  </metadata>
-  <metadata name="FilterToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="DiffContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>711, 17</value>
-  </metadata>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>136, 17</value>
-  </metadata>
-  <metadata name="gitItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>542, 17</value>
-  </metadata>
-  <metadata name="gitRevisionBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>352, 17</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>82</value>
   </metadata>
 </root>

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -108,7 +108,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public void Init(SplitterManager splitterManager)
+        public void InitSplitterManager(SplitterManager splitterManager)
         {
             splitterManager.AddSplitter(FileTreeSplitContainer, "FileTreeSplitContainer");
         }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -135,6 +135,12 @@
     <Compile Include="CommandsDialogs\GitIgnoreDialog\GitIgnoreModel.cs" />
     <Compile Include="CommandsDialogs\GitIgnoreDialog\GitLocalExcludeModel.cs" />
     <Compile Include="CommandsDialogs\GitIgnoreDialog\IGitIgnoreDialogModel.cs" />
+    <Compile Include="CommandsDialogs\RevisionDiff.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\RevisionDiff.Designer.cs">
+      <DependentUpon>RevisionDiff.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\RevisionFileTree.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1097,6 +1103,9 @@
     <EmbeddedResource Include="CommandsDialogs\BrowseDialog\FormUpdates.resx">
       <DependentUpon>FormUpdates.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\RevisionDiff.resx">
+      <DependentUpon>RevisionDiff.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\RevisionFileTree.resx">
       <DependentUpon>RevisionFileTree.cs</DependentUpon>

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -155,14 +155,6 @@ namespace GitUI
                     diffArgs, encoding, cacheResult);
         }
 
-        public static string GetSelectedPatch(this FileViewer diffViewer, RevisionGrid grid, GitItemStatus file)
-        {
-            IList<GitRevision> revisions = grid.GetSelectedRevisions();
-            string firstRevision = revisions.Count > 0 ? revisions[0].Guid : null;
-            string secondRevision = revisions.Count == 2 ? revisions[1].Guid : null;
-            return GetSelectedPatch(diffViewer, firstRevision, secondRevision, file);
-        }
-
         public static string GetSelectedPatch(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file)
         {
             if (firstRevision == null)

--- a/ResourceManager/GitExtensionsUserControl.cs
+++ b/ResourceManager/GitExtensionsUserControl.cs
@@ -94,6 +94,18 @@ namespace ResourceManager
             TranslationUtils.TranslateItemsFromFields(Name, this, translation);
         }
 
+        protected void TranslateItem(string itemName, object item)
+        {
+            var translation = Translator.GetTranslation(AppSettings.CurrentTranslation);
+            if (translation.Count == 0)
+                return;
+            foreach (var pair in translation)
+            {
+                IEnumerable<Tuple<string, object>> itemsToTranslate = new[] { new Tuple<string, object>(itemName, item) };
+                TranslationUtils.TranslateItemsFromList(Name, pair.Value, itemsToTranslate);
+            }
+        }
+
         #region Hotkeys
 
         /// <summary>Gets or sets a value that specifies if the hotkeys are used</summary>


### PR DESCRIPTION
The source moved almost verbatim from FormBrowse to the new control.
Minimal changes to facilitate the plumbing. It is something to revisit at a later stage.