### PR TITLE
Display branch name in bold only when it is the one checked out

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1654,6 +1654,7 @@ namespace GitUI
 
                             ArrowType arrowType = gitRef.Selected ? ArrowType.Filled :
                                                   gitRef.SelectedHeadMergeSource ? ArrowType.NotFilled : ArrowType.None;
+                            drawRefArgs.RefsFont = gitRef.Selected ? rowFont : RefsFont;
 
                             var superprojectRef = superprojectRefs.FirstOrDefault(spGitRef => gitRef.CompleteName == spGitRef.CompleteName);
                             if (superprojectRef != null)
@@ -1680,6 +1681,7 @@ namespace GitUI
 
                         ArrowType arrowType = gitRef.Selected ? ArrowType.Filled :
                                               gitRef.SelectedHeadMergeSource ? ArrowType.NotFilled : ArrowType.None;
+                        drawRefArgs.RefsFont = gitRef.Selected ? rowFont : RefsFont;
 
                         offset = DrawRef(drawRefArgs, offset, gitRefName, headColor, arrowType, true, false);
                     }


### PR DESCRIPTION
Having all the branches and remotes of the commit line corresponfing to the checked out branch/revision is misleading and bring confusion to developper (and not reflect how git works).

This PR is here to improve the highlighting of the current branch checked out (because no one understand or look at these little triangles!!!)

## Screenshots

### When a branch is checked out:
* before:
![image](https://user-images.githubusercontent.com/460196/34629460-7551ba94-f268-11e7-95e4-f22a60a7ef37.png)

* after (only the good branch is in bold):
![image](https://user-images.githubusercontent.com/460196/34629475-85afd376-f268-11e7-8db2-8902fa21d60d.png)

### When a revision is checked out:
* before:
![image](https://user-images.githubusercontent.com/460196/34629545-cbefcd82-f268-11e7-93bd-43ec1942761f.png)

* after (no branch is in bold because we are on a commit revision):
![image](https://user-images.githubusercontent.com/460196/34629573-e916ba9c-f268-11e7-877b-a925d6a4f030.png)

### When in a Submodule

* before:
![image](https://user-images.githubusercontent.com/460196/34629659-403e465a-f269-11e7-9449-862dcc189fc7.png)

* after (better because a submodule point toward a commit):

![image](https://user-images.githubusercontent.com/460196/34629707-78549530-f269-11e7-810c-319fb4850c81.png)

What did I do to test the code and ensure quality:

* Manual test

Has been tested on (remove any that don't apply):
 - GIT 2.14.3 (but should have no effect on the change) 
 - Windows 10
