### PR TITLE
Compile warning #4091 in shlobj.h

### DIFF
--- a/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
@@ -115,7 +115,7 @@
       <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <ResourceCompile />

--- a/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
@@ -67,7 +67,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
@@ -115,7 +115,7 @@
       <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <ResourceCompile />
@@ -126,6 +126,7 @@
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalDependencies>Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/GitExtensionsShellEx/StdAfx.h
+++ b/GitExtensionsShellEx/StdAfx.h
@@ -24,8 +24,10 @@ extern CComModule _Module;
 #include <atlconv.h>
 
 // warning C4091 in shlobj.h
-#pragma warning( disable : 4091 )
+#pragma warning( push )
+#pragma warning( disable: 4091 )
 #include <shlobj.h>
+#pragma warning( pop )
 #include <comdef.h>
 
 //{{AFX_INSERT_LOCATION}}

--- a/GitExtensionsShellEx/StdAfx.h
+++ b/GitExtensionsShellEx/StdAfx.h
@@ -23,6 +23,8 @@ extern CComModule _Module;
 #include <atlcom.h>
 #include <atlconv.h>
 
+// warning C4091 in shlobj.h
+#pragma warning( disable : 4091 )
 #include <shlobj.h>
 #include <comdef.h>
 

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -20,10 +20,10 @@ namespace GitCommandsTests.Git
         }
 
 #if !DEBUG
-        //Testcases that should assert in debug; should not occur but undefined behavior that should be blocked in GUI
-        //Cannot compare unstaged to unstaged or staged to staged but give predictive output in release builds
+        // Testcases that should assert in debug; should not occur but undefined behavior that should be blocked in GUI
+        // Cannot compare unstaged to unstaged or staged to staged but give predictive output in release builds
 
-        //Two empty parameters will compare working dir to index
+        // Two empty parameters will compare working dir to index
         [TestCase(null)]
         [TestCase("")]
         [TestCase(GitRevision.UnstagedGuid)]
@@ -32,7 +32,7 @@ namespace GitCommandsTests.Git
             _revisionDiffProvider.Get(firstRevision, GitRevision.UnstagedGuid).Should().BeEmpty();
         }
 
-        //Two staged revisions gives duplicated options, no reason to clean
+        // Two staged revisions gives duplicated options, no reason to clean
         [TestCase("^")]
         [TestCase(GitRevision.IndexGuid)]
         public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string firstRevision)


### PR DESCRIPTION
Also:
LNK4075 when building in Debug
SA1005 for test cases only run in Release builds

Fixes #4594

Changes proposed in this pull request:
 - Suppress and remove compile/link warnings
Annoying to see in AppVeyor builds

Screenshots before and after (if PR changes UI):
n/a

What did I do to test the code and ensure quality:
 - Build only - no changes to code

Has been tested on (remove any that don't apply):
 - Windows 10
