### PR TITLE
Issue 4453

### DIFF
--- a/GitCommands/Remote/GitRemoteManager.cs
+++ b/GitCommands/Remote/GitRemoteManager.cs
@@ -75,7 +75,7 @@ namespace GitCommands.Remote
             foreach (var remoteHead in moduleRefs)
             {
                 if (!remoteHead.IsRemote ||
-                    !StringExtensions.Contains(remoteHead.Name, remoteName))
+                    !remoteHead.Name.Contains(remoteName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     continue;
                 }
@@ -84,7 +84,7 @@ namespace GitCommands.Remote
                 {
                     if (localHead.IsRemote ||
                         !string.IsNullOrEmpty(localHead.GetTrackingRemote(localConfig)) ||
-                        !StringExtensions.Contains(remoteHead.Name, localHead.Name))
+                        !remoteHead.Name.Contains(localHead.Name, StringComparison.InvariantCultureIgnoreCase))
                     {
                         continue;
                     }

--- a/GitCommands/Remote/GitRemoteManager.cs
+++ b/GitCommands/Remote/GitRemoteManager.cs
@@ -70,18 +70,21 @@ namespace GitCommands.Remote
         {
             var module = GetModule();
             var localConfig = module.LocalConfigFile;
+            var moduleRefs = module.GetRefs(tags: false, branches: true);
 
-            foreach (var remoteHead in module.GetRefs(true, true))
+            foreach (var remoteHead in moduleRefs)
             {
-                foreach (var localHead in module.GetRefs(true, true))
+                if (!remoteHead.IsRemote ||
+                    !StringExtensions.Contains(remoteHead.Name, remoteName))
                 {
-                    if (!remoteHead.IsRemote ||
-                        localHead.IsRemote ||
+                    continue;
+                }
+
+                foreach (var localHead in moduleRefs)
+                {
+                    if (localHead.IsRemote ||
                         !string.IsNullOrEmpty(localHead.GetTrackingRemote(localConfig)) ||
-                        remoteHead.IsTag ||
-                        localHead.IsTag ||
-                        !remoteHead.Name.ToLower().Contains(localHead.Name.ToLower()) ||
-                        !remoteHead.Name.ToLower().Contains(remoteName.ToLower()))
+                        !StringExtensions.Contains(remoteHead.Name, localHead.Name))
                     {
                         continue;
                     }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -232,5 +232,15 @@ namespace System
 
             return str.Substring(0, maxLength - 3) + "...";
         }
+
+        /// <summary>
+        /// Uses the method IndexOf to check if the <paramref name="other"/> is contained inside the <paramref name="str"/>
+        /// </summary>
+        /// <returns>true if the <paramref name="other"/> is inside of <paramref name="str"/></returns>
+        public static bool Contains([NotNull]this string str, [NotNull] string other,
+            StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+        {
+            return str.IndexOf(other, stringComparison) != -1;
+        }
     }
 }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -234,11 +234,16 @@ namespace System
         }
 
         /// <summary>
-        /// Uses the method IndexOf to check if the <paramref name="other"/> is contained inside the <paramref name="str"/>
+        /// Returns a value indicating whether the <paramref name="other"/> occurs within <paramref name="str"/>.
         /// </summary>
-        /// <returns>true if the <paramref name="other"/> is inside of <paramref name="str"/></returns>
+        /// <param name="other">The string to seek. </param>
+        /// <param name="stringComparison">The Comparison type</param>
+        /// <returns>
+        /// true if the <paramref name="other"/> parameter occurs within <paramref name="str"/>,
+        /// or if <paramref name="other"/> is the empty string (""); otherwise, false.
+        /// </returns>
         public static bool Contains([NotNull]this string str, [NotNull] string other,
-            StringComparison stringComparison = StringComparison.InvariantCultureIgnoreCase)
+            StringComparison stringComparison)
         {
             return str.IndexOf(other, stringComparison) != -1;
         }

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -249,5 +249,105 @@ namespace GitCommandsTests.Remote
             _configFile.Received(1).AddConfigSection(sections[remoteDisabled ? 1 : 0]);
             _configFile.Received(1).Save();
         }
