### PR TITLE
Pad fields in RevisionHeader with spaces instead of tabs

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>

--- a/GitExtUtils/GitUI/UIExtensions.cs
+++ b/GitExtUtils/GitUI/UIExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
 
 namespace GitUI
 {
@@ -19,6 +21,20 @@ namespace GitUI
                 chx.CheckState = Checked.Value ? CheckState.Checked : CheckState.Unchecked;
             else
                 chx.CheckState = CheckState.Indeterminate;
+        }
+
+        public static bool IsFixedWidth(this Font ft, Graphics g)
+        {
+            char[] charSizes = { 'i', 'a', 'Z', '%', '#', 'a', 'B', 'l', 'm', ',', '.' };
+            float charWidth = g.MeasureString("I", ft).Width;
+
+            bool fixedWidth = true;
+
+            foreach (char c in charSizes)
+                if (Math.Abs(g.MeasureString(c.ToString(), ft).Width - charWidth) > float.Epsilon)
+                    fixedWidth = false;
+
+            return fixedWidth;
         }
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -36,6 +37,10 @@ namespace GitUI.CommitInfo
             {
                 _sortedRefs = null;
             };
+
+            using (Graphics g = CreateGraphics())
+                if (!AppSettings.Font.IsFixedWidth(g))
+                    _RevisionHeader.Font = new Font(FontFamily.GenericMonospace, AppSettings.Font.Size);
         }
 
         [DefaultValue(false)]
@@ -138,7 +143,6 @@ namespace GitUI.CommitInfo
             if (string.IsNullOrEmpty(_revision.Guid))
                 return; //is it regular case or should throw an exception
 
-            _RevisionHeader.SelectionTabs = GetRevisionHeaderTabStops();
             _RevisionHeader.Text = string.Empty;
             _RevisionHeader.Refresh();
             string error = "";
@@ -160,7 +164,8 @@ namespace GitUI.CommitInfo
             _RevisionHeader.SetXHTMLText(commitInformation.Header);
             _RevisionHeader.Height = GetRevisionHeaderHeight();
             _revisionInfo = commitInformation.Body;
-            updateText();
+
+            UpdateRevisionInfo();
             LoadAuthorImage(data.Author ?? data.Committer);
 
             if (AppSettings.CommitInfoShowContainedInBranches)
@@ -171,36 +176,6 @@ namespace GitUI.CommitInfo
 
             if (AppSettings.CommitInfoShowContainedInTags)
                 ThreadPool.QueueUserWorkItem(_ => loadTagInfo(_revision.Guid));
-        }
-
-        /// <summary>
-        /// Returns an array of strings contains titles of fields field returned by GetHeader.
-        /// Used to calculate layout in advance
-        /// </summary>
-        /// <returns></returns>
-        private static string[] GetPossibleHeaders()
-        {
-            return new string[]
-                   {
-                       Strings.GetAuthorText(), Strings.GetAuthorDateText(), Strings.GetCommitterText(),
-                       Strings.GetCommitDateText(), Strings.GetCommitHashText(), Strings.GetChildrenText(),
-                       Strings.GetParentsText()
-                   };
-        }
-
-        private int[] _revisionHeaderTabStops;
-        private int[] GetRevisionHeaderTabStops()
-        {
-            if (_revisionHeaderTabStops != null)
-                return _revisionHeaderTabStops;
-            int tabStop = 0;
-            foreach (string s in GetPossibleHeaders())
-            {
-                tabStop = Math.Max(tabStop, TextRenderer.MeasureText(s + "  ", _RevisionHeader.Font).Width);
-            }
-            // simulate a two column layout even when there's more then one tab used
-            _revisionHeaderTabStops = new int[] { tabStop, tabStop + 1, tabStop + 2, tabStop + 3 };
-            return _revisionHeaderTabStops;
         }
 
         private int GetRevisionHeaderHeight()
@@ -214,13 +189,13 @@ namespace GitUI.CommitInfo
         private void loadSortedRefs()
         {
             _sortedRefs = Module.GetSortedRefs();
-            this.InvokeAsync(updateText);
+            this.InvokeAsync(UpdateRevisionInfo);
         }
 
         private void loadAnnotatedTagInfo(GitRevision revision)
         {
             _annotatedTagsMessages = GetAnnotatedTagsMessages(revision);
-            this.InvokeAsync(updateText);
+            this.InvokeAsync(UpdateRevisionInfo);
         }
 
         private IDictionary<string, string> GetAnnotatedTagsMessages(GitRevision revision)
