### PR TITLE
Change hotkey settings names from const to static readonly

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1898,7 +1898,7 @@ namespace GitUI.CommandsDialogs
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "Browse";
+        public static readonly string HotkeySettingsName = "Browse";
 
         internal enum Commands
         {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -302,7 +302,7 @@ namespace GitUI.CommandsDialogs
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "Commit";
+        public static readonly string HotkeySettingsName = "Commit";
 
         internal enum Commands
         {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1055,7 +1055,7 @@ namespace GitUI.CommandsDialogs
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "FormMergeConflicts";
+        public static readonly string HotkeySettingsName = "FormMergeConflicts";
 
         internal enum Commands
         {

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -262,7 +262,7 @@ namespace GitUI.CommandsDialogs
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "Scripts";
+        public static readonly string HotkeySettingsName = "Scripts";
 
         internal enum Commands
         {

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -67,7 +67,7 @@ namespace GitUI.CommandsDialogs
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "BrowseDiff";
+        public static readonly string HotkeySettingsName = "BrowseDiff";
 
         internal enum Commands
         {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -962,7 +962,7 @@ namespace GitUI.Editor
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "FileViewer";
+        public static readonly string HotkeySettingsName = "FileViewer";
 
         internal enum Commands
         {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3127,7 +3127,7 @@ namespace GitUI
 
         #region Hotkey commands
 
-        public const string HotkeySettingsName = "RevisionGrid";
+        public static readonly string HotkeySettingsName = "RevisionGrid";
 
         internal enum Commands
         {


### PR DESCRIPTION
Review comment in #4168

There a few other 'public const string' still remaining.

Has been tested on (remove any that don't apply):
 - Windows 10
