### PR TITLE
fix: Commands are duplicated in GE Gitcommand log

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -151,14 +151,19 @@ namespace GitCommands
             var startInfo = CreateProcessStartInfo(fileName, arguments, workingDirectory, outputEncoding);
             var startProcess = Process.Start(startInfo);
             startProcess.EnableRaisingEvents = true;
-            startProcess.Exited += (sender, args) =>
+
+            EventHandler processExited = null;
+            processExited = (sender, args) =>
             {
+                startProcess.Exited -= processExited;
+
                 string quotedCmd = fileName;
                 if (quotedCmd.IndexOf(' ') != -1)
                     quotedCmd = quotedCmd.Quote();
                 var executionEndTimestamp = DateTime.Now;
                 AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp);
             };
+            startProcess.Exited += processExited;
 
             return startProcess;
         }


### PR DESCRIPTION
Fixes #4213
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/33831731-5b4093b8-decd-11e7-9b4c-5cdf0edb9e5b.png)

How did I test this code: manually

Has been tested on (remove any that don't apply):
 - GIT 2.14
 - Windows 8 
