### PR TITLE
Support git-diff with -R option

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -909,7 +909,7 @@ namespace GitCommands
 
                 if (line != null)
                 {
-                    var match = Regex.Match(line, @"diff --git (?:a|i|c)/(.+)\s(?:b|w|i)/(.+)");
+                    var match = Regex.Match(line, @"diff --git [abic]/(.+)\s[abwi]/(.+)");
                     if (match.Groups.Count > 1)
                     {
                         status.Name = match.Groups[1].Value;

--- a/GitCommands/Patch/PatchProcessor.cs
+++ b/GitCommands/Patch/PatchProcessor.cs
@@ -149,15 +149,6 @@ namespace PatchApply
             return patch;
         }
 
-        public static Patch CreatePatchFromString(string patchText, Encoding filesContentEncoding)
-        {
-            var processor = new PatchProcessor(filesContentEncoding);
-            string[] lines = patchText.Split('\n');
-            int i = 0;
-            Patch patch = processor.CreatePatchFromString(lines, ref i);
-            return patch;
-        }
-
         /// <summary>
         /// Diff part of patch is printed verbatim, everything else (header, warnings, ...) is printed in git encoding (GitModule.SystemEncoding)
         /// Since patch may contain diff for more than one file, it would be nice to obtaining encoding for each of file
@@ -208,7 +199,7 @@ namespace PatchApply
             else if (input.StartsWith("--- "))
             {
                 input = GitModule.UnquoteFileName(input);
-                Match regexMatch = Regex.Match(input, "[-]{3} [\\\"]?[aiwco12]/(.*)[\\\"]?");
+                Match regexMatch = Regex.Match(input, "[-]{3} [\\\"]?[abiwco12]/(.*)[\\\"]?");
 
                 if (regexMatch.Success)
                     patch.FileNameA = regexMatch.Groups[1].Value.Trim();
@@ -225,7 +216,7 @@ namespace PatchApply
             else if (input.StartsWith("+++ "))
             {
                 input = GitModule.UnquoteFileName(input);
-                Match regexMatch = Regex.Match(input, "[+]{3} [\\\"]?[biwco12]/(.*)[\\\"]?");
+                Match regexMatch = Regex.Match(input, "[+]{3} [\\\"]?[abiwco12]/(.*)[\\\"]?");
 
                 if (regexMatch.Success)
                     patch.FileNameB = regexMatch.Groups[1].Value.Trim();

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -280,6 +280,18 @@ namespace GitCommandsTests.Git
 			Assert.AreEqual(status.OldCommit, "2fb88514cfdc37a2708c24f71eca71c424b8d402");
 			Assert.AreEqual(status.OldName, fileName);
 
-		}
+            // Submodule name in reverse diff, rename
+
+            text = "diff --git b/Externals/conemu-inside-b a/Externals/conemu-inside-a\nindex a17ea0c..b5a3d51 160000\n--- b/Externals/conemu-inside-b\n+++ a/Externals/conemu-inside-a\n@@ -1 +1 @@\n-Subproject commit a17ea0c8ebe9d8cd7e634ba44559adffe633c11d\n+Subproject commit b5a3d51777c85a9aeee534c382b5ccbb86b485d3\n";
+            fileName = "Externals/conemu-inside-b";
+
+            status = GitCommandHelpers.GetSubmoduleStatus(text, testModule, fileName);
+
+            Assert.AreEqual(status.Commit, "b5a3d51777c85a9aeee534c382b5ccbb86b485d3");
+            Assert.AreEqual(status.Name, fileName);
+            Assert.AreEqual(status.OldCommit, "a17ea0c8ebe9d8cd7e634ba44559adffe633c11d");
+            fileName = "Externals/conemu-inside-a";
+            Assert.AreEqual(status.OldName, fileName);
+        }
     }
 }

--- a/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
+++ b/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
@@ -35,20 +35,35 @@ namespace GitCommandsTests.Patch
             return patchBytes;
         }
 
