### PR TITLE
Commit info in history form

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -24,9 +24,8 @@ namespace GitUI.CommandsDialogs
             this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.diffToolremotelocalStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.viewCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.manipuleerCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.manipulateCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.revertCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cherryPickThisCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -35,6 +34,8 @@ namespace GitUI.CommandsDialogs
             this.fullHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.tabControl1 = new System.Windows.Forms.TabControl();
+            this.CommitInfoTabPage = new System.Windows.Forms.TabPage();
+            this.CommitDiff = new GitUI.UserControls.CommitDiff();
             this.ViewTab = new System.Windows.Forms.TabPage();
             this.View = new GitUI.Editor.FileViewer();
             this.DiffTab = new System.Windows.Forms.TabPage();
@@ -66,6 +67,7 @@ namespace GitUI.CommandsDialogs
             this.splitContainer1.SuspendLayout();
             this.FileHistoryContextMenu.SuspendLayout();
             this.tabControl1.SuspendLayout();
+            this.CommitInfoTabPage.SuspendLayout();
             this.ViewTab.SuspendLayout();
             this.DiffTab.SuspendLayout();
             this.BlameTab.SuspendLayout();
@@ -109,9 +111,8 @@ namespace GitUI.CommandsDialogs
             this.openWithDifftoolToolStripMenuItem,
             this.diffToolremotelocalStripMenuItem,
             this.saveAsToolStripMenuItem,
-            this.viewCommitToolStripMenuItem,
             this.toolStripSeparator2,
-            this.manipuleerCommitToolStripMenuItem,
+            this.manipulateCommitToolStripMenuItem,
             this.toolStripSeparator1,
             this.followFileHistoryToolStripMenuItem,
             this.followFileHistoryRenamesToolStripMenuItem,
@@ -145,26 +146,19 @@ namespace GitUI.CommandsDialogs
             this.saveAsToolStripMenuItem.Text = "Save as";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
-            // viewCommitToolStripMenuItem
-            // 
-            this.viewCommitToolStripMenuItem.Name = "viewCommitToolStripMenuItem";
-            this.viewCommitToolStripMenuItem.Size = new System.Drawing.Size(339, 22);
-            this.viewCommitToolStripMenuItem.Text = "View commit";
-            this.viewCommitToolStripMenuItem.Click += new System.EventHandler(this.viewCommitToolStripMenuItem_Click);
-            // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(336, 6);
             // 
-            // manipuleerCommitToolStripMenuItem
+            // manipulateCommitToolStripMenuItem
             // 
-            this.manipuleerCommitToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.manipulateCommitToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.revertCommitToolStripMenuItem,
             this.cherryPickThisCommitToolStripMenuItem});
-            this.manipuleerCommitToolStripMenuItem.Name = "manipuleerCommitToolStripMenuItem";
-            this.manipuleerCommitToolStripMenuItem.Size = new System.Drawing.Size(339, 22);
-            this.manipuleerCommitToolStripMenuItem.Text = "Manipulate commit";
+            this.manipulateCommitToolStripMenuItem.Name = "manipulateCommitToolStripMenuItem";
+            this.manipulateCommitToolStripMenuItem.Size = new System.Drawing.Size(339, 22);
+            this.manipulateCommitToolStripMenuItem.Text = "Manipulate commit";
             // 
             // revertCommitToolStripMenuItem
             // 
@@ -215,6 +209,7 @@ namespace GitUI.CommandsDialogs
             // 
             // tabControl1
             // 
+            this.tabControl1.Controls.Add(this.CommitInfoTabPage);
             this.tabControl1.Controls.Add(this.ViewTab);
             this.tabControl1.Controls.Add(this.DiffTab);
             this.tabControl1.Controls.Add(this.BlameTab);
@@ -225,6 +220,26 @@ namespace GitUI.CommandsDialogs
             this.tabControl1.Size = new System.Drawing.Size(748, 314);
             this.tabControl1.TabIndex = 0;
             this.tabControl1.SelectedIndexChanged += new System.EventHandler(this.TabControl1SelectedIndexChanged);
