### PR TITLE
Fix git log command arguments and reduce allocations

### DIFF
--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -154,32 +154,29 @@ namespace GitCommands
             if (AppSettings.ShowReflogReferences)
                 logParam.Append(" --reflog");
 
-            if ((RefsOptions & RefsFiltringOptions.All) == RefsFiltringOptions.All)
+            if (RefsOptions.HasFlag(RefsFiltringOptions.All))
             {
                 logParam.Append(" --all");
             }
             else
             {
-                if ((RefsOptions & RefsFiltringOptions.Branches) == RefsFiltringOptions.Branches)
+                if (RefsOptions.HasFlag(RefsFiltringOptions.Branches))
                     logParam.Append(" --branches");
-                if ((RefsOptions & RefsFiltringOptions.Remotes) == RefsFiltringOptions.Remotes)
+                if (RefsOptions.HasFlag(RefsFiltringOptions.Remotes))
                     logParam.Append(" --remotes");
-                if ((RefsOptions & RefsFiltringOptions.Tags) == RefsFiltringOptions.Tags)
+                if (RefsOptions.HasFlag(RefsFiltringOptions.Tags))
                     logParam.Append(" --tags");
             }
 
-            if ((RefsOptions & RefsFiltringOptions.Boundary) == RefsFiltringOptions.Boundary)
+            if (RefsOptions.HasFlag(RefsFiltringOptions.Boundary))
                 logParam.Append(" --boundary");
-            if ((RefsOptions & RefsFiltringOptions.ShowGitNotes) == RefsFiltringOptions.ShowGitNotes)
+            if (RefsOptions.HasFlag(RefsFiltringOptions.ShowGitNotes))
                 logParam.Append(" --not --glob=notes --not");
-
-            if ((RefsOptions & RefsFiltringOptions.NoMerges) == RefsFiltringOptions.NoMerges)
+            if (RefsOptions.HasFlag(RefsFiltringOptions.NoMerges))
                 logParam.Append(" --no-merges");
-
-            if ((RefsOptions & RefsFiltringOptions.FirstParent) == RefsFiltringOptions.FirstParent)
+            if (RefsOptions.HasFlag(RefsFiltringOptions.FirstParent))
                 logParam.Append(" --first-parent");
-
-            if ((RefsOptions & RefsFiltringOptions.SimplifyByDecoration) == RefsFiltringOptions.SimplifyByDecoration)
+            if (RefsOptions.HasFlag(RefsFiltringOptions.SimplifyByDecoration))
                 logParam.Append(" --simplify-by-decoration");
 
             string branchFilter = BranchFilter;

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -185,10 +185,10 @@ namespace GitCommands
                 branchFilter = "--branches=" + BranchFilter;
 
             string arguments = String.Format(CultureInfo.InvariantCulture,
-                "log -z {2} --pretty=format:\"{1}\" {0} {3} -- {4}",
-                logParam,
-                formatString,
+                "log -z {0} --pretty=format:\"{1}\" {2} {3} -- {4}",
                 branchFilter,
+                formatString,
+                logParam,
                 RevisionFilter,
                 PathFilter);
 

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -123,24 +123,25 @@ namespace GitCommands
                 Updated(this, new RevisionGraphUpdatedEventArgs(null));
             _refs = GetRefs().ToDictionaryOfList(head => head.Guid);
 
-            string formatString =
+            const string shaOnlyFormat =
                 /* <COMMIT>       */ CommitBegin + "%n" +
                 /* Hash           */ "%H%n" +
                 /* Parents        */ "%P%n";
-            if (!ShaOnly)
-            {
-                formatString +=
-                    /* Tree                    */ "%T%n" +
-                    /* Author Name             */ "%aN%n" +
-                    /* Author Email            */ "%aE%n" +
-                    /* Author Date             */ "%at%n" +
-                    /* Committer Name          */ "%cN%n" +
-                    /* Committer Email         */ "%cE%n" +
-                    /* Committer Date          */ "%ct%n" +
-                    /* Commit message encoding */ "%e%x00" + //there is a bug: git does not recode commit message when format is given
-                    /* Commit Subject          */ "%s%x00" +
-                    /* Commit Body             */ "%B%x00";
-            }
+
+            const string fullFormat =
+                shaOnlyFormat +
+                /* Tree                    */ "%T%n" +
+                /* Author Name             */ "%aN%n" +
+                /* Author Email            */ "%aE%n" +
+                /* Author Date             */ "%at%n" +
+                /* Committer Name          */ "%cN%n" +
+                /* Committer Email         */ "%cE%n" +
+                /* Committer Date          */ "%ct%n" +
+                /* Commit message encoding */ "%e%x00" + //there is a bug: git does not recode commit message when format is given
+                /* Commit Subject          */ "%s%x00" +
+                /* Commit Body             */ "%B%x00";
+
+            var formatString = ShaOnly ? shaOnlyFormat : fullFormat;
 
             // NOTE:
             // when called from FileHistory and FollowRenamesInFileHistory is enabled the "--name-only" argument is set.

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -147,45 +147,40 @@ namespace GitCommands
             // when called from FileHistory and FollowRenamesInFileHistory is enabled the "--name-only" argument is set.
             // the filename is the next line after the commit-format defined above.
 
