### PR TITLE
Replace some lambdas with local functions

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -153,18 +153,18 @@ namespace GitCommands
             var startProcess = Process.Start(startInfo);
             startProcess.EnableRaisingEvents = true;
 
-            EventHandler processExited = null;
-            processExited = (sender, args) =>
+            void ProcessExited(object sender, EventArgs args)
             {
-                startProcess.Exited -= processExited;
+                startProcess.Exited -= ProcessExited;
 
                 string quotedCmd = fileName;
                 if (quotedCmd.IndexOf(' ') != -1)
                     quotedCmd = quotedCmd.Quote();
                 var executionEndTimestamp = DateTime.Now;
                 AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp);
-            };
-            startProcess.Exited += processExited;
+            }
+
+            startProcess.Exited += ProcessExited;
 
             return startProcess;
         }

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -605,22 +605,22 @@ namespace PatchApply
 
         public string ToResetUnstagedLinesPatch()
         {
-            SubChunkToPatchFnc subChunkToPatch = (SubChunk subChunk, ref int addedCount, ref int removedCount, ref bool wereSelectedLines) =>
-                {
-                    return subChunk.ToResetUnstagedLinesPatch(ref addedCount, ref removedCount, ref wereSelectedLines);
-                };
+            string SubChunkToPatch(SubChunk subChunk, ref int addedCount, ref int removedCount, ref bool wereSelectedLines)
+            {
+                return subChunk.ToResetUnstagedLinesPatch(ref addedCount, ref removedCount, ref wereSelectedLines);
+            }
 
-            return ToPatch(subChunkToPatch);
+            return ToPatch(SubChunkToPatch);
         }
 
         public string ToStagePatch(bool staged, bool isWholeFile)
         {
-            SubChunkToPatchFnc subChunkToPatch = (SubChunk subChunk, ref int addedCount, ref int removedCount, ref bool wereSelectedLines) =>
+            string SubChunkToPatch(SubChunk subChunk, ref int addedCount, ref int removedCount, ref bool wereSelectedLines)
             {
                 return subChunk.ToStagePatch(ref addedCount, ref removedCount, ref wereSelectedLines, staged, isWholeFile);
-            };
+            }
 
-            return ToPatch(subChunkToPatch);
+            return ToPatch(SubChunkToPatch);
         }
 
         protected string ToPatch(SubChunkToPatchFnc subChunkToPatch)

--- a/GitCommands/Remote/GitRemoteManager.cs
+++ b/GitCommands/Remote/GitRemoteManager.cs
@@ -111,16 +111,16 @@ namespace GitCommands.Remote
                 throw new ArgumentNullException("remote");
             }
 
-            Func<string, string, bool> isSettingForBranch = (setting, branchName) =>
+            bool IsSettingForBranch(string setting, string branchName)
             {
                 var head = new GitRef(_module, string.Empty, setting);
                 return head.IsHead && head.Name.Equals(branchName, StringComparison.OrdinalIgnoreCase);
-            };
+            }
 
             var remoteHead = remote.Push
                                    .Select(s => s.Split(':'))
                                    .Where(t => t.Length == 2)
-                                   .Where(t => isSettingForBranch(t[0], branch))
+                                   .Where(t => IsSettingForBranch(t[0], branch))
                                    .Select(t => new GitRef(_module, string.Empty, t[1]))
                                    .FirstOrDefault(h => h.IsHead);
 

--- a/GitCommands/Repository/RecentRepoInfo.cs
+++ b/GitCommands/Repository/RecentRepoInfo.cs
@@ -115,7 +115,7 @@ namespace GitCommands.Repository
                 }
             }
 
-            Action<bool, List<RecentRepoInfo>> addSortedRepos = delegate(bool mostRecent, List<RecentRepoInfo> addToList)
+            void AddSortedRepos(bool mostRecent, List<RecentRepoInfo> addToList)
             {
                 foreach (string caption in orderedRepos.Keys)
                 {
@@ -124,23 +124,23 @@ namespace GitCommands.Repository
                         if (repo.MostRecent == mostRecent)
                             addToList.Add(repo);
                 }
-            };
+            }
 
-            Action<List<RecentRepoInfo>, List<RecentRepoInfo>> addNotSortedRepos = delegate(List<RecentRepoInfo> list, List<RecentRepoInfo> addToList)
+            void AddNotSortedRepos(List<RecentRepoInfo> list, List<RecentRepoInfo> addToList)
             {
                 foreach (RecentRepoInfo repo in list)
                     addToList.Add(repo);
-            };
+            }
 
             if (SortMostRecentRepos)
