### PR TITLE
3810 turn off zebra striping

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -584,6 +584,12 @@ namespace GitCommands
             set { SetBool("revisiongraphshowworkingdirchanges", value); }
         }
 
+        public static bool RevisionGraphDrawAlternateBackColor
+        {
+            get { return GetBool("RevisionGraphDrawAlternateBackColor", true); }
+            set { SetBool("RevisionGraphDrawAlternateBackColor", value); }
+        }
+
         public static bool RevisionGraphDrawNonRelativesGray
         {
             get { return GetBool("revisiongraphdrawnonrelativesgray", true); }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.gbAppIcon = new System.Windows.Forms.GroupBox();
             this.label55 = new System.Windows.Forms.Label();
             this.IconPreviewSmall = new System.Windows.Forms.PictureBox();
             this.IconPreview = new System.Windows.Forms.PictureBox();
@@ -42,7 +42,7 @@
             this.PurpleIcon = new System.Windows.Forms.RadioButton();
             this.BlueIcon = new System.Windows.Forms.RadioButton();
             this.DefaultIcon = new System.Windows.Forms.RadioButton();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.gbRevisionGraph = new System.Windows.Forms.GroupBox();
             this.HighlightAuthoredRevisions = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesTextGray = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesGray = new System.Windows.Forms.CheckBox();
@@ -60,7 +60,7 @@
             this._NO_TRANSLATE_ColorTagLabel = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_ColorBranchLabel = new System.Windows.Forms.Label();
             this.label32 = new System.Windows.Forms.Label();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.gbDiffView = new System.Windows.Forms.GroupBox();
             this.label43 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel = new System.Windows.Forms.Label();
             this.label45 = new System.Windows.Forms.Label();
@@ -71,42 +71,42 @@
             this.label31 = new System.Windows.Forms.Label();
             this.label29 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_ColorAddedLineLabel = new System.Windows.Forms.Label();
-            this.groupBox5.SuspendLayout();
+            this.gbAppIcon.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.IconPreviewSmall)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.IconPreview)).BeginInit();
-            this.groupBox4.SuspendLayout();
-            this.groupBox3.SuspendLayout();
+            this.gbRevisionGraph.SuspendLayout();
+            this.gbDiffView.SuspendLayout();
             this.SuspendLayout();
             // 
-            // groupBox5
+            // gbAppIcon
             // 
-            this.groupBox5.Controls.Add(this.label55);
-            this.groupBox5.Controls.Add(this.IconPreviewSmall);
-            this.groupBox5.Controls.Add(this.IconPreview);
-            this.groupBox5.Controls.Add(this.IconStyle);
-            this.groupBox5.Controls.Add(this.label54);
-            this.groupBox5.Controls.Add(this.LightblueIcon);
-            this.groupBox5.Controls.Add(this.RandomIcon);
-            this.groupBox5.Controls.Add(this.YellowIcon);
-            this.groupBox5.Controls.Add(this.RedIcon);
-            this.groupBox5.Controls.Add(this.GreenIcon);
-            this.groupBox5.Controls.Add(this.PurpleIcon);
-            this.groupBox5.Controls.Add(this.BlueIcon);
-            this.groupBox5.Controls.Add(this.DefaultIcon);
-            this.groupBox5.Location = new System.Drawing.Point(402, 3);
-            this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(321, 279);
-            this.groupBox5.TabIndex = 15;
-            this.groupBox5.TabStop = false;
-            this.groupBox5.Text = "Application Icon";
+            this.gbAppIcon.Controls.Add(this.label55);
+            this.gbAppIcon.Controls.Add(this.IconPreviewSmall);
+            this.gbAppIcon.Controls.Add(this.IconPreview);
+            this.gbAppIcon.Controls.Add(this.IconStyle);
+            this.gbAppIcon.Controls.Add(this.label54);
+            this.gbAppIcon.Controls.Add(this.LightblueIcon);
+            this.gbAppIcon.Controls.Add(this.RandomIcon);
+            this.gbAppIcon.Controls.Add(this.YellowIcon);
+            this.gbAppIcon.Controls.Add(this.RedIcon);
+            this.gbAppIcon.Controls.Add(this.GreenIcon);
+            this.gbAppIcon.Controls.Add(this.PurpleIcon);
+            this.gbAppIcon.Controls.Add(this.BlueIcon);
+            this.gbAppIcon.Controls.Add(this.DefaultIcon);
+            this.gbAppIcon.Location = new System.Drawing.Point(402, 3);
+            this.gbAppIcon.Name = "gbAppIcon";
+            this.gbAppIcon.Size = new System.Drawing.Size(321, 279);
+            this.gbAppIcon.TabIndex = 1;
+            this.gbAppIcon.TabStop = false;
+            this.gbAppIcon.Text = "Application Icon";
             // 
             // label55
             // 
             this.label55.AutoSize = true;
             this.label55.Location = new System.Drawing.Point(13, 55);
             this.label55.Name = "label55";
-            this.label55.Size = new System.Drawing.Size(60, 15);
-            this.label55.TabIndex = 14;
+            this.label55.Size = new System.Drawing.Size(54, 13);
+            this.label55.TabIndex = 2;
             this.label55.Text = "Icon color";
             // 
             // IconPreviewSmall
@@ -137,8 +137,8 @@
             "Cow"});
             this.IconStyle.Location = new System.Drawing.Point(111, 23);
             this.IconStyle.Name = "IconStyle";
-            this.IconStyle.Size = new System.Drawing.Size(121, 23);
-            this.IconStyle.TabIndex = 11;
+            this.IconStyle.Size = new System.Drawing.Size(121, 21);
+            this.IconStyle.TabIndex = 1;
             this.IconStyle.SelectedIndexChanged += new System.EventHandler(this.IconStyle_SelectedIndexChanged);
             // 
             // label54
@@ -146,8 +146,8 @@
             this.label54.AutoSize = true;
             this.label54.Location = new System.Drawing.Point(13, 26);
             this.label54.Name = "label54";
-            this.label54.Size = new System.Drawing.Size(57, 15);
-            this.label54.TabIndex = 10;
+            this.label54.Size = new System.Drawing.Size(54, 13);
+            this.label54.TabIndex = 0;
             this.label54.Text = "Icon style";
             // 
             // LightblueIcon
@@ -155,8 +155,8 @@
             this.LightblueIcon.AutoSize = true;
             this.LightblueIcon.Location = new System.Drawing.Point(111, 81);
             this.LightblueIcon.Name = "LightblueIcon";
-            this.LightblueIcon.Size = new System.Drawing.Size(78, 19);
-            this.LightblueIcon.TabIndex = 7;
+            this.LightblueIcon.Size = new System.Drawing.Size(71, 17);
+            this.LightblueIcon.TabIndex = 4;
             this.LightblueIcon.TabStop = true;
             this.LightblueIcon.Text = "Light blue";
             this.LightblueIcon.UseVisualStyleBackColor = true;
