### PR TITLE
BrowseDiff Hotkey support: DEL to delete unstaged files

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -9,6 +9,7 @@ using GitCommands;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
 using ResourceManager;
+using GitUI.Hotkey;
 
 namespace GitUI.CommandsDialogs
 {
@@ -35,6 +36,7 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             Translate();
+            this.HotkeysEnabled = true;
         }
 
         public void ForceRefreshRevisions()
@@ -62,6 +64,56 @@ namespace GitUI.CommandsDialogs
                 DiffFiles.SetDiffs(revisions);
             }
         }
+
+        #region Hotkey commands
+
+        public const string HotkeySettingsName = "BrowseDiff";
+
+        internal enum Commands
+        {
+            DeleteSelectedFiles,
+        }
+
+        protected override bool ExecuteCommand(int cmd)
+        {
+            Commands command = (Commands)cmd;
+
+            switch (command)
+            {
+                case Commands.DeleteSelectedFiles: return DeleteSelectedFiles();
+                default: return base.ExecuteCommand(cmd);
+            }
+        }
+
+        /// <summary>
+        /// duplicated from GitExtensionsForm
+        /// </summary>
+        /// <param name="commandCode"></param>
+        /// <returns></returns>
+        private Keys GetShortcutKeys(int commandCode)
+        {
+            var hotkey = GetHotkeyCommand(commandCode);
+            return hotkey == null ? Keys.None : hotkey.KeyData;
+        }
+
+        internal Keys GetShortcutKeys(Commands cmd)
+        {
+            return GetShortcutKeys((int)cmd);
+        }
+
+        /// <summary>
+        /// duplicated from GitExtensionsForm
+        /// </summary>
+        /// <param name="commandCode"></param>
+        /// <returns></returns>
+        private HotkeyCommand GetHotkeyCommand(int commandCode)
+        {
+            if (Hotkeys == null)
+                return null;
+
+            return Hotkeys.FirstOrDefault(h => h.CommandCode == commandCode);
+        }
+        #endregion
 
         public string GetTabText()
         {
@@ -110,8 +162,9 @@ namespace GitUI.CommandsDialogs
 
         public void ReloadHotkeys()
         {
+            this.Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
+            this.diffDeleteFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Commands.DeleteSelectedFiles).ToShortcutKeyDisplayString();
             DiffText.ReloadHotkeys();
-            //TBD Shortcut key should be implemented but HotKeyManager is inaccessible in FormBrowse
         }
 
 
@@ -123,6 +176,7 @@ namespace GitUI.CommandsDialogs
             DiffFiles.DescribeRevision = DescribeRevision;
             DiffText.SetFileLoader(GetNextPatchFile);
             DiffText.Font = AppSettings.DiffFont;
+            ReloadHotkeys();
 
             GotFocus += (s, e1) => DiffFiles.Focus();
 

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -308,6 +308,8 @@ namespace GitUI.Hotkey
                     hk(FormResolveConflicts.Commands.ChooseRemote, Keys.R),
                     hk(FormResolveConflicts.Commands.Merge, Keys.M),
                     hk(FormResolveConflicts.Commands.Rescan, Keys.F5)),
+                new HotkeySettings(RevisionDiff.HotkeySettingsName,
+                    hk(RevisionDiff.Commands.DeleteSelectedFiles, Keys.Delete)),
                 new HotkeySettings(FormSettings.HotkeySettingsName,
                     scriptsHotkeys)
               };


### PR DESCRIPTION
Part of #4031
Some reimplementation needed after the split to RevisionDiff
Currently only used to delete files, should be added for at least stage/unstage and reset too.
 
Screenshots before and after (if PR changes UI):

![image](https://user-images.githubusercontent.com/6248932/32996773-a3b0c052-cd87-11e7-8751-d51913cfbc34.png)

Has been tested on (remove any that don't apply):
 - Windows 10