### PR TITLE
Test and fix AsyncLoader

### DIFF
--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -260,8 +260,11 @@ namespace GitCommands
                 return;
             }
 
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource?.Dispose();
+            if (_cancellationTokenSource != null)
+            {
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Dispose();
+            }
         }
     }
 

--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -1,240 +1,273 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace GitCommands
 {
-    public class AsyncLoader : IDisposable
+    public sealed class AsyncLoader : IDisposable
     {
-        private readonly TaskScheduler _continuationTaskScheduler;
-        private CancellationTokenSource _cancelledTokenSource;
-
-        public int Delay { get; set; }
-
-        public AsyncLoader()
-            : this(DefaultContinuationTaskScheduler)
-        {
-        }
-
-        public AsyncLoader(TaskScheduler continuationTaskScheduler)
-        {
-            _continuationTaskScheduler = continuationTaskScheduler;
-            Delay = 0;
-        }
-
-        private static int _defaultThreadId = -1;
-        private static TaskScheduler _defaultContinuationTaskScheduler;
-        public static TaskScheduler DefaultContinuationTaskScheduler
-        {
-            get
-            {
-                if (_defaultThreadId == Thread.CurrentThread.ManagedThreadId && _defaultContinuationTaskScheduler != null)
-                {
-                    return _defaultContinuationTaskScheduler;
-                }
-
-                return TaskScheduler.FromCurrentSynchronizationContext();
-            }
-
-            set
-            {
-                _defaultThreadId = Thread.CurrentThread.ManagedThreadId;
-                _defaultContinuationTaskScheduler = value;
-            }
-        }
-
-        public event EventHandler<AsyncErrorEventArgs> LoadingError = delegate { };
+        private static readonly ThreadLocal<TaskScheduler> _defaultScheduler = new ThreadLocal<TaskScheduler>(trackAllValues: false);
 
         /// <summary>
-        /// Does something on threadpool, executes continuation on current sync context thread, executes onError if the async request fails.
-        /// There does probably exist something like this in the .NET library, but I could not find it. //cocytus
+        /// Gets and sets the default <see cref="TaskScheduler"/> to use for continuations following calls to <c>Load</c> from the current thread.
         /// </summary>
-        /// <typeparam name="T">Result to be passed from doMe to continueWith</typeparam>
-        /// <param name="doMe">The stuff we want to do. Should return whatever continueWith expects.</param>
-        /// <param name="continueWith">Do this on original sync context.</param>
-        /// <param name="onError">Do this on original sync context if doMe barfs.</param>
-        public static Task<T> DoAsync<T>(Func<T> doMe, Action<T> continueWith, Action<AsyncErrorEventArgs> onError)
+        /// <remarks>
+        /// Defaults to <see cref="TaskScheduler.FromCurrentSynchronizationContext"/>.
+        /// </remarks>
+        [NotNull]
+        public static TaskScheduler DefaultContinuationTaskScheduler
         {
-            AsyncLoader loader = new AsyncLoader();
-            loader.LoadingError += (sender, e) => onError(e);
-            return loader.Load(doMe, continueWith);
+            get => _defaultScheduler.IsValueCreated ? _defaultScheduler.Value : TaskScheduler.FromCurrentSynchronizationContext();
+            set => _defaultScheduler.Value = value ?? throw new ArgumentNullException();
         }
 
-        public static Task<T> DoAsync<T>(Func<T> doMe, Action<T> continueWith)
+        /// <summary>
+        /// Invokes <paramref name="loadContent"/> on the thread pool, then executes <paramref name="continueWith"/> on the current synchronisation context.
+        /// </summary>
+        /// <remarks>
+        /// Note this method does not perform any cancellation of prior loads, nor does it support cancellation upon disposal.
+        /// If you require those features, use an instance of <see cref="AsyncLoader"/> instead.
+        /// </remarks>
+        /// <typeparam name="T">Type of data returned by <paramref name="loadContent"/> and accepted by <paramref name="continueWith"/>.</typeparam>
+        /// <param name="loadContent">A function to invoke on the thread pool that returns a value to be passed to <paramref name="continueWith"/>.</param>
+        /// <param name="continueWith">An action to invoke on the original synchronisation context with the return value from <paramref name="loadContent"/>.</param>
+        /// <param name="onError">
+        /// An optional callback for notification of exceptions from <paramref name="loadContent"/>.
+        /// Invoked on the original synchronisation context.
+        /// Invoked once per exception, so may be called multiple times.
+        /// Handlers must set <see cref="AsyncErrorEventArgs.Handled"/> to <c>true</c> to prevent any exceptions being re-thrown and faulting the async operation.
+        /// </param>
+        public static async void DoAsync<T>(Func<T> loadContent, Action<T> continueWith, Action<AsyncErrorEventArgs> onError = null)
         {
-            AsyncLoader loader = new AsyncLoader();
-            return loader.Load(doMe, continueWith);
+            using (var loader = new AsyncLoader())
+            {
+                if (onError != null)
+                {
+                    loader.LoadingError += (_, e) => onError(e);
+                }
+
+                await loader.Load(loadContent, continueWith);
+            }
         }
 
-        public static Task DoAsync(Action doMe, Action continueWith)
+        public event EventHandler<AsyncErrorEventArgs> LoadingError;
+
+        [NotNull] private readonly TaskScheduler _continuationTaskScheduler;
+        [CanBeNull] private CancellationTokenSource _cancellationTokenSource;
+        private int _disposed;
+
+        /// <summary>
+        /// Gets and sets an amount of time to delay calling <c>loadContent</c> actions after a call to one of the <c>Load</c> overloads.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="TimeSpan.Zero"/>.
+        /// </remarks>
+        public TimeSpan Delay { get; set; }
+
+        public AsyncLoader(TaskScheduler continuationTaskScheduler = null)
         {
-            AsyncLoader loader = new AsyncLoader();
-            return loader.Load(doMe, continueWith);
+            _continuationTaskScheduler = continuationTaskScheduler ?? DefaultContinuationTaskScheduler;
         }
 
-        public Task Load(Action loadContent, Action onLoaded)
-        {
-            return Load((token) => loadContent(), onLoaded);
-        }
+        public Task Load(Action loadContent, Action onLoaded) => Load(token => loadContent(), onLoaded);
 
         public Task Load(Action<CancellationToken> loadContent, Action onLoaded)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(AsyncLoader));
+            }
+
+            // Stop any prior operation
             Cancel();
