### PR TITLE
Await for diff being loaded.

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -10,6 +10,7 @@ using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
 using ResourceManager;
 using GitUI.Hotkey;
+using System.Threading.Tasks;
 
 namespace GitUI.CommandsDialogs
 {
@@ -168,52 +169,30 @@ namespace GitUI.CommandsDialogs
             return _revisionGrid.DescribeRevision(revision);
         }
 
-        private static int GetNextIdx(int curIdx, int maxIdx, bool searchBackward)
+        private bool GetNextPatchFile(bool searchBackward, bool loop, out int fileIndex, out Task loadFileContent)
         {
-            if (searchBackward)
+            fileIndex = -1;
+            loadFileContent = Task.FromResult<string>(null);
+            var revisions = _revisionGrid.GetSelectedRevisions();
+            if (revisions.Count == 0)
+                return false;
+
+            int idx = DiffFiles.SelectedIndex;
+            if (idx == -1)
+                return false;
+
+            fileIndex = DiffFiles.GetNextIndex(searchBackward, loop);
+            if (fileIndex == idx)
             {
-                if (curIdx == 0)
-                {
-                    curIdx = maxIdx;
-                }
-                else
-                {
-                    curIdx--;
-                }
+                if (!loop)
+                    return false;
             }
             else
             {
-                if (curIdx == maxIdx)
-                {
-                    curIdx = 0;
-                }
-                else
-                {
-                    curIdx++;
-                }
+                DiffFiles.SetSelectedIndex(fileIndex, notify: false);
             }
-            return curIdx;
-        }
-
-        private Tuple<int, string> GetNextPatchFile(bool searchBackward)
-        {
-            var revisions = _revisionGrid.GetSelectedRevisions();
-            if (revisions.Count == 0)
-                return null;
-            int idx = DiffFiles.SelectedIndex;
-            if (idx == -1)
-                return new Tuple<int, string>(idx, null);
-
-            idx = GetNextIdx(idx, DiffFiles.GitItemStatuses.Count() - 1, searchBackward);
-            DiffFiles.SetSelectedIndex(idx, notify: false);
-            return new Tuple<int, string>(idx, GetSelectedPatch(revisions, DiffFiles.SelectedItem));
-        }
-
-        private string GetSelectedPatch(IList<GitRevision> revisions, GitItemStatus file)
-        {
-            string firstRevision = revisions.Count > 0 ? revisions[0].Guid : null;
-            string secondRevision = revisions.Count == 2 ? revisions[1].Guid : null;
-            return DiffText.GetSelectedPatch(firstRevision, secondRevision, file);
+            loadFileContent = ShowSelectedFileDiff();
+            return true;
         }
 
         private ContextMenuSelectionInfo GetSelectionInfo()
@@ -254,7 +233,7 @@ namespace GitUI.CommandsDialogs
             RefreshArtificial();
         }
 
-        private void ShowSelectedFileDiff()
+        private async Task ShowSelectedFileDiff()
         {
             var items = _revisionGrid.GetSelectedRevisions();
             if (DiffFiles.SelectedItem == null || items.Count() == 0)
@@ -282,13 +261,13 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
             }
-            DiffText.ViewChanges(items, DiffFiles.SelectedItem, String.Empty);
+            await DiffText.ViewChanges(items, DiffFiles.SelectedItem, String.Empty);
         }
 
 
-        private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
+        private async void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ShowSelectedFileDiff();
+            await ShowSelectedFileDiff();
         }
 
         private void DiffFiles_DoubleClick(object sender, EventArgs e)
@@ -322,9 +301,9 @@ namespace GitUI.CommandsDialogs
                 DiffText.ViewPatch(String.Empty);
         }
 
-        private void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        private async void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
         {
-            ShowSelectedFileDiff();
+            await ShowSelectedFileDiff();
         }
 
         private void diffShowInFileTreeToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -8,13 +8,12 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
-using GitUI.CommandsDialogs;
-using GitUI.Hotkey;
-using ICSharpCode.TextEditor.Util;
-using PatchApply;
 using GitCommands.Settings;
+using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.Editor.Diff;
+using GitUI.Hotkey;
+using PatchApply;
 using ResourceManager;
 
 namespace GitUI.Editor
