### PR TITLE
FormBrowse Commands in toolbar menu raised exceptions for artificial …

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -1070,6 +1070,7 @@ namespace GitUI.CommandsDialogs
             this.commandsToolStripMenuItem.Name = "commandsToolStripMenuItem";
             this.commandsToolStripMenuItem.Size = new System.Drawing.Size(81, 20);
             this.commandsToolStripMenuItem.Text = "Commands";
+            this.commandsToolStripMenuItem.DropDownOpening += CommandsToolStripMenuItem_DropDownOpening;
             // 
             // commitToolStripMenuItem
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1051,7 +1051,7 @@ namespace GitUI.CommandsDialogs
                 return;
 
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            var revision = selectedRevisions.Count == 1 ? selectedRevisions.Single() : null;
+            var revision = selectedRevisions.Count == 1 ? selectedRevisions[0] : null;
 
             if (_buildReportTabPageExtension == null)
                 _buildReportTabPageExtension = new BuildReportTabPageExtension(CommitInfoTabControl, _buildReportTabCaption.Text);
@@ -2016,7 +2016,7 @@ namespace GitUI.CommandsDialogs
         {
             //Most options do not make sense for artificial commits or no revision selected at all
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            bool enabled = selectedRevisions.Count == 1 && !selectedRevisions.Single().IsArtificial();
+            bool enabled = selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial();
 
             this.resetToolStripMenuItem.Enabled =
             this.checkoutBranchToolStripMenuItem.Enabled =

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -534,16 +534,11 @@ namespace GitUI.CommandsDialogs
                 mergeToolStripMenuItem.Enabled = !bareRepository;
                 rebaseToolStripMenuItem1.Enabled = !bareRepository;
                 pullToolStripMenuItem1.Enabled = !bareRepository;
-                resetToolStripMenuItem.Enabled = !bareRepository;
                 cleanupToolStripMenuItem.Enabled = !bareRepository;
                 stashToolStripMenuItem.Enabled = !bareRepository;
                 checkoutBranchToolStripMenuItem.Enabled = !bareRepository;
                 mergeBranchToolStripMenuItem.Enabled = !bareRepository;
                 rebaseToolStripMenuItem.Enabled = !bareRepository;
-                runMergetoolToolStripMenuItem.Enabled = !bareRepository;
-                cherryPickToolStripMenuItem.Enabled = !bareRepository;
-                checkoutToolStripMenuItem.Enabled = !bareRepository;
-                bisectToolStripMenuItem.Enabled = !bareRepository;
                 applyPatchToolStripMenuItem.Enabled = !bareRepository;
                 SvnRebaseToolStripMenuItem.Enabled = !bareRepository;
                 SvnDcommitToolStripMenuItem.Enabled = !bareRepository;
@@ -2015,6 +2010,23 @@ namespace GitUI.CommandsDialogs
             SetWorkingDir("");
 
             base.OnClosed(e);
+        }
+
+        private void CommandsToolStripMenuItem_DropDownOpening(object sender, System.EventArgs e)
+        {
+            //Most options do not make sense for artificial commits or no revision selected at all
+            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            bool enabled = selectedRevisions.Count == 1 && !selectedRevisions.Single().IsArtificial();
+
+            this.resetToolStripMenuItem.Enabled =
+            this.checkoutBranchToolStripMenuItem.Enabled =
+            this.runMergetoolToolStripMenuItem.Enabled =
+            this.tagToolStripMenuItem.Enabled =
+            this.cherryPickToolStripMenuItem.Enabled =
+            this.archiveToolStripMenuItem.Enabled =
+            this.checkoutToolStripMenuItem.Enabled =
+            this.bisectToolStripMenuItem.Enabled =
+              enabled;
         }
 
         private void CloneSvnToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
…commits and no revisions at all

Related to #4031 and somewhat to #4098

The irrelevant commands are disabled
There are some existing checks for bareRepositories in InternalInitialize() (where some init code is running...) that also could be removed after this (some were missing from that menu). checkoutBranchToolStripMenuItem is a little special though.

Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/32984607-2d10b728-ccaa-11e7-8ff4-a876aedbc6ad.png)

- 
![image](https://user-images.githubusercontent.com/6248932/32984604-1624246e-ccaa-11e7-8c83-6335049737a8.png)


How did I test this code:
 - Empty, bare and artificial commits. (There may be some corner case to not select a rev also in other situation that I do not know that applies too)
 - Select Commands menu

Has been tested on (remove any that don't apply):
 - Windows 10