@@ -166,8 +166,8 @@
             this.RandomIcon.AutoSize = true;
             this.RandomIcon.Location = new System.Drawing.Point(111, 250);
             this.RandomIcon.Name = "RandomIcon";
-            this.RandomIcon.Size = new System.Drawing.Size(70, 19);
-            this.RandomIcon.TabIndex = 6;
+            this.RandomIcon.Size = new System.Drawing.Size(64, 17);
+            this.RandomIcon.TabIndex = 10;
             this.RandomIcon.TabStop = true;
             this.RandomIcon.Text = "Random";
             this.RandomIcon.UseVisualStyleBackColor = true;
@@ -177,8 +177,8 @@
             this.YellowIcon.AutoSize = true;
             this.YellowIcon.Location = new System.Drawing.Point(111, 222);
             this.YellowIcon.Name = "YellowIcon";
-            this.YellowIcon.Size = new System.Drawing.Size(60, 19);
-            this.YellowIcon.TabIndex = 5;
+            this.YellowIcon.Size = new System.Drawing.Size(55, 17);
+            this.YellowIcon.TabIndex = 9;
             this.YellowIcon.TabStop = true;
             this.YellowIcon.Text = "Yellow";
             this.YellowIcon.UseVisualStyleBackColor = true;
@@ -189,8 +189,8 @@
             this.RedIcon.AutoSize = true;
             this.RedIcon.Location = new System.Drawing.Point(111, 194);
             this.RedIcon.Name = "RedIcon";
-            this.RedIcon.Size = new System.Drawing.Size(45, 19);
-            this.RedIcon.TabIndex = 4;
+            this.RedIcon.Size = new System.Drawing.Size(44, 17);
+            this.RedIcon.TabIndex = 8;
             this.RedIcon.TabStop = true;
             this.RedIcon.Text = "Red";
             this.RedIcon.UseVisualStyleBackColor = true;
@@ -201,8 +201,8 @@
             this.GreenIcon.AutoSize = true;
             this.GreenIcon.Location = new System.Drawing.Point(111, 165);
             this.GreenIcon.Name = "GreenIcon";
-            this.GreenIcon.Size = new System.Drawing.Size(56, 19);
-            this.GreenIcon.TabIndex = 3;
+            this.GreenIcon.Size = new System.Drawing.Size(54, 17);
+            this.GreenIcon.TabIndex = 7;
             this.GreenIcon.TabStop = true;
             this.GreenIcon.Text = "Green";
             this.GreenIcon.UseVisualStyleBackColor = true;
@@ -213,8 +213,8 @@
             this.PurpleIcon.AutoSize = true;
             this.PurpleIcon.Location = new System.Drawing.Point(111, 137);
             this.PurpleIcon.Name = "PurpleIcon";
-            this.PurpleIcon.Size = new System.Drawing.Size(59, 19);
-            this.PurpleIcon.TabIndex = 2;
+            this.PurpleIcon.Size = new System.Drawing.Size(55, 17);
+            this.PurpleIcon.TabIndex = 6;
             this.PurpleIcon.TabStop = true;
             this.PurpleIcon.Text = "Purple";
             this.PurpleIcon.UseVisualStyleBackColor = true;
@@ -225,8 +225,8 @@
             this.BlueIcon.AutoSize = true;
             this.BlueIcon.Location = new System.Drawing.Point(111, 109);
             this.BlueIcon.Name = "BlueIcon";
-            this.BlueIcon.Size = new System.Drawing.Size(48, 19);
-            this.BlueIcon.TabIndex = 1;
+            this.BlueIcon.Size = new System.Drawing.Size(45, 17);
+            this.BlueIcon.TabIndex = 5;
             this.BlueIcon.TabStop = true;
             this.BlueIcon.Text = "Blue";
             this.BlueIcon.UseVisualStyleBackColor = true;
@@ -237,46 +237,46 @@
             this.DefaultIcon.AutoSize = true;
             this.DefaultIcon.Location = new System.Drawing.Point(111, 53);
             this.DefaultIcon.Name = "DefaultIcon";
-            this.DefaultIcon.Size = new System.Drawing.Size(63, 19);
-            this.DefaultIcon.TabIndex = 0;
+            this.DefaultIcon.Size = new System.Drawing.Size(60, 17);
+            this.DefaultIcon.TabIndex = 3;
             this.DefaultIcon.TabStop = true;
             this.DefaultIcon.Text = "Default";
             this.DefaultIcon.UseVisualStyleBackColor = true;
             this.DefaultIcon.CheckedChanged += new System.EventHandler(this.IconColor_CheckedChanged);
             // 
-            // groupBox4
+            // gbRevisionGraph
             // 
-            this.groupBox4.Controls.Add(this.HighlightAuthoredRevisions);
-            this.groupBox4.Controls.Add(this.DrawNonRelativesTextGray);
-            this.groupBox4.Controls.Add(this.DrawNonRelativesGray);
-            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorGraphLabel);
-            this.groupBox4.Controls.Add(this.StripedBanchChange);
-            this.groupBox4.Controls.Add(this.BranchBorders);
-            this.groupBox4.Controls.Add(this.MulticolorBranches);
-            this.groupBox4.Controls.Add(this.label33);
-            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorRemoteBranchLabel);
-            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorAuthoredRevisions);
-            this.groupBox4.Controls.Add(this.label1);
-            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorOtherLabel);
-            this.groupBox4.Controls.Add(this.label36);
-            this.groupBox4.Controls.Add(this.label25);
-            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorTagLabel);
-            this.groupBox4.Controls.Add(this._NO_TRANSLATE_ColorBranchLabel);
-            this.groupBox4.Controls.Add(this.label32);
-            this.groupBox4.Location = new System.Drawing.Point(3, 3);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(387, 322);
-            this.groupBox4.TabIndex = 14;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Revision graph";
+            this.gbRevisionGraph.Controls.Add(this.HighlightAuthoredRevisions);
+            this.gbRevisionGraph.Controls.Add(this.DrawNonRelativesTextGray);
+            this.gbRevisionGraph.Controls.Add(this.DrawNonRelativesGray);
+            this.gbRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorGraphLabel);
+            this.gbRevisionGraph.Controls.Add(this.StripedBanchChange);
+            this.gbRevisionGraph.Controls.Add(this.BranchBorders);
+            this.gbRevisionGraph.Controls.Add(this.MulticolorBranches);
+            this.gbRevisionGraph.Controls.Add(this.label33);
+            this.gbRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorRemoteBranchLabel);
+            this.gbRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorAuthoredRevisions);
+            this.gbRevisionGraph.Controls.Add(this.label1);
+            this.gbRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorOtherLabel);
+            this.gbRevisionGraph.Controls.Add(this.label36);
+            this.gbRevisionGraph.Controls.Add(this.label25);
+            this.gbRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorTagLabel);
+            this.gbRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorBranchLabel);
+            this.gbRevisionGraph.Controls.Add(this.label32);
+            this.gbRevisionGraph.Location = new System.Drawing.Point(3, 3);
+            this.gbRevisionGraph.Name = "gbRevisionGraph";
+            this.gbRevisionGraph.Size = new System.Drawing.Size(387, 322);
+            this.gbRevisionGraph.TabIndex = 0;
+            this.gbRevisionGraph.TabStop = false;
+            this.gbRevisionGraph.Text = "Revision graph";
             // 
             // HighlightAuthoredRevisions
             // 
             this.HighlightAuthoredRevisions.AutoSize = true;
             this.HighlightAuthoredRevisions.Location = new System.Drawing.Point(9, 145);
             this.HighlightAuthoredRevisions.Name = "HighlightAuthoredRevisions";
