### PR TITLE
Fix contention during scrolling

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -606,9 +606,9 @@ namespace GitUI.RevisionGridClasses
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Justification = "It looks like such lock was made intentionally but it is better to rewrite this")]
         private void UpdateGraph(int curCount, int scrollTo)
         {
-            while (curCount < scrollTo)
+            lock (_graphData)
             {
-                lock (_graphData)
+                while (curCount < scrollTo)
                 {
                     // Cache the next item
                     if (!_graphData.CacheTo(curCount))


### PR DESCRIPTION
During a profiling pass I observed a few cases of extreme contention locking `_graphData` causing the scrolling operation to be slow (in two cases producing a hang on the UI thread of more than 10 seconds). Hoisting the lock outside the loop substantially reduced the number of times the lock is acquired by the background thread, eliminating the primary source of the problem.