### PR TITLE
Added menu to perform immediate rebase and interactively rebase without the rebase dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -967,7 +967,7 @@ namespace GitUI.CommandsDialogs
         private void RebaseClick(object sender, EventArgs e)
         {
             if (Module.InTheMiddleOfRebase())
-                UICommands.StartRebaseDialog(this, null);
+                UICommands.ContinueRebase(this);
             else
                 UICommands.StartApplyPatchDialog(this);
         }
@@ -1387,11 +1387,11 @@ namespace GitUI.CommandsDialogs
                     from = revisions[0].Guid.Substring(0, 8);
                     to = currentBranch;
                 }
-                UICommands.StartRebaseDialog(this, from, to, null);
+                UICommands.StartRebaseDialog(this, from, to, null, interactive: false, startRebaseImmediately: false);
             }
             else
             {
-                UICommands.StartRebaseDialog(this, null);
+                UICommands.StartRebaseDialog(this, revisions.First().Guid);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -297,7 +297,7 @@ namespace GitUI.CommandsDialogs
             // Rebase failed -> special 'rebase' merge conflict
             if (Rebase.Checked && Module.InTheMiddleOfRebase())
             {
-                UICommands.StartRebaseDialog(owner, null);
+                UICommands.ContinueRebase(owner);
             }
             else if (Module.InTheMiddleOfAction())
             {

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -26,6 +26,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly string _defaultBranch;
         private readonly string _defaultToBranch;
+        private readonly bool _startRebaseImmediately;
 
         private FormRebase()
             : this(null)
@@ -48,11 +49,14 @@ namespace GitUI.CommandsDialogs
             _defaultBranch = defaultBranch;
         }
 
-        public FormRebase(GitUICommands aCommands, string from, string to, string defaultBranch)
+        public FormRebase(GitUICommands aCommands, string from, string to, string defaultBranch, bool interactive = false,
+            bool startRebaseImmediately = true)
             : this(aCommands, defaultBranch)
         {
             txtFrom.Text = from;
             _defaultToBranch = to;
+            chkInteractive.Checked = interactive;
+            _startRebaseImmediately = startRebaseImmediately;
         }
 
         private void FormRebaseLoad(object sender, EventArgs e)
@@ -86,6 +90,14 @@ namespace GitUI.CommandsDialogs
             chkAutosquash.Checked = "true" == autosquashSetting.Trim().ToLower();
 
             chkStash.Checked = AppSettings.RebaseAutoStash;
+            if (_startRebaseImmediately)
+            {
+                OkClick(null, null);
+            }
+            else
+            {
+                ShowOptions_LinkClicked(null, null);
+            }
         }
 
         private void EnableButtons()

--- a/GitUI/CommandsDialogs/MergeConflictHandler.cs
+++ b/GitUI/CommandsDialogs/MergeConflictHandler.cs
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (MessageBoxes.MiddleOfRebase(owner))
                 {
-                    aCommands.StartRebaseDialog(owner, null);
+                    aCommands.ContinueRebase(owner);
                 }
             }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -7,7 +7,6 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Settings;
 using GitUI.CommandsDialogs;
-using GitUI.CommandsDialogs.CommitDialog;
 using GitUI.CommandsDialogs.RepoHosting;
 using GitUI.CommandsDialogs.SettingsDialog;
 using GitUIPluginInterfaces;
@@ -1385,17 +1384,45 @@ namespace GitUI
             return StartRemotesDialog(null);
         }
 
-        public bool StartRebaseDialog(IWin32Window owner, string branch)
+        private bool StartRebaseDialog(IWin32Window owner, string onto, bool interactive = false,
+            bool startRebaseImmediately = true)
         {
-            return StartRebaseDialog(owner, string.Empty, null, branch);
+            return StartRebaseDialog(owner, string.Empty, null, onto, interactive, startRebaseImmediately);
         }
 
