### PR TITLE
Bitbucket Server tweaks

### DIFF
--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -93,7 +93,7 @@
   <file datatype="plaintext" original="BitbucketPullRequestForm" source-language="en">
     <body>
       <trans-unit id="$this.Text">
-        <source>Create Pull Request</source>
+        <source>Bitbucket Server</source>
         <target />
       </trans-unit>
       <trans-unit id="GridColumnName.HeaderText">

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
@@ -50,7 +50,7 @@
             this.lblCommitInfoTarget = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.createPullLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.lblLinkCreatePull = new System.Windows.Forms.LinkLabel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabView = new System.Windows.Forms.TabPage();
@@ -64,7 +64,7 @@
             this.btnMerge = new System.Windows.Forms.Button();
             this.btnApprove = new System.Windows.Forms.Button();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
-            this.viewPullLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.lblLinkViewPull = new System.Windows.Forms.LinkLabel();
             this.txtPRDescription = new System.Windows.Forms.TextBox();
             this.txtPRTitle = new System.Windows.Forms.TextBox();
             this.txtPRReviewers = new System.Windows.Forms.TextBox();
@@ -330,7 +330,7 @@
             // 
             // groupBox3
             // 
-            this.groupBox3.Controls.Add(this.createPullLinkLabel);
+            this.groupBox3.Controls.Add(this.lblLinkCreatePull);
             this.groupBox3.Controls.Add(this.lblReviewers);
             this.groupBox3.Controls.Add(this.label3);
             this.groupBox3.Controls.Add(this.txtDescription);
@@ -346,14 +346,14 @@
             // 
             // createPullLinkLabel
             // 
-            this.createPullLinkLabel.AutoSize = true;
-            this.createPullLinkLabel.Location = new System.Drawing.Point(128, 382);
-            this.createPullLinkLabel.Name = "createPullLinkLabel";
-            this.createPullLinkLabel.Size = new System.Drawing.Size(53, 13);
-            this.createPullLinkLabel.TabIndex = 12;
-            this.createPullLinkLabel.TabStop = true;
-            this.createPullLinkLabel.Text = "linkLabel1";
-            this.createPullLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.textLinkLabel_LinkClicked);
+            this.lblLinkCreatePull.AutoSize = true;
+            this.lblLinkCreatePull.Location = new System.Drawing.Point(128, 382);
+            this.lblLinkCreatePull.Name = "createPullLinkLabel";
+            this.lblLinkCreatePull.Size = new System.Drawing.Size(53, 13);
+            this.lblLinkCreatePull.TabIndex = 12;
+            this.lblLinkCreatePull.TabStop = true;
+            this.lblLinkCreatePull.Text = "linkLabel1";
+            this.lblLinkCreatePull.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.textLinkLabel_LinkClicked);
             // 
             // splitContainer1
             // 
@@ -495,7 +495,7 @@
             // 
             // groupBox6
             // 
-            this.groupBox6.Controls.Add(this.viewPullLinkLabel);
+            this.groupBox6.Controls.Add(this.lblLinkViewPull);
             this.groupBox6.Controls.Add(this.txtPRDescription);
             this.groupBox6.Controls.Add(this.txtPRTitle);
             this.groupBox6.Controls.Add(this.txtPRReviewers);
@@ -511,14 +511,14 @@
             // 
             // viewPullLinkLabel
             // 
-            this.viewPullLinkLabel.AutoSize = true;
-            this.viewPullLinkLabel.Location = new System.Drawing.Point(17, 382);
-            this.viewPullLinkLabel.Name = "viewPullLinkLabel";
-            this.viewPullLinkLabel.Size = new System.Drawing.Size(53, 13);
-            this.viewPullLinkLabel.TabIndex = 15;
-            this.viewPullLinkLabel.TabStop = true;
-            this.viewPullLinkLabel.Text = "linkLabel1";
-            this.viewPullLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.textLinkLabel_LinkClicked);
+            this.lblLinkViewPull.AutoSize = true;
+            this.lblLinkViewPull.Location = new System.Drawing.Point(17, 382);
+            this.lblLinkViewPull.Name = "viewPullLinkLabel";
+            this.lblLinkViewPull.Size = new System.Drawing.Size(53, 13);
+            this.lblLinkViewPull.TabIndex = 15;
+            this.lblLinkViewPull.TabStop = true;
+            this.lblLinkViewPull.Text = "linkLabel1";
+            this.lblLinkViewPull.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.textLinkLabel_LinkClicked);
             // 
             // txtPRDescription
             // 
