### PR TITLE
Refactoring to use same function to get the short sha

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -84,9 +84,10 @@ namespace GitCommands
         {
             if (sha == null)
                 throw new ArgumentNullException("sha");
-            if (sha.Length > 8)
+            const int maxShaLength = 10;
+            if (sha.Length > maxShaLength)
             {
-                sha = sha.Substring(0, 8);
+                sha = sha.Substring(0, maxShaLength);
             }
 
             return sha;

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -56,7 +56,7 @@ namespace GitUI.CommandsDialogs
                 {
                     labelDateCaption.Text = String.Format("{0}: {1}", Strings.GetCommitDateText(), _diffSelectedRevision.CommitDate);
                     labelAuthor.Text = _diffSelectedRevision.Author;
-                    gbDiffRevision.Text = _diffSelectedRevision.Guid.Substring(0, 10);
+                    gbDiffRevision.Text = GitRevision.ToShortSha(_diffSelectedRevision.Guid);
                     labelMessage.Text = _diffSelectedRevision.Subject;
                 }
             }

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -93,7 +93,7 @@ namespace GitUI.HelperDialogs
 
             if(!flowLayoutPanelParents.Visible)
                 return;
-            _parents = SelectedRevision.ParentGuids.ToDictionary(p=> p.Substring(0, 10), p=> p);
+            _parents = SelectedRevision.ParentGuids.ToDictionary(p=> GitRevision.ToShortSha(p), p=> p);
             linkLabelParent.Text = _parents.Keys.ElementAt(0);
 
             linkLabelParent2.Visible = _parents.Count > 1;

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -38,7 +38,7 @@ namespace GitUI.HelperDialogs
 
                 commitInfo.Revision = _revision;
 
-                Text = "Diff - " + _revision.Guid.Substring(0, 10) + " - " + _revision.AuthorDate + " - " + _revision.Author + " - " + Module.WorkingDir; ;
+                Text = "Diff - " + GitRevision.ToShortSha(_revision.Guid) + " - " + _revision.AuthorDate + " - " + _revision.Author + " - " + Module.WorkingDir; ;
             }
         }
 

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitUI.HelperDialogs;
+using GitCommands;
 
 namespace GitUI.UserControls
 {
@@ -48,7 +49,7 @@ namespace GitUI.UserControls
             }
             else
             {
-                textBoxCommitHash.Text = _selectedCommitHash.Substring(0, 10);
+                textBoxCommitHash.Text = GitRevision.ToShortSha(_selectedCommitHash);
                 Task.Factory.StartNew(() => this.Module.GetCommitCountString(this.Module.GetCurrentCheckout(), _selectedCommitHash))
                      .ContinueWith(t => lbCommits.Text = t.Result, TaskScheduler.FromCurrentSynchronizationContext());
             }

--- a/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -54,7 +54,7 @@ namespace GitUI.UserControls
 
                 if (Revision != null)
                 {
-                    groupBox1.Text = Revision.Guid.Length > 10 ? Revision.Guid.Substring(0, 10) : Revision.Guid;
+                    groupBox1.Text = GitRevision.ToShortSha(Revision.Guid);
                     labelAuthor.Text = string.Format("{0}", Revision.Author);
                     labelDate.Text = string.Format(Strings.GetCommitDateText() + ": {0}", Revision.CommitDate);
                     labelMessage.Text = string.Format("{0}", Revision.Subject);

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -177,7 +177,7 @@ namespace ResourceManager.CommitDataRenders
             }
             else
             {
-                commitsString = hashes.Select(guid => guid.Substring(0, 10)).Join(" ");
+                commitsString = hashes.Select(guid => GitRevision.ToShortSha(guid)).Join(" ");
             }
             return commitsString;
         }

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -65,9 +65,14 @@ namespace ResourceManager
                     linkText = Strings.GetCurrentIndex();
                 else
                 {
-                    linkText = preserveGuidInLinkText || guid.Length < 10
-                        ? guid
-                        : guid.Substring(0, 10);
+                    if (preserveGuidInLinkText)
+                    {
+                        linkText = guid;
+                    }
+                    else
+                    {
+                        linkText = GitRevision.ToShortSha(guid);
+                    }
                 }
             }
             return AddLink(linkText, "gitext://gotocommit/" + guid);

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
@@ -47,8 +47,13 @@ namespace ResourceManagerTests.CommitDataRenders
                                  "Committer:		<a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Commit date:	2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash:	" + _data.Guid + Environment.NewLine +