-        public bool StartRebaseDialog(IWin32Window owner, string from, string to, string onto)
+        public bool StartRebase(IWin32Window owner, string onto)
+        {
+            return StartRebaseDialog(owner, onto,
+                interactive: false, startRebaseImmediately: true);
+        }
+
+        public bool ContinueRebase(IWin32Window owner)
+        {
+            return StartRebaseDialog(owner, onto: null,
+                interactive: false, startRebaseImmediately: true);
+        }
+
+        public bool StartInteractiveRebase(IWin32Window owner, string onto)
+        {
+            return StartRebaseDialog(owner, onto,
+                interactive: true, startRebaseImmediately: true);
+        }
+
+        public bool StartRebaseDialogWithAdvOptions(IWin32Window owner, string onto)
+        {
+            return StartRebaseDialog(owner, onto,
+                interactive: false, startRebaseImmediately: false);
+        }
+
+        public bool StartRebaseDialog(IWin32Window owner, string from, string to, string onto,
+            bool interactive = false, bool startRebaseImmediately = true)
         {
             Func<bool> action = () =>
             {
-                using (var form = new FormRebase(this, from, to, onto))
+                using (var form = new FormRebase(this, from, to, onto, interactive, startRebaseImmediately))
+                {
                     form.ShowDialog(owner);
+                }
 
                 return true;
             };
@@ -1403,11 +1430,10 @@ namespace GitUI
             return DoActionOnRepo(owner, true, true, PreRebase, PostRebase, action);
         }
 
-        public bool StartRebaseDialog(string branch)
+        public bool StartRebaseDialog(IWin32Window owner, string onto)
         {
-            return StartRebaseDialog(null, branch);
+            return StartRebaseDialog(owner, onto, interactive: false, startRebaseImmediately: false);
         }
-
 
         public bool StartRenameDialog(string branch)
         {
@@ -2100,7 +2126,7 @@ namespace GitUI
             string branch = null;
             if (arguments.ContainsKey("branch"))
                 branch = arguments["branch"];
-            StartRebaseDialog(branch);
+            StartRebaseDialog(owner: null, onto: branch);
         }
 
         public bool StartFileEditorDialog(string filename, bool showWarning = false)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8303,6 +8303,18 @@ If this is a central repository (bare repository without a working directory):
         <source>Rebase current branch on</source>
         <target />
       </trans-unit>
+      <trans-unit id="rebaseToolStripMenuItem.Text">
+        <source>Selected commit</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="rebaseInteractivelyToolStripMenuItem.Text">
+        <source>Selected commit interactively</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="rebaseWithAdvOptionsToolStripMenuItem.Text">
+        <source>Selected commit with advanced options...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="renameBranchToolStripMenuItem.Text">
         <source>Rename branch</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -149,6 +149,9 @@ namespace GitUI
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.getHelpOnHowToUseTheseFeaturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.rebaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.rebaseInteractivelyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.rebaseWithAdvOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.Revisions)).BeginInit();
             this.mainContextMenu.SuspendLayout();
             this.NoCommits.SuspendLayout();
@@ -430,11 +433,14 @@ namespace GitUI
             // 
             // rebaseOnToolStripMenuItem
             // 
+            this.rebaseOnToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.rebaseToolStripMenuItem,
+            this.rebaseInteractivelyToolStripMenuItem,
+            this.rebaseWithAdvOptionsToolStripMenuItem});
             this.rebaseOnToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconRebase;
             this.rebaseOnToolStripMenuItem.Name = "rebaseOnToolStripMenuItem";
-            this.rebaseOnToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
+            this.rebaseOnToolStripMenuItem.Size = new System.Drawing.Size(270, 22);
             this.rebaseOnToolStripMenuItem.Text = "Rebase current branch on";
-            this.rebaseOnToolStripMenuItem.Click += new System.EventHandler(this.deleteBranchTagToolStripMenuItem_Click);
             // 
             // resetCurrentBranchToHereToolStripMenuItem
             // 
@@ -806,6 +812,26 @@ namespace GitUI
             this.rewordCommitToolStripMenuItem.Size = new System.Drawing.Size(272, 22);
             this.rewordCommitToolStripMenuItem.Text = "Reword commit";
             this.rewordCommitToolStripMenuItem.Click += new System.EventHandler(this.rewordCommitToolStripMenuItem_Click);
