### PR TITLE
Fix recent bug in FormCommitDiff

### DIFF
--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -31,7 +31,9 @@ namespace GitUI.HelperDialogs
 
             if (revision != null)
             {
-                DiffFiles.SetDiffs(revision);
+                commitInfo.Revision = revision;
+
+                DiffFiles.SetDiffs(new[] { revision });
 
                 Text = "Diff - " + GitRevision.ToShortSha(revision.Guid) + " - " + revision.AuthorDate + " - " + revision.Author + " - " + Module.WorkingDir; ;
             }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1114,13 +1114,15 @@ namespace GitUI
         public void SetDiffs(GitRevision selectedRev = null, GitRevision parentRev = null, IList<GitItemStatus> items = null)
         {
             Revision = selectedRev;
+
             if (parentRev == null)
             {
                 parentRev = new GitRevision("");
             }
 
-            IGitItemsWithParents dictionary = items == null ? null :
-                dictionary = new GitItemsWithParents { { parentRev, items } };
+            IGitItemsWithParents dictionary = items == null
+                ? null
+                : new GitItemsWithParents { { parentRev, items } };
 
             GitItemStatusesWithParents = dictionary;
         }


### PR DESCRIPTION
Fixes #4579, introduced in ab8d864 (PR #4562)

Launching `FormCommitDiff` from the revision grid showed an empty form.

Bug has two parts:

- calling an overload of `SetDiffs` that doesn't load revision data
- not setting `CommitInfo.Revision`

@gerhardol please review this for correctness.

Screenshots:

_before_

![image](https://user-images.githubusercontent.com/350947/37051008-4b053692-216d-11e8-891c-196a0b67617b.png)

_after_

![image](https://user-images.githubusercontent.com/350947/37050492-e94bab3a-216b-11e8-9835-ce77076a86f9.png)


Has been tested on:
 - Windows 10
