### PR TITLE
FormFileHistory: DiffToLocal hidden also when relevant

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -18,6 +18,7 @@ namespace GitUI.CommandsDialogs
         private readonly FilterBranchHelper _filterBranchHelper;
         private readonly AsyncLoader _asyncLoader;
         private readonly FormBrowseMenus _formBrowseMenus;
+        private readonly IFullPathResolver _fullPathResolver;
 
         private readonly TranslationString _buildReportTabCaption =
             new TranslationString("Build Report");
@@ -54,6 +55,7 @@ namespace GitUI.CommandsDialogs
             _formBrowseMenus.InsertAdditionalMainMenuItems(toolStripSeparator4);
 
             _commitDataManager = new CommitDataManager(() => Module);
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         public FormFileHistory(GitUICommands aCommands, string fileName, GitRevision revision, bool filterByRevision)
@@ -430,7 +432,7 @@ namespace GitUI.CommandsDialogs
 
             diffToolremotelocalStripMenuItem.Enabled =
                 selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.UnstagedGuid &&
-                File.Exists(Path.Combine(Module.WorkingDir, FileName));
+                File.Exists(_fullPathResolver.Resolve(FileName));
             openWithDifftoolToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;
             manipuleerCommitToolStripMenuItem.Enabled =

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -429,7 +429,8 @@ namespace GitUI.CommandsDialogs
             var selectedRevisions = FileChanges.GetSelectedRevisions();
 
             diffToolremotelocalStripMenuItem.Enabled =
-                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.UnstagedGuid && File.Exists(FileName);
+                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.UnstagedGuid &&
+                File.Exists(Path.Combine(Module.WorkingDir, FileName));
             openWithDifftoolToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;
             manipuleerCommitToolStripMenuItem.Enabled =


### PR DESCRIPTION
Regression in #4308 9f5fe413

Fixes #4315
bug, regression in 2.51.RC1
Introduced in 9f5fe41

Changes proposed in this pull request:
 - FormFileHistory, enable diff-to-local when local file exists
 
What did I do to test the code and ensure quality:
 - Context menu in revision grid
 - DiffToLocal isenabled when a local file exists

Has been tested on (remove any that don't apply):
 - Windows 10
