### PR TITLE
Bitbucket basic functionality #4204

### DIFF
--- a/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
@@ -687,6 +687,8 @@
             this.Controls.Add(this.tabControl1);
             this.Name = "BitbucketPullRequestForm";
             this.Text = "Create Pull Request";
+            this.Load += BitbucketPullRequestFormLoad;
+            this.Load += BitbucketViewPullRequestFormLoad;
             ((System.ComponentModel.ISupportInitialize)(this.ReviewersDataGrid)).EndInit();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -7,6 +7,7 @@ using GitUIPluginInterfaces;
 using System.Linq;
 using System.Threading;
 using ResourceManager;
+using GitCommands;
 
 namespace Bitbucket
 {
@@ -33,6 +34,8 @@ namespace Bitbucket
             _plugin = plugin;
             _settingsContainer = settings;
             _gitUiCommands = gitUiCommands;
+            //TODO Retrieve all users and set default reviewers
+            ReviewersDataGrid.Visible = false;
         }
 
         private void BitbucketPullRequestFormLoad(object sender, EventArgs e)
@@ -160,6 +163,7 @@ namespace Bitbucket
             }
             return list;
         }
+
         Dictionary<Repository, IEnumerable<string>> Branches = new Dictionary<Repository,IEnumerable<string>>();
         private IEnumerable<string> GetBitbucketBranches(Repository selectedRepo)
         {
@@ -206,7 +210,10 @@ namespace Bitbucket
         private void RefreshDDLBranch(ComboBox comboBox, object selectedValue)
         {
             List<string> lsNames = (GetBitbucketBranches((Repository)selectedValue)).ToList();
-            lsNames.Sort();
+            if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
+            {
+                lsNames.Sort();
+            }
             lsNames.Insert(0, "");
             comboBox.DataSource = lsNames;
         }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -207,15 +207,15 @@ namespace Bitbucket
             RefreshDDLBranch(ddlBranchTarget, ((ComboBox)sender).SelectedValue);
         }
 
-        private void RefreshDDLBranch(ComboBox comboBox, object selectedValue)
+        private void RefreshDDLBranch(ComboBox branchComboBox, object selectedValue)
         {
-            List<string> lsNames = (GetBitbucketBranches((Repository)selectedValue)).ToList();
+            List<string> branchNames = (GetBitbucketBranches((Repository)selectedValue)).ToList();
             if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
             {
-                lsNames.Sort();
+                branchNames.Sort();
             }
-            lsNames.Insert(0, "");
-            comboBox.DataSource = lsNames;
+            branchNames.Insert(0, "");
+            branchComboBox.DataSource = branchNames;
         }
 
         private void DdlBranchSourceSelectedValueChanged(object sender, EventArgs e)

--- a/Plugins/Bitbucket/Settings.cs
+++ b/Plugins/Bitbucket/Settings.cs
@@ -26,7 +26,7 @@ namespace Bitbucket
             var module = ((GitModule)gitModule);
 
             var remotes = module.GetRemotes()
-                .Select(r => module.GetSetting(string.Format(SettingKeyString.RemoteUrl, r)))
+                .Where(s => !string.IsNullOrWhiteSpace(s)).Distinct().Select(r => module.GetSetting(string.Format(SettingKeyString.RemoteUrl, r)))
                 .ToArray();
 
             foreach (var url in remotes)

--- a/Plugins/Bitbucket/Settings.cs
+++ b/Plugins/Bitbucket/Settings.cs
@@ -26,7 +26,9 @@ namespace Bitbucket
             var module = ((GitModule)gitModule);
 
             var remotes = module.GetRemotes()
-                .Where(s => !string.IsNullOrWhiteSpace(s)).Distinct().Select(r => module.GetSetting(string.Format(SettingKeyString.RemoteUrl, r)))
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct()
+                .Select(r => module.GetSetting(string.Format(SettingKeyString.RemoteUrl, r)))
                 .ToArray();
 
             foreach (var url in remotes)


### PR DESCRIPTION
The Bitbucket plugin had no functionality, because the load functions were never called. I have not tested old versions, but do not see when this last could have worked
The functionality is quite OK. The plugin can especially be used to see what branches to compare. Most reviewing should probably still be done in the Bitbucket web UI

I have done a few other tweaks:
 * Sort the branches in the same way as Browse branches. Default by last usage, possibly by name (previously the default)
 * Hidden the Reviewers form. The form was never filled with users or used (should have the default reviewers by default)


Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/33963779-78e90cbc-e056-11e7-893a-525dff4506a4.png)


How did I test this code:
 - Bitbucket server required
 - Created pull request
 - Viewed existing PRs
 - Approved PRs

Has been tested on (remove any that don't apply):
 - Windows 7
