### PR TITLE
Remove const GitModule

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -166,7 +166,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnRuntimeLoad(EventArgs e)
         {
-            _revisionDiffController = new RevisionDiffController(Module);
+            _revisionDiffController = new RevisionDiffController();
 
             DiffFiles.FilterVisible = true;
             DiffFiles.DescribeRevision = DescribeRevision;

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -65,13 +65,6 @@ namespace GitUI.CommandsDialogs
 
     public sealed class RevisionDiffController : IRevisionDiffController
     {
-        private readonly IGitModule _module;
-
-        public RevisionDiffController(IGitModule module)
-        {
-            _module = module;
-        }
-
         public bool ShouldShowDifftoolMenus(ContextMenuSelectionInfo selectionInfo)
         {
             return selectionInfo.IsAnyItemSelected && !selectionInfo.IsAnyCombinedDiff;


### PR DESCRIPTION
similar issue as fixed in f561501c7 (but GitModule not directly needed)

Module is not updated when git repo is changed
No functionality change
Module info can be transferred in ContextMenuSelectionInfo etc

How did I test this code:
 - Compile

Has been tested on (remove any that don't apply):
 - Windows 10
