### PR TITLE
Separate handling of artificial commits diff options

### DIFF
--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Translate GitRevision including artificial commits to diff options
+    /// Closely related to GitRevision.cs 
+    /// </summary>
+    public static class RevisionDiffProvider
+    {
+        private const string StagedOpt = "--cached";
+
+        /// <summary>
+        /// Translate the revision string to an option string
+        /// Artificial "commits" are options, handle aliases too
+        /// (order and handling of empty arguments is not handled here)
+        /// </summary>
+        /// <param name="rev"></param>
+        /// <returns></returns>
+        private static string ArtificialToDiffOptions(string rev)
+        {
+            if (rev.IsNullOrEmpty() || rev == GitRevision.UnstagedGuid) { rev = string.Empty; }
+            else if (rev == "^" || rev == GitRevision.UnstagedGuid + "^" || rev == GitRevision.IndexGuid) { rev = StagedOpt; }
+            else
+            {
+                //Normal commit
+                if (rev == "^^" || rev == GitRevision.UnstagedGuid + "^^" || rev == GitRevision.IndexGuid + "^") { rev = "HEAD"; }
+                else if (rev == "^^^" || rev == GitRevision.UnstagedGuid + "^^^" || rev == GitRevision.IndexGuid + "^^") { rev = "HEAD^"; }
+                rev = rev.QuoteNE();
+            }
+
+            return rev;
+        }
+
+        /// <summary>
+        /// options to git-diff from GE arguments, including artificial commits
+        /// </summary>
+        /// <param name="from">The first revision</param>
+        /// <param name="to">The second "current" revision</param>
+        /// <returns></returns>
+        public static string Get(string from, string to)
+        {
+            string extra = string.Empty;
+            from = ArtificialToDiffOptions(from);
+            to = ArtificialToDiffOptions(to);
+
+            //Note: As artificial are options, diff unstage..unstage and 
+            // stage..stage will show output, different from e.g. HEAD..HEAD
+            //Diff-to-itself is not always disabled why this is not handled as error in release builds
+            Debug.Assert(!(from == to && (from.IsNullOrEmpty() || from == StagedOpt)),
+                "Unexpectedly two identical artificial revisions to diff: " + from +
+                ". This will be displayed as diff to HEAD, not an identical diff.");
+
+            //As empty (unstaged) and --cached (staged) are options (not revisions),
+            // order must be preserved with -R
+            if (from != to && (from.IsNullOrEmpty() ||
+                from == StagedOpt && !to.IsNullOrEmpty()))
+            {
+                extra = "-R";
+            }
+
+            //Special case: Remove options comparing unstaged-staged
+            if (from.IsNullOrEmpty() && to == StagedOpt ||
+                from == StagedOpt && to.IsNullOrEmpty())
+            {
+                from = to = string.Empty;
+            }
+
+            //Reorder options - not strictly required
+            if (to == StagedOpt)
+            {
+                extra += " " + StagedOpt;
+                to = String.Empty;
+            }
+
+            return string.Join(" ", extra, from, to);
+        }
+    }
+}

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -7,32 +7,8 @@ namespace GitCommands
     /// Translate GitRevision including artificial commits to diff options
     /// Closely related to GitRevision.cs 
     /// </summary>
-    public static class RevisionDiffProvider
+    public class RevisionDiffProvider
     {
-        private const string StagedOpt = "--cached";
-
-        /// <summary>
-        /// Translate the revision string to an option string
-        /// Artificial "commits" are options, handle aliases too
-        /// (order and handling of empty arguments is not handled here)
-        /// </summary>
-        /// <param name="rev"></param>
-        /// <returns></returns>
-        private static string ArtificialToDiffOptions(string rev)
-        {
-            if (rev.IsNullOrEmpty() || rev == GitRevision.UnstagedGuid) { rev = string.Empty; }
-            else if (rev == "^" || rev == GitRevision.UnstagedGuid + "^" || rev == GitRevision.IndexGuid) { rev = StagedOpt; }
-            else
-            {
-                //Normal commit
-                if (rev == "^^" || rev == GitRevision.UnstagedGuid + "^^" || rev == GitRevision.IndexGuid + "^") { rev = "HEAD"; }
-                else if (rev == "^^^" || rev == GitRevision.UnstagedGuid + "^^^" || rev == GitRevision.IndexGuid + "^^") { rev = "HEAD^"; }
-                rev = rev.QuoteNE();
-            }
-
-            return rev;
-        }
-
         /// <summary>
         /// options to git-diff from GE arguments, including artificial commits
         /// </summary>
@@ -76,5 +52,29 @@ namespace GitCommands
 
             return string.Join(" ", extra, from, to);
         }
