### PR TITLE
fix: Tabcontrol dynamic tabs' content rendering

### DIFF
--- a/GitExtensions.VS2015.sln.DotSettings
+++ b/GitExtensions.VS2015.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1115,7 +1115,7 @@ namespace GitUI.CommandsDialogs
                 CommitInfoTabControl.SelectedIndexChanged -= CommitInfoTabControl_SelectedIndexChanged;
                 if (!revisions.Any() || GitRevision.IsArtificial(revisions[0].Guid))
                 {
-                    //Artificial commits cannot show tree (ls-tree) and has no commit info 
+                    //Artificial commits cannot show tree (ls-tree) and has no commit info
                     CommitInfoTabControl.RemoveIfExists(CommitInfoTabPage);
                     CommitInfoTabControl.RemoveIfExists(TreeTabPage);
                     CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
@@ -1123,15 +1123,27 @@ namespace GitUI.CommandsDialogs
                     if (_showRevisionInfoNextToRevisionGrid)
                     {
                         RevisionsSplitContainer.Panel2Collapsed = true;
-
                     }
+
+                    // Mono special - must re-select the tab for the content to render..
+                    CommitInfoTabControl.SelectedTab = null;
+                    CommitInfoTabControl.SelectedTab = DiffTabPage;
                 }
                 else
                 {
                     int i = 0;
                     if (!_showRevisionInfoNextToRevisionGrid)
                     {
+                        // Mono special - must re-select the tab for the content to render..
+                        if (!CommitInfoTabControl.TabPages.Contains(CommitInfoTabPage))
+                        {
+                            CommitInfoTabControl.SelectedTab = null;
+                        }
                         CommitInfoTabControl.InsertIfNotExists(i, CommitInfoTabPage);
+                        if (CommitInfoTabControl.SelectedTab == null)
+                        {
+                            CommitInfoTabControl.SelectedTab = CommitInfoTabPage;
+                        }
                         i++;
                     }
                     CommitInfoTabControl.InsertIfNotExists(i, TreeTabPage);


### PR DESCRIPTION
Added dynamic tabs have caused regression on Mono - tabs which aren't explicitly selected after being added do not render their content.
Relates to #4242

How did I test this code: manually

Has been tested on (remove any that don't apply):
 - GIT 2.11 
 - Ubuntu 17.04
 - Mono 5.2.0
