### PR TITLE
Removal of Mono references in the code

### DIFF
--- a/GitCommands/FileAssociatedIconProvider.cs
+++ b/GitCommands/FileAssociatedIconProvider.cs
@@ -53,13 +53,6 @@ namespace GitCommands
         /// </remarks>
         public Icon Get(string workingDirectory, string relativeFilePath)
         {
-            if (EnvUtils.IsMonoRuntime())
-            {
-                // Mono does not support icon extraction
-                // https://github.com/mono/mono/blob/master/mcs/class/System.Drawing/System.Drawing/Icon.cs#L314
-                return null;
-            }
-
             var extension = Path.GetExtension(relativeFilePath);
             if (string.IsNullOrWhiteSpace(extension))
             {

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1251,7 +1251,6 @@ namespace GitCommands
             return FindRenamesOpt() + findCopies;
         }
 
-#if !__MonoCS__
         static class NativeMethods
         {
             [DllImport("kernel32.dll")]
@@ -1266,11 +1265,9 @@ namespace GitCommands
             public static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent,
                int dwProcessGroupId);
         }
-#endif
 
         public static void TerminateTree(this Process process)
         {
-#if !__MonoCS__
             if (EnvUtils.RunningOnWindows())
             {
                 // Send Ctrl+C
@@ -1280,7 +1277,6 @@ namespace GitCommands
                 if (!process.HasExited)
                     System.Threading.Thread.Sleep(500);
             }
-#endif
             if (!process.HasExited)
                 process.Kill();
         }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -327,8 +327,8 @@ namespace GitCommands
 
         public static bool ShowRevisionInfoNextToRevisionGrid
         {
-            get { return !EnvUtils.IsMonoRuntime() && DetailedSettingsPath.GetBool("ShowRevisionInfoNextToRevisionGrid", false); }
-            set { DetailedSettingsPath.SetBool("ShowRevisionInfoNextToRevisionGrid", !EnvUtils.IsMonoRuntime() && value); }
+            get { return DetailedSettingsPath.GetBool("ShowRevisionInfoNextToRevisionGrid", false); }
+            set { DetailedSettingsPath.SetBool("ShowRevisionInfoNextToRevisionGrid", value); }
         }
 
         public static bool ProvideAutocompletion

--- a/GitCommands/Utils/EnvUtils.cs
+++ b/GitCommands/Utils/EnvUtils.cs
@@ -65,11 +65,6 @@ namespace GitCommands.Utils
             }
         }
 
