### PR TITLE
Installation scripts should allow for IDE build, also in Debug

### DIFF
--- a/Setup/BuildGitExtNative.cmd
+++ b/Setup/BuildGitExtNative.cmd
@@ -1,0 +1,25 @@
+@echo off
+
+cd /d "%~p0"
+
+SET Configuration=%1
+IF "%Configuration%"=="" SET Configuration=Release
+
+SET BuildType=%2
+IF "%BuildType%"=="" SET BuildType=Rebuild
+
+for /f "tokens=*" %%i in ('hMSBuild.bat -only-path -notamd64') do set msbuild="%%i"
+set projectShellEx=..\GitExtensionsShellEx\GitExtensionsShellEx.VS2015.sln
+set projectSshAskPass=..\GitExtSshAskPass\GitExtSshAskPass.VS2015.sln
+set SkipShellExtRegistration=1
+set msbuildparams=/p:Configuration=%Configuration% /t:%BuildType% /nologo /v:m
+
+%msbuild% %projectShellEx% /p:Platform=Win32 %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+%msbuild% %projectShellEx% /p:Platform=x64 %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+%msbuild% %projectSshAskPass% /p:Platform=Win32 %msbuildparams%
+IF ERRORLEVEL 1 EXIT /B 1
+
+echo.
+IF "%SKIP_PAUSE%"=="" pause

--- a/Setup/BuildInstallers.Mono.cmd
+++ b/Setup/BuildInstallers.Mono.cmd
@@ -2,6 +2,8 @@
 
 cd /d "%~p0"
 
+SET Configuration=%1
+IF "%Configuration%"=="" SET Configuration=Release
 if "%MONOPATH%"=="" SET MONOPATH=C:\Program Files (x86)\Mono-3.2.3\bin\
 
 set msbuild="%MONOPATH%\xbuild"
@@ -9,7 +11,7 @@ set project=..\GitExtensionsMono.sln
 set EnableNuGetPackageRestore=true
 
 call %msbuild% %project% /t:clean
-call %msbuild% %project% /p:TargetFrameworkProfile="" /p:Platform="Any CPU" /p:Configuration=Release /nologo /v:m
+call %msbuild% %project% /p:TargetFrameworkProfile="" /p:Platform="Any CPU" /p:Configuration=%Configuration% /nologo /v:m
 IF ERRORLEVEL 1 EXIT /B 1
 
 call MakeMonoArchive.cmd

--- a/Setup/BuildInstallers.VS2015.cmd
+++ b/Setup/BuildInstallers.VS2015.cmd
@@ -2,31 +2,22 @@
 
 cd /d "%~p0"
 
-set msbuild="%programfiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+SET Configuration=%1
+IF "%Configuration%"=="" SET Configuration=Release
+
+for /f "tokens=*" %%i in ('hMSBuild.bat -only-path -notamd64') do set msbuild="%%i"
 set project=..\GitExtensions.VS2015.sln
-set projectShellEx=..\GitExtensionsShellEx\GitExtensionsShellEx.VS2015.sln
-set projectSshAskPass=..\GitExtSshAskPass\GitExtSshAskPass.VS2015.sln
-set SkipShellExtRegistration=1
 set EnableNuGetPackageRestore=true
 ..\.nuget\nuget.exe restore %project%
-set msbuildparams=/p:Configuration=Release /t:Rebuild /nologo /v:m
+set msbuildparams=/p:Configuration=%Configuration% /t:Rebuild /nologo /v:m
+
+call BuildGitExtNative.cmd %Configuration% Rebuild
+IF ERRORLEVEL 1 EXIT /B 1
 
 %msbuild% %project% /p:Platform="Any CPU" %msbuildparams%
 IF ERRORLEVEL 1 EXIT /B 1
-%msbuild% %projectShellEx% /p:Platform=Win32 %msbuildparams%
-IF ERRORLEVEL 1 EXIT /B 1
-%msbuild% %projectShellEx% /p:Platform=x64 %msbuildparams%
-IF ERRORLEVEL 1 EXIT /B 1
-%msbuild% %projectSshAskPass% /p:Platform=Win32 %msbuildparams%
-IF ERRORLEVEL 1 EXIT /B 1
 
-call MakeInstallers.cmd
-IF ERRORLEVEL 1 EXIT /B 1
-
-%msbuild% %project% /p:Platform="Any CPU" /p:DefineConstants=__MonoCS__ %msbuildparams%
-IF ERRORLEVEL 1 EXIT /B 1
-
-call MakeMonoArchive.cmd
+call MakeInstallers.cmd %Configuration% Rebuild
 IF ERRORLEVEL 1 EXIT /B 1
 
 echo.

--- a/Setup/MakeInstallers.cmd
+++ b/Setup/MakeInstallers.cmd
@@ -1,7 +1,5 @@
 @echo off
 
-call DownloadExternals.cmd
-
 rem
 rem Update this version number with every release
 rem
@@ -13,14 +11,19 @@ if not "%APPVEYOR_BUILD_VERSION%"=="" (
     set numericVersion=%APPVEYOR_BUILD_VERSION%
 )
 
+SET Configuration=%1
+IF "%Configuration%"=="" SET Configuration=Release
+
+SET BuildType=%2
+IF "%BuildType%"=="" SET BuildType=Rebuild
+
 set normal=GitExtensions-%Version%-Setup.msi
 set complete=GitExtensions-%Version%-SetupComplete.msi
-
-set msbuild="%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
-set output=bin\Release\GitExtensions.msi
+for /f "tokens=*" %%i in ('hMSBuild.bat -only-path -notamd64') do set msbuild="%%i"
+set output=bin\%Configuration%\GitExtensions.msi
 set project=Setup.wixproj
 
-set build=%msbuild% %project% /t:Rebuild /p:Version=%version% /p:NumericVersion=%numericVersion% /p:Configuration=Release /nologo /v:m
+set build=%msbuild% %project% /t:%BuildType% /p:Version=%version% /p:NumericVersion=%numericVersion% /p:Configuration=%Configuration% /nologo /v:m
 
 echo Creating installers for Git Extensions %version%
 echo.
@@ -36,11 +39,11 @@ echo.
 echo Building %normal%
 %build% /p:IncludeRequiredSoftware=0
 IF ERRORLEVEL 1 EXIT /B 1
-copy bin\Release\GitExtensions.msi %normal%
+copy %output% %normal%
 IF ERRORLEVEL 1 EXIT /B 1
 
 echo Building %complete%
 %build% /p:IncludeRequiredSoftware=1
 IF ERRORLEVEL 1 EXIT /B 1
-copy bin\Release\GitExtensions.msi %complete%
+copy %output% %complete%
 IF ERRORLEVEL 1 EXIT /B 1

--- a/Setup/MakeMonoArchive.cmd
+++ b/Setup/MakeMonoArchive.cmd
@@ -1,7 +1,5 @@
 @echo off
 
-call DownloadExternals.cmd
-
 cd /d "%~p0"
 
 rem
@@ -9,35 +7,38 @@ rem Update this version number with every release
 rem
 setlocal
 set version=2.51
+
+SET Configuration=%1
+IF "%Configuration%"=="" SET Configuration=Release
 if not "%APPVEYOR_BUILD_VERSION%"=="" set version=%APPVEYOR_BUILD_VERSION%
 set normal=GitExtensions-%version%-Mono.zip
 set szip="..\packages\7-Zip.CommandLine.9.20.0\tools\7za"
 
