### PR TITLE
Git treefiles were not set as tracked, stash diff was inverted

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2225,8 +2225,8 @@ namespace GitCommands
             }
 
             //fix refs slashes
-            firstRevision = firstRevision == null ? "" : firstRevision.ToPosixPath();
-            secondRevision = secondRevision == null ? "" : secondRevision.ToPosixPath();
+            firstRevision = firstRevision?.ToPosixPath();
+            secondRevision = secondRevision?.ToPosixPath();
             string diffOptions = _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked);
             if (AppSettings.UsePatienceDiffAlgorithm)
                 extraDiffArguments = string.Concat(extraDiffArguments, " --patience");
@@ -2334,6 +2334,7 @@ namespace GitCommands
             var list = tree
                 .Select(file => new GitItemStatus
                 {
+                    IsTracked = true,
                     IsNew = true,
                     IsChanged = false,
                     IsDeleted = false,

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -139,7 +139,7 @@ namespace GitUI.CommandsDialogs
             }
             else if (stashedItem != null)
             {
-                if (stashedItem.IsNew && !stashedItem.IsTracked)
+                if (stashedItem.IsNew)
                 {
                     if (!stashedItem.IsSubmodule)
                         View.ViewGitItem(stashedItem.Name, stashedItem.TreeGuid);
@@ -153,7 +153,7 @@ namespace GitUI.CommandsDialogs
                     Encoding encoding = this.View.Encoding;
                     View.ViewPatch(() =>
                     {
-                        Patch patch = Module.GetSingleDiff(gitStash.Name, gitStash.Name + "^", stashedItem.Name, stashedItem.OldName, extraDiffArguments, encoding, false);
+                        Patch patch = Module.GetSingleDiff(gitStash.Name + "^", gitStash.Name, stashedItem.Name, stashedItem.OldName, extraDiffArguments, encoding, true, stashedItem.IsTracked);
                         if (patch == null)
                             return String.Empty;
                         if (stashedItem.IsSubmodule)


### PR DESCRIPTION
Part of #4373
GitItemStatus.IsTracked should be set for all file-revisions handled by Git, i.e. all but working file directory files
This was not set for GetTreeFiles(). This is called for revisions without parents: First/detached commit and stash-untracked.
These files were therefore presented as the difference to the local file if local exists.

In addition, stash-diff was displayed inverted. This was a regression from #4157 (This would have been a separate PR if not the same line was changed as for this PR)

Changes proposed in this pull request:
 - Set IsTracked for files in commits without parents
 
Screenshots before and after (if PR changes UI):
- Diff and presentation incorrect for commits without parents in browse-diff and view-stash

What did I do to test the code and ensure quality:
 - Manual test
 - Code review of all use of IsTracked. Only incorrect usage could be found, only change was in FormStash (that did not change anything). Of course, missing use of IsTracked was not found.

Has been tested on (remove any that don't apply):
 - Windows 10