-            this.HighlightAuthoredRevisions.Size = new System.Drawing.Size(176, 19);
-            this.HighlightAuthoredRevisions.TabIndex = 17;
+            this.HighlightAuthoredRevisions.Size = new System.Drawing.Size(159, 17);
+            this.HighlightAuthoredRevisions.TabIndex = 6;
             this.HighlightAuthoredRevisions.Text = "Highlight authored revisions";
             this.HighlightAuthoredRevisions.UseVisualStyleBackColor = true;
             // 
@@ -285,8 +285,8 @@
             this.DrawNonRelativesTextGray.AutoSize = true;
             this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(9, 120);
             this.DrawNonRelativesTextGray.Name = "DrawNonRelativesTextGray";
-            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(171, 19);
-            this.DrawNonRelativesTextGray.TabIndex = 17;
+            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(164, 17);
+            this.DrawNonRelativesTextGray.TabIndex = 5;
             this.DrawNonRelativesTextGray.Text = "Draw non relatives text gray";
             this.DrawNonRelativesTextGray.UseVisualStyleBackColor = true;
             // 
@@ -295,8 +295,8 @@
             this.DrawNonRelativesGray.AutoSize = true;
             this.DrawNonRelativesGray.Location = new System.Drawing.Point(9, 96);
             this.DrawNonRelativesGray.Name = "DrawNonRelativesGray";
-            this.DrawNonRelativesGray.Size = new System.Drawing.Size(183, 19);
-            this.DrawNonRelativesGray.TabIndex = 16;
+            this.DrawNonRelativesGray.Size = new System.Drawing.Size(172, 17);
+            this.DrawNonRelativesGray.TabIndex = 4;
             this.DrawNonRelativesGray.Text = "Draw non relatives graph gray";
             this.DrawNonRelativesGray.UseVisualStyleBackColor = true;
             // 
@@ -308,8 +308,8 @@
             this._NO_TRANSLATE_ColorGraphLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorGraphLabel.Location = new System.Drawing.Point(287, 21);
             this._NO_TRANSLATE_ColorGraphLabel.Name = "_NO_TRANSLATE_ColorGraphLabel";
-            this._NO_TRANSLATE_ColorGraphLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorGraphLabel.TabIndex = 15;
+            this._NO_TRANSLATE_ColorGraphLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorGraphLabel.TabIndex = 1;
             this._NO_TRANSLATE_ColorGraphLabel.Text = "Red";
             this._NO_TRANSLATE_ColorGraphLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -318,8 +318,8 @@
             this.StripedBanchChange.AutoSize = true;
             this.StripedBanchChange.Location = new System.Drawing.Point(9, 45);
             this.StripedBanchChange.Name = "StripedBanchChange";
-            this.StripedBanchChange.Size = new System.Drawing.Size(145, 19);
-            this.StripedBanchChange.TabIndex = 14;
+            this.StripedBanchChange.Size = new System.Drawing.Size(134, 17);
+            this.StripedBanchChange.TabIndex = 2;
             this.StripedBanchChange.Text = "Striped branch change";
             this.StripedBanchChange.UseVisualStyleBackColor = true;
             // 
@@ -328,8 +328,8 @@
             this.BranchBorders.AutoSize = true;
             this.BranchBorders.Location = new System.Drawing.Point(9, 71);
             this.BranchBorders.Name = "BranchBorders";
-            this.BranchBorders.Size = new System.Drawing.Size(136, 19);
-            this.BranchBorders.TabIndex = 13;
+            this.BranchBorders.Size = new System.Drawing.Size(127, 17);
+            this.BranchBorders.TabIndex = 3;
             this.BranchBorders.Text = "Draw branch borders";
             this.BranchBorders.UseVisualStyleBackColor = true;
             // 
@@ -338,8 +338,8 @@
             this.MulticolorBranches.AutoSize = true;
             this.MulticolorBranches.Location = new System.Drawing.Point(9, 20);
             this.MulticolorBranches.Name = "MulticolorBranches";
-            this.MulticolorBranches.Size = new System.Drawing.Size(132, 19);
-            this.MulticolorBranches.TabIndex = 12;
+            this.MulticolorBranches.Size = new System.Drawing.Size(118, 17);
+            this.MulticolorBranches.TabIndex = 0;
             this.MulticolorBranches.Text = "Multicolor branches";
             this.MulticolorBranches.UseVisualStyleBackColor = true;
             this.MulticolorBranches.CheckedChanged += new System.EventHandler(this.MulticolorBranches_CheckedChanged);
@@ -349,8 +349,8 @@
             this.label33.AutoSize = true;
             this.label33.Location = new System.Drawing.Point(6, 235);
             this.label33.Name = "label33";
-            this.label33.Size = new System.Drawing.Size(117, 15);
-            this.label33.TabIndex = 8;
+            this.label33.Size = new System.Drawing.Size(105, 13);
+            this.label33.TabIndex = 11;
             this.label33.Text = "Color remote branch";
             // 
             // _NO_TRANSLATE_ColorRemoteBranchLabel
@@ -361,8 +361,8 @@
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(287, 235);
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Name = "_NO_TRANSLATE_ColorRemoteBranchLabel";
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 9;
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 12;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -374,8 +374,8 @@
             this._NO_TRANSLATE_ColorAuthoredRevisions.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAuthoredRevisions.Location = new System.Drawing.Point(287, 292);
             this._NO_TRANSLATE_ColorAuthoredRevisions.Name = "_NO_TRANSLATE_ColorAuthoredRevisions";
-            this._NO_TRANSLATE_ColorAuthoredRevisions.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorAuthoredRevisions.TabIndex = 11;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorAuthoredRevisions.TabIndex = 16;
             this._NO_TRANSLATE_ColorAuthoredRevisions.Text = "Red";
             this._NO_TRANSLATE_ColorAuthoredRevisions.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -384,8 +384,8 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(6, 292);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(136, 15);
