### PR TITLE
Start Commit Count also if not starting with a normal repository

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -182,7 +182,7 @@ namespace GitUI.CommandsDialogs
 
             Translate();
 
-            if (AppSettings.ShowGitStatusInBrowseToolbar && !Module.IsBareRepository())
+            if (AppSettings.ShowGitStatusInBrowseToolbar)
             {
                 _toolStripGitStatus = new ToolStripGitStatus
                 {


### PR DESCRIPTION
Reported in #4295 

Regression of #4208
https://github.com/gitextensions/gitextensions/pull/4208/files#diff-6d931ecb996aeb8676180da98e3f6861R185

What did I do to test the code and ensure quality:
 - Enable Commit Count
 - Start GE without loading a normal repository. This can be to load a bare repo before closing GE or untick "start with last directory on startup"
 - Open normal repo with some staged and/or unstaged files
 - Commit count should be visible

Has been tested on (remove any that don't apply):
 - Windows 10
