### PR TITLE
Auto-pick SdkToolsPath

### DIFF
--- a/GitPlugin/GitPlugin.csproj
+++ b/GitPlugin/GitPlugin.csproj
@@ -199,9 +199,12 @@
   <Import Project="..\FxCop.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <Target Name="AfterBuild">
+    <GetFrameworkSdkPath>
+      <Output TaskParameter="Path" PropertyName="WindowsSdkPath" />
+    </GetFrameworkSdkPath>
     <MakeDir Directories="$(TargetDir)en-US" />
     <Message Text="Custom Step: Calling Resource Generator on $(ProjectDir)Properties\Resources.resx." />
-    <GenerateResource Sources="$(ProjectDir)Properties\Resources.resx" UseSourcePath="True" />
+    <GenerateResource Sources="$(ProjectDir)Properties\Resources.resx" UseSourcePath="True" SdkToolsPath="$(WindowsSdkPath)" />
     <Message Text="Custom Step: Calling AssemblyLinker to make an assembly at $(TargetDir)en-US\GitPlugin.resources.dll out of $(ProjectDir)Properties\Resources.resources." />
     <AL EmbedResources="$(ProjectDir)Properties\Resources.resources" Culture="en-US" OutputAssembly="$(TargetDir)en-US\GitPlugin.resources.dll" />
     <Message Text="Done with the Custom Step." />


### PR DESCRIPTION
Not sure what has changed in the recent months (maybe framework upgrade to 4.6.1?) but I couldn't build the setup any more because `resgen.exe` was not found.
It was expected under WindowsSdk 8 path but I had WindowsSdk 10 instead which should be just fine for `resgen.exe`

This change uses `GetFrameworkSdkPath` msbuild task to resolve the Sdk path automatically and provide it to the `GenerateResource` task.