### PR TITLE
Browse Diff: Incorrect comparision for multiple parents

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -152,9 +152,10 @@ namespace GitUI.CommandsDialogs
                 diffKind = GitUI.RevisionDiffKind.DiffAB;
             }
 
-            foreach (var selectedItem in DiffFiles.SelectedItems)
+            foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
-                _revisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, selectedItem.IsTracked);
+                IList<GitRevision> revs = new List<GitRevision> { DiffFiles.Revision, itemWithParent.ParentRevision };
+                _revisionGrid.OpenWithDifftool(revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -356,15 +356,15 @@ namespace GitUI.CommandsDialogs
 
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var selectedRows = FileChanges.GetSelectedRevisions();
+            var selectedRevisions = FileChanges.GetSelectedRevisions();
 
             string orgFileName = null;
-            if (selectedRows.Count > 0)
+            if (selectedRevisions.Count > 0)
             {
-                orgFileName = selectedRows[0].Name;
+                orgFileName = selectedRevisions[0].Name;
             }
 
-            FileChanges.OpenWithDifftool(FileName, orgFileName, RevisionDiffKind.DiffAB);
+            FileChanges.OpenWithDifftool(selectedRevisions, FileName, orgFileName, RevisionDiffKind.DiffAB, true);
         }
 
         private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -492,7 +492,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffToolremotelocalStripMenuItem_Click(object sender, EventArgs e)
         {
-            FileChanges.OpenWithDifftool(FileName, string.Empty, RevisionDiffKind.DiffBLocal);
+            FileChanges.OpenWithDifftool(FileChanges.GetSelectedRevisions(), FileName, string.Empty, RevisionDiffKind.DiffBLocal, true);
         }
 
         private void toolStripSplitLoad_ButtonClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -524,7 +524,8 @@ namespace GitUI.CommandsDialogs
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
-                _revisionGrid.OpenWithDifftool(itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
+                IList<GitRevision> revs = new List<GitRevision> { DiffFiles.Revision, itemWithParent.ParentRevision };
+                _revisionGrid.OpenWithDifftool(revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -16,11 +16,11 @@ namespace GitUI
     {
         public static SynchronizationContext UISynchronizationContext;
 
-        public static void OpenWithDifftool(this RevisionGrid grid, string fileName, string oldFileName, GitUI.RevisionDiffKind diffKind, bool isTracked = true)
+        public static void OpenWithDifftool(this RevisionGrid grid, IList<GitRevision> revisions, string fileName, string oldFileName, GitUI.RevisionDiffKind diffKind, bool isTracked)
         {
             // Note: Order in revisions is that first clicked is last in array
 
-            string error = RevisionDiffInfoProvider.Get(grid.GetSelectedRevisions(), diffKind,
+            string error = RevisionDiffInfoProvider.Get(revisions, diffKind,
                 out var extraDiffArgs, out var firstRevision, out var secondRevision);
 
             if (!string.IsNullOrEmpty(error))


### PR DESCRIPTION
For merge commits, the difftool compare was always done for the primary parent
This is also required to support feature #4564

Part of #4564, requires #4562
Submitted to show allow review of the change for this and following PRs

Changes proposed in this pull request:
 - Correct revisions for difftool invocations
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
 - Manual test open difftool

Has been tested on (remove any that don't apply):
 - Windows 10