-            this.label1.TabIndex = 10;
+            this.label1.Size = new System.Drawing.Size(124, 13);
+            this.label1.TabIndex = 15;
             this.label1.Text = "Color authored revisions";
             // 
             // _NO_TRANSLATE_ColorOtherLabel
@@ -396,8 +396,8 @@
             this._NO_TRANSLATE_ColorOtherLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(287, 263);
             this._NO_TRANSLATE_ColorOtherLabel.Name = "_NO_TRANSLATE_ColorOtherLabel";
-            this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 11;
+            this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 14;
             this._NO_TRANSLATE_ColorOtherLabel.Text = "Red";
             this._NO_TRANSLATE_ColorOtherLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -406,8 +406,8 @@
             this.label36.AutoSize = true;
             this.label36.Location = new System.Drawing.Point(6, 263);
             this.label36.Name = "label36";
-            this.label36.Size = new System.Drawing.Size(95, 15);
-            this.label36.TabIndex = 10;
+            this.label36.Size = new System.Drawing.Size(86, 13);
+            this.label36.TabIndex = 13;
             this.label36.Text = "Color other label";
             // 
             // label25
@@ -415,8 +415,8 @@
             this.label25.AutoSize = true;
             this.label25.Location = new System.Drawing.Point(6, 178);
             this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(56, 15);
-            this.label25.TabIndex = 4;
+            this.label25.Size = new System.Drawing.Size(51, 13);
+            this.label25.TabIndex = 7;
             this.label25.Text = "Color tag";
             // 
             // _NO_TRANSLATE_ColorTagLabel
@@ -427,8 +427,8 @@
             this._NO_TRANSLATE_ColorTagLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(287, 178);
             this._NO_TRANSLATE_ColorTagLabel.Name = "_NO_TRANSLATE_ColorTagLabel";
-            this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 5;
+            this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 8;
             this._NO_TRANSLATE_ColorTagLabel.Text = "Red";
             this._NO_TRANSLATE_ColorTagLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -440,8 +440,8 @@
             this._NO_TRANSLATE_ColorBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(287, 206);
             this._NO_TRANSLATE_ColorBranchLabel.Name = "_NO_TRANSLATE_ColorBranchLabel";
-            this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 7;
+            this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 10;
             this._NO_TRANSLATE_ColorBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -450,36 +450,36 @@
             this.label32.AutoSize = true;
             this.label32.Location = new System.Drawing.Point(6, 206);
             this.label32.Name = "label32";
-            this.label32.Size = new System.Drawing.Size(76, 15);
-            this.label32.TabIndex = 6;
+            this.label32.Size = new System.Drawing.Size(68, 13);
+            this.label32.TabIndex = 9;
             this.label32.Text = "Color branch";
             // 
-            // groupBox3
+            // gbDiffView
             // 
-            this.groupBox3.Controls.Add(this.label43);
-            this.groupBox3.Controls.Add(this._NO_TRANSLATE_ColorRemovedLineDiffLabel);
-            this.groupBox3.Controls.Add(this.label45);
-            this.groupBox3.Controls.Add(this._NO_TRANSLATE_ColorAddedLineDiffLabel);
-            this.groupBox3.Controls.Add(this.label27);
-            this.groupBox3.Controls.Add(this._NO_TRANSLATE_ColorSectionLabel);
-            this.groupBox3.Controls.Add(this._NO_TRANSLATE_ColorRemovedLine);
-            this.groupBox3.Controls.Add(this.label31);
-            this.groupBox3.Controls.Add(this.label29);
-            this.groupBox3.Controls.Add(this._NO_TRANSLATE_ColorAddedLineLabel);
-            this.groupBox3.Location = new System.Drawing.Point(3, 331);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(387, 173);
-            this.groupBox3.TabIndex = 13;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Difference view";
+            this.gbDiffView.Controls.Add(this.label43);
+            this.gbDiffView.Controls.Add(this._NO_TRANSLATE_ColorRemovedLineDiffLabel);
+            this.gbDiffView.Controls.Add(this.label45);
+            this.gbDiffView.Controls.Add(this._NO_TRANSLATE_ColorAddedLineDiffLabel);
+            this.gbDiffView.Controls.Add(this.label27);
+            this.gbDiffView.Controls.Add(this._NO_TRANSLATE_ColorSectionLabel);
+            this.gbDiffView.Controls.Add(this._NO_TRANSLATE_ColorRemovedLine);
+            this.gbDiffView.Controls.Add(this.label31);
+            this.gbDiffView.Controls.Add(this.label29);
+            this.gbDiffView.Controls.Add(this._NO_TRANSLATE_ColorAddedLineLabel);
+            this.gbDiffView.Location = new System.Drawing.Point(3, 331);
+            this.gbDiffView.Name = "gbDiffView";
+            this.gbDiffView.Size = new System.Drawing.Size(387, 173);
+            this.gbDiffView.TabIndex = 2;
+            this.gbDiffView.TabStop = false;
+            this.gbDiffView.Text = "Difference view";
             // 
             // label43
             // 
             this.label43.AutoSize = true;
             this.label43.Location = new System.Drawing.Point(6, 79);
             this.label43.Name = "label43";
-            this.label43.Size = new System.Drawing.Size(176, 15);
-            this.label43.TabIndex = 10;
+            this.label43.Size = new System.Drawing.Size(153, 13);
+            this.label43.TabIndex = 4;
             this.label43.Text = "Color removed line highlighting";
             // 
             // _NO_TRANSLATE_ColorRemovedLineDiffLabel
@@ -490,8 +490,8 @@
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Location = new System.Drawing.Point(284, 79);
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Name = "_NO_TRANSLATE_ColorRemovedLineDiffLabel";
-            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.TabIndex = 11;
+            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.TabIndex = 5;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Text = "Red";
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -500,8 +500,8 @@
             this.label45.AutoSize = true;
             this.label45.Location = new System.Drawing.Point(6, 109);
             this.label45.Name = "label45";
-            this.label45.Size = new System.Drawing.Size(162, 15);
-            this.label45.TabIndex = 12;
+            this.label45.Size = new System.Drawing.Size(141, 13);
+            this.label45.TabIndex = 6;
             this.label45.Text = "Color added line highlighting";
             // 
             // _NO_TRANSLATE_ColorAddedLineDiffLabel
@@ -512,8 +512,8 @@
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Location = new System.Drawing.Point(284, 109);
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Name = "_NO_TRANSLATE_ColorAddedLineDiffLabel";
-            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorAddedLineDiffLabel.TabIndex = 13;
+            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorAddedLineDiffLabel.TabIndex = 7;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Text = "Red";
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -522,8 +522,8 @@
             this.label27.AutoSize = true;
             this.label27.Location = new System.Drawing.Point(6, 18);
             this.label27.Name = "label27";