-            _cancelledTokenSource?.Dispose();
-            _cancelledTokenSource = new CancellationTokenSource();
 
-            var token = _cancelledTokenSource.Token;
+            // Create a new cancellation object
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = new CancellationTokenSource();
 
-            return Task.Factory.StartNew(() =>
-                    {
-                        if (Delay > 0)
-                        {
-                            token.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(Delay));
-                        }
+            // Copy reference to token (important)
+            var token = _cancellationTokenSource.Token;
 
-                        if (!token.IsCancellationRequested)
-                        {
-                            loadContent(token);
-                        }
-                    },
-                    token)
-                .ContinueWith(task =>
-                    {
-                        if (task.IsFaulted)
-                        {
-                            foreach (var e in task.Exception.InnerExceptions)
-                            {
-                                if (!OnLoadingError(e))
-                                {
-                                    throw e;
-                                }
-                            }
-
-                            return;
-                        }
-
-                        try
-                        {
-                            if (!token.IsCancellationRequested)
-                            {
-                                onLoaded();
-                            }
-                        }
-                        catch (Exception exception)
-                        {
-                            if (!OnLoadingError(exception))
-                            {
-                                throw;
-                            }
-                        }
-                    },
+            return Task.Factory
+                .StartNew(Load, token)
+                .ContinueWith(
+                    Continuation,
                     CancellationToken.None,
                     TaskContinuationOptions.NotOnCanceled,
                     _continuationTaskScheduler);
+
+            void Load()
+            {
+                // Defer the load operation if requested
+                if (Delay > TimeSpan.Zero)
+                {
+                    token.WaitHandle.WaitOne(Delay);
+                }
+
+                // Load content, so long as we haven't already been cancelled
+                if (!token.IsCancellationRequested)
+                {
+                    loadContent(token);
+                }
+            }
+
+            void Continuation(Task task)
+            {
+                if (task.IsFaulted)
+                {
+                    Debug.Assert(task.Exception != null, "Faulted task should have a non-null exception");
+
+                    foreach (var e in task.Exception.InnerExceptions)
+                    {
+                        if (!OnLoadingError(e))
+                        {
+                            throw e;
+                        }
+                    }
+
+                    return;
+                }
+
+                try
+                {
+                    // Invoke continuation unless cancelled
+                    if (!token.IsCancellationRequested)
+                    {
+                        onLoaded();
+                    }
+                }
+                catch (Exception exception)
+                {
+                    if (!OnLoadingError(exception))
+                    {
+                        throw;
+                    }
+                }
+            }
         }
 