-        public static bool IsMonoRuntime()
-        {
-            return Type.GetType("Mono.Runtime") != null;
-        }
-
         public static bool IsNet4FullOrHigher()
         {
             if (System.Environment.Version.Major > 4)

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -22,34 +22,31 @@ namespace GitExtensions
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            if (!EnvUtils.IsMonoRuntime())
+            try
             {
-                try
+                NBug.Settings.UIMode = NBug.Enums.UIMode.Full;
+
+                // Uncomment the following after testing to see that NBug is working as configured
+                NBug.Settings.ReleaseMode = true;
+                NBug.Settings.ExitApplicationImmediately = false;
+                NBug.Settings.WriteLogToDisk = false;
+                NBug.Settings.MaxQueuedReports = 10;
+                NBug.Settings.StopReportingAfter = 90;
+                NBug.Settings.SleepBeforeSend = 30;
+                NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
+
+                AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
+                Application.ThreadException += NBug.Handler.ThreadException;
+
+            }
+            catch (TypeInitializationException tie)
+            {
+                // is this exception caused by the configuration?
+                if (tie.InnerException != null
+                    && tie.InnerException.GetType()
+                        .IsSubclassOf(typeof(System.Configuration.ConfigurationException)))
                 {
-                    NBug.Settings.UIMode = NBug.Enums.UIMode.Full;
-
-                    // Uncomment the following after testing to see that NBug is working as configured
-                    NBug.Settings.ReleaseMode = true;
-                    NBug.Settings.ExitApplicationImmediately = false;
-                    NBug.Settings.WriteLogToDisk = false;
-                    NBug.Settings.MaxQueuedReports = 10;
-                    NBug.Settings.StopReportingAfter = 90;
-                    NBug.Settings.SleepBeforeSend = 30;
-                    NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
-
-                    AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
-                    Application.ThreadException += NBug.Handler.ThreadException;
-
-                }
-                catch (TypeInitializationException tie)
-                {
-                    // is this exception caused by the configuration?
-                    if (tie.InnerException != null
-                        && tie.InnerException.GetType()
-                            .IsSubclassOf(typeof(System.Configuration.ConfigurationException)))
-                    {
-                        HandleConfigurationException((System.Configuration.ConfigurationException)tie.InnerException);
-                    }
+                    HandleConfigurationException((System.Configuration.ConfigurationException)tie.InnerException);
                 }
             }
 

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -30,9 +30,6 @@ namespace GitUI.CommandsDialogs
 
         public void FillBuildReport(GitRevision revision)
         {
-            if (EnvUtils.IsMonoRuntime())
-                return;
-
             if (selectedGitRevision != null) selectedGitRevision.PropertyChanged -= RevisionPropertyChanged;
             selectedGitRevision = revision;
             if (selectedGitRevision != null) selectedGitRevision.PropertyChanged += RevisionPropertyChanged;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -27,9 +27,7 @@ using GitUI.UserControls.ToolStripClasses;
 using GitUIPluginInterfaces;
 using Microsoft.Win32;
 using ResourceManager;
-#if !__MonoCS__
 using Microsoft.WindowsAPICodePack.Taskbar;
-#endif
 
 namespace GitUI.CommandsDialogs
 {
@@ -117,12 +115,10 @@ namespace GitUI.CommandsDialogs
         private ToolStripItem _bisect;
         private ToolStripItem _warning;
 
-#if !__MonoCS__
         private ThumbnailToolBarButton _commitButton;
         private ThumbnailToolBarButton _pushButton;
         private ThumbnailToolBarButton _pullButton;
         private bool _toolbarButtonsCreated;
-#endif
         private readonly ToolStripMenuItem _toolStripGitStatus;
         private readonly GitStatusMonitor _gitStatusMonitor;
         private readonly FilterRevisionsHelper _filterRevisionsHelper;
@@ -388,12 +384,10 @@ namespace GitUI.CommandsDialogs
 
         private void BrowseLoad(object sender, EventArgs e)
         {
-#if !__MonoCS__
             if (EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
             {
                 TaskbarManager.Instance.ApplicationId = "GitExtensions";
             }
-#endif
             SetSplitterPositions();
             HideVariableMainMenuItems();
 
@@ -741,7 +735,6 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateJumplist(bool validWorkingDir)
         {
-#if !__MonoCS__
             if (!EnvUtils.RunningOnWindows() || !TaskbarManager.IsPlatformSupported)
                 return;
 
@@ -782,10 +775,8 @@ namespace GitUI.CommandsDialogs
             {
                 Trace.WriteLine(ex.Message, "UpdateJumplist");
             }
-#endif
         }
 
-#if !__MonoCS__
         private void CreateOrUpdateTaskBarButtons(bool validRepo)
         {
             if (EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
@@ -813,7 +804,6 @@ namespace GitUI.CommandsDialogs
                 _pullButton.Enabled = validRepo;
             }
         }
-#endif
 
         /// <summary>
         /// Converts an image into an icon.  This was taken off of the interwebs.
@@ -1051,9 +1041,6 @@ namespace GitUI.CommandsDialogs
 
         private void FillBuildReport()
         {
-            if (EnvUtils.IsMonoRuntime())
-                return;
-
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
             var revision = selectedRevisions.Count == 1 ? selectedRevisions[0] : null;
 
@@ -2736,14 +2723,12 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
-#if !__MonoCS__
                 if (_commitButton != null)
                     _commitButton.Dispose();
                 if (_pushButton != null)
                     _pushButton.Dispose();
                 if (_pullButton != null)
                     _pullButton.Dispose();
-#endif
                 if (_submodulesStatusCts != null)
                     _submodulesStatusCts.Dispose();
                 if (_formBrowseMenus != null)

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -168,42 +168,23 @@ namespace GitUI.CommandsDialogs
                 localChangesPanel
             };
 
-            if (EnvUtils.IsMonoRuntime())
-            {
-                var margin = flowLayoutPanel2.Controls[0].Margin;
-                flowLayoutPanel2.Height = flowLayoutPanel2.Controls.OfType<Control>().Max(c => c.Height) + margin.Top + margin.Bottom;
-                localChangesGB.Height = flowLayoutPanel2.Height * 2 + localChangesGB.Padding.Top + localChangesGB.Padding.Bottom;
-                localChangesPanel.Height = localChangesGB.Height + localChangesGB.Margin.Top + localChangesGB.Margin.Bottom;
+            Ok.Anchor = AnchorStyles.Right;
 
-                Ok.AutoSize = false;
-                var buttonWidth = TextRenderer.MeasureText(Ok.Text, AppSettings.Font).Width + 10;
+            flowLayoutPanel2.AutoSize = true;
+            flowLayoutPanel2.Dock = DockStyle.Fill;
+            localChangesGB.AutoSize = true;
+            localChangesGB.Height = flowLayoutPanel2.Height * 2 + localChangesGB.Padding.Top + localChangesGB.Padding.Bottom;
+            localChangesPanel.ColumnStyles[1].Width = Ok.Width + 10;
+            var height = localChangesGB.Height + localChangesGB.Margin.Top + localChangesGB.Margin.Bottom;
+            localChangesPanel.RowStyles[0].Height = height;
+            localChangesPanel.Height = height;
 
-                localChangesPanel.ColumnStyles[1].Width = buttonWidth + Ok.Margin.Left + Ok.Margin.Right;
-                Ok.Width = buttonWidth;
-
-                localChangesGB.Width = localChangesPanel.Width - (int)localChangesPanel.ColumnStyles[1].Width;
-                flowLayoutPanel2.Width = localChangesGB.Width - 2 * localChangesGB.Padding.Left - 2 * localChangesGB.Padding.Right;
-            }
-            else
-            {
-                Ok.Anchor = AnchorStyles.Right;
-
-                flowLayoutPanel2.AutoSize = true;
-                flowLayoutPanel2.Dock = DockStyle.Fill;
-                localChangesGB.AutoSize = true;
-                localChangesGB.Height = flowLayoutPanel2.Height * 2 + localChangesGB.Padding.Top + localChangesGB.Padding.Bottom;
-                localChangesPanel.ColumnStyles[1].Width = Ok.Width + 10;
-                var height = localChangesGB.Height + localChangesGB.Margin.Top + localChangesGB.Margin.Bottom;
-                localChangesPanel.RowStyles[0].Height = height;
-                localChangesPanel.Height = height;
-
-                Width = tableLayoutPanel1.PreferredSize.Width + 40;
-            }
+            Width = tableLayoutPanel1.PreferredSize.Width + 40;
 
             for (var i = 0; i < controls1.Length; i++)
             {
                 var margin = controls1[i].Margin;
-                var height = controls1[i].Height + margin.Top + margin.Bottom;
+                height = controls1[i].Height + margin.Top + margin.Bottom;
                 _controls.Add(controls1[i], height);
 
                 tableLayoutPanel1.RowStyles[i].Height = height;
@@ -520,29 +501,15 @@ namespace GitUI.CommandsDialogs
 
         private void RecalculateSizeConstraints()
         {
-            if (!EnvUtils.IsMonoRuntime())
-            {
-                MinimumSize = MaximumSize = new Size(0, 0);
-            }
+            MinimumSize = MaximumSize = new Size(0, 0);
 
             remoteOptionsPanel.Visible = Remotebranch.Checked;
             tableLayoutPanel1.RowStyles[2].Height = Remotebranch.Checked ? _controls[remoteOptionsPanel] : 0;
             tableLayoutPanel1.Height = _controls.Select(c => c.Key.Visible ? c.Value : 0).Sum() + tableLayoutPanel1.Padding.Top + tableLayoutPanel1.Padding.Bottom;
             Height = tableLayoutPanel1.Height + tableLayoutPanel1.Margin.Top + tableLayoutPanel1.Margin.Bottom + 40;
 
-            if (EnvUtils.IsMonoRuntime())
-            {
-                var minWidth = tableLayoutPanel1.PreferredSize.Width;
-                if (Width < minWidth)
-                {
-                    Width = minWidth;
-                }
-            }
-            else
-            {
-                MinimumSize = new Size(tableLayoutPanel1.PreferredSize.Width + 40, Height);
-                MaximumSize = new Size(Screen.PrimaryScreen.Bounds.Width, Height);
-            }
+            MinimumSize = new Size(tableLayoutPanel1.PreferredSize.Width + 40, Height);
+            MaximumSize = new Size(Screen.PrimaryScreen.Bounds.Width, Height);
         }
 
         private void rbReset_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -525,10 +525,8 @@ namespace GitUI.CommandsDialogs
                     }
                     else
                         Close();
-#if !__MonoCS__ // animated GIFs are not supported in Mono/Linux
                     //trying to properly dispose loading image issue #1037
                     Loading.Image.Dispose();
-#endif
                 }, false
             );
         }

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -30,8 +30,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             Translate();
 
-            // Mono is having troubles dynamically sizing the groupbox
-            groupBox1.AutoSize = !EnvUtils.IsMonoRuntime();
+            groupBox1.AutoSize = true;
 
             commitPickerSmallControl1.UICommandsSource = this;
             if (IsUICommandsInitialized)

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -14,7 +14,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _error = new TranslationString("Error");
         private bool _hasChanges;
         private string _fileName;
-        private bool _formClosing = false;
 
         public FormEditor(GitUICommands aCommands, string fileName, bool showWarning)
             : base(aCommands)
@@ -63,13 +62,6 @@ namespace GitUI.CommandsDialogs
 
         private void FormEditor_FormClosing(object sender, FormClosingEventArgs e)
         {
-            // prevent recursive calls to this method when setting DialogResult
-            // due to Mono bug https://bugzilla.xamarin.com/show_bug.cgi?id=5040
-            if(_formClosing)
-            {
-                return;
-            }
-
             // only offer to save if there's something to save.
             if (HasChanges)
             {
@@ -90,21 +82,18 @@ namespace GitUI.CommandsDialogs
                                 return;
                             }
                         }
-                        _formClosing = true;
                         DialogResult = DialogResult.OK;
                         break;
                     case DialogResult.Cancel:
                         e.Cancel = true;
                         return;
                     default:
-                        _formClosing = true;
                         DialogResult = DialogResult.Cancel;
                         break;
                 }
             }
             else
             {
-                _formClosing = true;
                 DialogResult = DialogResult.OK;
             }
         }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -293,13 +293,10 @@ namespace GitUI.CommandsDialogs
                 Diff.ViewChanges(FileChanges.GetSelectedRevisions(), file, "You need to select at least one revision to view diff.");
             }
 
