### PR TITLE
Browse Diff tab title is "unsupported" if a commit does not have a pa…

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -114,10 +114,7 @@ namespace GitUI.CommandsDialogs
                     return _diffNoSelection.Text;
 
                 case 1: // diff "parent" --> "selected revision"
-                    var revision = revisions[0];
-                    if (revision != null && revision.HasParent)
-                        return _diffParentWithSelection.Text;
-                    break;
+                    return _diffParentWithSelection.Text;
 
                 case 2: // diff "first clicked revision" --> "second clicked revision"
                     return _diffTwoSelected.Text;


### PR DESCRIPTION
…rent

Part of #4373

Changes proposed in this pull request:
 - Always set title on browse-diff tab to "A: parent -> B: selection" also if the selected commit has no parent. (Previously the title was set to "Diff (not supported)" if no parent.)

In 2.51, this was working somehow, the title was Diff (the changed code was the same, something else, did not investigate) 

Note: the title change should be removed as it is confusing when several are selected (what was selected first?). The title is lost when switching to another tab too. This is another issue though.

What did I do to test the code and ensure quality:
 - Code review

Has been tested on (remove any that don't apply):
 - Windows 10
