### PR TITLE
Add feature to be able to do a partial stash

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -666,15 +666,20 @@ namespace GitCommands
             return sforce;
         }
 
-        public static string StashSaveCmd(bool untracked, bool keepIndex, string message)
+        public static string StashSaveCmd(bool untracked, bool keepIndex, string message, IEnumerable<string> selectedFiles)
         {
-            var cmd = "stash save";
+            var isPartialStash = selectedFiles != null && selectedFiles.Any();
+            var cmd = isPartialStash ? "stash push" : "stash save";
             if (untracked && VersionInUse.StashUntrackedFilesSupported)
                 cmd += " -u";
             if (keepIndex)
                 cmd += " --keep-index";
             cmd = cmd.Combine(" ", message.QuoteNE());
 
+            if (isPartialStash)
+            {
+                cmd += " -- " + string.Join(" ", selectedFiles);
+            }
             return cmd;
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -180,6 +180,7 @@ namespace GitUI.CommandsDialogs
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.toolPanel = new System.Windows.Forms.ToolStripContainer();
             this.revisionGpgInfo1 = new GitUI.CommandsDialogs.RevisionGpgInfo();
+            this.createAStashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MainSplitContainer)).BeginInit();
             this.MainSplitContainer.Panel1.SuspendLayout();
@@ -304,7 +305,8 @@ namespace GitUI.CommandsDialogs
             this.stashChangesToolStripMenuItem,
             this.stashPopToolStripMenuItem,
             this.toolStripSeparator9,
-            this.manageStashesToolStripMenuItem});
+            this.manageStashesToolStripMenuItem,
+            this.createAStashToolStripMenuItem});
             this.toolStripSplitStash.Image = global::GitUI.Properties.Resources.stash;
             this.toolStripSplitStash.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripSplitStash.Name = "toolStripSplitStash";
@@ -1592,6 +1594,13 @@ namespace GitUI.CommandsDialogs
             this.revisionGpgInfo1.Size = new System.Drawing.Size(915, 258);
             this.revisionGpgInfo1.TabIndex = 0;
             // 
+            // createAStashToolStripMenuItem
+            // 
+            this.createAStashToolStripMenuItem.Name = "createAStashToolStripMenuItem";
+            this.createAStashToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.createAStashToolStripMenuItem.Text = "Create a stash...";
+            this.createAStashToolStripMenuItem.Click += new System.EventHandler(this.CreateStashToolStripMenuItemClick);
+            // 
             // FormBrowse
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1798,5 +1807,6 @@ namespace GitUI.CommandsDialogs
         private RevisionDiff revisionDiff;
         private ToolStripContainer toolPanel;
         private RevisionGpgInfo revisionGpgInfo1;
+        private ToolStripMenuItem createAStashToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -30,7 +30,7 @@ namespace GitUI.CommandsDialogs
             this.stashChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stashPopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-            this.viewStashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.manageStashesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
             this.toolStripButtonPull = new System.Windows.Forms.ToolStripSplitButton();
             this.mergeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -304,7 +304,7 @@ namespace GitUI.CommandsDialogs
             this.stashChangesToolStripMenuItem,
             this.stashPopToolStripMenuItem,
             this.toolStripSeparator9,
-            this.viewStashToolStripMenuItem});
+            this.manageStashesToolStripMenuItem});
             this.toolStripSplitStash.Image = global::GitUI.Properties.Resources.stash;
             this.toolStripSplitStash.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripSplitStash.Name = "toolStripSplitStash";
@@ -334,13 +334,13 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator9.Name = "toolStripSeparator9";
             this.toolStripSeparator9.Size = new System.Drawing.Size(126, 6);
             // 
-            // viewStashToolStripMenuItem
+            // manageStashesToolStripMenuItem
             // 
-            this.viewStashToolStripMenuItem.Name = "viewStashToolStripMenuItem";
-            this.viewStashToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
-            this.viewStashToolStripMenuItem.Text = "View stash";
-            this.viewStashToolStripMenuItem.ToolTipText = "View stash";
-            this.viewStashToolStripMenuItem.Click += new System.EventHandler(this.ViewStashToolStripMenuItemClick);
+            this.manageStashesToolStripMenuItem.Name = "manageStashesToolStripMenuItem";
+            this.manageStashesToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.manageStashesToolStripMenuItem.Text = "Manage stashes...";
+            this.manageStashesToolStripMenuItem.ToolTipText = "Manage stashes";
+            this.manageStashesToolStripMenuItem.Click += new System.EventHandler(this.ManageStashesToolStripMenuItemClick);
             // 
             // toolStripButton1
             // 
