### PR TITLE
Browse Diff: Submodule commands should operate on multiple submodules

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -421,10 +421,19 @@ namespace GitCommands
 
         public static string SubmoduleUpdateCmd(string name)
         {
-            if (string.IsNullOrEmpty(name))
-                return "submodule update --init --recursive";
+            name = name ?? "";
+            return SubmoduleUpdateCommand(name.Trim().QuoteNE());
+        }
 
-            return "submodule update --init --recursive \"" + name.Trim() + "\"";
+        public static string SubmoduleUpdateCmd(IEnumerable<string> submodules)
+        {
+            string submodulesQuoted = String.Join(" ", submodules.Select(s => s.Trim().QuoteNE()));
+            return SubmoduleUpdateCommand(submodulesQuoted);
+        }
+
+        private static string SubmoduleUpdateCommand(string name)
+        {
+            return "submodule update --init --recursive " + name;
         }
 
         public static string SubmoduleSyncCmd(string name)


### PR DESCRIPTION
Part of #4564

Changes proposed in this pull request:
 - Commands for submodules in Browse Difftab was added to 2.51 were only applicable for single submodules. This makes them work with multi selection too, limiting popups when possible.

Note: Multiselection will be enabled in a later PR, the screenshot is for future reference.
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/36947935-2fbafb1a-1fd3-11e8-8b0c-c93f90916002.png)

- 
![image](https://user-images.githubusercontent.com/6248932/36947949-5dd7c794-1fd3-11e8-99c9-396e85927103.png)

What did I do to test the code and ensure quality:
 - Manual tests - menu tests in later PRs

Has been tested on (remove any that don't apply):
 - Windows 10