-        public TestPatch CreateSmallPatchExample()
+        public TestPatch CreateSmallPatchExample(bool reverse = false)
         {
             TestPatch testPatch = new TestPatch();
             Encoding fileEncoding = Encoding.UTF8;
             testPatch.Patch.Type = PatchApply.Patch.PatchType.ChangeFile;
             testPatch.Patch.Apply = true;
-            testPatch.Patch.PatchHeader = "diff --git a/thisisatest.txt b/thisisatest.txt";
+            if (reverse)
+            {
+                testPatch.Patch.PatchHeader = "diff --git b/thisisatestb.txt a/thisisatesta.txt";
+            }
+            else
+            {
+                testPatch.Patch.PatchHeader = "diff --git a/thisisatesta.txt b/thisisatestb.txt";
+            }
             testPatch.Patch.PatchIndex = "index 5e4dce2..5eb1e6f 100644";
-            testPatch.Patch.FileNameA = "thisisatest.txt";
-            testPatch.Patch.FileNameB = "thisisatest.txt";
+            testPatch.Patch.FileNameA = "thisisatesta.txt";
+            testPatch.Patch.FileNameB = "thisisatestb.txt";
             testPatch.AppendHeaderLine(testPatch.Patch.PatchHeader);
             testPatch.AppendHeaderLine(testPatch.Patch.PatchIndex);
-            testPatch.AppendHeaderLine("--- a/" + testPatch.Patch.FileNameA);
-            testPatch.AppendHeaderLine("+++ b/" + testPatch.Patch.FileNameB);
+            if (reverse)
+            {
+                testPatch.AppendHeaderLine("--- b/" + testPatch.Patch.FileNameB);
+                testPatch.AppendHeaderLine("+++ a/" + testPatch.Patch.FileNameA);
+            }
+            else
+            {
+                testPatch.AppendHeaderLine("--- a/" + testPatch.Patch.FileNameA);
+                testPatch.AppendHeaderLine("+++ b/" + testPatch.Patch.FileNameB);
+            }
             testPatch.AppendDiffLine("@@ -1,2 +1,2 @@", fileEncoding);
             testPatch.AppendDiffLine(" iiiiii", fileEncoding);
             testPatch.AppendDiffLine("-ąśdkjaldskjlaksd", fileEncoding);
@@ -69,6 +84,25 @@ namespace GitCommandsTests.Patch
 
             Assert.AreEqual(expectedPatch.Patch.PatchHeader, createdPatch.PatchHeader);
             Assert.AreEqual(expectedPatch.Patch.FileNameA, createdPatch.FileNameA);
+            Assert.AreEqual(expectedPatch.Patch.PatchIndex, createdPatch.PatchIndex);
+            Assert.AreEqual(expectedPatch.Patch.Rate, createdPatch.Rate);
+            Assert.AreEqual(expectedPatch.Patch.Type, createdPatch.Type);
+            Assert.AreEqual(expectedPatch.Patch.Text, createdPatch.Text);
+        }
+
+
+        [TestMethod]
+        public void TestCorrectlyLoadReversePatch()
+        {
+            PatchManager manager = NewManager();
+            TestPatch expectedPatch = CreateSmallPatchExample(true);
+
+            manager.LoadPatch(expectedPatch.PatchOutput.ToString(), false, Encoding.UTF8);
+
+            PatchApply.Patch createdPatch = manager.Patches.First();
+
+            Assert.AreEqual(expectedPatch.Patch.PatchHeader, createdPatch.PatchHeader, "header");
+            Assert.AreEqual(expectedPatch.Patch.FileNameB, createdPatch.FileNameA, "fileA");
             Assert.AreEqual(expectedPatch.Patch.PatchIndex, createdPatch.PatchIndex);
             Assert.AreEqual(expectedPatch.Patch.Rate, createdPatch.Rate);
             Assert.AreEqual(expectedPatch.Patch.Type, createdPatch.Type);


### PR DESCRIPTION
Reverse order of compare, required to diff from working-dir "commit" to other commits

This is a part of #4031. 
Currently, the -R option is not used, so this commit in itself does not make any change.
Unit tests as requested by @RussKie https://github.com/gerhardol/gitextensions/commit/7234d28588cad4b22f3dbc6ad58d8542449904c7#commitcomment-25122598

Changes proposed in this pull request:
 - Handle diff with -R option
 
Screenshots before and after (if PR changes UI):
- No change now. When remaining of #4031 is merged, "b" may be listed first like below:
![image](https://user-images.githubusercontent.com/6248932/32688681-ee1b4896-c6d5-11e7-88f9-e34a2078f6e7.png)

How did I test this code:
 - Unit tests, in other branches
 
Has been tested on (remove any that don't apply):
 - GIT 2.15 - no change in this commit
 - Windows 10
