### PR TITLE
fix: Blank RevisionFileTree

### DIFF
--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -19,11 +19,11 @@ namespace GitCommands
 
     public sealed class GitRevisionInfoProvider : IGitRevisionInfoProvider
     {
-        private readonly IGitModule _module;
+        private readonly Func<IGitModule> _getModule;
 
-        public GitRevisionInfoProvider(IGitModule module)
+        public GitRevisionInfoProvider(Func<IGitModule> getModule)
         {
-            _module = module;
+            _getModule = getModule;
         }
 
         /// <summary>
@@ -43,8 +43,13 @@ namespace GitCommands
             {
                 throw new ArgumentException("Item must have a valid identifier", nameof(item.Guid));
             }
+            var module = _getModule();
+            if (module == null)
+            {
+                throw new ArgumentException($"Require a valid instance of {nameof(IGitModule)}");
+            }
 
-            var subItems = _module.GetTree(item.Guid, false).ToList();
+            var subItems = module.GetTree(item.Guid, false).ToList();
             foreach (var subItem in subItems.OfType<GitItem>())
             {
                 subItem.FileName = Path.Combine((item as GitItem)?.FileName ?? string.Empty, subItem.FileName ?? string.Empty);

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -181,8 +181,8 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnRuntimeLoad(EventArgs e)
         {
-            _revisionFileTreeController = new RevisionFileTreeController(Module,
-                                                                         new GitRevisionInfoProvider(Module),
+            _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
+                                                                         new GitRevisionInfoProvider(() => Module),
                                                                          new FileAssociatedIconProvider());
 
             tvGitTree.ImageList = new ImageList(components)

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -20,7 +20,7 @@ namespace GitCommandsTests
         public void Setup()
         {
             _module = Substitute.For<IGitModule>();
-            _provider = new GitRevisionInfoProvider(_module);
+            _provider = new GitRevisionInfoProvider(() => _module);
         }
 
         [Test]
@@ -36,6 +36,18 @@ namespace GitCommandsTests
         {
             var item = Substitute.For<IGitItem>();
             item.Guid.Returns(guid);
+
+            ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void LoadChildren_should_return_if_gitmodule_not_supplied()
+        {
+            var guid = Guid.NewGuid().ToString("N");
+            var item = Substitute.For<IGitItem>();
+            item.Guid.Returns(guid);
+
+            _provider = new GitRevisionInfoProvider(() => null);
 
             ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
         }

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -15,7 +15,6 @@ namespace GitUITests.CommandsDialogs
     [TestFixture]
     public class RevisionFileTreeControllerTests
     {
-        private IGitModule _module;
         private IFileAssociatedIconProvider _iconProvider;
         private IGitRevisionInfoProvider _revisionInfoProvider;
         private RevisionFileTreeController _controller;
@@ -26,10 +25,9 @@ namespace GitUITests.CommandsDialogs
         [SetUp]
         public void Setup()
         {
-            _module = Substitute.For<IGitModule>();
             _revisionInfoProvider = Substitute.For<IGitRevisionInfoProvider>();
             _iconProvider = Substitute.For<IFileAssociatedIconProvider>();
-            _controller = new RevisionFileTreeController(_module, _revisionInfoProvider, _iconProvider);
+            _controller = new RevisionFileTreeController(() => @"c:\repo", _revisionInfoProvider, _iconProvider);
 
              _rootNode = new TreeNode();
              _imageList = new ImageList();


### PR DESCRIPTION
Whenever repositories changed new GitModule instance was not correctly
reflected in RevisionFileTreeController and GitRevisionInfoProvider.

Fixes #4151
