### PR TITLE
Refresh Browse Diff filelist when actions (may) update the index

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1255,6 +1255,7 @@ namespace GitUI.CommandsDialogs
         private void ResetToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UICommands.StartResetChangesDialog(this);
+            revisionDiff.RefreshArtificial();
         }
 
         private void RunMergetoolToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -36,7 +36,6 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             Translate();
-
         }
 
         public void ForceRefreshRevisions()
@@ -51,6 +50,17 @@ namespace GitUI.CommandsDialogs
             {
                 _oldRevision = null;
                 _oldDiffItem = null;
+            }
+            RefreshArtificial();
+        }
+
+        public void RefreshArtificial()
+        {
+            var revisions = _revisionGrid.GetSelectedRevisions();
+
+            if (revisions.Count > 0 && revisions[0].IsArtificial())
+            {
+                DiffFiles.SetDiffs(revisions);
             }
         }
 
@@ -366,7 +376,7 @@ namespace GitUI.CommandsDialogs
             }
             bool err;
             Module.StageFiles(files, out err);
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void UnstageFileToolStripMenuItemClick(object sender, EventArgs e)
@@ -391,7 +401,7 @@ namespace GitUI.CommandsDialogs
             }
 
             Module.UnstageFiles(files);
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void cherryPickSelectedDiffFileToolStripMenuItem_Click(object sender, EventArgs e)
@@ -723,7 +733,7 @@ namespace GitUI.CommandsDialogs
                 {
                     File.Delete(Path.Combine(Module.WorkingDir, item.Name));
                 }
-                //TBD RefreshRevisions();
+                RefreshArtificial();
             }
             catch (Exception ex)
             {
@@ -744,14 +754,14 @@ namespace GitUI.CommandsDialogs
             var fileName = Path.Combine(Module.WorkingDir, item.Name);
 
             UICommands.StartFileEditorDialog(fileName);
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void diffCommitSubmoduleChanges_Click(object sender, EventArgs e)
         {
             GitUICommands submodulCommands = new GitUICommands(Module.WorkingDir + DiffFiles.SelectedItem.Name.EnsureTrailingPathSeparator());
             submodulCommands.StartCommitDialog(this, false);
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void diffResetSubmoduleChanges_Click(object sender, EventArgs e)
@@ -791,8 +801,7 @@ namespace GitUI.CommandsDialogs
                     }
                 }
             }
-
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void diffUpdateSubmoduleMenuItem_Click(object sender, EventArgs e)
@@ -805,8 +814,7 @@ namespace GitUI.CommandsDialogs
             {
                 //TBD FormProcess.ShowDialog(this, GitCommandHelpers.SubmoduleUpdateCmd(item.Name));
             }
-
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void diffStashSubmoduleChangesToolStripMenuItem_Click(object sender, EventArgs e)
@@ -820,8 +828,7 @@ namespace GitUI.CommandsDialogs
                 GitUICommands uiCmds = new GitUICommands(Module.GetSubmodule(item.Name));
                 uiCmds.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash);
             }
-
-            //TBD RefreshRevisions();
+            RefreshArtificial();
         }
 
         private void diffSubmoduleSummaryMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION

Part of 3. in https://github.com/gitextensions/gitextensions/issues/4031#issuecomment-342005174
This is likely not a complete update, all changes related to #4031 need to be merged to get an overview...

Changes proposed in this pull request:
 - Refresh the diff filelist in Browse for artificial commits for the commands that may update files or the index
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Make sure there are files in the index and or working tree (so the artificial commits are available, proposal to change in #4086)  
 - Modify the files outside GE, like from the file system. The index is not updated (discussion in #4031 how to improve). The lists are updated though when selecting the artificial indexes
 - Modify files from GE that affect the artificial, like stage/unstage files and verify that the index is updated

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