@@ -1664,7 +1664,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem stashChangesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem stashPopToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
-        private System.Windows.Forms.ToolStripMenuItem viewStashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem manageStashesToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator17;
         private ToolStripSeparator toolStripSeparator19;
         private ToolStripLabel toolStripLabel1;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1471,7 +1471,12 @@ namespace GitUI.CommandsDialogs
 
         private void ManageStashesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            UICommands.StartStashDialog(this);
+            UICommands.StartStashDialog(this, true);
+        }
+
+        private void CreateStashToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.StartStashDialog(this, false);
         }
 
         private void ExitToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1469,7 +1469,7 @@ namespace GitUI.CommandsDialogs
             UICommands.StashPop(this);
         }
 
-        private void ViewStashToolStripMenuItemClick(object sender, EventArgs e)
+        private void ManageStashesToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartStashDialog(this);
         }

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -39,6 +39,7 @@ namespace GitUI.CommandsDialogs
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.StashSelectedFiles = new System.Windows.Forms.Button();
             this.Stash = new System.Windows.Forms.Button();
             this.chkIncludeUntrackedFiles = new System.Windows.Forms.CheckBox();
             this.StashKeepIndex = new System.Windows.Forms.CheckBox();
@@ -51,12 +52,11 @@ namespace GitUI.CommandsDialogs
             this.toolStrip1 = new GitUI.ToolStripEx();
             this.showToolStripLabel = new System.Windows.Forms.ToolStripLabel();
             this.Stashes = new System.Windows.Forms.ToolStripComboBox();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripButton_customMessage = new System.Windows.Forms.ToolStripButton();
             this.refreshToolStripButton = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton_customMessage = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.View = new GitUI.Editor.FileViewer();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.StashSelectedFiles = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.gitStashBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -78,7 +78,6 @@ namespace GitUI.CommandsDialogs
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -89,7 +88,7 @@ namespace GitUI.CommandsDialogs
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.View);
-            this.splitContainer1.Size = new System.Drawing.Size(885, 650);
+            this.splitContainer1.Size = new System.Drawing.Size(708, 520);
             this.splitContainer1.SplitterDistance = 280;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 0;
@@ -112,7 +111,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(280, 650);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(280, 520);
             this.tableLayoutPanel2.TabIndex = 2;
             // 
             // tableLayoutPanel1
@@ -128,8 +127,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.Controls.Add(this.Apply, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.Clear, 0, 3);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(4, 494);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 370);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 5;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -137,17 +135,29 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(272, 152);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(274, 147);
             this.tableLayoutPanel1.TabIndex = 5;
+            // 
+            // StashSelectedFiles
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.StashSelectedFiles, 2);
+            this.StashSelectedFiles.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.StashSelectedFiles.Location = new System.Drawing.Point(3, 57);
+            this.StashSelectedFiles.Name = "StashSelectedFiles";
+            this.StashSelectedFiles.Size = new System.Drawing.Size(268, 25);
+            this.StashSelectedFiles.TabIndex = 18;
+            this.StashSelectedFiles.Text = "Save Changes of selected files to New Stash";
+            this.toolTip.SetToolTip(this.StashSelectedFiles, "Save local changes in selected files to a new stash, then revert local changes");
+            this.StashSelectedFiles.UseVisualStyleBackColor = true;
+            this.StashSelectedFiles.Click += new System.EventHandler(this.StashSelectedFiles_Click);
             // 
             // Stash
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.Stash, 2);
             this.Stash.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Stash.Location = new System.Drawing.Point(4, 39);
-            this.Stash.Margin = new System.Windows.Forms.Padding(4);
+            this.Stash.Location = new System.Drawing.Point(3, 26);
             this.Stash.Name = "Stash";
-            this.Stash.Size = new System.Drawing.Size(264, 31);
+            this.Stash.Size = new System.Drawing.Size(268, 25);
             this.Stash.TabIndex = 15;
             this.Stash.Text = "Save Changes to New Stash";
             this.toolTip.SetToolTip(this.Stash, "Save local changes to a new stash, then revert local changes");