-            if (!EnvUtils.IsMonoRuntime())
-            {
-                if (_buildReportTabPageExtension == null)
-                    _buildReportTabPageExtension = new BuildReportTabPageExtension(tabControl1, _buildReportTabCaption.Text);
+            if (_buildReportTabPageExtension == null)
+                _buildReportTabPageExtension = new BuildReportTabPageExtension(tabControl1, _buildReportTabCaption.Text);
 
-                _buildReportTabPageExtension.FillBuildReport(selectedRows.Count == 1 ? revision : null);
-            }
+            _buildReportTabPageExtension.FillBuildReport(selectedRows.Count == 1 ? revision : null);
         }
 
         private BuildReportTabPageExtension _buildReportTabPageExtension;

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -179,7 +179,6 @@ namespace GitUI.CommandsDialogs
             Close();
         }
 
-#pragma warning disable 618 // Mono marked SmtpClient obsolete
         private bool SendMail(string dir)
         {
             try
@@ -222,7 +221,6 @@ namespace GitUI.CommandsDialogs
             }
             return true;
         }
-#pragma warning restore 618 // Mono marked SmtpClient obsolete
 
         private void SaveToDir_CheckedChanged(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -25,14 +25,12 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             Translate();
 
-            // Mono doesn't like referencing dimensions from controls, use temp variables
             _rowBranchComboHeight = Branches.Height;
             _groupBoxWidth = groupBox1.Width;
 
             currentBranchLabel.Font = new Font(currentBranchLabel.Font, FontStyle.Bold);
             noCommit.Checked = AppSettings.DontCommitMerge;
 
-            helpImageDisplayUserControl1.SizeChanged += (s, e) => ApplyMonoLayout();
             helpImageDisplayUserControl1.IsOnHoverShowImage2NoticeText = _formMergeBranchHoverShowImageLabelText.Text;
             helpImageDisplayUserControl1.Visible = !AppSettings.DontShowHelpImages;
             _defaultBranch = defaultBranch;
@@ -49,31 +47,8 @@ namespace GitUI.CommandsDialogs
         }
 
 
