### PR TITLE
Issue 2838

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -232,14 +232,14 @@ namespace GitFlow
 
         private void btnPublish_Click(object sender, EventArgs e)
         {
-            var branchType = cbType.SelectedValue.ToString();
+            var branchType = cbManageType.SelectedValue.ToString();
             RunCommand(string.Format("flow {0} publish {1}", branchType, cbBranches.SelectedValue));
         }
 
         private void btnPull_Click(object sender, EventArgs e)
         {
-            var branchType = cbType.SelectedValue.ToString();
-            RunCommand(string.Format("flow {0} pull {1} {2}" + branchType, cbRemote.SelectedValue, cbBranches.SelectedValue));
+            var branchType = cbManageType.SelectedValue.ToString();
+            RunCommand(string.Format("flow {0} pull {1} {2}", branchType, cbRemote.SelectedValue, cbBranches.SelectedValue));
         }
 
         private void btnFinish_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #2838

Changes proposed in this pull request:
 - the branch type parameter for **publish** and **pull** commands on the GitFlow dialog were changed to make them use the currently selected value of the combo box in the "Manage existing branches" section (`cbManageType`, instead of `cbType` ).
 - also fixed the incorrect command formatting in pull
 
Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
 - Created a minimal test repository, initialized git flow, created, published, pulled a `hotfix` branch while `feature` was selected in cbType combo box

Has been tested on (remove any that don't apply):
 - GIT 2.16.1
 - Windows 10