### PR TITLE
fix: Unable to add remote having selected deactivated item

### DIFF
--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -507,7 +507,10 @@ Inactive remote is completely invisible to git.");
 
             if (Remotes.SelectedIndices.Count < 1)
             {
+                // we are here because we're adding a new remote - so no remotes selected
+                // we just need to enable the panel so the user can enter the information
                 _selectedRemote = null;
+                flpnlRemoteManagement.Enabled = true;
                 return;
             }
 


### PR DESCRIPTION
In the remote form a user couldn't add a new remote if a deactivated remote was selected - the management panel stayed disabled.
Enable the management panel when no remote is selected.

Fixes #4349

What did I do to test the code and ensure quality:
 - run the code manually to ensure the issue is fixed
