### PR TITLE
Improve find file dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -178,13 +178,11 @@ namespace GitUI.CommandsDialogs
 
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-
-                string nameAsLower = name.ToLower();
-
+                var predicate = GitUICommands.GetFindFilePredicate(name, Module.WorkingDir);
                 return candidates.Where(item =>
                 {
-                    return item.Name != null && item.Name.ToLower().Contains(nameAsLower)
-                        || item.OldName != null && item.OldName.ToLower().Contains(nameAsLower);
+                    return item.Name != null && predicate(item.Name)
+                        || item.OldName != null && predicate(item.OldName);
                 }
                     ).ToList();
             };

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -176,9 +176,11 @@ namespace GitUI.CommandsDialogs
 
             var candidates = DiffFiles.GitItemStatuses;
 
+            IFindFilePredicateProvider pathProvider = new FindFilePredicateProvider();
+
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-                var predicate = GitUICommands.GetFindFilePredicate(name, Module.WorkingDir);
+                var predicate = pathProvider.Get(name, Module.WorkingDir);
                 return candidates.Where(item =>
                 {
                     return item.Name != null && predicate(item.Name)

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
             _baseRevision = new GitRevision(baseCommitSha);
             _headRevision = new GitRevision(headCommitSha);
             _mergeBase = new GitRevision(Module.GetMergeBase(_baseRevision.Guid, _headRevision.Guid));
-            _findFilePredicateProvider = new FindFilePredicateProvider(() => Module.WorkingDir);
+            _findFilePredicateProvider = new FindFilePredicateProvider();
 
             lblBaseCommit.BackColor = AppSettings.DiffRemovedColor;
             lblHeadCommit.BackColor = AppSettings.DiffAddedColor;
@@ -180,7 +180,7 @@ namespace GitUI.CommandsDialogs
 
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-                var predicate = _findFilePredicateProvider.Get(name);
+                var predicate = _findFilePredicateProvider.Get(name, Module.WorkingDir);
                 return candidates.Where(item => predicate(item.Name) || predicate(item.OldName)).ToList();
             };
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -450,13 +450,11 @@ namespace GitUI.CommandsDialogs
 
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-
-                string nameAsLower = name.ToLower();
-
+                var predicate = GitUICommands.GetFindFilePredicate(name, Module.WorkingDir);
                 return candidates.Where(item =>
                 {
-                    return item.Name != null && item.Name.ToLower().Contains(nameAsLower)
-                        || item.OldName != null && item.OldName.ToLower().Contains(nameAsLower);
+                    return item.Name != null && predicate(item.Name)
+                        || item.OldName != null && predicate(item.OldName);
                 }
                     ).ToList();
             };

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs
             Translate();
             this.HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
-            _findFilePredicateProvider = new FindFilePredicateProvider(() => Module.WorkingDir);
+            _findFilePredicateProvider = new FindFilePredicateProvider();
         }
 
         public void ForceRefreshRevisions()
@@ -452,7 +452,7 @@ namespace GitUI.CommandsDialogs
 
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-                var predicate = _findFilePredicateProvider.Get(name);
+                var predicate = _findFilePredicateProvider.Get(name, Module.WorkingDir);
                 return candidates.Where(item => predicate(item.Name) || predicate(item.OldName)).ToList();
             };
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -448,9 +448,11 @@ namespace GitUI.CommandsDialogs
 
             var candidates = DiffFiles.GitItemStatuses;
 
+            IFindFilePredicateProvider pathProvider = new FindFilePredicateProvider();
+
             Func<string, IList<GitItemStatus>> FindDiffFilesMatches = (string name) =>
             {
-                var predicate = GitUICommands.GetFindFilePredicate(name, Module.WorkingDir);
+                var predicate = pathProvider.Get(name, Module.WorkingDir);
                 return candidates.Where(item =>
                 {
                     return item.Name != null && predicate(item.Name)

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -54,7 +54,7 @@ See the changes in the commit form.");
             InitializeComponent();
             Translate();
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
-            _findFilePredicateProvider = new FindFilePredicateProvider(() => Module.WorkingDir);
+            _findFilePredicateProvider = new FindFilePredicateProvider();
         }
 
 
@@ -225,7 +225,7 @@ See the changes in the commit form.");
         private IList<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree(_revision.TreeGuid);
-            var predicate = _findFilePredicateProvider.Get(name);
+            var predicate = _findFilePredicateProvider.Get(name, Module.WorkingDir);
 
             return candidates.Where(predicate).ToList();
         }

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -45,6 +45,7 @@ See the changes in the commit form.");
         private readonly Stack<string> _lastSelectedNodes = new Stack<string>();
         private IRevisionFileTreeController _revisionFileTreeController;
         private readonly IFullPathResolver _fullPathResolver;
+        private readonly IFindFilePredicateProvider _findFilePredicateProvider;
         private GitRevision _revision;
 
 
@@ -53,6 +54,7 @@ See the changes in the commit form.");
             InitializeComponent();
             Translate();
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
+            _findFilePredicateProvider = new FindFilePredicateProvider(() => Module.WorkingDir);
         }
 
 
