### PR TITLE
Fix4185

### DIFF
--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -42,11 +42,14 @@ namespace JenkinsIntegration
     [PartCreationPolicy(CreationPolicy.NonShared)]
     internal class JenkinsAdapter : IBuildServerAdapter
     {
+        private static readonly IBuildDurationFormatter _buildDurationFormatter = new BuildDurationFormatter();
         private IBuildServerWatcher _buildServerWatcher;
 
         private HttpClient _httpClient;
 
+        private IList<string> _projectsUrls = new List<string>();
         private IList<Task<IEnumerable<string>>> _getBuildUrls;
+        private static readonly Dictionary<string, BuildInfo> _finishedBuildsInfo = new Dictionary<string, BuildInfo>();    
 
         public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<string, bool> isCommitInRevisionGrid)
         {
@@ -72,8 +75,6 @@ namespace JenkinsIntegration
 
                 UpdateHttpClientOptions(buildServerCredentials);
 
-                _getBuildUrls = new List<Task<IEnumerable<string>>>();
-
                 string[] projectUrls = projectName.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var projectUrl in projectUrls.Select(s => baseAdress + "job/" + s.Trim() + "/"))
                 {
@@ -84,14 +85,24 @@ namespace JenkinsIntegration
 
         private void AddGetBuildUrl(string projectUrl)
         {
-            _getBuildUrls.Add(GetResponseAsync(FormatToGetJson(projectUrl), CancellationToken.None)
-                .ContinueWith(
-                    task =>
-                    {
-                        JObject jobDescription = JObject.Parse(task.Result);
-                        return jobDescription["builds"].Select(b => b["url"].ToObject<string>());
-                    },
-                    TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent));
+            _projectsUrls.Add(projectUrl);
+        }
+
+        private IList<Task<IEnumerable<string>>> GetBuildUrls(bool forceUpdate)
+        {
+            if (_getBuildUrls == null || forceUpdate)
+            {
+                _getBuildUrls = _projectsUrls.Select(
+                    projectUrl => GetResponseAsync(FormatToGetJson(projectUrl), CancellationToken.None)
+                    .ContinueWith(
+                        task =>
+                        {
+                            JObject jobDescription = JObject.Parse(task.Result);
+                            return jobDescription["builds"].Select(b => b["url"].ToObject<string>());
+                        },
+                        TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.AttachedToParent)).ToList();
+            }
+            return _getBuildUrls;
         }
 
         /// <summary>
@@ -114,11 +125,6 @@ namespace JenkinsIntegration
 
         public IObservable<BuildInfo> GetBuilds(IScheduler scheduler, DateTime? sinceDate = null, bool? running = null)
         {
-            if (_getBuildUrls == null || _getBuildUrls.Count() == 0)
-            {
-                return Observable.Empty<BuildInfo>(scheduler);
-            }
-
             return Observable.Create<BuildInfo>((observer, cancellationToken) =>
                 Task<IDisposable>.Factory.StartNew(
                     () => scheduler.Schedule(() => ObserveBuilds(sinceDate, running, observer, cancellationToken))));
@@ -128,13 +134,14 @@ namespace JenkinsIntegration
         {
             try
             {
-                if (_getBuildUrls.All(t => t.IsCanceled))
+                var buildUrls = GetBuildUrls(running ?? false);
+                if (buildUrls.All(t => t.IsCanceled))
                 {
                     observer.OnCompleted();
                     return;
                 }
 
-                foreach (var currentGetBuildUrls in _getBuildUrls)
+                foreach (var currentGetBuildUrls in buildUrls)
                 {
                     if (currentGetBuildUrls.IsFaulted)
                     {
@@ -144,27 +151,32 @@ namespace JenkinsIntegration
                         continue;
                     }
 
-                    var buildContents = currentGetBuildUrls.Result
+                    if (!running.Value)
+                    {
+                        var immutableBuilds = currentGetBuildUrls.Result.Where(buildUrl => _finishedBuildsInfo.ContainsKey(buildUrl));
+                        foreach (var buildInfo in immutableBuilds.Select(url => _finishedBuildsInfo[url]))
+                        {
+                            if (sinceDate.HasValue && (sinceDate.Value - buildInfo.StartDate).TotalMilliseconds <= buildInfo.Duration)
+                                continue;
+                            observer.OnNext(buildInfo);
+                        }
+                    }
+
+                    var mutableBuilds = currentGetBuildUrls.Result.Where(buildUrl => !_finishedBuildsInfo.ContainsKey(buildUrl));
+                    var buildContents = mutableBuilds
                         .Select(buildUrl => GetResponseAsync(FormatToGetJson(buildUrl), cancellationToken).Result)
                         .Where(s => !string.IsNullOrEmpty(s)).ToArray();
 
                     foreach (var buildDetails in buildContents)
                     {
                         JObject buildDescription = JObject.Parse(buildDetails);
-                        var startDate = TimestampToDateTime(buildDescription["timestamp"].ToObject<long>());
-                        var isRunning = buildDescription["building"].ToObject<bool>();
-
-                        if (sinceDate.HasValue && sinceDate.Value > startDate)
-                            continue;
-
-                        if (running.HasValue && running.Value != isRunning)
-                            continue;
 
                         var buildInfo = CreateBuildInfo(buildDescription);
-                        if (buildInfo.CommitHashList.Any())
+                        if (buildInfo.Status != BuildInfo.BuildStatus.InProgress)
                         {
-                            observer.OnNext(buildInfo);
+                            _finishedBuildsInfo[buildInfo.Url] = buildInfo;
                         }
+                        observer.OnNext(buildInfo);
                     }
                 }
                 observer.OnCompleted();
@@ -210,6 +222,15 @@ namespace JenkinsIntegration
             }
 
             var isRunning = buildDescription["building"].ToObject<bool>();
+            long? buildDuration;
+            if (isRunning)
+            {
+                buildDuration = null;
+            }
+            else
+            {
+                buildDuration = buildDescription["duration"].ToObject<long>();
+            }
 
             var status = ParseBuildStatus(statusValue);
             var statusText = isRunning ? string.Empty : status.ToString("G");
@@ -217,11 +238,13 @@ namespace JenkinsIntegration
                 {
                     Id = idValue,
                     StartDate = TimestampToDateTime(startDateTicks),
+                    Duration = buildDuration,
                     Status = isRunning ? BuildInfo.BuildStatus.InProgress : status,
                     Description = displayName + " " + statusText + testResults,
                     CommitHashList = commitHashList.ToArray(),
                     Url = webUrl
                 };
+            buildInfo.Description += _buildDurationFormatter.Format(buildInfo.Duration);
             return buildInfo;
         }
 

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -167,6 +167,7 @@ namespace JenkinsIntegration
                         }
                     }
                 }
