### PR TITLE
FileHistory: Show DiffTab when opening, not ViewFile

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -102,6 +102,11 @@ namespace GitUI.CommandsDialogs
             tabControl1.SelectedTab = BlameTab;
         }
 
+        public void SelectDiffTab()
+        {
+            tabControl1.SelectedTab = DiffTab;
+        }
+
         private void LoadFileHistory()
         {
             FileChanges.Visible = true;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1523,6 +1523,8 @@ namespace GitUI
 
                     if (showBlame)
                         form.SelectBlameTab();
+                    else
+                        form.SelectDiffTab();
 
                     return form;
                 };


### PR DESCRIPTION
If you open FileHistory, you are likely more interested in seeing the diff than the file contents
Order of tabs preserved (I would have preferred to set DiffTab first instead but change as little as possible)

Changes proposed in this pull request:
 - Tab selected when opening FileHistory
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Open FileHistory, for instance by double-clicking in TreeTab
 - Make sure the DiffTab is selected

Has been tested on (remove any that don't apply):
 - Windows 10
