### PR TITLE
Refactor GitRevision

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1154,7 +1154,7 @@ namespace GitCommands
             string cmd = "log -n1 --format=format:" + formatString + (shortFormat ? "%e%n%s" : messageFormat) + " " + commit;
             var revInfo = RunCacheableCmd(AppSettings.GitCommand, cmd, LosslessEncoding);
             string[] lines = revInfo.Split('\n');
-            var revision = new GitRevision(this, lines[0])
+            var revision = new GitRevision(lines[0])
             {
                 TreeGuid = lines[1],
                 ParentGuids = lines[2].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries),
@@ -2697,7 +2697,7 @@ namespace GitCommands
             {
                 sortedList = list.OrderBy(head =>
                 {
-                    var r = new GitRevision(this, head.Guid);
+                    var r = new GitRevision(head.Guid);
                     return r.CommitDate;
                 }).ToList();
             }
@@ -2705,7 +2705,7 @@ namespace GitCommands
             {
                 sortedList = list.OrderByDescending(head =>
                 {
-                    var r = new GitRevision(this, head.Guid);
+                    var r = new GitRevision(head.Guid);
                     return r.CommitDate;
                 }).ToList();
             }

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -23,15 +23,14 @@ namespace GitCommands
 
         public string[] ParentGuids;
         private readonly List<IGitRef> _refs = new List<IGitRef>();
-        public readonly GitModule Module;
         private BuildInfo _buildStatus;
 
-        public GitRevision(GitModule aModule, string guid)
+        public GitRevision(string guid)
         {
+            // TODO: this looks like an incorrect behaviour, rev.Guid must be validated and set to "" if null or empty.
             Guid = guid;
             Subject = "";
             SubjectCount = "";
-            Module = aModule;
         }
 
         public List<IGitRef> Refs { get { return _refs; } }
