### PR TITLE
Default application fonts to MessageBoxFont

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1126,21 +1126,21 @@ namespace GitCommands
             set => SetColor("authoredrevisionscolor", value);
         }
 
-        public static Font DiffFont
+        public static Font FixedWidthFont
         {
-            get => GetFont("difffont", new Font("Courier New", 10));
+            get => GetFont("difffont", new Font("Consolas", 10));
             set => SetFont("difffont", value);
         }
 
         public static Font CommitFont
         {
-            get => GetFont("commitfont", new Font(SystemFonts.DialogFont.Name, SystemFonts.MessageBoxFont.Size));
+            get => GetFont("commitfont", SystemFonts.MessageBoxFont);
             set => SetFont("commitfont", value);
         }
 
         public static Font Font
         {
-            get => GetFont("font", new Font(SystemFonts.DialogFont.Name, SystemFonts.DefaultFont.Size));
+            get => GetFont("font", SystemFonts.MessageBoxFont);
             set => SetFont("font", value);
         }
 

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -25,7 +25,6 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
             {
                 BackColor = Color.White,
                 Dock = DockStyle.Fill,
-                Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0),
                 Margin = new Padding(0),
                 Multiline = true,
                 ReadOnly = true,
@@ -50,7 +49,6 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
             return new TabControl
             {
                 Dock = DockStyle.Fill,
-                Font = new Font("Segoe UI", 10F, FontStyle.Bold, GraphicsUnit.Point, 0),
                 SelectedIndex = 0,
             };
         }

--- a/GitUI/CommandsDialogs/FormArchive.Designer.cs
+++ b/GitUI/CommandsDialogs/FormArchive.Designer.cs
@@ -260,7 +260,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelMessage.AutoEllipsis = true;
-            this.labelMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelMessage.Font = new System.Drawing.Font(this.labelMessage.Font, System.Drawing.FontStyle.Bold);
             this.labelMessage.Location = new System.Drawing.Point(5, 19);
             this.labelMessage.MaximumSize = new System.Drawing.Size(422, 50);
             this.labelMessage.Name = "labelMessage";
@@ -273,7 +273,7 @@
             // 
             this.labelAuthor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.labelAuthor.AutoSize = true;
-            this.labelAuthor.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelAuthor.Font = new System.Drawing.Font(this.labelAuthor.Font, System.Drawing.FontStyle.Bold);
             this.labelAuthor.Location = new System.Drawing.Point(98, 79);
             this.labelAuthor.Name = "labelAuthor";
             this.labelAuthor.Size = new System.Drawing.Size(19, 13);

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System.Windows.Forms;
 using GitUI.Editor;
 using GitUI.SpellChecker;
@@ -1112,7 +1113,6 @@ namespace GitUI.CommandsDialogs
             this.Message.Name = "Message";
             this.Message.Size = new System.Drawing.Size(336, 158);
             this.Message.TabIndex = 0;
-            this.Message.TextBoxFont = new System.Drawing.Font("Tahoma", 8.25F);
             this.Message.SelectionChanged += new System.EventHandler(this.Message_SelectionChanged);
             this.Message.Enter += new System.EventHandler(this.Message_Enter);
             this.Message.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Message_KeyDown);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -182,7 +182,7 @@ namespace GitUI.CommandsDialogs
 
             Translate();
 
-            SolveMergeconflicts.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Bold);
+            SolveMergeconflicts.Font = new Font(SolveMergeconflicts.Font, FontStyle.Bold);
 
             SelectedDiff.ExtraDiffArgumentsChanged += SelectedDiffExtraDiffArgumentsChanged;
 

--- a/GitUI/CommandsDialogs/FormCreateTag.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.Designer.cs
@@ -129,9 +129,8 @@ namespace GitUI.CommandsDialogs
             this.tagMessage.Location = new System.Drawing.Point(140, 142);
             this.tagMessage.Margin = new System.Windows.Forms.Padding(2);
             this.tagMessage.Name = "tagMessage";
-            this.tagMessage.Size = new System.Drawing.Size(306, 53);
+            this.tagMessage.Size = new System.Drawing.Size(327, 75);
             this.tagMessage.TabIndex = 9;
-            this.tagMessage.TextBoxFont = new System.Drawing.Font("Segoe UI", 9F);
             // 
             // label2
             // 
@@ -215,7 +214,7 @@ namespace GitUI.CommandsDialogs
             this.Controls.Add(this.tableLayoutPanel2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(450, 260);
+            this.MinimumSize = new System.Drawing.Size(455, 260);
             this.Name = "FormCreateTag";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -37,7 +37,7 @@ namespace GitUI.CommandsDialogs
             annotate.SelectedIndex = 0;
 
             tagMessage.MistakeFont = new Font(tagMessage.MistakeFont, FontStyle.Underline);
-            
+
             commitPickerSmallControl1.UICommandsSource = this;
             if (IsUICommandsInitialized)
             {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -36,7 +36,8 @@ namespace GitUI.CommandsDialogs
             annotate.Items.AddRange(DropwdownTagOperation);
             annotate.SelectedIndex = 0;
 
-            tagMessage.MistakeFont = new Font(SystemFonts.MessageBoxFont, FontStyle.Underline);
+            tagMessage.MistakeFont = new Font(tagMessage.MistakeFont, FontStyle.Underline);
+            
             commitPickerSmallControl1.UICommandsSource = this;
             if (IsUICommandsInitialized)
             {

--- a/GitUI/CommandsDialogs/FormSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSettings.Designer.cs
@@ -128,7 +128,6 @@ namespace GitUI.CommandsDialogs
             // settingsTreeView
             //
             this.settingsTreeView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.settingsTreeView.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.settingsTreeView.Location = new System.Drawing.Point(3, 3);
             this.settingsTreeView.MinimumSize = new System.Drawing.Size(100, 220);
             this.settingsTreeView.Name = "settingsTreeView";

--- a/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
@@ -83,8 +83,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                     _systemInfoReplacement = kvps.ToList();
 
-                    _systemInfoReplacement.Add(new KeyValuePair<string, string>("SF.DialogFont", SystemFonts.DialogFont.Name));
-                    _systemInfoReplacement.Add(new KeyValuePair<string, string>("SF.DialogFontSize", string.Format("{0}pt", SystemFonts.DialogFont.SizeInPoints)));
+                    // TODO: is it safe to rename the keys ('SF.DialogFont', 'SF.DialogFontSize') to 'SF.MessageBoxFont' or not?
+                    _systemInfoReplacement.Add(new KeyValuePair<string, string>("SF.DialogFont", SystemFonts.MessageBoxFont.Name));
+                    _systemInfoReplacement.Add(new KeyValuePair<string, string>("SF.DialogFontSize", string.Format("{0}pt", SystemFonts.MessageBoxFont.SizeInPoints)));
 
                     _systemInfoReplacement.Sort((p1, p2) => p2.Key.CompareTo(p1.Key)); // Required.
                 }

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
@@ -42,9 +42,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this._refreshCommentsBtn = new System.Windows.Forms.Button();
             this._postComment = new System.Windows.Forms.Button();
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
-
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
@@ -54,9 +52,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.flowLayoutPanel3.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).BeginInit();
-
             this.splitContainer3.Panel1.SuspendLayout();
             this.splitContainer3.Panel2.SuspendLayout();
             this.splitContainer3.SuspendLayout();
@@ -69,7 +65,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // 
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer2.Name = "splitContainer2";
             this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -80,9 +75,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.tabControl1);
