### PR TITLE
Sort branches/tags in the revision grid with current branch first in …

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1787,6 +1787,11 @@ namespace GitUI
                                                return left.IsRemote.CompareTo(right.IsRemote);
                                            }
 
+                                           if (left.Selected != right.Selected)
+                                           {
+                                               return right.Selected.CompareTo(left.Selected);
+                                           }
+
                                            return left.Name.CompareTo(right.Name);
                                        });
 


### PR DESCRIPTION
…each group

Fixes #4607

Changes proposed in this pull request:
 - Sort order for current branch should be higher priority than name 
 
Screenshots before and after (if PR changes UI):
- ![image](https://user-images.githubusercontent.com/6248932/37245490-e4466bea-2498-11e8-8255-74762a55afff.png)
-
- ![image](https://user-images.githubusercontent.com/6248932/37245477-b41c20d6-2498-11e8-83cb-fbea2aaf6abb.png)

What did I do to test the code and ensure quality:
 - Open Browse

Has been tested on (remove any that don't apply):
 - Windows 10
