### PR TITLE
Browse Diff presentation of Untracked files

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -2213,7 +2213,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public Patch GetSingleDiff(string @from, string to, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult)
+        public Patch GetSingleDiff(string @from, string to, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked=true)
         {
             if (!string.IsNullOrEmpty(fileName))
             {
@@ -2225,11 +2225,17 @@ namespace GitCommands
             }
 
             //fix refs slashes
-            from = from.ToPosixPath();
-            to = to == null ? "":to.ToPosixPath();
+            from = from == null ? "" : from.ToPosixPath();
+            to = to == null ? "" : to.ToPosixPath();
             string commitRange = _revisionDiffProvider.Get(from, to);
             if (AppSettings.UsePatienceDiffAlgorithm)
                 extraDiffArguments = string.Concat(extraDiffArguments, " --patience");
+            if (!isTracked)
+            {
+                extraDiffArguments = string.Concat(extraDiffArguments, " --no-index");
+                oldFileName = fileName;
+                fileName = "/dev/null";
+            }
 
             var patchManager = new PatchManager();
             var arguments = String.Format(DiffCommandWithStandardArgs + "{0} -M -C {1} -- {2} {3}", extraDiffArguments, commitRange,

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2227,19 +2227,12 @@ namespace GitCommands
             //fix refs slashes
             from = from == null ? "" : from.ToPosixPath();
             to = to == null ? "" : to.ToPosixPath();
-            string commitRange = _revisionDiffProvider.Get(from, to);
+            string diffOptions = _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked);
             if (AppSettings.UsePatienceDiffAlgorithm)
                 extraDiffArguments = string.Concat(extraDiffArguments, " --patience");
-            if (!isTracked)
-            {
-                extraDiffArguments = string.Concat(extraDiffArguments, " --no-index");
-                oldFileName = fileName;
-                fileName = "/dev/null";
-            }
 
             var patchManager = new PatchManager();
-            var arguments = String.Format(DiffCommandWithStandardArgs + "{0} -M -C {1} -- {2} {3}", extraDiffArguments, commitRange,
-                fileName.Quote(), oldFileName.Quote());
+            var arguments = String.Format(DiffCommandWithStandardArgs + "{0} -M -C {1}", extraDiffArguments, diffOptions);
             cacheResult = cacheResult && !GitRevision.IsArtificial(to) && !GitRevision.IsArtificial(from) && !to.IsNullOrEmpty() && !from.IsNullOrEmpty();
             string patch;
             if (cacheResult)
@@ -3103,11 +3096,11 @@ namespace GitCommands
                 });
         }
 
-        public string OpenWithDifftool(string filename, string oldFileName = "", string revision1 = null, string revision2 = null, string extraDiffArguments = "")
+        public string OpenWithDifftool(string filename, string oldFileName = "", string revision1 = null, string revision2 = null, string extraDiffArguments = "", bool isTracked=true)
         {
             var output = "";
 
-            string args = string.Join(" ", extraDiffArguments, _revisionDiffProvider.Get(revision1, revision2), "--", filename.QuoteNE(), oldFileName.QuoteNE());
+            string args = string.Join(" ", extraDiffArguments, _revisionDiffProvider.Get(revision1, revision2, filename, oldFileName, isTracked));
             RunGitCmdDetached("difftool --gui --no-prompt " + args);
             return output;
         }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3023,6 +3023,7 @@ namespace GitCommands
         {
             if (revision == GitRevision.UnstagedGuid) //working directory changes
             {
+                Debug.Assert(false, "Tried to get blob for unstaged file");
                 return null;
             }
             if (revision == GitRevision.IndexGuid) //index

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -8,21 +8,21 @@ namespace GitCommands.Git
         /// <summary>
         /// options to git-diff from GE arguments, including artificial commits
         /// </summary>
-        /// <param name="parentRev">The first revision</param>
-        /// <param name="currentRev">The second "current" revision</param>
+        /// <param name="firstRevision">The first revision, "A"</param>
+        /// <param name="secondRevision">The second "current" revision, "B"</param>
         /// <returns></returns>
-        string Get(string parentRev, string currentRev);
+        string Get(string firstRevision, string secondRevision);
 
         /// <summary>
         /// options to git-diff from GE arguments, including artificial commits
         /// </summary>
-        /// <param name="parentRev">The first revision</param>
-        /// <param name="currentRev">The second "current" revision</param>
+        /// <param name="firstRevision">The first revision, "A"</param>
+        /// <param name="secondRevision">The second "current" revision, "B"</param>
         /// <param name="fileName">The file to compare</param>
         /// <param name="oldFileName">The old name of the file</param>
         /// <param name="isTracked">The file is tracked</param>
         /// <returns></returns>
-        string Get(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked);
+        string Get(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked);
     }
 
     /// <summary>