-            this.label27.Size = new System.Drawing.Size(108, 15);
-            this.label27.TabIndex = 4;
+            this.label27.Size = new System.Drawing.Size(96, 13);
+            this.label27.TabIndex = 0;
             this.label27.Text = "Color removed line";
             // 
             // _NO_TRANSLATE_ColorSectionLabel
@@ -534,7 +534,7 @@
             this._NO_TRANSLATE_ColorSectionLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorSectionLabel.Location = new System.Drawing.Point(284, 138);
             this._NO_TRANSLATE_ColorSectionLabel.Name = "_NO_TRANSLATE_ColorSectionLabel";
-            this._NO_TRANSLATE_ColorSectionLabel.Size = new System.Drawing.Size(29, 17);
+            this._NO_TRANSLATE_ColorSectionLabel.Size = new System.Drawing.Size(28, 15);
             this._NO_TRANSLATE_ColorSectionLabel.TabIndex = 9;
             this._NO_TRANSLATE_ColorSectionLabel.Text = "Red";
             this._NO_TRANSLATE_ColorSectionLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -547,8 +547,8 @@
             this._NO_TRANSLATE_ColorRemovedLine.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemovedLine.Location = new System.Drawing.Point(284, 18);
             this._NO_TRANSLATE_ColorRemovedLine.Name = "_NO_TRANSLATE_ColorRemovedLine";
-            this._NO_TRANSLATE_ColorRemovedLine.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorRemovedLine.TabIndex = 5;
+            this._NO_TRANSLATE_ColorRemovedLine.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorRemovedLine.TabIndex = 1;
             this._NO_TRANSLATE_ColorRemovedLine.Text = "Red";
             this._NO_TRANSLATE_ColorRemovedLine.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -557,7 +557,7 @@
             this.label31.AutoSize = true;
             this.label31.Location = new System.Drawing.Point(6, 139);
             this.label31.Name = "label31";
-            this.label31.Size = new System.Drawing.Size(77, 15);
+            this.label31.Size = new System.Drawing.Size(69, 13);
             this.label31.TabIndex = 8;
             this.label31.Text = "Color section";
             // 
@@ -566,8 +566,8 @@
             this.label29.AutoSize = true;
             this.label29.Location = new System.Drawing.Point(6, 48);
             this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(94, 15);
-            this.label29.TabIndex = 6;
+            this.label29.Size = new System.Drawing.Size(84, 13);
+            this.label29.TabIndex = 2;
             this.label29.Text = "Color added line";
             // 
             // _NO_TRANSLATE_ColorAddedLineLabel
@@ -578,35 +578,34 @@
             this._NO_TRANSLATE_ColorAddedLineLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAddedLineLabel.Location = new System.Drawing.Point(284, 48);
             this._NO_TRANSLATE_ColorAddedLineLabel.Name = "_NO_TRANSLATE_ColorAddedLineLabel";
-            this._NO_TRANSLATE_ColorAddedLineLabel.Size = new System.Drawing.Size(29, 17);
-            this._NO_TRANSLATE_ColorAddedLineLabel.TabIndex = 7;
+            this._NO_TRANSLATE_ColorAddedLineLabel.Size = new System.Drawing.Size(28, 15);
+            this._NO_TRANSLATE_ColorAddedLineLabel.TabIndex = 3;
             this._NO_TRANSLATE_ColorAddedLineLabel.Text = "Red";
             this._NO_TRANSLATE_ColorAddedLineLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // ColorsSettingsPage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.groupBox5);
-            this.Controls.Add(this.groupBox4);
-            this.Controls.Add(this.groupBox3);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.gbAppIcon);
+            this.Controls.Add(this.gbRevisionGraph);
+            this.Controls.Add(this.gbDiffView);
             this.Name = "ColorsSettingsPage";
-            this.Size = new System.Drawing.Size(1796, 920);
-            this.groupBox5.ResumeLayout(false);
-            this.groupBox5.PerformLayout();
+            this.Size = new System.Drawing.Size(1360, 856);
+            this.gbAppIcon.ResumeLayout(false);
+            this.gbAppIcon.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.IconPreviewSmall)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.IconPreview)).EndInit();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox4.PerformLayout();
-            this.groupBox3.ResumeLayout(false);
-            this.groupBox3.PerformLayout();
+            this.gbRevisionGraph.ResumeLayout(false);
+            this.gbRevisionGraph.PerformLayout();
+            this.gbDiffView.ResumeLayout(false);
+            this.gbDiffView.PerformLayout();
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.GroupBox gbAppIcon;
         private System.Windows.Forms.Label label55;
         private System.Windows.Forms.PictureBox IconPreviewSmall;
         private System.Windows.Forms.PictureBox IconPreview;
@@ -620,7 +619,7 @@
         private System.Windows.Forms.RadioButton PurpleIcon;
         private System.Windows.Forms.RadioButton BlueIcon;
         private System.Windows.Forms.RadioButton DefaultIcon;
-        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.GroupBox gbRevisionGraph;
         private System.Windows.Forms.CheckBox DrawNonRelativesTextGray;
         private System.Windows.Forms.CheckBox DrawNonRelativesGray;
         private System.Windows.Forms.Label _NO_TRANSLATE_ColorGraphLabel;
@@ -635,7 +634,7 @@
         private System.Windows.Forms.Label _NO_TRANSLATE_ColorTagLabel;
         private System.Windows.Forms.Label _NO_TRANSLATE_ColorBranchLabel;
         private System.Windows.Forms.Label label32;
-        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.GroupBox gbDiffView;
         private System.Windows.Forms.Label label43;
         private System.Windows.Forms.Label _NO_TRANSLATE_ColorRemovedLineDiffLabel;
         private System.Windows.Forms.Label label45;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -43,6 +43,7 @@
             this.BlueIcon = new System.Windows.Forms.RadioButton();
             this.DefaultIcon = new System.Windows.Forms.RadioButton();
             this.gbRevisionGraph = new System.Windows.Forms.GroupBox();
+            this.chkDrawAlternateBackColor = new System.Windows.Forms.CheckBox();
             this.HighlightAuthoredRevisions = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesTextGray = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesGray = new System.Windows.Forms.CheckBox();
@@ -246,6 +247,7 @@
             // 
             // gbRevisionGraph
             // 
+            this.gbRevisionGraph.Controls.Add(this.chkDrawAlternateBackColor);
             this.gbRevisionGraph.Controls.Add(this.HighlightAuthoredRevisions);
             this.gbRevisionGraph.Controls.Add(this.DrawNonRelativesTextGray);
             this.gbRevisionGraph.Controls.Add(this.DrawNonRelativesGray);
