### PR TITLE
FileStatusList handling of parents and selected revision

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -718,7 +718,7 @@ namespace GitUI.CommandsDialogs
         {
             Cursor.Current = Cursors.WaitCursor;
             SolveMergeconflicts.Visible = Module.InTheMiddleOfConflictedMerge();
-            Staged.GitItemStatuses = Module.GetStagedFilesWithSubmodulesStatus();
+            Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), Module.GetStagedFilesWithSubmodulesStatus());
             Cursor.Current = Cursors.Default;
         }
 
@@ -747,8 +747,8 @@ namespace GitUI.CommandsDialogs
                 else
                     unStagedFiles.Add(fileStatus);
             }
-            Unstaged.GitItemStatuses = unStagedFiles;
-            Staged.GitItemStatuses = stagedFiles;
+            Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unStagedFiles);
+            Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), stagedFiles);
 
             Loading.Visible = false;
             LoadingStaged.Visible = false;
@@ -1309,8 +1309,8 @@ namespace GitUI.CommandsDialogs
                     item.IsStaged = false;
                     unStagedFiles.Add(item);
                 }
-                Staged.GitItemStatuses = stagedFiles;
-                Unstaged.GitItemStatuses = unStagedFiles;
+                Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unStagedFiles);
+                Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), stagedFiles);
                 _skipUpdate = false;
                 Staged.SelectStoredNextIndex();
 
@@ -1498,7 +1498,7 @@ namespace GitUI.CommandsDialogs
                     {
                         item.SubmoduleStatus.Result.Status = SubmoduleStatus.Unknown;
                     }
-                    Unstaged.GitItemStatuses = unStagedFiles;
+                    Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unStagedFiles);
                     Unstaged.ClearSelected();
                     _skipUpdate = false;
                     Unstaged.SelectStoredNextIndex();

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -100,7 +100,7 @@ namespace GitUI.CommandsDialogs
 
             IList<GitRevision> items = new List<GitRevision> { _headRevision, baseCommit };
             if (items.Count() == 1)
-                items.Add(new GitRevision(DiffFiles.SelectedItemParent));
+                items.Add(DiffFiles.SelectedItemParent);
             DiffText.ViewChanges(items, DiffFiles.SelectedItem, String.Empty);
         }
 

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -52,7 +52,6 @@ namespace GitUI.CommandsDialogs
         private void RevisionGridSelectionChanged(object sender, EventArgs e)
         {
             Cursor.Current = Cursors.WaitCursor;
-            DiffFiles.GitItemStatuses = null;
             DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
             Cursor.Current = Cursors.Default;
         }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -90,24 +90,20 @@ namespace GitUI.CommandsDialogs
         {
             GitStash gitStash = Stashes.SelectedItem as GitStash;
 
-            Stashed.GitItemStatuses = null;
+            Stashed.SetDiffs();
 
             Loading.Visible = true;
             Stashes.Enabled = false;
             refreshToolStripButton.Enabled = false;
             toolStripButton_customMessage.Enabled = false;
-            if (gitStash == null)
-            {
-                Stashed.GitItemStatuses = null;
-            }
-            else if (gitStash == currentWorkingDirStashItem)
+            if (gitStash == currentWorkingDirStashItem)
             {
                 toolStripButton_customMessage.Enabled = true;
                 _asyncLoader.Load(() => Module.GetAllChangedFiles(), LoadGitItemStatuses);
                 Clear.Enabled = false; // disallow Drop  (of current working directory)
                 Apply.Enabled = false; // disallow Apply (of current working directory)
             }
-            else
+            else if (gitStash != null)
             {
                 _asyncLoader.Load(() => Module.GetStashDiffFiles(gitStash.Name), LoadGitItemStatuses);
                 Clear.Enabled = true; // allow Drop
@@ -117,7 +113,7 @@ namespace GitUI.CommandsDialogs
 
         private void LoadGitItemStatuses(IList<GitItemStatus> gitItemStatuses)
         {
-            Stashed.GitItemStatuses = gitItemStatuses;
+            Stashed.SetDiffs(items: gitItemStatuses);
             Loading.Visible = false;
             Stashes.Enabled = true;
             refreshToolStripButton.Enabled = true;

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             _discussionWB.DocumentText = "";
             _diffViewer.ViewPatch("");
-            _fileStatusList.GitItemStatuses = null;
+            _fileStatusList.SetDiffs();
 
             _pullRequestsList.Items.Clear();
             var lvi = new ListViewItem("");
@@ -209,7 +209,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 return;
             _discussionWB.DocumentText = DiscussionHtmlCreator.CreateFor(_currentPullRequestInfo);
             _diffViewer.ViewPatch("");
-            _fileStatusList.GitItemStatuses = null;
+            _fileStatusList.SetDiffs();
 
             LoadDiffPatch();
             LoadDiscussion();
@@ -281,7 +281,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 _diffCache.Add(gis.Name, match.Groups[3].Value);
             }
 
-            _fileStatusList.GitItemStatuses = giss;
+            _fileStatusList.SetDiffs(items: giss);
         }
 
         private void _fetchBtn_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -203,10 +203,10 @@ namespace GitUI.CommandsDialogs
         {
             IList<GitRevision> selectedRevisions = _revisionGrid.GetSelectedRevisions();
 
-            bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item == DiffFiles.CombinedDiff.Text);
+            bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item.Guid == DiffFiles.CombinedDiff.Text);
             bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
             bool isAnyItemSelected = DiffFiles.SelectedItems.Count() > 0;