@@ -803,8 +803,8 @@
         private System.Windows.Forms.Label lblPRState;
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.Label label16;
-        private System.Windows.Forms.LinkLabel createPullLinkLabel;
-        private System.Windows.Forms.LinkLabel viewPullLinkLabel;
+        private System.Windows.Forms.LinkLabel lblLinkCreatePull;
+        private System.Windows.Forms.LinkLabel lblLinkViewPull;
         private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.lblReviewers = new System.Windows.Forms.Label();
@@ -49,9 +50,9 @@
             this.lblCommitInfoTarget = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.createPullLinkLabel = new System.Windows.Forms.LinkLabel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl1 = new System.Windows.Forms.TabControl();
-            this.tabCreate = new System.Windows.Forms.TabPage();
             this.tabView = new System.Windows.Forms.TabPage();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
             this.lbxPullRequests = new System.Windows.Forms.ListBox();
@@ -63,6 +64,7 @@
             this.btnMerge = new System.Windows.Forms.Button();
             this.btnApprove = new System.Windows.Forms.Button();
             this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.viewPullLinkLabel = new System.Windows.Forms.LinkLabel();
             this.txtPRDescription = new System.Windows.Forms.TextBox();
             this.txtPRTitle = new System.Windows.Forms.TextBox();
             this.txtPRReviewers = new System.Windows.Forms.TextBox();
@@ -80,6 +82,8 @@
             this.label17 = new System.Windows.Forms.Label();
             this.lblPRDestRepo = new System.Windows.Forms.Label();
             this.label18 = new System.Windows.Forms.Label();
+            this.tabCreate = new System.Windows.Forms.TabPage();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.ReviewersDataGrid)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -89,7 +93,6 @@
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
             this.tabControl1.SuspendLayout();
-            this.tabCreate.SuspendLayout();
             this.tabView.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).BeginInit();
             this.splitContainer3.Panel1.SuspendLayout();
@@ -103,6 +106,7 @@
             this.splitContainer2.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.groupBox5.SuspendLayout();
+            this.tabCreate.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
@@ -326,6 +330,7 @@
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.createPullLinkLabel);
             this.groupBox3.Controls.Add(this.lblReviewers);
             this.groupBox3.Controls.Add(this.label3);
             this.groupBox3.Controls.Add(this.txtDescription);
@@ -338,6 +343,17 @@
             this.groupBox3.TabIndex = 1;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Pull Request Info";
+            // 
+            // createPullLinkLabel
+            // 
+            this.createPullLinkLabel.AutoSize = true;
+            this.createPullLinkLabel.Location = new System.Drawing.Point(128, 382);
+            this.createPullLinkLabel.Name = "createPullLinkLabel";
+            this.createPullLinkLabel.Size = new System.Drawing.Size(53, 13);
+            this.createPullLinkLabel.TabIndex = 12;
+            this.createPullLinkLabel.TabStop = true;
+            this.createPullLinkLabel.Text = "linkLabel1";
+            this.createPullLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.textLinkLabel_LinkClicked);
             // 
             // splitContainer1
             // 
@@ -360,26 +376,13 @@
             this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.tabControl1.Controls.Add(this.tabCreate);
             this.tabControl1.Controls.Add(this.tabView);
+            this.tabControl1.Controls.Add(this.tabCreate);
             this.tabControl1.Location = new System.Drawing.Point(12, 12);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.Size = new System.Drawing.Size(803, 643);
             this.tabControl1.TabIndex = 3;
-            // 
-            // tabCreate
-            // 
-            this.tabCreate.Controls.Add(this.splitContainer1);
-            this.tabCreate.Controls.Add(this.btnCreate);
-            this.tabCreate.Controls.Add(this.groupBox3);
-            this.tabCreate.Location = new System.Drawing.Point(4, 22);
-            this.tabCreate.Name = "tabCreate";
-            this.tabCreate.Padding = new System.Windows.Forms.Padding(3);
-            this.tabCreate.Size = new System.Drawing.Size(795, 617);
-            this.tabCreate.TabIndex = 0;
-            this.tabCreate.Text = "Create Pull Request";
-            this.tabCreate.UseVisualStyleBackColor = true;
             // 
             // tabView
             // 
@@ -492,6 +495,7 @@
             // 
             // groupBox6
             // 
+            this.groupBox6.Controls.Add(this.viewPullLinkLabel);
             this.groupBox6.Controls.Add(this.txtPRDescription);
             this.groupBox6.Controls.Add(this.txtPRTitle);
             this.groupBox6.Controls.Add(this.txtPRReviewers);