-                                 "Children:		<a href='gitext://gotocommit/" + _data.ChildrenGuids[0] + "'>" + _data.ChildrenGuids[0].Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + _data.ChildrenGuids[1] + "'>" + _data.ChildrenGuids[1].Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + _data.ChildrenGuids[2] + "'>" + _data.ChildrenGuids[2].Substring(0, 10) + "</a>" + Environment.NewLine +
-                                 "Parent(s):		<a href='gitext://gotocommit/" + _data.ParentGuids[0] + "'>" + _data.ParentGuids[0].Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + _data.ParentGuids[1] + "'>" + _data.ParentGuids[1].Substring(0, 10) + "</a>";
+                                 "Children:		" +
+                                   "<a href='gitext://gotocommit/" + _data.ChildrenGuids[0] + "'>" + GitRevision.ToShortSha(_data.ChildrenGuids[0]) + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ChildrenGuids[1] + "'>" + GitRevision.ToShortSha(_data.ChildrenGuids[1]) + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ChildrenGuids[2] + "'>" + GitRevision.ToShortSha(_data.ChildrenGuids[2]) + "</a>" + Environment.NewLine +
+                                 "Parent(s):		" +
+                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[0] + "'>" + GitRevision.ToShortSha(_data.ParentGuids[0]) + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[1] + "'>" + GitRevision.ToShortSha(_data.ParentGuids[1]) + "</a>";
 
             var result = _rendererTabs.Render(_data, true);
 
@@ -63,8 +68,13 @@ namespace ResourceManagerTests.CommitDataRenders
                                  "Committer:		<a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Commit date:	2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash:	" + _data.Guid + Environment.NewLine +
-                                 "Children:		" + _data.ChildrenGuids[0].Substring(0, 10) + " " + _data.ChildrenGuids[1].Substring(0, 10) + " " + _data.ChildrenGuids[2].Substring(0, 10) + Environment.NewLine +
-                                 "Parent(s):		" + _data.ParentGuids[0].Substring(0, 10) + " " + _data.ParentGuids[1].Substring(0, 10);
+                                 "Children:		" +
+                                   GitRevision.ToShortSha(_data.ChildrenGuids[0]) + " " +
+                                   GitRevision.ToShortSha(_data.ChildrenGuids[1]) + " "+
+                                   GitRevision.ToShortSha(_data.ChildrenGuids[2]) + Environment.NewLine +
+                                 "Parent(s):		" + 
+                                   GitRevision.ToShortSha(_data.ParentGuids[0]) + " " +
+                                   GitRevision.ToShortSha(_data.ParentGuids[1]);
 
             var result = _rendererTabs.Render(_data, false);
 
@@ -79,8 +89,13 @@ namespace ResourceManagerTests.CommitDataRenders
                                  "Committer:   <a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Commit date: 2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash: " + _data.Guid + Environment.NewLine +
