### PR TITLE
Add common unit test utils as a separate project

### DIFF
--- a/GitExtensions.VS2015.sln
+++ b/GitExtensions.VS2015.sln
@@ -142,6 +142,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GravatarTests", "UnitTests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraCommitHintPlugin", "Plugins\JiraCommitHintPlugin\JiraCommitHintPlugin.csproj", "{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonTestUtils", "UnitTests\CommonTestUtils\CommonTestUtils.csproj", "{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -662,6 +664,18 @@ Global
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}.ReleaseTC|Any CPU.Build.0 = Release|Any CPU
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}.ReleaseTC|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}.ReleaseTC|Mixed Platforms.Build.0 = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.ReleaseTC|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.ReleaseTC|Any CPU.Build.0 = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.ReleaseTC|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.ReleaseTC|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -704,6 +718,7 @@ Global
 		{D9C9D8EF-E0BC-4CCD-829D-3523E750D0FE} = {020F800B-9170-4BB3-83C9-FCF83596D83C}
 		{93CE3A27-5A63-4436-8C64-CBCA75322C5B} = {020F800B-9170-4BB3-83C9-FCF83596D83C}
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57} = {3D5CA0E0-EF51-4488-A8B7-86CC330D7AD8}
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548} = {020F800B-9170-4BB3-83C9-FCF83596D83C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ECECB7EA-BCCF-44AD-B63E-C2FA45589FB0}

--- a/GitExtensionsMono.sln
+++ b/GitExtensionsMono.sln
@@ -90,6 +90,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReleaseNotesGeneratorTests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JiraCommitHintPlugin", "Plugins\JiraCommitHintPlugin\JiraCommitHintPlugin.csproj", "{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonTestUtils", "UnitTests\CommonTestUtils\CommonTestUtils.csproj", "{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -232,6 +234,10 @@ Global
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{AF6D7B1B-FAF6-4793-AC05-00C63A5BC0F5} = {3D5CA0E0-EF51-4488-A8B7-86CC330D7AD8}
@@ -263,6 +269,7 @@ Global
 		{93CE3A27-5A63-4436-8C64-CBCA75322C5B} = {0879812F-FE97-4B83-8679-FB006DA8229B}
 		{D9C9D8EF-E0BC-4CCD-829D-3523E750D0FE} = {0879812F-FE97-4B83-8679-FB006DA8229B}
 		{304AA3FB-3F0D-45DA-9C91-3C6575EF0F8B} = {2AF33D76-0742-41F8-B9B7-D5338119298E}
+		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548} = {0879812F-FE97-4B83-8679-FB006DA8229B}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = GitExtensions\GitExtensions.Mono.csproj

--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CommonTestUtils</RootNamespace>
+    <AssemblyName>CommonTestUtils</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EmbeddedResourceLoader.cs" />
+    <Compile Include="GitModuleTestHelper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <Project>{BD6AA2A2-997D-4AFF-ACC7-B64F6E51D181}</Project>
+      <Name>GitCommands</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <Project>{27559302-F35E-4B62-A6EC-11FF21A5FA6F}</Project>
+      <Name>GitUIPluginInterfaces</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/UnitTests/CommonTestUtils/EmbeddedResourceLoader.cs
+++ b/UnitTests/CommonTestUtils/EmbeddedResourceLoader.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Reflection;
+
+namespace CommonTestUtils
+{
+    public static class EmbeddedResourceLoader
+    {
+        public static string Load(Assembly asm, string fullResourceName)
+        {
+            using (var stream = asm.GetManifestResourceStream(fullResourceName))
+            {
+                using (var reader = new StreamReader(stream))
+                {
+                    string result = reader.ReadToEnd();
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using GitCommands;
 using GitUIPluginInterfaces;
 
-namespace GitCommandsTests
+namespace CommonTestUtils
 {
     public class GitModuleTestHelper : IDisposable
     {
@@ -44,7 +44,7 @@ namespace GitCommandsTests
         /// Creates a new file, writes the specified string to the file, and then closes the file. 
         /// If the target file already exists, it is overwritten.
         /// </summary>
-        /// <returns>The file to the newly created file.</returns>
+        /// <returns>The path to the newly created file.</returns>
         public string CreateFile(string parentDir, string fileName, string fileContent)
         {
             EnsureCreatedInTempFolder(parentDir);
@@ -64,7 +64,7 @@ namespace GitCommandsTests
         /// writes the specified string to the file and then closes the file. 
         /// If the target file already exists, it is overwritten.
         /// </summary>
-        /// <returns>The file to the newly created file.</returns>
+        /// <returns>The path to the newly created file.</returns>
         public string CreateRepoFile(string fileRelativePath, string fileName, string fileContent)
         {
             if (Path.IsPathRooted(fileRelativePath))
@@ -83,7 +83,7 @@ namespace GitCommandsTests
         /// writes the specified string to the file and then closes the file. 
         /// If the target file already exists, it is overwritten.
         /// </summary>
-        /// <returns>The file to the newly created file.</returns>
+        /// <returns>The path to the newly created file.</returns>
         public string CreateRepoFile(string fileName, string fileContent)
         {
             return CreateRepoFile("", fileName, fileContent);

--- a/UnitTests/CommonTestUtils/Properties/AssemblyInfo.cs
+++ b/UnitTests/CommonTestUtils/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CommonTestUtils1")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CommonTestUtils1")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7b1f2fa0-e17d-499b-af86-d49dbef8c548")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Abstractions;
+using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using GitUIPluginInterfaces;

--- a/UnitTests/GitCommandsTests/Git/GitDirectoryResolverTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitDirectoryResolverTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Abstractions;
+using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;

--- a/UnitTests/GitCommandsTests/Git/IndexLockManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/IndexLockManagerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Abstractions;
+using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -94,7 +94,6 @@
     <Compile Include="Helpers\FileInfoExtensions.cs" />
     <Compile Include="Helpers\FileInfoExtensionsTest.cs" />
     <Compile Include="Helpers\PathUtilTest.cs" />
-    <Compile Include="GitModuleTestHelper.cs" />
     <Compile Include="Patch\PatchManagerTest.cs" />
     <Compile Include="Patch\PatchTest.cs" />
     <Compile Include="PathEqualityComparerTests.cs" />
@@ -130,6 +129,10 @@
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{D3440FD7-AFC5-4351-8741-6CDBF15CE944}</Project>
       <Name>ResourceManager</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\CommonTestUtils\CommonTestUtils.csproj">
+      <Project>{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}</Project>
+      <Name>CommonTestUtils</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Extract utils common to all unit tests as a separate project so it can be references by any unit test project requiring it. 