+
+        /// <summary>
+        /// Translate the revision string to an option string
+        /// Artificial "commits" are options, handle aliases too
+        /// (order and handling of empty arguments is not handled here)
+        /// </summary>
+        /// <param name="rev"></param>
+        /// <returns></returns>
+        private static string ArtificialToDiffOptions(string rev)
+        {
+            if (rev.IsNullOrEmpty() || rev == GitRevision.UnstagedGuid) { rev = string.Empty; }
+            else if (rev == "^" || rev == GitRevision.UnstagedGuid + "^" || rev == GitRevision.IndexGuid) { rev = StagedOpt; }
+            else
+            {
+                //Normal commit
+                if (rev == "^^" || rev == GitRevision.UnstagedGuid + "^^" || rev == GitRevision.IndexGuid + "^") { rev = "HEAD"; }
+                else if (rev == "^^^" || rev == GitRevision.UnstagedGuid + "^^^" || rev == GitRevision.IndexGuid + "^^") { rev = "HEAD^"; }
+                rev = rev.QuoteNE();
+            }
+
+            return rev;
+        }
+
+        private const string StagedOpt = "--cached";
     }
 }

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -50,7 +50,7 @@ namespace GitCommands
                 to = String.Empty;
             }
 
-            return string.Join(" ", extra, from, to);
+            return string.Join(" ", extra, from, to).Trim();
         }
 
         /// <summary>

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Git\GitBranchNameOptions.cs" />
     <Compile Include="Git\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDirectoryResolver.cs" />
+    <Compile Include="Git\RevisionDiffProvider.cs" />
     <Compile Include="Git\GitTagController.cs" />
     <Compile Include="SshPathLocator.cs" />
     <Compile Include="Git\IndexLockManager.cs" />

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -22,14 +22,14 @@ namespace GitCommandsTests.Git
         [TestCase(GitRevision.UnstagedGuid)]
         public void RevisionDiffProvider_should_return_empty_if_To_is_UnstagedGuid(string from)
         {
-            RevisionDiffProvider.Get(from, GitRevision.UnstagedGuid).Trim().Should().BeEmpty();
+            RevisionDiffProvider.Get(from, GitRevision.UnstagedGuid).Should().BeEmpty();
         }
 
         [TestCase("^")]
         [TestCase(GitRevision.IndexGuid)]
         public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string from)
         {
-            RevisionDiffProvider.Get(from, GitRevision.IndexGuid).Trim().Should().Be("--cached --cached");
+            RevisionDiffProvider.Get(from, GitRevision.IndexGuid).Should().Be("--cached --cached");
         }
 #endif
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid)]
@@ -37,14 +37,14 @@ namespace GitCommandsTests.Git
         [TestCase(GitRevision.IndexGuid, null)]
         public void RevisionDiffProvider_staged_to_unstaged(string from, string to)
         {
-            RevisionDiffProvider.Get(from, to).Trim().Should().BeEmpty();
+            RevisionDiffProvider.Get(from, to).Should().BeEmpty();
         }
 
         [TestCase(GitRevision.UnstagedGuid, GitRevision.IndexGuid)]
         [TestCase("", "^")]
         public void RevisionDiffProvider_unstaged_to_staged(string from, string to)
         {
-            RevisionDiffProvider.Get(from, to).Trim().Should().Be("-R");
+            RevisionDiffProvider.Get(from, to).Should().Be("-R");
         }
 
         [TestCase(GitRevision.UnstagedGuid + "^^")]
