### PR TITLE
Get rid of Exception message box when running tests

### DIFF
--- a/UnitTests/GitCommandsTests/GitModuleTestHelper.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTestHelper.cs
@@ -93,6 +93,12 @@ namespace GitCommandsTests
         {
             try
             {
+                // if settings have been set, the corresponding local config file is in the directory
+                // we want to delete, so we need to make sure the timers that will try to auto-save there
+                // are stopped before actually deleting, else the timers will throw on a background thread.
+                // Note that the intermittent failures mentioned below are likely related too.
+                ((GitModule)Module).EffectiveConfigFile?.SettingsCache?.Dispose();
+                ((GitModule)Module).EffectiveSettings?.SettingsCache?.Dispose();
                 // Directory.Delete seems to intermittently fail, so delete the files first before deleting folders
                 Directory.GetFiles(TemporaryPath, "*", SearchOption.AllDirectories).ForEach(File.Delete);
                 Directory.Delete(TemporaryPath, true);


### PR DESCRIPTION
Although this exception doesn't actually break the tests, it is visually
annoying, and could possibly be related to leaked temporary folders.

It has been pointed at in #4121.