@@ -223,9 +225,7 @@ See the changes in the commit form.");
         private IList<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree(_revision.TreeGuid);
-
-            IFindFilePredicateProvider pathProvider = new FindFilePredicateProvider();
-            var predicate = pathProvider.Get(name, Module.WorkingDir);
+            var predicate = _findFilePredicateProvider.Get(name);
 
             return candidates.Where(predicate).ToList();
         }

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -223,7 +223,9 @@ See the changes in the commit form.");
         private IList<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree(_revision.TreeGuid);
-            var predicate = GitUICommands.GetFindFilePredicate(name, Module.WorkingDir);
+
+            IFindFilePredicateProvider pathProvider = new FindFilePredicateProvider();
+            var predicate = pathProvider.Get(name, Module.WorkingDir);
 
             return candidates.Where(predicate).ToList();
         }

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -223,10 +223,9 @@ See the changes in the commit form.");
         private IList<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree(_revision.TreeGuid);
+            var predicate = GitUICommands.GetFindFilePredicate(name, Module.WorkingDir);
 
-            var nameAsLower = name.ToLower();
-
-            return candidates.Where(fileName => fileName.ToLower().Contains(nameAsLower)).ToList();
+            return candidates.Where(predicate).ToList();
         }
 
         private void OnItemActivated()

--- a/GitUI/FindFilePredicateProvider.cs
+++ b/GitUI/FindFilePredicateProvider.cs
@@ -1,28 +1,46 @@
 ﻿using System;
 using GitCommands;