+                observer.OnCompleted();
             }
             catch (OperationCanceledException)
             {

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildDurationFormatter.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildDurationFormatter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitUIPluginInterfaces.BuildServerIntegration
+{
+    public interface IBuildDurationFormatter
+    {
+        string Format(long? durationMilliseconds);
+    }
+
+    public class BuildDurationFormatter : IBuildDurationFormatter
+    {
+        public string Format(long? durationMilliseconds)
+        {
+            if (durationMilliseconds.HasValue)
+            {
+                return " (" + TimeSpan.FromMilliseconds(durationMilliseconds.Value).ToString(@"mm\:ss") + ")";
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildInfo.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildInfo.cs
@@ -16,6 +16,7 @@ namespace GitUIPluginInterfaces.BuildServerIntegration
 
         public string Id { get; set; }
         public DateTime StartDate { get; set; }
+        public long? Duration { get; set; }
         public BuildStatus Status { get; set; }
         public string Description { get; set; }
         public string[] CommitHashList { get; set; }

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -69,6 +69,7 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="BuildServerIntegration\BuildDurationFormatter.cs" />
     <Compile Include="BuildServerIntegration\BuildInfo.cs" />
     <Compile Include="BuildServerIntegration\BuildServerAdapterMetadataAttribute.cs" />
     <Compile Include="BuildServerIntegration\BuildServerCredentials.cs" />


### PR DESCRIPTION
Fixes #4185.

Changes proposed in this pull request:

1. Notify observers about completion.
2. Cache finished builds info.
3. Correct filtering out finished builds.

How did I test this code:

Manually observed build report tab and build status info.

Has been tested on (remove any that don't apply):
 - Windows 10
