### PR TITLE
Restructure OpenWithDifftool() so it can handle artificial diff 

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3018,7 +3018,7 @@ namespace GitCommands
             if (!oldFileName.IsNullOrEmpty())
                 oldFileName = oldFileName.Quote();
 
-            string args = string.Join(" ", extraDiffArguments, revision2.QuoteNE(), revision1.QuoteNE(), "--", filename, oldFileName);
+            string args = string.Join(" ", extraDiffArguments, revision1.QuoteNE(), revision2.QuoteNE(), "--", filename, oldFileName);
             RunGitCmdDetached("difftool --gui --no-prompt " + args);
             return output;
         }

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -135,11 +135,9 @@ namespace GitUI.CommandsDialogs
                 diffKind = GitUIExtensions.DiffWithRevisionKind.DiffAB;
             }
 
-            string parentGuid = RevisionGrid.GetSelectedRevisions().Count() == 1 ? DiffFiles.SelectedItemParent : null;
-
             foreach (var selectedItem in DiffFiles.SelectedItems)
             {
-                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -322,7 +322,7 @@ namespace GitUI.CommandsDialogs
             {
                 orgFileName = selectedRows[0].Name;
             }
-            FileChanges.OpenWithDifftool(FileName, orgFileName, GitUIExtensions.DiffWithRevisionKind.DiffAB, null);
+            FileChanges.OpenWithDifftool(FileName, orgFileName, GitUIExtensions.DiffWithRevisionKind.DiffAB);
         }
 
         private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -422,7 +422,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffToolremotelocalStripMenuItem_Click(object sender, EventArgs e)
         {
-            FileChanges.OpenWithDifftool(FileName, string.Empty, GitUIExtensions.DiffWithRevisionKind.DiffBLocal, null);
+            FileChanges.OpenWithDifftool(FileName, string.Empty, GitUIExtensions.DiffWithRevisionKind.DiffBLocal);
         }
 
         private void toolStripSplitLoad_ButtonClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -481,9 +481,7 @@ namespace GitUI.CommandsDialogs
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
                 GitItemStatus selectedItem = itemWithParent.Item;
-                string parentGuid = _revisionGrid.GetSelectedRevisions().Count() == 1 ? itemWithParent.ParentGuid : null;
-
-                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, parentGuid);
+                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind);
             }
         }
 

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />
+    <Compile Include="Helpers\DiffKindRevisionTests.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractorTests.cs" />
     <Compile Include="SplitterManagerTest.cs" />
     <Compile Include="TranslationTest.cs" />

--- a/UnitTests/GitUITests/Helpers/DiffKindRevisionTests.cs
+++ b/UnitTests/GitUITests/Helpers/DiffKindRevisionTests.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows.Forms;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Git;
+using GitUI;
+using GitUI.Properties;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+using static GitUI.GitUIExtensions;
+
+namespace GitUITests.Helpers
+{
+    [TestFixture]
+    public class DiffKindRevisionTests
+    {
+        private GitModule _module;
+
+        [SetUp]
+        public void Setup()
+        {
+            _module = new GitModule("");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_error()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            Assert.AreNotEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            revisions = new List<GitRevision> { null };
+            Assert.AreNotEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "1 null rev");
+            revisions = new List<GitRevision> { null, null };
+            Assert.AreNotEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "2 null rev");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AB_1p()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions[0].ParentGuids = new string[] { "parent" };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("parent", firstRevision, "first");
+            Assert.AreEqual("HEAD", secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AB_1h()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("-M -C", extraDiffArgs);
+            Assert.AreEqual("HEAD^", firstRevision, "first");
+            Assert.AreEqual("HEAD", secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AB_2()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD^"), new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD", firstRevision, "first");
+            Assert.AreEqual("HEAD^", secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AL_1()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffALocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD^", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AL_2()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD^"), new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffALocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_ApL_1()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffAParentLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD^^", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_BL_1()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffBLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_BL_2()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD^"), new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffBLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD^", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_BpL_1()
+        {
+            IList<GitRevision> revisions = null;
+            string extraDiffArgs, firstRevision, secondRevision;
+            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            Assert.AreEqual("", DiffKindRevision.Get(revisions, DiffWithRevisionKind.DiffBParentLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
+            Assert.AreEqual("HEAD^", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+    }
+}


### PR DESCRIPTION
and add unit tests

This is a part of #4031 and rewrite/unittests were requested by @RussKie in
https://github.com/gerhardol/gitextensions/commit/7234d28588cad4b22f3dbc6ad58d8542449904c7#diff-95349e407fef1a99246ba82fa6aa7ba0

A small cleanup to handle order of revisions too, more to come in a later update.
That may also contain certain tweaks to the logic too.
This is a part of the solution, broken out so it can be reviewed.

Changes proposed in this pull request:
 - OpenWithDifftool()  rewrite
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Unit tests added
 - Manual tests

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