@@ -37,75 +37,66 @@ namespace GitCommands.Git
         /// <summary>
         /// options to git-diff from GE arguments, including artificial commits
         /// </summary>
-        /// <param name="parentRev">The first revision</param>
-        /// <param name="currentRev">The second "current" revision</param>
+        /// <param name="firstRevision">The first revision</param>
+        /// <param name="secondRevision">The second "current" revision</param>
         /// <returns></returns>
-        public string Get(string parentRev, string currentRev)
+        public string Get(string firstRevision, string secondRevision)
         {
-            return GetInternal(parentRev, currentRev);
+            return GetInternal(firstRevision, secondRevision);
         }
 
         /// <summary>
         /// options to git-diff from GE arguments, including artificial commits
         /// </summary>
-        /// <param name="parentRev">The first revision</param>
-        /// <param name="currentRev">The second "current" revision</param>
+        /// <param name="firstRevision">The first revision, "A"</param>
+        /// <param name="secondRevision">The second "current" revision, "B"</param>
         /// <param name="fileName">The file to compare</param>
         /// <param name="oldFileName">The old name of the file</param>
         /// <param name="isTracked">The file is tracked</param>
         /// <returns></returns>
-        public string Get(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public string Get(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            return GetInternal(parentRev, currentRev, fileName, oldFileName, isTracked);
+            return GetInternal(firstRevision, secondRevision, fileName, oldFileName, isTracked);
         }
 
-        /// <summary>
-        /// options to git-diff from GE arguments, including artificial commits
-        /// </summary>
-        /// <param name="parentRev">The first revision</param>
-        /// <param name="currentRev">The second "current" revision</param>
-        /// <param name="fileName">The file to compare</param>
-        /// <param name="oldFileName">The old name of the file</param>
-        /// <param name="isTracked">The file is tracked</param>
-        /// <returns></returns>
-        private string GetInternal(string parentRev, string currentRev, string fileName = null, string oldFileName = null, bool isTracked = true)
+        private string GetInternal(string firstRevision, string secondRevision, string fileName = null, string oldFileName = null, bool isTracked = true)
         {
             string extra = string.Empty;
-            parentRev = ArtificialToDiffOptions(parentRev);
-            currentRev = ArtificialToDiffOptions(currentRev);
+            firstRevision = ArtificialToDiffOptions(firstRevision);
+            secondRevision = ArtificialToDiffOptions(secondRevision);
 
             //Note: As artificial are options, diff unstage..unstage and 
             // stage..stage will show output, different from e.g. HEAD..HEAD
             //Diff-to-itself is not always disabled or is transient why this is not handled as error in release builds
-            Debug.Assert(!(parentRev == currentRev && (parentRev.IsNullOrEmpty() || parentRev == StagedOpt)),
-                "Unexpectedly two identical artificial revisions to diff: " + parentRev +
+            Debug.Assert(!(firstRevision == secondRevision && (firstRevision.IsNullOrEmpty() || firstRevision == StagedOpt)),
+                "Unexpectedly two identical artificial revisions to diff: " + firstRevision +
                 ". This will be displayed as diff to HEAD, not an identical diff.");
 
             //As empty (unstaged) and --cached (staged) are options (not revisions),
             // order must be preserved with -R
-            if (parentRev != currentRev && (parentRev.IsNullOrEmpty() ||
-                               parentRev == StagedOpt && !currentRev.IsNullOrEmpty()))
+            if (firstRevision != secondRevision && (firstRevision.IsNullOrEmpty() ||
+                               firstRevision == StagedOpt && !secondRevision.IsNullOrEmpty()))
             {
                 extra = "-R";
             }
 
             //Special case: Remove options comparing unstaged-staged
-            if (parentRev.IsNullOrEmpty() && currentRev == StagedOpt ||
-                parentRev == StagedOpt && currentRev.IsNullOrEmpty())
+            if (firstRevision.IsNullOrEmpty() && secondRevision == StagedOpt ||
+                firstRevision == StagedOpt && secondRevision.IsNullOrEmpty())
             {
-                parentRev = currentRev = string.Empty;
+                firstRevision = secondRevision = string.Empty;
             }
 
             //Reorder options - not strictly required
-            if (currentRev == StagedOpt)
+            if (secondRevision == StagedOpt)
             {
                 extra += " " + StagedOpt;
-                currentRev = String.Empty;
+                secondRevision = String.Empty;
             }
 
             if (fileName.IsNullOrWhiteSpace())
             {
-                extra = string.Join(" ", extra, parentRev, currentRev);
+                extra = string.Join(" ", extra, firstRevision, secondRevision);
             }
             else
             {
@@ -119,7 +110,7 @@ namespace GitCommands.Git
                 }
                 else
                 {
-                    extra += " " + parentRev + " " + currentRev;
+                    extra += " " + firstRevision + " " + secondRevision;
                 }
 
                 extra += " -- " + fileName.QuoteNE() + " " + oldFileName.QuoteNE();

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2019,7 +2019,7 @@ namespace GitUI.CommandsDialogs
         {
             foreach (var item in items)
             {
-                string output = Module.OpenWithDifftool(item.Name, null, from, to);
+                string output = Module.OpenWithDifftool(item.Name, null, from, to, "", item.IsTracked);
                 if (!string.IsNullOrEmpty(output))
                     MessageBox.Show(this, output);
             }

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -137,7 +137,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var selectedItem in DiffFiles.SelectedItems)
             {
-                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind);
+                RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, selectedItem.IsTracked);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -256,13 +256,13 @@ namespace GitUI.CommandsDialogs
 
         private void ShowSelectedFileDiff()
         {
-            if (DiffFiles.SelectedItem == null)
+            var items = _revisionGrid.GetSelectedRevisions();
+            if (DiffFiles.SelectedItem == null || items.Count() == 0)
             {
                 DiffText.ViewPatch("");
                 return;
             }
 
-            var items = _revisionGrid.GetSelectedRevisions();
             if (items.Count() == 1)
             {
                 items.Add(new GitRevision(Module, DiffFiles.SelectedItemParent));

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -513,7 +513,7 @@ namespace GitUI.CommandsDialogs
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
                 GitItemStatus selectedItem = itemWithParent.Item;
-                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind);
+                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -482,12 +482,14 @@ namespace GitUI.Editor
 
         public void ViewGitItemRevision(string fileName, string guid)
         {
-            if (guid == GitRevision.UnstagedGuid) //working directory changes
+            if (guid == GitRevision.UnstagedGuid)
             {
+                //No blob exists for unstaged, present contents from file system
                 ViewFile(fileName);
             }
             else
             {
+                //Retrieve blob, same as GitItemStatus.TreeGuid
                 string blob = Module.GetFileBlobHash(fileName, guid);
                 ViewGitItem(fileName, blob);
             }
@@ -549,6 +551,7 @@ namespace GitUI.Editor
                                 PictureBox.Image = image;
                             });
             }
+            //Check binary from extension/attributes (a secondary check for file contents before display)
             else if (IsBinaryFile(fileName))
             {
                 ViewText(null, "Binary file: " + fileName);

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -73,7 +73,9 @@ namespace GitUI
 
         public static void ViewChanges(this FileViewer diffViewer, IList<GitRevision> revisions, GitItemStatus file, string defaultText)
         {
-            var firstRevision = revisions.Count > 0 ? revisions[0] : null;
+            if (revisions.Count == 0)
+                return;
+            var firstRevision = revisions[0];
             string firstRevisionGuid = firstRevision?.Guid;
             string parentRevisionGuid = revisions.Count == 2 ? revisions[1].Guid : null;
             if (parentRevisionGuid == null && firstRevision != null)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -75,19 +75,20 @@ namespace GitUI
         {
             if (revisions.Count == 0)
                 return;
-            var firstRevision = revisions[0];
-            string firstRevisionGuid = firstRevision?.Guid;
-            string parentRevisionGuid = revisions.Count == 2 ? revisions[1].Guid : null;
-            if (parentRevisionGuid == null && firstRevision != null)
-                parentRevisionGuid = firstRevision.FirstParentGuid;
-            ViewChanges(diffViewer, firstRevisionGuid, parentRevisionGuid, file, defaultText);
+
+            var selectedRevision = revisions[0];
+            string secondRevision = selectedRevision?.Guid;
+            string firstRevision = revisions.Count >= 2 ? revisions[1].Guid : null;
+            if (firstRevision == null && selectedRevision != null)
+                firstRevision = selectedRevision.FirstParentGuid;
+            ViewChanges(diffViewer, firstRevision, secondRevision, file, defaultText);
         }
 
-        public static void ViewChanges(this FileViewer diffViewer, string revision, string parentRevision, GitItemStatus file, string defaultText)
+        public static void ViewChanges(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file, string defaultText)
         {
             diffViewer.ViewPatch(() =>
             {
-                string selectedPatch = diffViewer.GetSelectedPatch(parentRevision, revision, file);
+                string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
                 return selectedPatch ?? defaultText;
             });
         }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -18,7 +18,7 @@ namespace GitUI
         public static SynchronizationContext UISynchronizationContext;
 
 
-        public static void OpenWithDifftool(this RevisionGrid grid, string fileName, string oldFileName, GitUI.RevisionDiffKind diffKind)
+        public static void OpenWithDifftool(this RevisionGrid grid, string fileName, string oldFileName, GitUI.RevisionDiffKind diffKind, bool isTracked=true)
         {
             //Note: Order in revisions is that first clicked is last in array
             string extraDiffArgs;
@@ -32,7 +32,7 @@ namespace GitUI
             }
             else
             {
-                string output = grid.Module.OpenWithDifftool(fileName, oldFileName, firstRevision, secondRevision, extraDiffArgs);
+                string output = grid.Module.OpenWithDifftool(fileName, oldFileName, firstRevision, secondRevision, extraDiffArgs, isTracked);
                 if (!string.IsNullOrEmpty(output))
                     MessageBox.Show(grid, output);
             }

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -88,6 +88,43 @@ namespace GitCommandsTests.Git
         {
             _revisionDiffProvider.Get(from, to).Should().Be("\"123456789\" \"HEAD\"");
         }
+
+        [TestCase("123456789", GitRevision.UnstagedGuid, "a.txt", null, true)]
+        public void RevisionDiffProvider_fileNameTracked1(string from, string to, string fileName, string oldFileName, bool isTracked)
+        {
+            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("\"123456789\"  -- \"a.txt\"");
+        }
+
+        [TestCase("123456789", "HEAD", null, "b.txt", true)]
+        public void RevisionDiffProvider_fileNameTracked2(string from, string to, string fileName, string oldFileName, bool isTracked)
+        {
+            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"HEAD\"");
+        }
+
+        [TestCase("123456789", "234567890", "a.txt", "b.txt", true)]
+        public void RevisionDiffProvider_fileNameTracked3(string from, string to, string fileName, string oldFileName, bool isTracked)
+        {
+            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"234567890\" -- \"a.txt\" \"b.txt\"");
+        }
+
+        [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, "a.txt", null, false)]
+        public void RevisionDiffProvider_fileNameUntracked1(string from, string to, string fileName, string oldFileName, bool isTracked)
+        {
+            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
+        }
+
+        [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, null, "b.txt", false)]
+        public void RevisionDiffProvider_fileNameUntracked2(string from, string to, string fileName, string oldFileName, bool isTracked)
+        {
+            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().BeEmpty();
+        }
+
+        //Ignore revisions for untracked
+        [TestCase("123456789", "234567890", "a.txt", "b.txt", false)]
+        public void RevisionDiffProvider_fileNameUntracked3(string from, string to, string fileName, string oldFileName, bool isTracked)
+        {
+            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
+        }
     }
 }
 

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -27,103 +27,108 @@ namespace GitCommandsTests.Git
         [TestCase(null)]
         [TestCase("")]
         [TestCase(GitRevision.UnstagedGuid)]