-        public Task<T> Load<T>(Func<T> loadContent, Action<T> onLoaded)
-        {
-            return Load((token) => loadContent(), onLoaded);
-        }
+        public Task<T> Load<T>(Func<T> loadContent, Action<T> onLoaded) => Load(token => loadContent(), onLoaded);
 
         public Task<T> Load<T>(Func<CancellationToken, T> loadContent, Action<T> onLoaded)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(nameof(AsyncLoader));
+            }
+
+            // Stop any prior operation
             Cancel();
-            _cancelledTokenSource?.Dispose();
-            _cancelledTokenSource = new CancellationTokenSource();
-            var token = _cancelledTokenSource.Token;
-            return Task.Factory.StartNew(() =>
-                    {
-                        if (Delay > 0)
-                        {
-                            token.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(Delay));
-                        }
 
-                        if (token.IsCancellationRequested)
-                        {
-                            return default;
-                        }
+            // Create a new cancellation object
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = new CancellationTokenSource();
 
-                        return loadContent(token);
-                    },
-                    token)
-                .ContinueWith(task =>
-                    {
-                        if (task.IsFaulted)
-                        {
-                            foreach (var e in task.Exception.InnerExceptions)
-                            {
-                                if (!OnLoadingError(e))
-                                {
-                                    throw e;
-                                }
-                            }
+            // Copy reference to token (important)
+            var token = _cancellationTokenSource.Token;
 
-                            return default;
-                        }
-
-                        try
-                        {
-                            if (!token.IsCancellationRequested)
-                            {
-                                onLoaded(task.Result);
-                            }
-
-                            return task.Result;
-                        }
-                        catch (Exception exception)
-                        {
-                            if (!OnLoadingError(exception))
-                            {
-                                throw;
-                            }
-
-                            return default;
-                        }
-                    },
+            return Task.Factory
+                .StartNew(Load, token)
+                .ContinueWith(
+                    Continuation,
                     CancellationToken.None,
                     TaskContinuationOptions.NotOnCanceled,
                     _continuationTaskScheduler);
-        }
 
