### PR TITLE
Browse Diff Untracked: Delete and Edit menu items are not enabled

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -226,7 +226,7 @@ namespace GitUI.CommandsDialogs
             var isCombinedDiff = isExactlyOneItemSelected && DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
             var selectedItemStatus = DiffFiles.SelectedItem;
             bool isBareRepository = Module.IsBareRepository();
-            bool singleFileExists = isExactlyOneItemSelected && File.Exists(DiffFiles.SelectedItem.Name); 
+            bool singleFileExists = isExactlyOneItemSelected && File.Exists(FormBrowseUtil.GetFullPathFromGitItemStatus(Module, DiffFiles.SelectedItem));
 
             var selectionInfo = new ContextMenuSelectionInfo(selectedRevisions, selectedItemStatus, isAnyCombinedDiff, isExactlyOneItemSelected, isCombinedDiff, isAnyItemSelected, isBareRepository, singleFileExists);
             return selectionInfo;


### PR DESCRIPTION
New functionality in 2.50.02 #4031, regression from #4208 9f5fe413

Fixes #4316

Changes proposed in this pull request:
 - Functionality enabled in 2.51 #4031 is not enabled due to an incorrect check introduced in #4208 9f5fe41
 
Screenshots before and after (if PR changes UI):
- after
![image](https://user-images.githubusercontent.com/6248932/34611304-3198c506-f225-11e7-8b1f-bb5d5b24a38f.png)

What did I do to test the code and ensure quality:
 -   View Unstaged commits
 -   Edit and Delete menu items are available

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