-rd /q /s GitExtensions\
-rd /q %normal%
-xcopy /y ..\GitExtensions\bin\Release\ConEmu\* GitExtensions\ConEmu\
+rd /q /s GitExtensions\ 2>nul
+del %normal% 2>nul
+xcopy /y /i ..\GitExtensions\bin\%Configuration%\ConEmu GitExtensions\ConEmu
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\ConEmu.WinForms.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\ConEmu.WinForms.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\Git.hub.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\Git.hub.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitCommands.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitCommands.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitExtUtils.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitExtUtils.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitExtensions.exe GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitExtensions.exe GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitExtensions.exe.config GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitExtensions.exe.config GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitUI.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitUI.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\System.IO.Abstractions.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\System.IO.Abstractions.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitUIPluginInterfaces.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitUIPluginInterfaces.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\Gravatar.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\Gravatar.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BuildServerIntegration\TeamCityIntegration\bin\Release\TeamCityIntegration.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\BuildServerIntegration\TeamCityIntegration\bin\%Configuration%\TeamCityIntegration.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\bin\ICSharpCode.SharpZipLib.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
@@ -47,55 +48,55 @@ xcopy /y ..\bin\Microsoft.WindowsAPICodePack.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\bin\Microsoft.WindowsAPICodePack.Shell.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\NBug.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\NBug.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\SmartFormat.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\SmartFormat.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\NetSpell.SpellChecker.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\NetSpell.SpellChecker.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\PSTaskDialog.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\PSTaskDialog.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\ResourceManager.dll GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\ResourceManager.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Github3\bin\Release\RestSharp.dll GitExtensions\
+xcopy /y ..\Plugins\Github3\bin\%Configuration%\RestSharp.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BackgroundFetch\bin\Release\System.Reactive.Core.dll GitExtensions\
+xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.Core.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BackgroundFetch\bin\Release\System.Reactive.Interfaces.dll GitExtensions\
+xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.Interfaces.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BackgroundFetch\bin\Release\System.Reactive.Linq.dll GitExtensions\
+xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.Linq.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BackgroundFetch\bin\Release\System.Reactive.PlatformServices.dll GitExtensions\
+xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.PlatformServices.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\AutoCompileSubmodules\bin\Release\AutoCompileSubmodules.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\AutoCompileSubmodules\bin\%Configuration%\AutoCompileSubmodules.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BackgroundFetch\bin\Release\BackgroundFetch.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\BackgroundFetch.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\CreateLocalBranches\bin\Release\CreateLocalBranches.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\CreateLocalBranches\bin\%Configuration%\CreateLocalBranches.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\DeleteUnusedBranches\bin\Release\DeleteUnusedBranches.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\DeleteUnusedBranches\bin\%Configuration%\DeleteUnusedBranches.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\FindLargeFiles\bin\Release\FindLargeFiles.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\FindLargeFiles\bin\%Configuration%\FindLargeFiles.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Gerrit\bin\Release\Gerrit.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Gerrit\bin\%Configuration%\Gerrit.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Gerrit\bin\Release\Newtonsoft.Json.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Gerrit\bin\%Configuration%\Newtonsoft.Json.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\GitFlow\bin\Release\GitFlow.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\GitFlow\bin\%Configuration%\GitFlow.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Github3\bin\Release\Github3.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Github3\bin\%Configuration%\Github3.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Statistics\GitImpact\bin\Release\GitImpact.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Statistics\GitImpact\bin\%Configuration%\GitImpact.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Statistics\GitStatistics\bin\Release\GitStatistics.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Statistics\GitStatistics\bin\%Configuration%\GitStatistics.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Gource\bin\Release\Gource.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Gource\bin\%Configuration%\Gource.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\ProxySwitcher\bin\Release\ProxySwitcher.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\ProxySwitcher\bin\%Configuration%\ProxySwitcher.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Bitbucket\bin\Release\Bitbucket.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\Bitbucket\bin\%Configuration%\Bitbucket.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\ReleaseNotesGenerator\bin\Release\ReleaseNotesGenerator.dll GitExtensions\Plugins\
+xcopy /y ..\Plugins\ReleaseNotesGenerator\bin\%Configuration%\ReleaseNotesGenerator.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\GitUI\Translation\English.gif GitExtensions\Translation\
 IF ERRORLEVEL 1 EXIT /B 1
@@ -193,55 +194,55 @@ xcopy /y ..\bin\gitext.sh GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 
 IF "%ARCHIVE_WITH_PDB%"=="" GOTO create_archive
-xcopy /y ..\GitExtensions\bin\Release\ConEmu.WinForms.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\ConEmu.WinForms.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\Git.hub.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\Git.hub.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitCommands.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitCommands.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitExtUtils.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitExtUtils.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitExtensions.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitExtensions.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitUI.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitUI.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\GitUIPluginInterfaces.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\GitUIPluginInterfaces.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\Gravatar.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\Gravatar.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BuildServerIntegration\TeamCityIntegration\bin\Release\TeamCityIntegration.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\BuildServerIntegration\TeamCityIntegration\bin\%Configuration%\TeamCityIntegration.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\NBug.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\NBug.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\NetSpell.SpellChecker.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\NetSpell.SpellChecker.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\GitExtensions\bin\Release\ResourceManager.pdb GitExtensions\
+xcopy /y ..\GitExtensions\bin\%Configuration%\ResourceManager.pdb GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\AutoCompileSubmodules\bin\Release\AutoCompileSubmodules.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\AutoCompileSubmodules\bin\%Configuration%\AutoCompileSubmodules.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\BackgroundFetch\bin\Release\BackgroundFetch.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\BackgroundFetch.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\CreateLocalBranches\bin\Release\CreateLocalBranches.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\CreateLocalBranches\bin\%Configuration%\CreateLocalBranches.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\DeleteUnusedBranches\bin\Release\DeleteUnusedBranches.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\DeleteUnusedBranches\bin\%Configuration%\DeleteUnusedBranches.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\FindLargeFiles\bin\Release\FindLargeFiles.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\FindLargeFiles\bin\%Configuration%\FindLargeFiles.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Gerrit\bin\Release\Gerrit.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\Gerrit\bin\%Configuration%\Gerrit.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Github3\bin\Release\Github3.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\Github3\bin\%Configuration%\Github3.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Statistics\GitImpact\bin\Release\GitImpact.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\Statistics\GitImpact\bin\%Configuration%\GitImpact.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Statistics\GitStatistics\bin\Release\GitStatistics.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\Statistics\GitStatistics\bin\%Configuration%\GitStatistics.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Gource\bin\Release\Gource.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\Gource\bin\%Configuration%\Gource.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\ProxySwitcher\bin\Release\ProxySwitcher.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\ProxySwitcher\bin\%Configuration%\ProxySwitcher.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\Bitbucket\bin\Release\Bitbucket.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\Bitbucket\bin\%Configuration%\Bitbucket.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y ..\Plugins\ReleaseNotesGenerator\bin\Release\ReleaseNotesGenerator.pdb GitExtensions\Plugins\
+xcopy /y ..\Plugins\ReleaseNotesGenerator\bin\%Configuration%\ReleaseNotesGenerator.pdb GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 
 :create_archive

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -61,7 +61,7 @@
         <File Source="..\bin\gitex.cmd" />
       </Component>
       <Component Id="GitExtensions.exe" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\GitExtensions.exe">
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\GitExtensions.exe">
           <netfx:NativeImage Id="ngen_GitExtensions.exe" Platform="all" Priority="1" />
         </File>
         <ProgId Id="GitExtensions" Description="Git Extentions Shortcut" Advertise="no">
@@ -71,34 +71,34 @@
         </ProgId>
       </Component>
       <Component Id="GitExtensions.exe.config" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\GitExtensions.exe.config" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\GitExtensions.exe.config" />
       </Component>
       <Component Id="Gravatar.dll" Guid="*">
-        <File Source="..\Gravatar\bin\Release\Gravatar.dll" />
+        <File Source="..\Gravatar\bin\$(var.Configuration)\Gravatar.dll" />
       </Component>
       <Component Id="System.IO.Abstractions.dll" Guid="*">
-        <File Source="..\Gravatar\bin\Release\System.IO.Abstractions.dll" />
+        <File Source="..\Gravatar\bin\$(var.Configuration)\System.IO.Abstractions.dll" />
       </Component>
       <Component Id="GitCommands.dll" Guid="*">
-        <File Source="..\GitCommands\bin\Release\GitCommands.dll" />
+        <File Source="..\GitCommands\bin\$(var.Configuration)\GitCommands.dll" />
       </Component>
       <Component Id="GitExtUtils.dll" Guid="*">
-        <File Source="..\GitExtUtils\bin\Release\GitExtUtils.dll" />
+        <File Source="..\GitExtUtils\bin\$(var.Configuration)\GitExtUtils.dll" />
       </Component>
       <Component Id="GitUI.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\GitUI.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\GitUI.dll" />
       </Component>
       <Component Id="ConEmu.WinForms.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\ConEmu.WinForms.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\ConEmu.WinForms.dll" />
       </Component>
       <Component Id="NetSpell.SpellChecker.dll" Guid="*">
-        <File Source="..\NetSpell.SpellChecker\bin\Release\NetSpell.SpellChecker.dll" />
+        <File Source="..\NetSpell.SpellChecker\bin\$(var.Configuration)\NetSpell.SpellChecker.dll" />
       </Component>
       <Component Id="ResourceManager.dll" Guid="*">
