### PR TITLE
Remove redundant parts of conditional expressions

### DIFF
--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -138,7 +138,7 @@ namespace GitUI.CommandsDialogs
                     rev2 = revisions[1].Guid;
                     result = Module.FormatPatch(rev1, rev2, savePatchesToDir);
                 }
-                else if (revisions.Count > 2)
+                else
                 {
                     int n = 0;
                     foreach (GitRevision revision in revisions)

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -467,7 +467,7 @@ namespace GitUI.CommandsDialogs
                 if (AppSettings.AutoPullOnPushRejectedAction == null)
                 {
                     bool cancel = false;
-                    string destination = PushToRemote.Checked ? _NO_TRANSLATE_Remotes.Text : PushDestination.Text;
+                    string destination = _NO_TRANSLATE_Remotes.Text;
                     string buttons = _pullRepositoryButtons.Text;
                     switch (Module.LastPullAction)
                     {

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -792,7 +792,7 @@ namespace GitUI.SpellChecker
             {
                 var bullet = addBullet ? " - " : String.Empty;
                 var indexOfLine = TextBox.GetFirstCharIndexFromLine(afterLine);
-                var newLine = (lineLength > 0) ? Environment.NewLine : String.Empty;
+                var newLine = Environment.NewLine;
                 var newCursorPos = indexOfLine + newLine.Length + bullet.Length + lineLength - 1;
                 TextBox.SelectionLength = 0;
                 TextBox.SelectionStart = indexOfLine;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -858,7 +858,7 @@ namespace GitUI
                 if (sortedFirstGroupItem != null)
                     sortedFirstGroupItem.Selected = true;
             }
-            else if (FileStatusListView.Items.Count > 0)
+            else
                 FileStatusListView.Items[0].Selected = true;
         }
 


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. All issues were found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):
V3022 Expression 'FileStatusListView.Items.Count > 0' is always true. FileStatusList.cs 861
V3022 Expression '(lineLength > 0)' is always true. EditNetSpell.cs 795
V3022 Expression 'revisions.Count > 2' is always true. FormFormatPatch.cs 141
V3022 Expression 'PushToRemote.Checked' is always true. FormPush.cs 470
