### PR TITLE
fix: AOORE in "Open local repository" dialog under Mono

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardItem.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardItem.cs
@@ -84,7 +84,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             toolTip = new ToolTip
                               {
                                   InitialDelay = 1,
-                                  AutomaticDelay = 1,
+                                  AutomaticDelay = 100,
                                   AutoPopDelay = 5000,
                                   UseFading = false,
                                   UseAnimation = false,

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
@@ -98,7 +98,7 @@
             // 
             // toolTip1
             // 
-            this.toolTip1.AutomaticDelay = 0;
+            this.toolTip1.AutomaticDelay = 100;
             this.toolTip1.ShowAlways = true;
             this.toolTip1.ToolTipTitle = "Help";
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -696,7 +696,7 @@ namespace GitUI.CommandsDialogs
             // 
             // FilterToolTip
             // 
-            this.FilterToolTip.AutomaticDelay = 0;
+            this.FilterToolTip.AutomaticDelay = 100;
             this.FilterToolTip.ShowAlways = true;
             this.FilterToolTip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Error;
             this.FilterToolTip.ToolTipTitle = "RegEx";

--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -64,7 +64,7 @@
             // 
             // strategyToolTip
             // 
-            this.strategyToolTip.AutomaticDelay = 1;
+            this.strategyToolTip.AutomaticDelay = 100;
             this.strategyToolTip.AutoPopDelay = 0;
             this.strategyToolTip.InitialDelay = 1;
             this.strategyToolTip.ReshowDelay = 1;

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -93,7 +93,7 @@ namespace GitUI.CommandsDialogs
             // Tooltips support for the form
             var componentcontainer = new Container();
             _disposable1 = componentcontainer;
-            var tooltip = new ToolTip(componentcontainer) {AutomaticDelay = (int)TimeSpan.FromSeconds(10).TotalMilliseconds};
+            var tooltip = new ToolTip(componentcontainer) {AutomaticDelay =  100};
 
             Panel panelHeader = CreateViewHeader();
 

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -105,7 +105,7 @@ namespace GitUI
             // 
             // FilterToolTip
             // 
-            this.FilterToolTip.AutomaticDelay = 0;
+            this.FilterToolTip.AutomaticDelay = 100;
             this.FilterToolTip.ShowAlways = true;
             this.FilterToolTip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Error;
             this.FilterToolTip.ToolTipTitle = "RegEx";


### PR DESCRIPTION
Mono expects tooltip's AutomaticDelay to be greater than 0. Otherwise it throws:
`System.ArgumentOutOfRangeException: '0' is not a valid value for Interval. Interval must be greater than 0.`

Set all AutomaticDelay across the codebase to 100ms.

Fixes #4126