@@ -141,19 +140,6 @@ namespace GitCommands
             if (handler != null) handler(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        public static GitRevision CreateForShortSha1(GitModule aModule, string sha1)
-        {
-            if (!sha1.IsNullOrWhiteSpace() && sha1.Length < 40)
-            {
-                string fullSha1;
-                if (aModule.IsExistingCommitHash(sha1, out fullSha1))
-                {
-                    sha1 = fullSha1;
-                }
-            }
-
-            return new GitRevision(aModule, sha1);
-        }
 
         public static bool IsFullSha1Hash(string id)
         {

--- a/GitCommands/Git/GitRevisionProvider.cs
+++ b/GitCommands/Git/GitRevisionProvider.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using GitUIPluginInterfaces;
+
+namespace GitCommands.Git
+{
+    public interface IGitRevisionProvider
+    {
+        GitRevision Get(string sha1);
+    }
+
+    public sealed class GitRevisionProvider : IGitRevisionProvider
+    {
+        private readonly Func<IGitModule> _getModule;
+
+
+        public GitRevisionProvider(Func<IGitModule> getModule)
+        {
+            _getModule = getModule;
+        }
+
+
+        public GitRevision Get(string sha1)
+        {
+            if (sha1.IsNullOrWhiteSpace() || sha1.Length >= 40)
+            {
+                return new GitRevision(sha1);
+            }
+
+            var module = GetModule();
+            if (module.IsExistingCommitHash(sha1, out var fullSha1))
+            {
+                sha1 = fullSha1;
+            }
+
+            return new GitRevision(sha1);
+        }
+
+        private IGitModule GetModule()
+        {
+            var module = _getModule();
+            if (module == null)
+            {
+                throw new ArgumentException($"Require a valid instance of {nameof(IGitModule)}");
+            }
+            return module;
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Git\FileDeleteException.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />
     <Compile Include="Git\GitBranchNameOptions.cs" />
+    <Compile Include="Git\GitRevisionProvider.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDeleteRemoteBranchesCmd.cs" />

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -354,7 +354,7 @@ namespace GitCommands
                     Debug.Assert(lines.Length == 11);
                     Debug.Assert(lines[0] == CommitBegin);
 
-                    _revision = new GitRevision(_module, null);
+                    _revision = new GitRevision(null);
 
                     _revision.Guid = lines[1];
                     {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -207,13 +207,14 @@ namespace GitUI.CommandsDialogs
                         _toolStripGitStatus.Visible = false;
                         _toolStripGitStatus.Text = String.Empty;
                     }
-                    else if(status == GitStatusMonitorState.Running)
+                    else if (status == GitStatusMonitorState.Running)
                     {
                         _toolStripGitStatus.Visible = true;
                     }
                 };
 
-                _gitStatusMonitor.GitWorkingDirectoryStatusChanged += (s, e) => {
+                _gitStatusMonitor.GitWorkingDirectoryStatusChanged += (s, e) =>
+                {
                     var status = e.ItemStatuses.ToList();
                     _toolStripGitStatus.Image = commitIconProvider.GetCommitIcon(status);
 
@@ -316,7 +317,8 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public FormBrowse(GitUICommands aCommands, string filter, string selectCommit) : this(aCommands, filter)
+        public FormBrowse(GitUICommands aCommands, string filter, string selectCommit)
+            : this(aCommands, filter)
         {
             if (!string.IsNullOrEmpty(selectCommit))
             {
@@ -2017,7 +2019,7 @@ namespace GitUI.CommandsDialogs
             this.runMergetoolToolStripMenuItem.Enabled =
             this.cherryPickToolStripMenuItem.Enabled =
             this.checkoutToolStripMenuItem.Enabled =
-            this.toolStripMenuItemReflog.Enabled = 
+            this.toolStripMenuItemReflog.Enabled =
             this.bisectToolStripMenuItem.Enabled =
               enabled && !Module.IsBareRepository();
 

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -48,9 +48,9 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            _baseRevision = new GitRevision(Module, baseCommitSha);
-            _headRevision = new GitRevision(Module, headCommitSha);
-            _mergeBase = new GitRevision(Module, Module.GetMergeBase(_baseRevision.Guid, _headRevision.Guid));
+            _baseRevision = new GitRevision(baseCommitSha);
+            _headRevision = new GitRevision(headCommitSha);
+            _mergeBase = new GitRevision(Module.GetMergeBase(_baseRevision.Guid, _headRevision.Guid));
 
             lblBaseCommit.BackColor = AppSettings.DiffRemovedColor;
             lblHeadCommit.BackColor = AppSettings.DiffAddedColor;
@@ -98,7 +98,7 @@ namespace GitUI.CommandsDialogs
 
             IList<GitRevision> items = new List<GitRevision> { _headRevision, baseCommit };
             if (items.Count() == 1)
-                items.Add(new GitRevision(Module, DiffFiles.SelectedItemParent));
+                items.Add(new GitRevision(DiffFiles.SelectedItemParent));
             DiffText.ViewChanges(items, DiffFiles.SelectedItem, String.Empty);
         }
 
@@ -245,7 +245,7 @@ namespace GitUI.CommandsDialogs
                 if (form.ShowDialog(this) == DialogResult.OK)
                 {
                     displayStr = form.BranchName;
-                    revision = new GitRevision(Module, Module.RevParse(form.BranchName));
+                    revision = new GitRevision(Module.RevParse(form.BranchName));
                     PopulateDiffFiles();
                 }
             }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitCommands.Utils;
 using ResourceManager;
-using System.ComponentModel;
 
 namespace GitUI.CommandsDialogs
 {
@@ -19,6 +20,7 @@ namespace GitUI.CommandsDialogs
         private readonly AsyncLoader _asyncLoader;
         private readonly FormBrowseMenus _formBrowseMenus;
         private readonly IFullPathResolver _fullPathResolver;
+        private readonly IGitRevisionProvider _gitRevisionProvider;
 
         private readonly TranslationString _buildReportTabCaption =
             new TranslationString("Build Report");
@@ -56,6 +58,7 @@ namespace GitUI.CommandsDialogs
 
             _commitDataManager = new CommitDataManager(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
+            _gitRevisionProvider = new GitRevisionProvider(() => Module);
         }
 
         public FormFileHistory(GitUICommands aCommands, string fileName, GitRevision revision, bool filterByRevision)
@@ -480,14 +483,14 @@ namespace GitUI.CommandsDialogs
         {
             if (e.Command == "gotocommit")
             {
-                FileChanges.SetSelectedRevision(GitRevision.CreateForShortSha1(Module, e.Data));
+                FileChanges.SetSelectedRevision(_gitRevisionProvider.Get(e.Data));
             }
             else if (e.Command == "gotobranch" || e.Command == "gototag")
             {
                 string error = "";
                 CommitData commit = _commitDataManager.GetCommitData(e.Data, ref error);
                 if (commit != null)
-                    FileChanges.SetSelectedRevision(new GitRevision(Module, commit.Guid));
+                    FileChanges.SetSelectedRevision(new GitRevision(commit.Guid));
             }
             else if (e.Command == "navigatebackward")
             {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -39,9 +39,9 @@ namespace GitUI.CommandsDialogs
                 var imageList = new ImageList();
                 tabControl1.ImageList = imageList;
                 imageList.ColorDepth = ColorDepth.Depth8Bit;
-                imageList.Images.Add(global::GitUI.Properties.Resources.IconViewFile);
-                imageList.Images.Add(global::GitUI.Properties.Resources.IconDiff);
-                imageList.Images.Add(global::GitUI.Properties.Resources.IconBlame);
+                imageList.Images.Add(Properties.Resources.IconViewFile);
+                imageList.Images.Add(Properties.Resources.IconDiff);
+                imageList.Images.Add(Properties.Resources.IconBlame);
                 tabControl1.TabPages[0].ImageIndex = 0;
                 tabControl1.TabPages[1].ImageIndex = 1;
                 tabControl1.TabPages[2].ImageIndex = 2;
@@ -200,7 +200,7 @@ namespace GitUI.CommandsDialogs
                 // note: This implementation is quite a quick hack (by someone who does not speak C# fluently).
                 //
 
-                string arg = "log --format=\"%n\" --name-only --follow "+
+                string arg = "log --format=\"%n\" --name-only --follow " +
                     GitCommandHelpers.FindRenamesAndCopiesOpts()
                     + " -- \"" + fileName + "\"";
                 Process p = Module.RunGitCmdDetached(arg, GitModule.LosslessEncoding);
@@ -333,7 +333,7 @@ namespace GitUI.CommandsDialogs
             {
                 orgFileName = selectedRows[0].Name;
             }
-            FileChanges.OpenWithDifftool(FileName, orgFileName, GitUI.RevisionDiffKind.DiffAB);
+            FileChanges.OpenWithDifftool(FileName, orgFileName, RevisionDiffKind.DiffAB);
         }
 
         private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -459,7 +459,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffToolremotelocalStripMenuItem_Click(object sender, EventArgs e)
         {
-            FileChanges.OpenWithDifftool(FileName, string.Empty, GitUI.RevisionDiffKind.DiffBLocal);
+            FileChanges.OpenWithDifftool(FileName, string.Empty, RevisionDiffKind.DiffBLocal);
         }
 
         private void toolStripSplitLoad_ButtonClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -84,7 +84,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (var form = new FormCreateBranch(UICommands, new GitCommands.GitRevision((GitCommands.GitModule)UICommands.GitModule, GetShaOfRefLine())))
+            using (var form = new FormCreateBranch(UICommands, new GitCommands.GitRevision(GetShaOfRefLine())))
             {
                 form.CheckoutAfterCreation = false;
                 form.UserAbleToChangeRevision = false;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -283,7 +283,7 @@ namespace GitUI.CommandsDialogs
             if (currentItem == null)
                 throw new InvalidOperationException("There are no current selected item.");
 
-            return new GitRevision(Module, currentItem.Hash);
+            return new GitRevision(currentItem.Hash);
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -267,7 +267,7 @@ namespace GitUI.CommandsDialogs
 
             if (items.Count() == 1)
             {
-                items.Add(new GitRevision(Module, DiffFiles.SelectedItemParent));
+                items.Add(new GitRevision(DiffFiles.SelectedItemParent));
 
                 if (!string.IsNullOrWhiteSpace(DiffFiles.SelectedItemParent)
                     && DiffFiles.SelectedItemParent == DiffFiles.CombinedDiff.Text)

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -33,7 +33,7 @@ namespace GitUI.HelperDialogs
                 string guid = Module.RevParse(preselectCommit);
                 if (!String.IsNullOrEmpty(guid))
                 {
-                    revisionGrid.SetInitialRevision(new GitRevision(Module, guid));
+                    revisionGrid.SetInitialRevision(new GitRevision(guid));
                 }
             }
 
@@ -77,7 +77,7 @@ namespace GitUI.HelperDialogs
 
         private void linkLabelParent_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            revisionGrid.SetSelectedRevision(new GitRevision(revisionGrid.Module, _parents[((LinkLabel)sender).Text]));
+            revisionGrid.SetSelectedRevision(new GitRevision(_parents[((LinkLabel)sender).Text]));
         }
 
         private void revisionGrid_SelectionChanged(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2774,7 +2774,7 @@ namespace GitUI
             var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
 
             // Add working directory as virtual commit
-            var unstagedRev = new GitRevision(Module, GitRevision.UnstagedGuid)
+            var unstagedRev = new GitRevision(GitRevision.UnstagedGuid)
             {
                 Author = userName,
                 AuthorDate = DateTime.MaxValue,
@@ -2788,7 +2788,7 @@ namespace GitUI
             Revisions.Add(unstagedRev.Guid, unstagedRev.ParentGuids, DvcsGraph.DataType.Normal, unstagedRev);
 
             // Add index as virtual commit
-            var stagedRev = new GitRevision(Module, GitRevision.IndexGuid)
+            var stagedRev = new GitRevision(GitRevision.IndexGuid)
             {
                 Author = userName,
                 AuthorDate = DateTime.MaxValue,
@@ -3266,7 +3266,7 @@ namespace GitUI
                 case Commands.ShowFilteredBranches: ShowFilteredBranches_ToolStripMenuItemClick(null, null); break;
                 case Commands.ShowRemoteBranches: ShowRemoteBranches_ToolStripMenuItemClick(null, null); break;
                 case Commands.ShowFirstParent: ShowFirstParent_ToolStripMenuItemClick(null, null); break;
-                case Commands.SelectCurrentRevision: SetSelectedRevision(new GitRevision(Module, CurrentCheckout)); break;
+                case Commands.SelectCurrentRevision: SetSelectedRevision(new GitRevision(CurrentCheckout)); break;
                 case Commands.GoToCommit: _revisionGridMenuCommands.GotoCommitExcecute(); break;
                 case Commands.GoToParent: goToParentToolStripMenuItem_Click(null, null); break;
                 case Commands.GoToChild: goToChildToolStripMenuItem_Click(null, null); break;
@@ -3387,7 +3387,7 @@ namespace GitUI
             string revisionGuid = Module.RevParse(refName);
             if (!string.IsNullOrEmpty(revisionGuid))
             {
-                SetSelectedRevision(new GitRevision(Module, revisionGuid));
+                SetSelectedRevision(new GitRevision(revisionGuid));
             }
             else if (showNoRevisionMsg)
             {

--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -1,15 +1,12 @@
-﻿using GitUI.CommandsDialogs;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using GitUI.Hotkey;
-using System.Windows.Forms;
-using System.ComponentModel;
-using GitUI.CommandsDialogs.BrowseDialog;
-using ResourceManager;
 using System.Diagnostics;
+using System.Linq;
+using System.Windows.Forms;
 using GitCommands;
+using GitUI.CommandsDialogs.BrowseDialog;
+using GitUI.Hotkey;
+using ResourceManager;
 
 namespace GitUI.UserControls.RevisionGridClasses
 {
@@ -360,24 +357,24 @@ namespace GitUI.UserControls.RevisionGridClasses
             }
 
             {
-              var menuCommand = new MenuCommand();
-              menuCommand.Name = "showTagsToolStripMenuItem";
-              menuCommand.Text = "Show tags";
-              menuCommand.ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleShowTags);
-              menuCommand.ExecuteAction = () => _revisionGrid.ShowTags_ToolStripMenuItemClick(null, null);
-              menuCommand.IsCheckedFunc = () => AppSettings.ShowTags;
+                var menuCommand = new MenuCommand();
+                menuCommand.Name = "showTagsToolStripMenuItem";
+                menuCommand.Text = "Show tags";
+                menuCommand.ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleShowTags);
+                menuCommand.ExecuteAction = () => _revisionGrid.ShowTags_ToolStripMenuItemClick(null, null);
+                menuCommand.IsCheckedFunc = () => AppSettings.ShowTags;
 
-              resultList.Add(menuCommand);
+                resultList.Add(menuCommand);
             }
 
             {
-              var menuCommand = new MenuCommand();
-              menuCommand.Name = "showIdsToolStripMenuItem";
-              menuCommand.Text = "Show SHA-1";
-              menuCommand.ExecuteAction = () => _revisionGrid.ShowIds_ToolStripMenuItemClick(null, null);
-              menuCommand.IsCheckedFunc = () => AppSettings.ShowIds;
+                var menuCommand = new MenuCommand();
+                menuCommand.Name = "showIdsToolStripMenuItem";
+                menuCommand.Text = "Show SHA-1";
+                menuCommand.ExecuteAction = () => _revisionGrid.ShowIds_ToolStripMenuItemClick(null, null);
+                menuCommand.IsCheckedFunc = () => AppSettings.ShowIds;
 
-              resultList.Add(menuCommand);
+                resultList.Add(menuCommand);
             }
 
             {
@@ -394,7 +391,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 var menuCommand = new MenuCommand();
                 menuCommand.Name = "showIsMessageMultilineToolStripMenuItem";
                 menuCommand.Text = "Show indicator for multiline message";
-                menuCommand.ExecuteAction = () => 
+                menuCommand.ExecuteAction = () =>
                 {
                     AppSettings.ShowIndicatorForMultilineMessage = !AppSettings.ShowIndicatorForMultilineMessage;
                     _revisionGrid.ForceRefreshRevisions();

--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -505,7 +505,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 string revisionGuid = formGoToCommit.ValidateAndGetSelectedRevision();
                 if (!string.IsNullOrEmpty(revisionGuid))
                 {
-                    _revisionGrid.SetSelectedRevision(new GitRevision(_revisionGrid.Module, revisionGuid));
+                    _revisionGrid.SetSelectedRevision(new GitRevision(revisionGuid));
                 }
                 else
                 {

--- a/UnitTests/GitCommandsTests/ExternalLinks/ExternalLinkRevisionParserTests.cs
+++ b/UnitTests/GitCommandsTests/ExternalLinks/ExternalLinkRevisionParserTests.cs
@@ -27,7 +27,7 @@ namespace GitCommandsTests.ExternalLinks
         {
             _linkDef = Parse(GetGithubIssuesXmlDef()).First();
 
-            _revision = new GitRevision(null, "");
+            _revision = new GitRevision("");
 
             _remoteManager = Substitute.For<IGitRemoteManager>();
             _remoteManager.LoadRemotes(false).Returns(GetDefaultRemotes());

--- a/UnitTests/GitCommandsTests/Git/GitRevisionProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitRevisionProviderTests.cs
@@ -1,0 +1,64 @@
+using System;
+using FluentAssertions;
+using GitCommands.Git;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public class GitRevisionProviderTests
+    {
+        private GitRevisionProvider _provider;
+        private IGitModule _module;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _module = Substitute.For<IGitModule>();
+
+            _provider = new GitRevisionProvider(() => _module);
+        }
+
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("\t")]
+        public void Get_should_return_revision_if_null_or_empty(string sha1)
+        {
+            var rev = _provider.Get(sha1);
+
+            rev.Should().NotBeNull();
+            rev.Guid.Should().Be(sha1);
+        }
+
+        [Test]
+        public void Get_should_throw_if_module_is_not_provided()
+        {
+            _module = null;
+
+            ((Action)(() => _provider.Get("xx"))).ShouldThrow<ArgumentException>();
+        }
+
+        [TestCase("0123", true)]
+        [TestCase("0123", false)]
+        public void Get_should_get_full_sha_for_existing_commits(string sha1Fragment, bool existing)
+        {
+            const string fullSha = "01234567890";
+            _module.IsExistingCommitHash(sha1Fragment, out var _)
+                .Returns(x =>
+                {
+                    x[1] = fullSha;
+                    return existing;
+                });
+
+            var rev = _provider.Get(sha1Fragment);
+
+            rev.Should().NotBeNull();
+            rev.Guid.Should().Be(existing ? fullSha : sha1Fragment);
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
@@ -38,7 +38,7 @@ namespace GitCommandsTests.Git.Gpg
         {
             var guid = Guid.NewGuid().ToString("N");
 
-            GitRevision revision = new GitRevision(null, guid);
+            GitRevision revision = new GitRevision(guid);
 
             _module().RunGitCmd($"log --pretty=\"format:%G?\" -1 {revision.Guid}").Returns(gitCmdReturn);
             
@@ -68,8 +68,8 @@ namespace GitCommandsTests.Git.Gpg
         {
             var guid = Guid.NewGuid().ToString("N");
 
-            GitRevision revision = new GitRevision(null, "");
             
+            GitRevision revision = new GitRevision("");
             string gitRefCompleteName = "refs/tags/FirstTag^{}";
             
             for (int i = 0; i < numberOfTags; i++)
@@ -90,7 +90,7 @@ namespace GitCommandsTests.Git.Gpg
         {
             var guid = Guid.NewGuid().ToString("N");
 
-            GitRevision revision = new GitRevision(null, guid);
+            GitRevision revision = new GitRevision(guid);
 
             GitRef gitRef = new GitRef(_module(), guid, "refs/tags/FirstTag^{}");
             revision.Refs.Add(gitRef);
@@ -108,7 +108,7 @@ namespace GitCommandsTests.Git.Gpg
         {
             var guid = Guid.NewGuid().ToString("N");
 
-            GitRevision revision = new GitRevision(null, guid);
+            GitRevision revision = new GitRevision(guid);
 
             _module().RunGitCmd($"log --pretty=\"format:%GG\" -1 {guid}").Returns(returnString);
 
@@ -139,7 +139,7 @@ namespace GitCommandsTests.Git.Gpg
         {
             var guid = Guid.NewGuid().ToString("N");
 
-            GitRevision revision = new GitRevision(null, guid);
+            GitRevision revision = new GitRevision(guid);
 
             GitRef gitRef;
             string gitRefCompleteName = "";

--- a/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
@@ -1,14 +1,11 @@
 ﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
 using GitCommands;
 using GitCommands.Gpg;
-using NUnit.Framework;
 using GitUIPluginInterfaces;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using FluentAssertions;
-
+using NUnit.Framework;
 
 namespace GitCommandsTests.Git.Gpg
 {
@@ -21,7 +18,7 @@ namespace GitCommandsTests.Git.Gpg
         [SetUp]
         public void Setup()
         {
-            _module = Substitute.For<Func<IGitModule> >();
+            _module = Substitute.For<Func<IGitModule>>();
             _gpgController = new GitGpgController(_module);
         }
 
@@ -41,7 +38,7 @@ namespace GitCommandsTests.Git.Gpg
             GitRevision revision = new GitRevision(guid);
 
             _module().RunGitCmd($"log --pretty=\"format:%G?\" -1 {revision.Guid}").Returns(gitCmdReturn);
-            
+
             var actual = await _gpgController.GetRevisionCommitSignatureStatusAsync(revision);
 
             Assert.AreEqual(expected, actual);
@@ -53,7 +50,7 @@ namespace GitCommandsTests.Git.Gpg
         {
             ((Func<Task>)(async () => await _gpgController.GetRevisionCommitSignatureStatusAsync(null))).ShouldThrow<ArgumentNullException>();
         }
-        
+
 
         [TestCase]
         public void Validate_GetRevisionTagSignatureStatusAsync_null_revision()
@@ -68,15 +65,15 @@ namespace GitCommandsTests.Git.Gpg
         {
             var guid = Guid.NewGuid().ToString("N");
 
-            
             GitRevision revision = new GitRevision("");
+
             string gitRefCompleteName = "refs/tags/FirstTag^{}";
-            
+
             for (int i = 0; i < numberOfTags; i++)
             {
                 revision.Refs.Add(new GitRef(_module(), guid, gitRefCompleteName));
             }
-            
+
             var actual = await _gpgController.GetRevisionTagSignatureStatusAsync(revision);
 
             Assert.AreEqual(tagStatus, actual);
@@ -181,7 +178,7 @@ namespace GitCommandsTests.Git.Gpg
             }
 
             var actual = _gpgController.GetTagVerifyMessage(revision);
-            
+
             Assert.AreEqual(expected, actual);
         }
 

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
+    <Compile Include="Git\GitRevisionProviderTests.cs" />
     <Compile Include="Git\GitStashTests.cs" />
     <Compile Include="Git\Gpg\GitGpgControllerTests.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmdTests.cs" />

--- a/UnitTests/GitUITests/Helpers/DiffKindRevisionTests.cs
+++ b/UnitTests/GitUITests/Helpers/DiffKindRevisionTests.cs
@@ -1,29 +1,13 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Windows.Forms;
-using FluentAssertions;
 using GitCommands;
-using GitCommands.Git;
 using GitUI;
-using GitUI.Properties;
-using GitUIPluginInterfaces;
-using NSubstitute;
 using NUnit.Framework;
-using static GitUI.GitUIExtensions;
 
 namespace GitUITests.Helpers
 {
     [TestFixture]
     public class DiffKindRevisionTests
     {
-        private GitModule _module;
-
-        [SetUp]
-        public void Setup()
-        {
-            _module = new GitModule("");
-        }
-
         [Test]
         public void DiffKindRevisionTests_error()
         {
@@ -41,7 +25,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD") };
             revisions[0].ParentGuids = new string[] { "parent" };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("parent", firstRevision, "first");
@@ -53,7 +37,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("-M -C", extraDiffArgs);
             Assert.AreEqual("HEAD^", firstRevision, "first");
@@ -65,7 +49,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD^"), new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD^"), new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffAB, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD", firstRevision, "first");
             Assert.AreEqual("HEAD^", secondRevision, "second");
@@ -76,7 +60,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffALocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD^", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
@@ -87,7 +71,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD^"), new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD^"), new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffALocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
@@ -98,7 +82,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffAParentLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD^^", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
@@ -109,7 +93,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffBLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
@@ -120,7 +104,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD^"), new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD^"), new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffBLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD^", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
@@ -131,7 +115,7 @@ namespace GitUITests.Helpers
         {
             IList<GitRevision> revisions = null;
             string extraDiffArgs, firstRevision, secondRevision;
-            revisions = new List<GitRevision> { new GitRevision(_module, "HEAD") };
+            revisions = new List<GitRevision> { new GitRevision("HEAD") };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffBParentLocal, out extraDiffArgs, out firstRevision, out secondRevision), "null rev");
             Assert.AreEqual("HEAD^", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");

--- a/UnitTests/GitUITests/UserControls/AuthorEmailBasedRevisionHighlightingFixture.cs
+++ b/UnitTests/GitUITests/UserControls/AuthorEmailBasedRevisionHighlightingFixture.cs
@@ -25,14 +25,14 @@ namespace GitUITests.UserControls
         [Test]
         public void When_multiple_revisions_selected_Then_ProcessSelectionChange_should_return_NoAction()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
 
             var action = sut.ProcessRevisionSelectionChange(currentModule,
                                                new[]
                                                    {
-                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1),
-                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)
+                                                       NewRevisionWithAuthorEmail(ExpectedAuthorEmail1),
+                                                       NewRevisionWithAuthorEmail(ExpectedAuthorEmail1)
                                                    });
 
             action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.NoAction);
@@ -41,16 +41,16 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_multiple_revisions_selected_Then_AuthorEmailToHighlight_should_not_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule,
-                                               new[] {NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)});
+                                               new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
             sut.ProcessRevisionSelectionChange(currentModule,
                                                new[]
                                                    {
-                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail2),
-                                                       NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)
+                                                       NewRevisionWithAuthorEmail(ExpectedAuthorEmail2),
+                                                       NewRevisionWithAuthorEmail(ExpectedAuthorEmail1)
                                                    });
 
             sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1);
@@ -59,33 +59,33 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_no_previously_selected_revision_When_single_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
 
-            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
-            
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
+
             action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
-        } 
+        }
 
         [Test]
         public void Given_no_previously_selected_revision_When_single_revision_selected_Then_AuthorEmailToHighlight_should_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
 
-            sut.ProcessRevisionSelectionChange(currentModule, new[] {NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1)});
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1); 
+            sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1);
         }
 
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_ProcessSelectionChange_should_return_NoAction()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
             action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.NoAction);
         }
@@ -93,11 +93,11 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_AuthorEmailToHighlight_should_not_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
             sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail1);
         }
@@ -105,11 +105,11 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail2) });
+            var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail2) });
 
             action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
         }