-        private void ApplyMonoLayout()
-        {
-            if (!EnvUtils.IsMonoRuntime())
-            {
-                return;
-            }
-
-            tableLayoutPanel2.RowStyles[0].SizeType = SizeType.Absolute;
-            tableLayoutPanel2.RowStyles[0].Height = _rowBranchComboHeight + 4;
-
-            // Mono doesn't like referencing dimensions from controls, use temp variables
-            var col1Width = helpImageDisplayUserControl1.Width + 6;
-            var col2Width = _groupBoxWidth + 26;
-
-            tableLayoutPanel1.ColumnStyles[0].SizeType = SizeType.Absolute;
-            tableLayoutPanel1.ColumnStyles[0].Width = col1Width;
-            tableLayoutPanel1.ColumnStyles[1].SizeType = SizeType.Absolute;
-            tableLayoutPanel1.ColumnStyles[1].Width = col2Width;
-        }
-
-
         private void FormMergeBranchLoad(object sender, EventArgs e)
         {
-            ApplyMonoLayout();
-
             var selectedHead = Module.GetSelectedBranch();
             currentBranchLabel.Text = selectedHead;
 

--- a/GitUI/CommandsDialogs/RevisionGpgInfo.cs
+++ b/GitUI/CommandsDialogs/RevisionGpgInfo.cs
@@ -54,36 +54,19 @@ namespace GitUI.CommandsDialogs
             var heightRowCommit = 0f;
             var heightRowTag = 0f;
 
-            if (EnvUtils.IsMonoRuntime())
+            if (txtTagGpgInfo.Visible)
             {
-                if (txtTagGpgInfo.Visible)
-                {
-                    heightRowCommit =
-                        heightRowTag = (float)tableLayoutPanel1.Height / 2;
-                }
-                else
-                {
-                    heightRowCommit = tableLayoutPanel1.Height;
-                }
-
-                tableLayoutPanel1.RowStyles[0].SizeType = SizeType.Absolute;
-                tableLayoutPanel1.RowStyles[1].SizeType = SizeType.Absolute;
+                heightRowCommit = 50f;
+                heightRowTag = 50f;
             }
             else
             {
-                if (txtTagGpgInfo.Visible)
-                {
-                    heightRowCommit = 50f;
-                    heightRowTag = 50f;
-                }
-                else
-                {
-                    heightRowCommit = 100f;
-                }
-
-                tableLayoutPanel1.RowStyles[0].SizeType = SizeType.Percent;
-                tableLayoutPanel1.RowStyles[1].SizeType = SizeType.Percent;
+                heightRowCommit = 100f;
             }
+
+            tableLayoutPanel1.RowStyles[0].SizeType = SizeType.Percent;
+            tableLayoutPanel1.RowStyles[1].SizeType = SizeType.Percent;
+
             tableLayoutPanel1.RowStyles[0].Height = heightRowCommit;
             tableLayoutPanel1.RowStyles[1].Height = heightRowTag;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -21,7 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void SettingsToPage()
         {
             chkShowRevisionInfoNextToRevisionGrid.Checked = AppSettings.ShowRevisionInfoNextToRevisionGrid;
-            chkShowRevisionInfoNextToRevisionGrid.Visible = !EnvUtils.IsMonoRuntime();
+            chkShowRevisionInfoNextToRevisionGrid.Visible = true;
             base.SettingsToPage();
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -52,17 +52,9 @@ namespace GitUI.CommitInfo
 
             IHeaderRenderStyleProvider headerRenderer;
             IHeaderLabelFormatter labelFormatter;
-            if (EnvUtils.IsMonoRuntime())
-            {
-                labelFormatter = new MonospacedHeaderLabelFormatter();
-                headerRenderer = new MonospacedHeaderRenderStyleProvider();
-            }
-            else
-            {
-                labelFormatter = new TabbedHeaderLabelFormatter();
-                headerRenderer = new TabbedHeaderRenderStyleProvider();
-            }
-
+            labelFormatter = new TabbedHeaderLabelFormatter();
+            headerRenderer = new TabbedHeaderRenderStyleProvider();
+ 
             _commitDataHeaderRenderer = new CommitDataHeaderRenderer(labelFormatter, _dateFormatter, headerRenderer, _linkFactory);
             _commitDataBodyRenderer = new CommitDataBodyRenderer(() => Module, _linkFactory);
             _externalLinksLoader = new ExternalLinksLoader();
@@ -225,9 +217,6 @@ namespace GitUI.CommitInfo
 
         private int GetRevisionHeaderHeight()
         {
-            if (EnvUtils.IsMonoRuntime())
-                return (int)(_RevisionHeader.Lines.Length * (0.8 + _RevisionHeader.Font.GetHeight()));
-
             return _headerResize.Height;
         }
 
@@ -585,15 +574,7 @@ namespace GitUI.CommitInfo
 
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var commitInfo = string.Empty;
-            if (EnvUtils.IsMonoRuntime())
-            {
-                commitInfo = $"{_RevisionHeader.Text}{Environment.NewLine}{RevisionInfo.Text}";
-            }
-            else
-            {
-                commitInfo = $"{_RevisionHeader.GetPlaintText()}{Environment.NewLine}{RevisionInfo.GetPlaintText()}";
-            }
+            var commitInfo = $"{_RevisionHeader.GetPlaintText()}{Environment.NewLine}{RevisionInfo.GetPlaintText()}";
             Clipboard.SetText(commitInfo);
         }
 

--- a/GitUI/Editor/Diff/DiffViewerLineNumberCtrl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberCtrl.cs
@@ -32,9 +32,7 @@ namespace GitUI.Editor.Diff
                 else if (DiffLines.Any())
                 {
                     var size = Graphics.FromHwnd(textArea.Handle).MeasureString(_maxValueOfLineNum.ToString(), textArea.Font);
-                    // Workaround that right most numbers get clipped when using mono.
-                    var monoTextWidthAdjustment = EnvUtils.IsMonoRuntime() ? 10 : 0;
-                    _lastSize = new Size((int)size.Width * 2 + TextHorizontalMargin + monoTextWidthAdjustment, 0);
+                    _lastSize = new Size((int)size.Width * 2 + TextHorizontalMargin, 0);
                 }
 
                 return _lastSize;

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1132,12 +1132,6 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void SetXHTMLText(this RichTextBox rtb, string xhtmlText)
         {
-            if (EnvUtils.IsMonoRuntime())
-            {
-                SetXHTMLTextAsPlainText(rtb, xhtmlText);
-                return;
-            }
-
             rtb.Clear();
             RTFCurrentState cs = new RTFCurrentState();
 

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -10,9 +10,7 @@ using JetBrains.Annotations;
 
 using ResourceManager;
 using System.Windows.Threading;
-#if !__MonoCS__
 using Microsoft.WindowsAPICodePack.Taskbar;
-#endif
 
 namespace GitUI
 {
@@ -104,7 +102,6 @@ namespace GitUI
                             ProgressBar.Style = ProgressBarStyle.Blocks;
                         ProgressBar.Value = Math.Min(100, progressValue);
 
-#if !__MonoCS__
                         if (GitCommands.Utils.EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
                         {
                             try
@@ -116,7 +113,6 @@ namespace GitUI
                             {
                             }
                         }
-#endif
                     }
                     // Show last progress message in the title, unless it's showin in the control body already
                     if(!ConsoleOutput.IsDisplayingFullProcessOutput)
@@ -151,7 +147,6 @@ namespace GitUI
                 Ok.Focus();
                 AcceptButton = Ok;
                 Abort.Enabled = false;
-#if !__MonoCS__
                 if (GitCommands.Utils.EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
                 {
                     try
@@ -164,7 +159,6 @@ namespace GitUI
                     }
                     catch (InvalidOperationException) { }
                 }
-#endif
 
                 if (isSuccess)
                     picBoxSuccessFail.Image = GitUI.Properties.Resources.success;
@@ -259,7 +253,6 @@ namespace GitUI
 
             StartPosition = FormStartPosition.CenterParent;
 
-#if !__MonoCS__
             if (GitCommands.Utils.EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
             {
                 try
@@ -268,7 +261,6 @@ namespace GitUI
                 }
                 catch (InvalidOperationException) { }
             }
-#endif
             Reset();
             ProcessCallback(this);
         }
@@ -301,7 +293,6 @@ namespace GitUI
 
         internal void AfterClosed()
         {
-#if !__MonoCS__
             if (GitCommands.Utils.EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
             {
                 try
@@ -310,7 +301,6 @@ namespace GitUI
                 }
                 catch (InvalidOperationException) { }
             }
-#endif
         }
     }
 

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -8,9 +8,7 @@ using System.Windows.Forms;
 using GitUI.Properties;
 using ResourceManager;
 using Settings = GitCommands.AppSettings;
-#if !__MonoCS__
 using Microsoft.WindowsAPICodePack.Taskbar;
-#endif
 
 namespace GitUI
 {
@@ -58,7 +56,6 @@ namespace GitUI
             if (_enablePositionRestore)
                 SavePosition(GetType().Name);
 
-#if !__MonoCS__
             if (GitCommands.Utils.EnvUtils.RunningOnWindows() && TaskbarManager.IsPlatformSupported)
             {
                 try
@@ -67,7 +64,6 @@ namespace GitUI
                 }
                 catch (InvalidOperationException) { }
             }
-#endif
         }
 
         #region icon

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -2,9 +2,7 @@
 {
     using System.Diagnostics;
     using System.Windows.Forms;
-#if !__MonoCS__
     using Microsoft.WindowsAPICodePack.Dialogs;
-#endif
 
     public static class OsShellUtil
     {
@@ -48,7 +46,6 @@
         /// <returns>The path selected by the user, or null if the user cancels the dialog.</returns>
         public static string PickFolder(IWin32Window ownerWindow, string selectedPath = null)
         {
-#if !__MonoCS__
             if (GitCommands.Utils.EnvUtils.IsWindowsVistaOrGreater())
             {
                 // use Vista+ dialog
@@ -67,7 +64,6 @@
             }
             else
             {
-#endif
                 // use XP-era dialog
                 using (var dialog = new FolderBrowserDialog())
                 {
@@ -79,9 +75,7 @@
                     if (result == DialogResult.OK)
                         return dialog.SelectedPath;
                 }
-#if !__MonoCS__
             }
-#endif
 
             // return null if the user cancelled
             return null;

--- a/GitUI/Properties/Resources.Custom.cs
+++ b/GitUI/Properties/Resources.Custom.cs
@@ -16,11 +16,7 @@
         {
             get
             {
-                if(GitCommands.Utils.EnvUtils.IsMonoRuntime())
-                    return loadingpanel_static;
-                else
-                    return loadingpanel_animated;
-
+                return loadingpanel_animated;
             }
         }
     }

--- a/GitUI/UserControls/ExListView.cs
+++ b/GitUI/UserControls/ExListView.cs
@@ -55,7 +55,6 @@ namespace GitUI.UserControls
             DoubleBuffered = true;
         }
 
-#if !__MonoCS__
         #region Win32 Apis
 
         protected class NativeMethods
@@ -277,17 +276,14 @@ namespace GitUI.UserControls
                 NativeMethods.LVM_SETGROUPINFO, (IntPtr)group.IGroupId, ref group);
             Refresh();
         }
