### PR TITLE
Smarter default for Clone Destination directory

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -118,9 +118,10 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            //if there is no destination directory, then use current working directory
+            //if there is no destination directory, then use the parent of the current working directory
+            //this would clone the new repo at the same level as the current one by default
             if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && Module.WorkingDir.IsNotNullOrWhitespace())
-                _NO_TRANSLATE_To.Text = Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar);
+                _NO_TRANSLATE_To.Text = Path.GetDirectoryName(Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar));
 
             FromTextUpdate(null, null);
 


### PR DESCRIPTION
This should at least partly fix #2313.

Changes proposed in this pull request:

In the Clone Repository dialog set the Destination directory to the parent of the current working directory, rather than the working directory itself. It makes no sense to clone into the working directory itself, but the user is likely to want to the new working directory to be a sibling of the current one.
 
Tested on git 2.15, Windows 7 x64
