### PR TITLE
Remove Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-#Temporary file to satisfy Travis CI build (no longer needed when Mono is not built)
-
-language: perl 
-install: true
-
-script: "perl -e ''"


### PR DESCRIPTION
Fixes #4430
Travis was removed in #4434 and readded in #4438, but requirement is now removed so it can be removed in 3.00 again

Has been tested on (remove any that don't apply):
 - Windows 10