-#endif
 
         public void SetGroupState(ListViewGroupState state)
         {
-#if !__MonoCS__
             if (!EnvUtils.RunningOnWindows() || Environment.OSVersion.Version.Major < 6)   //Only Vista and forward 
                 // allows collapse of ListViewGroups
                 return;
             foreach (ListViewGroup lvg in Groups)
                 setGrpState(lvg, state);
-#endif
         }
     }
 }

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -130,7 +130,6 @@ namespace GitUI
         #endregion
 
         private ExListView FileStatusListView;
-        //This property cannot be private because this will break compilation in monodevelop
         private System.Windows.Forms.Label NoFiles;
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ComboBox FilterComboBox;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -51,10 +51,8 @@ namespace GitUI
 
             SelectFirstItemOnSetItems = true;
             _noDiffFilesChangesDefaultText = NoFiles.Text;
-#if !__MonoCS__ // TODO Drag'n'Drop doesn't work on Mono/Linux
             FileStatusListView.MouseMove += FileStatusListView_MouseMove;
             FileStatusListView.MouseDown += FileStatusListView_MouseDown;
-#endif
             if (_images == null)
             {
                 _images = new ImageList();
@@ -241,7 +239,6 @@ namespace GitUI
             return text;
         }
 
-#if !__MonoCS__ // TODO Drag'n'Drop doesnt work on Mono/Linux
         void FileStatusListView_MouseDown(object sender, MouseEventArgs e)
         {
             //SELECT
@@ -278,7 +275,6 @@ namespace GitUI
                     dragBoxFromMouseDown = Rectangle.Empty;
             }
         }
-#endif
 
         public override ContextMenuStrip ContextMenuStrip
         {
@@ -308,7 +304,6 @@ namespace GitUI
             }
         }
 
-#if !__MonoCS__ // TODO Drag'n'Drop doesnt work on Mono/Linux
         private Rectangle dragBoxFromMouseDown;
 
         void FileStatusListView_MouseMove(object sender, MouseEventArgs e)
@@ -376,7 +371,6 @@ namespace GitUI
                 }
             }
         }