-        public void RevisionDiffProvider_should_return_empty_if_To_is_UnstagedGuid(string from)
+        public void RevisionDiffProvider_should_return_empty_if_To_is_UnstagedGuid(string parentRev)
         {
-            _revisionDiffProvider.Get(from, GitRevision.UnstagedGuid).Should().BeEmpty();
+            _revisionDiffProvider.Get(parentRev, GitRevision.UnstagedGuid).Should().BeEmpty();
         }
 
         //Two staged revisions gives duplicated options, no reason to clean
         [TestCase("^")]
         [TestCase(GitRevision.IndexGuid)]
-        public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string from)
+        public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string parentRev)
         {
-            _revisionDiffProvider.Get(from, GitRevision.IndexGuid).Should().Be("--cached --cached");
+            _revisionDiffProvider.Get(parentRev, GitRevision.IndexGuid).Should().Be("--cached --cached");
         }
 #endif
 
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid)]
         [TestCase("^", "")]
         [TestCase(GitRevision.IndexGuid, null)]
-        public void RevisionDiffProvider_staged_to_unstaged(string from, string to)
+        public void RevisionDiffProvider_staged_to_unstaged(string parentRev, string currentRev)
         {
-            _revisionDiffProvider.Get(from, to).Should().BeEmpty();
+            _revisionDiffProvider.Get(parentRev, currentRev).Should().BeEmpty();
         }
 
         [TestCase(GitRevision.UnstagedGuid, GitRevision.IndexGuid)]
         [TestCase("", "^")]
