### PR TITLE
refactor: Extract MatchesSearchString functionality from GitRevision

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Text.RegularExpressions;
 using GitCommands.Git.Extensions;
 using GitUIPluginInterfaces;
@@ -92,17 +91,6 @@ namespace GitCommands
             return sha;
         }
 
-        public bool MatchesSearchString(string searchString)
-        {
-            if (Refs.Any(gitHead => gitHead.Name.ToLower().Contains(searchString)))
-                return true;
-
-            if ((searchString.Length > 2) && Guid.StartsWith(searchString, StringComparison.CurrentCultureIgnoreCase))
-                return true;
-
-            return (Author != null && Author.StartsWith(searchString, StringComparison.CurrentCultureIgnoreCase)) ||
-                    Subject.ToLower().Contains(searchString);
-        }
 
 
         /// <summary>

--- a/GitCommands/Git/GitRevisionTester.cs
+++ b/GitCommands/Git/GitRevisionTester.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+
+namespace GitCommands.Git
+{
+    public interface IGitRevisionTester
+    {
+        bool Matches(GitRevision revision, string criteria);
+    }
+
+    public class GitRevisionTester : IGitRevisionTester
+    {
+        public bool Matches(GitRevision revision, string criteria)
+        {
+            if (revision == null || string.IsNullOrWhiteSpace(criteria))
+            {
+                // don't throw exception for performance reasons
+                return false;
+            }
+
+            if (revision.Refs.Where(gitHead => !string.IsNullOrWhiteSpace(gitHead.Name))
+                             .Any(gitHead => gitHead.Name.IndexOf(criteria, StringComparison.OrdinalIgnoreCase) >= 0))
+            {
+                return true;
+            }
+
+            if (criteria.Length > 2 && revision.Guid.StartsWith(criteria, StringComparison.CurrentCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            return revision.Author?.StartsWith(criteria, StringComparison.CurrentCultureIgnoreCase) == true ||
+                   revision.Subject?.IndexOf(criteria, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Git\GitBranchNameOptions.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensions.cs" />
     <Compile Include="Git\LongShaProvider.cs" />
+    <Compile Include="Git\GitRevisionTester.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDeleteRemoteBranchesCmd.cs" />

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -70,6 +70,7 @@ namespace GitUI
         private readonly IAvatarService _gravatarService;
         private readonly IImageNameProvider _avatarImageNameProvider;
         private readonly ICommitDataManager _commitDataManager;
+        private readonly IGitRevisionTester _gitRevisionTester = new GitRevisionTester();
         private readonly FormRevisionFilter _revisionFilter = new FormRevisionFilter();
 
         private RefsFiltringOptions _refsOptions = RefsFiltringOptions.All | RefsFiltringOptions.Boundary;
@@ -607,14 +608,14 @@ namespace GitUI
 
             for (index = startIndex; index < Revisions.RowCount; ++index)
             {
-                if (GetRevision(index).MatchesSearchString(searchString))
+                if (_gitRevisionTester.Matches(GetRevision(index), searchString))
                     return index;
             }
 
             // We didn't find it so start searching from the top
             for (index = 0; index < startIndex; ++index)
             {
-                if (GetRevision(index).MatchesSearchString(searchString))
+                if (_gitRevisionTester.Matches(GetRevision(index), searchString))
                     return index;
             }
 
@@ -630,17 +631,16 @@ namespace GitUI
 
             for (index = startIndex; index >= 0; --index)
             {
-                if (GetRevision(index).MatchesSearchString(searchString))
+                if (_gitRevisionTester.Matches(GetRevision(index), searchString))
                     return index;
             }
 
             // We didn't find it so start searching from the bottom
             for (index = Revisions.RowCount - 1; index > startIndex; --index)
             {
-                if (GetRevision(index).MatchesSearchString(searchString))
+                if (_gitRevisionTester.Matches(GetRevision(index), searchString))
                     return index;
             }
-
 
             return null;
         }

--- a/UnitTests/GitCommandsTests/Git/GitRevisionTesterTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitRevisionTesterTests.cs
@@ -1,0 +1,64 @@
+﻿using FluentAssertions;
+using GitCommands;
+using GitCommands.Git;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public class GitRevisionTesterTests
+    {
+        private IGitRevisionTester _tester;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _tester = new GitRevisionTester();
+        }
+
+
+        [Test]
+        public void Matches_should_not_throw_if_revsion_null()
+        {
+            _tester.Matches(null, null).Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("\t")]
+        public void Matches_should_not_throw_if_criteria_null_or_empty(string criteria)
+        {
+            _tester.Matches(new GitRevision(""), criteria).Should().BeFalse();
+        }
+
+        [TestCase("myname")]
+        [TestCase("myName")]
+        public void Matches_should_match_name(string criteria)
+        {
+            var gitRef = Substitute.For<IGitRef>();
+            gitRef.Name.Returns(x => "Name is MyName");
+            var revision = new GitRevision("");
+            revision.Refs.Add(gitRef);
+
+            _tester.Matches(revision, criteria).Should().BeTrue();
+        }
+
+        [TestCase("001122", true)]
+        [TestCase("", false)]
+        [TestCase("0", false)]
+        [TestCase("012", false)]
+        public void Matches_should_match_guid(string criteria, bool expected)
+        {
+            var gitRef = Substitute.For<IGitRef>();
+            gitRef.Name.Returns(x => "Name is MyName");
+
+            var revision = new GitRevision("0011223344");
+            revision.Refs.Add(gitRef);
+
+            _tester.Matches(revision, criteria).Should().Be(expected);
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Git\GitBlameHeaderTest.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensionsTests.cs" />
     <Compile Include="Git\LongShaProviderTests.cs" />
+    <Compile Include="Git\GitRevisionTesterTests.cs" />
     <Compile Include="Git\GitStashTests.cs" />
     <Compile Include="Git\Gpg\GitGpgControllerTests.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmdTests.cs" />


### PR DESCRIPTION
GitRevision is a DTO yet it contains behavioural components.

Checking that GitRevision contains an arbitrary piece of information is not a responsibility of GitRevision.
GitRevisionTester is introduced which is responsible to checking whether a given GitRevision matches
the given criteria.

Added tests