### PR TITLE
wip Browse Diff: Show differences for several selections

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1068,8 +1068,6 @@ namespace GitUI.CommandsDialogs
 
         private void FillDiff()
         {
-            DiffTabPage.Text = _diffTabPageTitleBase;
-
             if (CommitInfoTabControl.SelectedTab != DiffTabPage)
             {
                 return;
@@ -1081,8 +1079,7 @@ namespace GitUI.CommandsDialogs
             }
 
             _selectedRevisionUpdatedTargets |= UpdateTargets.DiffList;
-
-            DiffTabPage.Text = revisionDiff.GetTabText();
+            revisionDiff.DisplayDiffTab();
         }
 
         private void FillCommitInfo()

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -152,9 +152,10 @@ namespace GitUI.CommandsDialogs
                 diffKind = GitUI.RevisionDiffKind.DiffAB;
             }
 
-            foreach (var selectedItem in DiffFiles.SelectedItems)
+            foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
-                _RevisionGrid.OpenWithDifftool(selectedItem.Name, selectedItem.OldName, diffKind, selectedItem.IsTracked);
+                IList<GitRevision> revs = new List<GitRevision> { DiffFiles.Revision, itemWithParent.ParentRevision };
+                RevisionGrid.OpenWithDifftool(revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -155,7 +155,7 @@ namespace GitUI.CommandsDialogs
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
                 IList<GitRevision> revs = new List<GitRevision> { DiffFiles.Revision, itemWithParent.ParentRevision };
-                RevisionGrid.OpenWithDifftool(revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
+                _RevisionGrid.OpenWithDifftool(revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -363,6 +363,7 @@ namespace GitUI.CommandsDialogs
             {
                 orgFileName = selectedRevisions[0].Name;
             }
+
             FileChanges.OpenWithDifftool(selectedRevisions, FileName, orgFileName, RevisionDiffKind.DiffAB, true);
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -356,15 +356,14 @@ namespace GitUI.CommandsDialogs
 
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var selectedRows = FileChanges.GetSelectedRevisions();
+            var selectedRevisions = FileChanges.GetSelectedRevisions();
 
             string orgFileName = null;
-            if (selectedRows.Count > 0)
+            if (selectedRevisions.Count > 0)
             {
-                orgFileName = selectedRows[0].Name;
+                orgFileName = selectedRevisions[0].Name;
             }
-
-            FileChanges.OpenWithDifftool(FileName, orgFileName, RevisionDiffKind.DiffAB);
+            FileChanges.OpenWithDifftool(selectedRevisions, FileName, orgFileName, RevisionDiffKind.DiffAB, true);
         }
 
         private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -492,7 +491,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffToolremotelocalStripMenuItem_Click(object sender, EventArgs e)
         {
-            FileChanges.OpenWithDifftool(FileName, string.Empty, RevisionDiffKind.DiffBLocal);
+            FileChanges.OpenWithDifftool(FileChanges.GetSelectedRevisions(), FileName, string.Empty, RevisionDiffKind.DiffBLocal, true);
         }
 
         private void toolStripSplitLoad_ButtonClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -523,7 +523,8 @@ namespace GitUI.CommandsDialogs
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
-                _revisionGrid.OpenWithDifftool(itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
+                IList<GitRevision> revs = new List<GitRevision> { DiffFiles.Revision, itemWithParent.ParentRevision };
+                _revisionGrid.OpenWithDifftool(revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -18,10 +18,6 @@ namespace GitUI.CommandsDialogs
     {
         private readonly TranslationString _saveFileFilterCurrentFormat = new TranslationString("Current format");
         private readonly TranslationString _saveFileFilterAllFiles = new TranslationString("All files");
-        private readonly TranslationString _diffNoSelection = new TranslationString("Diff (no selection)");
-        private readonly TranslationString _diffParentWithSelection = new TranslationString("Diff (A: parent --> B: selection)");
-        private readonly TranslationString _diffTwoSelected = new TranslationString("Diff (A: first --> B: second)");
-        private readonly TranslationString _diffNotSupported = new TranslationString("Diff (not supported)");
         private readonly TranslationString _deleteSelectedFilesCaption = new TranslationString("Delete");
         private readonly TranslationString _deleteSelectedFiles =
             new TranslationString("Are you sure you want delete the selected file(s)?");
@@ -38,6 +34,7 @@ namespace GitUI.CommandsDialogs
         public RevisionDiff()
         {
             InitializeComponent();
+            DiffFiles.AlwaysRevisionGroups = true;
             Translate();
             HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
@@ -101,32 +98,17 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        public string GetTabText()
+        public void DisplayDiffTab()
         {
-            var revisions = _revisionGrid.GetSelectedRevisions();
-
             DiffText.SaveCurrentScrollPos();
+            var revisions = _revisionGrid.GetSelectedRevisions();
             DiffFiles.SetDiffs(revisions);
-            if (_oldDiffItem != null && revisions.Count > 0 && revisions[0].Guid == _oldRevision)
+            if (_oldDiffItem != null && DiffFiles.Revision?.Guid == _oldRevision)
             {
                 DiffFiles.SelectedItem = _oldDiffItem;
                 _oldDiffItem = null;
                 _oldRevision = null;
             }
-
-            switch (revisions.Count)
-            {
-                case 0:
-                    return _diffNoSelection.Text;
-
-                case 1: // diff "parent" --> "selected revision"
-                    return _diffParentWithSelection.Text;
-
-                case 2: // diff "first clicked revision" --> "second clicked revision"
-                    return _diffTwoSelected.Text;
-            }
-
-            return _diffNotSupported.Text;
         }
 
         public void Bind(RevisionGrid revisionGrid, RevisionFileTree revisionFileTree)
@@ -177,8 +159,7 @@ namespace GitUI.CommandsDialogs
         {
             fileIndex = -1;
             loadFileContent = Task.FromResult<string>(null);
-            var revisions = _revisionGrid.GetSelectedRevisions();
-            if (revisions.Count == 0)
+            if (DiffFiles.Revision == null)
             {
                 return false;
             }
@@ -395,8 +376,7 @@ namespace GitUI.CommandsDialogs
 
             if (item.IsTracked)
             {
-                GitRevision revision = _revisionGrid.GetSelectedRevisions().FirstOrDefault();
-                UICommands.StartFileHistoryDialog(this, item.Name, revision, true, true);
+                UICommands.StartFileHistoryDialog(this, item.Name, DiffFiles.Revision, true, true);
             }
         }
 
@@ -493,7 +473,7 @@ namespace GitUI.CommandsDialogs
 
         private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (DiffFiles.SelectedItem == null)
+            if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null)
             {
                 return;
             }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -16,11 +16,11 @@ namespace GitUI
     {
         public static SynchronizationContext UISynchronizationContext;
 
-        public static void OpenWithDifftool(this RevisionGrid grid, string fileName, string oldFileName, GitUI.RevisionDiffKind diffKind, bool isTracked = true)
+        public static void OpenWithDifftool(this RevisionGrid grid, IList<GitRevision> revisions, string fileName, string oldFileName, GitUI.RevisionDiffKind diffKind, bool isTracked)
         {
             // Note: Order in revisions is that first clicked is last in array
 
-            string error = RevisionDiffInfoProvider.Get(grid.GetSelectedRevisions(), diffKind,
+            string error = RevisionDiffInfoProvider.Get(revisions, diffKind,
                 out var extraDiffArgs, out var firstRevision, out var secondRevision);
 
             if (!string.IsNullOrEmpty(error))

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -25,8 +25,6 @@ namespace GitUI
 
     public sealed partial class FileStatusList : GitModuleControl
     {
-        private readonly TranslationString _UnsupportedMultiselectAction =
-            new TranslationString("Operation not supported");
         private readonly TranslationString _DiffWithParent =
             new TranslationString("Diff with:");
         public readonly TranslationString CombinedDiff =
@@ -37,6 +35,7 @@ namespace GitUI
 
         private bool _filterVisible;
         private ToolStripItem _openSubmoduleMenuItem;
+        private bool _alwaysRevisionGroups = false;
 
         public DescribeRevisionDelegate DescribeRevision;
         private readonly IFullPathResolver _fullPathResolver;
@@ -49,7 +48,6 @@ namespace GitUI
             FilterVisible = false;
 
             SelectFirstItemOnSetItems = true;
-            _noDiffFilesChangesDefaultText = NoFiles.Text;
             FileStatusListView.MouseMove += FileStatusListView_MouseMove;
             FileStatusListView.MouseDown += FileStatusListView_MouseDown;
             if (_images == null)
@@ -81,6 +79,14 @@ namespace GitUI
 
             _filter = new Regex(".*");
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
+        }
+
+        public bool AlwaysRevisionGroups
+        {
+            set
+            {
+                _alwaysRevisionGroups = value;
+            }
         }
 
         private void CreateOpenSubmoduleMenuItem()
@@ -124,8 +130,6 @@ namespace GitUI
         }
 
         private static ImageList _images;
-
-        private readonly string _noDiffFilesChangesDefaultText;
 
         public void SetNoFilesText(string text)
         {
@@ -881,7 +885,7 @@ namespace GitUI
             }
 
             FileStatusListView.BeginUpdate();
-            FileStatusListView.ShowGroups = GitItemStatusesWithParents.Count > 1;
+            FileStatusListView.ShowGroups = GitItemStatusesWithParents.Count > 1 || _alwaysRevisionGroups;
             FileStatusListView.Groups.Clear();
             FileStatusListView.Items.Clear();
 
@@ -1139,13 +1143,7 @@ namespace GitUI
             }
 
             var dictionary = new GitItemsWithParents();
-            NoFiles.Text = _noDiffFilesChangesDefaultText; // Temporary
-            if (revisions.Count > 2)
-            {
-                // Not a limitations, to keep compatibility with existing RevisionDiff
-                NoFiles.Text = _UnsupportedMultiselectAction.Text;
-            }
-            else if (Revision != null)
+            if (Revision != null)
             {
                 GitRevision[] parentRevs;
                 if (revisions.Count == 1)


### PR DESCRIPTION
Part of #4564

Based on #4562, #4565, submitted to allow review of latest commit (rebasing after merge of the prerequists).
See also discussion in #4387 
Only last commit to be reviewed in this PR

Changes proposed in this pull request:
 - Allow comparing several selected revisions in Browse diff
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/36947349-add51f3e-1fca-11e8-8a30-2c5a7706c78b.png)
![image](https://user-images.githubusercontent.com/6248932/36947352-bf57df62-1fca-11e8-9908-cbcb2aa88f1a.png)
![image](https://user-images.githubusercontent.com/6248932/36947358-cd82ac16-1fca-11e8-8651-7040029550d9.png)


![image](https://user-images.githubusercontent.com/6248932/36947365-e83539d4-1fca-11e8-9f89-7b849a56f0e0.png)
![image](https://user-images.githubusercontent.com/6248932/36947370-f1039934-1fca-11e8-8745-f91cc71cbc63.png)
![image](https://user-images.githubusercontent.com/6248932/36947372-f8f69d80-1fca-11e8-8609-4aa664d036ed.png)

Note: Changes to submenu will come in a later PR

What did I do to test the code and ensure quality:
 - Manual tests (test cases in another PR)

Has been tested on (remove any that don't apply):
 - Windows 10