-        <File Source="..\ResourceManager\bin\Release\ResourceManager.dll" />
+        <File Source="..\ResourceManager\bin\$(var.Configuration)\ResourceManager.dll" />
       </Component>
       <Component Id="GitUIPluginInterfaces.dll" Guid="*">
-        <File Source="..\Plugins\GitUIPluginInterfaces\bin\Release\GitUIPluginInterfaces.dll" />
+        <File Source="..\Plugins\GitUIPluginInterfaces\bin\$(var.Configuration)\GitUIPluginInterfaces.dll" />
       </Component>
       <Component Id="ICSharpCode.TextEditor.dll" Guid="*">
         <File Source="..\bin\ICSharpCode.TextEditor.dll" />
@@ -107,13 +107,13 @@
         <File Source="..\bin\ICSharpCode.SharpZipLib.dll" />
       </Component>
       <Component Id="Git.hub.dll" Guid="*">
-        <File Source="..\Externals\Git.hub\Git.hub\bin\Release\Git.hub.dll" />
+        <File Source="..\Externals\Git.hub\Git.hub\bin\$(var.Configuration)\Git.hub.dll" />
       </Component>
       <Component Id="PSTaskDialog.dll" Guid="*">
         <File Source="..\bin\PSTaskDialog.dll" />
       </Component>
       <Component Id="RestSharp.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\RestSharp.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\RestSharp.dll" />
       </Component>
       <Component Id="Microsoft.WindowsAPICodePack.dll" Guid="*">
         <File Source="..\bin\Microsoft.WindowsAPICodePack.dll" />
@@ -122,22 +122,22 @@
         <File Source="..\bin\Microsoft.WindowsAPICodePack.Shell.dll" />
       </Component>
       <Component Id="NBug.dll" Guid="*">
-        <File Source="..\Externals\NBug\NBug\bin\Release\NBug.dll" />
+        <File Source="..\Externals\NBug\NBug\bin\$(var.Configuration)\NBug.dll" />
       </Component>
       <Component Id="SmartFormat.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\SmartFormat.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\SmartFormat.dll" />
       </Component>
       <Component Id="System.Reactive.Core.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\System.Reactive.Core.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.Core.dll" />
       </Component>
       <Component Id="System.Reactive.Interfaces.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\System.Reactive.Interfaces.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.Interfaces.dll" />
       </Component>
       <Component Id="System.Reactive.Linq.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\System.Reactive.Linq.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.Linq.dll" />
       </Component>
       <Component Id="System.Reactive.PlatformServices.dll" Guid="*">
-        <File Source="..\GitExtensions\bin\Release\System.Reactive.PlatformServices.dll" />
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.PlatformServices.dll" />
       </Component>
       <!--Remove unused dll, installed in versions <= 2.31-->
       <Component Id="GithubSharp.Core.dll" Guid="08F2D539-54CE-4895-ACA5-A7FBA73CA172">
@@ -145,20 +145,20 @@
       </Component>
       <?define ShellExCLSID = "{3C16B20A-BA16-4156-916F-0A375ECFFE24}"?>
       <Component Id="GitExtensionsShellEx32.dll" Guid="*">
-        <File Name="GitExtensionsShellEx32.dll" Source="..\GitExtensionsShellEx\Release\GitExtensionsShellEx32.dll" KeyPath="yes" />
+        <File Name="GitExtensionsShellEx32.dll" Source="..\GitExtensionsShellEx\$(var.Configuration)\GitExtensionsShellEx32.dll" KeyPath="yes" />
         <?foreach ShellExFileName in GitExtensionsShellEx32.dll?>
         <?include RegisterShellExtension.wxi?>
         <?endforeach ?>
       </Component>
       <Component Id="GitExtensionsShellEx64.dll" Guid="*" Win64="yes">
         <Condition>VersionNT64</Condition>
-        <File Name="GitExtensionsShellEx64.dll" Source="..\GitExtensionsShellEx\Release-x64\GitExtensionsShellEx64.dll" KeyPath="yes" />
+        <File Name="GitExtensionsShellEx64.dll" Source="..\GitExtensionsShellEx\$(var.Configuration)-x64\GitExtensionsShellEx64.dll" KeyPath="yes" />
         <?foreach ShellExFileName in GitExtensionsShellEx64.dll?>
         <?include RegisterShellExtension.wxi?>
         <?endforeach ?>
       </Component>
       <Component Id="GitExtSshAskPass.exe" Guid="*">
-        <File Source="..\GitExtSshAskPass\Release\GitExtSshAskPass.exe" />
+        <File Source="..\GitExtSshAskPass\$(var.Configuration)\GitExtSshAskPass.exe" />
       </Component>
       <Component Id="checksettings.reg" Guid="*">
         <RegistryValue Name="CheckSettings" Value="true" Root="HKCU" Key="$(var.AppRegKey)" Type="string" />
@@ -210,57 +210,57 @@
       </Component>
       <Component Id="VS2015_VSIX" Guid="*">
         <VSExtension:VsixPackage File="GitExtensionsVSIX.vsix" PackageId="GitExtensions..3166f76a-2b07-410a-a72a-509d6a2d146c" Target="community" TargetVersion="14.0" Vital="no" Permanent="no" />
-        <File Source="..\GitExtensionsVSIX\bin\Release\GitExtensionsVSIX.vsix" />
+        <File Source="..\GitExtensionsVSIX\bin\$(var.Configuration)\GitExtensionsVSIX.vsix" />
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="PluginsDir">
       <Component Id="DeleteUnusedBranches.dll" Guid="*">
-        <File Source="..\Plugins\DeleteUnusedBranches\bin\Release\DeleteUnusedBranches.dll" />
+        <File Source="..\Plugins\DeleteUnusedBranches\bin\$(var.Configuration)\DeleteUnusedBranches.dll" />
       </Component>
       <Component Id="AutoCompileSubmodules.dll" Guid="*">
-        <File Source="..\Plugins\AutoCompileSubmodules\bin\Release\AutoCompileSubmodules.dll" />
+        <File Source="..\Plugins\AutoCompileSubmodules\bin\$(var.Configuration)\AutoCompileSubmodules.dll" />
       </Component>
       <Component Id="BackgroundFetch.dll" Guid="*">
-        <File Source="..\Plugins\BackgroundFetch\bin\Release\BackgroundFetch.dll" />
+        <File Source="..\Plugins\BackgroundFetch\bin\$(var.Configuration)\BackgroundFetch.dll" />
       </Component>
       <Component Id="CreateLocalBranches.dll" Guid="*">
-        <File Source="..\Plugins\CreateLocalBranches\bin\Release\CreateLocalBranches.dll" />
+        <File Source="..\Plugins\CreateLocalBranches\bin\$(var.Configuration)\CreateLocalBranches.dll" />
       </Component>
       <Component Id="GitStatistics.dll" Guid="*">
-        <File Source="..\Plugins\Statistics\GitStatistics\bin\Release\GitStatistics.dll" />
+        <File Source="..\Plugins\Statistics\GitStatistics\bin\$(var.Configuration)\GitStatistics.dll" />
       </Component>
       <Component Id="GitImpact.dll" Guid="*">
-        <File Source="..\Plugins\Statistics\GitImpact\bin\Release\GitImpact.dll" />
+        <File Source="..\Plugins\Statistics\GitImpact\bin\$(var.Configuration)\GitImpact.dll" />
       </Component>
       <Component Id="Gource.dll" Guid="*">
-        <File Source="..\Plugins\Gource\bin\Release\Gource.dll" />
+        <File Source="..\Plugins\Gource\bin\$(var.Configuration)\Gource.dll" />
       </Component>
       <Component Id="Github3.dll" Guid="*">
-        <File Source="..\Plugins\Github3\bin\Release\Github3.dll" />
+        <File Source="..\Plugins\Github3\bin\$(var.Configuration)\Github3.dll" />
       </Component>
       <Component Id="GitFlow.dll" Guid="*">
-        <File Source="..\Plugins\GitFlow\bin\Release\GitFlow.dll" />
+        <File Source="..\Plugins\GitFlow\bin\$(var.Configuration)\GitFlow.dll" />
       </Component>
       <Component Id="Gerrit.dll" Guid="*">