-#endif
 
         public int UnfilteredItemsCount()
         {

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -459,7 +459,6 @@ namespace AppVeyorIntegration
 
         private Task<Stream> GetStreamFromHttpResponseAsync(HttpClient httpClient, Task<HttpResponseMessage> task, string restServicePath, CancellationToken cancellationToken)
         {
-#if !__MonoCS__
             var retry = task.IsCanceled && !cancellationToken.IsCancellationRequested;
 
             if (retry)
@@ -469,9 +468,6 @@ namespace AppVeyorIntegration
                 return task.Result.Content.ReadAsStreamAsync();
 
             return null;
-#else
-            return null;
-#endif
         }
 
         private Task<string> GetResponseAsync(HttpClient httpClient, string relativePath, CancellationToken cancellationToken)

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -374,7 +374,6 @@ namespace JenkinsIntegration
 
         private Task<Stream> GetStreamFromHttpResponseAsync(Task<HttpResponseMessage> task, string restServicePath, CancellationToken cancellationToken)
         {
-#if !__MonoCS__
             bool unauthorized = task.Status == TaskStatus.RanToCompletion &&
                                 task.Result.StatusCode == HttpStatusCode.Unauthorized;
 
@@ -423,9 +422,6 @@ namespace JenkinsIntegration
             }
 
             throw new HttpRequestException(task.Result.ReasonPhrase);
-#else
-            return null;
-#endif
         }
 
         private void UpdateHttpClientOptions(IBuildServerCredentials buildServerCredentials)

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -359,7 +359,6 @@ namespace TeamCityIntegration
 
         private Task<Stream> GetStreamFromHttpResponseAsync(Task<HttpResponseMessage> task, string restServicePath, CancellationToken cancellationToken)
         {
-#if !__MonoCS__
             bool retry = task.IsCanceled && !cancellationToken.IsCancellationRequested;
             bool unauthorized = task.Status == TaskStatus.RanToCompletion &&
                                 task.Result.StatusCode == HttpStatusCode.Unauthorized || task.Result.StatusCode == HttpStatusCode.Forbidden;
@@ -408,9 +407,6 @@ namespace TeamCityIntegration
             }
 
             throw new HttpRequestException(task.Result.ReasonPhrase);
-#else
-            return null;
-#endif
         }
 
         public void UpdateHttpClientOptionsNtlmAuth(IBuildServerCredentials buildServerCredentials)

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -46,7 +46,7 @@ namespace DeleteUnusedBranches
             _gitCommands = gitCommands;
             _gitUiCommands = gitUiCommands;
             _gitPlugin = gitPlugin;
-            imgLoading.Image = IsMonoRuntime() ? Resources.loadingpanel_static : Resources.loadingpanel;
+            imgLoading.Image = Resources.loadingpanel;
             RefreshObsoleteBranches();
         }
 
@@ -261,11 +261,6 @@ namespace DeleteUnusedBranches
         private string GetDefaultStatusText()
         {
             return string.Format(_branchesSelected.Text, _branches.Count(b => b.Delete), _branches.Count);
-        }
-
-        private static bool IsMonoRuntime()
-        {
-            return Type.GetType("Mono.Runtime") != null;
         }
 
         private struct RefreshContext

--- a/Plugins/DeleteUnusedBranches/Properties/Resources.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/Properties/Resources.Designer.cs
@@ -69,15 +69,5 @@ namespace DeleteUnusedBranches.Properties {
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Drawing.Bitmap.
-        /// </summary>
-        internal static System.Drawing.Bitmap loadingpanel_static {
-            get {
-                object obj = ResourceManager.GetObject("loadingpanel_static", resourceCulture);
-                return ((System.Drawing.Bitmap)(obj));
-            }
-        }
     }
 }

--- a/Plugins/Github3/OAuth.cs
+++ b/Plugins/Github3/OAuth.cs
@@ -26,7 +26,7 @@ namespace Github3
             }
             catch (NullReferenceException)
             {
-                MessageBox.Show(this, "Mono doesn't have installed WebBrowser.");
+                MessageBox.Show(this, "Failure starting WebBrowser.");
             }
         }
 

--- a/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
@@ -32,11 +32,6 @@ namespace GitCommandsTests
             _fileSystem = Substitute.For<IFileSystem>();
             _fileSystem.File.Returns(_file);
             _manager = new CommitTemplateManager(_module, _fullPathResolver, _fileSystem);
-
-            if (Type.GetType("Mono.Runtime") != null)
-            {
-                _workingDir = "/home/user/repo";
-            }
         }
 
 

--- a/UnitTests/GitCommandsTests/EnvironmentPathsProviderTests.cs
+++ b/UnitTests/GitCommandsTests/EnvironmentPathsProviderTests.cs
@@ -65,15 +65,6 @@ namespace GitCommandsTests
             EnvironmentPathsProvider.IsValidPath(given).Should().Be(expected);
         }
 
