### PR TITLE
Stash name size

### DIFF
--- a/GitCommands/Git/GitStash.cs
+++ b/GitCommands/Git/GitStash.cs
@@ -63,7 +63,7 @@ namespace GitCommands
             Branch = branchStart.Substring(0, branchStart.IndexOf(':'));
         }
 
-        public override string ToString() { return Name; }
+        public override string ToString() { return Message; }
 
         public override bool Equals(object obj)
         {

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -48,17 +48,15 @@ namespace GitUI.CommandsDialogs
             this.Loading = new System.Windows.Forms.PictureBox();
             this.Stashed = new GitUI.FileStatusList();
             this.toolStrip1 = new GitUI.ToolStripEx();
-            this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
-            this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
+            this.showToolStripLabel = new System.Windows.Forms.ToolStripLabel();
             this.Stashes = new System.Windows.Forms.ToolStripComboBox();
-            this.toolStripButton_customMessage = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripButton_customMessage = new System.Windows.Forms.ToolStripButton();
+            this.refreshToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.View = new GitUI.Editor.FileViewer();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.gitStashBindingSource)).BeginInit();
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
@@ -93,7 +91,7 @@ namespace GitUI.CommandsDialogs
             this.splitContainer1.SplitterDistance = 280;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 0;
-            this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer2_SplitterMoved);
+            this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
             // 
             // tableLayoutPanel2
             // 
@@ -263,9 +261,9 @@ namespace GitUI.CommandsDialogs
             this.toolStrip1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripButton1,
-            this.toolStripLabel1,
+            this.showToolStripLabel,
             this.Stashes,
+            this.refreshToolStripButton,
             this.toolStripButton_customMessage,
             this.toolStripSeparator1});
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
@@ -274,24 +272,24 @@ namespace GitUI.CommandsDialogs
             this.toolStrip1.Size = new System.Drawing.Size(280, 28);
             this.toolStrip1.TabIndex = 1;
             // 
-            // toolStripButton1
+            // refreshToolStripButton
             // 
-            this.toolStripButton1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButton1.Image = global::GitUI.Properties.Resources.arrow_refresh;
-            this.toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton1.Name = "toolStripButton1";
-            this.toolStripButton1.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.toolStripButton1.Size = new System.Drawing.Size(23, 25);
-            this.toolStripButton1.Text = "Refresh";
-            this.toolStripButton1.Click += new System.EventHandler(this.RefreshClick);
+            this.refreshToolStripButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.refreshToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.refreshToolStripButton.Image = global::GitUI.Properties.Resources.arrow_refresh;
+            this.refreshToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.refreshToolStripButton.Name = "refreshToolStripButton";
+            this.refreshToolStripButton.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
+            this.refreshToolStripButton.Size = new System.Drawing.Size(23, 25);
+            this.refreshToolStripButton.Text = "Refresh";
+            this.refreshToolStripButton.Click += new System.EventHandler(this.RefreshClick);
             // 
-            // toolStripLabel1
+            // showToolStripLabel
             // 
-            this.toolStripLabel1.Name = "toolStripLabel1";
-            this.toolStripLabel1.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.toolStripLabel1.Size = new System.Drawing.Size(48, 25);
-            this.toolStripLabel1.Text = "Show:";
+            this.showToolStripLabel.Name = "showToolStripLabel";
+            this.showToolStripLabel.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
+            this.showToolStripLabel.Size = new System.Drawing.Size(48, 25);
+            this.showToolStripLabel.Text = "Show:";
             // 
             // Stashes
             // 
@@ -322,6 +320,7 @@ namespace GitUI.CommandsDialogs
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.toolStripSeparator1.Size = new System.Drawing.Size(6, 28);
             // 
             // View
@@ -351,9 +350,7 @@ namespace GitUI.CommandsDialogs
             ((System.ComponentModel.ISupportInitialize)(this.gitStashBindingSource)).EndInit();
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-
             this.splitContainer1.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
@@ -378,8 +375,8 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.RichTextBox StashMessage;
         private FileViewer View;
         private ToolStripEx toolStrip1;
-        private System.Windows.Forms.ToolStripButton toolStripButton1;
-        private System.Windows.Forms.ToolStripLabel toolStripLabel1;
+        private System.Windows.Forms.ToolStripButton refreshToolStripButton;
+        private System.Windows.Forms.ToolStripLabel showToolStripLabel;
         private System.Windows.Forms.ToolStripComboBox Stashes;
         private PictureBox Loading;
         private CheckBox StashKeepIndex;

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -301,6 +301,7 @@ namespace GitUI.CommandsDialogs
             this.Stashes.Size = new System.Drawing.Size(175, 28);
             this.Stashes.ToolTipText = "Select a stash";
             this.Stashes.SelectedIndexChanged += new System.EventHandler(this.StashesSelectedIndexChanged);