-        <File Source="..\Plugins\Gerrit\bin\Release\Gerrit.dll" />
+        <File Source="..\Plugins\Gerrit\bin\$(var.Configuration)\Gerrit.dll" />
       </Component>
       <Component Id="ReleaseNotesGenerator.dll" Guid="*">
-        <File Source="..\Plugins\ReleaseNotesGenerator\bin\Release\ReleaseNotesGenerator.dll" />
+        <File Source="..\Plugins\ReleaseNotesGenerator\bin\$(var.Configuration)\ReleaseNotesGenerator.dll" />
       </Component>
       <Component Id="Newtonsoft.Json.dll" Guid="*">
         <File Source="..\packages\Newtonsoft.Json.10.0.3\lib\net40\Newtonsoft.Json.dll" />
       </Component>
       <Component Id="JiraCommitHintPlugin.dll" Guid="*">
-        <File Source="..\Plugins\JiraCommitHintPlugin\bin\Release\JiraCommitHintPlugin.dll" />
+        <File Source="..\Plugins\JiraCommitHintPlugin\bin\$(var.Configuration)\JiraCommitHintPlugin.dll" />
       </Component>
       <Component Id="Atlassian.Jira.dll" Guid="*">
-        <File Source="..\Plugins\JiraCommitHintPlugin\bin\Release\Atlassian.Jira.dll" />
+        <File Source="..\Plugins\JiraCommitHintPlugin\bin\$(var.Configuration)\Atlassian.Jira.dll" />
       </Component>
       <Component Id="NString.dll" Guid="*">
-        <File Source="..\Plugins\JiraCommitHintPlugin\bin\Release\NString.dll" />
+        <File Source="..\Plugins\JiraCommitHintPlugin\bin\$(var.Configuration)\NString.dll" />
       </Component>
       <Component Id="System.Collections.Immutable.dll" Guid="*">
-        <File Source="..\Plugins\JiraCommitHintPlugin\bin\Release\System.Collections.Immutable.dll" />
+        <File Source="..\Plugins\JiraCommitHintPlugin\bin\$(var.Configuration)\System.Collections.Immutable.dll" />
       </Component>
       <!--Remove unused dll, installed in versions <= 2.31-->
       <Component Id="Github.dll" Guid="0DA13691-140A-4490-8B4C-8AF537DAEB67">
@@ -275,57 +275,57 @@
         <RemoveRegistryValue Id="GithubAccess" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubpreferred access method" />
       </Component>
       <Component Id="FindLargeFiles.dll" Guid="*">
-        <File Source="..\Plugins\FindLargeFiles\bin\Release\FindLargeFiles.dll" />
+        <File Source="..\Plugins\FindLargeFiles\bin\$(var.Configuration)\FindLargeFiles.dll" />
       </Component>
       <Component Id="ProxySwitcher.dll" Guid="*">
-        <File Source="..\Plugins\ProxySwitcher\bin\Release\ProxySwitcher.dll" />
+        <File Source="..\Plugins\ProxySwitcher\bin\$(var.Configuration)\ProxySwitcher.dll" />
       </Component>
       <Component Id="Bitbucket.dll" Guid="*">
-        <File Source="..\Plugins\Bitbucket\bin\Release\Bitbucket.dll" />
+        <File Source="..\Plugins\Bitbucket\bin\$(var.Configuration)\Bitbucket.dll" />
         <!--Renamed dll, installed in versions <= 2.50.02-->
         <RemoveFile Name="Stash.dll" Id="Stash.dll" On="both" />
       </Component>
       <Component Id="TeamCityIntegration.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TeamCityIntegration\bin\Release\TeamCityIntegration.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TeamCityIntegration\bin\$(var.Configuration)\TeamCityIntegration.dll" />
       </Component>
       <Component Id="AppVeyorIntegration.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\AppVeyorIntegration\bin\Release\AppVeyorIntegration.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\AppVeyorIntegration\bin\$(var.Configuration)\AppVeyorIntegration.dll" />
       </Component>
       <Component Id="JenkinsIntegration.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\JenkinsIntegration\bin\Release\JenkinsIntegration.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\JenkinsIntegration\bin\$(var.Configuration)\JenkinsIntegration.dll" />
       </Component>
       <Component Id="TfsIntegration.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsIntegration\bin\Release\TfsIntegration.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsIntegration\bin\$(var.Configuration)\TfsIntegration.dll" />
       </Component>
       <Component Id="TfsInterop.Vs2012.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2012\bin\Release\TfsInterop.Vs2012.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2012\bin\$(var.Configuration)\TfsInterop.Vs2012.dll" />
       </Component>
       <!-- Component Id="TfsInterop.Vs2013.dll" Guid="*">
-                <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2013\bin\Release\TfsInterop.Vs2013.dll" />
+                <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2013\bin\$(var.Configuration)\TfsInterop.Vs2013.dll" />
             </Component -->
       <Component Id="TfsInterop.Vs2015.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\TfsInterop.Vs2015.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\TfsInterop.Vs2015.dll" />
       </Component>
       <Component Id="Microsoft.VisualStudio.Services.WebApi.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\Microsoft.VisualStudio.Services.WebApi.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.VisualStudio.Services.WebApi.dll" />
       </Component>
       <Component Id="Microsoft.TeamFoundation.Build2.WebApi.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\Microsoft.TeamFoundation.Build2.WebApi.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.TeamFoundation.Build2.WebApi.dll" />
       </Component>
       <Component Id="Microsoft.TeamFoundation.Common.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\Microsoft.TeamFoundation.Common.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.TeamFoundation.Common.dll" />
       </Component>
       <Component Id="Microsoft.TeamFoundation.Core.WebApi.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\Microsoft.TeamFoundation.Core.WebApi.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.TeamFoundation.Core.WebApi.dll" />
       </Component>
       <Component Id="Microsoft.VisualStudio.Services.Client.Interactive.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\Microsoft.VisualStudio.Services.Client.Interactive.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.VisualStudio.Services.Client.Interactive.dll" />
       </Component>
       <Component Id="Microsoft.VisualStudio.Services.Common.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\Microsoft.VisualStudio.Services.Common.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.VisualStudio.Services.Common.dll" />
       </Component>
       <Component Id="System.Net.Http.Formatting.dll" Guid="*">
-        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\Release\System.Net.Http.Formatting.dll" />
+        <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\System.Net.Http.Formatting.dll" />
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="IconsDir">
@@ -545,16 +545,16 @@
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="DirConEmu">
-            <Component Id="File.CER00" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\CmdInit.cmd" /></Component>
-            <Component Id="File.CER01" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmu.exe" /></Component>
-            <Component Id="File.CER03" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmu64.exe" /></Component>
-            <Component Id="File.CER04" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmuC.exe" /></Component>
-            <Component Id="File.CER05" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmuC64.exe" /></Component>
-            <Component Id="File.CER06" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmuCD.dll" /></Component>
-            <Component Id="File.CER07" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmuCD64.dll" /></Component>
-            <Component Id="File.CER08" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmuHk.dll" /></Component>
-            <Component Id="File.CER09" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\ConEmuHk64.dll" /></Component>
-            <Component Id="File.CER10" Guid="*"><File Source="..\GitExtensions\Bin\Release\ConEmu\GitShowBranch.cmd" /></Component>
+            <Component Id="File.CER00" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\CmdInit.cmd" /></Component>
+            <Component Id="File.CER01" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmu.exe" /></Component>
+            <Component Id="File.CER03" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmu64.exe" /></Component>
+            <Component Id="File.CER04" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmuC.exe" /></Component>
+            <Component Id="File.CER05" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmuC64.exe" /></Component>
+            <Component Id="File.CER06" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmuCD.dll" /></Component>
+            <Component Id="File.CER07" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmuCD64.dll" /></Component>
+            <Component Id="File.CER08" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmuHk.dll" /></Component>
+            <Component Id="File.CER09" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\ConEmuHk64.dll" /></Component>
+            <Component Id="File.CER10" Guid="*"><File Source="..\GitExtensions\Bin\$(var.Configuration)\ConEmu\GitShowBranch.cmd" /></Component>
     </DirectoryRef>
     <ComponentGroup Id="Component.ConEmuFiles">
           <ComponentRef Id="File.CER00" /><ComponentRef Id="File.CER01" /><ComponentRef Id="File.CER03" /><ComponentRef Id="File.CER04" /><ComponentRef Id="File.CER05" /><ComponentRef Id="File.CER06" /><ComponentRef Id="File.CER07" /><ComponentRef Id="File.CER08" /><ComponentRef Id="File.CER09" /><ComponentRef Id="File.CER10" />