@@ -158,10 +168,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.chkIncludeUntrackedFiles.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.chkIncludeUntrackedFiles.AutoSize = true;
-            this.chkIncludeUntrackedFiles.Location = new System.Drawing.Point(140, 4);
-            this.chkIncludeUntrackedFiles.Margin = new System.Windows.Forms.Padding(4);
+            this.chkIncludeUntrackedFiles.Location = new System.Drawing.Point(140, 3);
             this.chkIncludeUntrackedFiles.Name = "chkIncludeUntrackedFiles";
-            this.chkIncludeUntrackedFiles.Size = new System.Drawing.Size(128, 27);
+            this.chkIncludeUntrackedFiles.Size = new System.Drawing.Size(131, 17);
             this.chkIncludeUntrackedFiles.TabIndex = 14;
             this.chkIncludeUntrackedFiles.Text = "Include untracked files";
             this.toolTip.SetToolTip(this.chkIncludeUntrackedFiles, "All untracked files are also stashed and then cleaned");
@@ -171,10 +180,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.StashKeepIndex.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.StashKeepIndex.AutoSize = true;
-            this.StashKeepIndex.Location = new System.Drawing.Point(4, 4);
-            this.StashKeepIndex.Margin = new System.Windows.Forms.Padding(4);
+            this.StashKeepIndex.Location = new System.Drawing.Point(3, 3);
             this.StashKeepIndex.Name = "StashKeepIndex";
-            this.StashKeepIndex.Size = new System.Drawing.Size(116, 27);
+            this.StashKeepIndex.Size = new System.Drawing.Size(79, 17);
             this.StashKeepIndex.TabIndex = 13;
             this.StashKeepIndex.Text = "Keep index";
             this.toolTip.SetToolTip(this.StashKeepIndex, "All changes already added to the index are left intact");
@@ -184,10 +192,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.Apply, 2);
             this.Apply.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Apply.Location = new System.Drawing.Point(4, 117);
-            this.Apply.Margin = new System.Windows.Forms.Padding(4);
+            this.Apply.Location = new System.Drawing.Point(3, 119);
             this.Apply.Name = "Apply";
-            this.Apply.Size = new System.Drawing.Size(264, 31);
+            this.Apply.Size = new System.Drawing.Size(268, 25);
             this.Apply.TabIndex = 17;
             this.Apply.Text = "Apply Selected Stash";
             this.toolTip.SetToolTip(this.Apply, "Apply the selected stash on top of the current working directory state");
@@ -198,10 +205,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.tableLayoutPanel1.SetColumnSpan(this.Clear, 2);
             this.Clear.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Clear.Location = new System.Drawing.Point(4, 78);
-            this.Clear.Margin = new System.Windows.Forms.Padding(4);
+            this.Clear.Location = new System.Drawing.Point(3, 88);
             this.Clear.Name = "Clear";
-            this.Clear.Size = new System.Drawing.Size(264, 31);
+            this.Clear.Size = new System.Drawing.Size(268, 25);
             this.Clear.TabIndex = 16;
             this.Clear.Text = "Drop Selected Stash";
             this.toolTip.SetToolTip(this.Clear, "Remove the selected stash from the list");
@@ -213,11 +219,10 @@ namespace GitUI.CommandsDialogs
             this.StashMessage.BackColor = System.Drawing.SystemColors.Info;
             this.StashMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.StashMessage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.StashMessage.Location = new System.Drawing.Point(4, 392);
-            this.StashMessage.Margin = new System.Windows.Forms.Padding(4);
+            this.StashMessage.Location = new System.Drawing.Point(3, 289);
             this.StashMessage.Name = "StashMessage";
             this.StashMessage.ReadOnly = true;
-            this.StashMessage.Size = new System.Drawing.Size(272, 94);
+            this.StashMessage.Size = new System.Drawing.Size(274, 75);
             this.StashMessage.TabIndex = 3;
             this.StashMessage.Text = "";
             this.StashMessage.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.StashMessage_MouseDoubleClick);
@@ -227,10 +232,9 @@ namespace GitUI.CommandsDialogs
             this.panel1.Controls.Add(this.Loading);
             this.panel1.Controls.Add(this.Stashed);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(4, 32);
-            this.panel1.Margin = new System.Windows.Forms.Padding(4);
+            this.panel1.Location = new System.Drawing.Point(3, 28);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(272, 352);
+            this.panel1.Size = new System.Drawing.Size(274, 255);
             this.panel1.TabIndex = 4;
             // 
             // Loading
