### PR TITLE
fix: Remove index.lock when abort git operations

### DIFF
--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -172,17 +172,21 @@ namespace GitUI
 
         private void processAbort(FormStatus form)
         {
-            ConsoleOutput.KillProcess();
+            KillProcess();
         }
 
-        protected void KillGitCommand()
+        protected void KillProcess()
         {
             try
             {
                 ConsoleOutput.KillProcess();
+
+                var module = new GitModule(WorkingDirectory);
+                module.UnlockIndex(true);
             }
             catch
             {
+                // no-op
             }
         }
 

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -179,7 +179,9 @@ namespace GitUI
                         Reset();
                     }
                     else
-                        KillGitCommand();
+                    {
+                        KillProcess();
+                    }
                 }
             }
             base.DataReceived(sender, e);


### PR DESCRIPTION
Inspired by https://github.com/hiroponz/gitextensions/commit/e7c853c689bf925b3104141b62b7d07dd2e40848
Closes #1307
