### PR TITLE
Update Submodule for unstaged commits Browse diff

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -31,7 +31,6 @@ namespace GitUI.CommandsDialogs
         private GitItemStatus _oldDiffItem;
         private IRevisionDiffController _revisionDiffController;
 
-
         public RevisionDiff()
         {
             InitializeComponent();
@@ -321,8 +320,8 @@ namespace GitUI.CommandsDialogs
                 diffResetSubmoduleChanges.Visible =
                 diffStashSubmoduleChangesToolStripMenuItem.Visible =
                 diffUpdateSubmoduleMenuItem.Visible =
-                diffSubmoduleSummaryMenuItem.Visible = _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo);
-            diffUpdateSubmoduleMenuItem.Visible = false; //TBD
+                diffSubmoduleSummaryMenuItem.Visible =
+                diffUpdateSubmoduleMenuItem.Visible = _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo);
 
             diffToolStripSeparator13.Visible = _revisionDiffController.ShouldShowMenuEditFile(selectionInfo) || _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo);
 
@@ -794,7 +793,7 @@ namespace GitUI.CommandsDialogs
 
             //TBD RefreshRevisions();
         }
-
+        
         private void diffUpdateSubmoduleMenuItem_Click(object sender, EventArgs e)
         {
             var unStagedFiles = DiffFiles.SelectedItems.ToList();
@@ -803,7 +802,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in unStagedFiles.Where(it => it.IsSubmodule))
             {
-                //TBD FormProcess.ShowDialog(this, GitCommandHelpers.SubmoduleUpdateCmd(item.Name));
+                FormProcess.ShowDialog(null, Module, GitCommandHelpers.SubmoduleUpdateCmd(item.Name));
             }
 
             //TBD RefreshRevisions();

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -802,7 +802,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in unStagedFiles.Where(it => it.IsSubmodule))
             {
-                FormProcess.ShowDialog(null, Module, GitCommandHelpers.SubmoduleUpdateCmd(item.Name));
+                FormProcess.ShowDialog((FindForm() as FormBrowse), GitCommandHelpers.SubmoduleUpdateCmd(item.Name));
             }
 
             //TBD RefreshRevisions();


### PR DESCRIPTION
This is a follow-up to #4092. When submitted, this action worked but after a refactoring to RevisionDiff.cs (much needed though) this action was commented out when refactoring as it required slightly more changes.

The master issue is #4031
This is part of 3. in https://github.com/gitextensions/gitextensions/issues/4031#issuecomment-342005174

Screenshots before and after (if PR changes UI):
- See original PR for the Update Submodule menu item, missing in merged version of #4092

How did I test this code:
 - Change version for a submodule
 - View artificial commits
 - Verify that the option is is available and update submodule version

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10