### PR TITLE
FormBrowse: Add option to display reflog references

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -156,6 +156,11 @@ namespace GitCommands
                 logParam = " --topo-order";
             }
 
+            if (AppSettings.ShowReflogReferences)
+            {
+                logParam += " --reflog";
+            }
+
             if ((RefsOptions & RefsFiltringOptions.All) == RefsFiltringOptions.All)
                 logParam += " --all";
             else

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -770,6 +770,12 @@ namespace GitCommands
             set { SetBool("showRemoteBranches", value); }
         }
 
+        public static bool ShowReflogReferences
+        {
+            get { return GetBool("showReflogReferences", false); }
+            set { SetBool("showReflogReferences", value); }
+        }
+
         public static bool ShowSuperprojectTags
         {
             get { return GetBool("showSuperprojectTags", false); }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2631,6 +2631,12 @@ namespace GitUI
             _revisionGridMenuCommands.TriggerMenuChanged(); // check/uncheck ToolStripMenuItem
         }
 
+        internal void ShowReflogReferences_ToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            AppSettings.ShowReflogReferences = !AppSettings.ShowReflogReferences;
+            ForceRefreshRevisions();
+        }
+
         internal void ShowSuperprojectTags_ToolStripMenuItemClick(object sender, EventArgs e)
         {
             AppSettings.ShowSuperprojectTags = !AppSettings.ShowSuperprojectTags;

--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -254,6 +254,16 @@ namespace GitUI.UserControls.RevisionGridClasses
                 resultList.Add(menuCommand);
             }
 
+            {
+                var menuCommand = new MenuCommand();
+                menuCommand.Name = "ShowReflogReferences";
+                menuCommand.Text = "Show reflog references";
+                menuCommand.ExecuteAction = () => _revisionGrid.ShowReflogReferences_ToolStripMenuItemClick(null, null);
+                menuCommand.IsCheckedFunc = () => AppSettings.ShowReflogReferences;
+
+                resultList.Add(menuCommand);
+            }
+
             resultList.Add(MenuCommand.CreateSeparator());
 
             {


### PR DESCRIPTION
(A more graphical way to retrieve lost commits)
 
Screenshots:
- Add a new option:

![image](https://user-images.githubusercontent.com/460196/34631832-9f0e8a06-f272-11e7-93c4-b3db3973cda4.png)

- that permit to show lost commits logged in the reflogs (here an amended commit)

![image](https://user-images.githubusercontent.com/460196/34631868-c3a03806-f272-11e7-89b1-293fac725dc7.png)

This feature was previously achievable, as a trick, by adding `--reflog` to the `branches` combobox but it was a too much hidden feature ;)

What did I do to test the code and ensure quality:
 - manual test

Has been tested on (remove any that don't apply):
 - GIT 2.14.3 and above
 - Windows 10