+            // rebaseToolStripMenuItem
+            // 
+            this.rebaseToolStripMenuItem.Name = "rebaseToolStripMenuItem";
+            this.rebaseToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.rebaseToolStripMenuItem.Text = "Selected commit";
+            this.rebaseToolStripMenuItem.Click += new System.EventHandler(this.ToolStripItemClickRebaseBranch);
+            // 
+            // rebaseInteractivelyToolStripMenuItem
+            // 
+            this.rebaseInteractivelyToolStripMenuItem.Name = "rebaseInteractivelyToolStripMenuItem";
+            this.rebaseInteractivelyToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.rebaseInteractivelyToolStripMenuItem.Text = "Selected commit interactively";
+            this.rebaseInteractivelyToolStripMenuItem.Click += new System.EventHandler(this.OnRebaseInteractivelyClicked);
+            //
+            // rebaseWithAdvOptionsToolStripMenuItem
+            //
+            this.rebaseWithAdvOptionsToolStripMenuItem.Name = "rebaseWithAdvOptionsToolStripMenuItem";
+            this.rebaseWithAdvOptionsToolStripMenuItem.Size = new System.Drawing.Size(307, 22);
+            this.rebaseWithAdvOptionsToolStripMenuItem.Text = "Selected commit with advanced options...";
+            this.rebaseWithAdvOptionsToolStripMenuItem.Click += OnRebaseWithAdvOptionsClicked;
             // 
             // RevisionGrid
             // 
@@ -857,6 +883,8 @@ namespace GitUI
         private System.Windows.Forms.ToolStripMenuItem cherryPickCommitToolStripMenuItem;
         private System.Windows.Forms.Timer quickSearchTimer;
         private System.Windows.Forms.ToolStripMenuItem rebaseOnToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem rebaseToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem rebaseInteractivelyToolStripMenuItem;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.ToolStripMenuItem copyToClipboardToolStripMenuItem;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
@@ -902,5 +930,6 @@ namespace GitUI
         private ToolStripMenuItem getHelpOnHowToUseTheseFeaturesToolStripMenuItem;
         private ToolStripMenuItem openBuildReportToolStripMenuItem;
         private ToolStripMenuItem editCommitToolStripMenuItem;
+        private ToolStripMenuItem rebaseWithAdvOptionsToolStripMenuItem;
     }
 }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -105,6 +105,8 @@ namespace GitUI
 
 
         private IEnumerable<IGitRef> _LatestRefs = Enumerable.Empty<IGitRef>();
+
+        private string _rebaseOnTopOf;
         /// <summary>
         /// Refs loaded while the latest processing of git log
         /// </summary>
@@ -2309,11 +2311,11 @@ namespace GitUI
             var deleteBranchDropDown = new ContextMenuStrip();
             var checkoutBranchDropDown = new ContextMenuStrip();
             var mergeBranchDropDown = new ContextMenuStrip();
-            var rebaseDropDown = new ContextMenuStrip();
             var renameDropDown = new ContextMenuStrip();
 
             var revision = LatestSelectedRevision;
             var gitRefListsForRevision = new GitRefListsForRevision(revision);
+            _rebaseOnTopOf = null;
             foreach (var head in gitRefListsForRevision.AllTags)
             {
                 ToolStripItem toolStripItem = new ToolStripMenuItem(head.Name);
@@ -2342,21 +2344,17 @@ namespace GitUI
                     toolStripItem.Tag = GetRefUnambiguousName(head);
                     toolStripItem.Click += ToolStripItemClickMergeBranch;
                     mergeBranchDropDown.Items.Add(toolStripItem);
-
-                    toolStripItem = new ToolStripMenuItem(head.Name);
-                    toolStripItem.Tag = GetRefUnambiguousName(head);
-                    toolStripItem.Click += ToolStripItemClickRebaseBranch;
-                    rebaseDropDown.Items.Add(toolStripItem);
+                    if (_rebaseOnTopOf == null)
+                    {
+                        _rebaseOnTopOf = toolStripItem.Tag as string;
+                    }
                 }
             }
 
             //if there is no branch to rebase on, then allow user to rebase on selected commit
