### PR TITLE
Some menu and command suppressions related to bare repositories

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3042,6 +3042,7 @@ namespace GitCommands
             return messages.Select(cm =>
                 {
                     int idx = cm.IndexOf("\n");
+                    if (idx <= 0) return null;
                     string encodingName = cm.Substring(0, idx);
                     cm = cm.Substring(idx + 1, cm.Length - idx - 1);
                     cm = ReEncodeCommitMessage(cm, encodingName);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -182,7 +182,7 @@ namespace GitUI.CommandsDialogs
             Translate();
             LayoutRevisionInfo();
 
-            if (AppSettings.ShowGitStatusInBrowseToolbar)
+            if (AppSettings.ShowGitStatusInBrowseToolbar && !Module.IsBareRepository())
             {
                 _toolStripGitStatus = new ToolStripGitStatus
                 {
@@ -499,7 +499,7 @@ namespace GitUI.CommandsDialogs
             branchSelect.Enabled = validWorkingDir;
             toolStripButton1.Enabled = validWorkingDir && !bareRepository;
             if (_toolStripGitStatus != null)
-                _toolStripGitStatus.Enabled = validWorkingDir;
+                _toolStripGitStatus.Enabled = validWorkingDir && !Module.IsBareRepository();
             toolStripButtonPull.Enabled = validWorkingDir;
             toolStripButtonPush.Enabled = validWorkingDir;
             dashboardToolStripMenuItem.Visible = !validWorkingDir;
@@ -1111,7 +1111,7 @@ namespace GitUI.CommandsDialogs
                 var revisions = RevisionGrid.GetSelectedRevisions();
 
                 CommitInfoTabControl.SelectedIndexChanged -= CommitInfoTabControl_SelectedIndexChanged;
-                if (revisions.Any() && GitRevision.IsArtificial(revisions[0].Guid))
+                if (!revisions.Any() || GitRevision.IsArtificial(revisions[0].Guid))
                 {
                     //Artificial commits cannot show tree (ls-tree) and has no commit info 
                     CommitInfoTabControl.RemoveIfExists(CommitInfoTabPage);
@@ -2087,14 +2087,24 @@ namespace GitUI.CommandsDialogs
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
             bool enabled = selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial();
 
+            this.branchToolStripMenuItem.Enabled =
+            this.deleteBranchToolStripMenuItem.Enabled =
+            this.mergeBranchToolStripMenuItem.Enabled =
+            this.rebaseToolStripMenuItem.Enabled =
+            this.stashToolStripMenuItem.Enabled =
+              selectedRevisions.Count>0 && !Module.IsBareRepository();
+
             this.resetToolStripMenuItem.Enabled =
             this.checkoutBranchToolStripMenuItem.Enabled =
             this.runMergetoolToolStripMenuItem.Enabled =
-            this.tagToolStripMenuItem.Enabled =
             this.cherryPickToolStripMenuItem.Enabled =
-            this.archiveToolStripMenuItem.Enabled =
             this.checkoutToolStripMenuItem.Enabled =
             this.bisectToolStripMenuItem.Enabled =
+              enabled && !Module.IsBareRepository();
+
+            this.tagToolStripMenuItem.Enabled =
+            this.deleteTagToolStripMenuItem.Enabled =
+            this.archiveToolStripMenuItem.Enabled =
               enabled;
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1117,6 +1117,7 @@ namespace GitUI.CommandsDialogs
 
         void Staged_DoubleClick(object sender, EventArgs e)
         {
+            if (Module.IsBareRepository()) return;
             _currentFilesList = Staged;
             Unstage();
         }
@@ -1176,7 +1177,7 @@ namespace GitUI.CommandsDialogs
         private void UnstagedContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             //Do not show if no item selected
-            e.Cancel = !Unstaged.SelectedItems.Any();
+            e.Cancel = !Unstaged.SelectedItems.Any() || Module.IsBareRepository();
         }
 
         private void Unstaged_Enter(object sender, EventArgs e)
@@ -1196,6 +1197,7 @@ namespace GitUI.CommandsDialogs
 
         private void Unstage(bool canUseUnstageAll = true)
         {
+            if (Module.IsBareRepository()) return;
             if (canUseUnstageAll &&
                 Staged.GitItemStatuses.Count() > 10 &&
                 Staged.SelectedItems.Count() == Staged.GitItemStatuses.Count())
@@ -1308,7 +1310,7 @@ namespace GitUI.CommandsDialogs
 
         private void StageClick(object sender, EventArgs e)
         {
-            if (_currentFilesList != Unstaged)
+            if (_currentFilesList != Unstaged || Module.IsBareRepository())
                 return;
             Stage(Unstaged.SelectedItems.ToList());
             if (Unstaged.IsEmpty)
@@ -1317,7 +1319,7 @@ namespace GitUI.CommandsDialogs
 
         private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            if (!Staged.SelectedItems.Any())
+            if (!Staged.SelectedItems.Any() || Module.IsBareRepository())
             {
                 //Do not show if no item selected
                 e.Cancel = true;

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -230,8 +230,10 @@ namespace GitUI.CommandsDialogs
 
         private void openWithDifftoolToolStripMenuItem_DropDownOpening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            aLocalToolStripMenuItem.Enabled = _baseRevision != null && _baseRevision.Guid != GitRevision.UnstagedGuid;
-            bLocalToolStripMenuItem.Enabled = _headRevision != null && _headRevision.Guid != GitRevision.UnstagedGuid;
+            aLocalToolStripMenuItem.Enabled = _baseRevision != null && _baseRevision.Guid != GitRevision.UnstagedGuid && !Module.IsBareRepository();
+            bLocalToolStripMenuItem.Enabled = _headRevision != null && _headRevision.Guid != GitRevision.UnstagedGuid && !Module.IsBareRepository();
+            parentOfALocalToolStripMenuItem.Enabled = parentOfBLocalToolStripMenuItem.Enabled = !Module.IsBareRepository();
+
             bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
             blameToolStripMenuItem.Visible = isExactlyOneItemSelected && !(DiffFiles.SelectedItem.IsSubmodule || _baseRevision.IsArtificial());
         }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -415,7 +415,7 @@ namespace GitUI.CommandsDialogs
             var selectedRevisions = FileChanges.GetSelectedRevisions();
 
             diffToolremotelocalStripMenuItem.Enabled =
-                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.UnstagedGuid;
+                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.UnstagedGuid && File.Exists(FileName);
             openWithDifftoolToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;
             manipuleerCommitToolStripMenuItem.Enabled =

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -248,8 +248,10 @@ namespace GitUI.CommandsDialogs
             bool isAnyItemSelected = DiffFiles.SelectedItems.Count() > 0;
             var isCombinedDiff = isExactlyOneItemSelected && DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
             var selectedItemStatus = DiffFiles.SelectedItem;
+            bool isBareRepository = Module.IsBareRepository();
+            bool singleFileExists = isExactlyOneItemSelected && File.Exists(DiffFiles.SelectedItem.Name); 
 
-            var selectionInfo = new ContextMenuSelectionInfo(selectedRevisions, selectedItemStatus, isAnyCombinedDiff, isExactlyOneItemSelected, isCombinedDiff, isAnyItemSelected);
+            var selectionInfo = new ContextMenuSelectionInfo(selectedRevisions, selectedItemStatus, isAnyCombinedDiff, isExactlyOneItemSelected, isCombinedDiff, isAnyItemSelected, isBareRepository, singleFileExists);
             return selectionInfo;
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs
 
     public sealed class ContextMenuSelectionInfo
     {
-        public ContextMenuSelectionInfo(IList<GitRevision> selectedRevisions, GitItemStatus selectedDiff, bool isAnyCombinedDiff, bool isSingleGitItemSelected, bool isCombinedDiff, bool isAnyItemSelected)
+        public ContextMenuSelectionInfo(IList<GitRevision> selectedRevisions, GitItemStatus selectedDiff, bool isAnyCombinedDiff, bool isSingleGitItemSelected, bool isCombinedDiff, bool isAnyItemSelected, bool isBareRepository, bool singleFileExists)
         {
             SelectedRevisions = selectedRevisions;
             SelectedDiff = selectedDiff;
@@ -37,13 +37,17 @@ namespace GitUI.CommandsDialogs
             IsSingleGitItemSelected = isSingleGitItemSelected;
             IsCombinedDiff = isCombinedDiff;
             IsAnyItemSelected = isAnyItemSelected;
+            IsBareRepository = isBareRepository;
+            SingleFileExists = singleFileExists;
         }
         public IList<GitRevision> SelectedRevisions { get; }
         public GitItemStatus SelectedDiff { get; }
         public bool IsAnyCombinedDiff { get; }
         public bool IsSingleGitItemSelected { get; }
         public bool IsCombinedDiff { get; }
-        public bool IsAnyItemSelected { get;  }
+        public bool IsAnyItemSelected { get; }
+        public bool IsBareRepository { get; }
+        public bool SingleFileExists { get; }
     }
 
     public sealed class ContextMenuDiffToolInfo
@@ -86,18 +90,18 @@ namespace GitUI.CommandsDialogs
         {
             return !selectionInfo.IsCombinedDiff && selectionInfo.IsSingleGitItemSelected &&
                    !(selectionInfo.SelectedDiff.IsSubmodule || selectionInfo.SelectedRevisions[0].Guid == GitRevision.UnstagedGuid ||
-                     (selectionInfo.SelectedDiff.IsNew || selectionInfo.SelectedDiff.IsDeleted) && selectionInfo.SelectedRevisions[0].Guid == GitRevision.IndexGuid);
+                     (selectionInfo.SelectedDiff.IsNew || selectionInfo.SelectedDiff.IsDeleted) && selectionInfo.SelectedRevisions[0].Guid == GitRevision.IndexGuid) && selectionInfo.SingleFileExists;
         }
 
         public bool ShouldShowMenuEditFile(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsSingleGitItemSelected && !selectionInfo.SelectedDiff.IsSubmodule && selectionInfo.SelectedRevisions[0].IsArtificial();
+            return selectionInfo.IsSingleGitItemSelected && !selectionInfo.SelectedDiff.IsSubmodule && selectionInfo.SingleFileExists;
         }
 
         public bool ShouldShowMenuResetFile(ContextMenuSelectionInfo selectionInfo)
         {
             return selectionInfo.IsAnyItemSelected && !selectionInfo.IsCombinedDiff &&
-                !(selectionInfo.IsSingleGitItemSelected && (selectionInfo.SelectedDiff.IsSubmodule || selectionInfo.SelectedDiff.IsNew) && selectionInfo.SelectedRevisions[0].Guid == GitRevision.UnstagedGuid);
+                !(selectionInfo.IsSingleGitItemSelected && (selectionInfo.SelectedDiff.IsSubmodule || selectionInfo.SelectedDiff.IsNew) && selectionInfo.SelectedRevisions[0].Guid == GitRevision.UnstagedGuid) && !selectionInfo.IsBareRepository;
         }
 
         public bool ShouldShowMenuFileHistory(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -490,7 +490,7 @@ See the changes in the commit form.");
             }
 
             saveAsToolStripMenuItem.Visible = isFile;
-            resetToThisRevisionToolStripMenuItem.Visible = isFile;
+            resetToThisRevisionToolStripMenuItem.Visible = isFile && !Module.IsBareRepository();
             toolStripSeparatorFileSystemActions.Visible = isFile;
 
             fileHistoryToolStripMenuItem.Enabled = itemSelected;
@@ -514,6 +514,7 @@ See the changes in the commit form.");
             stopTrackingThisFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
             assumeUnchangedTheFileToolStripMenuItem.Visible = isFile;
             assumeUnchangedTheFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
+            findToolStripMenuItem.Enabled = tvGitTree.Nodes.Count>0;
 
             toolStripSeparatorFileTreeActions.Visible = isFile;
             toolStripSeparatorFileTreeActions.Enabled = isExistingFileOrDirectory;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -310,8 +310,9 @@ namespace GitUI.Editor
             treatAllFilesAsTextToolStripMenuItem.Visible = visible;
             copyNewVersionToolStripMenuItem.Visible = visible;
             copyOldVersionToolStripMenuItem.Visible = visible;
-            cherrypickSelectedLinesToolStripMenuItem.Visible = visible && !isStaging_diff;
-            revertSelectedLinesToolStripMenuItem.Visible = visible && !isStaging_diff;
+            //TODO The following should not be enabled if this is afile and the file does not exist
+            cherrypickSelectedLinesToolStripMenuItem.Visible = visible && !isStaging_diff && !Module.IsBareRepository();
+            revertSelectedLinesToolStripMenuItem.Visible = visible && !isStaging_diff && !Module.IsBareRepository();
             copyPatchToolStripMenuItem.Visible = visible;
         }
 

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -26,7 +26,7 @@ namespace GitUI.HelperDialogs
             : this(aCommands)
         {
             revisionGrid.MultiSelect = false;
-            revisionGrid.ShowUncommitedChangesIfPossible = showArtificial;
+            revisionGrid.ShowUncommitedChangesIfPossible = showArtificial && !revisionGrid.Module.IsBareRepository();
 
             if (!String.IsNullOrEmpty(preselectCommit))
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2424,16 +2424,16 @@ namespace GitUI
             deleteTagToolStripMenuItem.Enabled = deleteTagDropDown.Items.Count > 0;
 
             deleteBranchToolStripMenuItem.DropDown = deleteBranchDropDown;
-            deleteBranchToolStripMenuItem.Enabled = deleteBranchDropDown.Items.Count > 0;
+            deleteBranchToolStripMenuItem.Enabled = deleteBranchDropDown.Items.Count > 0 && !Module.IsBareRepository();
 
             checkoutBranchToolStripMenuItem.DropDown = checkoutBranchDropDown;
-            checkoutBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && checkoutBranchDropDown.Items.Count > 0;
+            checkoutBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && checkoutBranchDropDown.Items.Count > 0 && !Module.IsBareRepository();
 
             mergeBranchToolStripMenuItem.DropDown = mergeBranchDropDown;
-            mergeBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && mergeBranchDropDown.Items.Count > 0;
+            mergeBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && mergeBranchDropDown.Items.Count > 0 && !Module.IsBareRepository();
 
             rebaseOnToolStripMenuItem.DropDown = rebaseDropDown;
-            rebaseOnToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && rebaseDropDown.Items.Count > 0;
+            rebaseOnToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && rebaseDropDown.Items.Count > 0 && !Module.IsBareRepository();
 
             renameBranchToolStripMenuItem.DropDown = renameDropDown;
             renameBranchToolStripMenuItem.Enabled = renameDropDown.Items.Count > 0;
@@ -2444,8 +2444,8 @@ namespace GitUI
             manipulateCommitToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
 
             copyToClipboardToolStripMenuItem.Enabled = !revision.IsArtificial();
-            createNewBranchToolStripMenuItem.Enabled = !revision.IsArtificial();
-            resetCurrentBranchToHereToolStripMenuItem.Enabled = !revision.IsArtificial();
+            createNewBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
+            resetCurrentBranchToHereToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
             archiveRevisionToolStripMenuItem.Enabled = !revision.IsArtificial();
             createTagToolStripMenuItem.Enabled = !revision.IsArtificial();
 
@@ -2691,7 +2691,7 @@ namespace GitUI
             }
             string filtredCurrentCheckout = _filtredCurrentCheckout;
 
-            if (filtredCurrentCheckout == rev.Guid && ShowUncommitedChanges())
+            if (filtredCurrentCheckout == rev.Guid && ShowUncommitedChanges() && !Module.IsBareRepository())
             {
                 CheckUncommitedChanged(filtredCurrentCheckout);
             }


### PR DESCRIPTION
In some situations (like difftool to local) it made sense to check if local files existed instead

Cleanup related to #4031
This was mentioned in a comment from @KindDragon for #4166 
A few of the items caused exceptions, moste just exited with warnings
The functionality may not be perfect after this, but better
There are no test cases related to this handling, it does not make much sense to add any either
(I consider adding test cases for RevisionDiffController that could touch upon this but will not add general testcases.)

This PR should have low importance (I do not see a a use case for GE with bare repos), but it should be relative simple to review.

How did I test this code:
 - Happy testing both with empty bare repos and bare repos with info

Has been tested on (remove any that don't apply):
 - Windows 10