+            // 
+            // CommitInfoTabPage
+            // 
+            this.CommitInfoTabPage.Controls.Add(this.CommitDiff);
+            this.CommitInfoTabPage.Location = new System.Drawing.Point(4, 22);
+            this.CommitInfoTabPage.Name = "CommitInfoTabPage";
+            this.CommitInfoTabPage.Size = new System.Drawing.Size(740, 288);
+            this.CommitInfoTabPage.TabIndex = 3;
+            this.CommitInfoTabPage.Text = "Commit";
+            // 
+            // CommitDiff
+            // 
+            this.CommitDiff.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.CommitDiff.Location = new System.Drawing.Point(0, 0);
+            this.CommitDiff.MinimumSize = new System.Drawing.Size(150, 148);
+            this.CommitDiff.Name = "CommitDiff";
+            this.CommitDiff.Size = new System.Drawing.Size(740, 288);
+            this.CommitDiff.TabIndex = 0;
             // 
             // ViewTab
             // 
@@ -467,6 +482,7 @@ namespace GitUI.CommandsDialogs
             this.splitContainer1.ResumeLayout(false);
             this.FileHistoryContextMenu.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
+            this.CommitInfoTabPage.ResumeLayout(false);
             this.ViewTab.ResumeLayout(false);
             this.DiffTab.ResumeLayout(false);
             this.BlameTab.ResumeLayout(false);
@@ -482,6 +498,8 @@ namespace GitUI.CommandsDialogs
 
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.TabControl tabControl1;
+        private System.Windows.Forms.TabPage CommitInfoTabPage;
+        private UserControls.CommitDiff CommitDiff;
         private System.Windows.Forms.TabPage ViewTab;
         private System.Windows.Forms.TabPage DiffTab;
         private System.Windows.Forms.TabPage BlameTab;
@@ -496,11 +514,10 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem followFileHistoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fullHistoryToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem manipuleerCommitToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem manipulateCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cherryPickThisCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revertCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-        private System.Windows.Forms.ToolStripMenuItem viewCommitToolStripMenuItem;
         private System.Windows.Forms.ToolStrip ToolStrip;
         private System.Windows.Forms.ToolStripLabel toolStripLabel1;
         private System.Windows.Forms.ToolStripComboBox toolStripBranchFilterComboBox;

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -333,6 +333,10 @@ namespace GitUI.CommandsDialogs
                 file.IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName));
                 Diff.ViewChanges(FileChanges.GetSelectedRevisions(), file, "You need to select at least one revision to view diff.");
             }
+            else if (tabControl1.SelectedTab == CommitInfoTabPage)
+            {
+                CommitDiff.SetRevision(revision.Guid, fileName);
+            }
 
             if (_buildReportTabPageExtension == null)
             {
@@ -454,11 +458,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void viewCommitToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            FileChanges.ViewSelectedRevisions();
-        }
-
         private void FileHistoryContextMenuOpening(object sender, CancelEventArgs e)
         {
             var selectedRevisions = FileChanges.GetSelectedRevisions();
@@ -468,8 +467,7 @@ namespace GitUI.CommandsDialogs
                 File.Exists(_fullPathResolver.Resolve(FileName));
             openWithDifftoolToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;
-            manipuleerCommitToolStripMenuItem.Enabled =
-                viewCommitToolStripMenuItem.Enabled =
+            manipulateCommitToolStripMenuItem.Enabled =
                 selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial;
             saveAsToolStripMenuItem.Enabled = selectedRevisions.Count == 1;
         }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -353,6 +353,12 @@
       <DependentUpon>BranchSelector.cs</DependentUpon>
     </Compile>
     <Compile Include="UserControls\ComboBoxHelper.cs" />
+    <Compile Include="UserControls\CommitDiff.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControls\CommitDiff.Designer.cs">
+      <DependentUpon>CommitDiff.cs</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\CommitPickerSmallControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1231,6 +1237,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\BranchSelector.resx">
       <DependentUpon>BranchSelector.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserControls\CommitDiff.resx">
+      <DependentUpon>CommitDiff.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UserControls\CommitPickerSmallControl.resx">
       <DependentUpon>CommitPickerSmallControl.cs</DependentUpon>

