### PR TITLE
Add "undo last commit" feature

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -765,6 +765,12 @@ namespace GitCommands
             set { SetBool("DontConfirmResolveConflicts", value); }
         }
 
+        public static bool DontConfirmUndoLastCommit
+        {
+            get { return GetBool("DontConfirmUndoLastCommit", false); }
+            set { SetBool("DontConfirmUndoLastCommit", value); }
+        }
+
         public static bool IncludeUntrackedFilesInAutoStash
         {
             get { return GetBool("includeUntrackedFilesInAutoStash", false); }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -181,6 +181,7 @@ namespace GitUI.CommandsDialogs
             this.toolPanel = new System.Windows.Forms.ToolStripContainer();
             this.revisionGpgInfo1 = new GitUI.CommandsDialogs.RevisionGpgInfo();
             this.createAStashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.undoLastCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MainSplitContainer)).BeginInit();
             this.MainSplitContainer.Panel1.SuspendLayout();
@@ -1053,6 +1054,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.commandsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.commitToolStripMenuItem,
+            this.undoLastCommitToolStripMenuItem,
             this.pullToolStripMenuItem,
             this.pushToolStripMenuItem,
             this.toolStripSeparator21,
@@ -1594,6 +1596,14 @@ namespace GitUI.CommandsDialogs
             this.revisionGpgInfo1.Size = new System.Drawing.Size(915, 258);
             this.revisionGpgInfo1.TabIndex = 0;
             // 
+            // undoLastCommitToolStripMenuItem
+            //
+            this.undoLastCommitToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconResetFileTo;
+            this.undoLastCommitToolStripMenuItem.Name = "undoLastCommitToolStripMenuItem";
+            this.undoLastCommitToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.undoLastCommitToolStripMenuItem.Text = "Undo last commit";
+            this.undoLastCommitToolStripMenuItem.Click += new System.EventHandler(this.undoLastCommitToolStripMenuItem_Click);
+            // 
             // createAStashToolStripMenuItem
             // 
             this.createAStashToolStripMenuItem.Name = "createAStashToolStripMenuItem";
@@ -1808,5 +1818,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripContainer toolPanel;
         private RevisionGpgInfo revisionGpgInfo1;
         private ToolStripMenuItem createAStashToolStripMenuItem;
+        private ToolStripMenuItem undoLastCommitToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -108,7 +108,13 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _commitButtonText =
             new TranslationString("Commit");
-        #endregion
+
+        private readonly TranslationString _undoLastCommitText =
+            new TranslationString("You will still be able to find all the commit's changes in the staging area\n\nDo you want to continue?");
+ 
+        private readonly TranslationString _undoLastCommitCaption =
+            new TranslationString("Undo last commit");
+       #endregion
 
         private Dashboard _dashboard;
         private ToolStripItem _rebase;
@@ -2014,6 +2020,7 @@ namespace GitUI.CommandsDialogs
             this.stashToolStripMenuItem.Enabled =
               selectedRevisions.Count > 0 && !Module.IsBareRepository();
 
+            this.undoLastCommitToolStripMenuItem.Enabled =
             this.resetToolStripMenuItem.Enabled =
             this.checkoutBranchToolStripMenuItem.Enabled =
             this.runMergetoolToolStripMenuItem.Enabled =
