### PR TITLE
Support build integration support for variables 

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Git\Tag\TagOperation.cs" />
     <Compile Include="Git\Tag\TagOperationExtensions.cs" />
     <Compile Include="Remote\GitRemoteManager.cs" />
+    <Compile Include="Remote\RepoNameExtractor.cs" />
     <Compile Include="Repository\RepositoryDescriptionProvider.cs" />
     <Compile Include="Settings\BranchOrdering.cs" />
     <Compile Include="Git\GitGpgController.cs" />

--- a/GitCommands/Remote/RepoNameExtractor.cs
+++ b/GitCommands/Remote/RepoNameExtractor.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using GitCommands.Config;
+using GitUIPluginInterfaces;
+
+namespace GitCommands.Remote
+{
+    public interface IRepoNameExtractor
+    {
+        /// <summary>
+        /// Get a "repo shortname" from the current repo URL
+        /// There is no official Git repo shortname, this is one possible definition:
+        ///  The filename without extension for the remote URL
+        /// This function could have been included in GitModule
+        /// </summary>
+        void Get(out string repoProject, out string repoName);
+    }
+
+    public sealed class RepoNameExtractor : IRepoNameExtractor
+    {
+        private readonly Func<IGitModule> _getModule;
+
+        public RepoNameExtractor(Func<IGitModule> getModule)
+        {
+            _getModule = getModule;
+        }
+
+        /// <summary>
+        /// Get a "repo shortname" from the current repo URL
+        /// There is no official Git repo shortname, this is one possible definition:
+        ///  The filename without extension for the remote URL
+        /// This function could have been included in GitModule
+        /// </summary>
+        public void Get(out string repoProject, out string repoName)
+        {
+            var module = _getModule();
+
+            // Extract "name of repo" from remote url
+            string remoteName = module.GetCurrentRemote();
+            if (remoteName.IsNullOrWhiteSpace())
+            {
+                // No remote for the branch, for instance a submodule. Use first remote.
+                var remotes = module.GetRemotes();
+                if (remotes.Length > 0)
+                {
+                    remoteName = remotes[0];
+                }
+            }
+
+            var remoteUrl = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remoteName));
+            repoName = Path.GetFileNameWithoutExtension(remoteUrl);
+            try
+            {
+                repoProject = Path.GetFileNameWithoutExtension(Path.GetDirectoryName(remoteUrl));
+            }
+            catch
+            {
+                repoProject = "";
+            }
+        }
+    }
+}

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -71,6 +71,7 @@ namespace AppVeyorIntegration
                 throw new InvalidOperationException("Already initialized");
             }
 
+            _buildServerWatcher = buildServerWatcher;
             _isCommitInRevisionGrid = isCommitInRevisionGrid;
             var accountName = config.GetString("AppVeyorAccountName", null);
             _accountToken = config.GetString("AppVeyorAccountToken", null);
@@ -86,7 +87,6 @@ namespace AppVeyorIntegration
                     && !string.IsNullOrWhiteSpace(_gitHubToken);
 
             _fetchBuilds = new HashSet<string>();
-            _buildServerWatcher = buildServerWatcher;
 
             _httpClientAppVeyor = GetHttpClient(WebSiteUrl, _accountToken);
 
