### PR TITLE
Better display of "Find and replace" dialog on multiple screens computer

### DIFF
--- a/GitUI/Editor/FindAndReplaceForm.Designer.cs
+++ b/GitUI/Editor/FindAndReplaceForm.Designer.cs
@@ -176,6 +176,7 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FindAndReplaceForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Find and replace";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FindAndReplaceForm_FormClosing);
             this.ResumeLayout(false);

--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -114,6 +114,7 @@ namespace GitUI
             ReplaceMode = replaceMode;
 
             Owner = (Form) editor.TopLevelControl;
+            Location = new Point(Owner.Location.X + 100, Owner.Location.Y+100);
             Show();
 
             txtLookFor.SelectAll();


### PR DESCRIPTION
Always display the dialog near the top left corner of the parent form.

That prevent the dialog to be displayed on the 1st screen while
GitExtensions is displayed on the 3rd screen!

What did I do to test the code and ensure quality:
 - tested manually

Has been tested on (remove any that don't apply):
 - GIT 2.15 (but not important)
 - Windows 10
