### PR TITLE
FormCommitDiff: diff was reversed

### DIFF
--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.HelperDialogs
             if (DiffFiles.SelectedItem != null && _revision != null)
             {
                 Cursor.Current = Cursors.WaitCursor;
-                DiffText.ViewChanges(_revision.Guid, DiffFiles.SelectedItemParent, DiffFiles.SelectedItem, String.Empty);
+                DiffText.ViewChanges(DiffFiles.SelectedItemParent, _revision.Guid, DiffFiles.SelectedItem, String.Empty);
                 Cursor.Current = Cursors.Default;
             }
         }


### PR DESCRIPTION
Fixes #4374

Regression from #4313 when argument order was cleaned up
Previously, the order was occasionally first..second, other time it was second..first so changes were difficult. This place was missed in the review

What did I do to test the code and ensure quality:
 - View FormCommitDiff for changed files
 - Check for similar usage

Has been tested on (remove any that don't apply):
 - Windows 10