### PR TITLE
FileHistory: Show Blame tab also for artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -248,6 +248,7 @@ namespace GitUI.CommandsDialogs
                 RevisionInfo.DisplayAvatarOnRight();
                 CommitInfoTabControl.SuspendLayout();
                 CommitInfoTabControl.RemoveIfExists(CommitInfoTabPage);
+                //Move difftab to left
                 CommitInfoTabControl.RemoveIfExists(DiffTabPage);
                 CommitInfoTabControl.TabPages.Insert(0, DiffTabPage);
                 CommitInfoTabControl.SelectedTab = DiffTabPage;

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -70,7 +70,7 @@ namespace GitUI.CommandsDialogs
             Diff.ExtraDiffArgumentsChanged += DiffExtraDiffArgumentsChanged;
 
             bool isSubmodule = GitModule.IsValidGitWorkingDir(Path.Combine(Module.WorkingDir, FileName));
-            if (revision != null && revision.IsArtificial() || isSubmodule) //no blame for artificial
+            if (isSubmodule)
                 tabControl1.RemoveIfExists(BlameTab);
             FileChanges.SelectionChanged += FileChangesSelectionChanged;
             FileChanges.DisableContextMenu();
@@ -244,16 +244,6 @@ namespace GitUI.CommandsDialogs
             View.SaveCurrentScrollPos();
             Diff.SaveCurrentScrollPos();
 
-            var selectedRows = FileChanges.GetSelectedRevisions();
-            if (selectedRows.Count > 0)
-            {
-                bool isSubmodule = GitModule.IsValidGitWorkingDir(Path.Combine(Module.WorkingDir, FileName));
-                GitRevision revision = selectedRows[0];
-                if (revision.IsArtificial() || isSubmodule)
-                    tabControl1.RemoveIfExists(BlameTab);
-                else
-                    tabControl1.InsertIfNotExists(2, BlameTab);
-            }
             UpdateSelectedFileViewers();
         }
 


### PR DESCRIPTION
To be consistent with handling in #4275

The Blame tab is not adding anything to FileHistory, just dummy information as in the Browse Commit tab, but the behavior should be consistent.
(This was a review comment to #4275)

Changes proposed in this pull request:
 - Always show Blame tab also for artificial commits, no dynamic removal/add
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/34481196-062f752a-efb1-11e7-80d0-b8c70030ef55.png)

- 
![image](https://user-images.githubusercontent.com/6248932/34481174-e1f15a70-efb0-11e7-8acf-0ecde63dfc42.png)

What did I do to test the code and ensure quality:
 - View artificial commits (enable in settings)
 - Show file history for a file
 - Select artificial commit
 - Verify that Blame tab is visible, with dummy information

This PR just removes code, so this simple test is sufficient

Has been tested on (remove any that don't apply):
 - Windows 10