### PR TITLE
4485 fix

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -25,6 +25,7 @@ namespace GitUI.Editor
         private int _currentScrollPos = -1;
         private bool _currentViewIsPatch;
         private readonly IFileViewer _internalFileViewer;
+        private GetNextFileFnc _fileLoader;
         private readonly IFullPathResolver _fullPathResolver;
 
         public FileViewer()
@@ -444,9 +445,9 @@ namespace GitUI.Editor
             Reset(true, true, true);
         }
 
-        public void ViewPatch(Func<string> loadPatchText)
+        public Task ViewPatch(Func<string> loadPatchText)
         {
-            _async.Load(loadPatchText, ViewPatch);
+            return _async.Load(loadPatchText, ViewPatch);
         }
 
         public void ViewText(string fileName, string text)
@@ -1013,9 +1014,10 @@ namespace GitUI.Editor
             return (_internalFileViewer.GetText() != null && _internalFileViewer.GetText().Contains("@@"));
         }
 
-        public void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader)
+        public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _internalFileViewer.SetFileLoader(fileLoader);
+            _fileLoader = fileLoader;
         }
 
         private void encodingToolStripComboBox_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -68,15 +68,15 @@ namespace GitUI.Editor
             DoubleClick?.Invoke(sender, e);
         }
 
-        private void BlameFileKeyUp(object sender, KeyEventArgs e)
+        private async void BlameFileKeyUp(object sender, KeyEventArgs e)
         {
             if (e.Modifiers == Keys.Control && e.KeyCode == Keys.F)
                 Find();
 
             if (e.Modifiers == Keys.Shift && e.KeyCode == Keys.F3)
-                _findAndReplaceForm.FindNext(true, true, "Text not found");
+                await _findAndReplaceForm.FindNext(true, true, "Text not found");
             else if (e.KeyCode == Keys.F3)
-                _findAndReplaceForm.FindNext(true, false, "Text not found");
+                await _findAndReplaceForm.FindNext(true, false, "Text not found");
 
             VScrollBar_ValueChanged(this, e);
         }
@@ -353,7 +353,7 @@ namespace GitUI.Editor
             }
         }
 
-        public void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader)
+        public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _findAndReplaceForm.SetFileLoader(fileLoader);
         }

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -65,6 +65,6 @@ namespace GitUI.Editor
         Font Font { get; set; }
         void FocusTextArea();
 
-        void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader);
+        void SetFileLoader(GetNextFileFnc fileLoader);
     }
 }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitUI.Editor;
 using ResourceManager;
+using System.Threading.Tasks;
 
 namespace GitUI
 {
@@ -68,22 +69,22 @@ namespace GitUI
             return patch.Text;
         }
 
-        public static void ViewChanges(this FileViewer diffViewer, IList<GitRevision> revisions, GitItemStatus file, string defaultText)
+        public static Task ViewChanges(this FileViewer diffViewer, IList<GitRevision> revisions, GitItemStatus file, string defaultText)
         {
             if (revisions.Count == 0)
-                return;
+                return Task.FromResult(string.Empty);
 
             var selectedRevision = revisions[0];
             string secondRevision = selectedRevision?.Guid;
             string firstRevision = revisions.Count >= 2 ? revisions[1].Guid : null;
             if (firstRevision == null && selectedRevision != null)
                 firstRevision = selectedRevision.FirstParentGuid;
-            ViewChanges(diffViewer, firstRevision, secondRevision, file, defaultText);
+            return ViewChanges(diffViewer, firstRevision, secondRevision, file, defaultText);
         }
 
