### PR TITLE
Refactor app version to the main title

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -1,0 +1,61 @@
+using System;
+using GitCommands.Repository;
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Provides the ability to generate application title.
+    /// </summary>
+    public interface IAppTitleGenerator
+    {
+        /// <summary>
+        /// Generates main window title according to given repository.
+        /// </summary>
+        /// <param name="workingDir">Path to repository.</param>
+        /// <param name="isValidWorkingDir">Indicates whether the given path contains a valid repository.</param>
+        /// <param name="branchName">Current branch name.</param>
+        string Generate(string workingDir, bool isValidWorkingDir, string branchName);
+    }
+
+    /// <summary>
+    /// Generates application title.
+    /// </summary>
+    public sealed class AppTitleGenerator : IAppTitleGenerator
+    {
+        private const string DefaultTitle = "Git Extensions";
+        private const string RepositoryTitleFormat = "{0} ({1}) - Git Extensions";
+        private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
+
+
+        public AppTitleGenerator(IRepositoryDescriptionProvider repositoryDescriptionProvider)
+        {
+            _repositoryDescriptionProvider = repositoryDescriptionProvider;
+        }
+
+
+        /// <summary>
+        /// Generates main window title according to given repository.
+        /// </summary>
+        /// <param name="workingDir">Path to repository.</param>
+        /// <param name="isValidWorkingDir">Indicates whether the given path contains a valid repository.</param>
+        /// <param name="branchName">Current branch name.</param>
+        public string Generate(string workingDir, bool isValidWorkingDir, string branchName)
+        {
+            if (string.IsNullOrWhiteSpace(workingDir))
+            {
+                throw new ArgumentException(nameof(workingDir));
+            }
+
+            if (!isValidWorkingDir)
+            {
+                return DefaultTitle;
+            }
+            string repositoryDescription = _repositoryDescriptionProvider.Get(workingDir);
+            var title = string.Format(RepositoryTitleFormat, repositoryDescription, (branchName ?? "no branch").Trim('(', ')'));
+#if DEBUG
+            title += " -> DEBUG <-";
+#endif
+            return title;
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Git\Tag\TagOperation.cs" />
     <Compile Include="Git\Tag\TagOperationExtensions.cs" />
     <Compile Include="Remote\GitRemoteManager.cs" />
+    <Compile Include="Repository\RepositoryDescriptionProvider.cs" />
     <Compile Include="Settings\BranchOrdering.cs" />
     <Compile Include="Git\GitGpgController.cs" />
     <Compile Include="SshPathLocator.cs" />

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -81,6 +81,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Annotations.cs" />
+    <Compile Include="AppTitleGenerator.cs" />
     <Compile Include="AsyncLoader.cs" />
     <Compile Include="CommitData.cs" />
     <Compile Include="CommitDataManager.cs" />

--- a/GitCommands/Repository/RepositoryDescriptionProvider.cs
+++ b/GitCommands/Repository/RepositoryDescriptionProvider.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using GitCommands.Git;
+
+namespace GitCommands.Repository
+{
+    public interface IRepositoryDescriptionProvider
+    {
+        /// <summary>
+        /// Returns a short name for repository.
+        /// If the repository contains a description it is returned,
+        /// otherwise the last part of path is returned.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        /// <returns>Short name for repository</returns>
+        string Get(string repositoryDir);
+    }
+
+    public sealed class RepositoryDescriptionProvider : IRepositoryDescriptionProvider
+    {
+        private const string RepositoryDescriptionFileName = "description";
+        private const string DefaultDescription = "Unnamed repository; edit this file 'description' to name the repository.";
+        private readonly IGitDirectoryResolver _gitDirectoryResolver;
+
+
+        public RepositoryDescriptionProvider(IGitDirectoryResolver gitDirectoryResolver)
+        {
+            _gitDirectoryResolver = gitDirectoryResolver;
+        }
+
+
+        /// <summary>
+        /// Returns a short name for repository.
+        /// If the repository contains a description it is returned,
+        /// otherwise the last part of path is returned.
+        /// </summary>
+        /// <param name="repositoryDir">Path to repository.</param>
+        /// <returns>Short name for repository</returns>
+        public string Get(string repositoryDir)
+        {
+            var dirInfo = new DirectoryInfo(repositoryDir);
+            if (!dirInfo.Exists)
+            {
+                return dirInfo.Name;
+            }
+
+            string desc = ReadRepositoryDescription(repositoryDir);
+            if (desc.IsNullOrEmpty())
+            {
+                desc = Repositories.RepositoryHistory.Repositories
+                                        .Where(repo => repo.Path.Equals(repositoryDir, StringComparison.CurrentCultureIgnoreCase))
+                                        .Select(repo => repo.Title)
+                                        .FirstOrDefault();
+            }
+            return desc ?? dirInfo.Name;
+        }
+
+        /// <summary>
+        /// Reads repository description's first line from ".git\description" file.
+        /// </summary>
+        /// <param name="workingDir">Path to repository.</param>
+        /// <returns>If the repository has description, returns that description, else returns <c>null</c>.</returns>
+        private string ReadRepositoryDescription(string workingDir)
+        {
+
+            var repositoryPath = _gitDirectoryResolver.Resolve(workingDir);
+            var repositoryDescriptionFilePath = Path.Combine(repositoryPath, RepositoryDescriptionFileName);
+            if (!File.Exists(repositoryDescriptionFilePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var repositoryDescription = File.ReadLines(repositoryDescriptionFilePath).FirstOrDefault();
+                return string.Equals(repositoryDescription, DefaultDescription, StringComparison.CurrentCulture)
+                    ? null
+                    : repositoryDescription;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+        }
+
+    }
+}

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -132,6 +132,7 @@ namespace GitUI.CommandsDialogs
         private readonly SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("FormBrowse"));
         private readonly IFormBrowseController _controller;
         private readonly ICommitDataManager _commitDataManager;
+        private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
         private static bool _showRevisionInfoNextToRevisionGrid;
 
         /// <summary>
@@ -228,6 +229,7 @@ namespace GitUI.CommandsDialogs
                 _commitDataManager = new CommitDataManager(() => Module);
             }
 
+            _repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
             FillBuildReport();  // Ensure correct page visibility
             RevisionGrid.ShowBuildServerInfo = true;
 
@@ -650,29 +652,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        /// <summary>
-        /// Returns a short name for repository.
-        /// If the repository contains a description it is returned,
-        /// otherwise the last part of path is returned.
-        /// </summary>
-        /// <param name="repositoryDir">Path to repository.</param>
-        /// <returns>Short name for repository</returns>
-        private static string GetRepositoryShortName(string repositoryDir)
-        {
-            DirectoryInfo dirInfo = new DirectoryInfo(repositoryDir);
-            if (dirInfo.Exists)
-            {
-                string desc = ReadRepositoryDescription(repositoryDir);
-                if (desc.IsNullOrEmpty())
-                {
-                    desc = Repositories.RepositoryHistory.Repositories
-                        .Where(repo => repo.Path.Equals(repositoryDir, StringComparison.CurrentCultureIgnoreCase)).Select(repo => repo.Title)
-                        .FirstOrDefault();
-                }
-                return desc ?? dirInfo.Name;
-            }
-            return dirInfo.Name;
-        }
 
         private void LoadUserMenu()
         {
@@ -726,7 +705,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (validWorkingDir)
                 {
-                    string repositoryDescription = GetRepositoryShortName(Module.WorkingDir);
+                    string repositoryDescription = _repositoryDescriptionProvider.Get(Module.WorkingDir);
                     string baseFolder = Path.Combine(AppSettings.ApplicationDataPath.Value, "Recent");
                     if (!Directory.Exists(baseFolder))
                     {
@@ -963,33 +942,6 @@ namespace GitUI.CommandsDialogs
                 branchName = _noBranchTitle.Text;
             return string.Format(repositoryTitleFormat, repositoryDescription,
                 branchName.Trim('(', ')'), additionalTitleText);
-        }
-
-        /// <summary>
-        /// Reads repository description's first line from ".git\description" file.
-        /// </summary>
-        /// <param name="workingDir">Path to repository.</param>
-        /// <returns>If the repository has description, returns that description, else returns <c>null</c>.</returns>
-        private static string ReadRepositoryDescription(string workingDir)
-        {
-            const string repositoryDescriptionFileName = "description";
-            const string defaultDescription = "Unnamed repository; edit this file 'description' to name the repository.";
-
-            var repositoryPath = GitModule.GetGitDirectory(workingDir);
-            var repositoryDescriptionFilePath = Path.Combine(repositoryPath, repositoryDescriptionFileName);
-            if (!File.Exists(repositoryDescriptionFilePath))
-                return null;
-            try
-            {
-                var repositoryDescription = File.ReadLines(repositoryDescriptionFilePath).FirstOrDefault();
-                return string.Equals(repositoryDescription, defaultDescription, StringComparison.CurrentCulture)
-                           ? null
-                           : repositoryDescription;
-            }
-            catch (IOException)
-            {
-                return null;
-            }
         }
 
         private void RebaseClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -133,6 +133,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFormBrowseController _controller;
         private readonly ICommitDataManager _commitDataManager;
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
+        private readonly IAppTitleGenerator _appTitleGenerator;
         private static bool _showRevisionInfoNextToRevisionGrid;
 
         /// <summary>
@@ -230,6 +231,8 @@ namespace GitUI.CommandsDialogs
             }
 
             _repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
+            _appTitleGenerator = new AppTitleGenerator(_repositoryDescriptionProvider);
+
             FillBuildReport();  // Ensure correct page visibility
             RevisionGrid.ShowBuildServerInfo = true;
 
@@ -567,7 +570,8 @@ namespace GitUI.CommandsDialogs
             if (hard && hasWorkingDir)
                 ShowRevisions();
             RefreshWorkingDirCombo();
-            Text = GenerateWindowTitle(Module.WorkingDir, validWorkingDir, branchSelect.Text);
+            var branchName = !string.IsNullOrEmpty(branchSelect.Text) ? branchSelect.Text : _noBranchTitle.Text;
+            Text = _appTitleGenerator.Generate(Module.WorkingDir, validWorkingDir, branchName);
             UpdateJumplist(validWorkingDir);
 
             OnActivate();
@@ -918,30 +922,6 @@ namespace GitUI.CommandsDialogs
                     else
                         statusStrip.Hide();
                 });
-        }
-
-        /// <summary>
-        /// Generates main window title according to given repository.
-        /// </summary>
-        /// <param name="workingDir">Path to repository.</param>
-        /// <param name="isWorkingDirValid">If the given path contains valid repository.</param>
-        /// <param name="branchName">Current branch name.</param>
-        private string GenerateWindowTitle(string workingDir, bool isWorkingDirValid, string branchName)
-        {
-            const string defaultTitle = "Git Extensions";
-            const string repositoryTitleFormat = "{0} ({1}) - Git Extensions{2}";
-            // ReSharper disable once RedundantAssignment
-            string additionalTitleText = "";
-#if DEBUG
-            additionalTitleText = " -> DEBUG <-";
-#endif
-            if (!isWorkingDirValid)
-                return defaultTitle + additionalTitleText;
-            string repositoryDescription = GetRepositoryShortName(workingDir);
-            if (string.IsNullOrEmpty(branchName))
-                branchName = _noBranchTitle.Text;
-            return string.Format(repositoryTitleFormat, repositoryDescription,
-                branchName.Trim('(', ')'), additionalTitleText);
         }
 
         private void RebaseClick(object sender, EventArgs e)