-            this.splitContainer2.Size = new System.Drawing.Size(943, 545);
-            this.splitContainer2.SplitterDistance = 156;
-            this.splitContainer2.SplitterWidth = 5;
+            this.splitContainer2.Size = new System.Drawing.Size(754, 511);
+            this.splitContainer2.SplitterDistance = 146;
             this.splitContainer2.TabIndex = 6;
             // 
             // tableLayoutPanel2
@@ -93,11 +87,12 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel3, 0, 1);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(943, 156);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(754, 146);
             this.tableLayoutPanel2.TabIndex = 7;
             // 
             // flowLayoutPanel2
@@ -106,19 +101,19 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.flowLayoutPanel2.Controls.Add(this._chooseRepo);
             this.flowLayoutPanel2.Controls.Add(this._selectHostedRepoCB);
             this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(2, 2);
+            this.flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(937, 36);
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(750, 29);
             this.flowLayoutPanel2.TabIndex = 0;
             // 
             // _chooseRepo
             // 
             this._chooseRepo.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this._chooseRepo.AutoSize = true;
-            this._chooseRepo.Location = new System.Drawing.Point(4, 8);
-            this._chooseRepo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this._chooseRepo.Location = new System.Drawing.Point(3, 7);
             this._chooseRepo.Name = "_chooseRepo";
-            this._chooseRepo.Size = new System.Drawing.Size(132, 20);
+            this._chooseRepo.Size = new System.Drawing.Size(106, 15);
             this._chooseRepo.TabIndex = 4;
             this._chooseRepo.Text = "Choose repository:";
             // 
@@ -126,10 +121,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // 
             this._selectHostedRepoCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._selectHostedRepoCB.FormattingEnabled = true;
-            this._selectHostedRepoCB.Location = new System.Drawing.Point(144, 4);
-            this._selectHostedRepoCB.Margin = new System.Windows.Forms.Padding(4);
+            this._selectHostedRepoCB.Location = new System.Drawing.Point(115, 3);
             this._selectHostedRepoCB.Name = "_selectHostedRepoCB";
-            this._selectHostedRepoCB.Size = new System.Drawing.Size(322, 28);
+            this._selectHostedRepoCB.Size = new System.Drawing.Size(258, 23);
             this._selectHostedRepoCB.TabIndex = 0;
             this._selectHostedRepoCB.SelectedIndexChanged += new System.EventHandler(this._selectedOwner_SelectedIndexChanged);
             // 
@@ -141,11 +135,12 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.tableLayoutPanel3.Controls.Add(this._pullRequestsList, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel3, 1, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 45);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(2, 35);
+            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(937, 108);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(750, 109);
             this.tableLayoutPanel3.TabIndex = 1;
             // 
             // _pullRequestsList
@@ -160,11 +155,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.columnHeader4});
             this._pullRequestsList.FullRowSelect = true;
             this._pullRequestsList.HideSelection = false;
-            this._pullRequestsList.Location = new System.Drawing.Point(4, 4);
-            this._pullRequestsList.Margin = new System.Windows.Forms.Padding(4);
+            this._pullRequestsList.Location = new System.Drawing.Point(3, 3);
             this._pullRequestsList.MultiSelect = false;
             this._pullRequestsList.Name = "_pullRequestsList";
-            this._pullRequestsList.Size = new System.Drawing.Size(723, 100);
+            this._pullRequestsList.Size = new System.Drawing.Size(580, 103);
             this._pullRequestsList.TabIndex = 1;
             this._pullRequestsList.UseCompatibleStateImageBehavior = false;
             this._pullRequestsList.View = System.Windows.Forms.View.Details;
@@ -197,19 +191,19 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.flowLayoutPanel3.Controls.Add(this._closePullRequestBtn);
             this.flowLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel3.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel3.Location = new System.Drawing.Point(734, 3);
+            this.flowLayoutPanel3.Location = new System.Drawing.Point(588, 2);
+            this.flowLayoutPanel3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel3.Name = "flowLayoutPanel3";
-            this.flowLayoutPanel3.Size = new System.Drawing.Size(200, 102);
+            this.flowLayoutPanel3.Size = new System.Drawing.Size(160, 105);
             this.flowLayoutPanel3.TabIndex = 0;
             this.flowLayoutPanel3.WrapContents = false;
             // 
             // _fetchBtn
             // 
             this._fetchBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._fetchBtn.Location = new System.Drawing.Point(4, 4);
-            this._fetchBtn.Margin = new System.Windows.Forms.Padding(4);
+            this._fetchBtn.Location = new System.Drawing.Point(3, 3);
             this._fetchBtn.Name = "_fetchBtn";
-            this._fetchBtn.Size = new System.Drawing.Size(182, 36);
+            this._fetchBtn.Size = new System.Drawing.Size(155, 29);
             this._fetchBtn.TabIndex = 2;
             this._fetchBtn.Text = "Fetch to pr/ branch";
             this._fetchBtn.UseVisualStyleBackColor = true;
@@ -218,10 +212,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // _addAndFetchBtn
             // 
             this._addAndFetchBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this._addAndFetchBtn.Location = new System.Drawing.Point(4, 48);
-            this._addAndFetchBtn.Margin = new System.Windows.Forms.Padding(4);
+            this._addAndFetchBtn.Location = new System.Drawing.Point(3, 38);
             this._addAndFetchBtn.Name = "_addAndFetchBtn";
-            this._addAndFetchBtn.Size = new System.Drawing.Size(182, 36);
+            this._addAndFetchBtn.Size = new System.Drawing.Size(155, 29);
             this._addAndFetchBtn.TabIndex = 2;
             this._addAndFetchBtn.Text = "Add remote and fetch";
             this._addAndFetchBtn.UseVisualStyleBackColor = true;
