### PR TITLE
Commit count: Listing ignored files could hang GE

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1156,6 +1156,7 @@ namespace GitCommands
             gitItemStatus.IsSkipWorktree = x == 'S';
             gitItemStatus.IsRenamed = false;
             gitItemStatus.IsTracked = x != '?' && x != '!' && x != ' ' || !gitItemStatus.IsNew;
+            gitItemStatus.IsIgnored = x == '!';
             gitItemStatus.IsConflict = x == 'U';
             return gitItemStatus;
         }

--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -16,6 +16,7 @@ namespace GitCommands
             IsAssumeUnchanged = false;
             IsSkipWorktree = false;
             IsNew = false;
+            IsIgnored = false;
             IsStaged = true;
             IsSubmodule = false;
         }
@@ -28,7 +29,8 @@ namespace GitCommands
         {
             get
             {
-                if (!IsTracked) return "Untracked";
+                if (!IsIgnored) return "Ignored";
+                else if (!IsTracked) return "Untracked";
                 else if (IsDeleted) return "Deleted";
                 else if (IsChanged) return "Modified";
                 else if (IsNew) return "New";
@@ -45,6 +47,7 @@ namespace GitCommands
         public bool IsDeleted { get; set; }
         public bool IsChanged { get; set; }
         public bool IsNew { get; set; }
+        public bool IsIgnored { get; set; }
         public bool IsRenamed { get; set; }
         public bool IsCopied { get; set; }
         public bool IsConflict { get; set; }


### PR DESCRIPTION
Should be reviewed together with #4327, this PR is based on #4327 even if the changes can be separated.

Issue #4256
Listing ignored files with a separate "ls-files -o -i --exclude-standard" seem to never exit in some situations, see #4256
This reuses the git-status call with --ignored as an option to get the ignored files. (The option is only added when ls-files were called previously.) This call did not seem to hang with many ignored files and the command runtime does not increase much.

The solution is not optional though. It still lists all ignored files in memory. The time to find ignored files is faster, but a lot of memory is needed. #4256 has some discussions.
Also, processing all output to GitStatusItem first before creating the HashSet will require some more memory (temporary) than required.

There are likely better places to optimize (and this PR reduces CPU load by skipping a separate heavy ls-files), but memory and CPU usage (normally a few ms) can be improved by skipping ignored by default in GetAllChangedFilesFromString() and process the ignored separately. I felt this would make the solution more complex and duplicate code.

It would be more efficient from memory usage (some CPU hits) to use the Git 2.15.1 option --ignored=matching, but a fallback solution (at least) is needed.

Changes proposed in this pull request:
 - Use git-status to retrieve ignored files instead of ls-files

What did I do to test the code and ensure quality:
 - Test that ignored files are ignored in a similar way as before

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
  