### PR TITLE
Align submodule details. Fixes #1858

### DIFF
--- a/GitUI/CommandsDialogs/FormSubmodules.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.Designer.cs
@@ -284,6 +284,7 @@
             // 
             this.SubModuleStatus.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.SubModuleStatus.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.gitSubmoduleBindingSource, "Status", true));
+            this.SubModuleStatus.Dock = System.Windows.Forms.DockStyle.Top;
             this.SubModuleStatus.Location = new System.Drawing.Point(120, 183);
             this.SubModuleStatus.Name = "SubModuleStatus";
             this.SubModuleStatus.ReadOnly = true;
@@ -338,6 +339,7 @@
             // 
             this.SubModuleName.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.SubModuleName.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.gitSubmoduleBindingSource, "Name", true));
+            this.SubModuleName.Dock = System.Windows.Forms.DockStyle.Top;
             this.SubModuleName.Location = new System.Drawing.Point(120, 3);
             this.SubModuleName.Name = "SubModuleName";
             this.SubModuleName.ReadOnly = true;
@@ -389,6 +391,7 @@
             // SubModuleCommit
             // 
             this.SubModuleCommit.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.gitSubmoduleBindingSource, "CurrentCommitGuid", true));
+            this.SubModuleCommit.Dock = System.Windows.Forms.DockStyle.Top;
             this.SubModuleCommit.Location = new System.Drawing.Point(120, 111);
             this.SubModuleCommit.Name = "SubModuleCommit";
             this.SubModuleCommit.ReadOnly = true;


### PR DESCRIPTION
Fixes #1858 Submodule dialog: "Name" textbox too small for long names.

"Name" column in the list view could be amended as part of #4366 

Changes proposed in this pull request:
 - Align submodule details by right side
 
Screenshots before and after (if PR changes UI):
- before:
![2018-02-21_21-41-15_gitextensions](https://user-images.githubusercontent.com/1287655/36492856-f81400a2-174f-11e8-96be-963584501c54.png)

- after:
![2018-02-21_20-43-19_gitextensions](https://user-images.githubusercontent.com/1287655/36492789-c528a652-174f-11e8-87f2-3f1e6faad378.png)



What did I do to test the code and ensure quality:
 - manual testing

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
