### PR TITLE
Fixes on jira commit hint plugin

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2660,12 +2660,15 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        private int _alreadyLoadedTemplatesCount = -1;
         private void commitTemplatesToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
-            if (_shouldReloadCommitTemplates)
+            var registeredTemplatesCount = _commitTemplateManager.RegisteredTemplates.Count();
+            if (_shouldReloadCommitTemplates || _alreadyLoadedTemplatesCount != registeredTemplatesCount)
             {
                 LoadCommitTemplates();
                 _shouldReloadCommitTemplates = false;
+                _alreadyLoadedTemplatesCount = registeredTemplatesCount;
             }
         }
 

--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 namespace GitUIPluginInterfaces
 {
@@ -49,7 +50,14 @@ namespace GitUIPluginInterfaces
                     settingVal = Setting[settings];
                 }
 
-                control.Text = settingVal;
+                if (!control.Multiline)
+                {
+                    control.Text = settingVal;
+                }
+                else
+                {
+                    control.Text = settingVal.Replace("\n", Environment.NewLine);
+                }
             }
 
             public override void SaveSetting(ISettingsSource settings, bool areSettingsEffective, TextBox control)

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -76,7 +76,7 @@ namespace JiraCommitHintPlugin
                 GetMessageToCommit(localJira, localQuery, localStringTemplate).ContinueWith(t =>
                 {
                     var preview = t.Result.FirstOrDefault();
-                    MessageBox.Show($"First Task Preview:{Environment.NewLine}{Environment.NewLine}{(preview == null ? "[Empty Jira Query Result]" : preview.Text)}");
+                    MessageBox.Show(null, (preview == null ? "[Empty Jira Query Result]" : preview.Text), "First Task Preview");
                 });
             }
             catch (Exception ex)

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using Atlassian.Jira;
 using GitUIPluginInterfaces;
@@ -37,7 +38,10 @@ namespace JiraCommitHintPlugin
                 return false;
             if (jira == null)
                 return false;
-            MessageBox.Show(string.Join(Environment.NewLine, GetMessageToCommit(jira, query, stringTemplate).Select(t => t.Text).ToArray()));
+            GetMessageToCommit(jira, query, stringTemplate).ContinueWith(t =>
+            {
+                MessageBox.Show(string.Join(Environment.NewLine, t.Result.Select(jt => jt.Text).ToArray()));
+            });
             return false;
         }
 
@@ -69,8 +73,11 @@ namespace JiraCommitHintPlugin
                 var localJira = Jira.CreateRestClient(urlSettings.CustomControl.Text, userSettings.CustomControl.Text, passwordSettings.CustomControl.Text);
                 var localQuery = jdlQuerySettings.CustomControl.Text;
                 var localStringTemplate = stringTemplateSetting.CustomControl.Text;
-                var preview = GetMessageToCommit(localJira, localQuery, localStringTemplate).FirstOrDefault();
-                MessageBox.Show($"First Task Preview:{Environment.NewLine}{Environment.NewLine}{(preview == null ? "[Empty Jira Query Result]" : preview.Text)}");
+                GetMessageToCommit(localJira, localQuery, localStringTemplate).ContinueWith(t =>
+                {
+                    var preview = t.Result.FirstOrDefault();
+                    MessageBox.Show($"First Task Preview:{Environment.NewLine}{Environment.NewLine}{(preview == null ? "[Empty Jira Query Result]" : preview.Text)}");
+                });
             }
             catch (Exception ex)
             {
@@ -130,11 +137,15 @@ namespace JiraCommitHintPlugin
             if (jira?.Issues == null)
                 return;
 
-            currentMessages = GetMessageToCommit(jira, query, stringTemplate);
-            foreach (var message in currentMessages)
+            GetMessageToCommit(jira, query, stringTemplate).ContinueWith(t =>
             {
-                e.GitUICommands.AddCommitTemplate(message.Title, () => message.Text);
-            }
+                currentMessages = t.Result;
+                foreach (var message in currentMessages)
+                {
+                    e.GitUICommands.AddCommitTemplate(message.Title, () => message.Text);
+                }
+            }, TaskScheduler.FromCurrentSynchronizationContext());
+
         }
 
         private void gitUiCommands_PostRepositoryChanged(object sender, GitUIBaseEventArgs e)
@@ -150,11 +161,12 @@ namespace JiraCommitHintPlugin
             currentMessages = null;
         }
 
-        private static JiraTaskDTO[] GetMessageToCommit(Jira jira, string query, string stringTemplate)
+        private static async Task<JiraTaskDTO[]> GetMessageToCommit(Jira jira, string query, string stringTemplate)
         {
             try
             {
-                return jira.Issues.GetIssuesFromJqlAsync(query).Result
+                var results = await jira.Issues.GetIssuesFromJqlAsync(query);
+                return results
                     .Select(issue => new { title = issue.Key + " " + issue.Summary, message = StringTemplate.Format(stringTemplate, issue) })
                     .Select(i => new JiraTaskDTO(i.title, i.message))
                     .ToArray();

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -145,7 +145,6 @@ namespace JiraCommitHintPlugin
                     e.GitUICommands.AddCommitTemplate(message.Title, () => message.Text);
                 }
             }, TaskScheduler.FromCurrentSynchronizationContext());
-
         }
 
         private void gitUiCommands_PostRepositoryChanged(object sender, GitUIBaseEventArgs e)
@@ -167,8 +166,7 @@ namespace JiraCommitHintPlugin
             {
                 var results = await jira.Issues.GetIssuesFromJqlAsync(query);
                 return results
-                    .Select(issue => new { title = issue.Key + " " + issue.Summary, message = StringTemplate.Format(stringTemplate, issue) })
-                    .Select(i => new JiraTaskDTO(i.title, i.message))
+                    .Select(issue => new JiraTaskDTO(issue.Key + ": " + issue.Summary, StringTemplate.Format(stringTemplate, issue)))
                     .ToArray();
             }
             catch (Exception ex)


### PR DESCRIPTION
Changes proposed in this pull request:
 - (improve perf) Don't block FormCommit opening during http request to jira (the plugin made the commit form slow to open :( ). Introduce some async (remove a `.Result`)
- Fix display of multiline text in multiline setting textbox ( of jira setting panel "Message template" textbox )
- (minor) Better display of the preview message
 
What did I do to test the code and ensure quality:
 - manual test

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10
