### PR TITLE
Bitbucket server: XSRF error when approving or merging pull requests

### DIFF
--- a/Plugins/Bitbucket/BitbucketRequestBase.cs
+++ b/Plugins/Bitbucket/BitbucketRequestBase.cs
@@ -47,6 +47,8 @@ namespace Bitbucket
                 else
                     request.AddBody(RequestBody);
             }
+            //XSRF check fails when approving/creating
+            request.AddHeader("X-Atlassian-Token", "no-check");
 
             var response = client.Execute(request);
             if (response.ResponseStatus != ResponseStatus.Completed)


### PR DESCRIPTION
Closes #4345
https://confluence.atlassian.com/cloudkb/xsrf-check-failed-when-calling-cloud-apis-826874382.html

See the issue for an explanation of the status of the plugin in GE in 2.50 and earlier.

Changes proposed in this pull request:
 - Add header to Bitbucket requests

What did I do to test the code and ensure quality:
 - Manual testing in the plugin. Verified that PRs could be approved and merged as well as existing functionality is working as before.

Has been tested on (remove any that don't apply):
 - Windows 7 and 10