-                                 "Children:    <a href='gitext://gotocommit/" + _data.ChildrenGuids[0] + "'>" + _data.ChildrenGuids[0].Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + _data.ChildrenGuids[1] + "'>" + _data.ChildrenGuids[1].Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + _data.ChildrenGuids[2] + "'>" + _data.ChildrenGuids[2].Substring(0, 10) + "</a>" + Environment.NewLine +
-                                 "Parent(s):   <a href='gitext://gotocommit/" + _data.ParentGuids[0] + "'>" + _data.ParentGuids[0].Substring(0, 10) + "</a> <a href='gitext://gotocommit/" + _data.ParentGuids[1] + "'>" + _data.ParentGuids[1].Substring(0, 10) + "</a>";
+                                 "Children:    " + 
+                                   "<a href='gitext://gotocommit/" + _data.ChildrenGuids[0] + "'>" + GitRevision.ToShortSha(_data.ChildrenGuids[0]) + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ChildrenGuids[1] + "'>" + GitRevision.ToShortSha(_data.ChildrenGuids[1]) + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ChildrenGuids[2] + "'>" + GitRevision.ToShortSha(_data.ChildrenGuids[2]) + "</a>" + Environment.NewLine +
+                                 "Parent(s):   " +
+                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[0] + "'>" + GitRevision.ToShortSha(_data.ParentGuids[0]) + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[1] + "'>" + GitRevision.ToShortSha(_data.ParentGuids[1]) + "</a>";
 
             var result = _rendererSpaces.Render(_data, true);
 
@@ -95,8 +110,13 @@ namespace ResourceManagerTests.CommitDataRenders
                                  "Committer:   <a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Commit date: 2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash: " + _data.Guid + Environment.NewLine +
-                                 "Children:    " + _data.ChildrenGuids[0].Substring(0, 10) + " " + _data.ChildrenGuids[1].Substring(0, 10) + " " +_data.ChildrenGuids[2].Substring(0, 10) + Environment.NewLine +
-                                 "Parent(s):   " + _data.ParentGuids[0].Substring(0, 10) + " " + _data.ParentGuids[1].Substring(0, 10);
+                                 "Children:    " + 
+                                   GitRevision.ToShortSha(_data.ChildrenGuids[0]) + " " +
+                                   GitRevision.ToShortSha(_data.ChildrenGuids[1]) + " " +
+                                   GitRevision.ToShortSha(_data.ChildrenGuids[2]) + Environment.NewLine +
+                                 "Parent(s):   " +
+                                   GitRevision.ToShortSha(_data.ParentGuids[0]) + " " +
+                                   GitRevision.ToShortSha(_data.ParentGuids[1]);
 
             var result = _rendererSpaces.Render(_data, false);
 

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -21,6 +21,19 @@ namespace ResourceManagerTests.CommitDataRenders
         private ILinkFactory _linkFactory;
         private IDateFormatter _dateFormatter;
         private CommitDataHeaderRenderer _renderer;
+        private List<string> _childrenHashes = new List<string>
+        {
+            "3b6ce324e30ed7fda24483fd56a180c34a262202",
+            "2a8788ff15071a202505a96f80796dbff5750ddf",
+            "8e66fa8095a86138a7c7fb22318d2f819669831e"
+        };
+
+        private List<string> _parentHashes = new List<string>
+        {
+            "5542334ab518b329426783d74c8f4204c2d75a43",
+            "92bc4ad5e509f7dbe87dc4e679fcb879c3235788",
+            "bc911920838c15bcf86808904ecb897595b9ef5f"
+        };
 
         [SetUp]
         public void Setup()
@@ -165,14 +178,17 @@ namespace ResourceManagerTests.CommitDataRenders
                 new ReadOnlyCollection<string>(new List<string>()),
                 author, authorDate,
                 committer, commitDate, "");
-            data.ChildrenGuids = new List<string> { "3b6ce324e30ed7fda24483fd56a180c34a262202", "2a8788ff15071a202505a96f80796dbff5750ddf", "8e66fa8095a86138a7c7fb22318d2f819669831e" };
+            data.ChildrenGuids = _childrenHashes; 
 
             _linkFactory.CreateLink(author, Arg.Any<string>()).Returns(x => author);
             _dateFormatter.FormatDateAsRelativeLocal(authorDate).Returns("6 months ago (06/17/2017 23:38:40)");
 
             var result = _renderer.Render(data, false);
 