-        public void Cancel()
-        {
-            _cancelledTokenSource?.Cancel();
+            T Load()
+            {
+                // Defer the load operation if requested
+                if (Delay > TimeSpan.Zero)
+                {
+                    token.WaitHandle.WaitOne(Delay);
+                }
+
+                // Bail early if cancelled, returning default value for type
+                if (token.IsCancellationRequested)
+                {
+                    return default;
+                }
+
+                // Load content
+                return loadContent(token);
+            }
+
+            T Continuation(Task<T> task)
+            {
+                if (task.IsFaulted)
+                {
+                    foreach (var e in task.Exception.InnerExceptions)
+                    {
+                        if (!OnLoadingError(e))
+                        {
+                            throw e;
+                        }
+                    }
+
+                    return default;
+                }
+
+                try
+                {
+                    // Invoke continuation unless cancelled
+                    if (!token.IsCancellationRequested)
+                    {
+                        onLoaded(task.Result);
+                    }
+
+                    return task.Result;
+                }
+                catch (Exception exception)
+                {
+                    if (!OnLoadingError(exception))
+                    {
+                        throw;
+                    }
+
+                    return default;
+                }
+            }
         }
 
         private bool OnLoadingError(Exception exception)
         {
             var args = new AsyncErrorEventArgs(exception);
-            LoadingError(this, args);
+            LoadingError?.Invoke(this, args);
             return args.Handled;
         }
 
-        protected virtual void Dispose(bool disposing)
+        public void Cancel()
         {
-            if (disposing)
+            if (Volatile.Read(ref _disposed) != 0)
             {
-                _cancelledTokenSource?.Dispose();
+                throw new ObjectDisposedException(nameof(AsyncLoader));
             }
+
+            _cancellationTokenSource?.Cancel();
         }
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+            {
+                return;
+            }
+
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
         }
     }
 
-    public class AsyncErrorEventArgs : EventArgs
+    public sealed class AsyncErrorEventArgs : EventArgs
     {
+        public Exception Exception { get; }
+
+        public bool Handled { get; set; } = true;
+
         public AsyncErrorEventArgs(Exception exception)
         {
             Exception = exception;
-            Handled = true;
         }
-
-        public Exception Exception { get; }
-
-        public bool Handled { get; set; }
     }
 }

--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -71,7 +71,10 @@ namespace GitCommands
             _continuationTaskScheduler = continuationTaskScheduler ?? DefaultContinuationTaskScheduler;
         }
 
-        public Task Load(Action loadContent, Action onLoaded) => Load(token => loadContent(), onLoaded);
+        public Task Load(Action loadContent, Action onLoaded)
+        {
+            return Load(token => loadContent(), onLoaded);
+        }
 
         public Task Load(Action<CancellationToken> loadContent, Action onLoaded)
         {
@@ -148,7 +151,10 @@ namespace GitCommands
             }
         }
 
