### PR TITLE
Refresh the UI after the interactive rebase command

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3489,6 +3489,8 @@ namespace GitUI
                 formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", String.Format("sed -i -re '0,/pick/s//{0}/'", command));
                 formProcess.ShowDialog(this);
             }
+
+            RefreshRevisions();
         }
     }
 }


### PR DESCRIPTION
Fixes #3935.

Changes proposed in this pull request:
 - after _Edit commit_ or _Reword commit_ command is run, the revision grid is refreshed.
 
What did I do to test the code and ensure quality:
 - ran both commands and checked that the revision grid is properly refreshed
 - for the _Edit commit_ command, I also tried amending the commit and finishing the rebase outside of GE, so that no GE dialogs were opened which would cause the refresh themselves

Has been tested on (remove any that don't apply):
 - GIT 2.15.1
 - Windows 10