@@ -52,32 +52,32 @@ namespace GitCommandsTests.Git
         [TestCase("HEAD")]
         public void RevisionDiffProvider_head_to_unstaged(string from)
         {
-            RevisionDiffProvider.Get(from, GitRevision.UnstagedGuid).Trim().Should().Be("\"HEAD\"");
+            RevisionDiffProvider.Get(from, GitRevision.UnstagedGuid).Should().Be("\"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid + "^", "^")]
         [TestCase("HEAD", GitRevision.IndexGuid)]
         public void RevisionDiffProvider_head_to_staged(string from, string to)
         {
-            RevisionDiffProvider.Get(from, to).Trim().Should().Be("--cached \"HEAD\"");
+            RevisionDiffProvider.Get(from, to).Should().Be("--cached \"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid, "HEAD")]
         public void RevisionDiffProvider_staged_to_head(string from, string to)
         {
-            RevisionDiffProvider.Get(from, to).Trim().Should().Be("-R --cached \"HEAD\"");
+            RevisionDiffProvider.Get(from, to).Should().Be("-R --cached \"HEAD\"");
         }
 
         [TestCase("HEAD", "123456789")]
         public void RevisionDiffProvider_normal1(string from, string to)
         {
-            RevisionDiffProvider.Get(from, to).Trim().Should().Be("\"HEAD\" \"123456789\"");
+            RevisionDiffProvider.Get(from, to).Should().Be("\"HEAD\" \"123456789\"");
         }
 
         [TestCase("123456789", "HEAD")]
         public void RevisionDiffProvider_normal2(string from, string to)
         {
-            RevisionDiffProvider.Get(from, to).Trim().Should().Be("\"123456789\" \"HEAD\"");
+            RevisionDiffProvider.Get(from, to).Should().Be("\"123456789\" \"HEAD\"");
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -1,0 +1,41 @@
+using GitCommands;
+using NUnit.Framework;
+using System;
+using TestClass = NUnit.Framework.TestFixtureAttribute;
+using TestMethod = NUnit.Framework.TestAttribute;
+
+namespace GitCommandsTests.Git
+{
+    [TestClass]
+    public class RevisionDiffProviderTest
+    {
+        [TestMethod]
+        public void RevisionDiffProvider_diffoptions()
+        {
+            //See ArtificialToDiffOptions() for possible "aliases" for artificial commits
+
+#if !DEBUG
+            //Testcases that should assert in debug; should not occur but undefined behavior that should be blocked in GUI
+            //Cannot run in DEBUG
+            //In release build require empty parameters (compare working dir to index)
+            Assert.AreEqual("", RevisionDiffProvider.Get(GitRevision.UnstagedGuid, GitRevision.UnstagedGuid).Trim(), "assert 1");
+            Assert.AreEqual("", RevisionDiffProvider.Get("", GitRevision.UnstagedGuid).Trim(), "assert 2");
+            Assert.AreEqual("", RevisionDiffProvider.Get(null, GitRevision.UnstagedGuid).Trim(), "assert 3");
+            Assert.AreEqual("--cached --cached", RevisionDiffProvider.Get(GitRevision.IndexGuid, GitRevision.IndexGuid).Trim(), "assert 4");
+#endif
+
+            Assert.AreEqual("", RevisionDiffProvider.Get(GitRevision.IndexGuid, GitRevision.UnstagedGuid).Trim(), "unstaged staged");
+            Assert.AreEqual("", RevisionDiffProvider.Get("^", GitRevision.UnstagedGuid).Trim(), "unstaged ^");
+            Assert.AreEqual("", RevisionDiffProvider.Get(GitRevision.IndexGuid, "").Trim(), "unstaged empty");
+            Assert.AreEqual("\"HEAD\"", RevisionDiffProvider.Get(GitRevision.IndexGuid + "^", GitRevision.UnstagedGuid).Trim(), "unstaged 4");
+            Assert.AreEqual("-R", RevisionDiffProvider.Get(GitRevision.UnstagedGuid, GitRevision.IndexGuid).Trim(), "unstaged 5");
+
+            Assert.AreEqual("--cached \"HEAD\"", RevisionDiffProvider.Get("HEAD", GitRevision.IndexGuid).Trim(), "staged 1");
+            Assert.AreEqual("-R --cached \"HEAD\"", RevisionDiffProvider.Get(GitRevision.IndexGuid, "HEAD").Trim(), "staged 2");
+
+            Assert.AreEqual("\"HEAD\" \"HEAD\"", RevisionDiffProvider.Get("HEAD", "HEAD").Trim(), "other 1");
+            Assert.AreEqual("\"HEAD\" \"123456789\"", RevisionDiffProvider.Get("HEAD", "123456789").Trim(), "other 2");
+        }
+    }
+}
+

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
+    <Compile Include="Git\RevisionDiffProviderTest.cs" />
     <Compile Include="Git\GitBlameTest.cs" />
     <Compile Include="Git\GitBranchNameNormaliserTest.cs" />
     <Compile Include="Git\GitBranchNameOptionsTest.cs" />


### PR DESCRIPTION
Translate the artificial commits to diff options: index -> --cached, work-dir -> empty
Reverse diff in some situations is required to preserve the order like diff from index to any other commit

Part of #4031.
This code is not used yet. I believe the opdate is easiest to handle if this PR is reviewed and merged separetly, even if some dead code is briefly (?) added.

Changes proposed in this pull request:
 - Separate class for commit -> diff option handling
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Unit tests
 - Other branches

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