@@ -2796,6 +2803,16 @@ namespace GitUI.CommandsDialogs
         private void toolStripBranchFilterComboBox_Click(object sender, EventArgs e)
         {
             toolStripBranchFilterComboBox.DroppedDown = true;
+        }
+
+        private void undoLastCommitToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var dialogResult = MessageBox.Show(_undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            if (dialogResult == DialogResult.Yes)
+            {
+                Module.RunGitCmd("reset --soft HEAD~1");
+                RefreshRevisions();
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2807,8 +2807,7 @@ namespace GitUI.CommandsDialogs
 
         private void undoLastCommitToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var dialogResult = MessageBox.Show(_undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-            if (dialogResult == DialogResult.Yes)
+            if (AppSettings.DontConfirmUndoLastCommit || MessageBox.Show(this, _undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
                 Module.RunGitCmd("reset --soft HEAD~1");
                 RefreshRevisions();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -41,6 +41,7 @@
             this.chkAddTrackingRef = new System.Windows.Forms.CheckBox();
             this.chkPushNewBranch = new System.Windows.Forms.CheckBox();
             this.chkUpdateModules = new System.Windows.Forms.CheckBox();
+            this.chkUndoLastCommitConfirmation = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2.SuspendLayout();
             this.CheckoutGB.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
@@ -58,7 +59,7 @@
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(459, 275);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(459, 298);
             this.tableLayoutPanel2.TabIndex = 2;
             // 
             // CheckoutGB
@@ -69,7 +70,7 @@
             this.CheckoutGB.Dock = System.Windows.Forms.DockStyle.Top;
             this.CheckoutGB.Location = new System.Drawing.Point(3, 3);
             this.CheckoutGB.Name = "CheckoutGB";
-            this.CheckoutGB.Size = new System.Drawing.Size(453, 269);
+            this.CheckoutGB.Size = new System.Drawing.Size(453, 292);
             this.CheckoutGB.TabIndex = 0;
             this.CheckoutGB.TabStop = false;
             this.CheckoutGB.Text = "Don\'t ask to confirm to (use with caution)";
@@ -80,6 +81,7 @@
             this.tableLayoutPanel3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel3.ColumnCount = 1;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel3.Controls.Add(this.chkUndoLastCommitConfirmation, 0, 10);
             this.tableLayoutPanel3.Controls.Add(this.chkSecondAbortConfirmation, 0, 9);
             this.tableLayoutPanel3.Controls.Add(this.chkCommitAfterConflictsResolved, 0, 8);
             this.tableLayoutPanel3.Controls.Add(this.chkResolveConflicts, 0, 7);
@@ -92,7 +94,7 @@
             this.tableLayoutPanel3.Controls.Add(this.chkUpdateModules, 0, 6);
             this.tableLayoutPanel3.Location = new System.Drawing.Point(5, 19);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 10;
+            this.tableLayoutPanel3.RowCount = 11;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -103,7 +105,8 @@
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(442, 230);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(442, 253);
             this.tableLayoutPanel3.TabIndex = 1;
             // 
             // chkSecondAbortConfirmation
@@ -213,12 +216,23 @@
             this.chkUpdateModules.ThreeState = true;
             this.chkUpdateModules.UseVisualStyleBackColor = true;
             // 
+            // chkUndoLastCommitConfirmation
+            // 
+            this.chkUndoLastCommitConfirmation.AutoSize = true;
+            this.chkUndoLastCommitConfirmation.Location = new System.Drawing.Point(3, 233);
+            this.chkUndoLastCommitConfirmation.Name = "chkUndoLastCommitConfirmation";
+            this.chkUndoLastCommitConfirmation.Size = new System.Drawing.Size(107, 17);
+            this.chkUndoLastCommitConfirmation.TabIndex = 10;
+            this.chkUndoLastCommitConfirmation.Text = "Undo last commit";
+            this.chkUndoLastCommitConfirmation.ThreeState = true;
+            this.chkUndoLastCommitConfirmation.UseVisualStyleBackColor = true;
+            // 
             // ConfirmationsSettingsPage
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.Controls.Add(this.tableLayoutPanel2);
             this.Name = "ConfirmationsSettingsPage";
-            this.Size = new System.Drawing.Size(1109, 461);
+            this.Size = new System.Drawing.Size(1453, 919);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.CheckoutGB.ResumeLayout(false);
@@ -245,5 +259,6 @@
         private System.Windows.Forms.CheckBox chkCommitAfterConflictsResolved;
         private System.Windows.Forms.CheckBox chkResolveConflicts;
         private System.Windows.Forms.CheckBox chkSecondAbortConfirmation;
+        private System.Windows.Forms.CheckBox chkUndoLastCommitConfirmation;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -24,6 +24,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkResolveConflicts.Checked = AppSettings.DontConfirmResolveConflicts;
             chkCommitAfterConflictsResolved.Checked = AppSettings.DontConfirmCommitAfterConflictsResolved;
             chkSecondAbortConfirmation.Checked = AppSettings.DontConfirmSecondAbortConfirmation;
+            chkUndoLastCommitConfirmation.Checked = AppSettings.DontConfirmUndoLastCommit;
         }
 
         protected override void PageToSettings()
@@ -38,6 +39,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.DontConfirmResolveConflicts = chkResolveConflicts.Checked;
             AppSettings.DontConfirmCommitAfterConflictsResolved = chkCommitAfterConflictsResolved.Checked;
             AppSettings.DontConfirmSecondAbortConfirmation = chkSecondAbortConfirmation.Checked;
+            AppSettings.DontConfirmUndoLastCommit = chkUndoLastCommitConfirmation.Checked;
         }
 
         public static SettingsPageReference GetPageReference()


### PR DESCRIPTION
Changes proposed in this pull request:
 - And a feature to undo last commit of the current branch
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/460196/34654035-0a7a8bda-f3f6-11e7-8336-e9218dc42bcb.png)

What did I do to test the code and ensure quality:
 - manual testing

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