@@ -265,38 +267,48 @@
             this.gbRevisionGraph.Controls.Add(this.label32);
             this.gbRevisionGraph.Location = new System.Drawing.Point(3, 3);
             this.gbRevisionGraph.Name = "gbRevisionGraph";
-            this.gbRevisionGraph.Size = new System.Drawing.Size(387, 322);
+            this.gbRevisionGraph.Size = new System.Drawing.Size(387, 340);
             this.gbRevisionGraph.TabIndex = 0;
             this.gbRevisionGraph.TabStop = false;
             this.gbRevisionGraph.Text = "Revision graph";
             // 
+            // chkDrawAlternateBackColor
+            // 
+            this.chkDrawAlternateBackColor.AutoSize = true;
+            this.chkDrawAlternateBackColor.Location = new System.Drawing.Point(9, 68);
+            this.chkDrawAlternateBackColor.Name = "chkDrawAlternateBackColor";
+            this.chkDrawAlternateBackColor.Size = new System.Drawing.Size(157, 17);
+            this.chkDrawAlternateBackColor.TabIndex = 3;
+            this.chkDrawAlternateBackColor.Text = "Draw alternate background";
+            this.chkDrawAlternateBackColor.UseVisualStyleBackColor = true;
+            // 
             // HighlightAuthoredRevisions
             // 
             this.HighlightAuthoredRevisions.AutoSize = true;
-            this.HighlightAuthoredRevisions.Location = new System.Drawing.Point(9, 145);
+            this.HighlightAuthoredRevisions.Location = new System.Drawing.Point(9, 165);
             this.HighlightAuthoredRevisions.Name = "HighlightAuthoredRevisions";
             this.HighlightAuthoredRevisions.Size = new System.Drawing.Size(159, 17);
-            this.HighlightAuthoredRevisions.TabIndex = 6;
+            this.HighlightAuthoredRevisions.TabIndex = 7;
             this.HighlightAuthoredRevisions.Text = "Highlight authored revisions";
             this.HighlightAuthoredRevisions.UseVisualStyleBackColor = true;
             // 
             // DrawNonRelativesTextGray
             // 
             this.DrawNonRelativesTextGray.AutoSize = true;
-            this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(9, 120);
+            this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(9, 140);
             this.DrawNonRelativesTextGray.Name = "DrawNonRelativesTextGray";
             this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(164, 17);
-            this.DrawNonRelativesTextGray.TabIndex = 5;
+            this.DrawNonRelativesTextGray.TabIndex = 6;
             this.DrawNonRelativesTextGray.Text = "Draw non relatives text gray";
             this.DrawNonRelativesTextGray.UseVisualStyleBackColor = true;
             // 
             // DrawNonRelativesGray
             // 
             this.DrawNonRelativesGray.AutoSize = true;
-            this.DrawNonRelativesGray.Location = new System.Drawing.Point(9, 96);
+            this.DrawNonRelativesGray.Location = new System.Drawing.Point(9, 116);
             this.DrawNonRelativesGray.Name = "DrawNonRelativesGray";
             this.DrawNonRelativesGray.Size = new System.Drawing.Size(172, 17);
-            this.DrawNonRelativesGray.TabIndex = 4;
+            this.DrawNonRelativesGray.TabIndex = 5;
             this.DrawNonRelativesGray.Text = "Draw non relatives graph gray";
             this.DrawNonRelativesGray.UseVisualStyleBackColor = true;
             // 
@@ -326,10 +338,10 @@
             // BranchBorders
             // 
             this.BranchBorders.AutoSize = true;
-            this.BranchBorders.Location = new System.Drawing.Point(9, 71);
+            this.BranchBorders.Location = new System.Drawing.Point(9, 91);
             this.BranchBorders.Name = "BranchBorders";
             this.BranchBorders.Size = new System.Drawing.Size(127, 17);
-            this.BranchBorders.TabIndex = 3;
+            this.BranchBorders.TabIndex = 4;
             this.BranchBorders.Text = "Draw branch borders";
             this.BranchBorders.UseVisualStyleBackColor = true;
             // 
@@ -347,10 +359,10 @@
             // label33
             // 
             this.label33.AutoSize = true;
-            this.label33.Location = new System.Drawing.Point(6, 235);
+            this.label33.Location = new System.Drawing.Point(6, 251);
             this.label33.Name = "label33";
             this.label33.Size = new System.Drawing.Size(105, 13);
-            this.label33.TabIndex = 11;
+            this.label33.TabIndex = 12;
             this.label33.Text = "Color remote branch";
             // 
             // _NO_TRANSLATE_ColorRemoteBranchLabel
@@ -359,10 +371,10 @@
             this._NO_TRANSLATE_ColorRemoteBranchLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(287, 235);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(287, 251);
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Name = "_NO_TRANSLATE_ColorRemoteBranchLabel";
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(28, 15);
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 12;
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 13;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -372,20 +384,20 @@
             this._NO_TRANSLATE_ColorAuthoredRevisions.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorAuthoredRevisions.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorAuthoredRevisions.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorAuthoredRevisions.Location = new System.Drawing.Point(287, 292);
+            this._NO_TRANSLATE_ColorAuthoredRevisions.Location = new System.Drawing.Point(287, 308);
             this._NO_TRANSLATE_ColorAuthoredRevisions.Name = "_NO_TRANSLATE_ColorAuthoredRevisions";
             this._NO_TRANSLATE_ColorAuthoredRevisions.Size = new System.Drawing.Size(28, 15);
-            this._NO_TRANSLATE_ColorAuthoredRevisions.TabIndex = 16;
+            this._NO_TRANSLATE_ColorAuthoredRevisions.TabIndex = 17;
             this._NO_TRANSLATE_ColorAuthoredRevisions.Text = "Red";
             this._NO_TRANSLATE_ColorAuthoredRevisions.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 292);
+            this.label1.Location = new System.Drawing.Point(6, 308);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(124, 13);
-            this.label1.TabIndex = 15;
+            this.label1.TabIndex = 16;
             this.label1.Text = "Color authored revisions";
             // 
             // _NO_TRANSLATE_ColorOtherLabel
@@ -394,29 +406,29 @@
             this._NO_TRANSLATE_ColorOtherLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorOtherLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorOtherLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(287, 263);
+            this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(287, 279);
             this._NO_TRANSLATE_ColorOtherLabel.Name = "_NO_TRANSLATE_ColorOtherLabel";
             this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(28, 15);
-            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 14;
+            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 15;
             this._NO_TRANSLATE_ColorOtherLabel.Text = "Red";
             this._NO_TRANSLATE_ColorOtherLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label36
             // 
             this.label36.AutoSize = true;