@@ -191,17 +190,17 @@ namespace GitUI.Editor
 
         private void UICommandsSourceChanged(object sender, GitUICommandsChangedEventArgs e)
         {
-            if(e?.OldCommands != null)
+            if (e?.OldCommands != null)
                 e.OldCommands.PostSettings -= UICommands_PostSettings;
 
             var commandSource = sender as IGitUICommandsSource;
-            if( commandSource?.UICommands != null)
+            if (commandSource?.UICommands != null)
                 commandSource.UICommands.PostSettings += UICommands_PostSettings;
 
             this.Encoding = null;
         }
 
-        private void UICommands_PostSettings( object sender, GitUIPluginInterfaces.GitUIPostActionEventArgs e )
+        private void UICommands_PostSettings(object sender, GitUIPluginInterfaces.GitUIPostActionEventArgs e)
         {
             _internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition;
         }
@@ -455,9 +454,9 @@ namespace GitUI.Editor
             Reset(true, true, true);
         }
 
-        public void ViewPatch(Func<string> loadPatchText)
+        public Task ViewPatch(Func<string> loadPatchText)
         {
-            _async.Load(loadPatchText, ViewPatch);
+            return _async.Load(loadPatchText, ViewPatch);
         }
 
         public void ViewText(string fileName, string text)
@@ -1026,7 +1025,7 @@ namespace GitUI.Editor
             return (_internalFileViewer.GetText() != null && _internalFileViewer.GetText().Contains("@@"));
         }
 
-        public void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader)
+        public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _internalFileViewer.SetFileLoader(fileLoader);
         }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -72,15 +72,15 @@ namespace GitUI.Editor
                 DoubleClick(sender, e);
         }
 
-        private void BlameFileKeyUp(object sender, KeyEventArgs e)
+        private async void BlameFileKeyUp(object sender, KeyEventArgs e)
         {
             if (e.Modifiers == Keys.Control && e.KeyCode == Keys.F)
                 Find();
 
             if (e.Modifiers == Keys.Shift && e.KeyCode == Keys.F3)
-                _findAndReplaceForm.FindNext(true, true, "Text not found");
+                await _findAndReplaceForm.FindNext(true, true, "Text not found");
             else if (e.KeyCode == Keys.F3)
-                _findAndReplaceForm.FindNext(true, false, "Text not found");
+                await _findAndReplaceForm.FindNext(true, false, "Text not found");
 
             VScrollBar_ValueChanged(this, e);
         }
@@ -360,7 +360,7 @@ namespace GitUI.Editor
             }
         }
 
-        public void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader)
+        public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _findAndReplaceForm.SetFileLoader(fileLoader);
         }

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -65,6 +65,6 @@ namespace GitUI.Editor
         Font Font { get; set; }
         void FocusTextArea();
 
-        void SetFileLoader(Func<bool, Tuple<int, string>> fileLoader);
+        void SetFileLoader(GetNextFileFnc fileLoader);
     }
 }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -9,6 +9,7 @@ using GitCommands;
 using GitUI.Editor;
 using ICSharpCode.TextEditor.Util;
 using ResourceManager;
+using System.Threading.Tasks;
 
 namespace GitUI
 {
@@ -71,22 +72,22 @@ namespace GitUI
             return patch.Text;
         }
 
-        public static void ViewChanges(this FileViewer diffViewer, IList<GitRevision> revisions, GitItemStatus file, string defaultText)
+        public static Task ViewChanges(this FileViewer diffViewer, IList<GitRevision> revisions, GitItemStatus file, string defaultText)
         {
             if (revisions.Count == 0)
-                return;
+                return Task.FromResult(string.Empty);
 
             var selectedRevision = revisions[0];
             string secondRevision = selectedRevision?.Guid;
             string firstRevision = revisions.Count >= 2 ? revisions[1].Guid : null;
             if (firstRevision == null && selectedRevision != null)
                 firstRevision = selectedRevision.FirstParentGuid;
-            ViewChanges(diffViewer, firstRevision, secondRevision, file, defaultText);
+            return ViewChanges(diffViewer, firstRevision, secondRevision, file, defaultText);
         }
 
-        public static void ViewChanges(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file, string defaultText)
+        public static Task ViewChanges(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file, string defaultText)
         {
-            diffViewer.ViewPatch(() =>
+            return diffViewer.ViewPatch(() =>
             {
                 string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
                 return selectedPatch ?? defaultText;


### PR DESCRIPTION
Keep only one path of loading diff into fileviewer control.
Fixes #4485.

(cherry picked from commit 7c99be9f0a80975826256b10dcdbadea2e8b54f5)
