### PR TITLE
diff.submodule=log raises exception

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -93,7 +93,7 @@ namespace GitCommands
         private readonly IGitTreeParser _gitTreeParser = new GitTreeParser();
 
         public const string NoNewLineAtTheEnd = "\\ No newline at end of file";
-        private const string DiffCommandWithStandardArgs = "diff --no-color ";
+        private const string DiffCommandWithStandardArgs = " -c diff.submodule=short diff --no-color ";
 
         public GitModule(string workingdir)
         {


### PR DESCRIPTION
GE GUI should not fail if the user has this setting, the Git output format must be formatted so it can be parsed

Fixes #4130.

Changes proposed in this pull request:
 - Override config for diff.submodule so the git-diff command can be parsed regardless of user configuration
 
Screenshots before and after (if PR changes UI):
- See issue for the problem, no change for normal configuration

How did I test this code:
 - Set the configuration to log, short, unset agaimn an browse diff submodules.

Has been tested on (remove any that don't apply):
 - GIT 2.15 Independent of Git "diff --submodule" have been around since at least 1.7, further options (diff) added in 2.x. As the change only overrides the config, it is version independent.
 - Windows 10