-            this.label36.Location = new System.Drawing.Point(6, 263);
+            this.label36.Location = new System.Drawing.Point(6, 279);
             this.label36.Name = "label36";
             this.label36.Size = new System.Drawing.Size(86, 13);
-            this.label36.TabIndex = 13;
+            this.label36.TabIndex = 14;
             this.label36.Text = "Color other label";
             // 
             // label25
             // 
             this.label25.AutoSize = true;
-            this.label25.Location = new System.Drawing.Point(6, 178);
+            this.label25.Location = new System.Drawing.Point(6, 194);
             this.label25.Name = "label25";
             this.label25.Size = new System.Drawing.Size(51, 13);
-            this.label25.TabIndex = 7;
+            this.label25.TabIndex = 8;
             this.label25.Text = "Color tag";
             // 
             // _NO_TRANSLATE_ColorTagLabel
@@ -425,10 +437,10 @@
             this._NO_TRANSLATE_ColorTagLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorTagLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorTagLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(287, 178);
+            this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(287, 194);
             this._NO_TRANSLATE_ColorTagLabel.Name = "_NO_TRANSLATE_ColorTagLabel";
             this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(28, 15);
-            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 8;
+            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 9;
             this._NO_TRANSLATE_ColorTagLabel.Text = "Red";
             this._NO_TRANSLATE_ColorTagLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
@@ -438,20 +450,20 @@
             this._NO_TRANSLATE_ColorBranchLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorBranchLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this._NO_TRANSLATE_ColorBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
-            this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(287, 206);
+            this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(287, 222);
             this._NO_TRANSLATE_ColorBranchLabel.Name = "_NO_TRANSLATE_ColorBranchLabel";
             this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(28, 15);
-            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 10;
+            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 11;
             this._NO_TRANSLATE_ColorBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
             // 
             // label32
             // 
             this.label32.AutoSize = true;
-            this.label32.Location = new System.Drawing.Point(6, 206);
+            this.label32.Location = new System.Drawing.Point(6, 222);
             this.label32.Name = "label32";
             this.label32.Size = new System.Drawing.Size(68, 13);
-            this.label32.TabIndex = 9;
+            this.label32.TabIndex = 10;
             this.label32.Text = "Color branch";
             // 
             // gbDiffView
@@ -466,7 +478,7 @@
             this.gbDiffView.Controls.Add(this.label31);
             this.gbDiffView.Controls.Add(this.label29);
             this.gbDiffView.Controls.Add(this._NO_TRANSLATE_ColorAddedLineLabel);
-            this.gbDiffView.Location = new System.Drawing.Point(3, 331);
+            this.gbDiffView.Location = new System.Drawing.Point(3, 349);
             this.gbDiffView.Name = "gbDiffView";
             this.gbDiffView.Size = new System.Drawing.Size(387, 173);
             this.gbDiffView.TabIndex = 2;
@@ -648,5 +660,6 @@
         private System.Windows.Forms.CheckBox HighlightAuthoredRevisions;
         private System.Windows.Forms.Label _NO_TRANSLATE_ColorAuthoredRevisions;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.CheckBox chkDrawAlternateBackColor;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -56,6 +56,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             MulticolorBranches.Checked = AppSettings.MulticolorBranches;
             MulticolorBranches_CheckedChanged(null, null);
 
+            chkDrawAlternateBackColor.Checked = AppSettings.RevisionGraphDrawAlternateBackColor;
             DrawNonRelativesGray.Checked = AppSettings.RevisionGraphDrawNonRelativesGray;
             DrawNonRelativesTextGray.Checked = AppSettings.RevisionGraphDrawNonRelativesTextGray;
             BranchBorders.Checked = AppSettings.BranchBorders;
@@ -64,51 +65,40 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             _NO_TRANSLATE_ColorGraphLabel.BackColor = AppSettings.GraphColor;
             _NO_TRANSLATE_ColorGraphLabel.Text = AppSettings.GraphColor.Name;
-            _NO_TRANSLATE_ColorGraphLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorGraphLabel.BackColor);
+            _NO_TRANSLATE_ColorGraphLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorGraphLabel.BackColor);
             _NO_TRANSLATE_ColorTagLabel.BackColor = AppSettings.TagColor;
             _NO_TRANSLATE_ColorTagLabel.Text = AppSettings.TagColor.Name;
-            _NO_TRANSLATE_ColorTagLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorTagLabel.BackColor);
+            _NO_TRANSLATE_ColorTagLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorTagLabel.BackColor);
             _NO_TRANSLATE_ColorBranchLabel.BackColor = AppSettings.BranchColor;
             _NO_TRANSLATE_ColorBranchLabel.Text = AppSettings.BranchColor.Name;
-            _NO_TRANSLATE_ColorBranchLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorBranchLabel.BackColor);
+            _NO_TRANSLATE_ColorBranchLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorBranchLabel.BackColor);
             _NO_TRANSLATE_ColorRemoteBranchLabel.BackColor = AppSettings.RemoteBranchColor;
             _NO_TRANSLATE_ColorRemoteBranchLabel.Text = AppSettings.RemoteBranchColor.Name;
-            _NO_TRANSLATE_ColorRemoteBranchLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemoteBranchLabel.BackColor);
+            _NO_TRANSLATE_ColorRemoteBranchLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemoteBranchLabel.BackColor);
             _NO_TRANSLATE_ColorOtherLabel.BackColor = AppSettings.OtherTagColor;
             _NO_TRANSLATE_ColorOtherLabel.Text = AppSettings.OtherTagColor.Name;
-            _NO_TRANSLATE_ColorOtherLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorOtherLabel.BackColor);
+            _NO_TRANSLATE_ColorOtherLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorOtherLabel.BackColor);
 
             _NO_TRANSLATE_ColorAddedLineLabel.BackColor = AppSettings.DiffAddedColor;
             _NO_TRANSLATE_ColorAddedLineLabel.Text = AppSettings.DiffAddedColor.Name;
-            _NO_TRANSLATE_ColorAddedLineLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineLabel.BackColor);
+            _NO_TRANSLATE_ColorAddedLineLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineLabel.BackColor);
             _NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor = AppSettings.DiffAddedExtraColor;
             _NO_TRANSLATE_ColorAddedLineDiffLabel.Text = AppSettings.DiffAddedExtraColor.Name;
-            _NO_TRANSLATE_ColorAddedLineDiffLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor);
+            _NO_TRANSLATE_ColorAddedLineDiffLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor);
 
             _NO_TRANSLATE_ColorRemovedLine.BackColor = AppSettings.DiffRemovedColor;
             _NO_TRANSLATE_ColorRemovedLine.Text = AppSettings.DiffRemovedColor.Name;
