### PR TITLE
Fix #3501

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2098,7 +2098,10 @@ namespace GitCommands
                 command += " --signoff";
 
             if (!string.IsNullOrEmpty(author))
+            {
+                author = author.Trim().Trim('"');
                 command += " --author=\"" + author + "\"";
+            }                
 
             if (useExplicitCommitMessage)
             {

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
     <Compile Include="GitExtLinks\GitExtLinksTests.cs" />
+    <Compile Include="GitModuleTest.cs" />
     <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -1,0 +1,25 @@
+﻿using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class GitModuleTest
+    {
+        GitModule _gitModule;
+        [SetUp]
+        public void SetUp()
+        {
+            _gitModule = new GitModule(null);
+        }
+
+        [TestCase(@"  ""author <author@mail.com>""  ", @"commit --author=""author <author@mail.com>"" -F ""COMMITMESSAGE""")]
+        [TestCase(@"""author <author@mail.com>""", @"commit --author=""author <author@mail.com>"" -F ""COMMITMESSAGE""")]
+        [TestCase(@"author <author@mail.com>", @"commit --author=""author <author@mail.com>"" -F ""COMMITMESSAGE""")]
+        public void CommitCmdShouldTrimAuthor(string input, string expected)
+        {
+            var actual = _gitModule.CommitCmd(false, author: input);
+            StringAssert.AreEqualIgnoringCase(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3501 .

Changes proposed in this pull request:
 - author string spaces and quotes trimmed before concat in command string 
 
What did I do to test the code and ensure quality:
 - run application 
 - enter author with quotes
 - click commit
 - ensure that no error occured

ALso unit test had been written

Has been tested on (remove any that don't apply):
 - GIT 2.14 and above
 - Windows 10 and above