@@ -272,7 +247,7 @@ namespace GitUI.CommitInfo
         private void loadTagInfo(string revision)
         {
             _tags = Module.GetAllTagsWhichContainGivenCommit(revision).ToList();
-            this.InvokeAsync(updateText);
+            this.InvokeAsync(UpdateRevisionInfo);
         }
 
 
@@ -285,7 +260,7 @@ namespace GitUI.CommitInfo
             bool getRemote = AppSettings.CommitInfoShowContainedInBranchesRemote ||
                              AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
             _branches = Module.GetAllBranchesWhichContainGivenCommit(revision, getLocal, getRemote).ToList();
-            this.InvokeAsync(updateText);
+            this.InvokeAsync(UpdateRevisionInfo);
         }
 
         private void loadLinksForRevision(GitRevision revision)
@@ -294,7 +269,7 @@ namespace GitUI.CommitInfo
                 return;
 
             _linksInfo = GetLinksForRevision(revision);
-            this.InvokeAsync(updateText);
+            this.InvokeAsync(UpdateRevisionInfo);
         }
 
         private class ItemTpComparer : IComparer<string>
@@ -364,7 +339,7 @@ namespace GitUI.CommitInfo
             DisplayAvatarSetup(false);
         }
 
-        private void updateText()
+        private void UpdateRevisionInfo()
         {
             if (_sortedRefs != null)
             {
@@ -446,7 +421,7 @@ namespace GitUI.CommitInfo
             _annotatedTagsMessages = null;
             _tags = null;
             _linkFactory.Clear();
-            updateText();
+            UpdateRevisionInfo();
             gravatar1.Visible = AppSettings.ShowAuthorGravatar;
             if (AppSettings.ShowAuthorGravatar)
             {

--- a/UnitTests/GitCommandsTests/CommitInformationTest.cs
+++ b/UnitTests/GitCommandsTests/CommitInformationTest.cs
@@ -36,12 +36,12 @@ namespace GitCommandsTests
                           "Notes (p4notes):\n" +
                           "\tP4@547123";
 
-            var expectedHeader = "Author:\t\t<a href='mailto:John.Doe@test.com'>John Doe (Acme Inc) &lt;John.Doe@test.com&gt;</a>" + Environment.NewLine +
-                                 "Author date:\t3 days ago (" + LocalizationHelpers.GetFullDateString(authorTime) + ")" + Environment.NewLine +
-                                 "Committer:\t<a href='mailto:Jane.Doe@test.com'>Jane Doe (Acme Inc) &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
-                                 "Commit date:\t2 days ago (" + LocalizationHelpers.GetFullDateString(commitTime) + ")" + Environment.NewLine +
-                                 "Commit hash:\t" + commitGuid + Environment.NewLine +
-                                 "Parent(s):\t<a href='gitext://gotocommit/" + parentGuid1 + "'>" + parentGuid1.Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + parentGuid2 + "'>" + parentGuid2.Substring(0, 10) + "</a>";
+            var expectedHeader = "Author:      <a href='mailto:John.Doe@test.com'>John Doe (Acme Inc) &lt;John.Doe@test.com&gt;</a>" + Environment.NewLine +
+                                 "Author date: 3 days ago (" + LocalizationHelpers.GetFullDateString(authorTime) + ")" + Environment.NewLine +
+                                 "Committer:   <a href='mailto:Jane.Doe@test.com'>Jane Doe (Acme Inc) &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
+                                 "Commit date: 2 days ago (" + LocalizationHelpers.GetFullDateString(commitTime) + ")" + Environment.NewLine +
+                                 "Commit hash: " + commitGuid + Environment.NewLine +
+                                 "Parent(s):   <a href='gitext://gotocommit/" + parentGuid1 + "'>" + parentGuid1.Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + parentGuid2 + "'>" + parentGuid2.Substring(0, 10) + "</a>";
 
             var expectedBody = "\nI made a really neato change." + Environment.NewLine + Environment.NewLine +
                                "Notes (p4notes):" + Environment.NewLine +


### PR DESCRIPTION
* Mono didn't implement SelectionTabs for RichTextBox, so tabs aren't an option
* Monospaced font has to be used for the text, otherwise the padding won't work

 Credits go to @Carbenium, originally proposed in https://github.com/gitextensions/gitextensions/pull/3099

Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/33871263-e06391b0-df65-11e7-9815-e35346ba4ee3.png)
![image](https://user-images.githubusercontent.com/4403806/33871274-edb92f46-df65-11e7-95ad-7f64cdeb42e8.png)


How did I test this code: manually

Has been tested on (remove any that don't apply):
 - Windows 10
 - Ubuntu 17.04
