### PR TITLE
Amend issue template to require WHAT instead of HOW tests were done

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Screenshots before and after (if PR changes UI):
 -
 -
 
-How did I test this code:
+What did I do to test the code and ensure quality:
  - 
  - 
  - 


### PR DESCRIPTION
The original `How did I test this code` encourages the pull request author to answer the way how the tests were done, for example `Manually`, which doesn't provide value.

Feel free to reword as I'm not a native speaker.