-            string logParam;
-            if (AppSettings.OrderRevisionByDate)
-            {
-                logParam = " --date-order";
-            }
-            else
-            {
-                logParam = " --topo-order";
-            }
+            var logParam = new StringBuilder();
+
+            logParam.Append(AppSettings.OrderRevisionByDate ? " --date-order" : " --topo-order");
 
             if (AppSettings.ShowReflogReferences)
-            {
-                logParam += " --reflog";
-            }
+                logParam.Append(" --reflog");
 
             if ((RefsOptions & RefsFiltringOptions.All) == RefsFiltringOptions.All)
-                logParam += " --all";
+            {
+                logParam.Append(" --all");
+            }
             else
             {
                 if ((RefsOptions & RefsFiltringOptions.Branches) == RefsFiltringOptions.Branches)
-                    logParam += " --branches";
+                    logParam.Append(" --branches");
                 if ((RefsOptions & RefsFiltringOptions.Remotes) == RefsFiltringOptions.Remotes)
-                    logParam += " --remotes";
+                    logParam.Append(" --remotes");
                 if ((RefsOptions & RefsFiltringOptions.Tags) == RefsFiltringOptions.Tags)
-                    logParam += " --tags";
+                    logParam.Append(" --tags");
             }
+
             if ((RefsOptions & RefsFiltringOptions.Boundary) == RefsFiltringOptions.Boundary)
-                logParam += " --boundary";
+                logParam.Append(" --boundary");
             if ((RefsOptions & RefsFiltringOptions.ShowGitNotes) == RefsFiltringOptions.ShowGitNotes)
-                logParam += " --not --glob=notes --not";
+                logParam.Append(" --not --glob=notes --not");
 
             if ((RefsOptions & RefsFiltringOptions.NoMerges) == RefsFiltringOptions.NoMerges)
-                logParam += " --no-merges";
+                logParam.Append(" --no-merges");
 
             if ((RefsOptions & RefsFiltringOptions.FirstParent) == RefsFiltringOptions.FirstParent)
-                logParam += " --first-parent";
+                logParam.Append(" --first-parent");
 
             if ((RefsOptions & RefsFiltringOptions.SimplifyByDecoration) == RefsFiltringOptions.SimplifyByDecoration)
-                logParam += " --simplify-by-decoration";
+                logParam.Append(" --simplify-by-decoration");
 
             string branchFilter = BranchFilter;
             if ((!string.IsNullOrWhiteSpace(BranchFilter)) &&

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -145,13 +145,7 @@ namespace GitCommands
             // when called from FileHistory and FollowRenamesInFileHistory is enabled the "--name-only" argument is set.
             // the filename is the next line after the commit-format defined above.
 
-            string branchFilter = BranchFilter;
-            if (!string.IsNullOrWhiteSpace(BranchFilter) && BranchFilter.IndexOfAny(ShellGlobCharacters) != -1)
-                branchFilter = "--branches=" + BranchFilter;
-
             var arguments = new StringBuilder("log -z ");
-
-            arguments.Append(branchFilter);
 
             arguments.AppendFormat(" --pretty=format:\"{0}\"", ShaOnly ? shaOnlyFormat : fullFormat);
 
@@ -167,7 +161,10 @@ namespace GitCommands
             else
             {
                 if (RefsOptions.HasFlag(RefsFiltringOptions.Branches))
-                    arguments.Append(" --branches");
+                {
+                    if (!string.IsNullOrWhiteSpace(BranchFilter) && BranchFilter.IndexOfAny(ShellGlobCharacters) != -1)
+                        arguments.Append(" --branches=" + BranchFilter);
+                }
                 if (RefsOptions.HasFlag(RefsFiltringOptions.Remotes))
                     arguments.Append(" --remotes");
                 if (RefsOptions.HasFlag(RefsFiltringOptions.Tags))

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -166,7 +166,7 @@ namespace GitCommands
             else
             {
                 if ((RefsOptions & RefsFiltringOptions.Branches) == RefsFiltringOptions.Branches)
-                    logParam = " --branches";
+                    logParam += " --branches";
                 if ((RefsOptions & RefsFiltringOptions.Remotes) == RefsFiltringOptions.Remotes)
                     logParam += " --remotes";
                 if ((RefsOptions & RefsFiltringOptions.Tags) == RefsFiltringOptions.Tags)


### PR DESCRIPTION
Fixes #4516.

Changes proposed in this pull request:
 - Fix the git log command argument construction bug
 - Remove temporary strings during argument construction

What did I do to test the code and ensure quality:
 - Tested that string output was the same before/after
 - Manual tests
 - Unit tests

Has been tested on:
 - GIT 2.16
 - Windows 10
