### PR TITLE
fix: Do not hide tabs for artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1066,6 +1066,7 @@ namespace GitUI.CommandsDialogs
             {
                 return;
             }
+
             var revisions = RevisionGrid.GetSelectedRevisions();
             var revision = revisions.FirstOrDefault();
             if (revision == null)
@@ -1111,49 +1112,6 @@ namespace GitUI.CommandsDialogs
             try
             {
                 _selectedRevisionUpdatedTargets = UpdateTargets.None;
-
-                var revisions = RevisionGrid.GetSelectedRevisions();
-
-                CommitInfoTabControl.SelectedIndexChanged -= CommitInfoTabControl_SelectedIndexChanged;
-                if (!revisions.Any() || GitRevision.IsArtificial(revisions[0].Guid))
-                {
-                    //Artificial commits cannot show tree (ls-tree) and has no commit info 
-                    CommitInfoTabControl.RemoveIfExists(CommitInfoTabPage);
-                    CommitInfoTabControl.RemoveIfExists(TreeTabPage);
-                    CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
-
-                    if (_showRevisionInfoNextToRevisionGrid)
-                    {
-                        RevisionsSplitContainer.Panel2Collapsed = true;
-
-                    }
-                }
-                else
-                {
-                    int i = 0;
-                    if (!_showRevisionInfoNextToRevisionGrid)
-                    {
-                        CommitInfoTabControl.InsertIfNotExists(i, CommitInfoTabPage);
-                        i++;
-                    }
-                    CommitInfoTabControl.InsertIfNotExists(i, TreeTabPage);
-                    if (AppSettings.ShowGpgInformation.ValueOrDefault)
-                    {
-                        CommitInfoTabControl.InsertIfNotExists(i + 2, GpgInfoTabPage);
-                    }
-                    else
-                    {
-                        CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
-                    }
-
-                    if (_showRevisionInfoNextToRevisionGrid)
-                    {
-                        RevisionsSplitContainer.Panel2Collapsed = false;
-                    }
-                }
-                CommitInfoTabControl.SelectedIndexChanged += CommitInfoTabControl_SelectedIndexChanged;
-
-                //RevisionGrid.HighlightSelectedBranch();
 
                 FillFileTree();
                 FillDiff();
@@ -2090,7 +2048,7 @@ namespace GitUI.CommandsDialogs
             this.mergeBranchToolStripMenuItem.Enabled =
             this.rebaseToolStripMenuItem.Enabled =
             this.stashToolStripMenuItem.Enabled =
-              selectedRevisions.Count>0 && !Module.IsBareRepository();
+              selectedRevisions.Count > 0 && !Module.IsBareRepository();
 
             this.resetToolStripMenuItem.Enabled =
             this.checkoutBranchToolStripMenuItem.Enabled =

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -9,11 +9,11 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
 using GitCommands;
-using GitCommands.Utils;
 using GitCommands.GitExtLinks;
+using GitCommands.Utils;
+using GitUI.Editor;
 using GitUI.Editor.RichTextBoxExtension;
 using ResourceManager;
-using GitUI.Editor;
 using ResourceManager.CommitDataRenders;
 
 namespace GitUI.CommitInfo
@@ -411,8 +411,15 @@ namespace GitUI.CommitInfo
                     _branchInfo = GetBranchesWhichContainsThisCommit(_branches, ShowBranchesAsLinks);
                 }
             }
+
+            string body = _revisionInfo;
+            if (Revision != null && !Revision.IsArtificial())
+            {
+                body += "\n" + _annotatedTagsInfo + _linksInfo + _branchInfo + _tagInfo;
+            }
+
             RevisionInfo.SuspendLayout();
-            RevisionInfo.SetXHTMLText(_revisionInfo + "\n" + _annotatedTagsInfo + _linksInfo + _branchInfo + _tagInfo);
+            RevisionInfo.SetXHTMLText(body);
             RevisionInfo.SelectionStart = 0; //scroll up
             RevisionInfo.ScrollToCaret();    //scroll up
             RevisionInfo.ResumeLayout(true);

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using GitCommands.Git;
 using GitUI.BuildServerIntegration;
 using GitUI.CommandsDialogs;
