### PR TITLE
Refactor: Use IFullPathResolver to resolve paths

### DIFF
--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -121,7 +121,8 @@ namespace GitUI.AutoCompletion
             // Try to read the contents of the file: if it cannot be read, skip the operation silently.
             try
             {
-                return File.ReadAllText(Path.Combine(module.WorkingDir, file.Name));
+                IFullPathResolver _fullPathResolver = new FullPathResolver(() => module.WorkingDir);
+                return File.ReadAllText(_fullPathResolver.Resolve(file.Name));
             }
             catch
             {

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -121,8 +121,7 @@ namespace GitUI.AutoCompletion
             // Try to read the contents of the file: if it cannot be read, skip the operation silently.
             try
             {
-                IFullPathResolver _fullPathResolver = new FullPathResolver(() => module.WorkingDir);
-                return File.ReadAllText(_fullPathResolver.Resolve(file.Name));
+                return File.ReadAllText(Path.Combine(module.WorkingDir, file.Name));
             }
             catch
             {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
@@ -6,23 +6,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 {
     internal class FormBrowseUtil
     {
-        public static string GetFullPathFromGitItem(GitModule gitModule, GitItem gitItem)
-        {
-            return GetFullPathFromFilename(gitModule, gitItem.FileName);
-        }
-
-        public static string GetFullPathFromGitItemStatus(GitModule gitModule, GitItemStatus gitItemStatus)
-        {
-            return GetFullPathFromFilename(gitModule, gitItemStatus.Name);
-        }
-
-        public static string GetFullPathFromFilename(GitModule gitModule, string filename)
-        {
-            var filePath = Path.Combine(gitModule.WorkingDir, filename.ToNativePath());
-
-            return filePath;
-        }
-
         public static bool FileOrParentDirectoryExists(string path)
         {
             var fileInfo = new FileInfo(path);

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -18,6 +18,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly bool _localExclude;
         private readonly AsyncLoader _ignoredFilesLoader;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public FormAddToGitIgnore(GitUICommands aCommands, bool localExclude, params string[] filePatterns)
             : base(aCommands)
@@ -31,6 +32,7 @@ namespace GitUI.CommandsDialogs
                 Text = _addToLocalExcludeTitle.Text;
             if (filePatterns != null)
                 FilePattern.Text = string.Join(Environment.NewLine, filePatterns);
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         private string ExcludeFile
@@ -39,7 +41,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (!_localExclude)
                 {
-                    return Path.Combine(Module.WorkingDir, ".gitignore");
+                    return _fullPathResolver.Resolve(".gitignore");
                 }
                 else
                 {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1969,7 +1969,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in diffFiles.SelectedItems)
             {
-                string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(module, item);
+                string filePath = Path.Combine(module.WorkingDir, item.Name.ToNativePath());
                 FormBrowseUtil.ShowFileOrParentFolderInFileExplorer(filePath);
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -147,6 +147,7 @@ namespace GitUI.CommandsDialogs
         private string _userName = "";
         private string _userEmail = "";
         private SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("CommitDialog"));
+        private readonly IFullPathResolver _fullPathResolver;
 
         /// <summary>
         /// For VS designer
@@ -221,6 +222,7 @@ namespace GitUI.CommandsDialogs
             skipWorktreeToolStripMenuItem.ToolTipText = _skipWorktreeToolTip.Text;
             assumeUnchangedToolStripMenuItem.ToolTipText = _assumeUnchangedToolTip.Text;
             toolAuthor.Control.PreviewKeyDown += ToolAuthor_PreviewKeyDown;
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         private void ConfigureMessageBox()
@@ -862,7 +864,7 @@ namespace GitUI.CommandsDialogs
             long length = -1;
             string path = fileName;
             if (!File.Exists(fileName))
-                path = Path.Combine(Module.WorkingDir, fileName);
+                path = _fullPathResolver.Resolve(fileName);
             if (File.Exists(path))
             {
                 FileInfo fi = new FileInfo(path);
@@ -1578,7 +1580,7 @@ namespace GitUI.CommandsDialogs
                         {
                             try
                             {
-                                string path = Path.Combine(Module.WorkingDir, item.Name);
+                                string path = _fullPathResolver.Resolve(item.Name);
                                 if (File.Exists(path))
                                     File.Delete(path);
                                 else
@@ -1626,7 +1628,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 Unstaged.StoreNextIndexToSelect();
                 foreach (var item in Unstaged.SelectedItems)
-                    File.Delete(Path.Combine(Module.WorkingDir, item.Name));
+                    File.Delete(_fullPathResolver.Resolve(item.Name));
 
                 Initialize();
             }
@@ -1651,7 +1653,7 @@ namespace GitUI.CommandsDialogs
             try
             {
                 foreach (var gitItemStatus in Unstaged.SelectedItems)
-                    File.Delete(Path.Combine(Module.WorkingDir, gitItemStatus.Name));
+                    File.Delete(_fullPathResolver.Resolve(gitItemStatus.Name));
             }
             catch (Exception ex)
             {
@@ -1870,7 +1872,7 @@ namespace GitUI.CommandsDialogs
                 if (!String.IsNullOrEmpty(from) && !String.IsNullOrEmpty(to))
                 {
                     sb.AppendLine("Submodule " + item.Key + ":");
-                    GitModule module = new GitModule(Module.WorkingDir + item.Value.EnsureTrailingPathSeparator());
+                    GitModule module = new GitModule(_fullPathResolver.Resolve(item.Value.EnsureTrailingPathSeparator()));
                     string log = module.RunGitCmd(
                          string.Format("log --pretty=format:\"    %m %h - %s\" --no-merges {0}...{1}", from, to));
                     if (log.Length != 0)
@@ -1975,7 +1977,7 @@ namespace GitUI.CommandsDialogs
             var item = list.SelectedItem;
             var fileName = item.Name;
 
-            Process.Start((Path.Combine(Module.WorkingDir, fileName)).ToNativePath());
+            Process.Start(_fullPathResolver.Resolve(fileName).ToNativePath());
         }
 
         private void OpenWithToolStripMenuItemClick(object sender, EventArgs e)
@@ -1990,7 +1992,7 @@ namespace GitUI.CommandsDialogs
             var item = list.SelectedItem;
             var fileName = item.Name;
 
-            OsShellUtil.OpenAs(Module.WorkingDir + fileName.ToNativePath());
+            OsShellUtil.OpenAs(_fullPathResolver.Resolve(fileName.ToNativePath()));
         }
 
         private void FilenameToClipboardToolStripMenuItemClick(object sender, EventArgs e)
@@ -2010,7 +2012,7 @@ namespace GitUI.CommandsDialogs
                 if (fileNames.Length > 0)
                     fileNames.AppendLine();
 
-                fileNames.Append((Path.Combine(Module.WorkingDir, item.Name)).ToNativePath());
+                fileNames.Append(_fullPathResolver.Resolve(item.Name).ToNativePath());
             }
             Clipboard.SetText(fileNames.ToString());
         }
@@ -2070,7 +2072,7 @@ namespace GitUI.CommandsDialogs
                 return;
 
             var item = list.SelectedItem;
-            var fileName = Path.Combine(Module.WorkingDir, item.Name);
+            var fileName = _fullPathResolver.Resolve(item.Name);
 
             UICommands.StartFileEditorDialog(fileName);
 
@@ -2481,7 +2483,7 @@ namespace GitUI.CommandsDialogs
 
         private void commitSubmoduleChanges_Click(object sender, EventArgs e)
         {
-            GitUICommands submodulCommands = new GitUICommands(Module.WorkingDir + _currentItem.Name.EnsureTrailingPathSeparator());
+            GitUICommands submodulCommands = new GitUICommands(_fullPathResolver.Resolve(_currentItem.Name.EnsureTrailingPathSeparator()));
             submodulCommands.StartCommitDialog(this, false);
             Initialize();
         }
@@ -2495,7 +2497,7 @@ namespace GitUI.CommandsDialogs
                         Process process = new Process();
                         process.StartInfo.FileName = Application.ExecutablePath;
                         process.StartInfo.Arguments = "browse -commit=" + t.Result.Commit;
-                        process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, submoduleName.EnsureTrailingPathSeparator());
+                        process.StartInfo.WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator());
                         process.Start();
                     });
         }
