### PR TITLE
Commit menus raised exceptions if no items were Selected

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -203,6 +203,7 @@ namespace GitUI.CommandsDialogs
             this.interactiveAddtoolStripMenuItem});
             this.UnstagedFileContext.Name = "UnstagedFileContext";
             this.UnstagedFileContext.Size = new System.Drawing.Size(233, 370);
+            this.UnstagedFileContext.Opening += UnstagedContextMenu_Opening;
             // 
             // resetChanges
             // 
@@ -476,6 +477,7 @@ namespace GitUI.CommandsDialogs
             this.copyFolderNameMenuItem});
             this.UnstagedSubmoduleContext.Name = "UnstagedSubmoduleContext";
             this.UnstagedSubmoduleContext.Size = new System.Drawing.Size(229, 264);
+            this.UnstagedSubmoduleContext.Opening += UnstagedContextMenu_Opening;
             // 
             // commitSubmoduleChanges
             // 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1158,8 +1158,6 @@ namespace GitUI.CommandsDialogs
 
             ClearDiffViewIfNoFilesLeft();
 
-            Unstaged.ContextMenuStrip = null;
-
             if (!Unstaged.SelectedItems.Any())
                 return;
 
@@ -1173,6 +1171,12 @@ namespace GitUI.CommandsDialogs
                 Unstaged.ContextMenuStrip = UnstagedFileContext;
             else
                 Unstaged.ContextMenuStrip = UnstagedSubmoduleContext;
+        }
+
+        private void UnstagedContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            //Do not show if no item selected
+            e.Cancel = !Unstaged.SelectedItems.Any();
         }
 
         private void Unstaged_Enter(object sender, EventArgs e)
@@ -1313,6 +1317,8 @@ namespace GitUI.CommandsDialogs
 
         private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
+            //Do not show if no item selected
+            e.Cancel = !Staged.SelectedItems.Any();
             bool isFile = false;
             foreach(GitItemStatus item in Staged.SelectedItems)
             {
@@ -1355,9 +1361,6 @@ namespace GitUI.CommandsDialogs
                 return;
 
             ClearDiffViewIfNoFilesLeft();
-
-            if (!Staged.SelectedItems.Any())
-                return;
 
             Unstaged.ClearSelected();
             _currentSelection = Staged.SelectedItems.ToList();

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1317,19 +1317,25 @@ namespace GitUI.CommandsDialogs
 
         private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            //Do not show if no item selected
-            e.Cancel = !Staged.SelectedItems.Any();
-            bool isFile = false;
-            foreach(GitItemStatus item in Staged.SelectedItems)
+            if (!Staged.SelectedItems.Any())
             {
-                if (!item.IsSubmodule) { isFile = true; }
+                //Do not show if no item selected
+                e.Cancel = true;
             }
-            this.stagedToolStripSeparator14.Visible = isFile;
-            this.stagedEditFileToolStripMenuItem11.Visible = isFile;
-            this.stagedOpenDifftoolToolStripMenuItem9.Visible = isFile;
-            this.stagedOpenToolStripMenuItem7.Visible = isFile;
-            this.stagedToolStripSeparator17.Visible = isFile;
-            this.stagedOpenWithToolStripMenuItem8.Visible = isFile;
+            else
+            {
+                bool isFile = false;
+                foreach (GitItemStatus item in Staged.SelectedItems)
+                {
+                    if (!item.IsSubmodule) { isFile = true; }
+                }
+                this.stagedToolStripSeparator14.Visible = isFile;
+                this.stagedEditFileToolStripMenuItem11.Visible = isFile;
+                this.stagedOpenDifftoolToolStripMenuItem9.Visible = isFile;
+                this.stagedOpenToolStripMenuItem7.Visible = isFile;
+                this.stagedToolStripSeparator17.Visible = isFile;
+                this.stagedOpenWithToolStripMenuItem8.Visible = isFile;
+            }
         }
 
         void Unstaged_DoubleClick(object sender, EventArgs e)


### PR DESCRIPTION
Reported in #4098, related to #4031
This could occur also in other situations than reported, for example:
 * make sure at least one file is unstaged
 * select the file
 * right click outside of the file, select edit
 * an exception would occur

It was harder to provoke the error for staged though, the menu did not appear if you left clicked outside the file first before right clicking.

How did I test this code:
 - Manually, see above

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
