### PR TITLE
Allow to choose branch order between alphabetical and by date

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Git\Tag\GitTagController.cs" />
     <Compile Include="Git\Tag\TagOperation.cs" />
     <Compile Include="Git\Tag\TagOperationExtensions.cs" />
+    <Compile Include="Settings\BranchOrdering.cs" />
     <Compile Include="SshPathLocator.cs" />
     <Compile Include="Git\IndexLockManager.cs" />
     <Compile Include="Git\GitTreeParser.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1387,6 +1387,12 @@ namespace GitCommands
             set { SetBool("UseConsoleEmulatorForCommands", value); }
         }
 
+        public static BranchOrdering BranchOrderingCriteria
+        {
+            get { return GetEnum("BranchOrderingCriteria", BranchOrdering.ByLastAccessDate); }
+            set { SetEnum("BranchOrderingCriteria", value); }
+        }
+
         public static string GetGitExtensionsFullPath()
         {
             return Application.ExecutablePath;

--- a/GitCommands/Settings/BranchOrdering.cs
+++ b/GitCommands/Settings/BranchOrdering.cs
@@ -1,0 +1,8 @@
+namespace GitCommands
+{
+    public enum BranchOrdering
+    {
+        ByLastAccessDate = 0,
+        Alphabetically = 1,
+    }
+}

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -101,6 +101,7 @@ namespace GitUI.CommandsDialogs
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConfirmationsSettingsPage>(this), advancedPageRef);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this), detailedSettingsPage);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DiffViewerSettingsPage>(this), detailedSettingsPage);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ToolbarSettingsPage>(this), detailedSettingsPage);
 
             settingsTreeView.AddSettingsPage(new PluginsSettingsGroup(), null);
             SettingsPageReference pluginsPageRef = PluginsSettingsGroup.GetPageReference();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.Designer.cs
@@ -1,0 +1,111 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    partial class ToolbarSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.tableLayoutPanelForToolbar = new System.Windows.Forms.TableLayoutPanel();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cbBranchOrderingCriteria = new System.Windows.Forms.ComboBox();
+            this.tooltip = new System.Windows.Forms.ToolTip(this.components);
+            this.tableLayoutPanelForToolbar.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanelForToolbar
+            // 
+            this.tableLayoutPanelForToolbar.AutoSize = true;
+            this.tableLayoutPanelForToolbar.ColumnCount = 2;
+            this.tableLayoutPanelForToolbar.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelForToolbar.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelForToolbar.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanelForToolbar.Controls.Add(this.cbBranchOrderingCriteria, 1, 0);
+            this.tableLayoutPanelForToolbar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelForToolbar.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanelForToolbar.Name = "tableLayoutPanelForToolbar";
+            this.tableLayoutPanelForToolbar.RowCount = 9;
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.Size = new System.Drawing.Size(1333, 684);
+            this.tableLayoutPanelForToolbar.TabIndex = 1;
+            // 
+            // label2
+            // 
+            this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 7);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(175, 19);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Branch ordering criteria";
+            // 
+            // cbBranchOrderingCriteria
+            // 
+            this.cbBranchOrderingCriteria.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbBranchOrderingCriteria.FormattingEnabled = true;
+            this.cbBranchOrderingCriteria.Items.AddRange(new object[] {
+            "Last access date",
+            "Alphabetically"});
+            this.cbBranchOrderingCriteria.Location = new System.Drawing.Point(184, 3);
+            this.cbBranchOrderingCriteria.Name = "cbBranchOrderingCriteria";
+            this.cbBranchOrderingCriteria.Size = new System.Drawing.Size(213, 27);
+            this.cbBranchOrderingCriteria.TabIndex = 3;
+            // 
+            // tooltip
+            // 
+            this.tooltip.AutoPopDelay = 30000;
+            this.tooltip.InitialDelay = 500;
+            this.tooltip.ReshowDelay = 100;
+            // 
+            // ToolbarSettingsPage
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.tableLayoutPanelForToolbar);
+            this.Name = "ToolbarSettingsPage";
+            this.Size = new System.Drawing.Size(1333, 684);
+            this.tableLayoutPanelForToolbar.ResumeLayout(false);
+            this.tableLayoutPanelForToolbar.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelForToolbar;
+        private System.Windows.Forms.ToolTip tooltip;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ComboBox cbBranchOrderingCriteria;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.cs
@@ -1,0 +1,29 @@
+﻿using GitCommands;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    public partial class ToolbarSettingsPage : SettingsPageWithHeader
+    {
+        public ToolbarSettingsPage()
+        {
+            InitializeComponent();
+            Text = "Toolbar";
+            Translate();
+        }
+
+        protected override void SettingsToPage()
+        {
+            cbBranchOrderingCriteria.SelectedIndex = (int)AppSettings.BranchOrderingCriteria;
+        }
+
+        protected override void PageToSettings()
+        {
+            AppSettings.BranchOrderingCriteria = (BranchOrdering)cbBranchOrderingCriteria.SelectedIndex;
+        }
+
+        public static SettingsPageReference GetPageReference()
+        {
+            return new SettingsPageReferenceByType(typeof(ToolbarSettingsPage));
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -233,6 +233,12 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\DetailedSettingsPage.Designer.cs">
       <DependentUpon>DetailedSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\Pages\ToolbarSettingsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\Pages\ToolbarSettingsPage.Designer.cs">
+      <DependentUpon>ToolbarSettingsPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1154,6 +1160,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\DetailedSettingsPage.resx">
       <DependentUpon>DetailedSettingsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\ToolbarSettingsPage.resx">
+      <DependentUpon>ToolbarSettingsPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.resx">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>


### PR DESCRIPTION
Remark: this is work in progress, the location of the setting is under discussion, it should be moved somewhere else.

Fixes #3907.

Changes proposed in this pull request:
 - Add a configuration setting to choose the ordering criteria of the branches in the dropdown: by date (default) or alphabetically. 
 
Screenshots before and after (if PR changes UI):
![imagen](https://user-images.githubusercontent.com/6260564/32523813-4011f53e-c41d-11e7-9ace-41a131de407f.png)

How did I test this code:
Manually: 
1. Select branches in some order other than alphabetical
2. Verify that the dropdown shows the branches by selection date, from more recently to less recently selected.
3. Change the configuration from "Last access date" to "Alphabetically".
4. Verify that the dropdown shows the branches alphabetically
5. Change the configuration from "Alphabetically" to "Last access date".
6. Verify that the branches are ordered as explained in point 2.

Has been tested on (remove any that don't apply):
 - GIT 2.14
 - Windows 10