-            var isCombinedDiff = isExactlyOneItemSelected && DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent;
+            var isCombinedDiff = isExactlyOneItemSelected && DiffFiles.CombinedDiff.Text == DiffFiles.SelectedItemParent?.Guid;
             var selectedItemStatus = DiffFiles.SelectedItem;
             bool isBareRepository = Module.IsBareRepository();
             bool singleFileExists = isExactlyOneItemSelected && File.Exists(_fullPathResolver.Resolve(DiffFiles.SelectedItem.Name));
@@ -248,10 +248,10 @@ namespace GitUI.CommandsDialogs
 
             if (items.Count() == 1)
             {
-                items.Add(new GitRevision(DiffFiles.SelectedItemParent));
+                items.Add(DiffFiles.SelectedItemParent);
 
-                if (!string.IsNullOrWhiteSpace(DiffFiles.SelectedItemParent)
-                    && DiffFiles.SelectedItemParent == DiffFiles.CombinedDiff.Text)
+                if (!string.IsNullOrWhiteSpace(DiffFiles.SelectedItemParent?.Guid)
+                    && DiffFiles.SelectedItemParent?.Guid == DiffFiles.CombinedDiff.Text)
                 {
                     var diffOfConflict = Module.GetCombinedDiffContent(items.First(), DiffFiles.SelectedItem.Name,
                         DiffText.GetExtraDiffArguments(), DiffText.Encoding);
@@ -496,8 +496,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
-                GitItemStatus selectedItem = itemWithParent.Item;
-                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, itemWithParent.Item.IsTracked);
+                _revisionGrid.OpenWithDifftool(itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 
@@ -710,7 +709,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                if (DiffFiles.SelectedItem == null || !DiffFiles.Revision.IsArtificial ||
+                if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null || !DiffFiles.Revision.IsArtificial ||
                     MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
                     DialogResult.Yes)
                 {
@@ -718,7 +717,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 var selectedItems = DiffFiles.SelectedItems;
-                if (DiffFiles.Revision.Guid == GitRevision.IndexGuid)
+                if (DiffFiles.Revision?.Guid == GitRevision.IndexGuid)
                 {
                     var files = new List<GitItemStatus>();
                     var stagedItems = selectedItems.Where(item => item.IsStaged);

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using GitCommands;
 
@@ -6,8 +6,6 @@ namespace GitUI.HelperDialogs
 {
     public sealed partial class FormCommitDiff : GitModuleForm
     {
-        private readonly GitRevision _revision;
-
         private FormCommitDiff(GitUICommands aCommands)
             : base(aCommands)
         {
@@ -15,30 +13,27 @@ namespace GitUI.HelperDialogs
             Translate();
             DiffText.ExtraDiffArgumentsChanged += DiffText_ExtraDiffArgumentsChanged;
             DiffFiles.Focus();
-            DiffFiles.GitItemStatuses = null;
+            DiffFiles.SetDiffs();
         }
 
         private FormCommitDiff()
             : this(null)
         {
-
         }
 
-        public FormCommitDiff(GitUICommands aCommands, string revision)
+        public FormCommitDiff(GitUICommands aCommands, string revisionGuid)
             : this(aCommands)
         {
             // We cannot use the GitRevision from revision grid. When a filtered commit list
             // is shown (file history/normal filter) the parent guids are not the 'real' parents,
             // but the parents in the filtered list.
-            _revision = Module.GetRevision(revision);
+            GitRevision revision = Module.GetRevision(revisionGuid);
 
-            if (_revision != null)
+            if (revision != null)
             {
-                DiffFiles.SetDiff(_revision);
+                DiffFiles.SetDiffs(revision);
 
-                commitInfo.Revision = _revision;
-
-                Text = "Diff - " + GitRevision.ToShortSha(_revision.Guid) + " - " + _revision.AuthorDate + " - " + _revision.Author + " - " + Module.WorkingDir; ;
+                Text = "Diff - " + GitRevision.ToShortSha(revision.Guid) + " - " + revision.AuthorDate + " - " + revision.Author + " - " + Module.WorkingDir; ;
             }
         }
 
@@ -49,10 +44,10 @@ namespace GitUI.HelperDialogs
 
         private void ViewSelectedDiff()
         {
-            if (DiffFiles.SelectedItem != null && _revision != null)
+            if (DiffFiles.SelectedItem != null && DiffFiles.Revision != null)
             {
                 Cursor.Current = Cursors.WaitCursor;
-                DiffText.ViewChanges(DiffFiles.SelectedItemParent, _revision.Guid, DiffFiles.SelectedItem, String.Empty);
+                DiffText.ViewChanges(DiffFiles.SelectedItemParent?.Guid, DiffFiles.Revision?.Guid, DiffFiles.SelectedItem, String.Empty);
                 Cursor.Current = Cursors.Default;
             }
         }

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -71,7 +71,7 @@ namespace GitUI
             // 
             this.NoFiles.BackColor = System.Drawing.SystemColors.Window;
             this.NoFiles.ForeColor = System.Drawing.SystemColors.InactiveCaption;
-            this.NoFiles.Location = new System.Drawing.Point(6, 6);
+            this.NoFiles.Location = new System.Drawing.Point(5, 5);
             this.NoFiles.Margin = new System.Windows.Forms.Padding(0);
             this.NoFiles.Name = "NoFiles";
             this.NoFiles.Size = new System.Drawing.Size(201, 56);


### PR DESCRIPTION
Resolves #4561
Refactoring to consistently use Revision and Parents in FileStatusList
FileStatusList forms should use that instead of assuming parents from RevisionGrid.GetSelectedRevisions().
The changes will remove code too.

Note: This commits enables corrections for #4387 and #4396 etc too.

Changes proposed in this pull request:
 - Refactoring

What did I do to test the code and ensure quality:
 - Manual tests.

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10
