### PR TITLE
Regression of #4107, FirstParentGuid always returned a parent

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -124,7 +124,7 @@ namespace GitCommands
         {
             get
             {
-                return HasParent ? ParentGuids[0] : Guid + "^";
+                return HasParent ? ParentGuids[0] : null;
             }
         }
 

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -80,7 +80,7 @@ namespace GitUI
                 {
                     GitRevision revision = revisions[0];
                     if (diffKind == DiffWithRevisionKind.DiffALocal)
-                        revisionToCmp = parentGuid ?? revision.FirstParentGuid;
+                        revisionToCmp = parentGuid ?? revision.FirstParentGuid ?? revision.Guid + '^';
                     else if (diffKind == DiffWithRevisionKind.DiffBLocal)
                         revisionToCmp = revision.Guid;
                     else
@@ -97,10 +97,10 @@ namespace GitUI
                             revisionToCmp = revisions[0].Guid;
                             break;
                         case DiffWithRevisionKind.DiffAParentLocal:
-                            revisionToCmp = revisions[1].FirstParentGuid;
+                            revisionToCmp = revisions[1].FirstParentGuid ?? revisions[1].Guid + '^';
                             break;
                         case DiffWithRevisionKind.DiffBParentLocal:
-                            revisionToCmp = revisions[0].FirstParentGuid;
+                            revisionToCmp = revisions[0].FirstParentGuid ?? revisions[0].Guid + '^';
                             break;
                         default:
                             revisionToCmp = null;


### PR DESCRIPTION
#4107 has no negative effect of what I see, but if the FirstParentGuid is used in a different way it could
The change to "always" create FirstParentGuid was useful in some difftool scenarios, created explicitly instead

Changes proposed in this pull request:
 - Revert handling to before #4107
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Manually

Has been tested on (remove any that don't apply):
 - Windows 10
