### PR TITLE
fix: Non event script do not ask for confirmations

### DIFF
--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -51,15 +51,10 @@ namespace GitUI.Script
 
         public static void RunEventScripts(GitModuleForm form, ScriptEvent scriptEvent)
         {
-            foreach (ScriptInfo scriptInfo in GetScripts())
-                if (scriptInfo.Enabled && scriptInfo.OnEvent == scriptEvent)
-                {
-                    if (scriptInfo.AskConfirmation)
-                        if (MessageBox.Show(form, String.Format("Do you want to execute '{0}'?", scriptInfo.Name), "Script", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
-                            continue;
-
-                    ScriptRunner.RunScript(form, form.Module, scriptInfo.Name, null);
-                }
+            foreach (var scriptInfo in GetScripts().Where(scriptInfo => scriptInfo.Enabled && scriptInfo.OnEvent == scriptEvent))
+            {
+                ScriptRunner.RunScript(form, form.Module, scriptInfo.Name, null);
+            }
         }
 
         public static string SerializeIntoXml()
@@ -100,8 +95,8 @@ namespace GitUI.Script
             {
                 Scripts = new BindingList<ScriptInfo>();
                 DeserializeFromOldFormat(xml);
-                
-                Trace.WriteLine(ex.Message);                
+
+                Trace.WriteLine(ex.Message);
             }
         }
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -56,11 +56,12 @@ namespace GitUI.Script
                     continue;
                 if (revisionGrid != null)
                     continue;
-                MessageBox.Show(owner, 
+                MessageBox.Show(owner,
                     string.Format("Option {0} is only supported when started from revision grid.", option),
                     "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
+
             return RunScript(owner, aModule, scriptInfo, revisionGrid);
         }
 
@@ -78,8 +79,13 @@ namespace GitUI.Script
             return path;
         }
 
-        internal static bool RunScript(IWin32Window owner, GitModule aModule, ScriptInfo scriptInfo, RevisionGrid revisionGrid)
+        private static bool RunScript(IWin32Window owner, GitModule aModule, ScriptInfo scriptInfo, RevisionGrid revisionGrid)
         {
+            if (scriptInfo.AskConfirmation && DialogResult.No == MessageBox.Show(owner, String.Format("Do you want to execute '{0}'?", scriptInfo.Name), "Script", MessageBoxButtons.YesNo, MessageBoxIcon.Question))
+            {
+                return false;
+            }
+
             string originalCommand = scriptInfo.Command;
             string argument = scriptInfo.Arguments;
 
@@ -355,7 +361,7 @@ namespace GitUI.Script
         private static string ExpandCommandVariables(string originalCommand, GitModule aModule)
         {
             return originalCommand.Replace("{WorkingDir}", aModule.WorkingDir);
-           
+
         }
 
         private static GitRevision CalculateSelectedRevision(RevisionGrid revisionGrid, List<IGitRef> selectedRemoteBranches,


### PR DESCRIPTION
Previously only event scripts, if configured, asked for confirmation. Non event script would ignore the setting.

The confirmation logic has been moved so it applies to all types of scripts.

Fixes #1608

What did I do to test the code and ensure quality: run the app before and after the fix to verify that the confirmation is asked.

Has been tested on (remove any that don't apply):
 - GIT 2.13 and above
 - Windows 8