### PR TITLE
Enabled Ctrl+Alt+T as a hotkey for the Show Tags menu option. Show it…

### DIFF
--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -278,6 +278,7 @@ namespace GitUI.Hotkey
                     hk(RevisionGrid.Commands.ToggleShowGitNotes, Keys.None),
                     hk(RevisionGrid.Commands.ToggleRevisionCardLayout, Keys.Control | Keys.Shift | Keys.L),
                     hk(RevisionGrid.Commands.ToggleShowMergeCommits, Keys.Control | Keys.Shift | Keys.M),
+                    hk(RevisionGrid.Commands.ToggleShowTags, Keys.Control | Keys.Alt | Keys.T),
                     hk(RevisionGrid.Commands.ShowAllBranches, Keys.Control | Keys.Shift | Keys.A),
                     hk(RevisionGrid.Commands.ShowCurrentBranchOnly, Keys.Control | Keys.Shift | Keys.U),
                     hk(RevisionGrid.Commands.ShowFilteredBranches, Keys.Control | Keys.Shift | Keys.T),

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3242,6 +3242,7 @@ namespace GitUI
             SelectAsBaseToCompare,
             CompareToBase,
             CreateFixupCommit,
+            ToggleShowTags,
         }
 
         protected override bool ExecuteCommand(int cmd)
@@ -3259,6 +3260,7 @@ namespace GitUI
                 case Commands.ToggleShowGitNotes: ShowGitNotes_ToolStripMenuItemClick(null, null); break;
                 case Commands.ToggleRevisionCardLayout: ToggleRevisionCardLayout(); break;
                 case Commands.ToggleShowMergeCommits: ShowMergeCommits_ToolStripMenuItemClick(null, null); break;
+                case Commands.ToggleShowTags: ShowTags_ToolStripMenuItemClick(null, null); break;
                 case Commands.ShowAllBranches: ShowAllBranches_ToolStripMenuItemClick(null, null); break;
                 case Commands.ShowCurrentBranchOnly: ShowCurrentBranchOnly_ToolStripMenuItemClick(null, null); break;
                 case Commands.ShowFilteredBranches: ShowFilteredBranches_ToolStripMenuItemClick(null, null); break;

--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -363,6 +363,7 @@ namespace GitUI.UserControls.RevisionGridClasses
               var menuCommand = new MenuCommand();
               menuCommand.Name = "showTagsToolStripMenuItem";
               menuCommand.Text = "Show tags";
+              menuCommand.ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleShowTags);
               menuCommand.ExecuteAction = () => _revisionGrid.ShowTags_ToolStripMenuItemClick(null, null);
               menuCommand.IsCheckedFunc = () => AppSettings.ShowTags;
 


### PR DESCRIPTION
Fixes #4449 .

Changes proposed in this pull request:
- Add a hotkey for the Show tags menu item.

Screenshots before and after (if PR changes UI):
Before
![image](https://user-images.githubusercontent.com/1578466/36058254-f7e50072-0de0-11e8-8f8e-a8431a965b9e.png)

After
![image](https://user-images.githubusercontent.com/1578466/36058219-9da923fe-0de0-11e8-8e62-d04e9d20316b.png)


What did I do to test the code and ensure quality:
- Verified with no saved settings
- Verified with saved settings
- Verified the hotkey didn't map to anything.
- Verified the hotkey toggles visible tags, as expected.

Has been tested on (remove any that don't apply): Yes
 - GIT 2.10 and above
 - Windows 8.1 only

Notes:
- I would have preferred to place the new enum value, ToggleShowTags, near the other "Toggle" entries. However, doing so interfered with restoring saved settings. Didn't seem worth doing a migration for, so I added it at the end of the enum.