@@ -230,10 +223,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // _closePullRequestBtn
             // 
             this._closePullRequestBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this._closePullRequestBtn.Location = new System.Drawing.Point(4, 92);
-            this._closePullRequestBtn.Margin = new System.Windows.Forms.Padding(4);
+            this._closePullRequestBtn.Location = new System.Drawing.Point(3, 73);
             this._closePullRequestBtn.Name = "_closePullRequestBtn";
-            this._closePullRequestBtn.Size = new System.Drawing.Size(182, 36);
+            this._closePullRequestBtn.Size = new System.Drawing.Size(155, 29);
             this._closePullRequestBtn.TabIndex = 3;
             this._closePullRequestBtn.Text = "Close pull request";
             this._closePullRequestBtn.UseVisualStyleBackColor = true;
@@ -245,18 +237,20 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.tabControl1.Controls.Add(this.tabPage2);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(943, 384);
+            this.tabControl1.Size = new System.Drawing.Size(754, 361);
             this.tabControl1.TabIndex = 10;
             // 
             // tabPage1
             // 
             this.tabPage1.Controls.Add(this.splitContainer3);
-            this.tabPage1.Location = new System.Drawing.Point(4, 29);
+            this.tabPage1.Location = new System.Drawing.Point(4, 24);
+            this.tabPage1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(935, 351);
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.tabPage1.Size = new System.Drawing.Size(746, 333);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Diffs";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -264,8 +258,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // splitContainer3
             // 
             this.splitContainer3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer3.Location = new System.Drawing.Point(3, 3);
-            this.splitContainer3.Margin = new System.Windows.Forms.Padding(4);
+            this.splitContainer3.Location = new System.Drawing.Point(2, 2);
             this.splitContainer3.Name = "splitContainer3";
             this.splitContainer3.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -276,36 +269,37 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // splitContainer3.Panel2
             // 
             this.splitContainer3.Panel2.Controls.Add(this._diffViewer);
-            this.splitContainer3.Size = new System.Drawing.Size(929, 345);
-            this.splitContainer3.SplitterDistance = 122;
-            this.splitContainer3.SplitterWidth = 5;
+            this.splitContainer3.Size = new System.Drawing.Size(742, 329);
+            this.splitContainer3.SplitterDistance = 116;
             this.splitContainer3.TabIndex = 0;
             // 
             // _fileStatusList
             // 
             this._fileStatusList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._fileStatusList.FilterVisible = false;
             this._fileStatusList.Location = new System.Drawing.Point(0, 0);
-            this._fileStatusList.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this._fileStatusList.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this._fileStatusList.Name = "_fileStatusList";
-            this._fileStatusList.Size = new System.Drawing.Size(929, 122);
+            this._fileStatusList.Size = new System.Drawing.Size(742, 116);
             this._fileStatusList.TabIndex = 0;
             // 
             // _diffViewer
             // 
             this._diffViewer.Dock = System.Windows.Forms.DockStyle.Fill;
             this._diffViewer.Location = new System.Drawing.Point(0, 0);
-            this._diffViewer.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this._diffViewer.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this._diffViewer.Name = "_diffViewer";
-            this._diffViewer.Size = new System.Drawing.Size(929, 218);
+            this._diffViewer.Size = new System.Drawing.Size(742, 209);
             this._diffViewer.TabIndex = 0;
             // 
             // tabPage2
             // 
             this.tabPage2.Controls.Add(this.tableLayoutPanel1);
-            this.tabPage2.Location = new System.Drawing.Point(4, 25);
+            this.tabPage2.Location = new System.Drawing.Point(4, 24);
+            this.tabPage2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(935, 355);
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.tabPage2.Size = new System.Drawing.Size(746, 279);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Comments";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -318,34 +312,35 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.tableLayoutPanel1.Controls.Add(this._postCommentText, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(2, 2);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 80F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(929, 349);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(742, 275);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _discussionWB
             // 
             this._discussionWB.Dock = System.Windows.Forms.DockStyle.Fill;
             this._discussionWB.IsWebBrowserContextMenuEnabled = false;
-            this._discussionWB.Location = new System.Drawing.Point(4, 4);
-            this._discussionWB.Margin = new System.Windows.Forms.Padding(4);
-            this._discussionWB.MinimumSize = new System.Drawing.Size(25, 25);
+            this._discussionWB.Location = new System.Drawing.Point(3, 3);
+            this._discussionWB.MinimumSize = new System.Drawing.Size(20, 20);
             this._discussionWB.Name = "_discussionWB";
-            this._discussionWB.Size = new System.Drawing.Size(921, 198);
+            this._discussionWB.ScriptErrorsSuppressed = true;
+            this._discussionWB.Size = new System.Drawing.Size(736, 156);
             this._discussionWB.TabIndex = 9;
             this._discussionWB.WebBrowserShortcutsEnabled = false;
             // 
             // _postCommentText
             // 
             this._postCommentText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._postCommentText.Location = new System.Drawing.Point(2, 208);
+            this._postCommentText.Location = new System.Drawing.Point(2, 164);
             this._postCommentText.Margin = new System.Windows.Forms.Padding(2);
             this._postCommentText.Name = "_postCommentText";
-            this._postCommentText.Size = new System.Drawing.Size(925, 96);
+            this._postCommentText.Size = new System.Drawing.Size(738, 76);
             this._postCommentText.TabIndex = 10;
             this._postCommentText.TextBoxFont = new System.Drawing.Font("Segoe UI", 9F);
             // 
@@ -356,18 +351,18 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.flowLayoutPanel1.Controls.Add(this._postComment);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 309);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(2, 244);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(923, 37);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(738, 29);
             this.flowLayoutPanel1.TabIndex = 11;
             // 
             // _refreshCommentsBtn
             // 
             this._refreshCommentsBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this._refreshCommentsBtn.Location = new System.Drawing.Point(794, 4);
-            this._refreshCommentsBtn.Margin = new System.Windows.Forms.Padding(4);
+            this._refreshCommentsBtn.Location = new System.Drawing.Point(635, 3);
             this._refreshCommentsBtn.Name = "_refreshCommentsBtn";
-            this._refreshCommentsBtn.Size = new System.Drawing.Size(125, 29);
+            this._refreshCommentsBtn.Size = new System.Drawing.Size(100, 23);
             this._refreshCommentsBtn.TabIndex = 10;
             this._refreshCommentsBtn.Text = "Refresh";
             this._refreshCommentsBtn.UseVisualStyleBackColor = true;