-        public void RevisionDiffProvider_unstaged_to_staged(string from, string to)
+        public void RevisionDiffProvider_unstaged_to_staged(string parentRev, string currentRev)
         {
-            _revisionDiffProvider.Get(from, to).Should().Be("-R");
+            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("-R");
         }
 
         [TestCase(GitRevision.UnstagedGuid + "^^")]
         [TestCase(GitRevision.IndexGuid + "^")]
         [TestCase("HEAD")]
-        public void RevisionDiffProvider_head_to_unstaged(string from)
+        public void RevisionDiffProvider_head_to_unstaged(string parentRev)
         {
-            _revisionDiffProvider.Get(from, GitRevision.UnstagedGuid).Should().Be("\"HEAD\"");
+            _revisionDiffProvider.Get(parentRev, GitRevision.UnstagedGuid).Should().Be("\"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid + "^", "^")]
         [TestCase("HEAD", GitRevision.IndexGuid)]
-        public void RevisionDiffProvider_head_to_staged(string from, string to)
+        public void RevisionDiffProvider_head_to_staged(string parentRev, string currentRev)
         {
-            _revisionDiffProvider.Get(from, to).Should().Be("--cached \"HEAD\"");
+            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("--cached \"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid, "HEAD")]
-        public void RevisionDiffProvider_staged_to_head(string from, string to)
+        public void RevisionDiffProvider_staged_to_head(string parentRev, string currentRev)
         {
-            _revisionDiffProvider.Get(from, to).Should().Be("-R --cached \"HEAD\"");
+            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("-R --cached \"HEAD\"");
         }
 
         [TestCase("HEAD", "123456789")]
-        public void RevisionDiffProvider_normal1(string from, string to)
+        public void RevisionDiffProvider_normal1(string parentRev, string currentRev)
         {
-            _revisionDiffProvider.Get(from, to).Should().Be("\"HEAD\" \"123456789\"");
+            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("\"HEAD\" \"123456789\"");
         }
 
         [TestCase("123456789", "HEAD")]
-        public void RevisionDiffProvider_normal2(string from, string to)
+        public void RevisionDiffProvider_normal2(string parentRev, string currentRev)
         {
-            _revisionDiffProvider.Get(from, to).Should().Be("\"123456789\" \"HEAD\"");
+            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("\"123456789\" \"HEAD\"");
         }
 
+        //Standard usage when filename is included
         [TestCase("123456789", GitRevision.UnstagedGuid, "a.txt", null, true)]
-        public void RevisionDiffProvider_fileNameTracked1(string from, string to, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_tracked1(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("\"123456789\"  -- \"a.txt\"");
+            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("\"123456789\"  -- \"a.txt\"");
         }
 
+        //If fileName is null, ignore oldFileName and tracked
         [TestCase("123456789", "HEAD", null, "b.txt", true)]
-        public void RevisionDiffProvider_fileNameTracked2(string from, string to, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_nul_oldname(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"HEAD\"");
+            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"HEAD\"");
         }
 
+        //Include old filename if is included
         [TestCase("123456789", "234567890", "a.txt", "b.txt", true)]
-        public void RevisionDiffProvider_fileNameTracked3(string from, string to, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_oldfilename(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"234567890\" -- \"a.txt\" \"b.txt\"");
+            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"234567890\" -- \"a.txt\" \"b.txt\"");
         }
 
+        //normal testcase when untracked is set
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, "a.txt", null, false)]
-        public void RevisionDiffProvider_fileNameUntracked1(string from, string to, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_untracked1(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
+            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
         }
 
+        //If fileName is null, ignore oldFileName and tracked
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, null, "b.txt", false)]
-        public void RevisionDiffProvider_fileNameUntracked2(string from, string to, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileNameUntracked2(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().BeEmpty();
+            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().BeEmpty();
         }
 
         //Ignore revisions for untracked
         [TestCase("123456789", "234567890", "a.txt", "b.txt", false)]
-        public void RevisionDiffProvider_fileNameUntracked3(string from, string to, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileNameUntracked3(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
+            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -27,108 +27,108 @@ namespace GitCommandsTests.Git
         [TestCase(null)]
         [TestCase("")]
         [TestCase(GitRevision.UnstagedGuid)]
-        public void RevisionDiffProvider_should_return_empty_if_To_is_UnstagedGuid(string parentRev)
+        public void RevisionDiffProvider_should_return_empty_if_To_is_UnstagedGuid(string firstRevision)
         {
-            _revisionDiffProvider.Get(parentRev, GitRevision.UnstagedGuid).Should().BeEmpty();
+            _revisionDiffProvider.Get(firstRevision, GitRevision.UnstagedGuid).Should().BeEmpty();
         }
 
         //Two staged revisions gives duplicated options, no reason to clean
         [TestCase("^")]
         [TestCase(GitRevision.IndexGuid)]
-        public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string parentRev)
+        public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string firstRevision)
         {
-            _revisionDiffProvider.Get(parentRev, GitRevision.IndexGuid).Should().Be("--cached --cached");
+            _revisionDiffProvider.Get(firstRevision, GitRevision.IndexGuid).Should().Be("--cached --cached");
         }
 #endif
 
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid)]
         [TestCase("^", "")]
         [TestCase(GitRevision.IndexGuid, null)]
