### PR TITLE
More async

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -105,9 +105,8 @@ namespace GitCommands
                 return UserHomeDir;
 
             if (EnvUtils.RunningOnWindows())
-            {
                 return WindowsDefaultHomeDir;
-            }
+
             return Environment.GetFolderPath(Environment.SpecialFolder.Personal);
         }
 
@@ -115,13 +114,10 @@ namespace GitCommands
         {
             get
             {
-                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HOMEDRIVE")))
-                {
-                    string homePath = Environment.GetEnvironmentVariable("HOMEDRIVE");
-                    homePath += Environment.GetEnvironmentVariable("HOMEPATH");
-                    return homePath;
-                }
-                return Environment.GetEnvironmentVariable("USERPROFILE");
+                var homeDrive = Environment.GetEnvironmentVariable("HOMEDRIVE");
+                return !string.IsNullOrEmpty(homeDrive)
+                    ? homeDrive + Environment.GetEnvironmentVariable("HOMEPATH")
+                    : Environment.GetEnvironmentVariable("USERPROFILE");
             }
         }
 

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -944,6 +944,7 @@ namespace GitCommands
         }
 
         [CanBeNull]
+        [Obsolete]
         public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string fileName, string oldFileName, bool staged)
         {
             PatchApply.Patch patch = module.GetCurrentChanges(fileName, oldFileName, staged, "", module.FilesEncoding);
@@ -952,9 +953,24 @@ namespace GitCommands
         }
 
         [CanBeNull]
+        public static async Task<GitSubmoduleStatus> GetCurrentSubmoduleChangesAsync(GitModule module, string fileName, string oldFileName, bool staged)
+        {
+            PatchApply.Patch patch = module.GetCurrentChanges(fileName, oldFileName, staged, "", await module.FilesEncodingTask.Value);
+            string text = patch != null ? patch.Text : "";
+            return GetSubmoduleStatus(text, module, fileName);
+        }
+
+        [CanBeNull]
+        [Obsolete]
         public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string submodule)
         {
             return GetCurrentSubmoduleChanges(module, submodule, submodule, false);
+        }
+
+        [CanBeNull]
+        public static Task<GitSubmoduleStatus> GetCurrentSubmoduleChangesAsync(GitModule module, string submodule)
+        {
+            return GetCurrentSubmoduleChangesAsync(module, submodule, submodule, false);
         }
 
         public static GitSubmoduleStatus GetSubmoduleStatus(string text, GitModule module, string fileName)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3181,6 +3181,7 @@ namespace GitCommands
             return tree.Split(new char[] { '\0', '\n' });
         }
 
+        [Obsolete]
         public IEnumerable<IGitItem> GetTree(string id, bool full)
         {
             string args = "-z";

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -45,7 +45,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1573</NoWarn>
+    <NoWarn>1573;0612</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -73,6 +73,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -15,7 +15,7 @@ namespace GitCommands
         /// </summary>
         /// <param name="item"></param>
         /// <returns>The item's children.</returns>
-        Task<IEnumerable<IGitItem>> LoadChildren(IGitItem item);
+        Task<IEnumerable<IGitItem>> LoadChildrenAsync(IGitItem item);
     }
 
     public sealed class GitRevisionInfoProvider : IGitRevisionInfoProvider
@@ -34,7 +34,7 @@ namespace GitCommands
         /// <returns>The item's children.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="item"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><see cref="IGitItem.Guid"/> is not supplied.</exception>