@@ -375,30 +370,26 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // _postComment
             // 
             this._postComment.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this._postComment.Location = new System.Drawing.Point(622, 4);
-            this._postComment.Margin = new System.Windows.Forms.Padding(4);
+            this._postComment.Location = new System.Drawing.Point(498, 3);
             this._postComment.Name = "_postComment";
-            this._postComment.Size = new System.Drawing.Size(164, 29);
+            this._postComment.Size = new System.Drawing.Size(131, 23);
             this._postComment.TabIndex = 11;
             this._postComment.Text = "Post comment";
             this._postComment.UseVisualStyleBackColor = true;
             // 
             // ViewPullRequestsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(943, 545);
+            this.ClientSize = new System.Drawing.Size(754, 511);
             this.Controls.Add(this.splitContainer2);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "ViewPullRequestsForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "View Pull Requests";
             this.Load += new System.EventHandler(this.ViewPullRequestsForm_Load);
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel2.ResumeLayout(false);
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
-
             this.splitContainer2.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
@@ -410,15 +401,14 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.tabPage1.ResumeLayout(false);
             this.splitContainer3.Panel1.ResumeLayout(false);
             this.splitContainer3.Panel2.ResumeLayout(false);
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).EndInit();
-
             this.splitContainer3.ResumeLayout(false);
             this.tabPage2.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
+
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -164,7 +164,7 @@ namespace GitUI.CommandsDialogs
             DiffFiles.FilterVisible = true;
             DiffFiles.DescribeRevision = sha1 => DescribeRevision(sha1);
             DiffText.SetFileLoader(GetNextPatchFile);
-            DiffText.Font = AppSettings.DiffFont;
+            DiffText.Font = AppSettings.FixedWidthFont;
             ReloadHotkeys();
 
             GotFocus += (s, e1) => DiffFiles.Focus();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
@@ -7,7 +7,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class AppearanceFontsSettingsPage : SettingsPageWithHeader
     {
-        private Font _diffFont;
+        private Font _fixedWidthFont;
         private Font _applicationFont;
         private Font _commitFont;
 
@@ -21,20 +21,20 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void SettingsToPage()
         {
             SetCurrentApplicationFont(AppSettings.Font);
-            SetCurrentDiffFont(AppSettings.DiffFont);
+            SetCurrentDiffFont(AppSettings.FixedWidthFont);
             SetCurrentCommitFont(AppSettings.CommitFont);
         }
 
         protected override void PageToSettings()
         {
-            AppSettings.DiffFont = _diffFont;
+            AppSettings.FixedWidthFont = _fixedWidthFont;
             AppSettings.Font = _applicationFont;
             AppSettings.CommitFont = _commitFont;
         }
 
         private void diffFontChangeButton_Click(object sender, EventArgs e)
         {
-            diffFontDialog.Font = _diffFont;
+            diffFontDialog.Font = _fixedWidthFont;
             DialogResult result = diffFontDialog.ShowDialog(this);
 
             if (result == DialogResult.OK || result == DialogResult.Yes)
@@ -67,7 +67,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void SetCurrentDiffFont(Font newFont)
         {
-            _diffFont = newFont;
+            _fixedWidthFont = newFont;
             SetFontButtonText(newFont, diffFontChangeButton);
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -54,7 +54,7 @@
             this.lblCacheDays = new System.Windows.Forms.Label();
             this.lblNoImageService = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_DaysToCacheImages = new System.Windows.Forms.NumericUpDown();
-            this.diffFontDialog = new System.Windows.Forms.FontDialog();
+            this.fixedWidthFontDialog = new System.Windows.Forms.FontDialog();
             this.applicationDialog = new System.Windows.Forms.FontDialog();
             this.commitFontDialog = new System.Windows.Forms.FontDialog();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
@@ -432,11 +432,11 @@
             this._NO_TRANSLATE_DaysToCacheImages.TabIndex = 2;
             this._NO_TRANSLATE_DaysToCacheImages.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
-            // diffFontDialog
+            // fixedWidthFontDialog
             // 
-            this.diffFontDialog.AllowVerticalFonts = false;
-            this.diffFontDialog.Color = System.Drawing.SystemColors.ControlText;
-            this.diffFontDialog.FixedPitchOnly = true;
+            this.fixedWidthFontDialog.AllowVerticalFonts = false;
+            this.fixedWidthFontDialog.Color = System.Drawing.SystemColors.ControlText;
+            this.fixedWidthFontDialog.FixedPitchOnly = true;
             // 
             // applicationDialog
             // 
@@ -498,7 +498,7 @@
         private System.Windows.Forms.Label lblCacheDays;
         private System.Windows.Forms.Button ClearImageCache;
         private System.Windows.Forms.CheckBox ShowAuthorGravatar;
-        private System.Windows.Forms.FontDialog diffFontDialog;
+        private System.Windows.Forms.FontDialog fixedWidthFontDialog;
         private System.Windows.Forms.FontDialog applicationDialog;
         private System.Windows.Forms.FontDialog commitFontDialog;
         private System.Windows.Forms.TableLayoutPanel tlpnlLanguage;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.Designer.cs
@@ -30,6 +30,7 @@
         {
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
+            this.lvTranslations = new GitUI.UserControls.NativeListView();
             this.SuspendLayout();
             // 
             // label1
@@ -44,24 +45,40 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(12, 146);
+            this.label2.Location = new System.Drawing.Point(12, 33);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(339, 15);
+            this.label2.Size = new System.Drawing.Size(338, 15);
             this.label2.TabIndex = 7;
             this.label2.Text = "You can change the language at any time in the settings dialog";
+            // 
+            // lvTranslations
+            // 
+            this.lvTranslations.Activation = System.Windows.Forms.ItemActivation.OneClick;
+            this.lvTranslations.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lvTranslations.HotTracking = true;
+            this.lvTranslations.HoverSelection = true;
+            this.lvTranslations.Location = new System.Drawing.Point(12, 51);
+            this.lvTranslations.MultiSelect = false;
+            this.lvTranslations.Name = "lvTranslations";
+            this.lvTranslations.ShowGroups = false;
+            this.lvTranslations.Size = new System.Drawing.Size(776, 476);
+            this.lvTranslations.TabIndex = 0;
+            this.lvTranslations.UseCompatibleStateImageBehavior = false;
+            this.lvTranslations.ItemActivate += new System.EventHandler(this.lvTranslations_ItemActivate);
             // 
             // FormChooseTranslation
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(431, 168);
+            this.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.ClientSize = new System.Drawing.Size(800, 539);
+            this.Controls.Add(this.lvTranslations);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
             this.Name = "FormChooseTranslation";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Choose language";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormChooseTranslation_FormClosing);
             this.ResumeLayout(false);
@@ -73,5 +90,6 @@
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
+        private UserControls.NativeListView lvTranslations;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -14,8 +14,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             InitializeComponent();
 
-            this.label1.Font = FontUtil.MainInstructionFont;
-            this.label1.ForeColor = FontUtil.MainInstructionColor;
+            label1.Font = FontUtil.MainInstructionFont;
+            label1.ForeColor = FontUtil.MainInstructionColor;
             Translate();
         }
 
@@ -42,44 +42,19 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 }
             }
 
-            this.lvTranslations.LargeImageList = imageList;
+            lvTranslations.LargeImageList = imageList;
 
             foreach (string translation in translations)
             {
                 if (imageList.Images.ContainsKey(translation))
                 {
-                    this.lvTranslations.Items.Add(new ListViewItem(translation, translation) { Tag = translation });
-                }
-                if (File.Exists(Path.Combine(Translator.GetTranslationDir(), translation + ".gif")))
-                {
-                    translationImage.BackgroundImage = Image.FromFile(Path.Combine(Translator.GetTranslationDir(), translation + ".gif"));
+                    lvTranslations.Items.Add(new ListViewItem(translation, translation) { Tag = translation });
                 }
                 else
                 {
-                    this.lvTranslations.Items.Add(new ListViewItem(translation) { Tag = translation });
+                    lvTranslations.Items.Add(new ListViewItem(translation) { Tag = translation });
                 }
-
-                translationImage.Cursor = Cursors.Hand;
-                translationImage.Tag = translation;
-                translationImage.Click += translationImage_Click;
-
-                Controls.Add(translationImage);
-
-                    TextAlign = ContentAlignment.TopCenter
-                };
-                }
-                label.Click += translationImage_Click;
-                Controls.Add(label);
             }
