### PR TITLE
4250 fix unable to remove the file to be replaced

### DIFF
--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -1,23 +1,21 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
 using GitCommands.Utils;
 
 namespace GitCommands.Settings
 {
     public abstract class FileSettingsCache : SettingsCache
     {
-        private const double SAVETIME = 2000;
-        private DateTime? LastFileRead = null;
-        private DateTime LastFileModificationDate = DateTime.MaxValue;
-        private DateTime? LastModificationDate = null;
+        private const double SaveTime = 2000;
+        private DateTime? _lastFileRead;
+        private DateTime _lastFileModificationDate = DateTime.MaxValue;
+        private DateTime? _lastModificationDate;
         private readonly FileSystemWatcher _fileWatcher = new FileSystemWatcher();
-        private bool canEnableFileWatcher = false;
+        private readonly bool _canEnableFileWatcher;
 
-        private System.Timers.Timer SaveTimer = new System.Timers.Timer(SAVETIME);
-        private bool _autoSave = true;
+        private System.Timers.Timer _saveTimer = new System.Timers.Timer(SaveTime);
+        private readonly bool _autoSave;
 
         public string SettingsFilePath { get; private set; }
 
@@ -26,9 +24,9 @@ namespace GitCommands.Settings
             SettingsFilePath = aSettingsFilePath;
             _autoSave = autoSave;
 
-            SaveTimer.Enabled = false;
-            SaveTimer.AutoReset = false;
-            SaveTimer.Elapsed += new System.Timers.ElapsedEventHandler(OnSaveTimer);
+            _saveTimer.Enabled = false;
+            _saveTimer.AutoReset = false;
+            _saveTimer.Elapsed += OnSaveTimer;
 
             _fileWatcher.IncludeSubdirectories = false;
             _fileWatcher.EnableRaisingEvents = false;
@@ -40,15 +38,15 @@ namespace GitCommands.Settings
             {
                 _fileWatcher.Path = dir;
                 _fileWatcher.Filter = Path.GetFileName(SettingsFilePath);
-                canEnableFileWatcher = true;
-                _fileWatcher.EnableRaisingEvents = canEnableFileWatcher;
+                _canEnableFileWatcher = true;
+                _fileWatcher.EnableRaisingEvents = _canEnableFileWatcher;
             }
             FileChanged();
         }
 
         void _fileWatcher_Created(object sender, FileSystemEventArgs e)
         {
-            LastFileRead = null;
+            _lastFileRead = null;
             FileChanged();
         }
 
@@ -65,11 +63,11 @@ namespace GitCommands.Settings
             {
                 LockedAction(() =>
                 {
-                    if (SaveTimer != null)
+                    if (_saveTimer != null)
                     {
 
-                        SaveTimer.Dispose();
-                        SaveTimer = null;
+                        _saveTimer.Dispose();
+                        _saveTimer = null;
                         _fileWatcher.Changed -= _fileWatcher_Changed;
                         _fileWatcher.Renamed -= _fileWatcher_Renamed;
                         _fileWatcher.Created -= _fileWatcher_Created;
@@ -99,23 +97,24 @@ namespace GitCommands.Settings
         }
 
         private void FileChanged()
-        {           
-            LastFileModificationDate = GetLastFileModificationUTC();
+        {
+            _lastFileModificationDate = GetLastFileModificationUtc();
         }
 
-        private DateTime GetLastFileModificationUTC()
+        private DateTime GetLastFileModificationUtc()
         {
             try
             {
                 if (File.Exists(SettingsFilePath))
+                {
                     return File.GetLastWriteTimeUtc(SettingsFilePath);
-                else
-                    return DateTime.MaxValue;
+                }
             }
-            catch (Exception)
+            catch
             {
-                return DateTime.MaxValue;
+                // no-op
             }
+            return DateTime.MaxValue;
         }
 
         protected abstract void WriteSettings(string fileName);
@@ -125,8 +124,8 @@ namespace GitCommands.Settings
         {
             try
             {
-                if (!LastModificationDate.HasValue || (LastFileRead.HasValue
-                        && LastModificationDate.Value < LastFileRead.Value))
+                if (!_lastModificationDate.HasValue ||
+                    (_lastFileRead.HasValue && _lastModificationDate.Value < _lastFileRead.Value))
                 {
                     return;
                 }
@@ -142,15 +141,16 @@ namespace GitCommands.Settings
                 File.Copy(tmpFile, SettingsFilePath, true);
                 File.Delete(tmpFile);
 
-                LastFileModificationDate = GetLastFileModificationUTC();
-                LastFileRead = DateTime.UtcNow;
-                if (SaveTimer != null)
-                    _fileWatcher.EnableRaisingEvents = canEnableFileWatcher;
+                _lastFileModificationDate = GetLastFileModificationUtc();
+                _lastFileRead = DateTime.UtcNow;
+                if (_saveTimer != null)
+                {
+                    _fileWatcher.EnableRaisingEvents = _canEnableFileWatcher;
+                }
             }
-
             catch (IOException e)
             {
-                System.Diagnostics.Debug.WriteLine(e.Message);
+                Debug.WriteLine(e.Message);
                 throw;
             }
         }
@@ -162,32 +162,32 @@ namespace GitCommands.Settings
                 try
                 {
                     ReadSettings(SettingsFilePath);
-                    LastFileRead = DateTime.UtcNow;
-                    _fileWatcher.EnableRaisingEvents = canEnableFileWatcher;
+                    _lastFileRead = DateTime.UtcNow;
+                    _fileWatcher.EnableRaisingEvents = _canEnableFileWatcher;
                 }
                 catch (IOException e)
                 {
-                    System.Diagnostics.Debug.WriteLine(e.Message);
+                    Debug.WriteLine(e.Message);
                     throw;
                 }
             }
             else
             {
-                LastFileRead = DateTime.UtcNow;
-                LastFileModificationDate = LastFileRead.Value;
+                _lastFileRead = DateTime.UtcNow;
+                _lastFileModificationDate = _lastFileRead.Value;
             }
         }
 
         protected override bool NeedRefresh()
         {
-            return !LastFileRead.HasValue || LastFileModificationDate > LastFileRead.Value;
+            return !_lastFileRead.HasValue || _lastFileModificationDate > _lastFileRead.Value;
         }
 
         protected override void SettingsChanged()
         {
             base.SettingsChanged();
 
-            LastModificationDate = DateTime.UtcNow;
+            _lastModificationDate = DateTime.UtcNow;
 
             if (_autoSave)
                 StartSaveTimer();
@@ -204,12 +204,12 @@ namespace GitCommands.Settings
         private void StartSaveTimer()
         {
             //Resets timer so that the last call will let the timer event run and will cause the settings to be saved.
-            SaveTimer.Stop();
-            SaveTimer.AutoReset = true;
-            SaveTimer.Interval = SAVETIME;
-            SaveTimer.AutoReset = false;
+            _saveTimer.Stop();
+            _saveTimer.AutoReset = true;
+            _saveTimer.Interval = SaveTime;
+            _saveTimer.AutoReset = false;
 
-            SaveTimer.Start();
+            _saveTimer.Start();
         }
     }
 }

--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -125,24 +125,22 @@ namespace GitCommands.Settings
         {
             try
             {
-                var tmpFile = SettingsFilePath + ".tmp";
-
                 if (!LastModificationDate.HasValue || (LastFileRead.HasValue
                         && LastModificationDate.Value < LastFileRead.Value))
                 {
                     return;
                 }
 
+                var tmpFile = SettingsFilePath + ".tmp";
                 WriteSettings(tmpFile);
 
                 if (File.Exists(SettingsFilePath))
                 {
-                    File.Replace(tmpFile, SettingsFilePath, SettingsFilePath + ".backup", true);
+                    var backupName = SettingsFilePath + ".backup";
+                    File.Copy(SettingsFilePath, backupName, true);
                 }
-                else
-                {
-                    File.Move(tmpFile, SettingsFilePath);
-                }
+                File.Copy(tmpFile, SettingsFilePath, true);
+                File.Delete(tmpFile);
 
                 LastFileModificationDate = GetLastFileModificationUTC();
                 LastFileRead = DateTime.UtcNow;


### PR DESCRIPTION
Whenever <repo>/.gitconfig file gets updated there is a chance that the update would fail.
The issue is intermittent and may only happen on I/O-incapacitated systems (i.e. virtualised environment with McAfee AV).

The problem seems to be caused by `File.Replace` API. The code is refactored not to use it.

Fixes #4250

How did I test this code: manually

Has been tested on (remove any that don't apply):
 - GIT 2.12 and above
 - Windows 8.1
