### PR TITLE
Simplify editor string comparison

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -724,8 +724,7 @@ namespace GitCommands
         public void EditNotes(string revision)
         {
             string editor = GetEffectiveSetting("core.editor").ToLower();
-            if (editor.Contains("gitextensions") || editor.Contains("notepad") ||
-                editor.Contains("notepad++"))
+            if (editor.Contains("gitextensions") || editor.Contains("notepad"))
             {
                 RunGitCmd("notes edit " + revision);
             }


### PR DESCRIPTION
Changes proposed in this pull request:
 - Simplify editor string comparison (if editor contains "notepad" it also contains "notepad++" and other notepads)

Has been tested on (remove any that don't apply):
 - GIT 2.14.2
 - Windows 10