-
-            Height = 34 + y + imageHeight + labelHeight + SystemInformation.CaptionHeight + 37;
-            }
-            label2.Top = Height - SystemInformation.CaptionHeight - 25;
-        }
-
-        {
-            AppSettings.Translation = ((Control)sender).Tag.ToString();
-            Close();
         }
 
         private void FormChooseTranslation_FormClosing(object sender, FormClosingEventArgs e)
@@ -88,6 +63,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 AppSettings.Translation = "English";
             }
+        }
 
         private void lvTranslations_ItemActivate(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -13,6 +13,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public FormChooseTranslation()
         {
             InitializeComponent();
+
+            this.label1.Font = FontUtil.MainInstructionFont;
+            this.label1.ForeColor = FontUtil.MainInstructionColor;
             Translate();
         }
 
@@ -20,39 +23,40 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             base.OnLoad(e);
 
-            const int labelHeight = 20;
-            const int imageHeight = 75;
-            const int imageWidth = 150;
-            int x = -(imageWidth + 6);
-            int y = 0;
             var translations = new List<string>(Translator.GetAllTranslations());
             translations.Sort();
             translations.Insert(0, "English");
 
+            var imageList = new ImageList
+            {
+                ImageSize = new Size(150, 75),
+            };
+
             foreach (string translation in translations)
             {
-                x += imageWidth + 6;
-                if (x > imageWidth * 4)
+                var imagePath = Path.Combine(Translator.GetTranslationDir(), translation + ".gif");
+                if (File.Exists(imagePath))
                 {
-                    x = 0;
-                    y += imageHeight + 6 + labelHeight;
+                    var image = Image.FromFile(imagePath);
+                    imageList.Images.Add(translation, image);
                 }
+            }
 
-                var translationImage = new PictureBox
+            this.lvTranslations.LargeImageList = imageList;
+
+            foreach (string translation in translations)
+            {
+                if (imageList.Images.ContainsKey(translation))
                 {
-                    Top = y + 34,
-                    Left = x + 15,
-                    Height = imageHeight,
-                    Width = imageWidth,
-                    BackgroundImageLayout = ImageLayout.Stretch
-                };
+                    this.lvTranslations.Items.Add(new ListViewItem(translation, translation) { Tag = translation });
+                }
                 if (File.Exists(Path.Combine(Translator.GetTranslationDir(), translation + ".gif")))
                 {
                     translationImage.BackgroundImage = Image.FromFile(Path.Combine(Translator.GetTranslationDir(), translation + ".gif"));
                 }
                 else
                 {
-                    translationImage.BackColor = Color.Black;
+                    this.lvTranslations.Items.Add(new ListViewItem(translation) { Tag = translation });
                 }
 
                 translationImage.Cursor = Cursors.Hand;
@@ -61,26 +65,18 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
                 Controls.Add(translationImage);
 
-                var label = new Label
-                {
-                    Text = translation,
-                    Tag = translation,
-                    Left = translationImage.Left,
-                    Width = translationImage.Width,
-                    Top = translationImage.Bottom,
-                    Height = labelHeight,
                     TextAlign = ContentAlignment.TopCenter
                 };
+                }
                 label.Click += translationImage_Click;
                 Controls.Add(label);
             }
 
             Height = 34 + y + imageHeight + labelHeight + SystemInformation.CaptionHeight + 37;
-            Width = ((imageWidth + 6) * 4) + 24;
+            }
             label2.Top = Height - SystemInformation.CaptionHeight - 25;
         }
 
-        private void translationImage_Click(object sender, EventArgs e)
         {
             AppSettings.Translation = ((Control)sender).Tag.ToString();
             Close();
@@ -92,6 +88,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 AppSettings.Translation = "English";
             }
+
+        private void lvTranslations_ItemActivate(object sender, EventArgs e)
+        {
+            AppSettings.Translation = ((ListView)sender).SelectedItems[0].Tag.ToString();
+            Close();
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.Designer.cs
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             // 
             this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold);
+            this.label1.Font = new System.Drawing.Font(this.label1.Font, System.Drawing.FontStyle.Bold);
             this.label1.Location = new System.Drawing.Point(3, 12);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(98, 13);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -232,7 +232,7 @@ namespace GitUI.Editor
         protected override void OnRuntimeLoad()
         {
             ReloadHotkeys();
-            Font = AppSettings.DiffFont;
+            Font = AppSettings.FixedWidthFont;
         }
 
         public void ReloadHotkeys()

