### PR TITLE
Browse Diff: Disable and hide irrelevant menu items

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -279,19 +279,27 @@ namespace GitUI.CommandsDialogs
             if (selectedRevisions.Count > 1)
                 artificialRevSelected = artificialRevSelected || selectedRevisions[selectedRevisions.Count - 1].IsArtificial();
 
+            //Many options have no meaning for artificial commits or submodules
+            //Hide the obviously no action options when single selected, handle them in actions if multi select
+
             // disable items that need exactly one selected item
             bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
             var isCombinedDiff = isExactlyOneItemSelected &&
                 DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
             var isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item == DiffFiles.CombinedDiff.Text);
-            var enabled = isExactlyOneItemSelected && !isCombinedDiff;
+
             openWithDifftoolToolStripMenuItem.Enabled = !isAnyCombinedDiff;
-            saveAsToolStripMenuItem1.Enabled = enabled;
-            cherryPickSelectedDiffFileToolStripMenuItem.Enabled = enabled;
-            diffShowInFileTreeToolStripMenuItem.Enabled = isExactlyOneItemSelected;
-            fileHistoryDiffToolstripMenuItem.Enabled = isExactlyOneItemSelected;
-            blameToolStripMenuItem.Enabled = isExactlyOneItemSelected;
-            resetFileToToolStripMenuItem.Enabled = !isCombinedDiff;
+            saveAsToolStripMenuItem1.Visible = !isCombinedDiff && isExactlyOneItemSelected && !DiffFiles.SelectedItem.IsSubmodule;
+            cherryPickSelectedDiffFileToolStripMenuItem.Visible = !isCombinedDiff && isExactlyOneItemSelected &&
+                !(DiffFiles.SelectedItem.IsSubmodule || selectedRevisions[0].Guid == GitRevision.UnstagedGuid ||
+                (DiffFiles.SelectedItem.IsNew || DiffFiles.SelectedItem.IsDeleted) && selectedRevisions[0].Guid == GitRevision.IndexGuid);
+            //Visibility of FileTree is not known, assume (CommitInfoTabControl.Contains(TreeTabPage);)
+            diffShowInFileTreeToolStripMenuItem.Visible = isExactlyOneItemSelected && !selectedRevisions[0].IsArtificial(); 
+            fileHistoryDiffToolstripMenuItem.Enabled = isExactlyOneItemSelected && !(DiffFiles.SelectedItem.IsNew && selectedRevisions[0].IsArtificial());
+            blameToolStripMenuItem.Enabled = isExactlyOneItemSelected && !(DiffFiles.SelectedItem.IsSubmodule || selectedRevisions[0].IsArtificial());
+            resetFileToToolStripMenuItem.Enabled = !isCombinedDiff &&
+                !(isExactlyOneItemSelected &&
+                (DiffFiles.SelectedItem.IsSubmodule || DiffFiles.SelectedItem.IsNew) && selectedRevisions[0].Guid == GitRevision.UnstagedGuid);
 
             // openContainingFolderToolStripMenuItem.Enabled or not
             {


### PR DESCRIPTION
Was part of #4084, resubmitted after refactoring in master

Part of #4031.
This is not a complete correction of available menu items, specific issues are handled in other pull requests as well as future PRs. 

Changes proposed in this pull request:
 - Disable and hide irrelevant menu items
 
Screenshots before and after (if PR changes UI):
- See Browse Diff screenshots in #4084


How did I test this code:
 - Menu items for various combinations in the Diff panel

Has been tested on (remove any that don't apply):
 - Windows 7 and Win10
