### PR TITLE
Fix FormCommit file list filter input getting treated as hotkeys

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -159,7 +159,7 @@ namespace GitUI
         {
             get
             {
-                return FileStatusListView.Focused || FilterComboBox.Focused;
+                return FileStatusListView.Focused;
             }
         }
 
@@ -602,8 +602,8 @@ namespace GitUI
 
             if (isSubmoduleSelected)
             {
-                _openSubmoduleMenuItem.Font = AppSettings.OpenSubmoduleDiffInSeparateWindow ? 
-                    new Font(_openSubmoduleMenuItem.Font,  FontStyle.Bold) : 
+                _openSubmoduleMenuItem.Font = AppSettings.OpenSubmoduleDiffInSeparateWindow ?
+                    new Font(_openSubmoduleMenuItem.Font,  FontStyle.Bold) :
                     new Font(_openSubmoduleMenuItem.Font, FontStyle.Regular);
             }
         }


### PR DESCRIPTION
Right now in the master branch if you open FormCommit and with unstaged files in the filter type character 's' the files will get staged. This is because even in the textbox keypresses trigger the hotkeys.
I am scared to ever hit 'r' while in the filter box :)

This got introduced with [fd37574819] Merge pull request #3920 from pmiossec/form_commit_workflow_improvements

Reverting this change didn't seem to break anything so maybe @pmiossec could chip in why this change has been made.