### PR TITLE
fix: Creating new local branch triggers updating submodules

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -337,6 +337,8 @@ namespace GitUI.CommandsDialogs
                     UICommands.StashSave(owner, AppSettings.IncludeUntrackedFilesInAutoStash);
             }
 
+            var originalHash = Module.GetCurrentCheckout();
+
             ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
 
             if (UICommands.StartCommandLineProcessDialog(cmd, owner))
@@ -367,7 +369,11 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                UICommands.UpdateSubmodules(this);
+                var currentHash = Module.GetCurrentCheckout();
+                if (!string.Equals(originalHash, currentHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    UICommands.UpdateSubmodules(this);
+                }
 
                 ScriptManager.RunEventScripts(this, ScriptEvent.AfterCheckout);
 

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -44,24 +44,27 @@ namespace GitUI.CommandsDialogs
             try
             {
                 var commitHash = commitPickerSmallControl1.SelectedCommitHash;
-
                 if (commitHash.IsNullOrEmpty())
                 {
                     MessageBox.Show(this, _noRevisionSelectedMsgBox.Text, _noRevisionSelectedMsgBoxCaption.Text);
                     return;
                 }
 
+                var originalHash = Module.GetCurrentCheckout();
                 ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
 
                 string command = GitCommandHelpers.CheckoutCmd(commitHash, Force.Checked ? LocalChangesAction.Reset : 0);
-                FormProcess.ShowDialog(this, command);
-
-                UICommands.UpdateSubmodules(this);
+                if (FormProcess.ShowDialog(this, command))
+                {
+                    if (!string.Equals(commitHash, originalHash, StringComparison.OrdinalIgnoreCase))
+                    {
+                        UICommands.UpdateSubmodules(this);
+                    }
+                }
 
                 ScriptManager.RunEventScripts(this, ScriptEvent.AfterCheckout);
 
                 DialogResult = DialogResult.OK;
-
                 Close();
             }
             catch (Exception ex)

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -86,8 +86,14 @@ namespace GitUI.CommandsDialogs
             Ok.Focus();
 
             string commitGuid = commitPickerSmallControl1.SelectedCommitHash;
-            var branchName = BranchNameTextBox.Text.Trim();
+            if (commitGuid == null)
+            {
+                MessageBox.Show(this, _noRevisionSelected.Text, Text);
+                DialogResult = DialogResult.None;
+                return;
+            }
 
+            var branchName = BranchNameTextBox.Text.Trim();
             if (branchName.IsNullOrWhiteSpace())
             {
                 MessageBox.Show(_branchNameIsEmpty.Text, Text);
@@ -100,13 +106,10 @@ namespace GitUI.CommandsDialogs
                 DialogResult = DialogResult.None;
                 return;
             }
+
             try
             {
-                if (commitGuid == null)
-                {
-                    MessageBox.Show(this, _noRevisionSelected.Text, Text);
-                    return;
-                }
+                var originalHash = Module.GetCurrentCheckout();
 
                 string cmd;
                 if (Orphan.Checked)
@@ -125,7 +128,7 @@ namespace GitUI.CommandsDialogs
                     FormProcess.ShowDialog(this, cmd);
                 }
 
-                if (wasSuccessFul && chkbxCheckoutAfterCreate.Checked)
+                if (wasSuccessFul && chkbxCheckoutAfterCreate.Checked && !string.Equals(commitGuid, originalHash, StringComparison.OrdinalIgnoreCase))
                 {
                     UICommands.UpdateSubmodules(this);
                 }

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -64,9 +64,14 @@ namespace GitUI.HelperDialogs
             {
                 if (MessageBox.Show(this, resetHardWarning.Text, resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
                 {
-                    FormProcess.ShowDialog(this, GitCommandHelpers.ResetHardCmd(Revision.Guid));
-
-                    UICommands.UpdateSubmodules(this);
+                    var originalHash = Module.GetCurrentCheckout();
+                    if (FormProcess.ShowDialog(this, GitCommandHelpers.ResetHardCmd(Revision.Guid)))
+                    {
+                        if (!string.Equals(originalHash, Revision.Guid, StringComparison.OrdinalIgnoreCase))
+                        {
+                            UICommands.UpdateSubmodules(this);
+                        }
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Create or checkout branch or revision for the already checked out revision no longer triggers submodule update.
Fixes #3899

How did I test this code: manuallly
Has been tested on (remove any that don't apply):
 - GIT 2.13 and above
 - Windows 8