-                addSortedRepos(true, mostRecentRepoList);
+                AddSortedRepos(true, mostRecentRepoList);
             else
-                addNotSortedRepos(mostRecentRepos, mostRecentRepoList);
+                AddNotSortedRepos(mostRecentRepos, mostRecentRepoList);
 
             if (SortLessRecentRepos)
-                addSortedRepos(false, lessRecentRepoList);
+                AddSortedRepos(false, lessRecentRepoList);
             else
-                addNotSortedRepos(lessRecentRepos, lessRecentRepoList);
+                AddNotSortedRepos(lessRecentRepos, lessRecentRepoList);
         }
 
         private void AddToOrderedSignDir(SortedList<string, List<RecentRepoInfo>> orderedRepos, RecentRepoInfo repoInfo, bool shortenPath)
@@ -249,7 +249,7 @@ namespace GitCommands.Repository
                         root = dirInfo.Parent.Name;
                 }
 
-                Func<int, bool> shortenPathWithCompany = delegate(int skipCount)
+                bool ShortenPathWithCompany(int skipCount)
                 {
                     bool result = false;
                     string c = null;
@@ -280,17 +280,16 @@ namespace GitCommands.Repository
                     repoInfo.Caption = MakePath(repoInfo.Caption, workingDir);
 
                     return result && addDots;
-                };
+                }
 
 
-                Func<int, bool> shortenPath = delegate(int skipCount)
+                bool ShortenPath(int skipCount)
                 {
                     string path = repoInfo.Repo.Path;
                     string fistDir = (root ?? company) ?? repository;
                     string lastDir = workingDir;
                     if (fistDir != null && path.Length - lastDir.Length - fistDir.Length - skipCount > 0)
                     {
-
                         int middle = (path.Length - lastDir.Length) / 2 + (path.Length - lastDir.Length) % 2;
                         int leftEnd = middle - skipCount / 2;
                         int rightStart = middle + skipCount / 2 + skipCount % 2;
@@ -303,14 +302,14 @@ namespace GitCommands.Repository
                     }
 
                     return false;
-                };
+                }
 
                 //if fixed width is not set then short as in pull request vccp's example
                 //full "E:\CompanyName\Projects\git\ProductName\Sources\RepositoryName\WorkingDirName"
                 //short "E:\CompanyName\...\RepositoryName\WorkingDirName"
                 if (this.RecentReposComboMinWidth == 0)
                 {
-                    shortenPathWithCompany(0);
+                    ShortenPathWithCompany(0);
                 }
                 //else skip symbols beginning from the middle to both sides,
                 //so we'll see "E:\Compa...toryName\WorkingDirName" and "E:\...\WorkingDirName" at the end.
