### PR TITLE
Exception when trying to load the delete tag form

### DIFF
--- a/GitUI/UserControls/RemotesComboboxControl.cs
+++ b/GitUI/UserControls/RemotesComboboxControl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GitCommands.Remote;
+using System.Linq;
 
 namespace GitUI.UserControls
 {
@@ -37,7 +38,7 @@ namespace GitUI.UserControls
             }
 
             var remoteManager = new GitRemoteManager(Module);
-            comboBoxRemotes.DataSource = remoteManager.LoadRemotes(false);
+            comboBoxRemotes.DataSource = remoteManager.LoadRemotes(false).Select(x => x.Name).ToList();
         }
     }
 }


### PR DESCRIPTION
Fixes #4283

Changes proposed in this pull request:
 - Fix the exception
 - Fill the remotes dropdown
 - 
 
Screenshots before and after (if PR changes UI):
- Before
![image](https://user-images.githubusercontent.com/596334/34414236-15f058ee-ec23-11e7-973f-968e03046f4e.png)
- After
![image](https://user-images.githubusercontent.com/596334/34414255-313aa6ae-ec23-11e7-925e-0ca9678beb4e.png)


What did I do to test the code and ensure quality:
 - Create a tag with a repo that has multiple remotes
 - Make sure the dropdown list has the remotes when trying to delete the tag

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10