### PR TITLE
Better naming of archives done through a filetree directory

### DIFF
--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -126,6 +126,10 @@ namespace GitUI.CommandsDialogs
             // TODO (feature): if there is a tag on the revision use the tag name as suggestion
             // TODO (feature): let user decide via GUI
             string filenameSuggestion = string.Format("{0}_{1}", new DirectoryInfo(Module.WorkingDir).Name, revision);
+            if (checkBoxPathFilter.Checked && textBoxPaths.Lines.Length == 1 && !string.IsNullOrWhiteSpace(textBoxPaths.Lines[0]))
+            {
+                filenameSuggestion += "_" + textBoxPaths.Lines[0].Trim().Replace(".", "_");
+            }
 
             using (var saveFileDialog = new SaveFileDialog
             {


### PR DESCRIPTION
by adding the name of the folder in the archive name

How did I test this code:
 - Right click on a file or directory on the filtree
 - Select "Archive"
 - In the Archive form, click on "Save as..."
 - The save dialog open with the new filename containing the name of the selected item at the end of the filename. 

Has been tested on (remove any that don't apply):
 - Not dependent of a specific git version
 - Windows 10
