### PR TITLE
refactor: Extract IsArtificial functionality from GitRevision

### DIFF
--- a/GitCommands/Git/Extensions/GitRevisionExtensions.cs
+++ b/GitCommands/Git/Extensions/GitRevisionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace GitCommands.Git.Extensions
+{
+    public static class GitRevisionExtensions
+    {
+        public static bool IsArtificial(this string sha1)
+        {
+            return sha1 == GitRevision.UnstagedGuid ||
+                   sha1 == GitRevision.IndexGuid;
+        }
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GitCommands.Config;
 using GitCommands.Git;
+using GitCommands.Git.Extensions;
 using GitCommands.Settings;
 using GitCommands.Utils;
 using GitUIPluginInterfaces;
@@ -2224,7 +2225,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public Patch GetSingleDiff(string firstRevision, string secondRevision, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked=true)
+        public Patch GetSingleDiff(string firstRevision, string secondRevision, string fileName, string oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked = true)
         {
             if (!string.IsNullOrEmpty(fileName))
             {
@@ -2245,8 +2246,8 @@ namespace GitCommands
             var patchManager = new PatchManager();
             var arguments = String.Format(DiffCommandWithStandardArgs + "{0} -M -C {1}", extraDiffArguments, diffOptions);
             cacheResult = cacheResult &&
-                !GitRevision.IsArtificial(secondRevision) &&
-                !GitRevision.IsArtificial(firstRevision) &&
+                !secondRevision.IsArtificial() &&
+                !firstRevision.IsArtificial() &&
                 !secondRevision.IsNullOrEmpty() &&
                 !firstRevision.IsNullOrEmpty();
             string patch;
@@ -2297,7 +2298,7 @@ namespace GitCommands
 
         public List<GitItemStatus> GetDiffFiles(string firstRevision, string secondRevision, bool noCache = false)
         {
-            noCache = noCache || GitRevision.IsArtificial(firstRevision) || GitRevision.IsArtificial(secondRevision);
+            noCache = noCache || firstRevision.IsArtificial() || secondRevision.IsArtificial();
             string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             string result = noCache ? RunGitCmd(cmd) : this.RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
             var resultCollection = GitCommandHelpers.GetAllChangedFilesFromString(this, result, true);
@@ -2375,7 +2376,7 @@ namespace GitCommands
             if (!excludeAssumeUnchangedFiles || !excludeSkipWorktreeFiles)
             {
                 string lsOutput = RunGitCmd("ls-files -v");
-                if(!excludeAssumeUnchangedFiles)
+                if (!excludeAssumeUnchangedFiles)
                     result.AddRange(GitCommandHelpers.GetAssumeUnchangedFilesFromString(lsOutput));
                 if (!excludeSkipWorktreeFiles)
                     result.AddRange(GitCommandHelpers.GetSkipWorktreeFilesFromString(lsOutput));
@@ -3118,7 +3119,7 @@ namespace GitCommands
                 });
         }
 
-        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.UnstagedGuid, string extraDiffArguments = "", bool isTracked=true)
+        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.UnstagedGuid, string extraDiffArguments = "", bool isTracked = true)
         {
             var output = "";
 

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
+using GitCommands.Git.Extensions;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
 using JetBrains.Annotations;
@@ -104,16 +105,11 @@ namespace GitCommands
                     Subject.ToLower().Contains(searchString);
         }
 
-        public bool IsArtificial()
-        {
-            return IsArtificial(Guid);
-        }
 
-        public static bool IsArtificial(string guid)
-        {
-            return guid == UnstagedGuid ||
-                    guid == IndexGuid;
-        }
+        /// <summary>
+        /// Indicates whether the commit is an artificial commit.
+        /// </summary>
+        public bool IsArtificial => Guid.IsArtificial();
 
         public bool HasParent
         {

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Git\FileDeleteException.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />
     <Compile Include="Git\GitBranchNameOptions.cs" />
+    <Compile Include="Git\Extensions\GitRevisionExtensions.cs" />
     <Compile Include="Git\GitRevisionProvider.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2005,7 +2005,7 @@ namespace GitUI.CommandsDialogs
         {
             //Most options do not make sense for artificial commits or no revision selected at all
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            bool enabled = selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial();
+            bool enabled = selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial;
 
             this.branchToolStripMenuItem.Enabled =
             this.deleteBranchToolStripMenuItem.Enabled =

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -75,11 +75,11 @@ namespace GitUI.CommandsDialogs
 
             if (ckCompareToMergeBase.Checked)
             {
-                DiffFiles.SetDiffs(new List<GitRevision> {_headRevision, _mergeBase});
+                DiffFiles.SetDiffs(new List<GitRevision> { _headRevision, _mergeBase });
             }
             else
             {
-                DiffFiles.SetDiffs(new List<GitRevision> {_headRevision, _baseRevision});
+                DiffFiles.SetDiffs(new List<GitRevision> { _headRevision, _baseRevision });
             }
         }
 
@@ -235,7 +235,7 @@ namespace GitUI.CommandsDialogs
             parentOfALocalToolStripMenuItem.Enabled = parentOfBLocalToolStripMenuItem.Enabled = !Module.IsBareRepository();
 
             bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
-            blameToolStripMenuItem.Visible = isExactlyOneItemSelected && !(DiffFiles.SelectedItem.IsSubmodule || _baseRevision.IsArtificial());
+            blameToolStripMenuItem.Visible = isExactlyOneItemSelected && !(DiffFiles.SelectedItem.IsSubmodule || _baseRevision.IsArtificial);
         }
 
         private void PickAnotherBranch(GitRevision preSelectCommit, ref string displayStr, ref GitRevision revision)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -437,7 +437,7 @@ namespace GitUI.CommandsDialogs
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;
             manipuleerCommitToolStripMenuItem.Enabled =
                 viewCommitToolStripMenuItem.Enabled =
-                selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial();
+                selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial;
             saveAsToolStripMenuItem.Enabled = selectedRevisions.Count == 1;
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -8,8 +8,8 @@ using System.Windows.Forms;
 using GitCommands;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
-using ResourceManager;
 using GitUI.Hotkey;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs
             {
                 var revisions = _revisionGrid.GetSelectedRevisions();
 
-                if (revisions.Count > 0 && revisions[0].IsArtificial())
+                if (revisions.Count > 0 && revisions[0].IsArtificial)
                 {
                     DiffFiles.SetDiffs(revisions);
                 }
@@ -728,7 +728,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (DiffFiles.SelectedItem == null || !DiffFiles.Revision.IsArtificial() ||
+                if (DiffFiles.SelectedItem == null || !DiffFiles.Revision.IsArtificial ||
                     MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
                     DialogResult.Yes)
                 {
@@ -832,7 +832,7 @@ namespace GitUI.CommandsDialogs
             }
             RefreshArtificial();
         }
-        
+
         private void diffUpdateSubmoduleMenuItem_Click(object sender, EventArgs e)
         {
             var unStagedFiles = DiffFiles.SelectedItems.ToList();

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using GitCommands;
-using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs
 {
@@ -34,7 +33,7 @@ namespace GitUI.CommandsDialogs
         {
             SelectedRevisions = selectedRevisions;
             SelectedDiff = selectedDiff;
-            IsAnyCombinedDiff  = isAnyCombinedDiff;
+            IsAnyCombinedDiff = isAnyCombinedDiff;
             IsSingleGitItemSelected = isSingleGitItemSelected;
             IsCombinedDiff = isCombinedDiff;
             IsAnyItemSelected = isAnyItemSelected;
@@ -77,7 +76,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowMenuBlame(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsSingleGitItemSelected && !(selectionInfo.SelectedDiff.IsSubmodule || selectionInfo.SelectedRevisions[0].IsArtificial());
+            return selectionInfo.IsSingleGitItemSelected && !(selectionInfo.SelectedDiff.IsSubmodule || selectionInfo.SelectedRevisions[0].IsArtificial);
         }
 
         public bool ShouldShowMenuCherryPick(ContextMenuSelectionInfo selectionInfo)
@@ -100,7 +99,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowMenuFileHistory(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsSingleGitItemSelected && !(selectionInfo.SelectedDiff.IsNew && selectionInfo.SelectedRevisions[0].IsArtificial());
+            return selectionInfo.IsSingleGitItemSelected && !(selectionInfo.SelectedDiff.IsNew && selectionInfo.SelectedRevisions[0].IsArtificial);
         }
 
         public bool ShouldShowMenuSaveAs(ContextMenuSelectionInfo selectionInfo)
@@ -115,7 +114,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowMenuShowInFileTree(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsSingleGitItemSelected && !selectionInfo.SelectedRevisions[0].IsArtificial();
+            return selectionInfo.IsSingleGitItemSelected && !selectionInfo.SelectedRevisions[0].IsArtificial;
         }
 
         public bool ShouldShowMenuStage(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -206,7 +206,7 @@ namespace GitUI.CommitInfo
             LoadAuthorImage(data.Author ?? data.Committer);
 
             //No branch/tag data for artificial commands
-            if (GitRevision.IsArtificial(_revision.Guid))
+            if (_revision.IsArtificial)
                 return;
 
             if (AppSettings.CommitInfoShowContainedInBranches)
@@ -424,7 +424,7 @@ namespace GitUI.CommitInfo
             }
 
             string body = _revisionInfo;
-            if (Revision != null && !Revision.IsArtificial())
+            if (Revision != null && !Revision.IsArtificial)
             {
                 body += "\n" + _annotatedTagsInfo + _linksInfo + _branchInfo + _tagInfo;
             }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -889,7 +889,7 @@ namespace GitUI
                 description = revision.Subject;
             }
 
-            if (!revision.IsArtificial())
+            if (!revision.IsArtificial)
             {
                 description += " @" + revision.Guid.Substring(0, 4);
             }
@@ -1741,7 +1741,7 @@ namespace GitUI
                 }
                 else if (columnIndex == idColIndex)
                 {
-                    if (!revision.IsArtificial()) //do not show artificial GUID
+                    if (!revision.IsArtificial) //do not show artificial GUID
                     {
                         var text = revision.Guid;
                         var rect = RevisionGridUtils.GetCellRectangle(e);
@@ -1855,7 +1855,7 @@ namespace GitUI
             int dateColIndex = DateDataGridViewColumn.Index;
             int isMsgMultilineColIndex = IsMessageMultilineDataGridViewColumn.Index;
 
-            if (columnIndex == graphColIndex && !revision.IsArtificial()) //Do not show artificial guid
+            if (columnIndex == graphColIndex && !revision.IsArtificial) //Do not show artificial guid
             {
                 e.Value = revision.Guid;
             }
@@ -1885,7 +1885,7 @@ namespace GitUI
             }
             else if (AppSettings.ShowIndicatorForMultilineMessage && columnIndex == isMsgMultilineColIndex)
             {
-                if (revision.Body == null && !revision.IsArtificial())
+                if (revision.Body == null && !revision.IsArtificial)
                 {
                     var moduleRef = Module;
                     ThreadPool.QueueUserWorkItem(o => LoadIsMultilineMessageInfo(revision, columnIndex, e.RowIndex, Revisions.RowCount, moduleRef));
@@ -2108,7 +2108,7 @@ namespace GitUI
         public void ViewSelectedRevisions()
         {
             var selectedRevisions = GetSelectedRevisions();
-            if (selectedRevisions.Any(rev => !GitRevision.IsArtificial(rev.Guid)))
+            if (selectedRevisions.Any(rev => !rev.IsArtificial))
             {
                 Func<Form> provideForm = () =>
                 {
@@ -2335,7 +2335,7 @@ namespace GitUI
             foreach (var head in branchesWithNoIdenticalRemotes)
             {
                 if (head.CompleteName.Equals(currentBranchRef))
-                    currentBranchPointsToRevision = !revision.IsArtificial();
+                    currentBranchPointsToRevision = !revision.IsArtificial;
                 else
                 {
                     ToolStripItem toolStripItem = new ToolStripMenuItem(head.Name);
@@ -2437,7 +2437,7 @@ namespace GitUI
                 }
             }
 
-            bool bareRepositoryOrArtificial = Module.IsBareRepository() || revision.IsArtificial();
+            bool bareRepositoryOrArtificial = Module.IsBareRepository() || revision.IsArtificial;
             deleteTagToolStripMenuItem.DropDown = deleteTagDropDown;
             deleteTagToolStripMenuItem.Enabled = deleteTagDropDown.Items.Count > 0;
 
@@ -2461,11 +2461,11 @@ namespace GitUI
             cherryPickCommitToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
             manipulateCommitToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
 
-            copyToClipboardToolStripMenuItem.Enabled = !revision.IsArtificial();
+            copyToClipboardToolStripMenuItem.Enabled = !revision.IsArtificial;
             createNewBranchToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
             resetCurrentBranchToHereToolStripMenuItem.Enabled = !bareRepositoryOrArtificial;
-            archiveRevisionToolStripMenuItem.Enabled = !revision.IsArtificial();
-            createTagToolStripMenuItem.Enabled = !revision.IsArtificial();
+            archiveRevisionToolStripMenuItem.Enabled = !revision.IsArtificial;
+            createTagToolStripMenuItem.Enabled = !revision.IsArtificial;
 
             toolStripSeparator6.Enabled = branchNameCopyToolStripMenuItem.Enabled || tagNameCopyToolStripMenuItem.Enabled;
 

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using GitCommands;
+using GitCommands.Git.Extensions;
 
 namespace ResourceManager.CommitDataRenders
 {
@@ -72,7 +73,7 @@ namespace ResourceManager.CommitDataRenders
                 throw new ArgumentNullException(nameof(commitData));
             }
 
-            bool isArtificial = GitRevision.IsArtificial(commitData.Guid);
+            bool isArtificial = commitData.Guid.IsArtificial();
             bool authorIsCommiter = string.Equals(commitData.Author, commitData.Committer, StringComparison.CurrentCulture);
             bool datesEqual = commitData.AuthorDate.EqualsExact(commitData.CommitDate);
             var padding = _headerRendererStyleProvider.GetMaxWidth();

--- a/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Git.Extensions;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git.Extensions
+{
+    [TestFixture]
+    public class GitRevisionExtensionsTests
+    {
+        [TestCase(null, false)]
+        [TestCase("", false)]
+        [TestCase(" ", false)]
+        [TestCase("0000", false)]
+        [TestCase(GitRevision.UnstagedGuid, true)]
+        [TestCase(GitRevision.IndexGuid, true)]
+        public void IsArtificial_tests(string sha1, bool expected)
+        {
+            sha1.IsArtificial().Should().Be(expected);
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="GitRevisionInfoProviderTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
+    <Compile Include="Git\Extensions\GitRevisionExtensionsTests.cs" />
     <Compile Include="Git\GitRevisionProviderTests.cs" />
     <Compile Include="Git\GitStashTests.cs" />
     <Compile Include="Git\Gpg\GitGpgControllerTests.cs" />


### PR DESCRIPTION
GitRevision is a DTO yet it contains behavioural components.

Check for artificial commit is not a function of GitRevision.
Any revision inherently knows whether it is artificial or not. However checking an arbitrary hash for being artificial is not a function of GitRevision.
For now, the functionality moved into an extension method. This way it can be tested and used universally.