--- a/GitUI/HelperDialogs/FormCommitDiff.Designer.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.Designer.cs
@@ -30,124 +30,36 @@ namespace GitUI.HelperDialogs
         /// </summary>
         private void InitializeComponent()
         {
-            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
-            this.DiffFiles = new GitUI.FileStatusList();
-            this.DiffText = new GitUI.Editor.FileViewer();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.commitInfo = new GitUI.CommitInfo.CommitInfo();
-
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
-
-            this.splitContainer2.Panel1.SuspendLayout();
-            this.splitContainer2.Panel2.SuspendLayout();
-            this.splitContainer2.SuspendLayout();
-
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
+            this.CommitDiff = new GitUI.UserControls.CommitDiff();
             this.SuspendLayout();
             // 
-            // splitContainer2
+            // CommitDiff
             // 
-            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Name = "splitContainer2";
-            // 
-            // splitContainer2.Panel1
-            // 
-            this.splitContainer2.Panel1.Controls.Add(this.DiffFiles);
-            // 
-            // splitContainer2.Panel2
-            // 
-            this.splitContainer2.Panel2.Controls.Add(this.DiffText);
-            this.splitContainer2.Size = new System.Drawing.Size(717, 365);
-            this.splitContainer2.SplitterDistance = 238;
-            this.splitContainer2.TabIndex = 0;
-            // 
-            // DiffFiles
-            // 
-            this.DiffFiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DiffFiles.Location = new System.Drawing.Point(0, 0);
-            this.DiffFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.DiffFiles.Name = "DiffFiles";
-            this.DiffFiles.Size = new System.Drawing.Size(238, 365);
-            this.DiffFiles.TabIndex = 0;
-            this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFiles_SelectedIndexChanged);
-            // 
-            // DiffText
-            // 
-            this.DiffText.AutoSize = true;
-            this.DiffText.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.DiffText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DiffText.Location = new System.Drawing.Point(0, 0);
-            this.DiffText.Margin = new System.Windows.Forms.Padding(4);
-            this.DiffText.Name = "DiffText";
-            this.DiffText.Size = new System.Drawing.Size(475, 365);
-            this.DiffText.TabIndex = 0;
-            // 
-            // splitContainer1
-            // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer1.Panel1
-            // 
-            this.splitContainer1.Panel1.Controls.Add(this.commitInfo);
-            // 
-            // splitContainer1.Panel2
-            // 
-            this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
-            this.splitContainer1.Size = new System.Drawing.Size(717, 529);
-            this.splitContainer1.SplitterDistance = 160;
-            this.splitContainer1.TabIndex = 1;
-            // 
-            // commitInfo
-            // 
-            this.commitInfo.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.commitInfo.Location = new System.Drawing.Point(0, 0);
-            this.commitInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.commitInfo.Name = "commitInfo";
-            this.commitInfo.Size = new System.Drawing.Size(717, 160);
-            this.commitInfo.TabIndex = 0;
+            this.CommitDiff.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.CommitDiff.Location = new System.Drawing.Point(0, 0);
+            this.CommitDiff.MinimumSize = new System.Drawing.Size(150, 148);
+            this.CommitDiff.Name = "CommitDiff";
+            this.CommitDiff.Size = new System.Drawing.Size(716, 528);
+            this.CommitDiff.TabIndex = 0;
             // 
             // FormCommitDiff
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(717, 529);
-            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.CommitDiff);
             this.MinimumSize = new System.Drawing.Size(150, 148);
             this.Name = "FormCommitDiff";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Diff";
