### PR TITLE
Rename arguments related to diff to firstRevision, secondRevision to …

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2213,7 +2213,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public Patch GetSingleDiff(string @firstRevision, string secondRevision, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked=true)
+        public Patch GetSingleDiff(string firstRevision, string secondRevision, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked=true)
         {
             if (!string.IsNullOrEmpty(fileName))
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2213,7 +2213,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public Patch GetSingleDiff(string @from, string to, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked=true)
+        public Patch GetSingleDiff(string @firstRevision, string secondRevision, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked=true)
         {
             if (!string.IsNullOrEmpty(fileName))
             {
@@ -2225,15 +2225,19 @@ namespace GitCommands
             }
 
             //fix refs slashes
-            from = from == null ? "" : from.ToPosixPath();
-            to = to == null ? "" : to.ToPosixPath();
-            string diffOptions = _revisionDiffProvider.Get(from, to, fileName, oldFileName, isTracked);
+            firstRevision = firstRevision == null ? "" : firstRevision.ToPosixPath();
+            secondRevision = secondRevision == null ? "" : secondRevision.ToPosixPath();
+            string diffOptions = _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked);
             if (AppSettings.UsePatienceDiffAlgorithm)
                 extraDiffArguments = string.Concat(extraDiffArguments, " --patience");
 
             var patchManager = new PatchManager();
             var arguments = String.Format(DiffCommandWithStandardArgs + "{0} -M -C {1}", extraDiffArguments, diffOptions);
-            cacheResult = cacheResult && !GitRevision.IsArtificial(to) && !GitRevision.IsArtificial(from) && !to.IsNullOrEmpty() && !from.IsNullOrEmpty();
+            cacheResult = cacheResult &&
+                !GitRevision.IsArtificial(secondRevision) &&
+                !GitRevision.IsArtificial(firstRevision) &&
+                !secondRevision.IsNullOrEmpty() &&
+                !firstRevision.IsNullOrEmpty();
             string patch;
             if (cacheResult)
                 patch = RunCacheableCmd(AppSettings.GitCommand, arguments, LosslessEncoding);
@@ -2262,35 +2266,35 @@ namespace GitCommands
             return RunGitCmd(cmd);
         }
 
-        public string GetDiffFilesText(string from, string to)
+        public string GetDiffFilesText(string firstRevision, string secondRevision)
         {
-            return GetDiffFilesText(from, to, false);
+            return GetDiffFilesText(firstRevision, secondRevision, false);
         }
 
-        public string GetDiffFilesText(string from, string to, bool noCache)
+        public string GetDiffFilesText(string firstRevision, string secondRevision, bool noCache)
         {
-            string cmd = DiffCommandWithStandardArgs + "-M -C --name-status " + _revisionDiffProvider.Get(from, to);
+            string cmd = DiffCommandWithStandardArgs + "-M -C --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             return noCache ? RunGitCmd(cmd) : this.RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
         }
 
-        public List<GitItemStatus> GetDiffFilesWithSubmodulesStatus(string from, string to)
+        public List<GitItemStatus> GetDiffFilesWithSubmodulesStatus(string firstRevision, string secondRevision)
         {
-            var status = GetDiffFiles(from, to);
-            GetSubmoduleStatus(status, from, to);
+            var status = GetDiffFiles(firstRevision, secondRevision);
+            GetSubmoduleStatus(status, firstRevision, secondRevision);
             return status;
         }
 
-        public List<GitItemStatus> GetDiffFiles(string from, string to, bool noCache = false)
+        public List<GitItemStatus> GetDiffFiles(string firstRevision, string secondRevision, bool noCache = false)
         {
-            noCache = noCache || GitRevision.IsArtificial(from) || GitRevision.IsArtificial(to);
-            string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(from, to);
+            noCache = noCache || GitRevision.IsArtificial(firstRevision) || GitRevision.IsArtificial(secondRevision);
+            string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             string result = noCache ? RunGitCmd(cmd) : this.RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
             var resultCollection = GitCommandHelpers.GetAllChangedFilesFromString(this, result, true);
-            if (from == GitRevision.UnstagedGuid || to == GitRevision.UnstagedGuid)
+            if (firstRevision == GitRevision.UnstagedGuid || secondRevision == GitRevision.UnstagedGuid)
             {
                 //For unstaged the untracked must be added too
                 var files = GetUnstagedFilesWithSubmodulesStatus().Where(item => item.IsNew);
-                if (from == GitRevision.UnstagedGuid)
+                if (firstRevision == GitRevision.UnstagedGuid)
                 {
                     //The file is seen as "deleted" in 'to' revision
                     foreach (var item in files)
@@ -2396,7 +2400,7 @@ namespace GitCommands
                 }
         }
 
-        private void GetSubmoduleStatus(IList<GitItemStatus> status, string from, string to)
+        private void GetSubmoduleStatus(IList<GitItemStatus> status, string firstRevision, string secondRevision)
         {
             status.ForEach(item =>
             {
@@ -2404,7 +2408,7 @@ namespace GitCommands
                 {
                     item.SubmoduleStatus = Task.Factory.StartNew(() =>
                     {
-                        Patch patch = GetSingleDiff(from, to, item.Name, item.OldName, "", SystemEncoding, true);
+                        Patch patch = GetSingleDiff(firstRevision, secondRevision, item.Name, item.OldName, "", SystemEncoding, true);
                         string text = patch != null ? patch.Text : "";
                         var submoduleStatus = GitCommandHelpers.GetSubmoduleStatus(text, this, item.Name);
                         if (submoduleStatus.Commit != submoduleStatus.OldCommit)
@@ -3096,11 +3100,11 @@ namespace GitCommands
                 });
         }
 
-        public string OpenWithDifftool(string filename, string oldFileName = "", string revision1 = null, string revision2 = null, string extraDiffArguments = "", bool isTracked=true)
+        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = null, string secondRevision = null, string extraDiffArguments = "", bool isTracked=true)
         {
             var output = "";
 
-            string args = string.Join(" ", extraDiffArguments, _revisionDiffProvider.Get(revision1, revision2, filename, oldFileName, isTracked));
+            string args = string.Join(" ", extraDiffArguments, _revisionDiffProvider.Get(firstRevision, secondRevision, filename, oldFileName, isTracked));
             RunGitCmdDetached("difftool --gui --no-prompt " + args);
             return output;
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2015,11 +2015,11 @@ namespace GitUI.CommandsDialogs
             Clipboard.SetText(fileNames.ToString());
         }
 
-        private void OpenFilesWithDiffTool(IEnumerable<GitItemStatus> items, string from, string to)
+        private void OpenFilesWithDiffTool(IEnumerable<GitItemStatus> items, string firstRevision, string secondRevision)
         {
             foreach (var item in items)
             {
-                string output = Module.OpenWithDifftool(item.Name, null, from, to, "", item.IsTracked);
+                string output = Module.OpenWithDifftool(item.Name, null, firstRevision, secondRevision, "", item.IsTracked);
                 if (!string.IsNullOrEmpty(output))
                     MessageBox.Show(this, output);
             }


### PR DESCRIPTION
…have a consistent naming

No functionality change, just renaming of arguments.
For those that are reviewing(also without commit privileges), if you agree, please add a comment about that.
If you have better names, suggest that too.

This was discussed in #4313, the core files in the PR was changed already
firstRevision/secondRevision was the most commonly used arguments. Some arguments have been aligned to from/to in #4031 PRs.
Other names discussed was revA/revB.


What did I do to test the code and ensure quality:
 - Code review

Has been tested on (remove any that don't apply):
 - Windows 10
