### PR TITLE
Delete remote branch

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -585,9 +585,16 @@ namespace GitCommands
             }
         }
 
-        public static string MergedBranches()
+        public static string MergedBranches(bool includeRemote = false)
         {
-            return "branch --merged";
+            if (includeRemote)
+            {
+                return "branch -a --merged";
+            }
+            else
+            {
+                return "branch --merged";
+            }
         }
 
         /// <summary>Un-sets the git SSH command path.</summary>

--- a/GitCommands/Git/GitDeleteRemoteBranchCmd.cs
+++ b/GitCommands/Git/GitDeleteRemoteBranchCmd.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GitUIPluginInterfaces;
+
+namespace GitCommands
+{
+    public sealed class GitDeleteRemoteBranchesCmd : GitCommand
+    {
+        private readonly string remote;
+        private readonly List<IGitRef> branches;
+
+        public GitDeleteRemoteBranchesCmd(string remote, IEnumerable<IGitRef> branches)
+        {
+            if (string.IsNullOrEmpty(remote))
+                throw new ArgumentNullException("remote");
+
+            if (branches == null)
+                throw new ArgumentNullException("branches");
+
+            this.remote = remote;
+            this.branches = branches.ToList();
+
+            if (this.branches.Any(b => b.Remote != this.remote))
+            {
+                throw new ArgumentException($"Branch remote mismatch. Branch {this.branches.First(b => b.Remote != this.remote).CompleteName} does not belong to remote {remote}");
+            }
+        }
+
+        public override string GitComandName()
+        {
+            return "push";
+        }
+
+        protected override IEnumerable<string> CollectArguments()
+        {
+            yield return remote;
+
+            foreach (var branch in branches)
+            {
+                yield return " :\"" + branch.LocalName + "\"";
+            }
+        }
+
+        public override bool AccessesRemote()
+        {
+            return true;
+        }
+
+        public override bool ChangesRepoState()
+        {
+            return true;
+        }
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2716,9 +2716,25 @@ namespace GitCommands
             ByCommitDateDescending
         }
 
-        public ICollection<string> GetMergedBranches()
+        public ICollection<string> GetMergedBranches(bool includeRemote = false)
         {
-            return RunGitCmd(GitCommandHelpers.MergedBranches()).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            return RunGitCmd(GitCommandHelpers.MergedBranches(includeRemote)).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public ICollection<string> GetMergedRemoteBranches()
+        {
+            string remoteBranchPrefixForMergedBranches = "remotes/";
+            string refsPrefix = "refs/";
+
+            string[] mergedBranches = RunGitCmd(GitCommandHelpers.MergedBranches(includeRemote: true)).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            var remotes = GetRemotes(allowEmpty: false);
+
+            return mergedBranches
+                .Select(b => b.Trim())
+                .Where(b => b.StartsWith(remoteBranchPrefixForMergedBranches))
+                .Select(b => string.Concat(refsPrefix, b))
+                .Where(b => !string.IsNullOrEmpty(GitCommandHelpers.GetRemoteName(b, remotes))).ToList();
         }
 
         private string GetTree(bool tags, bool branches)

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Git\GitBranchNameOptions.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />
+    <Compile Include="Git\GitDeleteRemoteBranchCmd.cs" />
     <Compile Include="Git\GitDirectoryResolver.cs" />
     <Compile Include="Git\RevisionDiffProvider.cs" />
     <Compile Include="Git\Tag\GitTagController.cs" />

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.Designer.cs
@@ -1,0 +1,166 @@
+﻿namespace GitUI.CommandsDialogs
+{
+    partial class FormDeleteRemoteBranch
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormDeleteRemoteBranch));
+            this.Delete = new System.Windows.Forms.Button();
+            this.labelSelectBranches = new System.Windows.Forms.Label();
+            this.labelDeleteBranchWarning = new System.Windows.Forms.Label();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.DeleteRemote = new System.Windows.Forms.CheckBox();
+            this.Branches = new GitUI.BranchComboBox();
+            this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // Delete
+            // 
+            this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Delete.Enabled = false;
+            this.Delete.ForeColor = System.Drawing.Color.Black;
+            this.Delete.Image = global::GitUI.Properties.Resources.IconBranchDelete;
+            this.Delete.Location = new System.Drawing.Point(553, 80);
+            this.Delete.Margin = new System.Windows.Forms.Padding(4);
+            this.Delete.Name = "Delete";
+            this.Delete.Size = new System.Drawing.Size(150, 31);
+            this.Delete.TabIndex = 4;
+            this.Delete.Text = "Delete";
+            this.Delete.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.Delete.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.Delete.UseVisualStyleBackColor = true;
+            this.Delete.Click += new System.EventHandler(this.OkClick);
+            // 
+            // labelSelectBranches
+            // 
+            this.labelSelectBranches.AutoSize = true;
+            this.labelSelectBranches.ForeColor = System.Drawing.Color.Black;
+            this.labelSelectBranches.Location = new System.Drawing.Point(11, 11);
+            this.labelSelectBranches.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelSelectBranches.Name = "labelSelectBranches";
+            this.labelSelectBranches.Size = new System.Drawing.Size(104, 17);
+            this.labelSelectBranches.TabIndex = 1;
+            this.labelSelectBranches.Text = "Select branches";
+            // 
+            // labelDeleteBranchWarning
+            // 
+            this.labelDeleteBranchWarning.AutoSize = true;
+            this.labelDeleteBranchWarning.ForeColor = System.Drawing.Color.Black;
+            this.labelDeleteBranchWarning.Location = new System.Drawing.Point(49, 145);
+            this.labelDeleteBranchWarning.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelDeleteBranchWarning.MaximumSize = new System.Drawing.Size(625, 0);
+            this.labelDeleteBranchWarning.Name = "labelDeleteBranchWarning";
+            this.labelDeleteBranchWarning.Size = new System.Drawing.Size(612, 68);
+            this.labelDeleteBranchWarning.TabIndex = 5;
+            this.labelDeleteBranchWarning.Text = resources.GetString("labelDeleteBranchWarning.Text");
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = global::GitUI.Properties.Resources.IconWarning;
+            this.pictureBox1.InitialImage = global::GitUI.Properties.Resources.IconWarning;
+            this.pictureBox1.Location = new System.Drawing.Point(15, 178);
+            this.pictureBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(26, 25);
+            this.pictureBox1.TabIndex = 7;
+            this.pictureBox1.TabStop = false;
+            // 
+            // DeleteRemote
+            // 
+            this.DeleteRemote.AutoSize = true;
+            this.DeleteRemote.Location = new System.Drawing.Point(15, 86);
+            this.DeleteRemote.Margin = new System.Windows.Forms.Padding(4);
+            this.DeleteRemote.Name = "DeleteRemote";
+            this.DeleteRemote.Size = new System.Drawing.Size(176, 21);
+            this.DeleteRemote.TabIndex = 3;
+            this.DeleteRemote.Text = "Delete branche(s) from remote repository";
+            this.DeleteRemote.UseVisualStyleBackColor = true;
+            this.DeleteRemote.CheckedChanged += new System.EventHandler(this.DeleteRemote_CheckedChanged);
+            // 
+            // Branches
+            // 
+            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.Branches.BranchesToSelect = null;
+            this.Branches.Location = new System.Drawing.Point(15, 44);
+            this.Branches.Margin = new System.Windows.Forms.Padding(0);
+            this.Branches.Name = "Branches";
+            this.Branches.Size = new System.Drawing.Size(688, 26);
+            this.Branches.TabIndex = 2;
+            // 
+            // gotoUserManualControl1
+            // 
+            this.gotoUserManualControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.gotoUserManualControl1.AutoSize = true;
+            this.gotoUserManualControl1.Location = new System.Drawing.Point(12, 264);
+            this.gotoUserManualControl1.ManualSectionAnchorName = "delete-branch";
+            this.gotoUserManualControl1.ManualSectionSubfolder = "branches";
+            this.gotoUserManualControl1.Margin = new System.Windows.Forms.Padding(4);
+            this.gotoUserManualControl1.MinimumSize = new System.Drawing.Size(88, 25);
+            this.gotoUserManualControl1.Name = "gotoUserManualControl1";
+            this.gotoUserManualControl1.Size = new System.Drawing.Size(88, 25);
+            this.gotoUserManualControl1.TabIndex = 8;
+            // 
+            // FormDeleteRemoteBranch
+            // 
+            this.AcceptButton = this.Delete;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.ClientSize = new System.Drawing.Size(724, 295);
+            this.Controls.Add(this.gotoUserManualControl1);
+            this.Controls.Add(this.Branches);
+            this.Controls.Add(this.DeleteRemote);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.labelDeleteBranchWarning);
+            this.Controls.Add(this.Delete);
+            this.Controls.Add(this.labelSelectBranches);
+            this.Margin = new System.Windows.Forms.Padding(4);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(652, 326);
+            this.Name = "FormDeleteRemoteBranch";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Delete branch";
+            this.Load += new System.EventHandler(this.FormDeleteRemoteBranchLoad);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button Delete;
+        private System.Windows.Forms.Label labelSelectBranches;
+        private System.Windows.Forms.Label labelDeleteBranchWarning;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.CheckBox DeleteRemote;
+        private BranchComboBox Branches;
+        private UserControls.GotoUserManualControl gotoUserManualControl1;
+    }
+}

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using ResourceManager;
+using GitUIPluginInterfaces;
+using System.IO;
+using GitUI.Script;
+
+namespace GitUI.CommandsDialogs
+{
+    public sealed partial class FormDeleteRemoteBranch : GitModuleForm
+    {
+        private readonly TranslationString _deleteRemoteBranchesCaption = new TranslationString("Delete remote branches");
+        private readonly TranslationString _confirmDeleteUnmergedRemoteBranchMessage =
+            new TranslationString("At least one remote branch is unmerged. Are you sure you want to delete it?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
+
+        private readonly string _defaultRemoteBranch;
+        private readonly HashSet<string> _mergedBranches = new HashSet<string>();
+
+        public FormDeleteRemoteBranch(GitUICommands aCommands, string defaultRemoteBranch)
+            : base(aCommands)
+        {
+            InitializeComponent();
+            Translate();
+            _defaultRemoteBranch = defaultRemoteBranch;
+        }
+
+        private void FormDeleteRemoteBranchLoad(object sender, EventArgs e)
+        {
+            Branches.BranchesToSelect = Module.GetRefs(tags: true, branches: true).Where(h => h.IsRemote).ToList();
+            foreach (var branch in Module.GetMergedRemoteBranches())
+            {
+                _mergedBranches.Add(branch);
+            }
+
+            if (_defaultRemoteBranch != null)
+            {
+                Branches.SetSelectedText(_defaultRemoteBranch);
+            }
+        }
+
+        private void OkClick(object sender, EventArgs e)
+        {
+            try
+            {
+                if (!DeleteRemote.Checked)
+                {
+                    return;
+                }
+
+                List<IGitRef> selectedBranches = Branches.GetSelectedBranches().ToList();
+
+                var hasUnmergedBranches = selectedBranches.Any(branch => !_mergedBranches.Contains(branch.CompleteName));
+
+                if (hasUnmergedBranches)
+                {
+                    if (MessageBox.Show(this, _confirmDeleteUnmergedRemoteBranchMessage.Text, _deleteRemoteBranchesCaption.Text, MessageBoxButtons.YesNo) != DialogResult.Yes)
+                    {
+                        return;
+                    }
+                }
+
+                foreach (var remoteGroup in selectedBranches.GroupBy(b => b.Remote))
+                {
+                    string remote = remoteGroup.Key;
+
+                    EnsurePageant(remote);
+
+                    var cmd = new GitDeleteRemoteBranchesCmd(remote, remoteGroup);
+
+                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+
+                    using (var form = new FormRemoteProcess(Module, cmd.ToLine())
+                    {
+                        Remote = remote
+                    })
+                    {
+                        form.ShowDialog();
+
+                        if (!Module.InTheMiddleOfAction() && !form.ErrorOccurred())
+                        {
+                            ScriptManager.RunEventScripts(this, ScriptEvent.AfterPush);
+                        }
+                    }
+                }
+
+                UICommands.RepoChangedNotifier.Notify();
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex.Message);
+            }
+            Close();
+        }
+
+        private void DeleteRemote_CheckedChanged(object sender, EventArgs e)
+        {
+            Delete.Enabled = DeleteRemote.Checked;
+        }
+
+        private void EnsurePageant(string remote)
+        {
+            if (GitCommandHelpers.Plink())
+            {
+                if (!File.Exists(AppSettings.Pageant))
+                {
+                    MessageBoxes.PAgentNotFound(this);
+                }
+                else
+                {
+                    Module.StartPageantForRemote(remote);
+                }
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.resx
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.resx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="labelDeleteBranchWarning.Text" xml:space="preserve">
+    <value>When you delete a branch the commits can get lost because nothing points to them.
+Make sure that commits under remote branch(-es) to be deleted are reachable before proceeding.</value>
+  </data>
+</root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -169,6 +169,12 @@
       <DependentUpon>FormReflog.cs</DependentUpon>
     </Compile>
     <Compile Include="CommandsDialogs\FormSparseWorkingCopyViewModel.cs" />
+    <Compile Include="CommandsDialogs\FormDeleteRemoteBranch.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\FormDeleteRemoteBranch.Designer.cs">
+      <DependentUpon>FormDeleteRemoteBranch.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\FormMergeSubmodule.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1129,6 +1135,10 @@
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\FormCompareToBranch.resx">
       <DependentUpon>FormCompareToBranch.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\FormDeleteRemoteBranch.resx">
+      <DependentUpon>FormDeleteRemoteBranch.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\FormDiff.resx">
       <DependentUpon>FormDiff.cs</DependentUpon>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -46,6 +46,9 @@ namespace GitUI
         public event GitUIEventHandler PreDeleteBranch;
         public event GitUIPostActionEventHandler PostDeleteBranch;
 
+        public event GitUIEventHandler PreDeleteRemoteBranch;
+        public event GitUIPostActionEventHandler PostDeleteRemoteBranch;
+
         public event GitUIEventHandler PreCheckoutRevision;
         public event GitUIPostActionEventHandler PostCheckoutRevision;
 
@@ -292,6 +295,19 @@ namespace GitUI
                 {
                     using (var form = new FormDeleteBranch(this, branch))
                         form.ShowDialog(owner);
+                    return true;
+                }
+            );
+        }
+
+        public bool StartDeleteRemoteBranchDialog(IWin32Window owner, string remoteBranch)
+        {
+            return DoActionOnRepo(owner, true, false, PreDeleteRemoteBranch, PostDeleteRemoteBranch, () =>
+                {
+                    using (var form = new FormDeleteRemoteBranch(this, remoteBranch))
+                    {
+                        form.ShowDialog(owner);
+                    }
                     return true;
                 }
             );
@@ -1006,7 +1022,7 @@ namespace GitUI
             if (resetAction == FormResetChanges.ActionEnum.Cancel)
             {
                 return false;
-        }
+            }
 
             Cursor.Current = Cursors.WaitCursor;
 
@@ -1040,7 +1056,7 @@ namespace GitUI
 
         public bool StartResetChangesDialog()
         {
-            return StartResetChangesDialog((IWin32Window) null);
+            return StartResetChangesDialog((IWin32Window)null);
         }
 
         public bool StartRevertCommitDialog(IWin32Window owner, GitRevision revision)
@@ -1760,7 +1776,7 @@ namespace GitUI
             WrapRepoHostingCall("View pull requests", gitHoster,
                                 gh =>
                                 {
-                                    var frm = new ViewPullRequestsForm(this, gitHoster) {ShowInTaskbar = true};
+                                    var frm = new ViewPullRequestsForm(this, gitHoster) { ShowInTaskbar = true };
                                     frm.Show();
                                 });
         }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2416,6 +2416,26 @@ namespace GitUI
                 }
             }
 