@@ -97,7 +97,8 @@ namespace AppVeyorIntegration
             string[] projectNames = null;
             if (!useAllProjets)
             {
-                projectNames = projectNamesSetting.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+                projectNames = _buildServerWatcher.ReplaceVariables(projectNamesSetting)
+                    .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
             }
 
             if (Projects.Count == 0 ||

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -81,7 +81,8 @@ namespace JenkinsIntegration
 
                 UpdateHttpClientOptions(buildServerCredentials);
 
-                string[] projectUrls = projectName.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] projectUrls = _buildServerWatcher.ReplaceVariables(projectName)
+                    .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var projectUrl in projectUrls.Select(s => baseAdress + "job/" + s.Trim() + "/"))
                 {
                     AddGetBuildUrl(projectUrl);

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -110,7 +110,8 @@ namespace TeamCityIntegration
 
             _buildServerWatcher = buildServerWatcher;
 
-            ProjectNames = config.GetString("ProjectName", "").Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            ProjectNames = buildServerWatcher.ReplaceVariables(config.GetString("ProjectName", ""))
+                .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
 
             var buildIdFilerSetting = config.GetString("BuildIdFilter", "");
             if (!BuildServerSettingsHelper.IsRegexValid(buildIdFilerSetting))

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
@@ -60,7 +60,7 @@ namespace TfsIntegration
 
             _tfsServer = config.GetString("TfsServer", null);
             _tfsTeamCollectionName = config.GetString("TfsTeamCollectionName", null);
-            _projectName = config.GetString("ProjectName", null);
+            _projectName = _buildServerWatcher.ReplaceVariables(config.GetString("ProjectName", null));
             var tfsBuildDefinitionNameFilterSetting = config.GetString("TfsBuildDefinitionName", "");
             if (!BuildServerSettingsHelper.IsRegexValid(tfsBuildDefinitionNameFilterSetting))
             {

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerWatcher.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerWatcher.cs
@@ -7,5 +7,7 @@ namespace GitUIPluginInterfaces.BuildServerIntegration
         void LaunchBuildServerInfoFetchOperation();
 
         void CancelBuildStatusFetchOperation();
+
+        string ReplaceVariables(string projectNames);
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -122,6 +122,9 @@ namespace GitUIPluginInterfaces
         /// <returns>Registered remotes.</returns>
         string[] GetRemotes(bool allowEmpty);
 
+        /// <summary>Gets the remote of the current branch; or "" if no remote is configured.</summary>
+        string GetCurrentRemote();
+
         string GetSetting(string setting);
         string GetEffectiveSetting(string setting);
 

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="ExternalLinks\ExternalLinksManagerIntegrationTests.cs" />
     <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
+    <Compile Include="RepoNameExtractorTest.cs" />
     <Compile Include="GitModuleTest.cs" />
     <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />

--- a/UnitTests/GitCommandsTests/RepoNameExtractorTest.cs
+++ b/UnitTests/GitCommandsTests/RepoNameExtractorTest.cs
@@ -26,16 +26,29 @@ namespace GitCommandsTests
 
         // These test cases basically verifies Path.GetFileNameWithoutExtension(remoteUrl) and Path.GetFileNameWithoutExtension()
         [TestCase("origin", "https://github.com/project/repo.git", "project", "repo")]
-        [TestCase("origin", "file://github/project/repo.git", "project", "repo")]
-        [TestCase("origin", "https://github.com/extra/extra/project/repo.git", "project", "repo")]
+        [TestCase("origin1", "file://github/project/repo.git", "project", "repo")]
+        [TestCase("originx", "https://github.com/extra/extra/project/repo.git", "project", "repo")]
         [TestCase("", "https://github.com/project/repo.git", "project", "repo")]
         [TestCase("", null, null, null)]
         [TestCase(null, null, null, null)]
         [TestCase("remote", "https://github.com/project/", "project", "")]
         [TestCase("origin", "git@github.com/project/repo.git", "project", "repo")]
-        public void RepoNameExtractorTests(string remote, string url, string expProject, string expRepo)
+        public void RepoNameExtractorTest_ValidCurrentRemote(string remote, string url, string expProject, string expRepo)
         {
             _module.GetCurrentRemote().Returns(x => remote);
+            _module.GetRemotes().Returns(x => new[] { remote, "    ", "\t" });
+            _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote)).Returns(x => url);
+
+            _repoNameExtractor.Get(out string project, out string repo);
+            project.Should().Be(expProject);
+            repo.Should().Be(expRepo);
+        }
+
+        [TestCase("origin", "https://github.com/project/repo.git", "project", "repo")]
+        [TestCase("origin", "git@github.com/project/repo.git", "project", "repo")]
+        public void RepoNameExtractorTest_NoValidCurrentRemote(string remote, string url, string expProject, string expRepo)
+        {
+            _module.GetCurrentRemote().Returns("");
             _module.GetRemotes().Returns(x => new[] { remote, "    ", "\t" });
             _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote)).Returns(x => url);
 

--- a/UnitTests/GitCommandsTests/RepoNameExtractorTest.cs
+++ b/UnitTests/GitCommandsTests/RepoNameExtractorTest.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using GitCommands.Config;
+using GitCommands.Remote;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class RepoNameExtractorTest
+    {
+        private IGitModule _module;
+        private IConfigFileSettings _configFile;
+        private IRepoNameExtractor _repoNameExtractor;
+
+        [SetUp]
+        public void Setup()
+        {
+            _configFile = Substitute.For<IConfigFileSettings>();
+
+            _module = Substitute.For<IGitModule>();
+            _module.LocalConfigFile.Returns(_configFile);
+            _repoNameExtractor = new RepoNameExtractor(() => _module);
+        }
+
+        // These test cases basically verifies Path.GetFileNameWithoutExtension(remoteUrl) and Path.GetFileNameWithoutExtension()
+        [TestCase("origin", "https://github.com/project/repo.git", "project", "repo")]
+        [TestCase("origin", "file://github/project/repo.git", "project", "repo")]
+        [TestCase("origin", "https://github.com/extra/extra/project/repo.git", "project", "repo")]
+        [TestCase("", "https://github.com/project/repo.git", "project", "repo")]
+        [TestCase("", null, null, null)]
+        [TestCase(null, null, null, null)]
+        [TestCase("remote", "https://github.com/project/", "project", "")]
+        [TestCase("origin", "git@github.com/project/repo.git", "project", "repo")]
+        public void RepoNameExtractorTests(string remote, string url, string expProject, string expRepo)
+        {
+            _module.GetCurrentRemote().Returns(x => remote);
+            _module.GetRemotes().Returns(x => new[] { remote, "    ", "\t" });
+            _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote)).Returns(x => url);
+
+            _repoNameExtractor.Get(out string project, out string repo);
+            project.Should().Be(expProject);
+            repo.Should().Be(expRepo);
+        }
+    }
+}


### PR DESCRIPTION
%REPO_SHORTNAME%

From #4202

Changes proposed in this pull request:
Allow us of variables for the name of projects for build server integration. That makes it possible to have one global setup for many git repos.
 
Screenshots before and after (if PR changes UI):
- None

How did I test this code:
 - Together with #4279, mostly with the Jenkins plugin.
 - For logging-log4net repo, set the Jenkins project name to %REPO_SHORTNAME%

Has been tested on (remove any that don't apply):
 - Windows 7 and 10
