### PR TITLE
Refactor the GitRevisionProvider to LongShaProvider as it only sets the Sha property of the GitRevision object

### DIFF
--- a/GitCommands/Git/LongShaProvider.cs
+++ b/GitCommands/Git/LongShaProvider.cs
@@ -3,27 +3,27 @@ using GitUIPluginInterfaces;
 
 namespace GitCommands.Git
 {
-    public interface IGitRevisionProvider
+    public interface ILongShaProvider
     {
-        GitRevision Get(string sha1);
+        string Get(string sha1);
     }
 
-    public sealed class GitRevisionProvider : IGitRevisionProvider
+    public sealed class LongShaProvider : ILongShaProvider
     {
         private readonly Func<IGitModule> _getModule;
 
 
-        public GitRevisionProvider(Func<IGitModule> getModule)
+        public LongShaProvider(Func<IGitModule> getModule)
         {
             _getModule = getModule;
         }
 
 
-        public GitRevision Get(string sha1)
+        public string Get(string sha1)
         {
             if (sha1.IsNullOrWhiteSpace() || sha1.Length >= 40)
             {
-                return new GitRevision(sha1);
+                return sha1;
             }
 
             var module = GetModule();
@@ -32,7 +32,7 @@ namespace GitCommands.Git
                 sha1 = fullSha1;
             }
 
-            return new GitRevision(sha1);
+            return sha1;
         }
 
         private IGitModule GetModule()

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -109,7 +109,7 @@
     <Compile Include="Git\GitBranchNameNormaliser.cs" />
     <Compile Include="Git\GitBranchNameOptions.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensions.cs" />
-    <Compile Include="Git\GitRevisionProvider.cs" />
+    <Compile Include="Git\LongShaProvider.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDeleteRemoteBranchesCmd.cs" />

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -141,7 +141,7 @@ namespace GitUI.CommandsDialogs
         private readonly ICommitDataManager _commitDataManager;
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
         private readonly IAppTitleGenerator _appTitleGenerator;
-        private readonly IGitRevisionProvider _gitRevisionProvider;
+        private readonly ILongShaProvider _longShaProvider;
         private static bool _showRevisionInfoNextToRevisionGrid;
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace GitUI.CommandsDialogs
                 UICommands.BrowseRepo = this;
                 _controller = new FormBrowseController(new GitGpgController(() => Module));
                 _commitDataManager = new CommitDataManager(() => Module);
-                _gitRevisionProvider = new GitRevisionProvider(() => Module);
+                _longShaProvider = new LongShaProvider(() => Module);
             }
 
             _repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
@@ -328,7 +328,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!string.IsNullOrEmpty(selectCommit))
             {
-                RevisionGrid.SetInitialRevision(_gitRevisionProvider.Get(selectCommit));
+                RevisionGrid.SetInitialRevision(_longShaProvider.Get(selectCommit));
             }
         }
 
