### PR TITLE
Force branch selection when opening 'Merge branch' dialog (Ctrl + M)

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -43,6 +43,8 @@ namespace GitUI.CommandsDialogs
 
             advanced.Checked = AppSettings.AlwaysShowAdvOpt;
             advanced_CheckedChanged(null, null);
+
+            Branches.Select();
         }
 
 


### PR DESCRIPTION
Fixes #4464 

Changes proposed in this pull request:
 - Fixing the issue with the 'Branches' drop-down not being focused.

What did I do to test the code and ensure quality:
 - Tested it.

Has been tested on (remove any that don't apply):
 - GIT 2.10 and above
 - Windows 7 and above
