### PR TITLE
Add support for Github avatar

### DIFF
--- a/Gravatar/Gravatar.csproj
+++ b/Gravatar/Gravatar.csproj
@@ -95,5 +95,12 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Externals\Git.hub\Git.hub\Git.hub.csproj">
+      <Project>{f50b1dbf-1c9f-4437-87ec-7aba805cc446}</Project>
+      <Name>Git.hub</Name>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Fixes #3770.

Changes proposed in this pull request:
 - When the user's email adress is <username>@users.noreply.github.com, use Github API to retrieve avatar instead of Gravatar
 
Screenshots before and after (if PR changes UI):
- Before:
![image](https://user-images.githubusercontent.com/1864281/36074550-92632302-0f41-11e8-9fae-c0dfc670f7e4.png)
- After:
![image](https://user-images.githubusercontent.com/1864281/36074507-e678a760-0f40-11e8-89fd-4e9a07737273.png)

What did I do to test the code and ensure quality:
 - manual testing

Has been tested on (remove any that don't apply):
 - GIT 2.13.0
 - Windows 10 (FCU)