-        [Platform(Exclude = "Win")]
-        [TestCase("//my-pc/Work/GitExtensions/", true)]
-        [TestCase("/my-pc/Work/GitExtensions/", true)]
-        [TestCase("/my-pc/Work/GitExtensions", true)]
-        public void IsValidPath_Mono(string given, bool expected)
-        {
-            EnvironmentPathsProvider.IsValidPath(given).Should().Be(expected);
-        }
-
         private static IEnumerable<string> GetInvalidPaths()
         {
             if (Path.DirectorySeparatorChar == '\\')

--- a/UnitTests/GitCommandsTests/FileAssociatedIconProviderTests.cs
+++ b/UnitTests/GitCommandsTests/FileAssociatedIconProviderTests.cs
@@ -29,30 +29,18 @@ namespace GitCommandsTests
 
         [TestCase(null, null)]
         [TestCase("", "")]
-        [TestCase("aaaa", "")]
-        [Platform(Include = "Mono")]
-        public void Get_should_always_return_null_under_mono(string workingDirectory, string relativeFilePath)
-        {
-            _iconProvider.Get(workingDirectory, relativeFilePath).Should().BeNull();
-        }
-
-        [TestCase(null, null)]
-        [TestCase("", "")]
-        [Platform(Exclude = "Mono")]
         public void Get_should_return_null_if_path_null_or_empty(string workingDirectory, string relativeFilePath)
         {
             _iconProvider.Get(workingDirectory, relativeFilePath).Should().BeNull();
         }
 
         [Test]
-        [Platform(Exclude = "Mono")]
         public void Get_should_return_null_for_extensionless_file()
         {
             _iconProvider.Get(@"c:\folder", "file").Should().BeNull();
         }
 
         [Test]
-        [Platform(Exclude = "Mono")]
         public void Get_if_file_does_not_exist_create_temp()
         {
             const string folder = @"c:\non_existent_folder";
@@ -66,7 +54,6 @@ namespace GitCommandsTests
         }
 
         [Test]
-        [Platform(Exclude = "Mono")]
         public void Get_if_temp_file_cant_be_delete_ignore()
         {
             const string folder = @"c:\non_existent_folder";
@@ -85,7 +72,6 @@ namespace GitCommandsTests
         }
 
         [Test]
-        [Platform(Exclude = "Mono")]
         public void Get_should_add_entry_for_extension_once()
         {
             _iconProvider = new FileAssociatedIconProvider(); // use real file system

--- a/UnitTests/GitCommandsTests/FullPathResolverTests.cs
+++ b/UnitTests/GitCommandsTests/FullPathResolverTests.cs
@@ -16,11 +16,6 @@ namespace GitCommandsTests
         [SetUp]
         public void Setup()
         {
-            if (Type.GetType("Mono.Runtime") != null)
-            {
-                _workingDir = "/home/user/repo";
-            }
-
             _resolver = new FullPathResolver(() => _workingDir);
         }
 
@@ -33,35 +28,18 @@ namespace GitCommandsTests
             ((Action)(() => _resolver.Resolve(path))).ShouldThrow<ArgumentNullException>();
         }
 
-        [Platform(Include = "Win")]
         [TestCase(@"c:\")]
         public void Resolve_should_return_original_path_if_rooted(string path)
         {
             _resolver.Resolve(path).Should().Be(path);
         }
 
-        [Platform(Exclude = "Win")]
-        [TestCase(@"/home/user")]
-        public void Resolve_should_return_original_path_if_rooted_Mono(string path)
-        {
-            _resolver.Resolve(path).Should().Be(path);
-        }
-
-        [Platform(Include = "Win")]
         [TestCase("folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\filename.txt")]
         public void Resolve_should_throw_PathTooLongException(string path)
         {
             ((Action)(() => _resolver.Resolve(path))).ShouldThrow<PathTooLongException>();
         }
 
-        [Platform(Exclude = "Win")]
-        [TestCase("folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\filename.txt")]
-        public void Resolve_should_not_throw_PathTooLongException_Mono(string path)
-        {
-            ((Action)(() => _resolver.Resolve(path))).ShouldNotThrow<PathTooLongException>();
-        }
-
-        [Platform(Include = "Win")]
         [TestCase(@"file")]
         [TestCase("folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\filename.txt")]
         public void Resolve_should_return_full_path(string path)

--- a/UnitTests/GitCommandsTests/Git/GitDirectoryResolverTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitDirectoryResolverTests.cs
@@ -24,10 +24,6 @@ namespace GitCommandsTests.Git
         [SetUp]
         public void Setup()
         {
-            if (Type.GetType("Mono.Runtime") != null)
-            {
-                _workingDir = "/home/user/repo";
-            }
             _gitFile = Path.Combine(_workingDir, ".git");
             _gitWorkingDir = _gitFile.EnsureTrailingPathSeparator();
 
@@ -87,19 +83,6 @@ namespace GitCommandsTests.Git
             _directory.DidNotReceive().Exists(_gitWorkingDir);
         }
 
-        [Platform(Exclude = "Win")]
-        [Test]
-        public void Resolve_should_return_path_from_git_file_if_present_Mono()
-        {
-            _file.Exists(_gitFile).Returns(true);
-            _file.ReadLines(_gitFile).Returns(new[] { "", " ", @"gitdir: /home/user/repo/.git/modules/Externals/Git.hub", "text" });
-
-            _resolver.Resolve(_workingDir).Should().Be(@"/home/user/repo/.git/modules/Externals/Git.hub/");
-
-            _directory.DidNotReceive().Exists(_gitWorkingDir);
-        }
-
-        [Platform(Include = "Win")]
         [Test]
         public void Resolve_should_return_resolved_full_path_from_git_file_if_present()
         {
@@ -107,18 +90,6 @@ namespace GitCommandsTests.Git
             _file.ReadLines(_gitFile).Returns(new[] { "", " ", @"gitdir: ../.git/modules/Externals/Git.hub", "text" });
 
             _resolver.Resolve(_workingDir).Should().Be(@"c:\dev\.git\modules\Externals\Git.hub\");
-
-            _directory.DidNotReceive().Exists(_gitWorkingDir);
-        }
-
-        [Platform(Exclude = "Win")]
-        [Test]
-        public void Resolve_should_return_resolved_full_path_from_git_file_if_present_Mono()
-        {
-            _file.Exists(_gitFile).Returns(true);
-            _file.ReadLines(_gitFile).Returns(new[] { "", " ", @"gitdir: ../.git/modules/Externals/Git.hub", "text" });
-
-            _resolver.Resolve(_workingDir).Should().Be(@"/home/user/.git/modules/Externals/Git.hub/");
 
             _directory.DidNotReceive().Exists(_gitWorkingDir);
         }
@@ -133,7 +104,6 @@ namespace GitCommandsTests.Git
             }
         }
 
-        [Platform(Include = "Win")]
         [Test]
         public void Resolve_submodule_real_filsystem()
         {
@@ -145,20 +115,6 @@ namespace GitCommandsTests.Git
 
                 _resolver.Resolve(submodulePath).Should().Be($@"{helper.Module.WorkingDirGitDir}modules\Externals\Git.hub\");
                 _resolver.Resolve(helper.Module.WorkingDir).Should().Be(helper.Module.WorkingDirGitDir);
-            }
-        }
-
-        [Platform(Exclude = "Win")]
-        [Test]
-        public void Resolve_submodule_real_filsystem_Mono()
-        {
-            using (var helper = new GitModuleTestHelper())
-            {
-                var submodulePath = Path.Combine(helper.Module.WorkingDir, "External", "Git.hub");
-                helper.CreateFile(submodulePath, ".git", "\r \r\ngitdir: ../../.git/modules/Externals/Git.hub\r\ntext");
-                _resolver = new GitDirectoryResolver();
-
-                _resolver.Resolve(submodulePath).Should().Be($@"{helper.Module.WorkingDirGitDir}modules/Externals/Git.hub/");
             }
         }
     }

--- a/UnitTests/GitCommandsTests/Git/IndexLockManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/IndexLockManagerTests.cs
@@ -29,10 +29,6 @@ namespace GitCommandsTests.Git
         [SetUp]
         public void Setup()
         {
-            if (Type.GetType("Mono.Runtime") != null)
-            {
-                _workingDir = "/home/user/repo";
-            }
             _gitFile = Path.Combine(_workingDir, ".git");
             _gitWorkingDir = _gitFile.EnsureTrailingPathSeparator();
             _indexLockFile = Path.Combine(_gitWorkingDir, IndexLock);
@@ -119,33 +115,6 @@ namespace GitCommandsTests.Git
             var submoduleNbugWorkingDirGitDir = $@"{_gitWorkingDir}\modules\Externals\NBug\";
             var submoduleGithubIndexLock = $@"{_gitWorkingDir}\modules\Externals\Git.hub\{IndexLock}";
             var submoduleNbugIndexLock = $@"{_gitWorkingDir}\modules\Externals\NBug\{IndexLock}";
-
-            _module.GetSubmodulesLocalPaths().Returns(new[] { "Externals/Git.hub", "Externals/NBug" });
-            _module.GetSubmoduleFullPath(Arg.Any<string>())
-                .Returns(submoduleGithubWorkingDir, submoduleNbugWorkingDir);
-            _gitDirectoryResolver.Resolve(submoduleGithubWorkingDir).Returns(submoduleGithubWorkingDirGitDir);
-            _gitDirectoryResolver.Resolve(submoduleNbugWorkingDir).Returns(submoduleNbugWorkingDirGitDir);
-            _file.Exists(submoduleGithubIndexLock).Returns(true);
-            _file.Exists(submoduleNbugIndexLock).Returns(false);
-
-            _manager.UnlockIndex(true);
-
-            _file.Received().Delete(submoduleGithubIndexLock);
-            _file.DidNotReceive().Delete(submoduleNbugIndexLock);
-        }
-
-        [Platform(Exclude = "Win")]
-        [Test]
-        public void UnlockIndex_should_delete_submodule_locks_if_requested_Mono()
-        {
-            _file.Exists(_indexLockFile).Returns(true);
-
-            var submoduleGithubWorkingDir = $@"{_workingDir}/Externals/Git.hub/";
-            var submoduleNbugWorkingDir = $@"{_workingDir}/Externals/NBug/";
-            var submoduleGithubWorkingDirGitDir = $@"{_gitWorkingDir}/modules/Externals/Git.hub/";
-            var submoduleNbugWorkingDirGitDir = $@"{_gitWorkingDir}/modules/Externals/NBug/";
-            var submoduleGithubIndexLock = $@"{_gitWorkingDir}/modules/Externals/Git.hub/{IndexLock}";
-            var submoduleNbugIndexLock = $@"{_gitWorkingDir}/modules/Externals/NBug/{IndexLock}";
 
             _module.GetSubmodulesLocalPaths().Returns(new[] { "Externals/Git.hub", "Externals/NBug" });
             _module.GetSubmoduleFullPath(Arg.Any<string>())

--- a/UnitTests/GitCommandsTests/Helpers/FileInfoExtensions.cs
+++ b/UnitTests/GitCommandsTests/Helpers/FileInfoExtensions.cs
@@ -35,7 +35,6 @@ namespace GitCommandsTests.Helpers
                 if (currentFileBytes.Length != otherFileBytes.Length)
                     return false;
 
-#if !__MonoCS__ //Mono does not implement parallel.for
                 Parallel.For(0, currentFileBytes.LongLength, (i, state) =>
                 {
                     if (currentFileBytes[i] != otherFileBytes[i])
@@ -45,13 +44,6 @@ namespace GitCommandsTests.Helpers
                         return;
                     }
                 });
-#else
-                for(long i = 0;i<currentFileBytes.Length;i++)
-                {
-                    if(!currentFileBytes[i].Equals(otherFileBytes[i]))
-                        return false;
-                }
-#endif
                 return areEqual;
             }
             catch (NullReferenceException)