+            bool firstRemoteBranchForDelete = true;
+            foreach (var head in allBranches)
+            {
+                if (head.IsRemote)
+                {
+                    if (firstRemoteBranchForDelete)
+                    {
+                        firstRemoteBranchForDelete = false;
+                        if (deleteBranchDropDown.Items.Count > 0)
+                        {
+                            deleteBranchDropDown.Items.Add(new ToolStripSeparator());
+                        }
+                    }
+
+                    ToolStripItem toolStripItem = new ToolStripMenuItem(head.Name);
+                    toolStripItem.Click += ToolStripItemClickDeleteRemoteBranch;
+                    deleteBranchDropDown.Items.Add(toolStripItem); //Add to delete branch
+                }
+            }
+
             bool bareRepositoryOrArtificial = Module.IsBareRepository() || revision.IsArtificial();
             deleteTagToolStripMenuItem.DropDown = deleteTagDropDown;
             deleteTagToolStripMenuItem.Enabled = deleteTagDropDown.Items.Count > 0;
@@ -2499,6 +2519,16 @@ namespace GitUI
                 return;
 
             UICommands.StartDeleteBranchDialog(this, toolStripItem.Tag as string);
+        }
+
+        private void ToolStripItemClickDeleteRemoteBranch(object sender, EventArgs e)
+        {
+            var toolStripItem = sender as ToolStripItem;
+
+            if (toolStripItem == null)
+                return;
+
+            UICommands.StartDeleteRemoteBranchDialog(this, toolStripItem.Text);
         }
 
         private void ToolStripItemClickCheckoutBranch(object sender, EventArgs e)
@@ -2669,7 +2699,6 @@ namespace GitUI
                 Revisions.Prune();
                 return;
             }
-
 
             if (_filtredCurrentCheckout == null)
             {


### PR DESCRIPTION
Introduces a new form to delete remote branches from a FormBrowse commit context menu.
This PR is suggested solution for issue #1583

(sorry for diff noise, there is a separate commit dealing with some style/formatting issues)

Changes proposed in this pull request:
 - List remote branches in a commit context menu under local branches.
 
Screenshots:
This is I guess the most complex demo, deleting several (3) remote branches from two different remotes.
![test2](https://user-images.githubusercontent.com/483659/32701164-7e898670-c7c8-11e7-8866-80f8289354f3.gif)

Considerations:
- Maybe we don't need support for multiple remotes at the same time? That would simplify code a little.