@@ -2202,7 +2202,7 @@ namespace GitUI.CommandsDialogs
         {
             if (e.Command == "gotocommit")
             {
-                var revision = _gitRevisionProvider.Get(e.Data);
+                var revision = _longShaProvider.Get(e.Data);
                 var found = RevisionGrid.SetSelectedRevision(revision);
 
                 // When 'git log --first-parent' filtration is used, user can click on child commit
@@ -2210,7 +2210,7 @@ namespace GitUI.CommandsDialogs
                 // and to make it possible we add explicit branch filter and refresh.
                 if (AppSettings.ShowFirstParent && !found)
                 {
-                    _filterBranchHelper.SetBranchFilter(revision.Guid, refresh: true);
+                    _filterBranchHelper.SetBranchFilter(revision, refresh: true);
                     RevisionGrid.SetSelectedRevision(revision);
                 }
             }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -20,7 +20,7 @@ namespace GitUI.CommandsDialogs
         private readonly AsyncLoader _asyncLoader;
         private readonly FormBrowseMenus _formBrowseMenus;
         private readonly IFullPathResolver _fullPathResolver;
-        private readonly IGitRevisionProvider _gitRevisionProvider;
+        private readonly ILongShaProvider _longShaProvider;
 
         private readonly TranslationString _buildReportTabCaption =
             new TranslationString("Build Report");
@@ -58,13 +58,13 @@ namespace GitUI.CommandsDialogs
 
             _commitDataManager = new CommitDataManager(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
-            _gitRevisionProvider = new GitRevisionProvider(() => Module);
+            _longShaProvider = new LongShaProvider(() => Module);
         }
 
         public FormFileHistory(GitUICommands aCommands, string fileName, GitRevision revision, bool filterByRevision)
             : this(aCommands)
         {
-            FileChanges.SetInitialRevision(revision);
+            FileChanges.SetInitialRevision(revision.Guid);
             Translate();
 
             FileChanges.ShowBuildServerInfo = true;
@@ -483,7 +483,7 @@ namespace GitUI.CommandsDialogs
         {
             if (e.Command == "gotocommit")
             {
-                FileChanges.SetSelectedRevision(_gitRevisionProvider.Get(e.Data));
+                FileChanges.SetSelectedRevision(_longShaProvider.Get(e.Data));
             }
             else if (e.Command == "gotobranch" || e.Command == "gototag")
             {

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -33,7 +33,7 @@ namespace GitUI.HelperDialogs
                 string guid = Module.RevParse(preselectCommit);
                 if (!String.IsNullOrEmpty(guid))
                 {
-                    revisionGrid.SetInitialRevision(new GitRevision(guid));
+                    revisionGrid.SetInitialRevision(guid);
                 }
             }
 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -360,9 +360,9 @@ namespace GitUI
         }
 
 
-        public void SetInitialRevision(GitRevision initialSelectedRevision)
+        public void SetInitialRevision(string initialSelectedRevision)
         {
-            _initialSelectedRevision = initialSelectedRevision != null ? initialSelectedRevision.Guid : null;
+            _initialSelectedRevision = initialSelectedRevision;
         }
 
         private bool _isRefreshingRevisions = false;

--- a/UnitTests/GitCommandsTests/Git/LongShaProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Git/LongShaProviderTests.cs
@@ -8,9 +8,9 @@ using NUnit.Framework;
 namespace GitCommandsTests.Git
 {
     [TestFixture]
-    public class GitRevisionProviderTests
+    public class LongShaProviderTests
     {
-        private GitRevisionProvider _provider;
+        private LongShaProvider _provider;
         private IGitModule _module;
 
 
@@ -19,7 +19,7 @@ namespace GitCommandsTests.Git
         {
             _module = Substitute.For<IGitModule>();
 
-            _provider = new GitRevisionProvider(() => _module);
+            _provider = new LongShaProvider(() => _module);
         }
 
 
@@ -31,8 +31,7 @@ namespace GitCommandsTests.Git
         {
             var rev = _provider.Get(sha1);
 
-            rev.Should().NotBeNull();
-            rev.Guid.Should().Be(sha1);
+            rev.Should().Be(sha1);
         }
 
         [Test]
@@ -58,7 +57,7 @@ namespace GitCommandsTests.Git
             var rev = _provider.Get(sha1Fragment);
 
             rev.Should().NotBeNull();
-            rev.Guid.Should().Be(existing ? fullSha : sha1Fragment);
+            rev.Should().Be(existing ? fullSha : sha1Fragment);
         }
     }
 }

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -82,7 +82,7 @@
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensionsTests.cs" />
-    <Compile Include="Git\GitRevisionProviderTests.cs" />
+    <Compile Include="Git\LongShaProviderTests.cs" />
     <Compile Include="Git\GitStashTests.cs" />
     <Compile Include="Git\Gpg\GitGpgControllerTests.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmdTests.cs" />


### PR DESCRIPTION
No functionality change.

Changes proposed in this pull request:

The `GitRevisionProvider` returns a `GitRevision` object but only sets the `Guid/Sha` property, everything else in this object is null.
 
What did I do to test the code and ensure quality:
 - Compile the solution
 - Run the unit tests
 - FormBrowser: Select a commit in the revision grid, F5 to refresh, make sure selection of the commit is kept
 - FormChooseCommit: Right click a commit -> select the check out menu -> press the choose a commit button -> make sure the commit is selected by default.
 - FormFileHistory: find two commits that changed the same file -> select the older commit in the revision grid -> select the file in the diff and view its history -> make sure in the popup the older commit is selected.

Has been tested on (remove any that don't apply):
 - Windows10
 - Git 2.16.2