--- a/UnitTests/GitCommandsTests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommandsTests/AppTitleGeneratorTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Repository;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class AppTitleGeneratorTests
+    {
+        private const string ShortName = "gitextension";
+        private IRepositoryDescriptionProvider _repositoryDescriptionProvider;
+        private AppTitleGenerator _appTitleGenerator;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _repositoryDescriptionProvider = Substitute.For<IRepositoryDescriptionProvider>();
+            _repositoryDescriptionProvider.Get(Arg.Any<string>()).Returns(ShortName);
+
+            _appTitleGenerator = new AppTitleGenerator(_repositoryDescriptionProvider);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\t")]
+        public void Generate_should_throw_if_working_folder_invalid(string path)
+        {
+            ((Action)(() => _appTitleGenerator.Generate(path, false, null))).ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void Generate_should_return_default_title_if_not_valid_working_directory()
+        {
+            var title = _appTitleGenerator.Generate("a", false, null);
+            title.Should().Be("Git Extensions");
+        }
+
+        [Test]
+        public void Generate_should_include_no_branch_if_supplied()
+        {
+            var title = _appTitleGenerator.Generate("a", true, null);
+            title.Should().StartWith($"{ShortName} (no branch) - Git Extensions");
+        }
+
+        [Test]
+        public void Generate_should_include_suplied_branch_without_braces()
+        {
+            string branchName = "feature/my_(test)_branch";
+            var title = _appTitleGenerator.Generate("a", true, "(" + branchName + ")");
+            title.Should().StartWith($"{ShortName} ({branchName}) - Git Extensions");
+        }
+
+#if DEBUG
+        [Test]
+        public void Generate_should_include_debug_suffix()
+        {
+            var title = _appTitleGenerator.Generate("a", true, null);
+
+            title.Should().Be($"{ShortName} (no branch) - Git Extensions -> DEBUG <-");
+        }
+#endif
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppTitleGeneratorTests.cs" />
     <Compile Include="CommitDataManagerTest.cs" />
     <Compile Include="CommitTemplateManagerTests.cs" />
     <Compile Include="Config\ConfigFileTest.cs" />


### PR DESCRIPTION
* Extract the application title generation from FormBrowse into `AppTitleGenerator`.
* Move functionality dealing with repository description from FormBrowse into `RepositoryDescriptionProvider`

  