### PR TITLE
GitModule is not updated for RevisionFileTreeController.cs

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1725,6 +1725,7 @@ namespace GitUI.CommandsDialogs
             }
 
             HideDashboard();
+            fileTree.SetGitModule(RevisionGrid.Module);
             UICommands.RepoChangedNotifier.Notify();
             RevisionGrid.IndexWatcher.Reset();
             RegisterPlugins();

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -34,6 +34,14 @@ namespace GitUI.CommandsDialogs
             Translate();
         }
 
+        public void SetGitModule(GitModule module)
+        {
+            //GitRevisionInfoProvider is not needed in this module but is used in unit tests
+            if (_revisionFileTreeController != null)
+            {
+                _revisionFileTreeController.SetGitModule(module, new GitRevisionInfoProvider(module));
+            }
+        }
 
         public void ExpandToFile(string filePath)
         {
@@ -181,9 +189,8 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnRuntimeLoad(EventArgs e)
         {
-            _revisionFileTreeController = new RevisionFileTreeController(Module,
-                                                                         new GitRevisionInfoProvider(Module),
-                                                                         new FileAssociatedIconProvider());
+            _revisionFileTreeController = new RevisionFileTreeController(new FileAssociatedIconProvider());
+            this.SetGitModule(Module);
 
             tvGitTree.ImageList = new ImageList(components)
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -33,6 +33,12 @@ namespace GitUI.CommandsDialogs
         /// Clears the cache of the current revision's loaded children items.
         /// </summary>
         void ResetCache();
+
+        /// <summary>
+        /// Updates the GitModule
+        /// </summary>
+        /// <param name="module">The GitModule</param>
+        void SetGitModule(IGitModule module, IGitRevisionInfoProvider revisionInfoProvider);
     }
 
     internal sealed class RevisionFileTreeController : IRevisionFileTreeController
@@ -43,16 +49,14 @@ namespace GitUI.CommandsDialogs
             public const int Submodule = 2;
         }
 
-        private readonly IGitModule _module;
+        private IGitModule _module;
+        private IGitRevisionInfoProvider _revisionInfoProvider;
         private readonly IFileAssociatedIconProvider _iconProvider;
-        private readonly IGitRevisionInfoProvider _revisionInfoProvider;
         private readonly ConcurrentDictionary<string, IEnumerable<IGitItem>> _cachedItems = new ConcurrentDictionary<string, IEnumerable<IGitItem>>();
 
 
-        public RevisionFileTreeController(IGitModule module, IGitRevisionInfoProvider revisionInfoProvider, IFileAssociatedIconProvider iconProvider)
+        public RevisionFileTreeController(IFileAssociatedIconProvider iconProvider)
         {
-            _module = module;
-            _revisionInfoProvider = revisionInfoProvider;
             _iconProvider = iconProvider;
         }
 
@@ -147,6 +151,16 @@ namespace GitUI.CommandsDialogs
         public void ResetCache()
         {
             _cachedItems.Clear();
+        }
+
+        /// <summary>
+        /// Updates the GitModule
+        /// </summary>
+        /// <param name="module">The GitModule</param>
+        public void SetGitModule(IGitModule module, IGitRevisionInfoProvider revisionInfoProvider)
+        {
+            _module = module;
+            _revisionInfoProvider = revisionInfoProvider;
         }
     }
 }

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -29,7 +29,8 @@ namespace GitUITests.CommandsDialogs
             _module = Substitute.For<IGitModule>();
             _revisionInfoProvider = Substitute.For<IGitRevisionInfoProvider>();
             _iconProvider = Substitute.For<IFileAssociatedIconProvider>();
-            _controller = new RevisionFileTreeController(_module, _revisionInfoProvider, _iconProvider);
+            _controller = new RevisionFileTreeController(_iconProvider);
+            _controller.SetGitModule(_module, _revisionInfoProvider);
 
              _rootNode = new TreeNode();
              _imageList = new ImageList();


### PR DESCRIPTION
This is a regression for #4071. _module is not updated when the repo in FormBrowse/RevisionFileTree is updated as the value is passed at creation only
The handling is adapted to pass the module at updates

This has very minor negative effect: The icon provider cannot find the files on the file system so it creates a file in a temp dir
However, I wasted some time on RevisionDiffController trying to use the same pattern.

Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Unit Tests no update to handle the non-optimal scenario - would not detect anything
 - Manual tests

Has been tested on (remove any that don't apply):
 - Windows 10