### PR TITLE
Find in files is not finding all occurrences

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -212,7 +212,18 @@ namespace GitUI.CommandsDialogs
         private string GetSelectedPatch(IList<GitRevision> revisions, GitItemStatus file)
         {
             string firstRevision = revisions.Count > 0 ? revisions[0].Guid : null;
-            string secondRevision = revisions.Count == 2 ? revisions[1].Guid : null;
+            string secondRevision = DiffFiles.SelectedItemParent;
+            if (secondRevision == DiffFiles.CombinedDiff.Text)
+            {
+                //We cannot show the diff directly, see ShowSelectedFileDiff() for how it should be done
+                //This is handled better in later revisions
+                return null;
+            }
+            if (secondRevision == null)
+            {
+                //In 2.51 SelectedItemParent is not always set
+                secondRevision = revisions.Count == 2 ? revisions[1].Guid : revisions.Count == 1 ? revisions[0].FirstParentGuid : null;
+            }
             return DiffText.GetSelectedPatch(firstRevision, secondRevision, file);
         }
 


### PR DESCRIPTION
Fixes #4485
This also adds searching of the second parent for merge commits, not done in 2.50
(combined diff is not searched)

Changes proposed in this pull request:
 - Find when one revision was selected was not advancing to next file when searching
 - For merge commits, the second parent was never searched (combined diff still not is)
 
What did I do to test the code and ensure quality:
 - Manual tests

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10
