### PR TITLE
Commandline difftool raised Assert

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3100,7 +3100,7 @@ namespace GitCommands
                 });
         }
 
-        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = null, string secondRevision = null, string extraDiffArguments = "", bool isTracked=true)
+        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.UnstagedGuid, string extraDiffArguments = "", bool isTracked=true)
         {
             var output = "";
 


### PR DESCRIPTION
Related to #4374, seen in code review and tests related to #4385 

Command line has no arguments at all which is interpreted as two "working directory" revisions, where the result is undefined.
The combination raises Debug.Assert, but gives the diff from staged to unstaged
This diff changes the defaults to the values used

Changes proposed in this pull request:
 - Set default arguments corresponding to the expected use for difftool. All other usages set the parameters
 
Screenshots before and after (if PR changes UI):
- None

What did I do to test the code and ensure quality:
 - Manual test
   - Debug build
   - Run from command line: "GE executable" difftool "existing-file-with-changes"
 - Code review

Has been tested on (remove any that don't apply):
  - Windows 10
