### PR TITLE
Activate artificial commits by default #4033

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -615,7 +615,7 @@ namespace GitCommands
 
         public static bool RevisionGraphShowWorkingDirChanges
         {
-            get => GetBool("revisiongraphshowworkingdirchanges", false);
+            get => GetBool("revisiongraphshowworkingdirchanges", true);
             set => SetBool("revisiongraphshowworkingdirchanges", value);
         }
 

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -371,8 +371,8 @@ namespace GitCommands
 
         public static bool ShowGitStatusForArtificialCommits
         {
-            get => GetBool("showgitstatusForArtificialCommits", true);
-            set => SetBool("showgitstatusForArtificialCommits", value);
+            get => GetBool("showgitstatusforartificialcommits", true);
+            set => SetBool("showgitstatusforartificialcommits", value);
         }
 
         public static bool CommitInfoShowContainedInBranches => CommitInfoShowContainedInBranchesLocal ||

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -369,6 +369,12 @@ namespace GitCommands
             set => SetBool("showgitstatusinbrowsetoolbar", value);
         }
 
+        public static bool ShowGitStatusForArtificialCommits
+        {
+            get => GetBool("showgitstatusForArtificialCommits", true);
+            set => SetBool("showgitstatusForArtificialCommits", value);
+        }
+
         public static bool CommitInfoShowContainedInBranches => CommitInfoShowContainedInBranchesLocal ||
                                                                 CommitInfoShowContainedInBranchesRemote ||
                                                                 CommitInfoShowContainedInBranchesRemoteIfNoLocal;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -193,7 +193,11 @@ namespace GitUI.CommandsDialogs
 
             Translate();
 
