### PR TITLE
Fix the indent size for *.props and *.targets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ indent_style = space
 indent_size = 2
 insert_final_newline = false
 
+[*.{props,targets}]
+indent_size = 2
+
 [*.Designer.cs]
 trim_trailing_whitespace = false
 


### PR DESCRIPTION
Updates .editorconfig to fix the indent size when working in .props and/or .targets files.

📝 If accepted, please do not rebase or squash this pull request during the merge.