@@ -117,11 +117,11 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_AuthorEmailToHighlight_should_change()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail2) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail2) });
 
             sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail2);
         }
@@ -129,10 +129,10 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_no_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
-            var currentModule = NewModule(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
+            var currentModule = NewModule();
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
             var action = sut.ProcessRevisionSelectionChange(currentModule, new GitRevision[0]);
 
@@ -142,10 +142,10 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_no_revision_selected_Then_AuthorEmailToHighlight_should_be_value_of_current_user_email_setting()
         {
-            var sut = new AuthorEmailBasedRevisionHighlighting(); 
+            var sut = new AuthorEmailBasedRevisionHighlighting();
             var currentModule = NewModule();
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
-            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(currentModule, ExpectedAuthorEmail1) });
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
             sut.ProcessRevisionSelectionChange(currentModule, new GitRevision[0]);
 
@@ -157,12 +157,12 @@ namespace GitUITests.UserControls
             return new GitModule(Path.GetTempPath());
         }
 
-        private static GitRevision NewRevisionWithAuthorEmail(GitModule currentModule, string authorEmail)
+        private static GitRevision NewRevisionWithAuthorEmail(string authorEmail)
         {
-            return new GitRevision(currentModule, Guid.NewGuid().ToString())
-                {
-                    AuthorEmail = authorEmail
-                };
+            return new GitRevision(Guid.NewGuid().ToString())
+            {
+                AuthorEmail = authorEmail
+            };
         }
     }
 }


### PR DESCRIPTION
`GitRevision` is a DTO yet it contains behavioural components.
`GitRevision.CreateForShortSha1` functionality moved into `GitRevisionProvider`.
The functionality is moved as is.

Added unit tests