@@ -563,23 +563,23 @@
     <DirectoryRef Id="VS$(var.VsVersion)">
       <Directory Id="VS$(var.VsVersion)_Addins" Name="Addins">
         <Component Id="VS$(var.VsVersion)_GitPlugin.AddIn" Guid="*">
-          <File Id="VS$(var.VsVersion)_GitPlugin.AddIn" Source="..\GitPlugin\bin\Release\GitPlugin.AddIn" />
+          <File Id="VS$(var.VsVersion)_GitPlugin.AddIn" Source="..\GitPlugin\bin\$(var.Configuration)\GitPlugin.AddIn" />
           <RemoveFolder Id="VS$(var.VsVersion)_GitPlugin.AddIn" On="uninstall" />
           <RemoveFolder Id="VS$(var.VsVersion)_GitPlugin.AddIn_Parent" On="uninstall" Directory="VS$(var.VsVersion)" />
         </Component>
         <Component Id="VS$(var.VsVersion)_GitPlugin.dll" Guid="*">
-          <File Id="VS$(var.VsVersion)_GitPlugin.dll" Source="..\GitPlugin\bin\Release\GitPlugin.dll" />
+          <File Id="VS$(var.VsVersion)_GitPlugin.dll" Source="..\GitPlugin\bin\$(var.Configuration)\GitPlugin.dll" />
           <RemoveFolder Id="VS$(var.VsVersion)_GitPlugin.dll" On="uninstall" />
           <RemoveFolder Id="VS$(var.VsVersion)_GitPlugin.dll_Parent" On="uninstall" Directory="VS$(var.VsVersion)" />
         </Component>
         <Component Id="VS$(var.VsVersion)_GitPluginShared.dll" Guid="*">
-          <File Id="VS$(var.VsVersion)_GitPluginShared.dll" Source="..\GitPlugin\bin\Release\GitPluginShared.dll" />
+          <File Id="VS$(var.VsVersion)_GitPluginShared.dll" Source="..\GitPlugin\bin\$(var.Configuration)\GitPluginShared.dll" />
           <RemoveFolder Id="VS$(var.VsVersion)_GitPluginShared.dll" On="uninstall" />
           <RemoveFolder Id="VS$(var.VsVersion)_GitPluginShared.dll_Parent" On="uninstall" Directory="VS$(var.VsVersion)" />
         </Component>
         <Directory Id="VS$(var.VsVersion)_Addins_enUS" Name="en-US">
           <Component Id="VS$(var.VsVersion)_GitPlugin.resources.dll" Guid="*">
-            <File Id="VS$(var.VsVersion)_GitPlugin.resources.dll" Source="..\GitPlugin\bin\Release\en-US\GitPlugin.resources.dll" />
+            <File Id="VS$(var.VsVersion)_GitPlugin.resources.dll" Source="..\GitPlugin\bin\$(var.Configuration)\en-US\GitPlugin.resources.dll" />
             <RemoveFolder Id="VS$(var.VsVersion)_GitPlugin.resources.dll" On="uninstall" />
           </Component>
         </Directory>

--- a/Setup/Setup.wixproj
+++ b/Setup/Setup.wixproj
@@ -89,4 +89,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\WiX.3.11.0\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WiX.3.11.0\build\wix.props'))" />
   </Target>
+  <Target Name="BeforeBuild">
+    <Exec Command="
+	call DownloadExternals.cmd $(Configuration)
+	call BuildGitExtNative.cmd $(Configuration) build">
+    </Exec>
+  </Target>
 </Project>

