### PR TITLE
Update checked state in "Show remote branches" ToolStripMenuItem

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2587,6 +2587,7 @@ namespace GitUI
         {
             AppSettings.ShowRemoteBranches = !AppSettings.ShowRemoteBranches;
             InvalidateRevisions();
+            _revisionGridMenuCommands.TriggerMenuChanged(); // check/uncheck ToolStripMenuItem
         }
 
         internal void ShowSuperprojectTags_ToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #3730.

Changes proposed in this pull request:
 - Update checked state in "Show remote branches" ToolStripMenuItem when it is clicked.

I tested this code manually:
1. Click on View >> Show remote branches. 
2. It it was checked, it should become unchecked, and the remote branches in the commit list should not be shown. 
3. And vice-versa :)

Has been tested on:
 - GIT 2.14
 - Windows 10
