### PR TITLE
Do not call git-log etc for artificial commands in commit info

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -172,7 +172,10 @@ namespace GitUI.CommitInfo
             ResetTextAndImage();
 
             if (string.IsNullOrEmpty(_revision.Guid))
-                return; //is it regular case or should throw an exception
+            {
+                Debug.Assert(false, "Unexpectedly called ReloadCommitInfo() with empty revision");
+                return;
+            }
 
             _RevisionHeader.Text = string.Empty;
             _RevisionHeader.Refresh();
@@ -199,6 +202,10 @@ namespace GitUI.CommitInfo
 
             UpdateRevisionInfo();
             LoadAuthorImage(data.Author ?? data.Committer);
+
+            //No branch/tag data for artificial commands
+            if (GitRevision.IsArtificial(_revision.Guid))
+                return;
 
             if (AppSettings.CommitInfoShowContainedInBranches)
                 ThreadPool.QueueUserWorkItem(_ => loadBranchInfo(_revision.Guid));


### PR DESCRIPTION
Fixes #4361

Changes proposed in this pull request:
 - Prune commit info retrieval for artificial commits
 - assert for empty guid. this should never occur, but changes could cause this to happen and the coder should be notified
 
Screenshots before and after (if PR changes UI):
-none

What did I do to test the code and ensure quality:
 - View artificial commits
 - Verify no artificial commits in the log

Has been tested on (remove any that don't apply):
 - Windows 10