-            if (rebaseDropDown.Items.Count == 0 && !currentBranchPointsToRevision)
+            if (_rebaseOnTopOf == null && !currentBranchPointsToRevision)
             {
-                ToolStripItem toolStripItem = new ToolStripMenuItem(revision.Guid);
-                toolStripItem.Tag = revision.Guid;
-                toolStripItem.Click += ToolStripItemClickRebaseBranch;
-                rebaseDropDown.Items.Add(toolStripItem);
+                _rebaseOnTopOf = revision.Guid;
             }
 
             //if there is no branch to merge, then let user to merge selected commit into current branch
@@ -2366,6 +2364,10 @@ namespace GitUI
                 toolStripItem.Tag = revision.Guid;
                 toolStripItem.Click += ToolStripItemClickMergeBranch;
                 mergeBranchDropDown.Items.Add(toolStripItem);
+                if (_rebaseOnTopOf == null)
+                {
+                    _rebaseOnTopOf = toolStripItem.Tag as string;
+                }
             }
 
             // clipboard branch and tag menu handling
@@ -2450,8 +2452,7 @@ namespace GitUI
             mergeBranchToolStripMenuItem.DropDown = mergeBranchDropDown;
             mergeBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && mergeBranchDropDown.Items.Count > 0 && !Module.IsBareRepository();
 
-            rebaseOnToolStripMenuItem.DropDown = rebaseDropDown;
-            rebaseOnToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && rebaseDropDown.Items.Count > 0 && !Module.IsBareRepository();
+            rebaseOnToolStripMenuItem.Enabled = !bareRepositoryOrArtificial && !Module.IsBareRepository();
 
             renameBranchToolStripMenuItem.DropDown = renameDropDown;
             renameBranchToolStripMenuItem.Enabled = renameDropDown.Items.Count > 0;
@@ -2565,12 +2566,19 @@ namespace GitUI
 
         private void ToolStripItemClickRebaseBranch(object sender, EventArgs e)
         {
-            var toolStripItem = sender as ToolStripItem;
+            if (_rebaseOnTopOf == null) return;
+            UICommands.StartRebase(this, _rebaseOnTopOf);
+        }
+        private void OnRebaseInteractivelyClicked(object sender, EventArgs e)
+        {
+            if (_rebaseOnTopOf == null) return;
+            UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+        }
 
-            if (toolStripItem == null)
-                return;
-
-            UICommands.StartRebaseDialog(this, toolStripItem.Tag as string);
+        private void OnRebaseWithAdvOptionsClicked(object sender, EventArgs e)
+        {
+            if (_rebaseOnTopOf == null) return;
+            UICommands.StartRebaseDialogWithAdvOptions(this, _rebaseOnTopOf);
         }
 
         private void ToolStripItemClickRenameBranch(object sender, EventArgs e)

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -142,7 +142,7 @@ namespace GitUIPluginInterfaces
         bool StartPluginSettingsDialog();
         bool StartPullDialog();
         bool StartPushDialog();
-        bool StartRebaseDialog(string branch);
+        bool StartRebaseDialog(IWin32Window owner, string onto);
         bool StartRemotesDialog();
         bool StartResolveConflictsDialog();
         bool StartSettingsDialog();


### PR DESCRIPTION
Fixes #3853 .

Changes proposed in this pull request:

**What is the problem?**

- When rebasing, unlike merging, which branch is selected doesn't matter as long as the branches are pointing to the same commit.
- A lot of people don't know there is interactive rebase feature in GitExtensions as the option is an advanced option which is hidden by default.
- The popup dialog is not necessary, usually can be skipped.

**What is proposed?**
- Remove the branches from the sub context menu
- Add a rebase menu item (rebase straightway without the rebase dialog popup)
- Add an interactive rebase menu item(rebase straightway without the rebase dialog popup)
- Add a rebase with advanced options menu item(rebase with the rebase dialog popup)
 
 
Screenshots before and after (if PR changes UI):
**Before**
![image](https://user-images.githubusercontent.com/596334/28235793-27aa8518-6948-11e7-99f3-3f99ad080985.png)

**After**
![image](https://user-images.githubusercontent.com/596334/28239069-7bbfb568-6995-11e7-9c2a-7c9478a51cca.png)

What did I do to test the code and ensure quality:
 - Rebase basically, interactively and with adv options on commit
 - Rebase  basically, interactively and with adv options on branch
 - Rebase  basically, interactively and with adv options on tag

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10