-        public static void ViewChanges(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file, string defaultText)
+        public static Task ViewChanges(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file, string defaultText)
         {
-            diffViewer.ViewPatch(() =>
+            return diffViewer.ViewPatch(() =>
             {
                 string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
                 return selectedPatch ?? defaultText;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -162,6 +162,136 @@ namespace GitUI
             }
         }
 
+        public int GetNextIndex(bool searchBackward, bool loop)
+        {
+            int curIdx = SelectedIndex;
+            if (curIdx >= 0)
+            {
+                ListViewItem currentItem = FileStatusListView.Items[curIdx];
+                var currentGroup = currentItem.Group;
+
+                int maxIdx = GitItemStatuses.Count() - 1;
+
+                if (searchBackward)
+                {
+                    var nextItem = FindPrevItemInGroups(curIdx, currentGroup);
+                    if (nextItem == null)
+                    {
+                        return loop ? GetLastIndex() : curIdx;
+                    }
+                    return nextItem.Index;
+                }
+                else
+                {
+                    var nextItem = FindNextItemInGroups(curIdx, currentGroup);
+                    if (nextItem == null)
+                    {
+                        return loop ? 0 : curIdx;
+                    }
+                    return nextItem.Index;
+                }
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        private ListViewItem FindPrevItemInGroups(int curIdx, ListViewGroup currentGroup)
+        {
+            List<ListViewGroup> searchInGroups = new List<ListViewGroup>();
+            bool foundCurrentGroup = false;
+            for (int i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
+            {
+                if (FileStatusListView.Groups[i] == currentGroup)
+                {
+                    foundCurrentGroup = true;
+                }
+                if (foundCurrentGroup)
+                {
+                    searchInGroups.Add(FileStatusListView.Groups[i]);
+                }
+            }
+
+            foreach (ListViewGroup grp in searchInGroups)
+            {
+                for (int i = curIdx - 1; i >= 0; i--)
+                {
+                    if (FileStatusListView.Items[i].Group == grp)
+                    {
+                        return FileStatusListView.Items[i];
+                    }
+                }
+                curIdx = FileStatusListView.Items.Count;
+            }
+
+            return null;
+        }
+
+        private ListViewItem FindNextItemInGroups(int curIdx, ListViewGroup currentGroup)
+        {
+            List<ListViewGroup> searchInGroups = new List<ListViewGroup>();
+            bool foundCurrentGroup = false;
+            for (int i = 0; i < FileStatusListView.Groups.Count; i++)
+            {
+                if (FileStatusListView.Groups[i] == currentGroup)
+                {
+                    foundCurrentGroup = true;
+                }
+                if (foundCurrentGroup)
+                {
+                    searchInGroups.Add(FileStatusListView.Groups[i]);
+                }
+            }
+
+            foreach (ListViewGroup grp in searchInGroups)
+            {
+                for (int i = curIdx + 1; i < FileStatusListView.Items.Count; i++)
+                {
+                    if (FileStatusListView.Items[i].Group == grp)
+                    {
+                        return FileStatusListView.Items[i];
+                    }
+                }
+                curIdx = -1;
+            }
+
+            return null;
+        }
+
+        private int GetLastIndex()
+        {
+            if (FileStatusListView.Items.Count == 0)
+            {
+                return -1;
+            }
+
+            if (FileStatusListView.Groups.Count < 2)
+            {
+                return FileStatusListView.Items.Count - 1;
+            }
+
+            ListViewGroup lastNonEmptyGroup = null;
+            for (int i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
+            {
+                if (FileStatusListView.Groups[i].Items.Count > 0)
+                {
+                    lastNonEmptyGroup = FileStatusListView.Groups[i];
+                    break;
+                }
+            }
+
+            for (int i = FileStatusListView.Items.Count - 1; i >= 0; i--)
+            {
+                if (FileStatusListView.Items[i].Group == lastNonEmptyGroup)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         private string GetItemText(Graphics graphics, GitItemStatus gitItemStatus, int imageWidth)
         {
             var pathFormatter = new PathFormatter(graphics, FileStatusListView.Font);


### PR DESCRIPTION
Keep only one path of loading diff into fileviewer control and await for diff being loaded.

Fixes #4485.
Relates to #4540 

What did I do to test the code and ensure quality:
Tested manually.
async/await occurrences need to be aligned with solution that will get worked out in #4501

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
