### PR TITLE
Diff for initial commit of a file were presented as a diff to local

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
         private bool GetNextPatchFile(bool searchBackward, bool loop, out int fileIndex, out Task loadFileContent)
         {
             fileIndex = -1;
-            loadFileContent = Task.FromResult<string>(null);
+            loadFileContent = Task.CompletedTask;
             var revisions = _revisionGrid.GetSelectedRevisions();
             if (revisions.Count == 0)
             {

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 
@@ -39,24 +40,34 @@ namespace GitUI.HelperDialogs
             }
         }
 
-        private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
+        private async void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ViewSelectedDiff();
-        }
-
-        private void ViewSelectedDiff()
-        {
-            if (DiffFiles.SelectedItem != null && DiffFiles.Revision != null)
+            try
             {
-                Cursor.Current = Cursors.WaitCursor;
-                DiffText.ViewChanges(DiffFiles.SelectedItemParent?.Guid, DiffFiles.Revision?.Guid, DiffFiles.SelectedItem, string.Empty);
-                Cursor.Current = Cursors.Default;
+                await ViewSelectedDiff();
+            }
+            catch (OperationCanceledException)
+            {
             }
         }
 
-        private void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        private async Task ViewSelectedDiff()
         {
-            ViewSelectedDiff();
+            if (DiffFiles.SelectedItem != null && DiffFiles.Revision != null)
+            {
+                await DiffText.ViewChanges(DiffFiles.SelectedItemParent?.Guid, DiffFiles.Revision?.Guid, DiffFiles.SelectedItem, string.Empty);
+            }
+        }
+
+        private async void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                await ViewSelectedDiff();
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #4580
Regression from #4313

Non-existing commits are handled with the "revision" null which is mostly handled as a working directory file.
The compare options for working directory files were limited in 2.50. In 2.51 the changes are presented with git-diff if possible and the non-existing parent were incorrectly handled.

Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/37064284-98aa0f38-219c-11e8-9cf2-dc952a86084f.png)


- 
![image](https://user-images.githubusercontent.com/6248932/37064315-cc135334-219c-11e8-82dc-de09c8e1adfd.png)


What did I do to test the code and ensure quality:
 - Manual tests of initial commits and to compare to/from working directory for changed/new/deleted files

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10