@@ -504,6 +508,17 @@
             this.groupBox6.TabIndex = 4;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Pull Request Info";
+            // 
+            // viewPullLinkLabel
+            // 
+            this.viewPullLinkLabel.AutoSize = true;
+            this.viewPullLinkLabel.Location = new System.Drawing.Point(17, 382);
+            this.viewPullLinkLabel.Name = "viewPullLinkLabel";
+            this.viewPullLinkLabel.Size = new System.Drawing.Size(53, 13);
+            this.viewPullLinkLabel.TabIndex = 15;
+            this.viewPullLinkLabel.TabStop = true;
+            this.viewPullLinkLabel.Text = "linkLabel1";
+            this.viewPullLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.textLinkLabel_LinkClicked);
             // 
             // txtPRDescription
             // 
@@ -678,6 +693,19 @@
             this.label18.TabIndex = 4;
             this.label18.Text = "Branch";
             // 
+            // tabCreate
+            // 
+            this.tabCreate.Controls.Add(this.splitContainer1);
+            this.tabCreate.Controls.Add(this.btnCreate);
+            this.tabCreate.Controls.Add(this.groupBox3);
+            this.tabCreate.Location = new System.Drawing.Point(4, 22);
+            this.tabCreate.Name = "tabCreate";
+            this.tabCreate.Padding = new System.Windows.Forms.Padding(3);
+            this.tabCreate.Size = new System.Drawing.Size(795, 617);
+            this.tabCreate.TabIndex = 0;
+            this.tabCreate.Text = "Create Pull Request";
+            this.tabCreate.UseVisualStyleBackColor = true;
+            // 
             // BitbucketPullRequestForm
             // 
             this.AcceptButton = this.btnCreate;
@@ -686,9 +714,7 @@
             this.ClientSize = new System.Drawing.Size(827, 667);
             this.Controls.Add(this.tabControl1);
             this.Name = "BitbucketPullRequestForm";
-            this.Text = "Create Pull Request";
-            this.Load += BitbucketPullRequestFormLoad;
-            this.Load += BitbucketViewPullRequestFormLoad;
+            this.Text = "Bitbucket Server";
             ((System.ComponentModel.ISupportInitialize)(this.ReviewersDataGrid)).EndInit();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
@@ -701,7 +727,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
-            this.tabCreate.ResumeLayout(false);
             this.tabView.ResumeLayout(false);
             this.splitContainer3.Panel1.ResumeLayout(false);
             this.splitContainer3.Panel2.ResumeLayout(false);
@@ -719,6 +744,7 @@
             this.groupBox4.PerformLayout();
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
+            this.tabCreate.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -777,5 +803,8 @@
         private System.Windows.Forms.Label lblPRState;
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.LinkLabel createPullLinkLabel;
+        private System.Windows.Forms.LinkLabel viewPullLinkLabel;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -49,13 +49,13 @@ namespace Bitbucket
             Load += BitbucketViewPullRequestFormLoad;
             Load += BitbucketPullRequestFormLoad;
 
-            createPullLinkLabel.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests?create",
+            lblLinkCreatePull.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests?create",
                                       _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
-            toolTip1.SetToolTip(createPullLinkLabel, _linkLabelToolTip.Text);
+            toolTip1.SetToolTip(lblLinkCreatePull, _linkLabelToolTip.Text);
 
-            viewPullLinkLabel.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests",
+            lblLinkViewPull.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests",
                 _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
-            toolTip1.SetToolTip(viewPullLinkLabel, _linkLabelToolTip.Text);
+            toolTip1.SetToolTip(lblLinkViewPull, _linkLabelToolTip.Text);
         }
 
         private void BitbucketPullRequestFormLoad(object sender, EventArgs e)
@@ -319,7 +319,7 @@ namespace Bitbucket
             lblPRDestRepo.Text = curItem.DestDisplayName;
             lblPRDestBranch.Text = curItem.DestBranch;
 
-            viewPullLinkLabel.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests/{3}/overview",
+            lblLinkViewPull.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests/{3}/overview",
                 _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug, curItem.Id);
         }
 

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -17,6 +17,7 @@ namespace Bitbucket
         private readonly TranslationString _commited = new TranslationString("{0} committed\n{1}");
         private readonly TranslationString _success = new TranslationString("Success");
         private readonly TranslationString _error = new TranslationString("Error");
+        private readonly TranslationString _linkLabelToolTip = new TranslationString("Right-click to copy link");
 
         private Settings _settings;
         private readonly BitbucketPlugin _plugin;