-            this.splitContainer2.Panel1.ResumeLayout(false);
-            this.splitContainer2.Panel2.ResumeLayout(false);
-            this.splitContainer2.Panel2.PerformLayout();
-
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
-
-            this.splitContainer2.ResumeLayout(false);
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-
-            this.splitContainer1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.SplitContainer splitContainer2;
-        private FileStatusList DiffFiles;
-        private System.Windows.Forms.SplitContainer splitContainer1;
-        private FileViewer DiffText;
-        private CommitInfo.CommitInfo commitInfo;
+        private UserControls.CommitDiff CommitDiff;
     }
 }

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using GitCommands;
+﻿using System;
 
 namespace GitUI.HelperDialogs
 {
@@ -12,9 +9,6 @@ namespace GitUI.HelperDialogs
         {
             InitializeComponent();
             Translate();
-            DiffText.ExtraDiffArgumentsChanged += DiffText_ExtraDiffArgumentsChanged;
-            DiffFiles.Focus();
-            DiffFiles.SetDiffs();
         }
 
         private FormCommitDiff()
@@ -25,49 +19,13 @@ namespace GitUI.HelperDialogs
         public FormCommitDiff(GitUICommands commands, string revisionGuid)
             : this(commands)
         {
-            // We cannot use the GitRevision from revision grid. When a filtered commit list
-            // is shown (file history/normal filter) the parent guids are not the 'real' parents,
-            // but the parents in the filtered list.
-            GitRevision revision = Module.GetRevision(revisionGuid);
-
-            if (revision != null)
-            {
-                commitInfo.Revision = revision;
-
-                DiffFiles.SetDiffs(new[] { revision });
-
-                Text = "Diff - " + GitRevision.ToShortSha(revision.Guid) + " - " + revision.AuthorDate + " - " + revision.Author + " - " + Module.WorkingDir;
-            }
+            CommitDiff.TextChanged += CommitDiff_TextChanged;
+            CommitDiff.SetRevision(revisionGuid);
         }
 
-        private async void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
+        private void CommitDiff_TextChanged(object sender, EventArgs e)
         {
-            try
-            {
-                await ViewSelectedDiff();
-            }
-            catch (OperationCanceledException)
-            {
-            }
-        }
-
-        private async Task ViewSelectedDiff()
-        {
-            if (DiffFiles.SelectedItem != null && DiffFiles.Revision != null)
-            {
-                await DiffText.ViewChanges(DiffFiles.SelectedItemParent?.Guid, DiffFiles.Revision?.Guid, DiffFiles.SelectedItem, string.Empty);
-            }
-        }
-
-        private async void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
-        {
-            try
-            {
-                await ViewSelectedDiff();
-            }
-            catch (OperationCanceledException)
-            {
-            }
+            Text = CommitDiff.Text;
         }
     }
 }

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -20,7 +20,7 @@ namespace GitUI.HelperDialogs
             : this(commands)
         {
             CommitDiff.TextChanged += CommitDiff_TextChanged;
-            CommitDiff.SetRevision(revisionGuid);
+            CommitDiff.SetRevision(revisionGuid, null);
         }
 
         private void CommitDiff_TextChanged(object sender, EventArgs e)

--- a/GitUI/UserControls/CommitDiff.Designer.cs
+++ b/GitUI/UserControls/CommitDiff.Designer.cs
@@ -1,0 +1,141 @@
+﻿namespace GitUI.UserControls
+{
+    partial class CommitDiff
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.commitInfo = new GitUI.CommitInfo.CommitInfo();
+            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
+            this.DiffFiles = new GitUI.FileStatusList();
+            this.DiffText = new GitUI.Editor.FileViewer();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
+            this.splitContainer2.Panel1.SuspendLayout();
+            this.splitContainer2.Panel2.SuspendLayout();
+            this.splitContainer2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
+            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.commitInfo);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
+            this.splitContainer1.Size = new System.Drawing.Size(717, 529);
+            this.splitContainer1.SplitterDistance = 160;
+            this.splitContainer1.TabIndex = 1;
+            // 
+            // commitInfo
+            // 
+            this.commitInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commitInfo.Location = new System.Drawing.Point(0, 0);
+            this.commitInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.commitInfo.Name = "commitInfo";
+            this.commitInfo.Size = new System.Drawing.Size(717, 160);
+            this.commitInfo.TabIndex = 0;
+            // 
+            // splitContainer2
+            // 
+            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Name = "splitContainer2";
+            // 
+            // splitContainer2.Panel1
+            // 
+            this.splitContainer2.Panel1.Controls.Add(this.DiffFiles);
+            // 
+            // splitContainer2.Panel2
+            // 
+            this.splitContainer2.Panel2.Controls.Add(this.DiffText);
+            this.splitContainer2.Size = new System.Drawing.Size(717, 365);
+            this.splitContainer2.SplitterDistance = 238;
+            this.splitContainer2.TabIndex = 0;
+            // 
+            // DiffFiles
+            // 
+            this.DiffFiles.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DiffFiles.FilterVisible = false;
+            this.DiffFiles.Location = new System.Drawing.Point(0, 0);
+            this.DiffFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.DiffFiles.Name = "DiffFiles";
+            this.DiffFiles.Size = new System.Drawing.Size(238, 365);
+            this.DiffFiles.TabIndex = 0;
+            this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFiles_SelectedIndexChanged);
+            // 
+            // DiffText
+            // 
+            this.DiffText.AutoSize = true;
+            this.DiffText.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.DiffText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DiffText.Location = new System.Drawing.Point(0, 0);
+            this.DiffText.Margin = new System.Windows.Forms.Padding(4);
+            this.DiffText.Name = "DiffText";
+            this.DiffText.Size = new System.Drawing.Size(475, 365);
+            this.DiffText.TabIndex = 0;
+            // 
+            // CommitDiff
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.splitContainer1);
+            this.MinimumSize = new System.Drawing.Size(150, 148);
+            this.Name = "CommitDiff";
+            this.Size = new System.Drawing.Size(885, 578);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.splitContainer2.Panel1.ResumeLayout(false);
+            this.splitContainer2.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
+            this.splitContainer2.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private CommitInfo.CommitInfo commitInfo;
+        private System.Windows.Forms.SplitContainer splitContainer2;
+        private FileStatusList DiffFiles;
+        private Editor.FileViewer DiffText;
+    }
+}

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using GitCommands;
 