-        public Task<T> Load<T>(Func<T> loadContent, Action<T> onLoaded) => Load(token => loadContent(), onLoaded);
+        public Task<T> Load<T>(Func<T> loadContent, Action<T> onLoaded)
+        {
+            return Load(token => loadContent(), onLoaded);
+        }
 
         public Task<T> Load<T>(Func<CancellationToken, T> loadContent, Action<T> onLoaded)
         {

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -92,7 +92,6 @@ namespace GitCommands
         {
             if (disposing)
             {
-                _backgroundLoader.Cancel();
                 _backgroundLoader.Dispose();
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -240,9 +240,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             if (disposing)
             {
-                _tagsLoader.Cancel();
                 _tagsLoader.Dispose();
-                _branchesLoader.Cancel();
                 _branchesLoader.Dispose();
 
                 components?.Dispose();

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.Designer.cs
@@ -15,7 +15,6 @@
         {
             if (disposing)
             {
-                _ignoredFilesLoader.Cancel();
                 _ignoredFilesLoader.Dispose();
                 if (components != null)
                 {

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -114,7 +114,7 @@ namespace GitUI.CommandsDialogs
             _ignoredFilesLoader.Cancel();
             if (_NO_TRANSLATE_Preview.Enabled)
             {
-                _ignoredFilesLoader.Delay = 300;
+                _ignoredFilesLoader.Delay = TimeSpan.FromMilliseconds(300);
                 _NO_TRANSLATE_filesWillBeIgnored.Text = _updateStatusString.Text;
                 _NO_TRANSLATE_Preview.DataSource = new List<string> { _updateStatusString.Text };
                 _NO_TRANSLATE_Preview.Enabled = false;

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -459,8 +459,6 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
-                _branchListLoader.Cancel();
-
                 _branchListLoader.Dispose();
 
                 if (components != null)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -3098,7 +3098,6 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
-                _unstagedLoader.Cancel();
                 _unstagedLoader.Dispose();
                 if (_interactiveAddBashCloseWaitCts != null)
                 {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -548,7 +548,6 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
-                _asyncLoader.Cancel();
                 _asyncLoader.Dispose();
                 _filterRevisionsHelper.Dispose();
                 _filterBranchHelper.Dispose();

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -17,7 +17,6 @@ namespace GitUI.CommandsDialogs
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            _asyncLoader.Cancel();
             _asyncLoader.Dispose();
             if (disposing && (components != null))
             {

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -217,7 +217,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             if (disposing)
             {
-                _remoteLoader.Cancel();
                 _remoteLoader.Dispose();
                 components?.Dispose();
             }

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -455,7 +455,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             if (disposing)
             {
-                _loader.Cancel();
                 _loader.Dispose();
                 components?.Dispose();
             }

--- a/GitUI/CommandsDialogs/SearchWindow.Designer.cs
+++ b/GitUI/CommandsDialogs/SearchWindow.Designer.cs
@@ -13,7 +13,7 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            _backgroundLoader.Cancel();
+            _backgroundLoader.Dispose();
 
             if (disposing && (components != null))
             {
@@ -36,9 +36,9 @@
             this.textBox1 = new System.Windows.Forms.TextBox();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // listBox1
-            // 
+            //
             this.listBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.listBox1.FormattingEnabled = true;
             this.listBox1.Location = new System.Drawing.Point(12, 58);
@@ -47,9 +47,9 @@
             this.listBox1.TabIndex = 2;
             this.listBox1.DoubleClick += new System.EventHandler(this.listBox1_DoubleClick);
             this.listBox1.KeyUp += new System.Windows.Forms.KeyEventHandler(this.listBox1_KeyUp);
-            // 
+            //
             // panel1
-            // 
+            //
             this.panel1.BackColor = System.Drawing.SystemColors.Window;
             this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.panel1.Controls.Add(this.label1);
@@ -58,18 +58,18 @@
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(301, 51);
             this.panel1.TabIndex = 7;
-            // 
+            //
             // label1
-            // 
+            //
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(3, 8);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(96, 13);
             this.label1.TabIndex = 8;
             this.label1.Text = "Enter file name:";
-            // 
+            //
             // textBox1
-            // 
+            //
             this.textBox1.Location = new System.Drawing.Point(6, 23);
             this.textBox1.Name = "textBox1";
             this.textBox1.Size = new System.Drawing.Size(290, 20);
@@ -77,9 +77,9 @@
             this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
             this.textBox1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBox1_KeyDown);
             this.textBox1.KeyUp += new System.Windows.Forms.KeyEventHandler(this.textBox1_KeyUp);
-            // 
+            //
             // SearchWindow
-            // 
+            //
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BackColor = System.Drawing.Color.Lime;

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -91,7 +91,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         {
             if (disposing)
             {
-                _branchesLoader.Cancel();
                 _branchesLoader.Dispose();
 
                 components?.Dispose();

--- a/UnitTests/GitCommandsTests/AsyncLoaderTests.cs
+++ b/UnitTests/GitCommandsTests/AsyncLoaderTests.cs
@@ -4,9 +4,10 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCommands;
+using GitCommandsTests.Helpers;
 using NUnit.Framework;
 
-namespace GitCommandsTests.Helpers
+namespace GitCommandsTests
 {
     public sealed class AsyncLoaderTests
     {

--- a/UnitTests/GitCommandsTests/AsyncLoaderTests.cs
+++ b/UnitTests/GitCommandsTests/AsyncLoaderTests.cs
@@ -28,7 +28,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task RegularCase()
+        public async Task Load_should_execute_async_operation_and_callback()
         {
             var loadSignal = new SemaphoreSlim(0);
 
@@ -57,7 +57,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task Threads()
+        public async Task Load_performed_on_thread_pool_and_result_handled_via_callers_context()
         {
             var callerThread = Thread.CurrentThread;
             Thread loadThread = null;
@@ -79,7 +79,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task CancelDuringLoad()
+        public async Task Cancel_during_load_means_callback_not_fired()
         {
             var loadSignal = new SemaphoreSlim(0);
 
@@ -110,7 +110,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task CancelDuringDelay()
+        public async Task Cancel_during_delay_means_load_not_fired()
         {
             // Deliberately use a long delay as cancellation should cut it short
             _loader.Delay = TimeSpan.FromMilliseconds(5000);
@@ -137,7 +137,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task DisposeCalledDuringOperation()
+        public async Task Dispose_during_load_means_callback_not_fired()
         {
             var loadSignal = new SemaphoreSlim(0);
 
@@ -168,7 +168,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task DelayedLoad()
+        public async Task Delay_causes_load_callback_to_be_deferred()
         {
             _loader.Delay = TimeSpan.FromMilliseconds(100);
 
@@ -182,7 +182,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public async Task ErrorEventHandled()
+        public async Task Error_raised_via_event_and_marked_as_handled_does_not_fault_task()
         {
             var observed = new List<Exception>();
 
@@ -203,7 +203,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void ErrorEventUnhandled()
+        public void Error_raised_via_event_and_not_marked_as_handled_faults_task()
         {
             var observed = new List<Exception>();
 
@@ -225,7 +225,7 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void UseAfterDispose()
+        public void Using_load_or_cancel_after_dispose_throws()
         {
             var loader = new AsyncLoader();
 

--- a/UnitTests/GitCommandsTests/AsyncLoaderTests.cs
+++ b/UnitTests/GitCommandsTests/AsyncLoaderTests.cs
@@ -178,7 +178,7 @@ namespace GitCommandsTests
                 () => sw.Stop(),
                 () => { });
 
-            Assert.GreaterOrEqual(sw.Elapsed, _loader.Delay);
+            Assert.GreaterOrEqual(sw.Elapsed, _loader.Delay - TimeSpan.FromMilliseconds(10));
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -104,7 +104,9 @@
     <Compile Include="Git\GitDirectoryResolverTests.cs" />
     <Compile Include="Git\Tag\GitTagControllerTest.cs" />
     <Compile Include="Git\GitTreeParserTests.cs" />
+    <Compile Include="Helpers\AsyncLoaderTests.cs" />
     <Compile Include="Helpers\PathUtilTest.cs" />
+    <Compile Include="Helpers\SingleThreadTaskScheduler.cs" />
     <Compile Include="Patch\PatchManagerTest.cs" />
     <Compile Include="Patch\PatchTest.cs" />
     <Compile Include="PathEqualityComparerTests.cs" />

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -104,7 +104,7 @@
     <Compile Include="Git\GitDirectoryResolverTests.cs" />
     <Compile Include="Git\Tag\GitTagControllerTest.cs" />
     <Compile Include="Git\GitTreeParserTests.cs" />
-    <Compile Include="Helpers\AsyncLoaderTests.cs" />
+    <Compile Include="AsyncLoaderTests.cs" />
     <Compile Include="Helpers\PathUtilTest.cs" />
     <Compile Include="Helpers\SingleThreadTaskScheduler.cs" />
     <Compile Include="Patch\PatchManagerTest.cs" />

--- a/UnitTests/GitCommandsTests/Helpers/AsyncLoaderTests.cs
+++ b/UnitTests/GitCommandsTests/Helpers/AsyncLoaderTests.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Helpers
+{
+    public sealed class AsyncLoaderTests
+    {
+        private AsyncLoader _loader;
+
+        [SetUp]
+        public void SetUp()
+        {
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+
+            _loader = new AsyncLoader();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _loader.Dispose();
+        }
+
+        [Test]
+        public async Task RegularCase()
+        {
+            var loadSignal = new SemaphoreSlim(0);
+
+            var started = 0;
+            var completed = 0;
+            var task = _loader.Load(
+                () =>
+                {
+                    started++;
+                    loadSignal.Release();
+                    Thread.Sleep(100);
+                },
+                () => completed++);
+
+            Assert.True(await loadSignal.WaitAsync(1000));
+
+            Assert.AreEqual(1, started);
+            Assert.AreEqual(0, completed);
+
+            await task;
+
+            Assert.AreEqual(1, started);
+            Assert.AreEqual(1, completed);
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+        }
+
+        [Test]
+        public async Task Threads()
+        {
+            var callerThread = Thread.CurrentThread;
+            Thread loadThread = null;
+            Thread continuationThread = null;
+
+            Assert.False(callerThread.IsThreadPoolThread);
+
+            using (var scheduler = new SingleThreadTaskScheduler())
+            using (var loader = new AsyncLoader(scheduler))
+            {
+                await loader.Load(
+                    () => loadThread = Thread.CurrentThread,
+                    () => continuationThread = Thread.CurrentThread);
+            }
+
+            Assert.True(loadThread.IsThreadPoolThread);
+            Assert.AreNotSame(loadThread, callerThread);
+            Assert.AreNotSame(loadThread, continuationThread);
+        }
+
+        [Test]
+        public async Task CancelDuringLoad()
+        {
+            var loadSignal = new SemaphoreSlim(0);
+
+            var started = 0;
+            var completed = 0;
+            var task = _loader.Load(
+                () =>
+                {
+                    started++;
+                    loadSignal.Release();
+                    Thread.Sleep(100);
+                },
+                () => completed++);
+
+            Assert.True(await loadSignal.WaitAsync(1000));
+
+            Assert.AreEqual(1, started);
+            Assert.AreEqual(0, completed);
+
+            _loader.Cancel();
+
+            await task;
+
+            Assert.AreEqual(1, started);
+            Assert.AreEqual(0, completed, "Should not have called the follow-up action");
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+        }
+
+        [Test]
+        public async Task CancelDuringDelay()
+        {
+            // Deliberately use a long delay as cancellation should cut it short
+            _loader.Delay = TimeSpan.FromMilliseconds(5000);
+
+            var started = 0;
+            var completed = 0;
+            var task = _loader.Load(
+                () => started++,
+                () => completed++);
+
+            await Task.Delay(50);
+
+            Assert.AreEqual(0, started);
+            Assert.AreEqual(0, completed);
+
+            _loader.Cancel();
+
+            await task;
+
+            Assert.AreEqual(0, started);
+            Assert.AreEqual(0, completed);
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+        }
+
+        [Test]
+        public async Task DisposeCalledDuringOperation()
+        {
+            var loadSignal = new SemaphoreSlim(0);
+
+            var started = 0;
+            var completed = 0;
+            var task = _loader.Load(
+                () =>
+                {
+                    started++;
+                    loadSignal.Release();
+                    Thread.Sleep(100);
+                },
+                () => completed++);
+
+            Assert.True(await loadSignal.WaitAsync(1000));
+
+            Assert.AreEqual(1, started);
+            Assert.AreEqual(0, completed);
+
+            _loader.Dispose();
+
+            await task;
+
+            Assert.AreEqual(1, started);
+            Assert.AreEqual(0, completed, "Should not have called the follow-up action");
+
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+        }
+
+        [Test]
+        public async Task DelayedLoad()
+        {
+            _loader.Delay = TimeSpan.FromMilliseconds(100);
+
+            var sw = Stopwatch.StartNew();
+
+            await _loader.Load(
+                () => sw.Stop(),
+                () => { });
+
+            Assert.GreaterOrEqual(sw.Elapsed, _loader.Delay);
+        }
+
+        [Test]
+        public async Task ErrorEventHandled()
+        {
+            var observed = new List<Exception>();
+
+            _loader.LoadingError += (_, e) =>
+            {
+                observed.Add(e.Exception);
+                e.Handled = true;
+            };
+
+            var ex = new Exception();
+
+            await _loader.Load(
+                () => throw ex,
+                Assert.Fail);
+
+            Assert.AreEqual(1, observed.Count);
+            Assert.AreSame(ex, observed[0]);
+        }
+
+        [Test]
+        public void ErrorEventUnhandled()
+        {
+            var observed = new List<Exception>();
+
+            _loader.LoadingError += (_, e) =>
+            {
+                observed.Add(e.Exception);
+                e.Handled = false;
+            };
+
+            var ex = new Exception();
+
+            var oe = Assert.ThrowsAsync<Exception>(() => _loader.Load(
+                () => throw ex,
+                Assert.Fail));
+
+            Assert.AreEqual(1, observed.Count);
+            Assert.AreSame(ex, observed[0]);
+            Assert.AreSame(oe, observed[0]);
+        }
+
+        [Test]
+        public void UseAfterDispose()
+        {
+            var loader = new AsyncLoader();
+
+            // Safe to dispose multiple times
+            loader.Dispose();
+            loader.Dispose();
+            loader.Dispose();
+
+            // Any use after dispose should throw
+            Assert.Throws<ObjectDisposedException>(() => loader.Load(() => { }, () => { }));
+            Assert.Throws<ObjectDisposedException>(() => loader.Load(_ => { }, () => { }));
+            Assert.Throws<ObjectDisposedException>(() => loader.Load(() => 1, i => { }));
+            Assert.Throws<ObjectDisposedException>(() => loader.Load(_ => 1, i => { }));
+            Assert.Throws<ObjectDisposedException>(() => loader.Cancel());
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/Helpers/SingleThreadTaskScheduler.cs
+++ b/UnitTests/GitCommandsTests/Helpers/SingleThreadTaskScheduler.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitCommandsTests.Helpers
+{
+    /// <summary>
+    /// Simple <see cref="TaskScheduler"/> implementation that owns a single thread
+    /// and schedules all work on it. No tasks may execute inline under this scheduler.
+    /// </summary>
+    /// <remarks>Only really useful for testing purposes.</remarks>
+    internal sealed class SingleThreadTaskScheduler : TaskScheduler, IDisposable
+    {
+        private readonly BlockingCollection<Task> _queue = new BlockingCollection<Task>();
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly Thread _thread;
+
+        public SingleThreadTaskScheduler()
+        {
+            _thread = new Thread(() =>
+            {
+                try
+                {
+                    foreach (var task in _queue.GetConsumingEnumerable(_cts.Token))
+                    {
+                        TryExecuteTask(task);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // ignored
+                }
+            });
+
+            _thread.Start();
+        }
+
+        protected override void QueueTask(Task task) => _queue.Add(task);
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        protected override IEnumerable<Task> GetScheduledTasks() => _queue;
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _thread.Join();
+            _cts.Dispose();
+            _queue.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #4517.

Following #4501 I started looking at the behaviour of `AsyncLoader`
and adding some tests. This flagged up a mismatch between the intention
and behaviour of the class. My longer term goal is to implement a similar class that supports `Func<Task>` for use in #4501.

This PR adds thorough tests to `AsyncLoader`, and fixes the bug around
cancellation during disposal.

It also allows more than one thread to specify `DefaultContinuationTaskScheduler`
via the use of `ThreadLocal`.

Added more documentation as my understanding grew.

Also prevents use-after-dispose via `ObjectDisposedException`.

Has been tested on:
 - GIT 2.16
 - Windows 10