+            this.Stashes.DropDown += Stashes_DropDown;
             // 
             // toolStripButton_customMessage
             // 

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -293,6 +293,7 @@ namespace GitUI.CommandsDialogs
             // 
             // Stashes
             // 
+            this.Stashes.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Stashes.DropDownWidth = 200;
             this.Stashes.MaxDropDownItems = 30;
             this.Stashes.Name = "Stashes";

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
             StashKeepIndex.Checked = AppSettings.StashKeepIndex;
             chkIncludeUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInManualStash;
 
-            splitContainer2_SplitterMoved(null, null);
+            splitContainer1_SplitterMoved(null, null);
         }
 
         GitStash currentWorkingDirStashItem;
@@ -90,7 +90,7 @@ namespace GitUI.CommandsDialogs
 
             Loading.Visible = true;
             Stashes.Enabled = false;
-            toolStripButton1.Enabled = false;
+            refreshToolStripButton.Enabled = false;
             toolStripButton_customMessage.Enabled = false;
             if (gitStash == null)
             {
@@ -116,7 +116,7 @@ namespace GitUI.CommandsDialogs
             Stashed.GitItemStatuses = gitItemStatuses;
             Loading.Visible = false;
             Stashes.Enabled = true;
-            toolStripButton1.Enabled = true;
+            refreshToolStripButton.Enabled = true;
         }
 
         private void StashedSelectedIndexChanged(object sender, EventArgs e)
@@ -257,15 +257,15 @@ namespace GitUI.CommandsDialogs
             RefreshAll();
         }
 
-        private void splitContainer2_SplitterMoved(object sender, SplitterEventArgs e)
+        private void splitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
         {
-            Stashes.Size = new Size(toolStrip1.Width - 15 - toolStripButton1.Width - toolStripLabel1.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
-            Stashes.DropDownWidth = Math.Max(Stashes.Size.Width, splitContainer1.Width - 2 * toolStripLabel1.Width);
+            Stashes.Size = new Size(toolStrip1.Width - 15 - refreshToolStripButton.Width - showToolStripLabel.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
+            Stashes.DropDownWidth = Math.Max(Stashes.Size.Width, splitContainer1.Width - 2 * showToolStripLabel.Width);
         }
 
         private void FormStash_Resize(object sender, EventArgs e)
         {
-            splitContainer2_SplitterMoved(null, null);
+            splitContainer1_SplitterMoved(null, null);
         }
 
         private void toolStripButton_customMessage_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitUI.UserControls;
 using PatchApply;
 using ResourceManager;
 
@@ -52,7 +53,7 @@ namespace GitUI.CommandsDialogs
             StashKeepIndex.Checked = AppSettings.StashKeepIndex;
             chkIncludeUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInManualStash;
 
-            splitContainer1_SplitterMoved(null, null);
+            ResizeStashedDropdown();
         }
 
         GitStash currentWorkingDirStashItem;
@@ -117,6 +118,11 @@ namespace GitUI.CommandsDialogs
             Loading.Visible = false;
             Stashes.Enabled = true;
             refreshToolStripButton.Enabled = true;
+        }
+
+        private void ResizeStashedDropdown()
+        {
+            Stashes.Size = new Size(toolStrip1.Width - 15 - refreshToolStripButton.Width - showToolStripLabel.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
         }
 
         private void StashedSelectedIndexChanged(object sender, EventArgs e)
@@ -239,6 +245,11 @@ namespace GitUI.CommandsDialogs
             Cursor.Current = Cursors.Default;
         }
 
+        private void Stashes_DropDown(object sender, EventArgs e)
+        {
+            Stashes.ResizeComboBoxDropDownWidth(Stashes.Size.Width, splitContainer1.Width - 2 * showToolStripLabel.Width);
+        }
+
         private void RefreshClick(object sender, EventArgs e)
         {
             RefreshAll();
@@ -259,13 +270,12 @@ namespace GitUI.CommandsDialogs
 
         private void splitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
         {
-            Stashes.Size = new Size(toolStrip1.Width - 15 - refreshToolStripButton.Width - showToolStripLabel.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
-            Stashes.DropDownWidth = Math.Max(Stashes.Size.Width, splitContainer1.Width - 2 * showToolStripLabel.Width);
+            ResizeStashedDropdown();
         }
 
         private void FormStash_Resize(object sender, EventArgs e)
         {
-            splitContainer1_SplitterMoved(null, null);
+            ResizeStashedDropdown();
         }
 
         private void toolStripButton_customMessage_Click(object sender, EventArgs e)
@@ -308,6 +318,5 @@ namespace GitUI.CommandsDialogs
                 StashMessage.ReadOnly = false;
             }
         }