@@ -15,7 +16,7 @@ namespace GitUI.UserControls
             DiffFiles.SetDiffs();
         }
 
-        public void SetRevision(string revisionGuid)
+        public void SetRevision(string revisionGuid, string fileToSelect)
         {
             // We cannot use the GitRevision from revision grid. When a filtered commit list
             // is shown (file history/normal filter) the parent guids are not the 'real' parents,
@@ -24,9 +25,17 @@ namespace GitUI.UserControls
 
             if (revision != null)
             {
-                commitInfo.Revision = revision;
-
                 DiffFiles.SetDiffs(new[] { revision });
+                if (fileToSelect != null)
+                {
+                    var itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Name == fileToSelect);
+                    if (itemToSelect != null)
+                    {
+                        DiffFiles.SelectedItem = itemToSelect;
+                    }
+                }
+
+                commitInfo.Revision = revision;
 
                 Text = "Diff - " + GitRevision.ToShortSha(revision.Guid) + " - " + revision.AuthorDate + " - " + revision.Author + " - " + Module.WorkingDir;
             }

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using GitCommands;
+
+namespace GitUI.UserControls
+{
+    public partial class CommitDiff : GitModuleControl
+    {
+        public CommitDiff()
+        {
+            InitializeComponent();
+            Translate();
+            DiffText.ExtraDiffArgumentsChanged += DiffText_ExtraDiffArgumentsChanged;
+            DiffFiles.Focus();
+            DiffFiles.SetDiffs();
+        }
+
+        public void SetRevision(string revisionGuid)
+        {
+            // We cannot use the GitRevision from revision grid. When a filtered commit list
+            // is shown (file history/normal filter) the parent guids are not the 'real' parents,
+            // but the parents in the filtered list.
+            GitRevision revision = Module.GetRevision(revisionGuid);
+
+            if (revision != null)
+            {
+                commitInfo.Revision = revision;
+
+                DiffFiles.SetDiffs(new[] { revision });
+
+                Text = "Diff - " + GitRevision.ToShortSha(revision.Guid) + " - " + revision.AuthorDate + " - " + revision.Author + " - " + Module.WorkingDir;
+            }
+        }
+
+        private async void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                await ViewSelectedDiff();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private async void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                await ViewSelectedDiff();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        private async Task ViewSelectedDiff()
+        {
+            GitRevision revision = DiffFiles.Revision;
+            if (DiffFiles.SelectedItem != null && revision != null)
+            {
+                await DiffText.ViewChanges(DiffFiles.SelectedItemParent?.Guid, revision.Guid, DiffFiles.SelectedItem, string.Empty);
+            }
+        }
+    }
+}

--- a/GitUI/UserControls/CommitDiff.resx
+++ b/GitUI/UserControls/CommitDiff.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Very often when viewing file history I feel the need to see commit info / context when a specific change was made. Opening a commit from a context menu is too slow (too many context switches from UX perspective).

Changes proposed in this pull request:
 - Extract CommitDiff user control from FormCommitDiff
 - Add Commit tab in FormFileHistory and use CommitDiff in it
 - Remove Open Commit context menu item
 - UX bliss :)
 
Screenshots before and after (if PR changes UI):
- Before
![image](https://user-images.githubusercontent.com/483659/36903364-32d20c10-1e36-11e8-8adb-5fb3113566e8.png)

- After. Notice commit tab in file history
![image](https://user-images.githubusercontent.com/483659/36902753-42221856-1e34-11e8-9242-4aacf80544d8.png)

Has been tested on (remove any that don't apply):
 - GIT 2.16.1
 - Windows 10