--- a/Setup/hMSBuild.bat
+++ b/Setup/hMSBuild.bat
@@ -1,0 +1,496 @@
+@echo off
+
+:: hMSBuild - v1.2.2.62992 [ 3ee58c3 ]
+:: Copyright (c) 2017  Denis Kuzmin [ entry.reg@gmail.com ]
+:: -
+:: Distributed under the MIT license
+:: https://github.com/3F/hMSBuild
+
+setlocal enableDelayedExpansion
+
+
+:: - - -
+:: Settings by default
+
+set vswhereByDefault=1.0.62
+set vswhereCache=%temp%\hMSBuild_vswhere
+
+set /a notamd64=0
+set /a novs=0
+set /a nonet=0
+set /a novswhere=0
+set /a nocachevswhere=0
+set /a hMSBuildDebug=0
+set "displayOnlyPath="
+set "vswVersion="
+
+set ERROR_SUCCESS=0
+set ERROR_FILE_NOT_FOUND=2
+set ERROR_PATH_NOT_FOUND=3
+
+set "args=%* "
+
+
+:: - - -
+:: Help command
+
+set _hl=%args:"=%
+set _hr=%_hl%
+
+set _hr=%_hr:-help =%
+set _hr=%_hr:-h =%
+set _hr=%_hr:-? =%
+
+if not "%_hl%"=="%_hr%" goto usage
+goto commands
+
+:usage
+
+echo.
+@echo :: hMSBuild - v1.2.2.62992 [ 3ee58c3 ]
+@echo Copyright (c) 2017  Denis Kuzmin [ entry.reg@gmail.com :: github.com/3F ]
+echo Distributed under the MIT license
+@echo https://github.com/3F/hMSBuild 
+echo.
+@echo.
+@echo Usage: hMSBuild [args to hMSBuild] [args to msbuild.exe or GetNuTool core]
+echo ------
+echo.
+echo Arguments:
+echo ----------
+echo  -novswhere             - Do not search via vswhere.
+echo  -novs                  - Disable searching from Visual Studio.
+echo  -nonet                 - Disable searching from .NET Framework.
+echo  -vswhere-version {num} - Specific version of vswhere. Where {num}:
+echo                           * Versions: 1.0.50 ...
+echo                           * Keywords: 
+echo                             `latest` to get latest available version; 
+echo                             `local`  to use only local versions: 
+echo                                      (.bat;.exe /or from +15.2.26418.1 VS-build);
+echo.
+echo  -nocachevswhere        - Do not cache vswhere. Use this also for reset cache.
+echo  -notamd64              - To use 32bit version of found msbuild.exe if it's possible.
+echo  -eng                   - Try to use english language for all build messages.
+echo  -GetNuTool {args}      - Access to GetNuTool core. https://github.com/3F/GetNuTool
+echo  -only-path             - Only display fullpath to found MSBuild.
+echo  -debug                 - To show additional information from hMSBuild.
+echo  -version               - Display version of hMSBuild.
+echo  -help                  - Display this help. Aliases: -help -h -?
+echo.
+echo. 
+echo -------- 
+echo Samples:
+echo -------- 
+echo hMSBuild -vswhere-version 1.0.50 -notamd64 "Conari.sln" /t:Rebuild
+echo hMSBuild -vswhere-version latest "Conari.sln"
+echo.
+echo hMSBuild -novswhere -novs -notamd64 "Conari.sln"
+echo hMSBuild -novs "DllExport.sln"
+echo hMSBuild vsSolutionBuildEvent.sln
+echo.
+echo hMSBuild -GetNuTool -unpack
+echo hMSBuild -GetNuTool /p:ngpackages="Conari;regXwild"
+echo.
+echo "hMSBuild -novs "DllExport.sln" || goto err"
+echo.
+echo ---------------------
+echo Possible Error Codes: ERROR_FILE_NOT_FOUND (0x2), ERROR_PATH_NOT_FOUND (0x3), ERROR_SUCCESS (0x0)
+echo ---------------------
+echo.
+
+exit /B 0
+
+:: - - -
+:: Handler of user commands
+
+:commands
+
+call :isEmptyOrWhitespace args _is
+if [!_is!]==[1] goto action
+
+set /a idx=1 & set cmdMax=12
+:loopargs
+
+    if "!args:~0,11!"=="-GetNuTool " (
+        call :popars %1 & shift
+        goto gntcall
+    )
+    
+    if "!args:~0,11!"=="-novswhere " (
+        call :popars %1 & shift
+        set novswhere=1
+    )
+    
+    if "!args:~0,16!"=="-nocachevswhere " (
+        call :popars %1 & shift
+        set nocachevswhere=1
+    )
+    
+    if "!args:~0,6!"=="-novs " (
+        call :popars %1 & shift
+        set novs=1
+    )
+    
+    if "!args:~0,7!"=="-nonet " (
+        call :popars %1 & shift
+        set nonet=1
+    )
+
+    :: backward compatibility - version 1.1
+    if "!args:~0,16!"=="-vswhereVersion " set _OrConditionVSWVer=1
+    if "!args:~0,17!"=="-vswhere-version " set _OrConditionVSWVer=1
+    if defined _OrConditionVSWVer (
+        set "_OrConditionVSWVer="
+        call :popars %1 & shift
+        set vswVersion=%2
+        echo selected new vswhere version: !vswVersion!
+        call :popars %2 & shift
+    )
+
+    if "!args:~0,10!"=="-notamd64 " (
+        call :popars %1 & shift
+        set notamd64=1
+    )
+    
+    if "!args:~0,5!"=="-eng " (
+        call :popars %1 & shift
+        chcp 437 >nul
+    )
+
+    if "!args:~0,11!"=="-only-path " (
+        call :popars %1 & shift
+        set displayOnlyPath=1
+    )
+
+    if "!args:~0,7!"=="-debug " (
+        call :popars %1 & shift
+        set hMSBuildDebug=1
+    )
+    
+    if "!args:~0,9!"=="-version " (
+        @echo hMSBuild - v1.2.2.62992 [ 3ee58c3 ]
+        exit /B 0
+    )
+    
+set /a "idx+=1"
+if !idx! LSS %cmdMax% goto loopargs
+
+goto action
+
+:popars
+set args=!!args:%1 ^=!!
+call :trim args
+set "args=!args! "
+exit /B 0
+
+:: - - -
+:: Main logic of searching
+:action
+
+if "!nocachevswhere!"=="1" (
+    call :dbgprint "resetting cache of vswhere"
+    rmdir /S/Q "%vswhereCache%" 2>nul
+)
+
+if not "!novswhere!"=="1" if not "!novs!"=="1" (
+    call :vswhere
+    if "!ERRORLEVEL!"=="0" goto runmsbuild
+)
+
+if not "!novs!"=="1" (
+    call :msbvsold
+    if "!ERRORLEVEL!"=="0" goto runmsbuild
+)
+
+if not "!nonet!"=="1" (
+    call :msbnetf
+    if "!ERRORLEVEL!"=="0" goto runmsbuild
+)
+
+echo MSBuild tools was not found. Try to use other settings. Use key `-help` for details.
+exit /B %ERROR_FILE_NOT_FOUND%
+
+:runmsbuild
+
+call :isEmptyOrWhitespace msbuildPath _is
+if [!_is!]==[1] (
+    echo Something went wrong. Use `-debug` key for details.
+    exit /B %ERROR_FILE_NOT_FOUND%
+)
+
+if defined displayOnlyPath (
+    echo !msbuildPath!
+    exit /B 0
+)
+set xMSBuild="!msbuildPath!"
+
+echo hMSBuild: !xMSBuild! 
+call :dbgprint "Arguments: !args!"
+
+!xMSBuild! !args!
+exit /B %ERRORLEVEL%
+
+:: - - -
+:: Tools from VS2017+
+:vswhere
+
+call :dbgprint "trying via vswhere..."
+
+if defined vswVersion (
+    if not "!vswVersion!"=="local" (
+        call :vswhereRemote
+        call :vswhereBin
+        exit /B !ERRORLEVEL!
+    )
+)
+
+call :vswhereLocal
+if "!ERRORLEVEL!"=="%ERROR_PATH_NOT_FOUND%" (
+    if "!vswVersion!"=="local" (
+        exit /B %ERROR_PATH_NOT_FOUND%
+    )
+    call :vswhereRemote
+)
+call :vswhereBin
+exit /B !ERRORLEVEL!
+
+:vswhereLocal
+
+:: Only with +15.2.26418.1 VS-build
+:: https://github.com/3F/hMSBuild/issues/1
+
+if exist "%~dp0vswhere.bat" set vswbin="%~dp0vswhere" & exit /B 0
+if exist "%~dp0vswhere.exe" set vswbin="%~dp0vswhere" & exit /B 0
+
+set rlocalp=Microsoft Visual Studio\Installer
+if exist "%ProgramFiles(x86)%\!rlocalp!" set vswbin="%ProgramFiles(x86)%\!rlocalp!\vswhere" & exit /B 0
+if exist "%ProgramFiles%\!rlocalp!" set vswbin="%ProgramFiles%\!rlocalp!\vswhere" & exit /B 0
+
+call :dbgprint "local vswhere is not found."
+exit /B %ERROR_PATH_NOT_FOUND%
+
+:vswhereRemote
+
+if "!nocachevswhere!"=="1" (
+    set tvswhere=%temp%\%random%%random%vswhere
+) else (
+    set tvswhere=%vswhereCache%
+)
+
+call :dbgprint "tvswhere: !tvswhere!"
+
+if "!vswVersion!"=="latest" (
+    set vswpkg=vswhere
+) else (
+    set vswpkg=vswhere/!vswVersion!
+)
+
+call :dbgprint "vswpkg: !vswpkg!"
+
+if "!hMSBuildDebug!"=="1" (
+    call :gntpoint /p:ngpackages="!vswpkg!:vswhere" /p:ngpath="!tvswhere!"
+) else (
+    call :gntpoint /p:ngpackages="!vswpkg!:vswhere" /p:ngpath="!tvswhere!" >nul
+)
+set vswbin="!tvswhere!\vswhere\tools\vswhere"
+
+exit /B 0
+
+:vswhereBin
+call :dbgprint "vswbin: "!vswbin!""
+
+for /f "usebackq tokens=1* delims=: " %%a in (`!vswbin! -latest -requires Microsoft.Component.MSBuild`) do (
+    if /i "%%a"=="installationPath" set vspath=%%b
+    if /i "%%a"=="installationVersion" set vsver=%%b
+)
+
+call :dbgprint "vspath: !vspath!"
+call :dbgprint "vsver: !vsver!"
+
+if defined tvswhere (
+    if "!nocachevswhere!"=="1" (
+        call :dbgprint "reset vswhere"
+        rmdir /S/Q "!tvswhere!"
+    )
+)
+
+if [!vsver!]==[] (
+    call :dbgprint "VS2017+ was not found via vswhere"
+    exit /B %ERROR_PATH_NOT_FOUND%
+)
+
+for /f "tokens=1,2 delims=." %%a in ("!vsver!") do (
+    set vsver=%%a.0
+)
+set msbuildPath=!vspath!\MSBuild\!vsver!\Bin
+
+call :dbgprint "found path to msbuild: !msbuildPath!"
+
+if exist "!msbuildPath!\amd64" (
+    call :dbgprint "found /amd64"
+    set msbuildPath=!msbuildPath!\amd64
+)
+call :msbuildfind 
+exit /B 0
+
+:: - - -
+:: Tools from Visual Studio - 2015, 2013, ...
+:msbvsold
+call :dbgprint "trying via MSBuild tools from Visual Studio - 2015, 2013, ..."
+
+for %%v in (14.0, 12.0) do (
+    call :rtools %%v Y & if [!Y!]==[1] exit /B 0
+)
+call :dbgprint "msbvsold: unfortunately we didn't find anything."
+exit /B %ERROR_FILE_NOT_FOUND%
+
+:: - - -
+:: Tools from .NET Framework - .net 4.0, ...
+:msbnetf
+
+call :dbgprint "trying via MSBuild tools from .NET Framework - .net 4.0, ..."
+
+for %%v in (4.0, 3.5, 2.0) do (
+    call :rtools %%v Y & if [!Y!]==[1] exit /B 0
+)
+call :dbgprint "msbnetf: unfortunately we didn't find anything."
+exit /B %ERROR_FILE_NOT_FOUND%
+
+:rtools
+call :dbgprint "checking of version: %1"
+    
+for /F "usebackq tokens=2* skip=2" %%a in (
+    `reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\%1" /v MSBuildToolsPath 2^> nul`
+) do if exist %%b (
+    call :dbgprint "found: %%b"
+        
+    set msbuildPath=%%b
+    call :msbuildfind
+    set /a %2=1
+    exit /B 0
+)
+set /a %2=0
+exit /B 0
+
+:gntcall
+call :dbgprint "direct access to GetNuTool..."
+call :gntpoint !args!
+exit /B 0
+
+:msbuildfind
+
+set msbuildPath=!msbuildPath!\MSBuild.exe
+
+if not "!notamd64!" == "1" (
+    exit /B 0
+)
+
+:: 7z & amd64\msbuild - https://github.com/3F/vsSolutionBuildEvent/issues/38
+set _amd=!msbuildPath:Framework64=Framework!
+set _amd=!_amd:amd64=!
+
+if exist "!_amd!" (
+    call :dbgprint "Return 32bit version of MSBuild.exe because you wanted this via -notamd64"
+    set msbuildPath=!_amd!
+    exit /B 0
+)
+
+call :dbgprint "We know that 32bit version of MSBuild.exe is important for you, but we found only this."
+exit /B 0
+
+:: =
+
+:dbgprint
+if "!hMSBuildDebug!"=="1" (
+    set msgfmt=%1
+    set msgfmt=!msgfmt:~0,-1! 
+    set msgfmt=!msgfmt:~1!
+    echo.[%TIME% ] !msgfmt!
+)
+exit /B 0
+
+:trim
+:: Usage: call :trim variable
+call :_v %%%1%%
+set %1=%_trimv%
+exit /B 0
+:_v
+set "_trimv=%*"
+exit /B 0
+
+:isEmptyOrWhitespace
+:: Usage: call :isEmptyOrWhitespace input output(1/0)
+setlocal enableDelayedExpansion
+set "_v=!%1!"
+
+if not defined _v endlocal & set /a %2=1 & exit /B 0
+ 
+set _v=%_v: =%
+set "_v= %_v%"
+if [^%_v:~1,1%]==[] endlocal & set /a %2=1 & exit /B 0
+ 
+endlocal & set /a %2=0
+exit /B 0
+
+:gntpoint
+setlocal disableDelayedExpansion 
+
+:: ========================= GetNuTool =========================
+
+@echo off
+:: GetNuTool - Executable version
+:: Copyright (c) 2015-2017  Denis Kuzmin [ entry.reg@gmail.com ]
+:: https://github.com/3F/GetNuTool
+
+set gntcore=gnt.core
+set tgnt="%temp%\%random%%random%%gntcore%"
+
+set "args=%* "
+set a=%args:~0,30%
+set a=%a:"=%
+
+if "%a:~0,8%"=="-unpack " goto unpack
+if "%a:~0,9%"=="-msbuild " goto ufound
+
+for %%v in (4.0, 14.0, 12.0, 3.5, 2.0) do (
+    for /F "usebackq tokens=2* skip=2" %%a in (
+        `reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\%%v" /v MSBuildToolsPath 2^> nul`
+    ) do if exist %%b (
+        set msbuildexe="%%b\MSBuild.exe"
+        goto found
+    )
+)
+echo MSBuild was not found, try: gnt -msbuild "fullpath" args 1>&2
+exit /B 2
+
+:ufound
+call :popa %1
+shift
+set msbuildexe=%1
+call :popa %1
+
+:found
+call :core
+%msbuildexe% %tgnt% /nologo /p:wpath="%~dp0/" /v:m %args%
+del /Q/F %tgnt%
+exit /B 0
+
+:popa
+call set args=%%args:%1 ^=%%
+exit /B 0
+
+:unpack
+set tgnt="%~dp0\%gntcore%"
+echo Generate minified version in %tgnt% ...
+
+:core
+<nul set /P ="">%tgnt%
+<nul set /P =^<!-- GetNuTool - github.com/3F/GetNuTool --^>^<!-- Copyright (c) 2015-2017  Denis Kuzmin [ entry.reg@gmail.com ] --^>^<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"^>^<PropertyGroup^>^<ngconfig Condition="'$(ngconfig)' == ''"^>packages.config^</ngconfig^>^<ngserver Condition="'$(ngserver)' == ''"^>https://www.nuget.org/api/v2/package/^</ngserver^>^<ngpackages Condition="'$(ngpackages)' == ''"^>^</ngpackages^>^<ngpath Condition="'$(ngpath)' == ''"^>packages^</ngpath^>^</PropertyGroup^>^<Target Name="get" BeforeTargets="Build" DependsOnTargets="header"^>^<PrepareList config="$(ngconfig)" plist="$(ngpackages)" wpath="$(wpath)"^>^<Output PropertyName="plist" TaskParameter="Result"/^>^</PrepareList^>^<NGDownload plist="$(plist)" url="$(ngserver)" wpath="$(wpath)" defpath="$(ngpath)" debug="$(debug)"/^>^</Target^>^<Target Name="pack" DependsOnTargets="header"^>^<NGPack dir="$(ngin)" dout="$(ngout)" wpath="$(wpath)" vtool="$(GetNuTool)" debug="$(debug)"/^>^</Target^>^<PropertyGroup^>^<TaskCoreDllPath Condition="Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll')"^>$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll^</TaskCoreDllPath^>^<TaskCoreDllPath Condition="'$(TaskCoreDllPath)' == '' and Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll')"^>$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll^</TaskCoreDllPath^>^</PropertyGroup^>^<UsingTask TaskName="PrepareList" TaskFactory="CodeTaskFactory" AssemblyFile="$(TaskCoreDllPath)"^>^<ParameterGroup^>^<config Parame>> %tgnt%
+<nul set /P =terType="System.String" Required="true"/^>^<plist ParameterType="System.String"/^>^<wpath ParameterType="System.String"/^>^<Result ParameterType="System.String" Output="true"/^>^</ParameterGroup^>^<Task^>^<Reference Include="System.Xml"/^>^<Reference Include="System.Xml.Linq"/^>^<Using Namespace="System"/^>^<Using Namespace="System.Collections.Generic"/^>^<Using Namespace="System.IO"/^>^<Using Namespace="System.Xml.Linq"/^>^<Code Type="Fragment" Language="cs"^>^<![CDATA[if(!String.IsNullOrEmpty(plist)){Result=plist;return true;}var _err=Console.Error;Action^<string,Queue^<string^>^> h=delegate(string cfg,Queue^<string^> list){foreach(var pkg in XDocument.Load(cfg).Descendants("package")){var id=pkg.Attribute("id");var version=pkg.Attribute("version");var output=pkg.Attribute("output");if(id==null){_err.WriteLine("Some 'id' does not exist in '{0}'",cfg);return;}var link=id.Value;if(version!=null){link+="/"+version.Value;}if(output!=null){list.Enqueue(link+":"+output.Value);continue;}list.Enqueue(link);}};var ret=new Queue^<string^>();foreach(var cfg in config.Split('^|',';')){var lcfg=Path.Combine(wpath,cfg??"");if(File.Exists(lcfg)){h(lcfg,ret);}else{_err.WriteLine(".config '{0}' was not found.",lcfg);}}if(ret.Count ^< 1){_err.WriteLine("List of packages is empty. Use .config or /p:ngpackages=\"...\"\n");}else{Result=String.Join(";",ret.ToArray());}]]^>^</Code^>^</Task^>^</UsingTask^>^<UsingTask TaskName="NGDownload" TaskFactory="CodeTaskFactory" AssemblyFile="$(TaskCoreDllPath)"^>^<ParameterGroup^>^<plist ParameterType="System.String"/^>^<url Paramet>> %tgnt%
+<nul set /P =erType="System.String" Required="true"/^>^<wpath ParameterType="System.String"/^>^<defpath ParameterType="System.String"/^>^<debug ParameterType="System.Boolean"/^>^</ParameterGroup^>^<Task^>^<Reference Include="WindowsBase"/^>^<Using Namespace="System"/^>^<Using Namespace="System.IO"/^>^<Using Namespace="System.IO.Packaging"/^>^<Using Namespace="System.Net"/^>^<Code Type="Fragment" Language="cs"^>^<![CDATA[if(plist==null){return false;}var ignore=new string[]{"/_rels/","/package/","/[Content_Types].xml"};Action^<string,object^> dbg=delegate(string s,object p){if(debug){Console.WriteLine(s,p);}};Func^<string,string^> loc=delegate(string p){return Path.Combine(wpath,p??"");};Action^<string,string,string^> get=delegate(string link,string name,string path){var to=Path.GetFullPath(loc(path??name));if(Directory.Exists(to)){Console.WriteLine("`{0}` is already exists: \"{1}\"",name,to);return;}Console.Write("Getting `{0}` ... ",link);var tmp=Path.Combine(Path.GetTempPath(),Guid.NewGuid().ToString());using(var l=new WebClient()){try{l.Headers.Add("User-Agent","GetNuTool");l.UseDefaultCredentials=true;l.DownloadFile(url+link,tmp);}catch(Exception ex){Console.Error.WriteLine(ex.Message);return;}}Console.WriteLine("Extracting into \"{0}\"",to);using(var pkg=ZipPackage.Open(tmp,FileMode.Open,FileAccess.Read)){foreach(var part in pkg.GetParts()){var uri=Uri.UnescapeDataString(part.Uri.OriginalString);if(ignore.Any(x=^> uri.StartsWith(x,StringComparison.Ordinal))){continue;}var dest=Path.Combine(to,uri.TrimStart('/'));dbg("- `{0}`",uri);var dir=Path.GetDirectoryNam>> %tgnt%
+<nul set /P =e(dest);if(!Directory.Exists(dir)){Directory.CreateDirectory(dir);}using(var src=part.GetStream(FileMode.Open,FileAccess.Read))using(var target=File.OpenWrite(dest)){try{src.CopyTo(target);}catch(FileFormatException ex){dbg("[x]?crc: {0}",dest);}}}}File.Delete(tmp);};foreach(var pkg in plist.Split(';')){var ident=pkg.Split(':');var link=ident[0];var path=(ident.Length ^> 1)?ident[1]: null;var name=link.Replace('/','.');if(!String.IsNullOrEmpty(defpath)){path=Path.Combine(defpath,path??name);}get(link,name,path);}]]^>^</Code^>^</Task^>^</UsingTask^>^<UsingTask TaskName="NGPack" TaskFactory="CodeTaskFactory" AssemblyFile="$(TaskCoreDllPath)"^>^<ParameterGroup^>^<dir ParameterType="System.String" Required="true"/^>^<dout ParameterType="System.String"/^>^<wpath ParameterType="System.String"/^>^<vtool ParameterType="System.String" Required="true"/^>^<debug ParameterType="System.Boolean"/^>^</ParameterGroup^>^<Task^>^<Reference Include="System.Xml"/^>^<Reference Include="System.Xml.Linq"/^>^<Reference Include="WindowsBase"/^>^<Using Namespace="System"/^>^<Using Namespace="System.Collections.Generic"/^>^<Using Namespace="System.IO"/^>^<Using Namespace="System.Linq"/^>^<Using Namespace="System.IO.Packaging"/^>^<Using Namespace="System.Xml.Linq"/^>^<Using Namespace="System.Text.RegularExpressions"/^>^<Code Type="Fragment" Language="cs"^>^<![CDATA[var EXT_NUSPEC=".nuspec";var EXT_NUPKG=".nupkg";var TAG_META="metadata";var DEF_CONTENT_TYPE="application/octet";var MANIFEST_URL="http://schemas.microsoft.com/packaging/2010/07/manifest";var ID="id";var VER="version">> %tgnt%
+<nul set /P =;Action^<string,object^> dbg=delegate(string s,object p){if(debug){Console.WriteLine(s,p);}};var _err=Console.Error;dir=Path.Combine(wpath,dir);if(!Directory.Exists(dir)){_err.WriteLine("`{0}` was not found.",dir);return false;}dout=Path.Combine(wpath,dout??"");var nuspec=Directory.GetFiles(dir,"*"+EXT_NUSPEC,SearchOption.TopDirectoryOnly).FirstOrDefault();if(nuspec==null){_err.WriteLine("{0} was not found in `{1}`",EXT_NUSPEC,dir);return false;}Console.WriteLine("Found {0}: `{1}`",EXT_NUSPEC,nuspec);var root=XDocument.Load(nuspec).Root.Elements().FirstOrDefault(x=^> x.Name.LocalName==TAG_META);if(root==null){_err.WriteLine("{0} does not contain {1}.",nuspec,TAG_META);return false;}var metadata=new Dictionary^<string,string^>();foreach(var tag in root.Elements()){metadata[tag.Name.LocalName.ToLower()]=tag.Value;}if(metadata[ID].Length ^> 100 ^|^|!Regex.IsMatch(metadata[ID],@"^\w+([_.-]\w+)*$",RegexOptions.IgnoreCase ^| RegexOptions.ExplicitCapture)){_err.WriteLine("The format of `{0}` is not correct.",ID);return false;}var ignore=new string[]{Path.Combine(dir,"_rels"),Path.Combine(dir,"package"),Path.Combine(dir,"[Content_Types].xml")};var pout=String.Format("{0}.{1}{2}",metadata[ID],metadata[VER],EXT_NUPKG);if(!String.IsNullOrWhiteSpace(dout)){if(!Directory.Exists(dout)){Directory.CreateDirectory(dout);}pout=Path.Combine(dout,pout);}Console.WriteLine("Started packing `{0}` ...",pout);using(var pkg=Package.Open(pout,FileMode.Create)){var manifestUri=new Uri(String.Format("/{0}{1}",metadata[ID],EXT_NUSPEC),UriKind.Relative);pkg.CreateRelationship(manif>> %tgnt%
+<nul set /P =estUri,TargetMode.Internal,MANIFEST_URL);foreach(var file in Directory.GetFiles(dir,"*.*",SearchOption.AllDirectories)){if(ignore.Any(x=^> file.StartsWith(x,StringComparison.Ordinal))){continue;}string pUri;if(file.StartsWith(dir,StringComparison.OrdinalIgnoreCase)){pUri=file.Substring(dir.Length).TrimStart(Path.DirectorySeparatorChar);}else{pUri=file;}dbg("- `{0}`",pUri);var escaped=String.Join("/",pUri.Split('\\','/').Select(p=^> Uri.EscapeDataString(p)));var uri=PackUriHelper.CreatePartUri(new Uri(escaped,UriKind.Relative));var part=pkg.CreatePart(uri,DEF_CONTENT_TYPE,CompressionOption.Maximum);using(var tstream=part.GetStream())using(var fs=new FileStream(file,FileMode.Open,FileAccess.Read)){fs.CopyTo(tstream);}}Func^<string,string^> getmeta=delegate(string key){return(metadata.ContainsKey(key))?metadata[key]:"";};var _p=pkg.PackageProperties;_p.Creator=getmeta("authors");_p.Description=getmeta("description");_p.Identifier=metadata[ID];_p.Version=metadata[VER];_p.Keywords=getmeta("tags");_p.Title=getmeta("title");_p.LastModifiedBy="GetNuTool v"+vtool;}]]^>^</Code^>^</Task^>^</UsingTask^>^<Target Name="Build" DependsOnTargets="get"/^>^<PropertyGroup^>^<GetNuTool^>1.6.1.10620_bde3e50^</GetNuTool^>^<wpath Condition="'$(wpath)' == ''"^>$(MSBuildProjectDirectory)^</wpath^>^</PropertyGroup^>^<Target Name="header"^>^<Message Text="%%0D%%0AGetNuTool v$(GetNuTool) - github.com/3F%%0D%%0A=========%%0D%%0A" Importance="high"/^>^</Target^>^</Project^>>> %tgnt%
+
+
+exit /B 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,4 +34,6 @@ build_script:
     Write-Output "Platform: $env:IdeVersion"
     & Setup\BuildInstallers.$env:IdeVersion.cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    #Get-ChildItem Setup\GitExtensions-*.msi | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+    & Setup\MakeMonoArchive.cmd
     Get-ChildItem Setup\GitExtensions-*-Mono.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,6 @@ build_script:
     Write-Output "Platform: $env:IdeVersion"
     & Setup\BuildInstallers.$env:IdeVersion.cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-    #Get-ChildItem Setup\GitExtensions-*.msi | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
     & Setup\MakeMonoArchive.cmd
+    #Upload a portable archive, not a installer
     Get-ChildItem Setup\GitExtensions-*-Mono.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
The current build scripts have a number of hardcoding and requires a number of manual updates.
This is a step to simplify the build process and make it easier for users to test creating Setup

 * Download and build the binaries when building wix project
 * Use variables in product.wxs, no Mono in VS*cmd, use Configuration variables, remove c++ projects. It is now possible to build setup in Debug
 * Use hMSBuild to build, common 2017/2015 detection of msbuild

Second step of #4069 
This is not making much difference in itself, it is a preparation for future changes

What did I do to test the code and ensure quality:
 - Build on Appveyor
 - Manual builds

Has been tested on (remove any that don't apply):
 - Windows 10