-            _NO_TRANSLATE_ColorRemovedLine.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemovedLine.BackColor);
+            _NO_TRANSLATE_ColorRemovedLine.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemovedLine.BackColor);
             _NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor = AppSettings.DiffRemovedExtraColor;
             _NO_TRANSLATE_ColorRemovedLineDiffLabel.Text = AppSettings.DiffRemovedExtraColor.Name;
-            _NO_TRANSLATE_ColorRemovedLineDiffLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor);
+            _NO_TRANSLATE_ColorRemovedLineDiffLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor);
             _NO_TRANSLATE_ColorSectionLabel.BackColor = AppSettings.DiffSectionColor;
             _NO_TRANSLATE_ColorSectionLabel.Text = AppSettings.DiffSectionColor.Name;
-            _NO_TRANSLATE_ColorSectionLabel.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorSectionLabel.BackColor);
+            _NO_TRANSLATE_ColorSectionLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorSectionLabel.BackColor);
 
             _NO_TRANSLATE_ColorAuthoredRevisions.BackColor = AppSettings.AuthoredRevisionsColor;
             _NO_TRANSLATE_ColorAuthoredRevisions.Text = AppSettings.AuthoredRevisionsColor.Name;
-            _NO_TRANSLATE_ColorAuthoredRevisions.ForeColor =
-                ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAuthoredRevisions.BackColor);
+            _NO_TRANSLATE_ColorAuthoredRevisions.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorAuthoredRevisions.BackColor);
 
             string iconColor = AppSettings.IconColor.ToLower();
             DefaultIcon.Checked = iconColor == "default";
@@ -127,6 +117,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             AppSettings.MulticolorBranches = MulticolorBranches.Checked;
+            AppSettings.RevisionGraphDrawAlternateBackColor = chkDrawAlternateBackColor.Checked;
             AppSettings.RevisionGraphDrawNonRelativesGray = DrawNonRelativesGray.Checked;
             AppSettings.RevisionGraphDrawNonRelativesTextGray = DrawNonRelativesTextGray.Checked;
             AppSettings.BranchBorders = BranchBorders.Checked;
@@ -228,12 +219,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void ColorLabel_Click(object sender, EventArgs e)
         {
-            PickColor((Label) sender);
+            PickColor((Label)sender);
         }
 
         private void PickColor(Control targetColorControl)
         {
-            using (var colorDialog = new ColorDialog {Color = targetColorControl.BackColor})
+            using (var colorDialog = new ColorDialog { Color = targetColorControl.BackColor })
             {
                 colorDialog.ShowDialog(this);
                 targetColorControl.BackColor = colorDialog.Color;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -105,7 +105,7 @@ namespace GitUI
         /// </summary>
         private IEnumerable<IGitRef> LatestRefs
         {
-            get { return _LatestRefs;  }
+            get { return _LatestRefs; }
             set
             {
                 _LatestRefs = value;
@@ -371,12 +371,12 @@ namespace GitUI
             {
                 _quickSearchLabel
                     = new Label
-                          {
-                              Location = new Point(10, 10),
-                              BorderStyle = BorderStyle.FixedSingle,
-                              ForeColor = SystemColors.InfoText,
-                              BackColor = SystemColors.Info
-                          };
+                    {
+                        Location = new Point(10, 10),
+                        BorderStyle = BorderStyle.FixedSingle,
+                        ForeColor = SystemColors.InfoText,
+                        BackColor = SystemColors.Info
+                    };
                 Controls.Add(_quickSearchLabel);
             }
 
@@ -1509,27 +1509,21 @@ namespace GitUI
             {
                 cellBackgroundBrush = _authoredRevisionsBrush;
             }
+            else if (ShouldRenderAlternateBackColor(e.RowIndex))
+            {
+                cellBackgroundBrush = new SolidBrush(ColorHelper.MakeColorDarker(e.CellStyle.BackColor));
+                // TODO if default background is nearly black, we should make it lighter instead
+            }
             else
             {
-                if (e.RowIndex % 2 == 0)
-                {
-                    //e.Graphics.FillRectangle(Brushes.White, e.CellBounds);
-                    cellBackgroundBrush = new SolidBrush(e.CellStyle.BackColor);
-                }
-                else
-                {
-                    //Brush brush = new SolidBrush(Color.FromArgb(255, 240, 240, 240));
-                    //e.Graphics.FillRectangle(brush, e.CellBounds);
-                    cellBackgroundBrush = new SolidBrush(ColorHelper.MakeColorDarker(e.CellStyle.BackColor));
-                    // TODO if default background is nearly black, we should make it lighter instead
-                }
+                cellBackgroundBrush = new SolidBrush(e.CellStyle.BackColor);
             }
             // Draw cell background
             e.Graphics.FillRectangle(cellBackgroundBrush, e.CellBounds);
             Color? backColor = null;
             if (cellBackgroundBrush is SolidBrush)
                 backColor = (cellBackgroundBrush as SolidBrush).Color;
-            
+
             // Draw graphics column
             if (e.ColumnIndex == graphColIndex)
             {
@@ -1725,8 +1719,6 @@ namespace GitUI
                             authorText = string.Empty;
                         }
 
-
-
                         e.Graphics.DrawString(authorText, rowFont, foreBrush,
                                               new PointF(gravatarLeft + gravatarSize + 5, gravatarTop + 6));
                         e.Graphics.DrawString(timeText, rowFont, foreBrush,
@@ -1778,6 +1770,11 @@ namespace GitUI
             return AppSettings.HighlightAuthoredRevisions &&
                    AuthorEmailEqualityComparer.Instance.Equals(revision.AuthorEmail,
                                                                _revisionHighlighting.AuthorEmailToHighlight);
+        }
+
+        private bool ShouldRenderAlternateBackColor(int rowIndex)
+        {
+            return AppSettings.RevisionGraphDrawAlternateBackColor && rowIndex % 2 == 0;
         }
 
         private float DrawRef(DrawRefArgs drawRefArgs, float offset, string name, Color headColor, ArrowType arrowType, bool dashedLine = false, bool fill = false)
@@ -2471,9 +2468,9 @@ namespace GitUI
             set
             {
                 _AmbiguousRefs = value;
-            }            
+            }
         }
-            
+
         private string GetRefUnambiguousName(IGitRef gitRef)
         {
             if (AmbiguousRefs.Contains(gitRef.Name))
@@ -2728,7 +2725,7 @@ namespace GitUI
             }
             else
             {
-                unstageCount ="";
+                unstageCount = "";
                 stageCount = "";
             }
 


### PR DESCRIPTION
Fixes #3810.

Changes proposed in this pull request:
 - alternate back color (zebra) can be turned off, if desired
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/33818079-19bd847c-de97-11e7-9cf4-c85ba1c0dcad.png)

How did I test this code: manualy

Has been tested on (remove any that don't apply):
 - Windows 8.1