@@ -239,9 +243,8 @@ namespace GitUI.CommandsDialogs
             this.Loading.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
             this.Loading.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Loading.Location = new System.Drawing.Point(0, 0);
-            this.Loading.Margin = new System.Windows.Forms.Padding(4);
             this.Loading.Name = "Loading";
-            this.Loading.Size = new System.Drawing.Size(272, 352);
+            this.Loading.Size = new System.Drawing.Size(274, 255);
             this.Loading.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.Loading.TabIndex = 12;
             this.Loading.TabStop = false;
@@ -251,9 +254,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.Stashed.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Stashed.Location = new System.Drawing.Point(0, 0);
-            this.Stashed.Margin = new System.Windows.Forms.Padding(5);
+            this.Stashed.Margin = new System.Windows.Forms.Padding(4);
             this.Stashed.Name = "Stashed";
-            this.Stashed.Size = new System.Drawing.Size(272, 352);
+            this.Stashed.Size = new System.Drawing.Size(274, 255);
             this.Stashed.TabIndex = 2;
             this.Stashed.SelectedIndexChanged += new System.EventHandler(this.StashedSelectedIndexChanged);
             // 
@@ -272,7 +275,7 @@ namespace GitUI.CommandsDialogs
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
             this.toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStrip1.Size = new System.Drawing.Size(280, 28);
+            this.toolStrip1.Size = new System.Drawing.Size(280, 25);
             this.toolStrip1.TabIndex = 1;
             // 
             // refreshToolStripButton
@@ -291,7 +294,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.showToolStripLabel.Name = "showToolStripLabel";
             this.showToolStripLabel.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.showToolStripLabel.Size = new System.Drawing.Size(48, 25);
+            this.showToolStripLabel.Size = new System.Drawing.Size(39, 22);
             this.showToolStripLabel.Text = "Show:";
             // 
             // Stashes
@@ -301,7 +304,7 @@ namespace GitUI.CommandsDialogs
             this.Stashes.MaxDropDownItems = 30;
             this.Stashes.Name = "Stashes";
             this.Stashes.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.Stashes.Size = new System.Drawing.Size(175, 28);
+            this.Stashes.Size = new System.Drawing.Size(141, 25);
             this.Stashes.ToolTipText = "Select a stash";
             this.Stashes.SelectedIndexChanged += new System.EventHandler(this.StashesSelectedIndexChanged);
             this.Stashes.DropDown += Stashes_DropDown;
@@ -316,7 +319,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripButton_customMessage.ImageTransparentColor = System.Drawing.Color.White;
             this.toolStripButton_customMessage.Name = "toolStripButton_customMessage";
             this.toolStripButton_customMessage.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.toolStripButton_customMessage.Size = new System.Drawing.Size(23, 25);
+            this.toolStripButton_customMessage.Size = new System.Drawing.Size(23, 22);
             this.toolStripButton_customMessage.Text = "Custom stash message";
             this.toolStripButton_customMessage.ToolTipText = "Write custom stash message";
             this.toolStripButton_customMessage.Click += new System.EventHandler(this.toolStripButton_customMessage_Click);
@@ -326,38 +329,24 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 28);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
             // 
             // View
             // 
             this.View.Dock = System.Windows.Forms.DockStyle.Fill;
             this.View.Location = new System.Drawing.Point(0, 0);
-            this.View.Margin = new System.Windows.Forms.Padding(5);
+            this.View.Margin = new System.Windows.Forms.Padding(4);
             this.View.Name = "View";
-            this.View.Size = new System.Drawing.Size(600, 650);
+            this.View.Size = new System.Drawing.Size(423, 520);
             this.View.TabIndex = 0;
