### PR TITLE
Always show artificial commits in RevisionGrid

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2662,6 +2662,7 @@ namespace GitUI
                 return;
             }
 
+
             if (_filtredCurrentCheckout == null)
             {
                 if (rev.Guid == CurrentCheckout)
@@ -2706,10 +2707,7 @@ namespace GitUI
             var workingDir = new GitRevision(Module, GitRevision.UnstagedGuid)
             {
                 Subject = count + Strings.GetCurrentUnstagedChanges(),
-                ParentGuids =
-                    staged > 0
-                        ? new[] { GitRevision.IndexGuid }
-                        : new[] { filtredCurrentCheckout }
+                ParentGuids = new[] { GitRevision.IndexGuid }
             };
             Revisions.Add(workingDir.Guid, workingDir.ParentGuids, DvcsGraph.DataType.Normal, workingDir);
 


### PR DESCRIPTION
Also limit count of changes to the Browse window (does not really make sense in FileHistory)
This is #4031 item 2., discussed in #4086

The RevisionGrid is only updated at explicit commands as normal commits are not changed.
Artificial commits are dynamic and will have contents/no contents from many commands. However, they always "exist".
Now you have to refresh the the complete revision grid to see when staged or unstaged appear. As the diff lists are not cached for artificial commands, the content will be updated just by selecting the artificial commit in question.
(The count is not updated dynamically yet).


Screenshots before and after (if PR changes UI):
- Artificial commits with 0 was not shown before
- 
![image](https://user-images.githubusercontent.com/6248932/32704410-e1028f36-c804-11e7-8e9b-dd4d039d3153.png)

How did I test this code:
 - Open Browse, make sure that there are no staged/unstaged files
 - Make sure that both commits are listed with (0) count
 - Open FileHistory
 - Make sure count is not listed

Has been tested on (remove any that don't apply):
 - Windows 10