-        public void RevisionDiffProvider_staged_to_unstaged(string parentRev, string currentRev)
+        public void RevisionDiffProvider_staged_to_unstaged(string firstRevision, string secondRevision)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev).Should().BeEmpty();
+            _revisionDiffProvider.Get(firstRevision, secondRevision).Should().BeEmpty();
         }
 
         [TestCase(GitRevision.UnstagedGuid, GitRevision.IndexGuid)]
         [TestCase("", "^")]
-        public void RevisionDiffProvider_unstaged_to_staged(string parentRev, string currentRev)
+        public void RevisionDiffProvider_unstaged_to_staged(string firstRevision, string secondRevision)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("-R");
+            _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("-R");
         }
 
         [TestCase(GitRevision.UnstagedGuid + "^^")]
         [TestCase(GitRevision.IndexGuid + "^")]
         [TestCase("HEAD")]
-        public void RevisionDiffProvider_head_to_unstaged(string parentRev)
+        public void RevisionDiffProvider_head_to_unstaged(string firstRevision)
         {
-            _revisionDiffProvider.Get(parentRev, GitRevision.UnstagedGuid).Should().Be("\"HEAD\"");
+            _revisionDiffProvider.Get(firstRevision, GitRevision.UnstagedGuid).Should().Be("\"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid + "^", "^")]
         [TestCase("HEAD", GitRevision.IndexGuid)]
-        public void RevisionDiffProvider_head_to_staged(string parentRev, string currentRev)
+        public void RevisionDiffProvider_head_to_staged(string firstRevision, string secondRevision)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("--cached \"HEAD\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("--cached \"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid, "HEAD")]
-        public void RevisionDiffProvider_staged_to_head(string parentRev, string currentRev)
+        public void RevisionDiffProvider_staged_to_head(string firstRevision, string secondRevision)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("-R --cached \"HEAD\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("-R --cached \"HEAD\"");
         }
 
         [TestCase("HEAD", "123456789")]
-        public void RevisionDiffProvider_normal1(string parentRev, string currentRev)
+        public void RevisionDiffProvider_normal1(string firstRevision, string secondRevision)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("\"HEAD\" \"123456789\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("\"HEAD\" \"123456789\"");
         }
 
         [TestCase("123456789", "HEAD")]
-        public void RevisionDiffProvider_normal2(string parentRev, string currentRev)
+        public void RevisionDiffProvider_normal2(string firstRevision, string secondRevision)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev).Should().Be("\"123456789\" \"HEAD\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("\"123456789\" \"HEAD\"");
         }
 
         //Standard usage when filename is included
         [TestCase("123456789", GitRevision.UnstagedGuid, "a.txt", null, true)]
