### PR TITLE
Update the bundled Git version to latest version 2.16.2.1

### DIFF
--- a/Setup/DownloadExternals.cmd
+++ b/Setup/DownloadExternals.cmd
@@ -1,15 +1,18 @@
 @echo off
 
 REM Also update in Product.wxs and UI\RequiredSoftwareDlg.wxs
+set GIT_VERSION=2.16.2
+set GIT_VERSION_MINOR=.1
+set KDIFF3_VERSION=0.9.97
 
 md %~p0\cache\ 2> NUL
 
-IF NOT EXIST "%~p0\cache\Git-2.13.2-32-bit.exe" (
-    "%~p0\tools\curl.exe" -L -k -o %~p0\cache\Git-2.13.2-32-bit.exe https://github.com/git-for-windows/git/releases/download/v2.13.2.windows.1/Git-2.13.2-32-bit.exe
+IF NOT EXIST "%~p0\cache\Git-%GIT_VERSION%%GIT_VERSION_MINOR%-32-bit.exe" (
+    "%~p0\tools\curl.exe" -L -k -o %~p0\cache\Git-%GIT_VERSION%%GIT_VERSION_MINOR%-32-bit.exe https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%.windows%GIT_VERSION_MINOR%/Git-%GIT_VERSION%%GIT_VERSION_MINOR%-32-bit.exe
     IF ERRORLEVEL 1 EXIT /B 1
 )
 
-IF NOT EXIST "%~p0\cache\KDiff3-32bit-Setup_0.9.97.exe" (
-    "%~p0\tools\curl.exe" -L -k -o %~p0\cache\KDiff3-32bit-Setup_0.9.97.exe http://sourceforge.net/projects/kdiff3/files/kdiff3/0.9.97/KDiff3-32bit-Setup_0.9.97.exe/download -L http://sourceforge.net/ > NUL
+IF NOT EXIST "%~p0\cache\KDiff3-32bit-Setup_%KDIFF3_VERSION%.exe" (
+    "%~p0\tools\curl.exe" -L -k -o %~p0\cache\KDiff3-32bit-Setup_%KDIFF3_VERSION%.exe http://sourceforge.net/projects/kdiff3/files/kdiff3/%KDIFF3_VERSION%/KDiff3-32bit-Setup_%KDIFF3_VERSION%.exe/download -L http://sourceforge.net/ > NUL
     IF ERRORLEVEL 1 EXIT /B 1
 )

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -928,7 +928,7 @@
     <?if $(var.IncludeRequiredSoftware) = 1 ?>
     <Binary Id="KDiff" SourceFile="cache\KDiff3-32bit-Setup_0.9.97.exe" />
     <CustomAction Id="InstallKDiff" Impersonate="no" BinaryKey="KDiff" Execute="deferred" ExeCommand="" Return="ignore" />
-    <Binary Id="Git" SourceFile="cache\Git-2.13.2-32-bit.exe" />
+    <Binary Id="Git" SourceFile="cache\Git-2.16.2.1-32-bit.exe" />
     <CustomAction Id="InstallGit" Impersonate="no" BinaryKey="Git" Execute="deferred" ExeCommand="/COMPONENTS=&quot;assoc,assoc_sh&quot;" Return="ignore" />
     <InstallExecuteSequence>
       <Custom Action="InstallKDiff" After="InstallFiles"><![CDATA[INSTALLKDIFF3=1]]></Custom>

--- a/Setup/UI/RequiredSoftwareDlg.wxs
+++ b/Setup/UI/RequiredSoftwareDlg.wxs
@@ -14,7 +14,7 @@
         <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Required Software" />
         <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Install the additional software required to run Git Extensions" />
 
-        <Control Id="GitTitle" Type="Text" Height="15" Width="200" X="15" Y="70" Text="{\WixUI_Font_Title}Git for Windows 32bit 2.13.2" />
+        <Control Id="GitTitle" Type="Text" Height="15" Width="200" X="15" Y="70" Text="{\WixUI_Font_Title}Git for Windows 32bit 2.16.2.1" />
         <Control Id="GitDescription" Type="Text" Height="46" Width="238" X="25" Y="86" Text="Git for Windows is the native version of Git that powers Git Extensions. You must have a version of Git installed for Git Extensions to function properly." />
         <Control Id="GitCheckBox" Type="CheckBox" Height="20" Width="78" X="274" Y="87" Text="Install Git" Property="INSTALLGIT" CheckBoxValue="1" />
 


### PR DESCRIPTION
Part of #4515 an a few other issues
Resolves #4523 
This is a preparation if unbundling of Git is not done for next GE 2.51 release

Note: master has 2.16.1.2, this has the currently latest 2.16.2.1 version

Changes proposed in this pull request:
 - Update Git package
 
What did I do to test the code and ensure quality:
 - Running 2.16.2.1 manually

Has been tested on (remove any that don't apply):
 - GIT 2.16.2.1
 - Windows 7 / 10