@@ -321,7 +320,7 @@ namespace GitCommands.Repository
                     int skipCount = 0;
                     do
                     {
-                        canShorten = shortenPath(skipCount);
+                        canShorten = ShortenPath(skipCount);
                         skipCount++;
                         captionSize = Graphics.MeasureString(repoInfo.Caption, MeasureFont);
                     }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1581,21 +1581,22 @@ namespace GitCommands
 
         private static void LoadEncodings()
         {
-            Action<Encoding> addEncoding = delegate (Encoding e) { AvailableEncodings[e.HeaderName] = e; };
-            Action<string> addEncodingByName = delegate (string s) { try { addEncoding(Encoding.GetEncoding(s)); } catch { } };
+            void AddEncoding(Encoding e) { AvailableEncodings[e.HeaderName] = e; }
+
+            void AddEncodingByName(string s) { try { AddEncoding(Encoding.GetEncoding(s)); } catch { } }
 
             string availableEncodings = GetString("AvailableEncodings", "");
             if (string.IsNullOrWhiteSpace(availableEncodings))
             {
                 // Default encoding set
-                addEncoding(Encoding.Default);
-                addEncoding(new ASCIIEncoding());
-                addEncoding(new UnicodeEncoding());
-                addEncoding(new UTF7Encoding());
-                addEncoding(new UTF8Encoding(false));
+                AddEncoding(Encoding.Default);
+                AddEncoding(new ASCIIEncoding());
+                AddEncoding(new UnicodeEncoding());
+                AddEncoding(new UTF7Encoding());
+                AddEncoding(new UTF8Encoding(false));
                 try
                 {
-                    addEncoding(Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
+                    AddEncoding(Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
                 }
                 catch
                 {
@@ -1609,13 +1610,13 @@ namespace GitCommands
                 {
                     // create utf-8 without BOM
                     if (encodingName == utf8.HeaderName)
-                        addEncoding(utf8);
+                        AddEncoding(utf8);
                     // default encoding
                     else if (encodingName == "Default")
-                        addEncoding(Encoding.Default);
+                        AddEncoding(Encoding.Default);
                     // add encoding by name
                     else
-                        addEncodingByName(encodingName);
+                        AddEncodingByName(encodingName);
                 }
             }
         }

--- a/ResourceManager/Xliff/TranslationUtl.cs
+++ b/ResourceManager/Xliff/TranslationUtl.cs
@@ -155,9 +155,9 @@ namespace ResourceManager.Xliff
                             var listValue = list[index] as string;
                             if (listValue != null)
                             {
-                                Func<string> provideDefaultValue = () => listValue;
+                                string ProvideDefaultValue() => listValue;
                                 string value = translation.TranslateItem(category, itemName, propertyName,
-                                    provideDefaultValue);
+                                    ProvideDefaultValue);
 
                                 if (!string.IsNullOrEmpty(value))
                                 {
@@ -168,8 +168,8 @@ namespace ResourceManager.Xliff
                     }
                     else if (property.PropertyType.IsEquivalentTo(typeof(string)))
                     {
-                        Func<string> provideDefaultValue = () => (string)property.GetValue(itemObj, null);
-                        string value = translation.TranslateItem(category, itemName, propertyName, provideDefaultValue);
+                        string ProvideDefaultValue() => (string)property.GetValue(itemObj, null);
+                        string value = translation.TranslateItem(category, itemName, propertyName, ProvideDefaultValue);
 
                         if (!string.IsNullOrEmpty(value))
                         {
@@ -179,7 +179,7 @@ namespace ResourceManager.Xliff
                         else if (property.Name == "ToolTipText" &&
                                  !string.IsNullOrEmpty((string)property.GetValue(itemObj, null)))
                         {
-                            value = translation.TranslateItem(category, itemName, "Text", provideDefaultValue);
+                            value = translation.TranslateItem(category, itemName, "Text", ProvideDefaultValue);
                             if (!string.IsNullOrEmpty(value))
                             {
                                 if (property.CanWrite)
@@ -204,8 +204,8 @@ namespace ResourceManager.Xliff
                 return;
             }
 
-            Func<string> provideDefaultValue = () => "";
-            string value = translation.TranslateItem(category, propName, "Text", provideDefaultValue);
+            string ProvideDefaultValue() => "";
+            string value = translation.TranslateItem(category, propName, "Text", ProvideDefaultValue);
             if (!String.IsNullOrEmpty(value))
             {
                 if (propertyInfo.CanWrite)

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -198,7 +198,7 @@ namespace GitCommandsTests.Remote
 
             _controller.SaveRemote(remote, remote.Name, remoteUrl, remotePushUrl, remotePuttySshKey);
 
-            Action<string, string> ensure = (setting, value) =>
+            void Ensure(string setting, string value)
             {
                 setting = string.Format(setting, remote.Name);
                 if (!string.IsNullOrWhiteSpace(value))
@@ -209,10 +209,11 @@ namespace GitCommandsTests.Remote
                 {
                     _module.Received(1).UnsetSetting(setting);
                 }
-            };
-            ensure(SettingKeyString.RemoteUrl, remoteUrl);
-            ensure(SettingKeyString.RemotePushUrl, remotePushUrl);
-            ensure(SettingKeyString.RemotePuttySshKey, remotePuttySshKey);
+            }
+
+            Ensure(SettingKeyString.RemoteUrl, remoteUrl);
+            Ensure(SettingKeyString.RemotePushUrl, remotePushUrl);
+            Ensure(SettingKeyString.RemotePuttySshKey, remotePuttySshKey);
         }
 
         [Test]


### PR DESCRIPTION
Local functions offer some performance benefits, as well as looking a bit nicer (see the example in `GitCommandHelper.cs` where the `null` assignment can be removed in favour of a single declaration).

The main performance improvement is the compiler's ability to avoid heap allocation when closing over state.

For more information, see https://stackoverflow.com/a/40949214/24874

Has been tested on:
 - GIT 2.16
 - Windows 10
