### PR TITLE
Fix crash when double click to open `FileHistory` form

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -313,8 +313,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-
-                UICommands.StartFileHistoryDialog(this, (DiffFiles.SelectedItem).Name);
+                UICommands.StartFileHistoryDialog(this, DiffFiles.SelectedItem.Name, DiffFiles.Revision, false);
             }
         }
 
@@ -482,8 +481,7 @@ namespace GitUI.CommandsDialogs
 
             if (item.IsTracked)
             {
-                GitRevision revision = _revisionGrid.GetSelectedRevisions().FirstOrDefault();
-                UICommands.StartFileHistoryDialog(this, item.Name, revision, false);
+                UICommands.StartFileHistoryDialog(this, item.Name, DiffFiles.Revision, false);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -239,7 +239,7 @@ See the changes in the commit form.");
             {
                 case GitObjectType.Blob:
                     {
-                        UICommands.StartFileHistoryDialog(this, gitItem.FileName, null);
+                        UICommands.StartFileHistoryDialog(this, gitItem.FileName, _revision);
                         break;
                     }
                 case GitObjectType.Commit:


### PR DESCRIPTION
from 'file tree' and 'diff' tabs

Fixes #4524