+
+        [Test]
+        public void ConfigureRemotes_Should_not_update_localHead_if_remoteHead_is_local()
+        {
+            var refs = new[]
+            {
+                CreateSubstituteRef("f6323b8e80f96dff017dd14bdb28a576556adab4", "refs/heads/local", ""),
+            };
+
+            _module.GetRefs().ReturnsForAnyArgs(refs);
+
+            _controller.ConfigureRemotes("origin");
+
+            var mergeWith = "";
+            Assert.AreEqual(mergeWith, refs[0].MergeWith);
+            refs[0].Received(0).MergeWith = mergeWith;
+        }
+
+        [Test]
+        public void ConfigureRemotes_Should_not_update_localHead_if_localHead_is_remote()
+        {
+            var refs = new[]
+            {
+                CreateSubstituteRef("02e10a13e06e7562f7c3c516abb2a0e1a0c0dd90", "refs/remotes/origin/develop", "origin"),
+            };
+            _module.GetRefs().ReturnsForAnyArgs(refs);
+
+            _controller.ConfigureRemotes("origin");
+
+            var mergeWith = "";
+            Assert.AreEqual(mergeWith, refs[0].MergeWith);
+            refs[0].Received(0).MergeWith = mergeWith;
+        }
+
+        [Test]
+        public void ConfigureRemotes_Should_not_update_localHead_if_remoteHead_is_not_the_remote_origin_of_the_localHead()
+        {
+            var refs = new[]
+            {
+                CreateSubstituteRef("f6323b8e80f96dff017dd14bdb28a576556adab4", "refs/heads/develop", ""),
+                CreateSubstituteRef("ddca5a9cdc3ab10e042ae6cf5f8da2dd25c4b75f", "refs/remotes/origin/master", "origin"),
+            };
+            _module.GetRefs().ReturnsForAnyArgs(refs);
+
+            _controller.ConfigureRemotes("origin");
+
+            var mergeWith = "";
+
+            Assert.AreEqual(mergeWith, refs[0].MergeWith);
+            refs[0].Received(0).MergeWith = mergeWith;
+        }
+
+        [Test]
+        public void ConfigureRemotes_Should_not_update_localHead_if_remoteHead_is_Tag()
+        {
+            var refs = new[]
+            {
+                CreateSubstituteRef("02e10a13e06e7562f7c3c516abb2a0e1a0c0dd90", "refs/tags/local-tag", ""),
+            };
+            _module.GetRefs().ReturnsForAnyArgs(refs);
+
+            _controller.ConfigureRemotes("origin");
+
+            var mergeWith = "";
+
+            Assert.AreEqual(mergeWith, refs[0].MergeWith);
+            refs[0].Received(0).MergeWith = mergeWith;
+        }
+
+        [Test]
+        public void ConfigureRemotes_Should_update_localHead_if_remoteHead_is_the_remote_origin_of_the_localHead()
+        {
+            var refs = new[]
+            {
+                CreateSubstituteRef("f6323b8e80f96dff017dd14bdb28a576556adab4", "refs/heads/develop", ""),
+                CreateSubstituteRef("02e10a13e06e7562f7c3c516abb2a0e1a0c0dd90", "refs/remotes/origin/develop", "origin"),
+            };
+            _module.GetRefs().ReturnsForAnyArgs(refs);
+
+            _controller.ConfigureRemotes("origin");
+            var mergeWith = "develop";
+            Assert.AreEqual(mergeWith, refs[0].MergeWith);
+            refs[0].Received(1).MergeWith = mergeWith;
+        }
+
+        private IGitRef CreateSubstituteRef(string guid, string completeName, string remote)
+        {
+            var isRemote = !string.IsNullOrEmpty(remote);
+            var name = (isRemote ? remote + "/" : "") + completeName.Split('/').LastOrDefault();
+            var isTag = completeName.StartsWith("refs/tags/", StringComparison.InvariantCultureIgnoreCase);
+            var gitRef = Substitute.For<IGitRef>();
+            gitRef.Module.Returns(_module);
+            gitRef.Guid.Returns(guid);
+            gitRef.CompleteName.Returns(completeName);
+            gitRef.Name.Returns(name);
+            gitRef.Remote.Returns(remote);
+            gitRef.IsRemote.Returns(isRemote);
+            gitRef.IsTag.Returns(isTag);
+            return gitRef;
+        }
     }
 }

--- a/UnitTests/GitCommandsTests/StringExtensionTests.cs
+++ b/UnitTests/GitCommandsTests/StringExtensionTests.cs
@@ -25,7 +25,7 @@ namespace GitCommandsTests
         [TestCase("Hello World", "ldi", false)]
         public void Contains_works_as_expected(string str, string other, bool expected)
         {
-            Assert.AreEqual(expected, str.Contains(other));
+            Assert.AreEqual(expected, str.Contains(other, StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }

--- a/UnitTests/GitCommandsTests/StringExtensionTests.cs
+++ b/UnitTests/GitCommandsTests/StringExtensionTests.cs
@@ -16,5 +16,16 @@ namespace GitCommandsTests
         {
             Assert.AreEqual(expected, s.ShortenTo(length));
         }
+
+        [TestCase("Hello World", "Hello", true)]
+        [TestCase("Hello World", " ", true)]
+        [TestCase("Hello World", "World", true)]
+        [TestCase("Hello World", "", true)]
+        [TestCase("Hello World", "Hi", false)]
+        [TestCase("Hello World", "ldi", false)]
+        public void Contains_works_as_expected(string str, string other, bool expected)
+        {
+            Assert.AreEqual(expected, str.Contains(other));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4453 .
It came to my attention that after the commit:
 [Fixed "automatically configure the default push..." feature when adding remote](https://github.com/gitextensions/gitextensions/commit/4cb98fe33467426212d2616e62f2cfc5223a00cf)

it broke the use of the double loop that existed by changing the Line:95

    //  From
    localHead.MergeWith = remoteHead.Name;
    //  To
    localHead.MergeWith = localHead.Name;

So could someone validate that this is the correct behavior?
Also there is no Unit Test for this function.  
Should we create  Unit Test for this ?

Changes proposed in this pull request:
 - Refactored `GitRemoteManager.ConfigureRemotes` to use only one  loop

What did I do to test the code and ensure quality:
 - Run all unit tests
 - Run the app and check the affected part.

Has been tested on (remove any that don't apply):
 - GIT 2.16.2
 - Windows 10


Thanks