@@ -2526,7 +2528,7 @@ namespace GitUI.CommandsDialogs
                     {
                         try
                         {
-                            string path = Path.Combine(module.WorkingDir, file.Name);
+                            string path = _fullPathResolver.Resolve(file.Name);
                             if (File.Exists(path))
                                 File.Delete(path);
                             else
@@ -2677,7 +2679,7 @@ namespace GitUI.CommandsDialogs
             foreach (var item in list.SelectedItems)
             {
                 var fileNames = new StringBuilder();
-                fileNames.Append((Path.Combine(Module.WorkingDir, item.Name)).ToNativePath());
+                fileNames.Append(_fullPathResolver.Resolve(item.Name).ToNativePath());
 
                 string filePath = fileNames.ToString();
                 if (File.Exists(filePath))

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -71,7 +71,7 @@ namespace GitUI.CommandsDialogs
 
             Diff.ExtraDiffArgumentsChanged += DiffExtraDiffArgumentsChanged;
 
-            bool isSubmodule = GitModule.IsValidGitWorkingDir(Path.Combine(Module.WorkingDir, FileName));
+            bool isSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(FileName));
             if (isSubmodule)
                 tabControl1.RemoveIfExists(BlameTab);
             FileChanges.SelectionChanged += FileChangesSelectionChanged;
@@ -150,7 +150,7 @@ namespace GitUI.CommandsDialogs
             fileName = fileName.ToPosixPath();
 
             // we will need this later to look up proper casing for the file
-            var fullFilePath = Path.Combine(Module.WorkingDir, fileName);
+            var fullFilePath = _fullPathResolver.Resolve(fileName);
 
             //The section below contains native windows (kernel32) calls
             //and breaks on Linux. Only use it on Windows. Casing is only
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs
                 GitItemStatus file = new GitItemStatus();
                 file.IsTracked = true;
                 file.Name = fileName;
-                file.IsSubmodule = GitModule.IsValidGitWorkingDir(Path.Combine(Module.WorkingDir, fileName));
+                file.IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName));
                 Diff.ViewChanges(FileChanges.GetSelectedRevisions(), file, "You need to select at least one revision to view diff.");
             }
 