-            // 
-            // StashSelectedFiles
-            // 
-            this.tableLayoutPanel1.SetColumnSpan(this.StashSelectedFiles, 2);
-            this.StashSelectedFiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.StashSelectedFiles.Location = new System.Drawing.Point(3, 57);
-            this.StashSelectedFiles.Name = "StashSelectedFiles";
-            this.StashSelectedFiles.Size = new System.Drawing.Size(268, 25);
-            this.StashSelectedFiles.TabIndex = 18;
-            this.StashSelectedFiles.Text = "Save Changes of selected files to New Stash";
-            this.toolTip.SetToolTip(this.StashSelectedFiles, "Save local changes in selected files to a new stash, then revert local changes");
-            this.StashSelectedFiles.UseVisualStyleBackColor = true;
-            this.StashSelectedFiles.Click += new System.EventHandler(this.StashSelectedFiles_Click);
             // 
             // FormStash
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(885, 650);
+            this.ClientSize = new System.Drawing.Size(708, 520);
             this.Controls.Add(this.splitContainer1);
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MinimumSize = new System.Drawing.Size(796, 588);
+            this.MinimumSize = new System.Drawing.Size(640, 478);
             this.Name = "FormStash";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Stash";

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -56,6 +56,7 @@ namespace GitUI.CommandsDialogs
             this.refreshToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.View = new GitUI.Editor.FileViewer();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.StashSelectedFiles = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.gitStashBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -120,11 +121,12 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Controls.Add(this.StashSelectedFiles, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.Stash, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.chkIncludeUntrackedFiles, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.StashKeepIndex, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.Apply, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.Clear, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.Apply, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.Clear, 0, 3);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(4, 494);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
@@ -335,6 +337,19 @@ namespace GitUI.CommandsDialogs
             this.View.Size = new System.Drawing.Size(600, 650);
             this.View.TabIndex = 0;
             // 
+            // StashSelectedFiles
+            // 
+            this.tableLayoutPanel1.SetColumnSpan(this.StashSelectedFiles, 2);
+            this.StashSelectedFiles.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.StashSelectedFiles.Location = new System.Drawing.Point(3, 57);
+            this.StashSelectedFiles.Name = "StashSelectedFiles";
+            this.StashSelectedFiles.Size = new System.Drawing.Size(268, 25);
+            this.StashSelectedFiles.TabIndex = 18;
+            this.StashSelectedFiles.Text = "Save Changes of selected files to New Stash";
+            this.toolTip.SetToolTip(this.StashSelectedFiles, "Save local changes in selected files to a new stash, then revert local changes");
+            this.StashSelectedFiles.UseVisualStyleBackColor = true;
+            this.StashSelectedFiles.Click += new System.EventHandler(this.StashSelectedFiles_Click);
+            // 
             // FormStash
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -390,5 +405,6 @@ namespace GitUI.CommandsDialogs
         private TableLayoutPanel tableLayoutPanel1;
         private Panel panel1;
         private ToolTip toolTip;
+        private Button StashSelectedFiles;
     }
 }

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -146,8 +146,8 @@ namespace GitUI.CommandsDialogs
             this.StashSelectedFiles.Name = "StashSelectedFiles";
             this.StashSelectedFiles.Size = new System.Drawing.Size(268, 25);
             this.StashSelectedFiles.TabIndex = 18;
-            this.StashSelectedFiles.Text = "Save Changes of selected files to New Stash";
-            this.toolTip.SetToolTip(this.StashSelectedFiles, "Save local changes in selected files to a new stash, then revert local changes");
+            this.StashSelectedFiles.Text = "Stash selected changes";
+            this.toolTip.SetToolTip(this.StashSelectedFiles, "Stash changes for the selected files, then revert them to the original state");
             this.StashSelectedFiles.UseVisualStyleBackColor = true;
             this.StashSelectedFiles.Click += new System.EventHandler(this.StashSelectedFiles_Click);
             // 
@@ -159,7 +159,7 @@ namespace GitUI.CommandsDialogs
             this.Stash.Name = "Stash";
             this.Stash.Size = new System.Drawing.Size(268, 25);
             this.Stash.TabIndex = 15;
-            this.Stash.Text = "Save Changes to New Stash";
+            this.Stash.Text = "Stash all changes";
             this.toolTip.SetToolTip(this.Stash, "Save local changes to a new stash, then revert local changes");
             this.Stash.UseVisualStyleBackColor = true;
             this.Stash.Click += new System.EventHandler(this.StashClick);

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -130,6 +131,9 @@ namespace GitUI.CommandsDialogs
         {
             GitStash gitStash = Stashes.SelectedItem as GitStash;
             GitItemStatus stashedItem = Stashed.SelectedItem;
+
+            EnablePartialStash();
+
             Cursor.Current = Cursors.WaitCursor;
 
             if (stashedItem != null &&
@@ -179,6 +183,22 @@ namespace GitUI.CommandsDialogs
 
             var msg = toolStripButton_customMessage.Checked ? " " + StashMessage.Text.Trim() : string.Empty;
             UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg);
+            Initialize();
+            Cursor.Current = Cursors.Default;
+        }
+
+        private void StashSelectedFiles_Click(object sender, EventArgs e)
+        {
+            if (chkIncludeUntrackedFiles.Checked && !GitCommandHelpers.VersionInUse.StashUntrackedFilesSupported)
+            {
+                if (MessageBox.Show(stashUntrackedFilesNotSupported.Text, stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == System.Windows.Forms.DialogResult.Cancel)
+                    return;
+            }
+
+            Cursor.Current = Cursors.WaitCursor;
+
+            var msg = toolStripButton_customMessage.Checked ? " " + StashMessage.Text.Trim() : string.Empty;
+            UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg, Stashed.SelectedItems.Select(i => i.Name));
             Initialize();
             Cursor.Current = Cursors.Default;
         }
