### PR TITLE
Reset to artificial commits require special handling

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1526,7 +1526,23 @@ namespace GitCommands
             if (files.IsNullOrWhiteSpace())
                 return string.Empty;
 
-            return RunGitCmd("checkout " + force.AsForce() + revision.Quote() + " -- " + files);
+            //Special handling for artificial commits
+            if (revision == GitRevision.IndexGuid)
+            {
+                revision = "";
+            }
+            else if (revision == GitRevision.UnstagedGuid)
+            {
+                Debug.Assert(false, "Unexpectedly reset to unstaged - should be blocked in GUI");
+                //However, not an error to user, just nothing happens
+                return "";
+            }
+            else
+            {
+                revision = revision.QuoteNE();
+            }
+
+            return RunGitCmd("checkout " + force.AsForce() + revision + " -- " + files);
         }
 
         public string RemoveFiles(IEnumerable<string> fileList, bool force)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1526,18 +1526,18 @@ namespace GitCommands
             if (files.IsNullOrWhiteSpace())
                 return string.Empty;
 
-            //Special handling for artificial commits
+            if (revision == GitRevision.UnstagedGuid)
+            {
+                Debug.Assert(false, "Unexpectedly reset to unstaged - should be blocked in GUI");
+                //Not an error to user, just nothing happens
+                return "";
+            }
+
             if (revision == GitRevision.IndexGuid)
             {
                 revision = "";
             }
-            else if (revision == GitRevision.UnstagedGuid)
-            {
-                Debug.Assert(false, "Unexpectedly reset to unstaged - should be blocked in GUI");
-                //However, not an error to user, just nothing happens
-                return "";
-            }
-            else
+            else 
             {
                 revision = revision.QuoteNE();
             }

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -30,6 +30,7 @@ namespace GitCommands
         {
             Guid = guid;
             Subject = "";
+            SubjectCount = "";
             Module = aModule;
         }
 
@@ -56,6 +57,8 @@ namespace GitCommands
         }
 
         public string Subject { get; set; }
+        //Count for artificial commits (could be changed to object lists)
+        public string SubjectCount { get; set; }
         public string Body { get; set; }
         //UTF-8 when is null or empty
         public string MessageEncoding { get; set; }
@@ -74,7 +77,7 @@ namespace GitCommands
             {
                 sha = sha.Substring(0, 4) + ".." + sha.Substring(sha.Length - 4, 4);
             }
-            return String.Format("{0}:{1}", sha, Subject);
+            return String.Format("{0}:{1}{2}", sha, SubjectCount, Subject);
         }
 
         public static string ToShortSha(String sha)

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -222,6 +222,7 @@ namespace GitUI.CommandsDialogs
             }
 
             Module.CheckoutFiles(itemsToCheckout.Select(item => item.Name), revision, false);
+            RefreshArtificial();
         }
 
         private void ShowSelectedFileDiff()

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -683,7 +683,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToSelectedToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
-                    resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]) + ")";
+                    resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0], 50) + ")";
                 }
                 if (revisions[0].HasParent)
                 {
@@ -692,7 +692,7 @@ namespace GitUI.CommandsDialogs
                     GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].FirstParentGuid);
                     if (parentRev != null)
                     {
-                        resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev) + ")";
+                        resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev, 50) + ")";
                     }
                 }
                 else
@@ -716,7 +716,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToFirstToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
-                    resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1]) + ")";
+                    resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1], 50) + ")";
                 }
 
                 if (revisions[0].Guid == GitRevision.UnstagedGuid)
@@ -727,7 +727,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToSecondToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
-                    resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]) + ")";
+                    resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0], 50) + ")";
                 }
             }
             else

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -619,10 +619,16 @@ namespace GitUI.CommandsDialogs
 
             if (selectedRevsCount == 1)
             {
-                resetFileToSelectedToolStripMenuItem.Visible = true;
-                TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
-                resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
-
+                if (revisions[0].Guid == GitRevision.UnstagedGuid)
+                {
+                    resetFileToSelectedToolStripMenuItem.Visible = false;
+                }
+                else
+                {
+                    resetFileToSelectedToolStripMenuItem.Visible = true;
+                    TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
+                    resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+                }
                 if (revisions[0].HasParent)
                 {
                     resetFileToParentToolStripMenuItem.Visible = true;
@@ -646,13 +652,27 @@ namespace GitUI.CommandsDialogs
 
             if (selectedRevsCount == 2)
             {
-                resetFileToFirstToolStripMenuItem.Visible = true;
-                TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
-                resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1]).ShortenTo(50) + ")";
+                if (revisions[1].Guid == GitRevision.UnstagedGuid)
+                {
+                    resetFileToFirstToolStripMenuItem.Visible = false;
+                }
+                else
+                {
+                    resetFileToFirstToolStripMenuItem.Visible = true;
+                    TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
+                    resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1]).ShortenTo(50) + ")";
+                }
 