-        public void RevisionDiffProvider_fileName_tracked1(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_tracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("\"123456789\"  -- \"a.txt\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("\"123456789\"  -- \"a.txt\"");
         }
 
         //If fileName is null, ignore oldFileName and tracked
         [TestCase("123456789", "HEAD", null, "b.txt", true)]
-        public void RevisionDiffProvider_fileName_nul_oldname(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_null_with_oldname(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"HEAD\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"HEAD\"");
         }
 
         //Include old filename if is included
         [TestCase("123456789", "234567890", "a.txt", "b.txt", true)]
-        public void RevisionDiffProvider_fileName_oldfilename(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_oldfilename(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"234567890\" -- \"a.txt\" \"b.txt\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("\"123456789\" \"234567890\" -- \"a.txt\" \"b.txt\"");
         }
 
         //normal testcase when untracked is set
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, "a.txt", null, false)]
-        public void RevisionDiffProvider_fileName_untracked1(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_untracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
         }
 
         //If fileName is null, ignore oldFileName and tracked
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, null, "b.txt", false)]
-        public void RevisionDiffProvider_fileNameUntracked2(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_null_Untracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().BeEmpty();
+            _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().BeEmpty();
         }
 
         //Ignore revisions for untracked
         [TestCase("123456789", "234567890", "a.txt", "b.txt", false)]
-        public void RevisionDiffProvider_fileNameUntracked3(string parentRev, string currentRev, string fileName, string oldFileName, bool isTracked)
+        public void RevisionDiffProvider_fileName_oldfilename_Untracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
-            _revisionDiffProvider.Get(parentRev, currentRev, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
+            _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
         }
     }
 }


### PR DESCRIPTION
Reported in #4301, some explanations there as well as screenshots
This mostly drops some special checks, a few lines to handle untracked with git-diff --no-index
 * "if (parentRevision == null)" in ViewChanges() were never taken. If so, it would have displayed the untracked similar to FormCommit.
    Using ViewFile as done in FormCommit would have been cleaner and better presentation than current but not presenting as diff. For instance,  FileReader.ReadFileContent(fullPath, diffViewer.Encoding) will not check for binary files and will present garbage or give exceptions.
 * IsItemUntracked() was slightly incorrect (should have used file.IsTracked)
 
Screenshots before and after (if PR changes UI):
- See #4301 

What did I do to test the code and ensure quality:
 - Enable view of artificial commits, view Unstaged commit
 - Add new files (text and binary), submodules
 - View the files in Diff tab
 - Select Unstaged, the Staged, compare the revisions

Has been tested on (remove any that don't apply):
 - Windows 10
