### PR TITLE
Don't validate invalid workingDir

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -41,15 +41,16 @@ namespace GitCommands
         /// <param name="branchName">Current branch name.</param>
         public string Generate(string workingDir, bool isValidWorkingDir, string branchName)
         {
+            if (!isValidWorkingDir)
+            {
+                return DefaultTitle;
+            }
+
             if (string.IsNullOrWhiteSpace(workingDir))
             {
                 throw new ArgumentException(nameof(workingDir));
             }
 
-            if (!isValidWorkingDir)
-            {
-                return DefaultTitle;
-            }
             string repositoryDescription = _repositoryDescriptionProvider.Get(workingDir);
             var title = string.Format(RepositoryTitleFormat, repositoryDescription, (branchName ?? "no branch").Trim('(', ')'));
 #if DEBUG


### PR DESCRIPTION
A quick one. We shouldn't validate working dir when generating app title when working dir is known to be invalid.

Currently opening GitExtensions without opening a repo gives an exception.