-                resetFileToSecondToolStripMenuItem.Visible = true;
-                TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
-                resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+                if (revisions[0].Guid == GitRevision.UnstagedGuid)
+                {
+                    resetFileToSecondToolStripMenuItem.Visible = false;
+                }
+                else
+                {
+                    resetFileToSecondToolStripMenuItem.Visible = true;
+                    TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
+                    resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+                }
             }
             else
             {

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -556,6 +556,7 @@ namespace GitUI.CommandsDialogs
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
             IList<GitRevision> selectedRevisions = _revisionGrid.GetSelectedRevisions();
+            //Should be blocked in the GUI but not an error to show to the user
             Debug.Assert(selectedRevisions.Count == 1 || selectedRevisions.Count == 2,
                 "Unexpectedly number of revisions for difftool" + selectedRevisions.Count);
             if (selectedRevisions.Count < 1)
@@ -682,7 +683,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToSelectedToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToSelectedToolStripMenuItem.Name, resetFileToSelectedToolStripMenuItem);
-                    resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+                    resetFileToSelectedToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]) + ")";
                 }
                 if (revisions[0].HasParent)
                 {
@@ -691,7 +692,7 @@ namespace GitUI.CommandsDialogs
                     GitRevision parentRev = _revisionGrid.GetRevision(revisions[0].FirstParentGuid);
                     if (parentRev != null)
                     {
-                        resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev).ShortenTo(50) + ")";
+                        resetFileToParentToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(parentRev) + ")";
                     }
                 }
                 else
@@ -715,7 +716,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToFirstToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToFirstToolStripMenuItem.Name, resetFileToFirstToolStripMenuItem);
-                    resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1]).ShortenTo(50) + ")";
+                    resetFileToFirstToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[1]) + ")";
                 }
 
                 if (revisions[0].Guid == GitRevision.UnstagedGuid)
@@ -726,7 +727,7 @@ namespace GitUI.CommandsDialogs
                 {
                     resetFileToSecondToolStripMenuItem.Visible = true;
                     TranslateItem(resetFileToSecondToolStripMenuItem.Name, resetFileToSecondToolStripMenuItem);
-                    resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]).ShortenTo(50) + ")";
+                    resetFileToSecondToolStripMenuItem.Text += " (" + _revisionGrid.DescribeRevision(revisions[0]) + ")";
                 }
             }
             else

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -863,7 +863,7 @@ namespace GitUI
             return GetSelectedRevisions(null);
         }
 
-        public string DescribeRevision(GitRevision revision, int maxLength = 50)
+        public string DescribeRevision(GitRevision revision, int maxLength = 0)
         {
             var gitRefListsForRevision = new GitRefListsForRevision(revision);
             var descriptiveRefs = gitRefListsForRevision.AllBranches.Concat(gitRefListsForRevision.AllTags);

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -870,16 +870,29 @@ namespace GitUI
 
             string description;
 
-            if (descriptiveRefs.Any())
+            //Special handling for artificial commits (.Subject may contain count)
+            if (revision.Guid == GitRevision.IndexGuid)
             {
-                description = GetRefUnambiguousName(descriptiveRefs.First());
+                description = Strings.GetCurrentIndex();
+            }
+            else if (revision.Guid == GitRevision.UnstagedGuid)
+            {
+                description = Strings.GetCurrentUnstagedChanges();
             }
             else
             {
-                description = revision.Subject;
-            }
+                if (descriptiveRefs.Any())
+                {
+                    description = GetRefUnambiguousName(descriptiveRefs.First());
+                }
+                else
+                {
+                    description = revision.Subject;
+                }
 
-            description = description + " @" + revision.Guid.Substring(0, 4);
+
+                description += " @" + revision.Guid.Substring(0, 4);
+            }
 
             return description;
         }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -863,7 +863,7 @@ namespace GitUI
             return GetSelectedRevisions(null);
         }
 
-        public string DescribeRevision(GitRevision revision)
+        public string DescribeRevision(GitRevision revision, int maxLength = 50)
         {
             var gitRefListsForRevision = new GitRefListsForRevision(revision);
             var descriptiveRefs = gitRefListsForRevision.AllBranches.Concat(gitRefListsForRevision.AllTags);
@@ -882,6 +882,11 @@ namespace GitUI
             if (!revision.IsArtificial())
             {
                 description += " @" + revision.Guid.Substring(0, 4);
+            }
+
+            if (maxLength > 0)
+            {
+                description = description.ShortenTo(maxLength);
             }
 
             return description;


### PR DESCRIPTION
Reset to Unstaged commits does not make sense at all and should be hidden in the GUI
Reset to Staged will require special handling of GitRevision. IndexGuid (Compare to RevisionDiffProvider, options to git-diff)

Part of #4031 
This is a reworked part of #4157 applicable to master too. This commit slightly changes the behavior and will be modified.

I did consider "reset to HEAD" for Unstaged commit to be always available, but that would be inconsistent behavior as well as when #4157 is merged selecting HEAD-Unstaged will give two options in the menu (not easily to find when this occurs).
 
How did I test this code:
 - Select Unstaged commit (with changes)
  - Verify that there is an option to reset to Index only
 - Select Index Commit (with changes)
  - Verify that there are options to reset to Index and HEAD 
 - Select any normal commit
  - Verify that both the selected commit and the parent appears in the menu
Note: Comparing artificial to any other will be possible in #4157 , the results with two commits will be similar. 

Has been tested on (remove any that don't apply):
 - Windows 10
