### PR TITLE
workaround for Travis build requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+#Temporary file to satisfy Travis CI build (no longer needed when Mono is not built)
+
+language: perl 
+install: true
+
+script: "perl -e ''"


### PR DESCRIPTION
Temporary workaround after #4430 removed Mono and thereby Travis builds
The proper solution is to remove the requirement for successful builds