### PR TITLE
GitRevision: Make HasParent a property

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -126,7 +126,7 @@ namespace GitCommands
             }
         }
 
-        public string GetParentGuid
+        public string FirstParentGuid
         {
             get
             {

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -118,9 +118,20 @@ namespace GitCommands
                     guid == IndexGuid;
         }
 
-        public bool HasParent()
+        public bool HasParent
         {
-            return ParentGuids != null && ParentGuids.Length > 0;
+            get
+            {
+                return ParentGuids != null && ParentGuids.Length > 0;
+            }
+        }
+
+        public string GetParentGuid
+        {
+            get
+            {
+                return HasParent ? ParentGuids[0] : Guid + "^";
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -76,7 +76,7 @@ namespace GitUI.CommandsDialogs
 
                 case 1: // diff "parent" --> "selected revision"
                     var revision = revisions[0];
-                    if (revision != null && revision.ParentGuids != null && revision.ParentGuids.Length != 0)
+                    if (revision != null && revision.HasParent)
                         return _diffParentWithSelection.Text;
                     break;
 
@@ -497,12 +497,12 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (!revisions[0].HasParent())
+            if (!revisions[0].HasParent)
             {
                 throw new ApplicationException("This menu should be disabled for revisions that don't have a parent.");
             }
 
-            ResetSelectedItemsTo(revisions[0].ParentGuids[0], false);
+            ResetSelectedItemsTo(revisions[0].GetParentGuid, false);
         }
 
         private void resetFileToSecondToolStripMenuItem_Click(object sender, EventArgs e)
@@ -540,11 +540,11 @@ namespace GitUI.CommandsDialogs
                 TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
                 resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
 
-                if (revisions[0].HasParent())
+                if (revisions[0].HasParent)
                 {
                     resetFileToParentToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToParentToolStripMenuItem.Name, resetFileToParentToolStripMenuItem);
-                    GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].ParentGuids[0]);
+                    GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].GetParentGuid);
                     if (parentRev != null)
                     {
                         resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev).ShortenTo(50) + ")";

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -502,7 +502,7 @@ namespace GitUI.CommandsDialogs
                 throw new ApplicationException("This menu should be disabled for revisions that don't have a parent.");
             }
 
-            ResetSelectedItemsTo(revisions[0].GetParentGuid, false);
+            ResetSelectedItemsTo(revisions[0].FirstParentGuid, false);
         }
 
         private void resetFileToSecondToolStripMenuItem_Click(object sender, EventArgs e)
@@ -544,7 +544,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToParentToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToParentToolStripMenuItem.Name, resetFileToParentToolStripMenuItem);
-                    GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].GetParentGuid);
+                    GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].FirstParentGuid);
                     if (parentRev != null)
                     {
                         resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev).ShortenTo(50) + ")";

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -80,7 +80,7 @@ namespace GitUI
                 {
                     GitRevision revision = revisions[0];
                     if (diffKind == DiffWithRevisionKind.DiffALocal)
-                        revisionToCmp = parentGuid ?? (revision.ParentGuids.Length == 0 ? null : revision.ParentGuids[0]);
+                        revisionToCmp = parentGuid ?? revision.GetParentGuid;
                     else if (diffKind == DiffWithRevisionKind.DiffBLocal)
                         revisionToCmp = revision.Guid;
                     else
@@ -97,10 +97,10 @@ namespace GitUI
                             revisionToCmp = revisions[0].Guid;
                             break;
                         case DiffWithRevisionKind.DiffAParentLocal:
-                            revisionToCmp = revisions[1].ParentGuids.Length == 0 ? null : revisions[1].ParentGuids[0];
+                            revisionToCmp = revisions[1].GetParentGuid;
                             break;
                         case DiffWithRevisionKind.DiffBParentLocal:
-                            revisionToCmp = revisions[0].ParentGuids.Length == 0 ? null : revisions[0].ParentGuids[0];
+                            revisionToCmp = revisions[0].GetParentGuid;
                             break;
                         default:
                             revisionToCmp = null;
@@ -195,8 +195,8 @@ namespace GitUI
             var firstRevision = revisions.Count > 0 ? revisions[0] : null;
             string firstRevisionGuid = firstRevision == null ? null : firstRevision.Guid;
             string parentRevisionGuid = revisions.Count == 2 ? revisions[1].Guid : null;
-            if (parentRevisionGuid == null && firstRevision != null && firstRevision.ParentGuids != null && firstRevision.ParentGuids.Length > 0)
-                parentRevisionGuid = firstRevision.ParentGuids[0];
+            if (parentRevisionGuid == null && firstRevision != null)
+                parentRevisionGuid = firstRevision.GetParentGuid;
             ViewChanges(diffViewer, firstRevisionGuid, parentRevisionGuid, file, defaultText);
         }
 

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -80,7 +80,7 @@ namespace GitUI
                 {
                     GitRevision revision = revisions[0];
                     if (diffKind == DiffWithRevisionKind.DiffALocal)
-                        revisionToCmp = parentGuid ?? revision.GetParentGuid;
+                        revisionToCmp = parentGuid ?? revision.FirstParentGuid;
                     else if (diffKind == DiffWithRevisionKind.DiffBLocal)
                         revisionToCmp = revision.Guid;
                     else
@@ -97,10 +97,10 @@ namespace GitUI
                             revisionToCmp = revisions[0].Guid;
                             break;
                         case DiffWithRevisionKind.DiffAParentLocal:
-                            revisionToCmp = revisions[1].GetParentGuid;
+                            revisionToCmp = revisions[1].FirstParentGuid;
                             break;
                         case DiffWithRevisionKind.DiffBParentLocal:
-                            revisionToCmp = revisions[0].GetParentGuid;
+                            revisionToCmp = revisions[0].FirstParentGuid;
                             break;
                         default:
                             revisionToCmp = null;
@@ -196,7 +196,7 @@ namespace GitUI
             string firstRevisionGuid = firstRevision == null ? null : firstRevision.Guid;
             string parentRevisionGuid = revisions.Count == 2 ? revisions[1].Guid : null;
             if (parentRevisionGuid == null && firstRevision != null)
-                parentRevisionGuid = firstRevision.GetParentGuid;
+                parentRevisionGuid = firstRevision.FirstParentGuid;
             ViewChanges(diffViewer, firstRevisionGuid, parentRevisionGuid, file, defaultText);
         }
 

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -88,7 +88,7 @@ namespace GitUI.HelperDialogs
             }
             SelectedRevision = revisions[0];
 