-            if (AppSettings.ShowGitStatusInBrowseToolbar)
+            // Activation of the control requires restart of Browse, limit also deactivation for consistency
+            bool countToolbar = AppSettings.ShowGitStatusInBrowseToolbar;
+            bool countArtificial = AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowWorkingDirChanges;
+
+            if (countToolbar || countArtificial)
             {
                 _toolStripGitStatus = new ToolStripMenuItem
                 {
@@ -225,7 +229,7 @@ namespace GitUI.CommandsDialogs
                     var status = e.ItemStatuses.ToList();
                     _toolStripGitStatus.Image = commitIconProvider.GetCommitIcon(status);
 
-                    if (status.Count == 0)
+                    if (status.Count == 0 || !countToolbar)
                     {
                         _toolStripGitStatus.Text = _commitButtonText.Text;
                     }
@@ -234,7 +238,10 @@ namespace GitUI.CommandsDialogs
                         _toolStripGitStatus.Text = string.Format(_commitButtonText + " ({0})", status.Count.ToString());
                     }
 
-                    RevisionGrid.UpdateArtificialCommitCount(status);
+                    if (countArtificial)
+                    {
+                        RevisionGrid.UpdateArtificialCommitCount(status);
+                    }
 
                     // The diff filelist is not updated, as the selected diff is unset
                     ////_revisionDiff.RefreshArtificial();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -316,7 +316,7 @@
             this.chkCheckForUncommittedChangesInCheckoutBranch.Location = new System.Drawing.Point(3, 95);
             this.chkCheckForUncommittedChangesInCheckoutBranch.Name = "chkCheckForUncommittedChangesInCheckoutBranch";
             this.chkCheckForUncommittedChangesInCheckoutBranch.Size = new System.Drawing.Size(303, 17);
-            this.chkCheckForUncommittedChangesInCheckoutBranch.TabIndex = 5;
+            this.chkCheckForUncommittedChangesInCheckoutBranch.TabIndex = 6;
             this.chkCheckForUncommittedChangesInCheckoutBranch.Text = "Check for uncommitted changes in checkout branch dialog";
             this.chkCheckForUncommittedChangesInCheckoutBranch.UseVisualStyleBackColor = true;
             // 
@@ -338,7 +338,7 @@
             this.chkShowGitStatusForArtificialCommits.Location = new System.Drawing.Point(3, 3);
             this.chkShowGitStatusForArtificialCommits.Name = "chkShowGitStatusForArtificialCommits";
             this.chkShowGitStatusForArtificialCommits.Size = new System.Drawing.Size(451, 17);
-            this.chkShowGitStatusForArtificialCommits.TabIndex = 1;
+            this.chkShowGitStatusForArtificialCommits.TabIndex = 2;
             this.chkShowGitStatusForArtificialCommits.Text = "Show number of changed files for artificial commits (restart required)";
             this.chkShowGitStatusForArtificialCommits.UseVisualStyleBackColor = true;
             // 
@@ -348,7 +348,7 @@
             this.chkShowStashCountInBrowseWindow.Location = new System.Drawing.Point(3, 72);
             this.chkShowStashCountInBrowseWindow.Name = "chkShowStashCountInBrowseWindow";
             this.chkShowStashCountInBrowseWindow.Size = new System.Drawing.Size(266, 17);
-            this.chkShowStashCountInBrowseWindow.TabIndex = 4;
+            this.chkShowStashCountInBrowseWindow.TabIndex = 5;
             this.chkShowStashCountInBrowseWindow.Text = "Show stash count on status bar in browse window";
             this.chkShowStashCountInBrowseWindow.UseVisualStyleBackColor = true;
             // 
@@ -358,7 +358,7 @@
             this.chkUseFastChecks.Location = new System.Drawing.Point(3, 49);
             this.chkUseFastChecks.Name = "chkUseFastChecks";
             this.chkUseFastChecks.Size = new System.Drawing.Size(274, 17);
-            this.chkUseFastChecks.TabIndex = 3;
+            this.chkUseFastChecks.TabIndex = 4;
             this.chkUseFastChecks.Text = "Use FileSystemWatcher to check if index is changed";
             this.chkUseFastChecks.UseVisualStyleBackColor = true;
             // 
@@ -368,7 +368,7 @@
             this.chkShowCurrentChangesInRevisionGraph.Location = new System.Drawing.Point(3, 26);
             this.chkShowCurrentChangesInRevisionGraph.Name = "chkShowCurrentChangesInRevisionGraph";
             this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(337, 17);
-            this.chkShowCurrentChangesInRevisionGraph.TabIndex = 2;
+            this.chkShowCurrentChangesInRevisionGraph.TabIndex = 3;
             this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes as an artificial commit";
             this.chkShowCurrentChangesInRevisionGraph.UseVisualStyleBackColor = true;
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.Designer.cs
@@ -47,6 +47,7 @@
             this.tableLayoutPanelPerformance = new System.Windows.Forms.TableLayoutPanel();
             this.chkCheckForUncommittedChangesInCheckoutBranch = new System.Windows.Forms.CheckBox();
             this.chkShowGitStatusInToolbar = new System.Windows.Forms.CheckBox();
+            this.chkShowGitStatusForArtificialCommits = new System.Windows.Forms.CheckBox();
             this.chkShowStashCountInBrowseWindow = new System.Windows.Forms.CheckBox();
             this.chkUseFastChecks = new System.Windows.Forms.CheckBox();
             this.chkShowCurrentChangesInRevisionGraph = new System.Windows.Forms.CheckBox();
@@ -287,13 +288,14 @@
             this.tableLayoutPanelPerformance.ColumnCount = 2;
             this.tableLayoutPanelPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanelPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 4);
+            this.tableLayoutPanelPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 5);
             this.tableLayoutPanelPerformance.Controls.Add(this.chkShowGitStatusInToolbar, 0, 0);