-            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   8ea78df688ec4719a9756c1199a515d1{Environment.NewLine}Children:      3b6ce324e3 2a8788ff15 8e66fa8095");
+            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   8ea78df688ec4719a9756c1199a515d1{Environment.NewLine}" +
+                $"Children:      {GitRevision.ToShortSha(_childrenHashes[0])} " +
+                $"{GitRevision.ToShortSha(_childrenHashes[1])} " +
+                $"{GitRevision.ToShortSha(_childrenHashes[2])}");
             _labelFormatter.Received(1).FormatLabel(Strings.GetAuthorText(), Arg.Any<int>());
             _labelFormatter.Received(1).FormatLabel(Strings.GetDateText(), Arg.Any<int>());
             _labelFormatter.Received(1).FormatLabel(Strings.GetCommitHashText(), Arg.Any<int>());
@@ -190,7 +206,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             var data = new CommitData("8ea78df688ec4719a9756c1199a515d1",
                 Guid.NewGuid().ToString("N"),
-                new ReadOnlyCollection<string>(new List<string> { "3b6ce324e30ed7fda24483fd56a180c34a262202", "2a8788ff15071a202505a96f80796dbff5750ddf", "8e66fa8095a86138a7c7fb22318d2f819669831e" }),
+                _parentHashes.AsReadOnly(),
                 author, authorDate,
                 committer, commitDate, "");
 
@@ -199,7 +215,8 @@ namespace ResourceManagerTests.CommitDataRenders
 
             var result = _renderer.Render(data, false);
 
-            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   8ea78df688ec4719a9756c1199a515d1{Environment.NewLine}Parent(s):     3b6ce324e3 2a8788ff15 8e66fa8095");
+            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   8ea78df688ec4719a9756c1199a515d1{Environment.NewLine}" +
+                $"Parent(s):     {GitRevision.ToShortSha(_parentHashes[0])} {GitRevision.ToShortSha(_parentHashes[1])} {GitRevision.ToShortSha(_parentHashes[2])}");
             _labelFormatter.Received(1).FormatLabel(Strings.GetAuthorText(), Arg.Any<int>());
             _labelFormatter.Received(1).FormatLabel(Strings.GetDateText(), Arg.Any<int>());
             _labelFormatter.Received(1).FormatLabel(Strings.GetCommitHashText(), Arg.Any<int>());
@@ -218,7 +235,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             var data = new CommitData(artificialGuid,
                 Guid.NewGuid().ToString("N"),
-                new ReadOnlyCollection<string>(new List<string> { "3b6ce324e30ed7fda24483fd56a180c34a262202", "2a8788ff15071a202505a96f80796dbff5750ddf", "8e66fa8095a86138a7c7fb22318d2f819669831e" }),
+                _childrenHashes.AsReadOnly(),
                 author, authorDate,
                 committer, commitDate, "");
 


### PR DESCRIPTION
## Changes proposed in this pull request:

There were couple of places using the `SubString(0, 10)` to get the short SHA, this pull request refactored them to use the same function.
 
## Screenshots before and after (if PR changes UI):
The only UI change is the length of the SHA changed from 8 to 10 when checking out a branch with reset pending changes ticked.

![image](https://user-images.githubusercontent.com/596334/34562752-ae5a005a-f18a-11e7-979f-fce37770c77b.png)

## What did I do to test the code and ensure quality:
 - Verified that the SHAs of the children and parents are displayed correctly as hyper links when a commit is selected.
 - Verified the SHAs of the children and parents are displayed correctly as normal text on the commit detail form (via double clicking a commit)
 - Verified the SHA is displayed correctly when checking out branch with reset local changes is ticked.
 - Didn't test Mono, but I believe no regression

## Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
  