@@ -34,12 +35,10 @@ namespace Bitbucket
             _plugin = plugin;
             _settingsContainer = settings;
             _gitUiCommands = gitUiCommands;
-            //TODO Retrieve all users and set default reviewers
+            //Reviewers are not implemented
+            lblReviewers.Visible = false;
             ReviewersDataGrid.Visible = false;
-        }
 
-        private void BitbucketPullRequestFormLoad(object sender, EventArgs e)
-        {
             _settings = Settings.Parse(_gitUiCommands.GitModule, _settingsContainer, _plugin);
             if (_settings == null)
             {
@@ -47,6 +46,23 @@ namespace Bitbucket
                 Close();
                 return;
             }
+            Load += BitbucketViewPullRequestFormLoad;
+            Load += BitbucketPullRequestFormLoad;
+
+            createPullLinkLabel.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests?create",
+                                      _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
+            toolTip1.SetToolTip(createPullLinkLabel, _linkLabelToolTip.Text);
+
+            viewPullLinkLabel.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests",
+                _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
+            toolTip1.SetToolTip(viewPullLinkLabel, _linkLabelToolTip.Text);
+        }
+
+        private void BitbucketPullRequestFormLoad(object sender, EventArgs e)
+        {
+            if (_settings == null)
+                return;
+
             //_bitbucketUsers.AddRange(GetBitbucketUsers().Select(a => a.Slug));
             ThreadPool.QueueUserWorkItem(state =>
             {
@@ -71,6 +87,7 @@ namespace Bitbucket
         {
             if (_settings == null)
                 return;
+
             ThreadPool.QueueUserWorkItem(state =>
             {
                 var pullReqs = GetPullRequests();
@@ -85,7 +102,6 @@ namespace Bitbucket
                 catch(System.InvalidOperationException){
                     return;
                 }
-
             });
         }
 
@@ -149,6 +165,8 @@ namespace Bitbucket
                     _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
+        //Users/reviewers are not implemented and hidden
+        /*
         private IEnumerable<BitbucketUser> GetBitbucketUsers()
         {
             var list = new List<BitbucketUser>();
@@ -163,7 +181,7 @@ namespace Bitbucket
             }
             return list;
         }
-
+        */
         Dictionary<Repository, IEnumerable<string>> Branches = new Dictionary<Repository,IEnumerable<string>>();
         private IEnumerable<string> GetBitbucketBranches(Repository selectedRepo)
         {
@@ -300,6 +318,9 @@ namespace Bitbucket
             lblPRSourceBranch.Text = curItem.SrcBranch;
             lblPRDestRepo.Text = curItem.DestDisplayName;
             lblPRDestBranch.Text = curItem.DestBranch;
+
+            viewPullLinkLabel.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests/{3}/overview",
+                _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug, curItem.Id);
         }
 
         private void BtnMergeClick(object sender, EventArgs e)
@@ -351,6 +372,26 @@ namespace Bitbucket
             else
                 MessageBox.Show(string.Join(Environment.NewLine, response.Messages),
                     _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+        private void textLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            try
+            {
+                var link = (sender as LinkLabel).Text;
+                if (e.Button == MouseButtons.Right)
+                {
+                    //Just copy the text
+                    Clipboard.SetText(link);
+                }
+                else
+                {
+                    System.Diagnostics.Process.Start(link);
+                }
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.resx
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Plugins/Bitbucket/GetPullRequest.cs
+++ b/Plugins/Bitbucket/GetPullRequest.cs
@@ -112,7 +112,7 @@ namespace Bitbucket
         {
             get
             {
-                return string.Format("/rest/api/latest/projects/{0}/repos/{1}/pull-requests?directions=incoming&order=oldest",
+                return string.Format("/rest/api/latest/projects/{0}/repos/{1}/pull-requests?directions=incoming",
                                      _projectKey, _repoName);
             }
         }


### PR DESCRIPTION
Issue #4229
A few of the improvements in the issue implemented.
 * A link to copy the URL to the web interface
 * View PRs as first tab, Create as second (as create is very limited)
 * Sort PRs so the newest is on top

Screenshots before and after (if PR changes UI):
PRs are not shown, not connected to BB server
- 
![image](https://user-images.githubusercontent.com/6248932/35782894-b4dfb6a8-09ff-11e8-9ab6-bda4faef74be.png)

- 
![image](https://user-images.githubusercontent.com/6248932/35782914-f63538ee-09ff-11e8-8a05-4d9ec28de1eb.png)

What did I do to test the code and ensure quality:
 - Manual tests

Has been tested on (remove any that don't apply):
 - Windows 7 and 10