--- a/GitUI/FontUtil.cs
+++ b/GitUI/FontUtil.cs
@@ -7,21 +7,19 @@
     {
         static FontUtil()
         {
-            var hTheme = NativeMethods.OpenThemeData(IntPtr.Zero, "TEXTSTYLE");
-            if (hTheme != IntPtr.Zero)
+            var themeHandle = NativeMethods.OpenThemeData(IntPtr.Zero, "TEXTSTYLE");
+            if (themeHandle != IntPtr.Zero)
             {
                 // TODO: use C# 7.0 out var parameters
-                NativeMethods.LOGFONT pFont;
-                NativeMethods.GetThemeFont(hTheme, IntPtr.Zero, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_FONT, out pFont);
+                NativeMethods.GetThemeFont(themeHandle, IntPtr.Zero, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_FONT, out var logFont);
 
-                MainInstructionFont = Font.FromLogFont(pFont);
+                MainInstructionFont = Font.FromLogFont(logFont);
 
-                NativeMethods.COLORREF pColor;
-                NativeMethods.GetThemeColor(hTheme, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_TEXTCOLOR, out pColor);
+                NativeMethods.GetThemeColor(themeHandle, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_TEXTCOLOR, out var colorRef);
 
-                MainInstructionColor = Color.FromArgb(pColor.R, pColor.G, pColor.B);
+                MainInstructionColor = Color.FromArgb(colorRef.R, colorRef.G, colorRef.B);
 
-                NativeMethods.CloseThemeData(hTheme);
+                NativeMethods.CloseThemeData(themeHandle);
             }
             else
             {

--- a/GitUI/FontUtil.cs
+++ b/GitUI/FontUtil.cs
@@ -1,0 +1,37 @@
+﻿namespace GitUI
+{
+    using System;
+    using System.Drawing;
+
+    public static class FontUtil
+    {
+        static FontUtil()
+        {
+            var hTheme = NativeMethods.OpenThemeData(IntPtr.Zero, "TEXTSTYLE");
+            if (hTheme != IntPtr.Zero)
+            {
+                // TODO: use C# 7.0 out var parameters
+                NativeMethods.LOGFONT pFont;
+                NativeMethods.GetThemeFont(hTheme, IntPtr.Zero, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_FONT, out pFont);
+
+                MainInstructionFont = Font.FromLogFont(pFont);
+
+                NativeMethods.COLORREF pColor;
+                NativeMethods.GetThemeColor(hTheme, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_TEXTCOLOR, out pColor);
+
+                MainInstructionColor = Color.FromArgb(pColor.R, pColor.G, pColor.B);
+
+                NativeMethods.CloseThemeData(hTheme);
+            }
+            else
+            {
+                MainInstructionFont = SystemFonts.CaptionFont;
+                MainInstructionColor = SystemColors.WindowText;
+            }
+        }
+
+        public static Font MainInstructionFont { get; }
+
+        public static Color MainInstructionColor { get; }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -268,6 +268,7 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="FontUtil.cs" />
     <Compile Include="Editor\GitHighlightingStrategyBase.cs" />
     <Compile Include="Editor\RebaseTodoHighlightingStrategy.cs" />
     <Compile Include="FindFilePredicateProvider.cs" />

--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -101,18 +101,18 @@ namespace GitUI
 
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
         internal static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
-        
+
         [DllImport("uxtheme.dll", ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal static extern IntPtr OpenThemeData(IntPtr hWnd, String classList);
+        internal static extern IntPtr OpenThemeData(IntPtr hWnd, string classList);
 
         [DllImport("uxtheme.dll", ExactSpelling = true)]
-        internal static extern Int32 CloseThemeData(IntPtr hTheme);
+        internal static extern int CloseThemeData(IntPtr hTheme);
 
         [DllImport("uxtheme", ExactSpelling = true)]
-        internal static extern Int32 GetThemeColor(IntPtr hTheme, int iPartId, int iStateId, int iPropId, out COLORREF pColor);
+        internal static extern int GetThemeColor(IntPtr hTheme, int iPartId, int iStateId, int iPropId, out COLORREF pColor);
 
         [DllImport("uxtheme", ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal static extern Int32 GetThemeFont(IntPtr hTheme, IntPtr hdc, int iPartId, int iStateId, int iPropId, out LOGFONT pFont);
+        internal static extern int GetThemeFont(IntPtr hTheme, IntPtr hdc, int iPartId, int iStateId, int iPropId, out LOGFONT pFont);
 
         #endregion
     }

--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -34,8 +34,44 @@ namespace GitUI
             public CHARRANGE chrg;         // Range of text to draw (see earlier declaration)
         }
 
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal struct LOGFONT
+        {
+            public const int LF_FACESIZE = 32;
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            [MarshalAsAttribute(UnmanagedType.ByValTStr, SizeConst = LF_FACESIZE)]
+            public string lfFaceName;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct COLORREF
+        {
+            public byte R;
+            public byte G;
+            public byte B;
+        }
+
         internal const int WM_USER = 0x0400;
         internal const int EM_FORMATRANGE = WM_USER + 57;
+
+        // from vsstyle.h
+        internal const int TEXT_MAININSTRUCTION = 1;
+
+        // from vssym32.h
+        internal const int TMT_TEXTCOLOR = 3803;
+        internal const int TMT_FONT = 210;
 
         [DllImport("user32")]
         internal static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wp, ref FORMATRANGE lp);
@@ -65,6 +101,19 @@ namespace GitUI
 
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
         internal static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
+        
+        [DllImport("uxtheme.dll", ExactSpelling = true, CharSet = CharSet.Unicode)]
+        internal static extern IntPtr OpenThemeData(IntPtr hWnd, String classList);
+
+        [DllImport("uxtheme.dll", ExactSpelling = true)]
+        internal static extern Int32 CloseThemeData(IntPtr hTheme);
+
+        [DllImport("uxtheme", ExactSpelling = true)]
+        internal static extern Int32 GetThemeColor(IntPtr hTheme, int iPartId, int iStateId, int iPropId, out COLORREF pColor);
+
+        [DllImport("uxtheme", ExactSpelling = true, CharSet = CharSet.Unicode)]
+        internal static extern Int32 GetThemeFont(IntPtr hTheme, IntPtr hdc, int iPartId, int iStateId, int iPropId, out LOGFONT pFont);
+
         #endregion
     }
 

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -719,7 +719,7 @@ namespace GitUI.SpellChecker
             if (!ContainsFocus && string.IsNullOrEmpty(TextBox.Text) && TextBoxFont != null)
             {
                 _isWatermarkShowing = true;
-                TextBox.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Italic);
+                TextBox.Font = new Font(TextBox.Font, FontStyle.Italic);
                 TextBox.ForeColor = SystemColors.InactiveCaption;
                 TextBox.Text = WatermarkText;
             }

--- a/GitUI/UserControls/CommitSummaryUserControl.Designer.cs
+++ b/GitUI/UserControls/CommitSummaryUserControl.Designer.cs
@@ -56,7 +56,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelMessage.AutoEllipsis = true;
-            this.labelMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelMessage.Font = new System.Drawing.Font(this.labelMessage.Font, System.Drawing.FontStyle.Bold);
             this.labelMessage.Location = new System.Drawing.Point(12, 22);
             this.labelMessage.MaximumSize = new System.Drawing.Size(1000, 50);
             this.labelMessage.Name = "labelMessage";
@@ -70,7 +70,7 @@
             // 
             this.labelAuthor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.labelAuthor.AutoSize = true;
-            this.labelAuthor.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelAuthor.Font = new System.Drawing.Font(this.labelAuthor.Font, System.Drawing.FontStyle.Bold);
             this.labelAuthor.Location = new System.Drawing.Point(100, 89);
             this.labelAuthor.Name = "labelAuthor";
             this.labelAuthor.Size = new System.Drawing.Size(19, 13);
@@ -82,7 +82,7 @@
             this.labelTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.labelTags.AutoSize = true;
             this.labelTags.BackColor = System.Drawing.Color.LightSteelBlue;
-            this.labelTags.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelTags.Font = new System.Drawing.Font(this.labelTags.Font, System.Drawing.FontStyle.Bold);
             this.labelTags.Location = new System.Drawing.Point(100, 112);
             this.labelTags.Name = "labelTags";
             this.labelTags.Size = new System.Drawing.Size(19, 13);
@@ -93,7 +93,7 @@
             // 
             this.labelBranches.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.labelBranches.AutoSize = true;
-            this.labelBranches.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelBranches.Font = new System.Drawing.Font(this.labelBranches.Font, System.Drawing.FontStyle.Bold);
             this.labelBranches.Location = new System.Drawing.Point(100, 135);
             this.labelBranches.Name = "labelBranches";
             this.labelBranches.Size = new System.Drawing.Size(19, 13);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -82,7 +82,7 @@ namespace GitUI
 
             HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: true);
             Controls.SetChildIndex(NoFiles, 0);
-            NoFiles.Font = new Font(SystemFonts.MessageBoxFont, FontStyle.Italic);
+            NoFiles.Font = new Font(NoFiles.Font, FontStyle.Italic);
 
             _filter = new Regex(".*");
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -159,7 +159,6 @@ namespace GitUI
             // 
             this.Revisions.AllowUserToAddRows = false;
             this.Revisions.AllowUserToDeleteRows = false;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.Revisions.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
             this.Revisions.BackgroundColor = System.Drawing.SystemColors.Window;
             this.Revisions.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
@@ -181,14 +180,12 @@ namespace GitUI
             this.Revisions.ContextMenuStrip = this.mainContextMenu;
             dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.GradientActiveCaption;
             dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.Revisions.DefaultCellStyle = dataGridViewCellStyle4;
             this.Revisions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Revisions.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.Revisions.GridColor = System.Drawing.SystemColors.Window;
             this.Revisions.Location = new System.Drawing.Point(0, 0);
             this.Revisions.Name = "Revisions";
@@ -201,9 +198,7 @@ namespace GitUI
             dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.Revisions.RowHeadersDefaultCellStyle = dataGridViewCellStyle5;
             this.Revisions.RowHeadersVisible = false;
-            dataGridViewCellStyle6.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.Revisions.RowsDefaultCellStyle = dataGridViewCellStyle6;
-            this.Revisions.RowTemplate.DefaultCellStyle.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.Revisions.RowTemplate.DefaultCellStyle.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(157)))), ((int)(((byte)(185)))), ((int)(((byte)(235)))));
             this.Revisions.RowTemplate.DefaultCellStyle.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             this.Revisions.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.False;