-        public async Task<IEnumerable<IGitItem>> LoadChildren(IGitItem item)
+        public async Task<IEnumerable<IGitItem>> LoadChildrenAsync(IGitItem item)
         {
             if (item == null)
             {

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using GitCommands.Git;
 using GitUIPluginInterfaces;
+using System.Threading.Tasks;
 
 namespace GitCommands
 {
@@ -14,7 +15,7 @@ namespace GitCommands
         /// </summary>
         /// <param name="item"></param>
         /// <returns>The item's children.</returns>
-        IEnumerable<IGitItem> LoadChildren(IGitItem item);
+        Task<IEnumerable<IGitItem>> LoadChildren(IGitItem item);
     }
 
     public sealed class GitRevisionInfoProvider : IGitRevisionInfoProvider
@@ -33,7 +34,7 @@ namespace GitCommands
         /// <returns>The item's children.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="item"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><see cref="IGitItem.Guid"/> is not supplied.</exception>
-        public IEnumerable<IGitItem> LoadChildren(IGitItem item)
+        public async Task<IEnumerable<IGitItem>> LoadChildren(IGitItem item)
         {
             if (item == null)
             {
@@ -49,7 +50,7 @@ namespace GitCommands
                 throw new ArgumentException($"Require a valid instance of {nameof(IGitModule)}");
             }
 
-            var subItems = module.GetTree(item.Guid, false).ToList();
+            var subItems = (await module.GetTreeAsync(item.Guid, false)).ToList();
             foreach (var subItem in subItems.OfType<GitItem>())
             {
                 subItem.FileName = Path.Combine((item as GitItem)?.FileName ?? string.Empty, subItem.FileName ?? string.Empty);

--- a/GitCommands/Remote/GitRemote.cs
+++ b/GitCommands/Remote/GitRemote.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using GitCommands.Config;
 
 namespace GitCommands.Remote
 {

--- a/GitCommands/SynchronizedProcessReader.cs
+++ b/GitCommands/SynchronizedProcessReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -67,6 +68,7 @@ namespace GitCommands
         /// <para />
         /// To use the process's default encoding, use <see cref="Read"/> instead.
         /// </remarks>
+        [Obsolete("Use non-blocking, async version instead")]
         public static void ReadBytes(Process process, out byte[] stdOutput, out byte[] stdError)
         {
             var stdOutTask = Task.Run(async () => await process.StandardOutput.BaseStream.ReadToEndAsync());
@@ -74,6 +76,30 @@ namespace GitCommands
 
             stdOutput = stdOutTask.GetAwaiter().GetResult();
             stdError = stdErrTask.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Asynchronously reads <see cref="System.Diagnostics.Process.StandardOutput"/> and
+        /// <see cref="System.Diagnostics.Process.StandardError"/> of <paramref name="process"/>, returning them
+        /// as byte arrays.
+        /// </summary>
+        /// <remarks>
+        /// As this method returns byte data, it may later be interpreted using whatever <see cref="Encoding"/>
+        /// is required.
+        /// <para />
+        /// To use the process's default encoding, use <see cref="Read"/> instead.
+        /// </remarks>
+        public static async Task<(byte[] stdOut, byte[] stdError)> ReadBytesAsync(Process process)
+        {
+            // Read both streams concurrently
+            var stdOutTask = process.StandardOutput.BaseStream.ReadToEndAsync();
+            var stdErrTask = process.StandardError.BaseStream.ReadToEndAsync();
+
+            // Await the stream output as a byte array
+            var stdOut = await stdOutTask;
+            var stdErr = await stdErrTask;
+
+            return (stdOut, stdErr);
         }
     }
 

--- a/GitCommands/SynchronizedProcessReader.cs
+++ b/GitCommands/SynchronizedProcessReader.cs
@@ -22,10 +22,17 @@ namespace GitCommands
             stdErrReadTask = Task.Run(async () => Error = await process.StandardError.BaseStream.ReadToEndAsync());
         }
 
+        [Obsolete]
         public void WaitForExit()
         {
             stdOutReadTask.Wait();
             stdErrReadTask.Wait();
+            Process.WaitForExit();
+        }
+
+        public async Task WaitForExitAsync()
+        {
+            await Task.WhenAll(stdOutReadTask, stdErrReadTask);
             Process.WaitForExit();
         }
 
@@ -49,6 +56,7 @@ namespace GitCommands
         /// <para />
         /// If raw byte streams are required, use <see cref="ReadBytes"/> instead.
         /// </remarks>
+        [Obsolete]
         public static void Read(Process process, out string stdOutput, out string stdError)
         {
             var stdOutTask = Task.Run(async () => await process.StandardOutput.ReadToEndAsync());
@@ -108,11 +116,9 @@ namespace GitCommands
         public static async Task<byte[]> ReadToEndAsync(this Stream stream)
         {
             if (!stream.CanRead)
-            {
                 return null;
-            }
 
-            using (MemoryStream memStream = new MemoryStream())
+            using (var memStream = new MemoryStream())
             {
                 await stream.CopyToAsync(memStream);
                 return memStream.ToArray();

--- a/GitCommands/packages.config
+++ b/GitCommands/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="SmartFormat.NET" version="2.0.0.0" targetFramework="net461" />
   <package id="System.IO.Abstractions" version="2.0.0.144" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -126,7 +126,7 @@ See the changes in the commit form.");
             findToolStripMenuItem_Click(null, null);
         }
 
-        public void LoadRevision(GitRevision revision)
+        public async void LoadRevision(GitRevision revision)
         {
             _revision = revision;
             _revisionFileTreeController.ResetCache();
@@ -152,7 +152,7 @@ See the changes in the commit form.");
                 //restore selected file and scroll position when new selection is done
                 if (_revision != null)
                 {
-                    _revisionFileTreeController.LoadChildren(_revision, tvGitTree.Nodes, tvGitTree.ImageList.Images);
+                    await _revisionFileTreeController.LoadChildren(_revision, tvGitTree.Nodes, tvGitTree.ImageList.Images);
                     //GitTree.Sort();
                     TreeNode lastMatchedNode = null;
                     // Load state

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -631,18 +631,20 @@ See the changes in the commit form.");
 
         private void assumeUnchangedToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            var itemStatus = new GitItemStatus
+            {
+                Name = GetSelectedFile()
+            };
 
-            bool wereErrors;
-            var itemStatus = new GitItemStatus();
-            itemStatus.Name = GetSelectedFile();
             if (itemStatus.Name == null)
                 return;
+
             var answer = MessageBox.Show(_assumeUnchangedMessage.Text, _assumeUnchangedCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (answer == DialogResult.No)
                 return;
 
-            Module.AssumeUnchangedFiles(new List<GitItemStatus> { itemStatus }, true, out wereErrors);
+            Module.AssumeUnchangedFiles(new List<GitItemStatus> { itemStatus }, true, out var wereErrors);
 
             if (wereErrors)
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -88,7 +88,7 @@ namespace GitUI.CommandsDialogs
         /// <remarks>The method DOES NOT check any input parameters for performance reasons.</remarks>
         public async Task LoadChildren(IGitItem item, TreeNodeCollection nodes, ImageList.ImageCollection imageCollection)
         {
-            var childrenItems = _cachedItems.GetOrAdd(item.Guid, await _revisionInfoProvider.LoadChildren(item));
+            var childrenItems = _cachedItems.GetOrAdd(item.Guid, await _revisionInfoProvider.LoadChildrenAsync(item));
             if (childrenItems == null)
             {
                 return;

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -8,6 +8,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUIPluginInterfaces;
+using System.Threading.Tasks;
 
 namespace GitUI.CommandsDialogs
 {
@@ -28,7 +29,7 @@ namespace GitUI.CommandsDialogs
         /// <param name="item"></param>
         /// <param name="nodes"></param>
         /// <param name="imageCollection"></param>
-        void LoadChildren(IGitItem item, TreeNodeCollection nodes, ImageList.ImageCollection imageCollection);
+        Task LoadChildren(IGitItem item, TreeNodeCollection nodes, ImageList.ImageCollection imageCollection);
 
         /// <summary>
         /// Clears the cache of the current revision's loaded children items.
@@ -85,9 +86,9 @@ namespace GitUI.CommandsDialogs
         /// <param name="nodes"></param>
         /// <param name="imageCollection"></param>
         /// <remarks>The method DOES NOT check any input parameters for performance reasons.</remarks>
-        public void LoadChildren(IGitItem item, TreeNodeCollection nodes, ImageList.ImageCollection imageCollection)
+        public async Task LoadChildren(IGitItem item, TreeNodeCollection nodes, ImageList.ImageCollection imageCollection)
         {
-            var childrenItems = _cachedItems.GetOrAdd(item.Guid, _revisionInfoProvider.LoadChildren(item));
+            var childrenItems = _cachedItems.GetOrAdd(item.Guid, await _revisionInfoProvider.LoadChildren(item));
             if (childrenItems == null)
             {
                 return;

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -75,7 +75,7 @@ namespace GitUI
             {
                 Task.Run(async () =>
                 {
-                    var branches = await GetBranchAndTagRefs(local, tag, remote);
+                    var branches = await GetBranchAndTagRefsAsync(local, tag, remote);
 
                     foreach (var branch in branches)
                         _NO_TRANSLATE_toolStripBranches.Items.Add(branch);
@@ -118,7 +118,7 @@ namespace GitUI
             return Module.GetRefs(true, false).Select(tag => tag.Name);
         }
 
-        private async Task<List<string>> GetBranchAndTagRefs(bool local, bool tag, bool remote)
+        private async Task<List<string>> GetBranchAndTagRefsAsync(bool local, bool tag, bool remote)
         {
             var list = await GetBranchHeadsAsync(local, remote);
             if (tag)
@@ -169,7 +169,7 @@ namespace GitUI
         private async Task UpdateBranchFilterItemsAsync()
         {
             string filter = _NO_TRANSLATE_toolStripBranches.Items.Count > 0 ? _NO_TRANSLATE_toolStripBranches.Text : string.Empty;
-            var branches = await GetBranchAndTagRefs(localToolStripMenuItem.Checked, tagsToolStripMenuItem.Checked, remoteToolStripMenuItem.Checked);
+            var branches = await GetBranchAndTagRefsAsync(localToolStripMenuItem.Checked, tagsToolStripMenuItem.Checked, remoteToolStripMenuItem.Checked);
             var matches = branches.Where(branch => branch.IndexOf(filter, StringComparison.InvariantCultureIgnoreCase) >= 0).ToArray();
 
             var index = _NO_TRANSLATE_toolStripBranches.SelectionStart;

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -113,16 +113,16 @@ namespace GitUI
             return list;
         }
 
-        private IEnumerable<string> GetTagsRefs()
+        private async Task<IEnumerable<string>> GetTagsRefsAsync()
         {
-            return Module.GetRefs(true, false).Select(tag => tag.Name);
+            return (await Module.GetRefsAsync(true, false)).Select(tag => tag.Name);
         }
 
         private async Task<List<string>> GetBranchAndTagRefsAsync(bool local, bool tag, bool remote)
         {
             var list = await GetBranchHeadsAsync(local, remote);
             if (tag)
-                list.AddRange(GetTagsRefs());
+                list.AddRange(await GetTagsRefsAsync());
             return list;
         }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -45,7 +45,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>1573</NoWarn>
+    <NoWarn>1573;0612</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -402,8 +402,6 @@ namespace TeamCityIntegration
                     UpdateHttpClientOptionsNtlmAuth(buildServerCredentials);
                     return GetStreamAsync (restServicePath, cancellationToken);
                 }
-
-                throw new OperationCanceledException(task.Result.ReasonPhrase);
             }
 
             throw new HttpRequestException(task.Result.ReasonPhrase);
@@ -425,7 +423,6 @@ namespace TeamCityIntegration
                 Console.WriteLine(exception);
                 throw;
             }
-
         }
 
         public void UpdateHttpClientOptionsGuestAuth()

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/app.config
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/app.config
@@ -34,6 +34,10 @@
         <assemblyIdentity name="Microsoft.VisualStudio.Services.WebApi" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.serviceModel>

--- a/Plugins/Gerrit/Gerrit.csproj
+++ b/Plugins/Gerrit/Gerrit.csproj
@@ -25,6 +25,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>0612</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Plugins/Gerrit/app.config
+++ b/Plugins/Gerrit/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/Plugins/GitUIPluginInterfaces/GitCmdResult.cs
+++ b/Plugins/GitUIPluginInterfaces/GitCmdResult.cs
@@ -8,25 +8,22 @@ namespace GitUIPluginInterfaces
         public string StdError;
         public int ExitCode;
 
-        public bool ExitedSuccessfully
-        {
-            get
-            {
-                return ExitCode == 0;
-            }
-        }
+        public bool ExitedSuccessfully => ExitCode == 0;
 
         public string GetString()
         {
-            StringBuilder sb = new StringBuilder();
-            if (this.StdOutput != null && this.StdOutput.Length > 0)
-                sb.Append(this.StdOutput);
-            if (this.StdError != null && this.StdError.Length > 0 && this.StdOutput != null && this.StdOutput.Length > 0)
+            var hasOut = !string.IsNullOrEmpty(StdOutput);
+            var hasErr = !string.IsNullOrEmpty(StdError);
+
+            var sb = new StringBuilder();
+            if (hasOut)
+                sb.Append(StdOutput);
+            if (hasErr && hasOut)
                 sb.AppendLine();
-            if (this.StdError != null && this.StdError.Length > 0)
-                sb.Append(this.StdError);
+            if (hasErr)
+                sb.Append(StdError);
+
             return sb.ToString();
         }
-
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -14,6 +14,7 @@ namespace GitUIPluginInterfaces
         string AddRemote(string remoteName, string path);
         IList<IGitRef> GetRefs(bool tags = true, bool branches = true);
         IEnumerable<string> GetSettings(string setting);
+        [Obsolete]
         IEnumerable<IGitItem> GetTree(string id, bool full);
         Task<IEnumerable<IGitItem>> GetTreeAsync(string id, bool full);
 
@@ -40,6 +41,7 @@ namespace GitUIPluginInterfaces
         /// <summary>
         /// Run git command, console window is hidden, wait for exit, redirect output
         /// </summary>
+        [Obsolete]
         string RunGitCmd(string arguments, Encoding encoding = null, byte[] stdInput = null);
         Task<string> RunGitCmdAsync(string arguments, Encoding encoding = null, byte[] stdInput = null);
 

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -15,6 +15,7 @@ namespace GitUIPluginInterfaces
         IList<IGitRef> GetRefs(bool tags = true, bool branches = true);
         IEnumerable<string> GetSettings(string setting);
         IEnumerable<IGitItem> GetTree(string id, bool full);
+        Task<IEnumerable<IGitItem>> GetTreeAsync(string id, bool full);
 
         /// <summary>
         /// Removes the registered remote by running <c>git remote rm</c> command.

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace GitUIPluginInterfaces
 {
@@ -39,6 +40,7 @@ namespace GitUIPluginInterfaces
         /// Run git command, console window is hidden, wait for exit, redirect output
         /// </summary>
         string RunGitCmd(string arguments, Encoding encoding = null, byte[] stdInput = null);
+        Task<string> RunGitCmdAsync(string arguments, Encoding encoding = null, byte[] stdInput = null);
 
         /// <summary>
         /// Run git command, console window is hidden, wait for exit, redirect output
@@ -55,7 +57,7 @@ namespace GitUIPluginInterfaces
         /// </summary>
         CmdResult RunCmdResult(string cmd, string arguments, Encoding encoding = null, byte[] stdInput = null);
 
-        string RunBatchFile(string batchFile);
+//        string RunBatchFile(string batchFile);
 
         /// <summary>
         /// Determines whether the given repository has index.lock file.

--- a/Plugins/GitUIPluginInterfaces/ISetting.cs
+++ b/Plugins/GitUIPluginInterfaces/ISetting.cs
@@ -41,15 +41,16 @@ namespace GitUIPluginInterfaces
         /// Saves value from Control to settings
         /// </summary>
         /// <param name="settings"></param>
+        /// <param name="areSettingsEffective"></param>
         void SaveSetting(ISettingsSource settings, bool areSettingsEffective);
 
         /// <summary>
-        /// returns caption assotiated with this control or null if the control layouts
+        /// returns caption associated with this control or null if the control layouts
         /// the caption by itself
         /// </summary>
         string Caption();
 
-        ISetting GetSetting();        
+        ISetting GetSetting();
     }
 
     public abstract class SettingControlBinding<S, T> : ISettingControlBinding where T : Control where S : ISetting
@@ -88,6 +89,7 @@ namespace GitUIPluginInterfaces
         /// Saves value from Control to settings
         /// </summary>
         /// <param name="settings"></param>
+        /// <param name="areSettingsEffective"></param>
         public void SaveSetting(ISettingsSource settings, bool areSettingsEffective)
         {
             SaveSetting(settings, areSettingsEffective, Control);

--- a/Plugins/JiraCommitHintPlugin/app.config
+++ b/Plugins/JiraCommitHintPlugin/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/ResourceManager/ResourceManager.csproj
+++ b/ResourceManager/ResourceManager.csproj
@@ -65,6 +65,9 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/ResourceManager/packages.config
+++ b/ResourceManager/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="SmartFormat.NET" version="2.0.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/TranslationApp/app.config
+++ b/TranslationApp/app.config
@@ -17,6 +17,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <connectionStrings></connectionStrings>

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -41,7 +41,7 @@ namespace CommonTestUtils
 
 
         /// <summary>
-        /// Creates a new file, writes the specified string to the file, and then closes the file. 
+        /// Creates a new file, writes the specified string to the file, and then closes the file.
         /// If the target file already exists, it is overwritten.
         /// </summary>
         /// <returns>The path to the newly created file.</returns>
@@ -60,8 +60,8 @@ namespace CommonTestUtils
         }
 
         /// <summary>
-        /// Creates a new file under the working folder to the specified directory, 
-        /// writes the specified string to the file and then closes the file. 
+        /// Creates a new file under the working folder to the specified directory,
+        /// writes the specified string to the file and then closes the file.
         /// If the target file already exists, it is overwritten.
         /// </summary>
         /// <returns>The path to the newly created file.</returns>
@@ -79,8 +79,8 @@ namespace CommonTestUtils
         }
 
         /// <summary>
-        /// Creates a new file to the root of the working folder, 
-        /// writes the specified string to the file and then closes the file. 
+        /// Creates a new file to the root of the working folder,
+        /// writes the specified string to the file and then closes the file.
         /// If the target file already exists, it is overwritten.
         /// </summary>
         /// <returns>The path to the newly created file.</returns>

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
@@ -15,7 +17,6 @@ namespace GitCommandsTests
         private IGitModule _module;
         private GitRevisionInfoProvider _provider;
 
-
         [SetUp]
         public void Setup()
         {
@@ -26,7 +27,7 @@ namespace GitCommandsTests
         [Test]
         public void LoadChildren_should_throw_if_null()
         {
-            ((Action)(() => _provider.LoadChildren(null))).ShouldThrow<ArgumentNullException>();
+            Assert.ThrowsAsync<ArgumentNullException>(() => _provider.LoadChildren(null));
         }
 
         [TestCase(null)]
@@ -37,7 +38,7 @@ namespace GitCommandsTests
             var item = Substitute.For<IGitItem>();
             item.Guid.Returns(guid);
 
-            ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
+            Assert.ThrowsAsync<ArgumentException>(() => _provider.LoadChildren(item));
         }
 
         [Test]
@@ -49,40 +50,41 @@ namespace GitCommandsTests
 
             _provider = new GitRevisionInfoProvider(() => null);
 
-            ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
+            Assert.ThrowsAsync<ArgumentException>(() => _provider.LoadChildren(item));
         }
 
         [Test]
-        public void LoadChildren_should_return_shallow_tree_for_non_GitItem()
+        public async Task LoadChildren_should_return_shallow_tree_for_non_GitItem()
         {
             var guid = Guid.NewGuid().ToString("N");
             var item = Substitute.For<IGitItem>();
             item.Guid.Returns(guid);
 
             var items = new[] { Substitute.For<IGitItem>(), Substitute.For<IGitItem>(), Substitute.For<IGitItem>() };
-            _module.GetTree(guid, false).Returns(items);
 
-            var children = _provider.LoadChildren(item);
+            _module.GetTreeAsync(guid, false).Returns(items);
+
+            var children = await _provider.LoadChildren(item);
 
             children.Should().BeEquivalentTo(items);
-            _module.Received(1).GetTree(guid, false);
+            _module.Received(1).GetTreeAsync(guid, false);
         }
 
         [Test]
-        public void LoadChildren_should_return_shallow_tree_for_GitItem_with_updated_FileName()
+        public async Task LoadChildren_should_return_shallow_tree_for_GitItem_with_updated_FileName()
         {
-            var guid = Guid.NewGuid().ToString("N");
-            var item = new GitItem("", "", guid, "folder");
+            var item = new GitItem("", "", Guid.NewGuid().ToString("N"), "folder");
+            var expectedChildren = new[] { Substitute.For<IGitItem>(), new GitItem("", "", "", "file2"), new GitItem("", "", "", "file3") };
 
-            var items = new[] { Substitute.For<IGitItem>(), new GitItem("", "", "", "file2"), new GitItem("", "", "", "file3") };
-            _module.GetTree(guid, false).Returns(items);
+            _module.GetTreeAsync(item.Guid, full: false).Returns(expectedChildren);
 
-            var children = _provider.LoadChildren(item);
+            var children = await _provider.LoadChildren(item);
 
-            children.Should().BeEquivalentTo(items);
-            ((GitItem)items[1]).FileName.Should().Be(Path.Combine(item.FileName, "file2"));
-            ((GitItem)items[2]).FileName.Should().Be(Path.Combine(item.FileName, "file3"));
-            _module.Received(1).GetTree(guid, false);
+            children.Count().Should().Be(3);
+            children.Should().BeEquivalentTo(expectedChildren);
+            ((GitItem)expectedChildren[1]).FileName.Should().Be(Path.Combine(item.FileName, "file2"));
+            ((GitItem)expectedChildren[2]).FileName.Should().Be(Path.Combine(item.FileName, "file3"));
+            _module.Received(1).GetTreeAsync(item.Guid, false);
         }
     }
 }

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -27,7 +27,7 @@ namespace GitCommandsTests
         [Test]
         public void LoadChildren_should_throw_if_null()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _provider.LoadChildren(null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _provider.LoadChildrenAsync(null));
         }
 
         [TestCase(null)]
@@ -38,7 +38,7 @@ namespace GitCommandsTests
             var item = Substitute.For<IGitItem>();
             item.Guid.Returns(guid);
 
-            Assert.ThrowsAsync<ArgumentException>(() => _provider.LoadChildren(item));
+            Assert.ThrowsAsync<ArgumentException>(() => _provider.LoadChildrenAsync(item));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace GitCommandsTests
 
             _provider = new GitRevisionInfoProvider(() => null);
 
-            Assert.ThrowsAsync<ArgumentException>(() => _provider.LoadChildren(item));
+            Assert.ThrowsAsync<ArgumentException>(() => _provider.LoadChildrenAsync(item));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace GitCommandsTests
 
             _module.GetTreeAsync(guid, false).Returns(items);
 
-            var children = await _provider.LoadChildren(item);
+            var children = await _provider.LoadChildrenAsync(item);
 
             children.Should().BeEquivalentTo(items);
             _module.Received(1).GetTreeAsync(guid, false);
@@ -78,7 +78,7 @@ namespace GitCommandsTests
 
             _module.GetTreeAsync(item.Guid, full: false).Returns(expectedChildren);
 
-            var children = await _provider.LoadChildren(item);
+            var children = await _provider.LoadChildrenAsync(item);
 
             children.Count().Should().Be(3);
             children.Should().BeEquivalentTo(expectedChildren);

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -46,7 +46,7 @@ namespace GitUITests.CommandsDialogs
         public async Task LoadItemsInTreeView_should_not_add_nods_if_no_children()
         {
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(x => (IEnumerable<IGitItem>)null);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(x => (IEnumerable<IGitItem>)null);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -59,7 +59,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new IGitItem[] { new MockGitItem("file1"), new MockGitItem("file2") };
             var item = new MockGitItem("folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -79,7 +79,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new[] { CreateGitItem("file1", true, false, false), CreateGitItem("file2", true, false, false) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -99,7 +99,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new[] { CreateGitItem("file1", false, true, false), CreateGitItem("file2", false, true, false) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -119,7 +119,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new[] { CreateGitItem("file1", false, false, true), CreateGitItem("file2", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -136,7 +136,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new[] { CreateGitItem("file1.", false, false, true), CreateGitItem("file2", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -157,7 +157,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new[] { CreateGitItem("file1.foo", false, false, true), CreateGitItem("file2.txt", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
 
             await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
@@ -178,7 +178,7 @@ namespace GitUITests.CommandsDialogs
         {
             var items = new[] { CreateGitItem("file1.txt", false, false, true), CreateGitItem("file2.txt", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(items);
+            _revisionInfoProvider.LoadChildrenAsync(item).Returns(items);
             var image = Resources.cow_head;
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(image);
 

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using FluentAssertions;
 using GitCommands;
@@ -42,25 +43,25 @@ namespace GitUITests.CommandsDialogs
 
 
         [Test]
-        public void LoadItemsInTreeView_should_not_add_nods_if_no_children()
+        public async Task LoadItemsInTreeView_should_not_add_nods_if_no_children()
         {
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
-            _revisionInfoProvider.LoadChildren(item).Returns(x =>null);
+            _revisionInfoProvider.LoadChildren(item).Returns(x => (IEnumerable<IGitItem>)null);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(0);
             _imageList.Images.Count.Should().Be(0);
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_add_all_none_GitItem_items_with_1st_level_nodes()
+        public async Task LoadItemsInTreeView_should_add_all_none_GitItem_items_with_1st_level_nodes()
         {
             var items = new IGitItem[] { new MockGitItem("file1"), new MockGitItem("file2") };
             var item = new MockGitItem("folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -74,13 +75,13 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_add_IsTree_as_folders()
+        public async Task LoadItemsInTreeView_should_add_IsTree_as_folders()
         {
             var items = new[] { CreateGitItem("file1", true, false, false), CreateGitItem("file2", true, false, false) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -94,13 +95,13 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_add_IsCommit_as_submodue()
+        public async Task LoadItemsInTreeView_should_add_IsCommit_as_submodule()
         {
             var items = new[] { CreateGitItem("file1", false, true, false), CreateGitItem("file2", false, true, false) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -114,13 +115,13 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_add_IsBlob_as_file()
+        public async Task LoadItemsInTreeView_should_add_IsBlob_as_file()
         {
             var items = new[] { CreateGitItem("file1", false, false, true), CreateGitItem("file2", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -131,13 +132,13 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_not_load_icons_for_file_without_extension()
+        public async Task LoadItemsInTreeView_should_not_load_icons_for_file_without_extension()
         {
             var items = new[] { CreateGitItem("file1.", false, false, true), CreateGitItem("file2", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -152,13 +153,13 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_not_add_icons_for_file_if_none_provided()
+        public async Task LoadItemsInTreeView_should_not_add_icons_for_file_if_none_provided()
         {
             var items = new[] { CreateGitItem("file1.foo", false, false, true), CreateGitItem("file2.txt", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -173,7 +174,7 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void LoadItemsInTreeView_should_add_icon_for_file_extension_only_once()
+        public async Task LoadItemsInTreeView_should_add_icon_for_file_extension_only_once()
         {
             var items = new[] { CreateGitItem("file1.txt", false, false, true), CreateGitItem("file2.txt", false, false, true) };
             var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
@@ -181,7 +182,7 @@ namespace GitUITests.CommandsDialogs
             var image = Resources.cow_head;
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(image);
 
-            _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
+            await _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
 
             _rootNode.Nodes.Count.Should().Be(items.Length);
             for (int i = 0; i < items.Length - 1; i++)
@@ -196,10 +197,9 @@ namespace GitUITests.CommandsDialogs
         }
 
 
-        private IGitItem CreateGitItem(string name, bool isTree, bool isCommit, bool isBlol)
+        private IGitItem CreateGitItem(string name, bool isTree, bool isCommit, bool isBlob)
         {
-            var item = new GitItem("", isTree ? "tree" : isBlol ? "blob" : isCommit ? "commit" : "", "", name);
-            return item;
+            return new GitItem("", isTree ? "tree" : isBlob ? "blob" : isCommit ? "commit" : "", "", name);
         }
 
         [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/UnitTests/GitUITests/UserControls/AuthorEmailBasedRevisionHighlightingFixture.cs
+++ b/UnitTests/GitUITests/UserControls/AuthorEmailBasedRevisionHighlightingFixture.cs
@@ -25,7 +25,7 @@ namespace GitUITests.UserControls
         [Test]
         public void When_multiple_revisions_selected_Then_ProcessSelectionChange_should_return_NoAction()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
 
             var action = sut.ProcessRevisionSelectionChange(currentModule,
@@ -41,7 +41,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_multiple_revisions_selected_Then_AuthorEmailToHighlight_should_not_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule,
                                                new[] {NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)});
@@ -59,29 +59,29 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_no_previously_selected_revision_When_single_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
 
             var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
-            
+
             action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
-        } 
+        }
 
         [Test]
         public void Given_no_previously_selected_revision_When_single_revision_selected_Then_AuthorEmailToHighlight_should_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
 
             sut.ProcessRevisionSelectionChange(currentModule, new[] {NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)});
 
-            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1); 
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1);
         }
 
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_ProcessSelectionChange_should_return_NoAction()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
 
@@ -93,7 +93,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_AuthorEmailToHighlight_should_not_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
 
@@ -105,7 +105,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
 
@@ -117,7 +117,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_AuthorEmailToHighlight_should_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
 
@@ -129,8 +129,8 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_no_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
-            var currentModule = NewModule(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
+            var currentModule = NewModule();
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
 
@@ -142,7 +142,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_no_revision_selected_Then_AuthorEmailToHighlight_should_be_value_of_current_user_email_setting()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });

--- a/UnitTests/GitUITests/app.config
+++ b/UnitTests/GitUITests/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Follows on from #4474.

Changes proposed in this pull request:
 - Make the methods that are blocking the threadpool async, to keep them free.

Has been tested on:
 - GIT 2.16
 - Windows 10

---
 
@jbialobr I went through that stack and made it async "all the way up". I did this for a few other common pathways, and I no longer see any freeze. Could you please build this `async` branch on your machine and see whether it works for you?

Approach:

- Find a stack that's commonly blocking a thread pool (worker) thread
- Find a the lowest-level sync method that should be made async
- Duplicate it, making the copy async
- Mark the original `[Obsolete]`
- Walk up the stack, making callers async using the same process described above

By leaving obsolete methods we are able to migrate code incrementally, yet not lose track of where we need to go back and tidy up. This approach could eventually convert the entire codebase to async.

Currently compiler warnings fail the build. I've had to exclude warning 0612 (use of obsolete member) from a few projects. We can revert this once migration is complete.

Of course this all depends upon how performance is. Please test this out, and take a look at the code. If it seems promising, I'll continue with it a bit more and report back.