### PR TITLE
Patch grid: scroll to next to apply line

### DIFF
--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using PatchApply;
 using ResourceManager;
@@ -32,10 +34,18 @@ namespace GitUI
 
         public void Initialize()
         {
+            IList<PatchFile> patchFiles;
+
             if (Module.InTheMiddleOfInteractiveRebase())
-                Patches.DataSource = Module.GetInteractiveRebasePatchFiles();
+                Patches.DataSource = patchFiles = Module.GetInteractiveRebasePatchFiles();
             else
-                Patches.DataSource = Module.GetRebasePatchFiles();
+                Patches.DataSource = patchFiles = Module.GetRebasePatchFiles();
+
+            if (patchFiles.Any())
+            {
+                int rowsInView = Patches.DisplayedRowCount(false);
+                Patches.FirstDisplayedScrollingRowIndex = Math.Max(0, patchFiles.TakeWhile(pf => !pf.IsNext).Count() - rowsInView / 2);
+            }
         }
 
         private void Patches_DoubleClick(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #4233  .

Changes proposed in this pull request:
Scroll patch grid so the next to apply patch is visible, when possible in the middle of the view so previous and next patches are visible

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
