### PR TITLE
Fixed crash when double click to open File History Form

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -64,7 +64,7 @@ namespace GitUI.CommandsDialogs
         public FormFileHistory(GitUICommands aCommands, string fileName, GitRevision revision, bool filterByRevision)
             : this(aCommands)
         {
-            FileChanges.SetInitialRevision(revision.Guid);
+            FileChanges.SetInitialRevision(revision?.Guid);
             Translate();
 
             FileChanges.ShowBuildServerInfo = true;


### PR DESCRIPTION
Fixes #4524

Although #4525 has also fixed the same issue, it might be safer to add the null check to keep the original behavior unchanged.

Changes proposed in this pull request:
 - Fixed crash when double click to open File History Form

What did I do to test the code and ensure quality:
 - Double click the file in the File Tree tab to open the its history
 - Double click the file in the Diff tab to open the its history
 - Right click and select the `View History` menu of the file in the File Tree tab to open the its history
 - Right click and select the `View History` menu of the file in the Diff tab to open the its history

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10