### PR TITLE
Save putty key during clone

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -37,6 +37,7 @@ namespace GitUI.CommandsDialogs
         private bool openedFromProtocolHandler;
         private readonly string url;
         private EventHandler<GitModuleEventArgs> GitModuleChanged;
+        private string _puttySshKey;
         private readonly IList<string> _defaultBranchItems;
 
         // for translation only
@@ -200,6 +201,13 @@ namespace GitUI.CommandsDialogs
 
                 Repositories.AddMostRecentRepository(dirTo);
 
+                if (!String.IsNullOrEmpty(_puttySshKey))
+                {
+                    var clonedGitModule = new GitModule(dirTo);
+                    clonedGitModule.SetSetting(string.Format(SettingKeyString.RemotePuttySshKey, "origin"), _puttySshKey);
+                    clonedGitModule.LocalConfigFile.Save();
+                }
+
                 if (openedFromProtocolHandler && AskIfNewRepositoryShouldBeOpened(dirTo))
                 {
                     Hide();
@@ -273,7 +281,7 @@ namespace GitUI.CommandsDialogs
 
         private void LoadSshKeyClick(object sender, EventArgs e)
         {
-            BrowseForPrivateKey.BrowseAndLoad(this);
+            _puttySshKey = BrowseForPrivateKey.BrowseAndLoad(this);
         }
 
         private void FormCloneLoad(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #4235 .

Changes proposed in this pull request:
 - Currently specifying a putty key file during cloning it it not saved to the .git/config of the clone repostory. This PR changes this.

 How did I test this code:
 - Cloned a repository from github using a putty key file from the gitextensions browse form
 - Not sure how to test Explorer shell extension path


Has been tested on (remove any that don't apply):
 - GIT 2.14
 - Windows 10
