### PR TITLE
Bitbucket plugin: Exception if not initialized

### DIFF
--- a/Plugins/Stash/StashPullRequestForm.cs
+++ b/Plugins/Stash/StashPullRequestForm.cs
@@ -116,6 +116,14 @@ namespace Stash
 
         private void BtnCreateClick(object sender, EventArgs e)
         {
+            if (ddlBranchSource.SelectedValue == null ||
+                ddlBranchTarget.SelectedValue == null ||
+                ddlRepositorySource.SelectedValue == null ||
+                ddlRepositoryTarget.SelectedValue == null)
+            {
+                return;
+            }
+
             var info = new PullRequestInfo
             {
                 Title = txtTitle.Text,
@@ -290,6 +298,8 @@ namespace Stash
         private void BtnMergeClick(object sender, EventArgs e)
         {
             var curItem = lbxPullRequests.SelectedItem as PullRequest;
+            if (curItem == null) return;
+
             var mergeInfo = new MergeRequestInfo
             {
                 Id = curItem.Id,
@@ -313,6 +323,8 @@ namespace Stash
         private void BtnApproveClick(object sender, EventArgs e)
         {
             var curItem = lbxPullRequests.SelectedItem as PullRequest;
+            if (curItem == null) return;
+
             var mergeInfo = new MergeRequestInfo
             {
                 Id = curItem.Id,


### PR DESCRIPTION
The Bitbucket plugin always made an exception when creating or approving pull requests
The core reason is that nothing is loaded (also with a configuration), but that is separate.
In #4204

How did I test this code:
 - Open Bitbucket plugin
 - Press Create, Approve, Merge

Has been tested on (remove any that don't apply):
 - Windows 10
