### PR TITLE
#4535 Reset folder in file tree regression in 2.51

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -477,6 +477,7 @@ See the changes in the commit form.");
             var itemSelected = gitItem != null;
             var isFile = itemSelected && gitItem.ObjectType == GitObjectType.Blob;
             var isFolder = itemSelected && gitItem.ObjectType == GitObjectType.Tree;
+            var isFileOrFolder = isFile || isFolder;
             var isExistingFileOrDirectory = itemSelected && FormBrowseUtil.IsFileOrDirectory(_fullPathResolver.Resolve(gitItem.FileName));
 
             if (itemSelected && gitItem.ObjectType == GitObjectType.Commit)
@@ -493,14 +494,13 @@ See the changes in the commit form.");
             }
 
             saveAsToolStripMenuItem.Visible = isFile;
-            resetToThisRevisionToolStripMenuItem.Visible = isFile && !Module.IsBareRepository();
-            toolStripSeparatorFileSystemActions.Visible = isFile;
+            resetToThisRevisionToolStripMenuItem.Visible = isFileOrFolder && !Module.IsBareRepository();
+            toolStripSeparatorFileSystemActions.Visible = isFileOrFolder;
 
-            fileHistoryToolStripMenuItem.Enabled = itemSelected;
             copyFilenameToClipboardToolStripMenuItem.Visible = itemSelected;
             fileTreeOpenContainingFolderToolStripMenuItem.Enabled = isExistingFileOrDirectory;
             fileTreeArchiveToolStripMenuItem.Enabled = itemSelected;
-            fileTreeCleanWorkingTreeToolStripMenuItem.Visible = isFolder;
+            fileTreeCleanWorkingTreeToolStripMenuItem.Visible = isFileOrFolder;
             fileTreeCleanWorkingTreeToolStripMenuItem.Enabled = isExistingFileOrDirectory;
 
             blameToolStripMenuItem1.Visible = isFile;
@@ -513,14 +513,13 @@ See the changes in the commit form.");
             openFileWithToolStripMenuItem.Visible = isFile;
 
             toolStripSeparatorGitActions.Visible = isFile;
-            stopTrackingThisFileToolStripMenuItem.Visible = isFile;
-            stopTrackingThisFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
-            assumeUnchangedTheFileToolStripMenuItem.Visible = isFile;
-            assumeUnchangedTheFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
+            stopTrackingThisFileToolStripMenuItem.Visible = 
+                stopTrackingThisFileToolStripMenuItem.Enabled = isFile;
+            assumeUnchangedTheFileToolStripMenuItem.Visible = 
+                assumeUnchangedTheFileToolStripMenuItem.Enabled = isFile;
             findToolStripMenuItem.Enabled = tvGitTree.Nodes.Count>0;
 
             toolStripSeparatorFileTreeActions.Visible = isFile;
-            toolStripSeparatorFileTreeActions.Enabled = isExistingFileOrDirectory;
             expandSubtreeToolStripMenuItem.Visible = isFolder;
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -503,6 +503,7 @@ See the changes in the commit form.");
             fileTreeCleanWorkingTreeToolStripMenuItem.Visible = isFileOrFolder;
             fileTreeCleanWorkingTreeToolStripMenuItem.Enabled = isExistingFileOrDirectory;
 
+            fileHistoryToolStripMenuItem.Enabled = itemSelected;
             blameToolStripMenuItem1.Visible = isFile;
 
             editCheckedOutFileToolStripMenuItem.Visible = isFile;
@@ -513,10 +514,10 @@ See the changes in the commit form.");
             openFileWithToolStripMenuItem.Visible = isFile;
 
             toolStripSeparatorGitActions.Visible = isFile;
-            stopTrackingThisFileToolStripMenuItem.Visible = 
-                stopTrackingThisFileToolStripMenuItem.Enabled = isFile;
-            assumeUnchangedTheFileToolStripMenuItem.Visible = 
-                assumeUnchangedTheFileToolStripMenuItem.Enabled = isFile;
+            stopTrackingThisFileToolStripMenuItem.Visible = isFile;
+            stopTrackingThisFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
+            assumeUnchangedTheFileToolStripMenuItem.Visible = isFile;
+            assumeUnchangedTheFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
             findToolStripMenuItem.Enabled = tvGitTree.Nodes.Count>0;
 
             toolStripSeparatorFileTreeActions.Visible = isFile;


### PR DESCRIPTION
Fixes #4535

Changes proposed in this pull request:
Reset folder was not visible after #4165 and other PRs. In 2.50 it was possible to get various exceptions and irrelevant menu items.

Also, some other menu items were cleaned up in this PR

Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/36758795-b6476dc4-1c15-11e8-8412-f645a61d7f78.png)
![image](https://user-images.githubusercontent.com/6248932/36758815-c3215f1e-1c15-11e8-8ea8-53fc5714e9ab.png)
![image](https://user-images.githubusercontent.com/6248932/36758844-d73bacc0-1c15-11e8-81f0-0b25d7fadbf9.png)

![image](https://user-images.githubusercontent.com/6248932/36758875-e5f6f198-1c15-11e8-8ad8-8e327bfe5f7f.png)
![image](https://user-images.githubusercontent.com/6248932/36758889-f1c1bbe8-1c15-11e8-96c2-9560b3fb7ba3.png)
![image](https://user-images.githubusercontent.com/6248932/36758897-fa4697ca-1c15-11e8-867a-ce0de3a893fc.png)


What did I do to test the code and ensure quality:
 - Manual tests

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10
