### PR TITLE
Change text in settings for artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -356,7 +356,7 @@
             this.chkShowCurrentChangesInRevisionGraph.Name = "chkShowCurrentChangesInRevisionGraph";
             this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(337, 17);
             this.chkShowCurrentChangesInRevisionGraph.TabIndex = 2;
-            this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes in revision graph";
+            this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes as an artificial commit";
             this.chkShowCurrentChangesInRevisionGraph.UseVisualStyleBackColor = true;
             // 
             // label12

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7175,7 +7175,7 @@ global settings.
         <target />
       </trans-unit>
       <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes in revision graph</source>
+        <source>Show current working directory changes as an artificial commit</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">


### PR DESCRIPTION
Part of #4031
(Only #4209 remains)

Changes proposed in this pull request:
 - Change settings text to better explain the functionality
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/34084656-8ceb50a4-e384-11e7-864c-838dd7a245db.png)


Has been tested on (remove any that don't apply):
 - Windows 7 and above