@@ -218,7 +213,6 @@ namespace GitUI
             // 
             // Graph
             // 
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.GraphDataGridViewColumn.DefaultCellStyle = dataGridViewCellStyle3;
             this.GraphDataGridViewColumn.Frozen = true;
             this.GraphDataGridViewColumn.HeaderText = "";

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -51,12 +51,6 @@ namespace GitUI
                     _authoredRevisionsBrush.Dispose();
                     _authoredRevisionsBrush = null;
                 }
-
-                if (_fontOfSHAColumn != null)
-                {
-                    _fontOfSHAColumn.Dispose();
-                    _fontOfSHAColumn = null;
-                }
             }
 
             if (disposing && (components != null))

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1971,7 +1971,7 @@ namespace GitUI
                     {
                         // do not show artificial GUID
                         var text = revision.Guid;
-                        DrawColumnText(e, text, _fontOfSHAColumn, foreColor);
+                        DrawColumnText(e, text, rowFont, foreColor);
                     }
                 }
                 else if (columnIndex == BuildServerWatcher.BuildStatusImageColumnIndex)
@@ -3205,7 +3205,6 @@ namespace GitUI
         }
 
         private bool _settingsLoaded;
-        private Font _fontOfSHAColumn;
 
         private void RunScript(object sender, EventArgs e)
         {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -334,7 +334,7 @@ namespace GitUI
                 _normalFont = value;
                 MessageDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 DateDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
-                _fontOfSHAColumn = new Font("Consolas", _normalFont.SizeInPoints);
+                _fontOfSHAColumn = AppSettings.FixedWidthFont;
                 IdDataGridViewColumn.DefaultCellStyle.Font = _fontOfSHAColumn;
                 IsMessageMultilineDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 IsMessageMultilineDataGridViewColumn.Width = TextRenderer.MeasureText(MultilineMessageIndicator, NormalFont).Width;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -328,14 +328,13 @@ namespace GitUI
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Font NormalFont
         {
-            get { return _normalFont; }
+            get => _normalFont;
             set
             {
                 _normalFont = value;
                 MessageDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 DateDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
-                _fontOfSHAColumn = AppSettings.FixedWidthFont;
-                IdDataGridViewColumn.DefaultCellStyle.Font = _fontOfSHAColumn;
+                IdDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 IsMessageMultilineDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 IsMessageMultilineDataGridViewColumn.Width = TextRenderer.MeasureText(MultilineMessageIndicator, NormalFont).Width;
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -105,14 +105,6 @@ namespace GitUI.RevisionGridClasses
 
             InitializeComponent();
 
-            ColumnHeadersDefaultCellStyle.Font = SystemFonts.DefaultFont;
-            Font = SystemFonts.DefaultFont;
-            DefaultCellStyle.Font = SystemFonts.DefaultFont;
-            AlternatingRowsDefaultCellStyle.Font = SystemFonts.DefaultFont;
-            RowsDefaultCellStyle.Font = SystemFonts.DefaultFont;
-            RowHeadersDefaultCellStyle.Font = SystemFonts.DefaultFont;
-            RowTemplate.DefaultCellStyle.Font = SystemFonts.DefaultFont;
-
             _whiteBorderPen = new Pen(Brushes.White, _laneLineWidth);
             _blackBorderPen = new Pen(Brushes.Black, _laneLineWidth + 1);
 

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
@@ -87,7 +87,7 @@ namespace TeamCityIntegration.Settings
             // 
             labelProjectNameComment.Anchor = System.Windows.Forms.AnchorStyles.Left;
             labelProjectNameComment.AutoSize = true;
-            labelProjectNameComment.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            labelProjectNameComment.Font = new System.Drawing.Font(labelProjectNameComment.Font, System.Drawing.FontStyle.Italic);
             labelProjectNameComment.Location = new System.Drawing.Point(117, 72);
             labelProjectNameComment.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
             labelProjectNameComment.Name = "labelProjectNameComment";
@@ -98,7 +98,7 @@ namespace TeamCityIntegration.Settings
             // labelBuildIdFilter
             // 
             labelBuildIdFilter.AutoSize = true;
-            labelBuildIdFilter.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            labelBuildIdFilter.Font = new System.Drawing.Font(labelBuildIdFilter.Font, System.Drawing.FontStyle.Italic);
             labelBuildIdFilter.Location = new System.Drawing.Point(3, 0);
             labelBuildIdFilter.Name = "labelBuildIdFilter";
             labelBuildIdFilter.Size = new System.Drawing.Size(45, 15);
@@ -140,7 +140,7 @@ namespace TeamCityIntegration.Settings
             // labelRegexError
             // 
             this.labelRegexError.AutoSize = true;
-            this.labelRegexError.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            this.labelRegexError.Font = new System.Drawing.Font(this.labelRegexError.Font, System.Drawing.FontStyle.Italic);
             this.labelRegexError.ForeColor = System.Drawing.Color.Red;
             this.labelRegexError.Location = new System.Drawing.Point(54, 0);
             this.labelRegexError.Name = "labelRegexError";

--- a/Plugins/BuildServerIntegration/TfsIntegration/Settings/TfsSettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/Settings/TfsSettingsUserControl.Designer.cs
@@ -91,7 +91,7 @@ namespace TfsIntegration.Settings
             // 
             labelBuildIdFilter.Anchor = System.Windows.Forms.AnchorStyles.Left;
             labelBuildIdFilter.AutoSize = true;
-            labelBuildIdFilter.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            labelBuildIdFilter.Font = new System.Drawing.Font(labelBuildIdFilter.Font, System.Drawing.FontStyle.Italic);
             labelBuildIdFilter.Location = new System.Drawing.Point(138, 101);
             labelBuildIdFilter.Name = "labelBuildIdFilter";
             labelBuildIdFilter.Size = new System.Drawing.Size(45, 15);
@@ -101,7 +101,7 @@ namespace TfsIntegration.Settings
             // labelRegexError
             // 
             this.labelRegexError.AutoSize = true;
-            this.labelRegexError.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic);
+            this.labelRegexError.Font = new System.Drawing.Font(this.labelRegexError.Font, System.Drawing.FontStyle.Italic);
             this.labelRegexError.ForeColor = System.Drawing.Color.Red;
             this.labelRegexError.Location = new System.Drawing.Point(138, 121);
             this.labelRegexError.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -64,7 +64,7 @@ namespace GitStatistics
             InitializeComponent();
             Translate();
 
-            TotalLinesOfCode.Font = new Font(SystemFonts.MessageBoxFont.FontFamily, 9.75F, FontStyle.Bold, GraphicsUnit.Point);
+            TotalLinesOfCode.Font = new Font(TotalLinesOfCode.Font, FontStyle.Bold);
             TotalLinesOfCode2.Font = TotalLinesOfCode.Font;
             TotalLinesOfTestCode.Font = TotalLinesOfCode.Font;
             TotalCommits.Font = TotalLinesOfCode.Font;

--- a/TranslationApp/FormTranslate.Designer.cs
+++ b/TranslationApp/FormTranslate.Designer.cs
@@ -385,7 +385,6 @@ namespace TranslationApp
             this.translatedText.Name = "translatedText";
             this.translatedText.Size = new System.Drawing.Size(556, 117);
             this.translatedText.TabIndex = 14;
-            this.translatedText.TextBoxFont = new System.Drawing.Font("Segoe UI", 10.2F);
             this.translatedText.TextChanged += new System.EventHandler(this.translatedText_TextChanged);
             this.translatedText.Enter += new System.EventHandler(this.translatedText_Enter);
             this.translatedText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.translatedText_KeyDown);


### PR DESCRIPTION
Fixes #4511.

Changes proposed in this pull request:
 - Make the default font SystemFonts.MessageBoxFont (Segoe UI for Vista+ with themes enabled, Tahoma for Windows XP and Vista/7 in Classic mode).
 - Make default fixed-width font Consolas (assuming we don't care about XP support).
 - Remove hard-coded font references (respect application setting).
 - Updated first-load language selection dialog to use ListView control.
 
Screenshots before and after (if PR changes UI):
- Dashboard before/after:
![2018-02-22 gitextensions dashboard - old](https://user-images.githubusercontent.com/2142963/36584346-779a64dc-18cd-11e8-85d7-069c8c4d5f7b.png)
![2018-02-22 gitextensions dashboard - new](https://user-images.githubusercontent.com/2142963/36584347-77f28af4-18cd-11e8-8e30-e9150936625c.png)

- Language selection before/after:
![2018-02-22 gitextensions choose lang - old](https://user-images.githubusercontent.com/2142963/36584337-6f47beba-18cd-11e8-9559-5bf43ea79cf0.png)
![2018-02-22 gitextensions choose lang - new](https://user-images.githubusercontent.com/2142963/36584339-6fa967d2-18cd-11e8-84d4-87e37d47579c.png)

What did I do to test the code and ensure quality:
 - Reset application (deleted `GitExtensions.settings`); observed default fonts displayed in UI.
 - Tested updated first-load language selection dialog.

Has been tested on (remove any that don't apply):
 - GIT 2.16.2
 - Windows 10
 - Windows 7 (with themes and without)
