### PR TITLE
fix: "View Stash" throws AOORE

### DIFF
--- a/GitCommands/Git/GitStash.cs
+++ b/GitCommands/Git/GitStash.cs
@@ -1,27 +1,29 @@
 ﻿using System;
 
-namespace GitCommands
+namespace GitCommands.Git
 {
     /// <summary>Stored local modifications.</summary>
     public class GitStash
     {
+        /// <summary>"stash@{i}"</summary>
+        private const string NameFormat = "stash@{{{0}}}";
+        private readonly string _stash;
+
+
         /// <summary>Name of the stash. <remarks>Usually, "stash@{n}"</remarks></summary>
         public string Name { get; set; }
         /// <summary>Short description of the commit the stash was based on.</summary>
         public string Message { get; set; }
         /// <summary>Gets the index of the stash in the list.</summary>
         public int Index { get; set; }
-        readonly string _stash;
 
-        /// <summary>"stash@{i}"</summary>
-        const string NameFormat = "stash@{{{0}}}";
 
         /// <summary>Initializes a new <see cref="GitStash"/> with all properties null.</summary>
         public GitStash(string stash)
         {
             if (string.IsNullOrWhiteSpace(stash))
             {
-                throw new ArgumentException("Stash has NO characters.", "stash");
+                throw new ArgumentException("stash");
             }
             _stash = stash;
         }
@@ -43,6 +45,7 @@ namespace GitCommands
                 Message = stash.Substring(msgStart).Trim();
             }
         }
+
 
         public override string ToString() { return Message; }
 

--- a/GitCommands/Git/GitStash.cs
+++ b/GitCommands/Git/GitStash.cs
@@ -9,19 +9,12 @@ namespace GitCommands
         public string Name { get; set; }
         /// <summary>Short description of the commit the stash was based on.</summary>
         public string Message { get; set; }
-        /// <summary>Name of the branch that was current when the stash was made.</summary>
-        public string Branch { get; set; }
         /// <summary>Gets the index of the stash in the list.</summary>
         public int Index { get; set; }
         readonly string _stash;
 
         /// <summary>"stash@{i}"</summary>
         const string NameFormat = "stash@{{{0}}}";
-        const string DefaultFormat = "WIP on ";
-        const string CustomFormat = "On ";
-        const string AutostashFormat = "autostash";
-        static int DefaultFormatLength = DefaultFormat.Length;
-        static int CustomFormatLength = CustomFormat.Length;
 
         /// <summary>Initializes a new <see cref="GitStash"/> with all properties null.</summary>
         public GitStash(string stash)
@@ -36,7 +29,6 @@ namespace GitCommands
         public GitStash(string stash, int i)
             : this(stash)
         {
-
             // "stash@{i}: WIP on {branch}: {PreviousCommitMiniSHA} {PreviousCommitMessage}"
             // "stash@{i}: On {branch}: {Message}"
             // "stash@{i}: autostash"
@@ -49,18 +41,7 @@ namespace GitCommands
             if (msgStart < stash.Length)
             {
                 Message = stash.Substring(msgStart).Trim();
-                if(Message != AutostashFormat)
-                    FindBranch();
             }
-        }
-
-        void FindBranch()
-        {
-            int trimLength = Message.StartsWith(DefaultFormat)
-                ? DefaultFormatLength // "WIP on "
-                : CustomFormatLength;//  "On "
-            var branchStart = Message.Remove(0, trimLength);// "{branch}: {SHA} {msg}"
-            Branch = branchStart.Substring(0, branchStart.IndexOf(':'));
         }
 
         public override string ToString() { return Message; }

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -1,4 +1,5 @@
 using System.Windows.Forms;
+using GitCommands.Git;
 using GitUI.Editor;
 
 namespace GitUI.CommandsDialogs
@@ -69,7 +70,7 @@ namespace GitUI.CommandsDialogs
             // 
             // gitStashBindingSource
             // 
-            this.gitStashBindingSource.DataSource = typeof(GitCommands.GitStash);
+            this.gitStashBindingSource.DataSource = typeof(GitStash);
             // 
             // splitContainer1
             // 

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitUI.UserControls;
 using PatchApply;
 using ResourceManager;

--- a/UnitTests/GitCommandsTests/Git/GitStashTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitStashTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public class GitStashTests
+    {
+        [TestCase("stash@{0}: Very descriptive message", 0, "stash@{0}", "Very descriptive message")]
+        [TestCase("stash@{1}: On 4263_View_Stash_AOORE: Testing things", 1, "stash@{1}", "On 4263_View_Stash_AOORE: Testing things")]
+        [TestCase("stash@{2}: WIP on 4263_View_Stash_AOORE: a8348732f Merge pull request #4259 from RussKie/fix_4258_NRE_in_FormPull", 2, "stash@{2}", "WIP on 4263_View_Stash_AOORE: a8348732f Merge pull request #4259 from RussKie/fix_4258_NRE_in_FormPull")]
+        [TestCase("stash@{3}: WIP on master: Test", 3, "stash@{3}", "WIP on master: Test")]
+        public void Can_parse_stash_names(string rawStash, int index, string name, string message)
+        {
+            var stash = new GitStash(rawStash, index);
+
+            stash.Index.Should().Be(index);
+            stash.Message.Should().Be(message);
+            stash.Name.Should().Be(name);
+        }
+    }
+}
+

--- a/UnitTests/GitCommandsTests/Git/GitStashTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitStashTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using GitCommands;
+using GitCommands.Git;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Git

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
+    <Compile Include="Git\GitStashTests.cs" />
     <Compile Include="Git\Gpg\GitGpgControllerTests.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmdTests.cs" />
     <Compile Include="Git\RevisionDiffProviderTest.cs" />


### PR DESCRIPTION
As reported Eclipse does not follow the traditional git stash naming conventions and may use something like the following:

    stash@{2}: classpathModify

This caused GE to fail with ArgumentOutOfRange exception while trying to parse the branch information.

* GitStash.Branch property removed as it is not being used anywhere.
* Added basic tests

Fixes #4263 