### PR TITLE
Make blame options -w -M -C switchable #2342

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2947,7 +2947,13 @@ namespace GitCommands
         {
             from = from.ToPosixPath();
             filename = filename.ToPosixPath();
-            string blameCommand = string.Format("blame --porcelain -M -w -l{0} \"{1}\" -- \"{2}\"", lines != null ? " -L " + lines : "", from, filename);
+
+            string detectCopyInFileOpt = AppSettings.DetectCopyInFileOnBlame ? " -M" : string.Empty;
+            string detectCopyInAllOpt = AppSettings.DetectCopyInAllOnBlame ? " -C" : string.Empty;
+            string ignoreWhitespaceOpt = AppSettings.IgnoreWhitespaceOnBlame ? " -w" : string.Empty;
+            string linesOpt = lines != null ? " -L " + lines : string.Empty;
+
+            string blameCommand = $"blame --porcelain{detectCopyInFileOpt}{detectCopyInAllOpt}{ignoreWhitespaceOpt} -l{linesOpt} \"{from}\" -- \"{filename}\"";
             var itemsStrings =
                 RunCacheableCmd(
                     AppSettings.GitCommand,

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -578,6 +578,25 @@ namespace GitCommands
             set { SetBool("LoadBlameOnShow", value); }
         }
 
+        public static bool DetectCopyInFileOnBlame
+        {
+            get { return GetBool("DetectCopyInFileOnBlame", true); }
+            set { SetBool("DetectCopyInFileOnBlame", value); }
+        }
+
+        public static bool DetectCopyInAllOnBlame
+        {
+            get { return GetBool("DetectCopyInAllOnBlame", false); }
+            set { SetBool("DetectCopyInAllOnBlame", value); }
+        }
+
+        public static bool IgnoreWhitespaceOnBlame
+        {
+            get { return GetBool("IgnoreWhitespaceOnBlame", true); }
+            set { SetBool("IgnoreWhitespaceOnBlame", value); }
+        }
+
+
         public static bool OpenSubmoduleDiffInSeparateWindow
         {
             get { return GetBool("opensubmodulediffinseparatewindow", false); }

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -56,6 +56,10 @@ namespace GitUI.CommandsDialogs
             this.loadHistoryOnShowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadBlameOnShowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ShowFullHistory = new System.Windows.Forms.ToolStripButton();
+            this.toolStripBlameOptions = new System.Windows.Forms.ToolStripDropDownButton();
+            this.ignoreWhitespaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.detectMoveAndCopyInThisFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -302,7 +306,8 @@ namespace GitUI.CommandsDialogs
             this.ShowFirstParent,
             this.toolStripSeparator3,
             this.toolStripSplitLoad,
-            this.ShowFullHistory});
+            this.ShowFullHistory,
+            this.toolStripBlameOptions});
             this.ToolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.ToolStrip.Location = new System.Drawing.Point(0, 0);
             this.ToolStrip.Name = "ToolStrip";
@@ -410,6 +415,41 @@ namespace GitUI.CommandsDialogs
             this.ShowFullHistory.ToolTipText = "Show Full History";
             this.ShowFullHistory.Click += new System.EventHandler(this.ShowFullHistory_Click);
             // 
+            // toolStripBlameOptions
+            // 
+            this.toolStripBlameOptions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripBlameOptions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ignoreWhitespaceToolStripMenuItem,
+            this.detectMoveAndCopyInThisFileToolStripMenuItem,
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem});
+            this.toolStripBlameOptions.Image = global::GitUI.Properties.Resources.IconBlame;
+            this.toolStripBlameOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripBlameOptions.Name = "toolStripBlameOptions";
+            this.toolStripBlameOptions.Size = new System.Drawing.Size(29, 22);
+            this.toolStripBlameOptions.Text = "Blame options";
+            this.toolStripBlameOptions.ToolTipText = "Blame options";
+            // 
+            // ignoreWhitespaceToolStripMenuItem
+            // 
+            this.ignoreWhitespaceToolStripMenuItem.Name = "ignoreWhitespaceToolStripMenuItem";
+            this.ignoreWhitespaceToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.ignoreWhitespaceToolStripMenuItem.Text = "Ignore whitespace";
+            this.ignoreWhitespaceToolStripMenuItem.Click += new System.EventHandler(this.ignoreWhitespaceToolStripMenuItem_Click);
+            // 
+            // detectMoveAndCopyInThisFileToolStripMenuItem
+            // 
+            this.detectMoveAndCopyInThisFileToolStripMenuItem.Name = "detectMoveAndCopyInThisFileToolStripMenuItem";
+            this.detectMoveAndCopyInThisFileToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.detectMoveAndCopyInThisFileToolStripMenuItem.Text = "Detect move and copy in this file";
+            this.detectMoveAndCopyInThisFileToolStripMenuItem.Click += new System.EventHandler(this.detectMoveAndCopyInThisFileToolStripMenuItem_Click);
+            // 
+            // detectMoveAndCopyInAllFilesToolStripMenuItem
+            // 
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem.Name = "detectMoveAndCopyInAllFilesToolStripMenuItem";
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem.Text = "Detect move and copy in all files";
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem.Click += new System.EventHandler(this.detectMoveAndCopyInAllFilesToolStripMenuItem_Click);
+            // 
             // FormFileHistory
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -478,5 +518,9 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripButton ShowFirstParent;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripButton ShowFullHistory;
+        private System.Windows.Forms.ToolStripDropDownButton toolStripBlameOptions;
+        private System.Windows.Forms.ToolStripMenuItem ignoreWhitespaceToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem detectMoveAndCopyInThisFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem detectMoveAndCopyInAllFilesToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -77,12 +77,22 @@ namespace GitUI.CommandsDialogs
             FileChanges.SelectionChanged += FileChangesSelectionChanged;
             FileChanges.DisableContextMenu();
 