-            flowLayoutPanelParents.Visible = SelectedRevision.ParentGuids.Length != 0;
+            flowLayoutPanelParents.Visible = SelectedRevision.HasParent;
 
             if(!flowLayoutPanelParents.Visible)
                 return;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1025,7 +1025,7 @@ namespace GitUI
 
             if (revision == null)
                 GitItemStatuses = null;
-            else if (revision.ParentGuids == null || revision.ParentGuids.Length == 0)
+            else if (!revision.HasParent)
                 GitItemStatuses = Module.GetTreeFiles(revision.TreeGuid, true);
             else
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3262,8 +3262,8 @@ namespace GitUI
             {
                 if (_parentChildNavigationHistory.HasPreviousParent)
                     _parentChildNavigationHistory.NavigateToPreviousParent(r.Guid);
-                else if (r.HasParent())
-                    _parentChildNavigationHistory.NavigateToParent(r.Guid, r.ParentGuids[0]);
+                else if (r.HasParent)
+                    _parentChildNavigationHistory.NavigateToParent(r.Guid, r.GetParentGuid);
             }
         }
 
@@ -3421,7 +3421,7 @@ namespace GitUI
             if (LatestSelectedRevision == null)
                 return;
 
-            String rebaseCmd = GitCommandHelpers.RebaseCmd(LatestSelectedRevision.ParentGuids[0],
+            String rebaseCmd = GitCommandHelpers.RebaseCmd(LatestSelectedRevision.GetParentGuid,
                 interactive: true, preserveMerges: false, autosquash: false, autostash: true);
 
             using (var formProcess = new FormProcess(null, rebaseCmd, Module.WorkingDir, null, true))

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3263,7 +3263,7 @@ namespace GitUI
                 if (_parentChildNavigationHistory.HasPreviousParent)
                     _parentChildNavigationHistory.NavigateToPreviousParent(r.Guid);
                 else if (r.HasParent)
-                    _parentChildNavigationHistory.NavigateToParent(r.Guid, r.GetParentGuid);
+                    _parentChildNavigationHistory.NavigateToParent(r.Guid, r.FirstParentGuid);
             }
         }
 
@@ -3421,7 +3421,7 @@ namespace GitUI
             if (LatestSelectedRevision == null)
                 return;
 
-            String rebaseCmd = GitCommandHelpers.RebaseCmd(LatestSelectedRevision.GetParentGuid,
+            String rebaseCmd = GitCommandHelpers.RebaseCmd(LatestSelectedRevision.FirstParentGuid,
                 interactive: true, preserveMerges: false, autosquash: false, autostash: true);
 
             using (var formProcess = new FormProcess(null, rebaseCmd, Module.WorkingDir, null, true))


### PR DESCRIPTION
Requested by @RussKie in https://github.com/gerhardol/gitextensions/commit/7234d28588cad4b22f3dbc6ad58d8542449904c7#diff-320265b67fc16a7d7a11a99771f9e1a4L121
Converted to use of GetParentGuid where applicable

Part of #4031 

Changes proposed in this pull request:
 - Refactoring
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Review, manually

Has been tested on (remove any that don't apply):
 - Windows 7 and Win10
