### PR TITLE
Remove settings that restricted ReSharper to C# 6.0 syntax

### DIFF
--- a/GitUI/GitUI.csproj.DotSettings
+++ b/GitUI/GitUI.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
No code and behavior change. Just remove the settings so that ReSharper can detect the currently language version instead of being restricted to 6.0