+            bool blameTabExists = tabControl1.Contains(BlameTab);
+
             UpdateFollowHistoryMenuItems();
             fullHistoryToolStripMenuItem.Checked = AppSettings.FullHistoryInFileHistory;
             ShowFullHistory.Checked = AppSettings.FullHistoryInFileHistory;
             loadHistoryOnShowToolStripMenuItem.Checked = AppSettings.LoadFileHistoryOnShow;
-            loadBlameOnShowToolStripMenuItem.Checked = AppSettings.LoadBlameOnShow && tabControl1.Contains(BlameTab);
+            loadBlameOnShowToolStripMenuItem.Checked = AppSettings.LoadBlameOnShow && blameTabExists;
             saveAsToolStripMenuItem.Visible = !isSubmodule;
+
+            toolStripBlameOptions.Visible = blameTabExists;
+            if (blameTabExists)
+            {
+                ignoreWhitespaceToolStripMenuItem.Checked = AppSettings.IgnoreWhitespaceOnBlame;
+                detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
+                detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
+            }
 
             if (filterByRevision && revision != null && revision.Guid != null)
                 _filterBranchHelper.SetBranchFilter(revision.Guid, false);
@@ -258,7 +268,7 @@ namespace GitUI.CommandsDialogs
             Text += " - " + Module.WorkingDir;
         }
 
-        private void UpdateSelectedFileViewers()
+        private void UpdateSelectedFileViewers(bool force = false)
         {
             var selectedRows = FileChanges.GetSelectedRevisions();
 
@@ -275,7 +285,7 @@ namespace GitUI.CommandsDialogs
             SetTitle(fileName);
 
             if (tabControl1.SelectedTab == BlameTab)
-                Blame.LoadBlame(revision, children, fileName, FileChanges, BlameTab, Diff.Encoding);
+                Blame.LoadBlame(revision, children, fileName, FileChanges, BlameTab, Diff.Encoding, force: force);
             else if (tabControl1.SelectedTab == ViewTab)
             {
                 var scrollpos = View.ScrollPos;
@@ -519,6 +529,27 @@ namespace GitUI.CommandsDialogs
         private void toolStripBranchFilterComboBox_Click(object sender, EventArgs e)
         {
             toolStripBranchFilterComboBox.DroppedDown = true;
+        }
+
+        private void ignoreWhitespaceToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.IgnoreWhitespaceOnBlame = !AppSettings.IgnoreWhitespaceOnBlame;
+            ignoreWhitespaceToolStripMenuItem.Checked = AppSettings.IgnoreWhitespaceOnBlame;
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void detectMoveAndCopyInAllFilesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.DetectCopyInFileOnBlame = !AppSettings.DetectCopyInFileOnBlame;
+            detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void detectMoveAndCopyInThisFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.DetectCopyInAllOnBlame = !AppSettings.DetectCopyInAllOnBlame;
+            detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
+            UpdateSelectedFileViewers(true);
         }
     }
 }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -191,11 +191,11 @@ namespace GitUI.Blame
         
         private AsyncLoader blameLoader = new AsyncLoader();
 
-        public void LoadBlame(GitRevision revision, List<string> children, string fileName, RevisionGrid revGrid, Control controlToMask, Encoding encoding, int? initialLine = null)
+        public void LoadBlame(GitRevision revision, List<string> children, string fileName, RevisionGrid revGrid, Control controlToMask, Encoding encoding, int? initialLine = null, bool force = false)
         {
             //refresh only when something changed
             string guid = revision.Guid;
-            if (guid.Equals(_blameHash) && fileName == _fileName && revGrid == _revGrid && encoding == _encoding)
+            if (!force && guid.Equals(_blameHash) && fileName == _fileName && revGrid == _revGrid && encoding == _encoding)
                 return;
 
             if (controlToMask != null)


### PR DESCRIPTION
In some cases blame show incorrect history. 

Closes #2342.

How reproduce:
1) Create and commit file with this content:
`1`
`#if (defined(WIN32) || defined(WIN64)) && defined(RELEASE)`
`2`
`#endif`
`3`
`#if (defined(WIN32) || defined(WIN64)) && (defined(RELEASE) || !defined(DEBUG))`
`4`
`#endif`
`5`
2) Modify file to this:
`1`
`#if (defined(WIN32) || defined(WIN64)) && (defined(RELEASE) || !defined(DEBUG))`
`2`
`#endif`
`3`
`#if (defined(WIN32) || defined(WIN64)) && (defined(RELEASE) || !defined(DEBUG))`
`4`
`#endif`
`5`
3) Show blame.

I expect to see that second line changed in second commit, but blame show another.

Changes proposed in this pull request:
 - Remove -M parameter from blame command. It make git don't try detect copy or move lines in file. Furthermore i don't sure that parameter -w is necessary by default, but it not so important as -M.
 
Screenshots before and after (if PR changes UI):
 - Before:
![old](https://user-images.githubusercontent.com/5438647/36062134-2604c406-0e77-11e8-9e94-e116ed93e912.png)

 - After:
![new](https://user-images.githubusercontent.com/5438647/36062138-2e7bbb4e-0e77-11e8-9dfd-7051035f3509.png)

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10 x64
