### PR TITLE
Browse Difftool Menu Items cleanup

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -544,31 +544,19 @@ namespace GitUI.CommandsDialogs
             //Should be blocked in the GUI but not an error to show to the user
             Debug.Assert(selectedRevisions.Count == 1 || selectedRevisions.Count == 2,
                 "Unexpectedly number of revisions for difftool" + selectedRevisions.Count);
-            if (selectedRevisions.Count < 1)
+            if (selectedRevisions.Count < 1 || selectedRevisions.Count > 2)
             {
                 return null;
             }
 
-            bool aIsLocal = false;
-            bool bIsLocal = false;
-            bool showParentItems = selectedRevisions.Count == 2;
+            bool aIsLocal = selectedRevisions.Count == 2 && selectedRevisions[1].Guid == GitRevision.UnstagedGuid;
+            bool bIsLocal = selectedRevisions[0].Guid == GitRevision.UnstagedGuid;
+            bool multipleRevisionsSelected = selectedRevisions.Count == 2;
 
             bool localExists = false;
-            bool bIsNormal = false; //B is not new or deleted (we cannot easily check A)
-            bIsLocal = selectedRevisions[0].Guid == GitRevision.UnstagedGuid;
+            bool bIsNormal = false; //B is assumed to be new or deleted (check from DiffFiles)
 
-            if (selectedRevisions.Count == 2)
-            {
-                aIsLocal = selectedRevisions[0].Guid == GitRevision.UnstagedGuid;
-            }
-            //Temporary, until parent is set to HEAD instead of staged
-            else
-            {
-                aIsLocal = bIsLocal;
-                bIsLocal = bIsLocal || selectedRevisions[0].Guid == GitRevision.IndexGuid;
-            }
-
-            //enable *<->Local items only when local file exists
+            //enable *<->Local items only when (any) local file exists
             foreach (var item in DiffFiles.SelectedItems)
             {
                 bIsNormal = bIsNormal || !(item.IsNew || item.IsDeleted);
@@ -581,7 +569,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            var selectionInfo = new ContextMenuDiffToolInfo(aIsLocal, bIsLocal, bIsNormal, localExists, showParentItems);
+            var selectionInfo = new ContextMenuDiffToolInfo(aIsLocal, bIsLocal, bIsNormal, localExists, multipleRevisionsSelected);
             return selectionInfo;
         }
 
@@ -594,9 +582,8 @@ namespace GitUI.CommandsDialogs
             bLocalToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuBLocal(selectionInfo);
             parentOfALocalToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuAParentLocal(selectionInfo);
             parentOfBLocalToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuBParentLocal(selectionInfo);
-            //Nothing preventing to show the parents (as done in FormDiff)
-            parentOfALocalToolStripMenuItem.Visible =
-                parentOfBLocalToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuParents(selectionInfo);
+            parentOfALocalToolStripMenuItem.Visible = parentOfALocalToolStripMenuItem.Enabled || _revisionDiffController.ShouldShowMenuAParent(selectionInfo);
+            parentOfBLocalToolStripMenuItem.Visible = parentOfBLocalToolStripMenuItem.Enabled || _revisionDiffController.ShouldShowMenuBParent(selectionInfo);
         }
 
         private void resetFileToFirstToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -24,7 +24,8 @@ namespace GitUI.CommandsDialogs
         bool ShouldShowMenuBLocal(ContextMenuDiffToolInfo selectionInfo);
         bool ShouldShowMenuAParentLocal(ContextMenuDiffToolInfo selectionInfo);
         bool ShouldShowMenuBParentLocal(ContextMenuDiffToolInfo selectionInfo);
-        bool ShouldShowMenuParents(ContextMenuDiffToolInfo selectionInfo);
+        bool ShouldShowMenuAParent(ContextMenuDiffToolInfo selectionInfo);
+        bool ShouldShowMenuBParent(ContextMenuDiffToolInfo selectionInfo);
     }
 
     public sealed class ContextMenuSelectionInfo
@@ -48,19 +49,19 @@ namespace GitUI.CommandsDialogs
 
     public sealed class ContextMenuDiffToolInfo
     {
-        public ContextMenuDiffToolInfo(bool aIsLocal, bool bIsLocal, bool bIsNormal, bool localExists, bool showParentItems)
+        public ContextMenuDiffToolInfo(bool aIsLocal, bool bIsLocal, bool bIsNormal, bool localExists, bool multipleRevisionsSelected)
         {
             AIsLocal = aIsLocal;
             BIsLocal = bIsLocal;
             BIsNormal = bIsNormal;
             LocalExists = localExists;
-            ShowParentItems = showParentItems;
+            MultipleRevisionsSelected = multipleRevisionsSelected;
         }
         public bool AIsLocal { get; }
         public bool BIsLocal { get; }
         public bool BIsNormal { get; }
         public bool LocalExists { get; }
-        public bool ShowParentItems { get; }
+        public bool MultipleRevisionsSelected { get; }
     }
 
     public sealed class RevisionDiffController : IRevisionDiffController
@@ -164,9 +165,14 @@ namespace GitUI.CommandsDialogs
             return selectionInfo.LocalExists && selectionInfo.BIsNormal;
         }
 
-        public bool ShouldShowMenuParents(ContextMenuDiffToolInfo selectionInfo)
+        public bool ShouldShowMenuAParent(ContextMenuDiffToolInfo selectionInfo)
         {
-            return selectionInfo.ShowParentItems;
+            return ShouldShowMenuALocal(selectionInfo) && selectionInfo.AIsLocal;
+        }
+
+        public bool ShouldShowMenuBParent(ContextMenuDiffToolInfo selectionInfo)
+        {
+            return ShouldShowMenuBLocal(selectionInfo) && (selectionInfo.BIsLocal || selectionInfo.MultipleRevisionsSelected);
         }
     }
 }


### PR DESCRIPTION
From #4031
The diff parent of a/b to local menu options should be visible in more situations
Refactoring of the calculations of options

Screenshots before and after (if PR changes UI):
-
![image](https://user-images.githubusercontent.com/6248932/33788687-e41ffa0e-dc73-11e7-971d-3d5fad814cad.png)


How did I test this code:
 - Manually

Has been tested on (remove any that don't apply):
 - Windows 10