@@ -233,6 +253,8 @@ namespace GitUI.CommandsDialogs
 
         private void StashesSelectedIndexChanged(object sender, EventArgs e)
         {
+            EnablePartialStash();
+
             Cursor.Current = Cursors.WaitCursor;
 
             InitializeSoft();
@@ -244,6 +266,11 @@ namespace GitUI.CommandsDialogs
                 StashMessage.Text = noStashes.Text;
 
             Cursor.Current = Cursors.Default;
+        }
+
+        private void EnablePartialStash()
+        {
+            StashSelectedFiles.Enabled = Stashes.SelectedIndex == 0 && Stashed.SelectedItems.Any();
         }
 
         private void Stashes_DropDown(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -23,6 +23,8 @@ namespace GitUI.CommandsDialogs
         readonly TranslationString cannotBeUndone = new TranslationString("This action cannot be undone.");
         readonly TranslationString areYouSure = new TranslationString("Are you sure you want to drop the stash? This action cannot be undone.");
         readonly TranslationString dontShowAgain = new TranslationString("Don't show me this message again.");
+        public bool ManageStashes { get; set; }
+
 
         private AsyncLoader _asyncLoader = new AsyncLoader();
 
@@ -79,7 +81,7 @@ namespace GitUI.CommandsDialogs
             Stashes.Items.Clear();
             foreach (GitStash stashedItem in stashedItems)
                 Stashes.Items.Add(stashedItem);
-            if (Stashes.Items.Count > 1)// more than just the default ("Current working directory changes")
+            if (ManageStashes && Stashes.Items.Count > 1)// more than just the default ("Current working directory changes")
                 Stashes.SelectedIndex = 1;// -> auto-select first non-default
             else if (Stashes.Items.Count > 0)// (no stashes) -> select default ("Current working directory changes")
                 Stashes.SelectedIndex = 0;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -964,11 +964,11 @@ namespace GitUI
             return StartFormatPatchDialog(null);
         }
 
-        public bool StartStashDialog(IWin32Window owner)
+        public bool StartStashDialog(IWin32Window owner, bool manageStashes = true)
         {
             Func<bool> action = () =>
             {
-                using (var form = new FormStash(this))
+                using (var form = new FormStash(this) { ManageStashes = manageStashes })
                     form.ShowDialog(owner);
 
                 return true;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -337,11 +337,11 @@ namespace GitUI
             return StartCheckoutRevisionDialog(null);
         }
 
-        public bool StashSave(IWin32Window owner, bool includeUntrackedFiles, bool keepIndex = false, string message = "")
+        public bool StashSave(IWin32Window owner, bool includeUntrackedFiles, bool keepIndex = false, string message = "", IEnumerable<string> selectedFiles = null)
         {
             Func<bool> action = () =>
             {
-                var arguments = GitCommandHelpers.StashSaveCmd(includeUntrackedFiles, keepIndex, message);
+                var arguments = GitCommandHelpers.StashSaveCmd(includeUntrackedFiles, keepIndex, message, selectedFiles);
                 FormProcess.ShowDialog(owner, Module, arguments);
                 return true;
             };


### PR DESCRIPTION
by selecting the files to add.
 
Screenshots before and after (if PR changes UI):
- Renamed "View stash" to "Manage stashes..."
- Add an item to open the stash form directly on the working directory changes to be able to create the stash more easily 

![image](https://user-images.githubusercontent.com/460196/34655649-7fba2c86-f40d-11e7-8c16-964e89e812cb.png)

- being able to select the files to stash (and not imperatively all!)

![image](https://user-images.githubusercontent.com/460196/34655718-9af574a0-f40e-11e7-9e01-853754f7206c.png)


What did I do to test the code and ensure quality:
 - manual testing
Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10

  