### PR TITLE
Fix navigating a file tree with a keyboard

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -265,7 +265,10 @@ namespace GitUI.CommandsDialogs
             else
             {
                 FileText.ViewText("", "");
-                e.Node.Toggle();
+                if (e.Action == TreeViewAction.ByMouse)
+                {
+                    e.Node.Toggle();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes folder nodes auto-expanding in the file tree when navigating with keyboard (up/down).

The change is to expand folder node after select only if it was initiated by a mouse.

Based on the commit message where this behavior was introduced it seems this was only intended for mouse-select actions and not keyboard-select actions.
Currently it's unpractical to go down the folder list with a keyboard as each node keeps expanding deeper and deeper while you want to remain on the same level.