### PR TITLE
Change the display name for Bitbucket Server plugin

### DIFF
--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -13,7 +13,7 @@ namespace Bitbucket
 
         public BitbucketPlugin()
         {
-            SetNameAndDescription("Create Bitbucket Pull Request");
+            SetNameAndDescription("Bitbucket Server");
             Translate();
         }
 


### PR DESCRIPTION
Use the product name instead of a description on one of the tasks is does (that is translated)
Clarify that the plugin is for Bitbucket Server only, a completely different API from Bitbucket Cloud

Part of #4204 

Screenshots before and after (if PR changes UI):
- Screenshot before #4210 was merged, sorted earlier in the list now
![image](https://user-images.githubusercontent.com/6248932/33962690-aa98de9e-e052-11e7-8037-2a49b30023dc.png)

-
![image](https://user-images.githubusercontent.com/6248932/33962592-5b15992a-e052-11e7-9c7e-6ef78102b305.png)

-