-
     }
 }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -259,7 +259,8 @@ namespace GitUI.CommandsDialogs
 
         private void splitContainer2_SplitterMoved(object sender, SplitterEventArgs e)
         {
-            Stashes.Size = new Size(Math.Min(200, toolStrip1.Width - 25 - toolStripButton1.Width - toolStripLabel1.Width - toolStripButton_customMessage.Width), Stashes.Size.Height);
+            Stashes.Size = new Size(toolStrip1.Width - 15 - toolStripButton1.Width - toolStripLabel1.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
+            Stashes.DropDownWidth = Math.Max(Stashes.Size.Width, splitContainer1.Width - 2 * toolStripLabel1.Width);
         }
 
         private void FormStash_Resize(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs
             StashKeepIndex.Checked = AppSettings.StashKeepIndex;
             chkIncludeUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInManualStash;
 
-            ResizeStashedDropdown();
+            ResizeStashesWidth();
         }
 
         GitStash currentWorkingDirStashItem;
@@ -120,7 +120,7 @@ namespace GitUI.CommandsDialogs
             refreshToolStripButton.Enabled = true;
         }
 
-        private void ResizeStashedDropdown()
+        private void ResizeStashesWidth()
         {
             Stashes.Size = new Size(toolStrip1.Width - 15 - refreshToolStripButton.Width - showToolStripLabel.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
         }
@@ -270,12 +270,12 @@ namespace GitUI.CommandsDialogs
 
         private void splitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
         {
-            ResizeStashedDropdown();
+            ResizeStashesWidth();
         }
 
         private void FormStash_Resize(object sender, EventArgs e)
         {
-            ResizeStashedDropdown();
+            ResizeStashesWidth();
         }
 
         private void toolStripButton_customMessage_Click(object sender, EventArgs e)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -59,6 +59,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="PSTaskDialog">
       <HintPath>..\Bin\PSTaskDialog.dll</HintPath>
     </Reference>

--- a/GitUI/UserControls/ComboBoxHelper.cs
+++ b/GitUI/UserControls/ComboBoxHelper.cs
@@ -5,7 +5,17 @@ namespace GitUI.UserControls
 {
     public static class ComboBoxHelper
     {
-        public static void ResizeComboBoxDropDownWidth(ComboBox comboBox, int minWidth, int maxWidth)
+        public static void ResizeComboBoxDropDownWidth(this ComboBox comboBox, int minWidth, int maxWidth)
+        {
+            AutoSizeDropDownWidth(comboBox, minWidth, maxWidth);
+        }
+
+        public static void ResizeComboBoxDropDownWidth(this ToolStripComboBox comboBox, int minWidth, int maxWidth)
+        {
+            AutoSizeDropDownWidth(comboBox.Control, minWidth, maxWidth);
+        }
+
+        private static void AutoSizeDropDownWidth(dynamic comboBox, int minWidth, int maxWidth)
         {
             var calculatedWidth = 0;
             using (var graphics = comboBox.CreateGraphics())
@@ -13,7 +23,7 @@ namespace GitUI.UserControls
                 foreach (object obj in comboBox.Items)
                 {
                     var area = graphics.MeasureString(obj.ToString(), comboBox.Font);
-                    calculatedWidth = Math.Max((int) area.Width, calculatedWidth);
+                    calculatedWidth = Math.Max((int)area.Width, calculatedWidth);
                 }
             }
             comboBox.DropDownWidth = Math.Min(Math.Max(calculatedWidth, minWidth), maxWidth);


### PR DESCRIPTION
Fixes #4120 .
The existing implementation set the size of the combobox to the minimum of 200 and the available size (should probably have been max)
The width for the drop down was the same as for the combobox, may as well use the complete form

Some minor refactoring as well. 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/33225681-c4f2c6b8-d17c-11e7-97f8-51589da89704.png)


How did I test this code:
 - Manually resizing

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
No mono tests. container sizes cannot be dynamically changed, not sure if the init function run, setting the size