### PR TITLE
Feat add app version to the main title

### DIFF
--- a/GitCommands/AppInformationalVersionProvider.cs
+++ b/GitCommands/AppInformationalVersionProvider.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace GitCommands
+{
+    public interface IAppInformationalVersionProvider
+    {
+        /// <summary>
+        /// Retrieves the app's current information version.
+        /// </summary>
+        /// <returns>The app's current information version.</returns>
+        string Get();
+    }
+
+    public sealed class AppInformationalVersionProvider : IAppInformationalVersionProvider
+    {
+        /// <summary>
+        /// Retrieves the app's current information version;
+        /// or <see langword="null"/> if <see cref="AssemblyInformationalVersionAttribute"/> is not applied.
+        /// </summary>
+        /// <returns>The app's current information version.</returns>
+        public string Get()
+        {
+            var attr = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attr?.InformationalVersion;
+        }
+    }
+}

--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -1,0 +1,69 @@
+using System;
+using GitCommands.Repository;
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Provides the ability to generate application title.
+    /// </summary>
+    public interface IAppTitleGenerator
+    {
+        /// <summary>
+        /// Generates main window title according to given repository.
+        /// </summary>
+        /// <param name="workingDir">Path to repository.</param>
+        /// <param name="isValidWorkingDir">Indicates whether the given path contains a valid repository.</param>
+        /// <param name="branchName">Current branch name.</param>
+        string Generate(string workingDir, bool isValidWorkingDir, string branchName);
+    }
+
+    /// <summary>
+    /// Generates application title.
+    /// </summary>
+    public sealed class AppTitleGenerator : IAppTitleGenerator
+    {
+        private const string DefaultTitle = "Git Extensions";
+        private const string RepositoryTitleFormat = "{0} ({1}) - Git Extensions";
+        private readonly IAppInformationalVersionProvider _appInformationalVersionProvider;
+        private readonly IRepositoryShortNameProvider _repositoryShortNameProvider;
+
+
+        public AppTitleGenerator(IAppInformationalVersionProvider appInformationalVersionProvider, IRepositoryShortNameProvider repositoryShortNameProvider)
+        {
+            _appInformationalVersionProvider = appInformationalVersionProvider;
+            _repositoryShortNameProvider = repositoryShortNameProvider;
+        }
+
+
+        /// <summary>
+        /// Generates main window title according to given repository.
+        /// </summary>
+        /// <param name="workingDir">Path to repository.</param>
+        /// <param name="isValidWorkingDir">Indicates whether the given path contains a valid repository.</param>
+        /// <param name="branchName">Current branch name.</param>
+        public string Generate(string workingDir, bool isValidWorkingDir, string branchName)
+        {
+            if (string.IsNullOrWhiteSpace(workingDir))
+            {
+                throw new ArgumentException(nameof(workingDir));
+            }
+
+            if (!isValidWorkingDir)
+            {
+                return DefaultTitle;
+            }
+            string repositoryDescription = _repositoryShortNameProvider.Get(workingDir);
+            var title = string.Format(RepositoryTitleFormat, repositoryDescription, (branchName ?? "no branch").Trim('(', ')'));
+
+            var informationalVersion = _appInformationalVersionProvider.Get();
+            if (!string.IsNullOrWhiteSpace(informationalVersion))
+            {
+                title += $" v{informationalVersion}";
+            }
+#if DEBUG
+            title += " -> DEBUG <-";
+#endif
+            return title;
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Git\Tag\TagOperation.cs" />
     <Compile Include="Git\Tag\TagOperationExtensions.cs" />
     <Compile Include="Remote\GitRemoteManager.cs" />
+    <Compile Include="Repository\RepositoryShortNameProvider.cs" />
     <Compile Include="Settings\BranchOrdering.cs" />
     <Compile Include="Git\GitGpgController.cs" />
     <Compile Include="SshPathLocator.cs" />

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -81,6 +81,8 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Annotations.cs" />
+    <Compile Include="AppInformationalVersionProvider.cs" />
+    <Compile Include="AppTitleGenerator.cs" />
     <Compile Include="AsyncLoader.cs" />
     <Compile Include="CommitData.cs" />
     <Compile Include="CommitDataManager.cs" />

--- a/GitCommands/Repository/RepositoryShortNameProvider.cs
+++ b/GitCommands/Repository/RepositoryShortNameProvider.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using GitCommands.Git;
+
+namespace GitCommands.Repository
+{
+    public interface IRepositoryShortNameProvider
+    {
+        /// <summary>
+        /// Returns a short name for repository.
+        /// If the repository contains a description it is returned,
+        /// otherwise the last part of path is returned.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        /// <returns>Short name for repository</returns>
+        string Get(string repositoryDir);
+    }
+
+    public sealed class RepositoryShortNameProvider : IRepositoryShortNameProvider
+    {
+        private const string RepositoryDescriptionFileName = "description";
+        private const string DefaultDescription = "Unnamed repository; edit this file 'description' to name the repository.";
+        private readonly IGitDirectoryResolver _gitDirectoryResolver;
+
+
+        public RepositoryShortNameProvider(IGitDirectoryResolver gitDirectoryResolver)
+        {
+            _gitDirectoryResolver = gitDirectoryResolver;
+        }
+
+
+        /// <summary>
+        /// Returns a short name for repository.
+        /// If the repository contains a description it is returned,
+        /// otherwise the last part of path is returned.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        /// <returns>Short name for repository</returns>
+        public string Get(string repositoryDir)
+        {
+            var dirInfo = new DirectoryInfo(repositoryDir);
+            if (!dirInfo.Exists)
+            {
+                return dirInfo.Name;
+            }
+
+            string desc = ReadRepositoryDescription(repositoryDir);
+            if (desc.IsNullOrEmpty())
+            {
+                desc = Repositories.RepositoryHistory.Repositories
+                                        .Where(repo => repo.Path.Equals(repositoryDir, StringComparison.CurrentCultureIgnoreCase))
+                                        .Select(repo => repo.Title)
+                                        .FirstOrDefault();
+            }
+            return desc ?? dirInfo.Name;
+        }
+
+        /// <summary>
+        /// Reads repository description's first line from ".git\description" file.
+        /// </summary>
+        /// <param name="workingDir">Path to repository.</param>
+        /// <returns>If the repository has description, returns that description, else returns <c>null</c>.</returns>
+        private string ReadRepositoryDescription(string workingDir)
+        {
+
+            var repositoryPath = _gitDirectoryResolver.Resolve(workingDir);
+            var repositoryDescriptionFilePath = Path.Combine(repositoryPath, RepositoryDescriptionFileName);
+            if (!File.Exists(repositoryDescriptionFilePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var repositoryDescription = File.ReadLines(repositoryDescriptionFilePath).FirstOrDefault();
+                return string.Equals(repositoryDescription, DefaultDescription, StringComparison.CurrentCulture)
+                    ? null
+                    : repositoryDescription;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+        }
+
+    }
+}

--- a/UnitTests/GitCommandsTests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommandsTests/AppTitleGeneratorTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Diagnostics;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Repository;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class AppTitleGeneratorTests
+    {
+        private const string ShortName = "gitextension";
+        private IAppInformationalVersionProvider _appInformationalVersionProvider;
+        private IRepositoryShortNameProvider _repositoryShortNameProvider;
+        private AppTitleGenerator _appTitleGenerator;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _appInformationalVersionProvider = Substitute.For<IAppInformationalVersionProvider>();
+            _repositoryShortNameProvider = Substitute.For<IRepositoryShortNameProvider>();
+            _repositoryShortNameProvider.Get(Arg.Any<string>()).Returns(ShortName);
+
+            _appTitleGenerator = new AppTitleGenerator(_appInformationalVersionProvider, _repositoryShortNameProvider);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\t")]
+        public void Generate_should_throw_if_working_folder_invalid(string path)
+        {
+            ((Action)(() => _appTitleGenerator.Generate(path, false, null))).ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void Generate_should_return_default_title_if_not_valid_working_directory()
+        {
+            var title = _appTitleGenerator.Generate("a", false, null);
+            title.Should().Be("Git Extensions");
+        }
+
+        [Test]
+        public void Generate_should_include_no_branch_if_supplied()
+        {
+            var title = _appTitleGenerator.Generate("a", true, null);
+            title.Should().StartWith($"{ShortName} (no branch) - Git Extensions");
+        }
+
+        [Test]
+        public void Generate_should_include_suplied_branch_without_braces()
+        {
+            string branchName = "feature/my_(test)_branch";
+            var title = _appTitleGenerator.Generate("a", true, "(" + branchName + ")");
+            title.Should().StartWith($"{ShortName} ({branchName}) - Git Extensions");
+        }
+
+        [Test]
+        public void Generate_should_include_version_number()
+        {
+            var version = "1.2.3.4";
+            _appInformationalVersionProvider.Get().Returns(version);
+            var title = _appTitleGenerator.Generate("a", true, null);
+
+            title.Should().StartWith($"{ShortName} (no branch) - Git Extensions v{version}");
+        }
+
+        [Conditional("DEBUG")]
+        [Test]
+        public void Generate_should_include_debug_suffix()
+        {
+            var version = "1.2.3.4";
+            _appInformationalVersionProvider.Get().Returns(version);
+            var title = _appTitleGenerator.Generate("a", true, null);
+
+            title.Should().Be($"{ShortName} (no branch) - Git Extensions v{version} -> DEBUG <-");
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppTitleGeneratorTests.cs" />
     <Compile Include="CommitDataManagerTest.cs" />
     <Compile Include="CommitTemplateManagerTests.cs" />
     <Compile Include="Config\ConfigFileTest.cs" />


### PR DESCRIPTION
Existing title generator routine extracted from FormBrowse into `AppTitleGenerator`. To make it testable reading of the app version (provided by `AssemblyInformationalVersionAttribute`) is extracted to `AppInformationalVersionProvider`.
Added unit tests for `AppTitleGenerator`.

Closes #4299
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/34515212-20071286-f0c5-11e7-913c-ac017ec9ccdd.png)

What did I do to test the code and ensure quality:
 - unit tests
 - run the app manually

Has been tested on (remove any that don't apply):
 - GIT 2.12
 - Windows 10