+using JetBrains.Annotations;
 
 namespace GitUI
 {
     public interface IFindFilePredicateProvider
     {
-        Func<string, bool> Get(string name, string workingDir);
+        /// <summary>
+        /// Returns the names of files that match the specified search pattern
+        /// </summary>
+        /// <param name="searchPattern">The search string to match against the pathes of files</param>
+        Func<string, bool> Get([NotNull] string searchPattern);
     }
 
     public sealed class FindFilePredicateProvider : IFindFilePredicateProvider
     {
-        public Func<string, bool> Get(string name, string workingDir)
+        private readonly Func<string> _workingDirGetter;
+
+        public FindFilePredicateProvider([NotNull] Func<string> workingDirGetter)
         {
-            var pattern = name.ToPosixPath();
-            var dir = workingDir.ToPosixPath();
+            if (workingDirGetter == null)
+                throw new ArgumentNullException(nameof(workingDirGetter));
+
+            _workingDirGetter = workingDirGetter;
+        }
+
+        public Func<string, bool> Get(string searchPattern)
+        {
+            if (searchPattern == null)
+                throw new ArgumentNullException(nameof(searchPattern));
+
+            var pattern = searchPattern.ToPosixPath();
+            var dir = (_workingDirGetter() ?? string.Empty).ToPosixPath();
 
             if (pattern.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
             {
                 pattern = pattern.Substring(dir.Length).TrimStart('/');
-                return fileName => fileName.StartsWith(pattern, StringComparison.OrdinalIgnoreCase);
+                return fileName => fileName != null && fileName.StartsWith(pattern, StringComparison.OrdinalIgnoreCase);
             }
 
             // Method Contains have no override with StringComparison parameter
-            return fileName => fileName.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
+            return fileName => fileName != null && fileName.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }

--- a/GitUI/FindFilePredicateProvider.cs
+++ b/GitUI/FindFilePredicateProvider.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using GitCommands;
+
+namespace GitUI
+{
+    public interface IFindFilePredicateProvider
+    {
+        Func<string, bool> Get(string name, string workingDir);
+    }
+
+    public sealed class FindFilePredicateProvider : IFindFilePredicateProvider
+    {
+        public Func<string, bool> Get(string name, string workingDir)
+        {
+            var pattern = name.ToPosixPath();
+            var dir = workingDir.ToPosixPath();
+
+            if (pattern.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
+            {
+                pattern = pattern.Substring(dir.Length).TrimStart('/');
+                return fileName => fileName.StartsWith(pattern, StringComparison.OrdinalIgnoreCase);
+            }
+
+            // Method Contains have no override with StringComparison parameter
+            return fileName => fileName.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/GitUI/FindFilePredicateProvider.cs
+++ b/GitUI/FindFilePredicateProvider.cs
@@ -10,28 +10,21 @@ namespace GitUI
         /// Returns the names of files that match the specified search pattern
         /// </summary>
         /// <param name="searchPattern">The search string to match against the pathes of files</param>
-        Func<string, bool> Get([NotNull] string searchPattern);
+        /// <param name="workingDir"></param>
+        Func<string, bool> Get([NotNull] string searchPattern, [NotNull] string workingDir);
     }
 
     public sealed class FindFilePredicateProvider : IFindFilePredicateProvider
     {
-        private readonly Func<string> _workingDirGetter;
-
-        public FindFilePredicateProvider([NotNull] Func<string> workingDirGetter)
-        {
-            if (workingDirGetter == null)
-                throw new ArgumentNullException(nameof(workingDirGetter));
-
-            _workingDirGetter = workingDirGetter;
-        }
-
-        public Func<string, bool> Get(string searchPattern)
+        public Func<string, bool> Get(string searchPattern, string workingDir)
         {
             if (searchPattern == null)
                 throw new ArgumentNullException(nameof(searchPattern));
+            if (workingDir == null)
+                throw new ArgumentNullException(nameof(workingDir));
 
             var pattern = searchPattern.ToPosixPath();
-            var dir = (_workingDirGetter() ?? string.Empty).ToPosixPath();
+            var dir = workingDir.ToPosixPath();
 
             if (pattern.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
             {

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -268,6 +268,7 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="FindFilePredicateProvider.cs" />
     <Compile Include="RevisionDiffInfoProvider.cs" />
     <Compile Include="RevisionDiffKind.cs" />
     <Compile Include="FormStatusOutputLog.cs" />

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -2174,25 +2174,12 @@ namespace GitUI
             return arguments;
         }
 
-        internal static Func<string, bool> GetFindFilePredicate(string name, string workingDir)
-        {
-            var pattern = name.ToPosixPath();
-            var dir = workingDir.ToPosixPath();
-
-            if (pattern.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
-            {
-                pattern = pattern.Substring(dir.Length);
-                return fileName => fileName.StartsWith(pattern, StringComparison.OrdinalIgnoreCase);
-            }
-
-            // Method Contains have no override with StringComparison parameter
-            return fileName => fileName.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
-        }
-
         private IList<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree("HEAD");
-            var predicate = GetFindFilePredicate(name, Module.WorkingDir);
+
+            IFindFilePredicateProvider pathProvider = new FindFilePredicateProvider();
+            var predicate = pathProvider.Get(name, Module.WorkingDir);
 
             return candidates.Where(predicate).ToList();
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -35,7 +35,7 @@ namespace GitUI
             IImageCache avatarCache = new DirectoryImageCache(AppSettings.GravatarCachePath, AppSettings.AuthorImageCacheDays);
             _gravatarService = new GravatarService(avatarCache);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
-            _fildFilePredicateProvider = new FindFilePredicateProvider(() => Module.WorkingDir);
+            _fildFilePredicateProvider = new FindFilePredicateProvider();
         }
 
         public GitUICommands(string workingDir)
@@ -2180,7 +2180,7 @@ namespace GitUI
         {
             var candidates = Module.GetFullTree("HEAD");
 
-            var predicate = _fildFilePredicateProvider.Get(name);
+            var predicate = _fildFilePredicateProvider.Get(name, Module.WorkingDir);
 
             return candidates.Where(predicate).ToList();
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -23,6 +23,7 @@ namespace GitUI
         private readonly IAvatarService _gravatarService;
         private readonly ICommitTemplateManager _commitTemplateManager;
         private readonly IFullPathResolver _fullPathResolver;
+        private readonly IFindFilePredicateProvider _fildFilePredicateProvider;
 
         public GitUICommands(GitModule module)
         {
@@ -34,6 +35,7 @@ namespace GitUI
             IImageCache avatarCache = new DirectoryImageCache(AppSettings.GravatarCachePath, AppSettings.AuthorImageCacheDays);
             _gravatarService = new GravatarService(avatarCache);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
+            _fildFilePredicateProvider = new FindFilePredicateProvider(() => Module.WorkingDir);
         }
 
         public GitUICommands(string workingDir)
@@ -2178,8 +2180,7 @@ namespace GitUI
         {
             var candidates = Module.GetFullTree("HEAD");
 
-            IFindFilePredicateProvider pathProvider = new FindFilePredicateProvider();
-            var predicate = pathProvider.Get(name, Module.WorkingDir);
+            var predicate = _fildFilePredicateProvider.Get(name);
 
             return candidates.Where(predicate).ToList();
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -2174,13 +2174,27 @@ namespace GitUI
             return arguments;
         }
 
+        internal static Func<string, bool> GetFindFilePredicate(string name, string workingDir)
+        {
+            var pattern = name.ToPosixPath();
+            var dir = workingDir.ToPosixPath();
+
+            if (pattern.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
+            {
+                pattern = pattern.Substring(dir.Length);
+                return fileName => fileName.StartsWith(pattern, StringComparison.OrdinalIgnoreCase);
+            }
+
+            // Method Contains have no override with StringComparison parameter
+            return fileName => fileName.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
         private IList<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree("HEAD");
+            var predicate = GetFindFilePredicate(name, Module.WorkingDir);
 
-            string nameAsLower = name.ToLower();
-
-            return candidates.Where(fileName => fileName.ToLower().Contains(nameAsLower)).ToList();
+            return candidates.Where(predicate).ToList();
         }
 
         private void Commit(Dictionary<string, string> arguments)

--- a/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
+++ b/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
@@ -8,10 +8,21 @@ namespace GitUITests
     [TestFixture]
     public class FindFilePredicateProviderTest
     {
+        private static readonly string patternDefault = "test2";
+        private static readonly string workingDirDefault = @"D:\";
+
+        private IFindFilePredicateProvider provider;
+
+        [SetUp]
+        public void Init()
+        {
+            provider = new FindFilePredicateProvider();
+        }
+
         [TestCase(null)]
         public void Get_should_throw_if_pattern_is_null(string pattern)
         {
-            Action predicate = () => { GetPredicate(pattern); };
+            Action predicate = () => { provider.Get(pattern, workingDirDefault); };
             predicate.ShouldThrow<ArgumentNullException>();
         }
 
@@ -19,25 +30,22 @@ namespace GitUITests
         [TestCase(" ")]
         public void Get_should_not_throw_if_pattern_is_empty(string pattern)
         {
-            Action predicate = () => { GetPredicate(pattern); };
+            Action predicate = () => { provider.Get(pattern, workingDirDefault); };
             predicate.ShouldNotThrow<ArgumentNullException>();
         }
 
-        [TestCase]
-        public void Get_should_throw_if_workingDir_getter_is_null()
+        [TestCase(null)]
+        public void Get_should_throw_if_workingDir_is_null(string workingDir)
         {
-            // ReSharper disable once AssignNullToNotNullAttribute
-            // ReSharper disable once ObjectCreationAsStatement
-            Action predicate = () => { new FindFilePredicateProvider(null); };
+            Action predicate = () => { provider.Get(patternDefault, workingDir); };
             predicate.ShouldThrow<ArgumentNullException>();
         }
 
-        [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
-        public void Get_should_not_throw_if_workingDir_is_null_or_empty(string workingDir)
+        public void Get_should_throw_if_workingDir_is_empty(string workingDir)
         {
-            Action predicate = () => { GetPredicate( workingDir: workingDir); };
+            Action predicate = () => { provider.Get(patternDefault, workingDir); };
             predicate.ShouldNotThrow<ArgumentNullException>();
         }
 
@@ -45,14 +53,14 @@ namespace GitUITests
         [TestCase(@"\test2\t", "test1/test2/test3")]
         public void Get_should_correct_work_with_slashes_and_backslashes_in_pattern(string pattern, string filePath)
         {
-            var predicate = GetPredicate(pattern);
+            var predicate = provider.Get(pattern, workingDirDefault);
             Assert.True(predicate(filePath));
         }
 
         [TestCase(@"\test2\t", "D:/test1/test2/test3/")]
         public void Get_should_not_throw_then_workingDir_lenght_greater_that_pattern_length(string pattern, string workingDir)
         {
-            Action predicate = () => { GetPredicate( pattern, workingDir); };
+            Action predicate = () => { provider.Get(pattern, workingDir); };
             predicate.ShouldNotThrow<ArgumentNullException>();
         }
 
@@ -64,7 +72,7 @@ namespace GitUITests
         [TestCase(@"D:/test1", @"D:", "test1/test2/test3/")]
         public void Get_should_work_correct_when_workingDir_end_with_slash_or_not(string pattern, string workingDir, string filePath)
         {
-            var predicate = GetPredicate(pattern, workingDir);
+            var predicate = provider.Get(pattern, workingDir);
             Assert.True(predicate(filePath));
         }
 
@@ -72,7 +80,7 @@ namespace GitUITests
         [TestCase(@"D:\Test\test1", @"D:/TEST", "teSt1/test2/test3/")]
         public void Get_should_work_with_diferent_cases(string pattern, string workingDir, string filePath)
         {
-            var predicate = GetPredicate(pattern, workingDir);
+            var predicate = provider.Get(pattern, workingDir);
             Assert.True(predicate(filePath));
         }
 
@@ -82,7 +90,7 @@ namespace GitUITests
         [TestCase(@"//d/test/test1", @"//d/test\", "test1/test2/test3/", ExpectedResult = true)]
         public bool Get_should_use_startwith_when_pattern_started_with_workingDir(string pattern, string workingDir, string filePath)
         {
-            var predicate = GetPredicate(pattern, workingDir);
+            var predicate = provider.Get(pattern, workingDir);
             return predicate(filePath);
         }
 
@@ -90,14 +98,19 @@ namespace GitUITests
         [TestCase(@"test1", @"D:/test", "test1/test2/test3/", ExpectedResult = true)]
         public bool Get_should_use_contains_when_pattern_does_not_started_with_workingDir(string pattern, string workingDir, string filePath)
         {
-            var predicate = GetPredicate(pattern, workingDir);
+            var predicate = provider.Get(pattern, workingDir);
             return predicate(filePath);
         }
 
-        private static Func<string, bool> GetPredicate(string pattern = "test2", string workingDir = @"D:\")
+        [TestCase( null )]
+        [TestCase( "" )]
+        [TestCase( " " )]
+        public void Get_should_not_throw_then_filePath_is_null_or_empty( string filePath )
         {
-            var provider = new FindFilePredicateProvider(() => workingDir);
-            return provider.Get(pattern);
+            var predicate = provider.Get(patternDefault, workingDirDefault);
+
+            Action executor = () => { predicate( filePath ); };
+            executor.ShouldNotThrow<ArgumentNullException>();
         }
     }
 }

--- a/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
+++ b/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
@@ -1,4 +1,6 @@
-﻿using GitUI;
+﻿using System;
+using FluentAssertions;
+using GitUI;
 using NUnit.Framework;
 
 namespace GitUITests
@@ -6,31 +8,96 @@ namespace GitUITests
     [TestFixture]
     public class FindFilePredicateProviderTest
     {
-        private IFindFilePredicateProvider provider;
-
-        [SetUp]
-        public void Init()
+        [TestCase(null)]
+        public void Get_should_throw_if_pattern_is_null(string pattern)
         {
-            provider = new FindFilePredicateProvider();
+            Action predicate = () => { GetPredicate(pattern); };
+            predicate.ShouldThrow<ArgumentNullException>();
         }
 
-        [TestCase(@"Code", @"D:\", "TestCode", ExpectedResult = true)]
-        [TestCase(@"Code", @"D:\", "TestCode/File1", ExpectedResult = true)]
-        [TestCase(@"code", @"D:\", "TestCode/File1", ExpectedResult = true)]
-        [TestCase(@"/Code", @"D:\", "TestCode/File1", ExpectedResult = false)]
-        [TestCase(@"Code/", @"D:\", "TestCode/File1", ExpectedResult = true)]
-        [TestCase(@"Code\", @"D:\", "TestCode/File1", ExpectedResult = true)]
-        [TestCase(@"D:/Code\", @"D:\", "TestCode/File1", ExpectedResult = false)]
-        [TestCase(@"D:/Test/", @"D:\", "TestCode/File1", ExpectedResult = false)]
-        [TestCase(@"D:\Test", @"D:\", "TestCode/File1", ExpectedResult = true)]
-        [TestCase(@"//d/git\Test", @"//d/git", "TestCode/File1", ExpectedResult = true)]
-        [TestCase(@"c/dir1/dir2", @"F:\", "src/dir1/dir2/dir3", ExpectedResult = true)]
-        [TestCase(@"c\dir1/dir2", @"F:\", "src/dir1/dir2/dir3", ExpectedResult = true)]
-        [TestCase(@"c/dir1\dir2", @"F:\", "src/dir1/dir2/dir3", ExpectedResult = true)]
-        public bool UsageScenario(string pattern, string workingDir, string fileName)
+        [TestCase("")]
+        [TestCase(" ")]
+        public void Get_should_not_throw_if_pattern_is_empty(string pattern)
         {
-            var predicate = provider.Get(pattern, workingDir);
-            return predicate.Invoke(fileName);
+            Action predicate = () => { GetPredicate(pattern); };
+            predicate.ShouldNotThrow<ArgumentNullException>();
+        }
+
+        [TestCase]
+        public void Get_should_throw_if_workingDir_getter_is_null()
+        {
+            // ReSharper disable once AssignNullToNotNullAttribute
+            // ReSharper disable once ObjectCreationAsStatement
+            Action predicate = () => { new FindFilePredicateProvider(null); };
+            predicate.ShouldThrow<ArgumentNullException>();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void Get_should_not_throw_if_workingDir_is_null_or_empty(string workingDir)
+        {
+            Action predicate = () => { GetPredicate( workingDir: workingDir); };
+            predicate.ShouldNotThrow<ArgumentNullException>();
+        }
+
+        [TestCase(@"test2/t", "test1/test2/test3")]
+        [TestCase(@"\test2\t", "test1/test2/test3")]
+        public void Get_should_correct_work_with_slashes_and_backslashes_in_pattern(string pattern, string filePath)
+        {
+            var predicate = GetPredicate(pattern);
+            Assert.True(predicate(filePath));
+        }
+
+        [TestCase(@"\test2\t", "D:/test1/test2/test3/")]
+        public void Get_should_not_throw_then_workingDir_lenght_greater_that_pattern_length(string pattern, string workingDir)
+        {
+            Action predicate = () => { GetPredicate( pattern, workingDir); };
+            predicate.ShouldNotThrow<ArgumentNullException>();
+        }
+
+        [TestCase(@"D:\test1", @"D:/", "test1/test2/test3/")]
+        [TestCase(@"D:/test1", @"D:/", "test1/test2/test3/")]
+        [TestCase(@"D:\test1", @"D:\", "test1/test2/test3/")]
+        [TestCase(@"D:/test1", @"D:\", "test1/test2/test3/")]
+        [TestCase(@"D:\test1", @"D:", "test1/test2/test3/")]
+        [TestCase(@"D:/test1", @"D:", "test1/test2/test3/")]
+        public void Get_should_work_correct_when_workingDir_end_with_slash_or_not(string pattern, string workingDir, string filePath)
+        {
+            var predicate = GetPredicate(pattern, workingDir);
+            Assert.True(predicate(filePath));
+        }
+
+        [TestCase(@"tEsT2", @"D:/", "Test1/teST2/test3/")]
+        [TestCase(@"D:\Test\test1", @"D:/TEST", "teSt1/test2/test3/")]
+        public void Get_should_work_with_diferent_cases(string pattern, string workingDir, string filePath)
+        {
+            var predicate = GetPredicate(pattern, workingDir);
+            Assert.True(predicate(filePath));
+        }
+
+        [TestCase(@"D:/test1", @"D:/", "test1/test2/test3/", ExpectedResult = true)]
+        [TestCase(@"D:/test2", @"D:/", "test1/test2/test3/", ExpectedResult = false)]
+        [TestCase(@"D:/test/test1", @"D:/test", "test1/test2/test3/", ExpectedResult = true)]
+        [TestCase(@"//d/test/test1", @"//d/test\", "test1/test2/test3/", ExpectedResult = true)]
+        public bool Get_should_use_startwith_when_pattern_started_with_workingDir(string pattern, string workingDir, string filePath)
+        {
+            var predicate = GetPredicate(pattern, workingDir);
+            return predicate(filePath);
+        }
+
+        [TestCase(@"test2", @"D:/", "test1/test2/test3/", ExpectedResult = true)]
+        [TestCase(@"test1", @"D:/test", "test1/test2/test3/", ExpectedResult = true)]
+        public bool Get_should_use_contains_when_pattern_does_not_started_with_workingDir(string pattern, string workingDir, string filePath)
+        {
+            var predicate = GetPredicate(pattern, workingDir);
+            return predicate(filePath);
+        }
+
+        private static Func<string, bool> GetPredicate(string pattern = "test2", string workingDir = @"D:\")
+        {
+            var provider = new FindFilePredicateProvider(() => workingDir);
+            return provider.Get(pattern);
         }
     }
 }

--- a/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
+++ b/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
@@ -1,0 +1,36 @@
+﻿using GitUI;
+using NUnit.Framework;
+
+namespace GitUITests
+{
+    [TestFixture]
+    public class FindFilePredicateProviderTest
+    {
+        private IFindFilePredicateProvider provider;
+
+        [SetUp]
+        public void Init()
+        {
+            provider = new FindFilePredicateProvider();
+        }
+
+        [TestCase(@"Code", @"D:\", "TestCode", ExpectedResult = true)]
+        [TestCase(@"Code", @"D:\", "TestCode/File1", ExpectedResult = true)]
+        [TestCase(@"code", @"D:\", "TestCode/File1", ExpectedResult = true)]
+        [TestCase(@"/Code", @"D:\", "TestCode/File1", ExpectedResult = false)]
+        [TestCase(@"Code/", @"D:\", "TestCode/File1", ExpectedResult = true)]
+        [TestCase(@"Code\", @"D:\", "TestCode/File1", ExpectedResult = true)]
+        [TestCase(@"D:/Code\", @"D:\", "TestCode/File1", ExpectedResult = false)]
+        [TestCase(@"D:/Test/", @"D:\", "TestCode/File1", ExpectedResult = false)]
+        [TestCase(@"D:\Test", @"D:\", "TestCode/File1", ExpectedResult = true)]
+        [TestCase(@"//d/git\Test", @"//d/git", "TestCode/File1", ExpectedResult = true)]
+        [TestCase(@"c/dir1/dir2", @"F:\", "src/dir1/dir2/dir3", ExpectedResult = true)]
+        [TestCase(@"c\dir1/dir2", @"F:\", "src/dir1/dir2/dir3", ExpectedResult = true)]
+        [TestCase(@"c/dir1\dir2", @"F:\", "src/dir1/dir2/dir3", ExpectedResult = true)]
+        public bool UsageScenario(string pattern, string workingDir, string fileName)
+        {
+            var predicate = provider.Get(pattern, workingDir);
+            return predicate.Invoke(fileName);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />
+    <Compile Include="FindFilePredicateProviderTest.cs" />
     <Compile Include="Helpers\DiffKindRevisionTests.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractorTests.cs" />
     <Compile Include="SplitterManagerTest.cs" />


### PR DESCRIPTION
Fixed: #4472 Find file dialog doesn't work with backslash ('\\') and full file path.

Changes proposed in this pull request:
 - Replace backslash(\\) by slash(/) in filename;
 - Skip repository path if filename start with it;
 
Screenshots before and after (if PR changes UI):
- After changes:
- ![1](https://user-images.githubusercontent.com/5438647/36096880-52b1e7de-1009-11e8-8d1d-364133260459.png)

What did I do to test the code and ensure quality:
 - Test file search from File Tree tab (Ctrl+Shift+F);
 - Test file search from Diff tab (Ctrl+F);
 - Test command 'searchfile' using for VS plugin;

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 10 x64