-            this.tableLayoutPanelPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 3);
-            this.tableLayoutPanelPerformance.Controls.Add(this.chkUseFastChecks, 0, 2);
-            this.tableLayoutPanelPerformance.Controls.Add(this.chkShowCurrentChangesInRevisionGraph, 0, 1);
-            this.tableLayoutPanelPerformance.Controls.Add(this.label12, 0, 6);
-            this.tableLayoutPanelPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 6);
+            this.tableLayoutPanelPerformance.Controls.Add(this.chkShowGitStatusForArtificialCommits, 0, 1);
+            this.tableLayoutPanelPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 4);
+            this.tableLayoutPanelPerformance.Controls.Add(this.chkUseFastChecks, 0, 3);
+            this.tableLayoutPanelPerformance.Controls.Add(this.chkShowCurrentChangesInRevisionGraph, 0, 2);
+            this.tableLayoutPanelPerformance.Controls.Add(this.label12, 0, 7);
+            this.tableLayoutPanelPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 7);
             this.tableLayoutPanelPerformance.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanelPerformance.Location = new System.Drawing.Point(3, 17);
             this.tableLayoutPanelPerformance.Name = "tableLayoutPanelPerformance";
@@ -328,6 +330,17 @@
             this.chkShowGitStatusInToolbar.TabIndex = 1;
             this.chkShowGitStatusInToolbar.Text = "Show number of changed files on commit button (restart required)";
             this.chkShowGitStatusInToolbar.UseVisualStyleBackColor = true;
+            // 
+            // chkShowGitStatusForArtificialCommits
+            // 
+            this.chkShowGitStatusForArtificialCommits.AutoSize = true;
+            this.tableLayoutPanelPerformance.SetColumnSpan(this.chkShowGitStatusForArtificialCommits, 2);
+            this.chkShowGitStatusForArtificialCommits.Location = new System.Drawing.Point(3, 3);
+            this.chkShowGitStatusForArtificialCommits.Name = "chkShowGitStatusForArtificialCommits";
+            this.chkShowGitStatusForArtificialCommits.Size = new System.Drawing.Size(451, 17);
+            this.chkShowGitStatusForArtificialCommits.TabIndex = 1;
+            this.chkShowGitStatusForArtificialCommits.Text = "Show number of changed files for artificial commits (restart required)";
+            this.chkShowGitStatusForArtificialCommits.UseVisualStyleBackColor = true;
             // 
             // chkShowStashCountInBrowseWindow
             // 
@@ -553,6 +566,7 @@
         private System.Windows.Forms.GroupBox groupBoxPerformance;
         private System.Windows.Forms.CheckBox chkCheckForUncommittedChangesInCheckoutBranch;
         private System.Windows.Forms.CheckBox chkShowGitStatusInToolbar;
+        private System.Windows.Forms.CheckBox chkShowGitStatusForArtificialCommits;
         private System.Windows.Forms.CheckBox chkShowCurrentChangesInRevisionGraph;
         private System.Windows.Forms.CheckBox chkUseFastChecks;
         private System.Windows.Forms.CheckBox chkShowStashCountInBrowseWindow;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
@@ -37,6 +37,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowCurrentChangesInRevisionGraph.Checked = AppSettings.RevisionGraphShowWorkingDirChanges;
             chkShowStashCountInBrowseWindow.Checked = AppSettings.ShowStashCount;
             chkShowGitStatusInToolbar.Checked = AppSettings.ShowGitStatusInBrowseToolbar;
+            chkShowGitStatusForArtificialCommits.Checked = AppSettings.ShowGitStatusForArtificialCommits;
             SmtpServer.Text = AppSettings.SmtpServer;
             SmtpServerPort.Text = AppSettings.SmtpPort.ToString();
             chkUseSSL.Checked = AppSettings.SmtpUseSsl;
@@ -57,6 +58,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.IncludeUntrackedFilesInAutoStash = chkStashUntrackedFiles.Checked;
             AppSettings.FollowRenamesInFileHistory = chkFollowRenamesInFileHistory.Checked;
             AppSettings.ShowGitStatusInBrowseToolbar = chkShowGitStatusInToolbar.Checked;