@@ -337,7 +337,7 @@ namespace GitUI.CommandsDialogs
                 if (string.IsNullOrEmpty(orgFileName))
                     orgFileName = FileName;
 
-                string fullName = Module.WorkingDir + orgFileName.ToNativePath();
+                string fullName = _fullPathResolver.Resolve(orgFileName.ToNativePath());
 
                 using (var fileDialog = new SaveFileDialog
                 {

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -25,12 +25,14 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Save changes?");
 
         public string GitAttributesFile = string.Empty;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public FormGitAttributes(GitUICommands aCommands)
             : base(aCommands)
         {
             InitializeComponent();
             Translate();
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         protected override void OnRuntimeLoad(EventArgs e)
@@ -44,9 +46,9 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (File.Exists(Module.WorkingDir + ".gitattributes"))
+                if (File.Exists(_fullPathResolver.Resolve(".gitattributes")))
                 {
-                    _NO_TRANSLATE_GitAttributesText.ViewFile(Module.WorkingDir + ".gitattributes");
+                    _NO_TRANSLATE_GitAttributesText.ViewFile(_fullPathResolver.Resolve(".gitattributes"));
                 }
             }
             catch (Exception ex)
@@ -67,7 +69,7 @@ namespace GitUI.CommandsDialogs
             {
                 FileInfoExtensions
                     .MakeFileTemporaryWritable(
-                        Module.WorkingDir + ".gitattributes",
+                        _fullPathResolver.Resolve(".gitattributes"),
                         x =>
                         {
                             this.GitAttributesFile = _NO_TRANSLATE_GitAttributesText.GetText();

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -46,9 +46,10 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (File.Exists(_fullPathResolver.Resolve(".gitattributes")))
+                var path = _fullPathResolver.Resolve(".gitattributes");
+                if (File.Exists(path))
                 {
-                    _NO_TRANSLATE_GitAttributesText.ViewFile(_fullPathResolver.Resolve(".gitattributes"));
+                    _NO_TRANSLATE_GitAttributesText.ViewFile(path);
                 }
             }
             catch (Exception ex)

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -26,12 +26,14 @@ namespace GitUI.CommandsDialogs
         
 
         public string MailMapFile = string.Empty;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public FormMailMap(GitUICommands aCommands)
             : base(aCommands)
         {
             InitializeComponent();
             Translate();
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         protected override void OnRuntimeLoad(EventArgs e)
@@ -45,9 +47,9 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (File.Exists(Module.WorkingDir + ".mailmap"))
+                if (File.Exists(_fullPathResolver.Resolve(".mailmap")))
                 {
-                    _NO_TRANSLATE_MailMapText.ViewFile(Module.WorkingDir + ".mailmap");
+                    _NO_TRANSLATE_MailMapText.ViewFile(_fullPathResolver.Resolve(".mailmap"));
                 }
             }
             catch (Exception ex)
@@ -68,7 +70,7 @@ namespace GitUI.CommandsDialogs
             {
                 FileInfoExtensions
                     .MakeFileTemporaryWritable(
-                        Module.WorkingDir + ".mailmap",
+                        _fullPathResolver.Resolve(".mailmap"),
                         x =>
                         {
                             this.MailMapFile = _NO_TRANSLATE_MailMapText.GetText();

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -47,9 +47,10 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (File.Exists(_fullPathResolver.Resolve(".mailmap")))
+                var path = _fullPathResolver.Resolve(".mailmap");
+                if (File.Exists(path))
                 {
-                    _NO_TRANSLATE_MailMapText.ViewFile(_fullPathResolver.Resolve(".mailmap"));
+                    _NO_TRANSLATE_MailMapText.ViewFile(path);
                 }
             }
             catch (Exception ex)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -101,6 +101,7 @@ namespace GitUI.CommandsDialogs
         private bool _bInternalUpdate;
         private const string AllRemotes = "[ All ]";
         private readonly IGitRemoteManager _remoteManager;
+        private readonly IFullPathResolver _fullPathResolver;
 
         private FormPull()
             : this(null, null, null)
@@ -142,6 +143,7 @@ namespace GitUI.CommandsDialogs
             bool isRepoShallow = File.Exists(aCommands.Module.ResolveGitInternalPath("shallow"));
             if (isRepoShallow)
                 Unshallow.Visible = true;
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
 
@@ -276,7 +278,7 @@ namespace GitUI.CommandsDialogs
 
         private bool InitModules()
         {
-            if (!File.Exists(Module.WorkingDir + ".gitmodules"))
+            if (!File.Exists(_fullPathResolver.Resolve(".gitmodules")))
                 return false;
             if (!IsSubmodulesInitialized())
             {

--- a/GitUI/CommandsDialogs/GitIgnoreDialog/GitIgnoreModel.cs
+++ b/GitUI/CommandsDialogs/GitIgnoreDialog/GitIgnoreModel.cs
@@ -24,12 +24,14 @@ namespace GitUI.CommandsDialogs.GitIgnoreDialog
             new TranslationString("Save changes to .gitignore?");
 
         private readonly IGitModule _module;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public GitIgnoreModel(IGitModule module)
         {
             _module = module;
 
             Translator.Translate(this, AppSettings.CurrentTranslation);
+            _fullPathResolver = new FullPathResolver(() => _module.WorkingDir);
         }
 
         public string FormCaption
@@ -39,7 +41,7 @@ namespace GitUI.CommandsDialogs.GitIgnoreDialog
 
         public string ExcludeFile
         {
-            get { return Path.Combine(_module.WorkingDir, ".gitignore"); }
+            get { return _fullPathResolver.Resolve(".gitignore"); }
         }
 
         public string FileOnlyInWorkingDirSupported

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -31,12 +31,14 @@ namespace GitUI.CommandsDialogs
         private string _oldRevision;
         private GitItemStatus _oldDiffItem;
         private IRevisionDiffController _revisionDiffController;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public RevisionDiff()
         {
             InitializeComponent();
             Translate();
             this.HotkeysEnabled = true;
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         public void ForceRefreshRevisions()
@@ -229,7 +231,7 @@ namespace GitUI.CommandsDialogs
             var isCombinedDiff = isExactlyOneItemSelected && DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
             var selectedItemStatus = DiffFiles.SelectedItem;
             bool isBareRepository = Module.IsBareRepository();
-            bool singleFileExists = isExactlyOneItemSelected && File.Exists(FormBrowseUtil.GetFullPathFromGitItemStatus(Module, DiffFiles.SelectedItem));
+            bool singleFileExists = isExactlyOneItemSelected && File.Exists(_fullPathResolver.Resolve(DiffFiles.SelectedItem.Name));
 
             var selectionInfo = new ContextMenuSelectionInfo(selectedRevisions, selectedItemStatus, isAnyCombinedDiff, isExactlyOneItemSelected, isCombinedDiff, isAnyItemSelected, isBareRepository, singleFileExists);
             return selectionInfo;
@@ -308,7 +310,7 @@ namespace GitUI.CommandsDialogs
                         Process process = new Process();
                         process.StartInfo.FileName = Application.ExecutablePath;
                         process.StartInfo.Arguments = "browse -commit=" + t.Result.Commit;
-                        process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, submoduleName.EnsureTrailingPathSeparator());
+                        process.StartInfo.WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator());
                         process.Start();
                     });
             }
@@ -376,7 +378,7 @@ namespace GitUI.CommandsDialogs
 
                 foreach (var item in DiffFiles.SelectedItems)
                 {
-                    string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                    string filePath = _fullPathResolver.Resolve(item.Name);
                     if (FormBrowseUtil.FileOrParentDirectoryExists(filePath))
                     {
                         openContainingFolderToolStripMenuItem.Enabled = true;
@@ -542,7 +544,7 @@ namespace GitUI.CommandsDialogs
             foreach (var item in DiffFiles.SelectedItems)
             {
                 bIsNormal = bIsNormal || !(item.IsNew || item.IsDeleted);
-                string filePath = FormBrowseUtil.GetFullPathFromGitItemStatus(Module, item);
+                string filePath = _fullPathResolver.Resolve(item.Name);
                 if (File.Exists(filePath) || Directory.Exists(filePath))
                 {
                     localExists = true;
@@ -702,7 +704,7 @@ namespace GitUI.CommandsDialogs
 
             GitItemStatus item = DiffFiles.SelectedItem;
 
-            var fullName = Path.Combine(Module.WorkingDir, item.Name);
+            var fullName = _fullPathResolver.Resolve(item.Name);
             using (var fileDialog =
                 new SaveFileDialog
                 {
@@ -761,7 +763,7 @@ namespace GitUI.CommandsDialogs
                 var items = DiffFiles.SelectedItems.Where(item => !item.IsSubmodule);
                 foreach (var item in items)
                 {
-                    File.Delete(Path.Combine(Module.WorkingDir, item.Name));
+                    File.Delete(_fullPathResolver.Resolve(item.Name));
                 }
                 RefreshArtificial();
             }
@@ -781,7 +783,7 @@ namespace GitUI.CommandsDialogs
         private void diffEditFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var item = DiffFiles.SelectedItem;
-            var fileName = Path.Combine(Module.WorkingDir, item.Name);
+            var fileName = _fullPathResolver.Resolve(item.Name);
 
             UICommands.StartFileEditorDialog(fileName);
             RefreshArtificial();
@@ -789,7 +791,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffCommitSubmoduleChanges_Click(object sender, EventArgs e)
         {
-            GitUICommands submodulCommands = new GitUICommands(Module.WorkingDir + DiffFiles.SelectedItem.Name.EnsureTrailingPathSeparator());
+            GitUICommands submodulCommands = new GitUICommands(_fullPathResolver.Resolve(DiffFiles.SelectedItem.Name.EnsureTrailingPathSeparator()));
             submodulCommands.StartCommitDialog(this, false);
             RefreshArtificial();
         }
@@ -820,7 +822,7 @@ namespace GitUI.CommandsDialogs
                     {
                         try
                         {
-                            string path = Path.Combine(module.WorkingDir, file.Name);
+                            string path = _fullPathResolver.Resolve(file.Name);
                             if (File.Exists(path))
                                 File.Delete(path);
                             else

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -26,6 +26,7 @@ namespace GitUI.Editor
         private int _currentScrollPos = -1;
         private bool _currentViewIsPatch;
         private readonly IFileViewer _internalFileViewer;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public FileViewer()
         {
@@ -104,6 +105,7 @@ namespace GitUI.Editor
             if (RunTime() && ContextMenuStrip == null)
                 ContextMenuStrip = contextMenu;
             contextMenu.Opening += ContextMenu_Opening;
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         void FileViewer_GitUICommandsSourceSet(object sender, GitUICommandsSourceEventArgs e)
@@ -517,7 +519,7 @@ namespace GitUI.Editor
         {
             FilePreamble = null;
 
-            string fullPath = Path.GetFullPath(Path.Combine(Module.WorkingDir, fileName));
+            string fullPath = Path.GetFullPath(_fullPathResolver.Resolve(fileName));
 
             if (fileName.EndsWith("/") || Directory.Exists(fullPath))
             {
@@ -596,7 +598,7 @@ namespace GitUI.Editor
         {
             try
             {
-                using (Stream stream = File.OpenRead(Path.Combine(Module.WorkingDir, fileName)))
+                using (Stream stream = File.OpenRead(_fullPathResolver.Resolve(fileName)))
                 {
                     return CreateImage(fileName, stream);
                 }
@@ -632,7 +634,7 @@ namespace GitUI.Editor
             if (File.Exists(fileName))
                 path = fileName;
             else
-                path = Path.Combine(Module.WorkingDir, fileName);
+                path = _fullPathResolver.Resolve(fileName);
 
             if (File.Exists(path))
             {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -22,7 +22,7 @@ namespace GitUI
     {
         private readonly IAvatarService _gravatarService;
         private readonly ICommitTemplateManager _commitTemplateManager;
-
+        private readonly IFullPathResolver _fullPathResolver;
 
         public GitUICommands(GitModule module)
         {
@@ -33,6 +33,7 @@ namespace GitUI
 
             IImageCache avatarCache = new DirectoryImageCache(AppSettings.GravatarCachePath, AppSettings.AuthorImageCacheDays);
             _gravatarService = new GravatarService(avatarCache);
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         public GitUICommands(string workingDir)
@@ -1034,7 +1035,7 @@ namespace GitUI
             {
                 try
                 {
-                    string path = Path.Combine(Module.WorkingDir, fileName);
+                    string path = _fullPathResolver.Resolve(fileName);
                     if (File.Exists(path))
                         File.Delete(path);
                     else

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -40,6 +40,7 @@ namespace GitUI
         private ToolStripItem _openSubmoduleMenuItem;
 
         public DescribeRevisionDelegate DescribeRevision;
+        private readonly IFullPathResolver _fullPathResolver;
 
         public FileStatusList()
         {
@@ -81,6 +82,7 @@ namespace GitUI
             NoFiles.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Italic);
 
             _filter = new Regex(".*");
+            _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
         }
 
         private void CreateOpenSubmoduleMenuItem()
@@ -324,7 +326,7 @@ namespace GitUI
 
                     foreach (GitItemStatus item in SelectedItems)
                     {
-                        string fileName = Path.Combine(Module.WorkingDir, item.Name);
+                        string fileName = _fullPathResolver.Resolve(item.Name);
 
                         fileList.Add(fileName.ToNativePath());
                     }
@@ -583,7 +585,7 @@ namespace GitUI
                     Process process = new Process();
                     process.StartInfo.FileName = Application.ExecutablePath;
                     process.StartInfo.Arguments = "browse -commit=" + t.Result.Commit;
-                    process.StartInfo.WorkingDirectory = Path.Combine(Module.WorkingDir, submoduleName.EnsureTrailingPathSeparator());
+                    process.StartInfo.WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator());
                     process.Start();
                 });
         }


### PR DESCRIPTION
Part of review for #4318, done in the occurrences where it seemed natural

Fixes #4316

Changes proposed in this pull request:
 - Consistently use IFullPathResolver to resolve paths to files
 
Screenshots before and after (if PR changes UI):
- None

What did I do to test the code and ensure quality:
 - Code review, partial tests

Has been tested on (remove any that don't apply):
 - Windows 10
