### PR TITLE
Fix issue that excess rebase command being performed when continue rebase

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1029,7 +1029,7 @@ namespace GitUI.CommandsDialogs
         {
             if (Module.InTheMiddleOfRebase())
             {
-                UICommands.ContinueRebase(this);
+                UICommands.StartTheContinueRebaseDialog(this);
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -314,7 +314,7 @@ namespace GitUI.CommandsDialogs
             // Rebase failed -> special 'rebase' merge conflict
             if (Rebase.Checked && Module.InTheMiddleOfRebase())
             {
-                UICommands.ContinueRebase(owner);
+                UICommands.StartTheContinueRebaseDialog(owner);
             }
             else if (Module.InTheMiddleOfAction())
             {

--- a/GitUI/CommandsDialogs/MergeConflictHandler.cs
+++ b/GitUI/CommandsDialogs/MergeConflictHandler.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (MessageBoxes.MiddleOfRebase(owner))
                 {
-                    commands.ContinueRebase(owner);
+                    commands.StartTheContinueRebaseDialog(owner);
                 }
             }
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1420,9 +1420,10 @@ namespace GitUI
             return StartRebaseDialog(owner, onto, interactive: false);
         }
 
-        public bool ContinueRebase(IWin32Window owner)
+        public bool StartTheContinueRebaseDialog(IWin32Window owner)
         {
-            return StartRebaseDialog(owner, onto: null, interactive: false);
+            return StartRebaseDialog(owner, onto: null,
+                interactive: false, startRebaseImmediately: false);
         }
 
         public bool StartInteractiveRebase(IWin32Window owner, string onto)


### PR DESCRIPTION
Fixes #4593

Changes proposed in this pull request:
 - Fix the excessive rebase command when continue rebase.

What did I do to test the code and ensure quality:
 - do an interactive rebase, edit one of the commit, and stop in middle
 - press the `you are in middle of a rebase` at the bottom right
 - make sure it only pops up the continue rebase dialog and no rebase has been performed.

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10