### PR TITLE
Fix AppVeyor ignoring test outcome

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ test_script:
         -output:"OpenCover.GitExtensions.xml" `
         -target:"nunit3-console.exe" `
         -targetargs:"$testAssemblies"
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
     $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
     $codecov = "packages\Codecov.$codecov_version\tools\codecov.exe"
     &$codecov -f ".\OpenCover.GitExtensions.xml"


### PR DESCRIPTION
Fixes #4602

This was verified by submitting a test commit to #4601, which contained a failing test at the time. AppVeyor build [3.00.00.1862](https://ci.appveyor.com/project/gitextensions/gitextensions/build/3.00.00.1862) failed as expected.

📝 If accepted, please do not rebase or squash this pull request during the merge.