@@ -2761,18 +2762,33 @@ namespace GitUI
                 stageCount = "";
             }
 
-            //Add working directory as virtual commit
+            var userName = Module.GetEffectiveSetting(SettingKeyString.UserName);
+            var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
+
+            // Add working directory as virtual commit
             var workingDir = new GitRevision(Module, GitRevision.UnstagedGuid)
             {
+                Author = userName,
+                AuthorDate = DateTime.MaxValue,
+                AuthorEmail = userEmail,
+                Committer = userName,
+                CommitDate = DateTime.MaxValue,
+                CommitterEmail = userEmail,
                 SubjectCount = unstageCount,
                 Subject = Strings.GetCurrentUnstagedChanges(),
                 ParentGuids = new[] { GitRevision.IndexGuid }
             };
             Revisions.Add(workingDir.Guid, workingDir.ParentGuids, DvcsGraph.DataType.Normal, workingDir);
 
-            //Add index as virtual commit
+            // Add index as virtual commit
             var index = new GitRevision(Module, GitRevision.IndexGuid)
             {
+                Author = userName,
+                AuthorDate = DateTime.MaxValue,
+                AuthorEmail = userEmail,
+                Committer = userName,
+                CommitDate = DateTime.MaxValue,
+                CommitterEmail = userEmail,
                 SubjectCount = stageCount,
                 Subject = Strings.GetCurrentIndex(),
                 ParentGuids = new[] { filtredCurrentCheckout }

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -208,6 +208,33 @@ namespace ResourceManagerTests.CommitDataRenders
             _labelFormatter.DidNotReceive().FormatLabel(Strings.GetCommitDateText(), Arg.Any<int>());
         }
 
+        [TestCase(GitRevision.IndexGuid)]
+        [TestCase(GitRevision.UnstagedGuid)]
+        public void Render_should_render_minimal_info_for_artificial_commits(string artificialGuid)
+        {
+            var author = "John Doe (Acme Inc) <John.Doe@test.com>";
+            var committer = author;
+            var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
+            var commitDate = authorDate;
+            var data = new CommitData(artificialGuid,
+                Guid.NewGuid().ToString("N"),
+                new ReadOnlyCollection<string>(new List<string> { "3b6ce324e30ed7fda24483fd56a180c34a262202", "2a8788ff15071a202505a96f80796dbff5750ddf", "8e66fa8095a86138a7c7fb22318d2f819669831e" }),
+                author, authorDate,
+                committer, commitDate, "");
+
+            _linkFactory.CreateLink(author, Arg.Any<string>()).Returns(x => author);
+
+            var result = _renderer.Render(data, false);
+
+            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Parent(s):     3b6ce324e3 2a8788ff15 8e66fa8095");
+            _labelFormatter.Received(1).FormatLabel(Strings.GetAuthorText(), Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(Strings.GetDateText(), Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(Strings.GetCommitHashText(), Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(Strings.GetAuthorDateText(), Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(Strings.GetCommitterText(), Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(Strings.GetCommitDateText(), Arg.Any<int>());
+        }
+
         [Test]
         public void RenderPlain_should_throw_if_data_null()
         {


### PR DESCRIPTION
Dynamically added/hidden tabs added implementation complexity, reduced UX and caused regressions under Mono.
Tabs now remain visible for artificial commits and provide minimal information.
Closes #4242 
Obsoletes #4254 #4273 
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/34346565-1b480990-ea4d-11e7-93fd-8a2b67b6b852.png)
![image](https://user-images.githubusercontent.com/4403806/34346570-296f8124-ea4d-11e7-9e7a-ee6ae815ebfc.png)
![image](https://user-images.githubusercontent.com/4403806/34346576-358da29c-ea4d-11e7-9a2d-73a6a47fbc24.png)

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10 and above