--- a/UnitTests/GitCommandsTests/PathEqualityComparerTests.cs
+++ b/UnitTests/GitCommandsTests/PathEqualityComparerTests.cs
@@ -15,21 +15,11 @@ namespace GitCommandsTests
         }
 
 
-        [Platform(Include = "Win")]
         [TestCase("C:\\WORK\\GitExtensions\\", "C:/Work/GitExtensions/")]
         [TestCase("\\\\my-pc\\Work\\GitExtensions\\", "//my-pc/WORK/GitExtensions/")]
         public void Equals(string input, string expected)
         {
             Assert.AreEqual(_comparer.Equals(input, expected), true);
-        }
-
-        [Platform(Exclude = "Win")]
-        [TestCase("/Work/GitExtensions/", "/Work/GitExtensions/", true)]
-        [TestCase("/WORK/GitExtensions/", "/Work/GitExtensions/", false)]
-        [TestCase("//my-pc/Work/GitExtensions/", "//my-pc/Work/GitExtensions/", true)]
-        public void Equals_Mono(string input, string expected, bool isEqual)
-        {
-            Assert.AreEqual(_comparer.Equals(input, expected), isEqual);
         }
     }
 }

--- a/UnitTests/GravatarTests/DirectoryImageCacheTests.cs
+++ b/UnitTests/GravatarTests/DirectoryImageCacheTests.cs
@@ -29,11 +29,6 @@ namespace GravatarTests
         [SetUp]
         public void Setup()
         {
-            if (Type.GetType("Mono.Runtime") != null)
-            {
-                _folderPath = "/home/user/gitextensions/images";
-            }
-
             _fileSystem = Substitute.For<IFileSystem>();
             _directory = Substitute.For<DirectoryBase>();
             _fileSystem.Directory.Returns(_directory);


### PR DESCRIPTION
Part of #4415

Changes proposed in this pull request:
 - Remove Mono conditionals in the code

The intention with this PR is to have a clean cut of Mono implementation, in case someone wants to add Mono on master later. (However, changes and refactoring makes this difficult.)
The refactoring has been kept to a minimal to simplify verification of this PR (for instance variable handling in forms have been adapted for Mono, but that is a very minor optimization.)

Note that there are still some references to EnvUtils to RunningOnWindows/Unix that are kept, that are not too annoying and could be useful in the future.
 
What did I do to test the code and ensure quality:
 - Code review
 - Random testing

Has been tested on (remove any that don't apply):
 - Windows 10