+            AppSettings.ShowGitStatusForArtificialCommits = chkShowGitStatusForArtificialCommits.Checked;
             AppSettings.SmtpServer = SmtpServer.Text;
             if (int.TryParse(SmtpServerPort.Text, out var port))
             {

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8842,7 +8842,7 @@ When OpenSSH is used, command line dialogs are shown!
         <target />
       </trans-unit>
       <trans-unit id="_currentUnstagedChanges.Text">
-        <source>Current unstaged changes</source>
+        <source>Working directory</source>
         <target />
       </trans-unit>
       <trans-unit id="_dateText.Text">

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1843,6 +1843,12 @@ namespace GitUI
                         offset = DrawRef(drawRefArgs, offset, gitRefName, headColor, arrowType, true, false);
                     }
 
+                    if (revision.IsArtificial)
+                    {
+                        drawRefArgs.RefsFont = new Font(drawRefArgs.RefsFont, FontStyle.Italic);
+                        rowFont = new Font(rowFont, FontStyle.Italic);
+                    }
+
                     if (IsCardLayout())
                     {
                         offset = baseOffset;
@@ -1891,12 +1897,24 @@ namespace GitUI
                         e.Graphics.DrawString(timeText, rowFont, foreBrush,
                                               new PointF(gravatarLeft + gravatarSize + 5, e.CellBounds.Bottom - textHeight - 4));
                     }
+
+                    if (revision.IsArtificial)
+                    {
+                        // Get offset for "count" text
+                        SizeF textSize = drawRefArgs.Graphics.MeasureString(text, rowFont);
+
+                        offset += 1 + textSize.Width;
+                        offset = DrawRef(drawRefArgs, offset, revision.Subject, AppSettings.BranchColor, ArrowType.None, false, true);
+                    }
                 }
                 else if (columnIndex == authorColIndex)
                 {
-                    var text = (string)e.FormattedValue;
-                    e.Graphics.DrawString(text, rowFont, foreBrush,
-                                          new PointF(e.CellBounds.Left, e.CellBounds.Top + 4));
+                    if (!revision.IsArtificial)
+                    {
+                        var text = (string)e.FormattedValue;
+                        e.Graphics.DrawString(text, rowFont, foreBrush,
+                                              new PointF(e.CellBounds.Left, e.CellBounds.Top + 4));
+                    }
                 }
                 else if (columnIndex == dateColIndex)
                 {
@@ -2037,7 +2055,14 @@ namespace GitUI
             }
             else if (columnIndex == messageColIndex)
             {
-                e.Value = revision.SubjectCount + revision.Subject;
+                if (revision.IsArtificial)
+                {
+                    e.Value = revision.SubjectCount;
+                }
+                else
+                {
+                    e.Value = revision.Subject;
+                }
             }
             else if (columnIndex == authorColIndex)
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1843,12 +1843,6 @@ namespace GitUI
                         offset = DrawRef(drawRefArgs, offset, gitRefName, headColor, arrowType, true, false);
                     }
 
-                    if (revision.IsArtificial)
-                    {
-                        drawRefArgs.RefsFont = new Font(drawRefArgs.RefsFont, FontStyle.Italic);
-                        rowFont = new Font(rowFont, FontStyle.Italic);
-                    }
-
                     if (IsCardLayout())
                     {
                         offset = baseOffset;

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -111,7 +111,7 @@ namespace ResourceManager
         private readonly TranslationString _messageText    = new TranslationString("Message");
         private readonly TranslationString _parentsText    = new TranslationString("Parent(s)");
         private readonly TranslationString _childrenText   = new TranslationString("Children");
-        private readonly TranslationString _currentUnstagedChanges = new TranslationString("Current unstaged changes");
+        private readonly TranslationString _currentUnstagedChanges = new TranslationString("Working directory");
         private readonly TranslationString _currentIndex   = new TranslationString("Commit index");
         private readonly TranslationString _loadingData    = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");


### PR DESCRIPTION
As #4031 is more or less merged, I suggest this setting is enabled by default
Only affects new installations

Changes proposed in this pull request:
 - Setting default value for "Show current working directory changes as an artificial commit" to be enabled by default  
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/37246358-301f7e08-24a8-11e8-8339-683aa990e0c1.png)

Has been tested on (remove any that don't apply):
 - Windows 7 and above
