### PR TITLE
BuildReport exception displaying the report

### DIFF
--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -55,20 +55,27 @@ namespace GitUI.CommandsDialogs
 
                     if (isFavIconMissing || tabControl.SelectedTab == buildReportTabPage)
                     {
-                        if (revision.BuildStatus.ShowInBuildReportTab)
+                        try
                         {
-                            url = null;
-                            buildReportWebBrowser.Navigate(revision.BuildStatus.Url);
-                        }
-                        else
-                        {
-                            url = revision.BuildStatus.Url;
-                            buildReportWebBrowser.Navigate("about:blank");
-                        }
+                            if (revision.BuildStatus.ShowInBuildReportTab)
+                            {
+                                url = null;
+                                buildReportWebBrowser.Navigate(revision.BuildStatus.Url);
+                            }
+                            else
+                            {
+                                url = revision.BuildStatus.Url;
+                                buildReportWebBrowser.Navigate("about:blank");
+                            }
 
-                        if (isFavIconMissing)
+                            if (isFavIconMissing)
+                            {
+                                buildReportWebBrowser.Navigated += BuildReportWebBrowserOnNavigated;
+                            }
+                        }
+                        catch
                         {
-                            buildReportWebBrowser.Navigated += BuildReportWebBrowserOnNavigated;
+                            //No propagation to the user if the report fails
                         }
                     }
 


### PR DESCRIPTION
Fixes #4322

Changes proposed in this pull request:
 - try-catch around invoking WebBrowserCtrl Navigate
 
Screenshots before and after (if PR changes UI):
- None

What did I do to test the code and ensure quality:
code review

Has been tested on (remove any that don't apply):
 - Windows 10/7
