### PR TITLE
Add ScriptEvent BeforeMerge, AfterMerge

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
+using GitUI.Script;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -99,6 +100,7 @@ namespace GitUI.CommandsDialogs
         {
             Module.EffectiveSettings.NoFastForwardMerge = noFastForward.Checked;
             AppSettings.DontCommitMerge = noCommit.Checked;
+            ScriptManager.RunEventScripts(this, ScriptEvent.BeforeMerge);
 
             var successfullyMerged = FormProcess.ShowDialog(this, GitCommandHelpers.MergeBranchCmd(Branches.GetSelectedText(),
                                                                                                    fastForward.Checked,
@@ -113,6 +115,7 @@ namespace GitUI.CommandsDialogs
 
             if (successfullyMerged || wasConflict)
             {
+                ScriptManager.RunEventScripts(this, ScriptEvent.AfterMerge);
                 UICommands.RepoChangedNotifier.Notify();
                 Close();
             }

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -12,7 +12,9 @@ namespace GitUI.Script
         AfterPush,
         ShowInUserMenuBar,
         BeforeCheckout,
-        AfterCheckout
+        AfterCheckout,
+        BeforeMerge,
+        AfterMerge
     }
 
     public class ScriptInfo


### PR DESCRIPTION
Fixes #4380 .

Changes proposed in this pull request:
 - Add two ScriptEvents,  BeforeMerge, AfterMerge

 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/12792499/35181289-e24b72ce-fdf9-11e7-9ee9-06e8a34ab5db.png)


What did I do to test the code and ensure quality:
 - Manual


Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10
