### PR TITLE
fix: FormCreateBranch layout under Mono

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
+using GitCommands.Utils;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -28,6 +29,9 @@ namespace GitUI.CommandsDialogs
 
             InitializeComponent();
             Translate();
+
+            // Mono is having troubles dynamically sizing the groupbox
+            groupBox1.AutoSize = !EnvUtils.IsMonoRuntime();
 
             commitPickerSmallControl1.UICommandsSource = this;
             if (IsUICommandsInitialized)


### PR DESCRIPTION
Mono failed to correctly size and layout the groupbox pushing all controls below it beyond the client rectangle.

Fixes #4319
 
Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/5592397/34613641-813faefc-f23f-11e7-9de5-c21953377e07.png)
- after
![image](https://user-images.githubusercontent.com/4403806/34865060-4a745544-f7cb-11e7-8cb3-b8f253d66609.png)


What did I do to test the code and ensure quality:
 - run it manually before and after

Has been tested on (remove any that don't apply):
 - Windows 10
 - Ubuntu 17.04
