### PR TITLE
Remove redundant code

### DIFF
--- a/GitCommands/Annotations.cs
+++ b/GitCommands/Annotations.cs
@@ -171,8 +171,8 @@ namespace JetBrains.Annotations
             ForceFullStates = forceFullStates;
         }
 
-        public string FDT { get; private set; }
-        public bool ForceFullStates { get; private set; }
+        public string FDT { get; }
+        public bool ForceFullStates { get; }
     }
 
     /// <summary>
@@ -215,7 +215,7 @@ namespace JetBrains.Annotations
         /// <summary>
         /// Gets enumerations of specified base types
         /// </summary>
-        public Type[] BaseTypes { get; private set; }
+        public Type[] BaseTypes { get; }
     }
 
     /// <summary>

--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -233,7 +233,7 @@ namespace GitCommands
             Handled = true;
         }
 
-        public Exception Exception { get; private set; }
+        public Exception Exception { get; }
 
         public bool Handled { get; set; }
     }

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -157,7 +157,7 @@ namespace GitCommands
             var treeGuid = lines[1];
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
-            string[] parentLines = lines[2].Split(new char[] { ' ' });
+            string[] parentLines = lines[2].Split(new[] { ' ' });
             ReadOnlyCollection<string> parentGuids = parentLines.ToList().AsReadOnly();
 
             var author = module.ReEncodeStringFromLossless(lines[3]);

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -157,7 +157,7 @@ namespace GitCommands
             var treeGuid = lines[1];
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
-            string[] parentLines = lines[2].Split(new[] { ' ' });
+            string[] parentLines = lines[2].Split(' ');
             ReadOnlyCollection<string> parentGuids = parentLines.ToList().AsReadOnly();
 
             var author = module.ReEncodeStringFromLossless(lines[3]);

--- a/GitCommands/CommitHelper.cs
+++ b/GitCommands/CommitHelper.cs
@@ -63,9 +63,9 @@ namespace GitCommands
 
         public static string GetCommitMessage(GitModule module)
         {
-            if (File.Exists(CommitHelper.GetCommitMessagePath(module)))
+            if (File.Exists(GetCommitMessagePath(module)))
             {
-                return File.ReadAllText(CommitHelper.GetCommitMessagePath(module), module.CommitEncoding);
+                return File.ReadAllText(GetCommitMessagePath(module), module.CommitEncoding);
             }
 
             return string.Empty;
@@ -89,9 +89,9 @@ namespace GitCommands
         public static bool GetAmendState(GitModule module)
         {
             bool amendState = false;
-            if (AppSettings.RememberAmendCommitState && File.Exists(CommitHelper.GetAmendPath(module)))
+            if (AppSettings.RememberAmendCommitState && File.Exists(GetAmendPath(module)))
             {
-                var amendSaveStateFilePath = CommitHelper.GetAmendPath(module);
+                var amendSaveStateFilePath = GetAmendPath(module);
                 bool.TryParse(File.ReadAllText(amendSaveStateFilePath), out amendState);
                 try
                 {

--- a/GitCommands/CommitTemplateManager.cs
+++ b/GitCommands/CommitTemplateManager.cs
@@ -114,8 +114,7 @@ namespace GitCommands
         /// <param name="templateName">The name of the template.</param>
         public void Unregister(string templateName)
         {
-            Func<string> notUsed;
-            RegisteredTemplatesDic.TryRemove(templateName, out notUsed);
+            RegisteredTemplatesDic.TryRemove(templateName, out _);
         }
     }
 }

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -54,7 +54,7 @@ namespace GitCommands.Config
             parser.Parse();
         }
 
-        public static readonly char[] CommentChars = new[] { ';', '#' };
+        public static readonly char[] CommentChars = { ';', '#' };
 
         public void LoadFromString(string str)
         {

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -311,8 +311,8 @@ namespace GitCommands.Config
 
             private ConfigFile _configFile;
             private string _fileContent;
-            private IConfigSection _section = null;
-            private string _key = null;
+            private IConfigSection _section;
+            private string _key;
             private string FileName => _configFile.FileName;
 
             // parsed char
@@ -384,8 +384,8 @@ namespace GitCommands.Config
                 _key = null;
             }
 
-            private bool _escapedSection = false;
-            private bool _quotedStringInSection = false;
+            private bool _escapedSection;
+            private bool _quotedStringInSection;
 
             private ParsePart ReadSection(char c)
             {
@@ -473,8 +473,8 @@ namespace GitCommands.Config
                 }
             }
 
-            private bool _quotedValue = false;
-            private bool _escapedValue = false;
+            private bool _quotedValue;
+            private bool _escapedValue;
 
             private ParsePart ReadValue(char c)
             {

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -327,7 +327,7 @@ namespace GitCommands.Config
 
             public void Parse(string fileContent = null)
             {
-                _fileContent = fileContent ?? File.ReadAllText(FileName, ConfigFile.GetEncoding());
+                _fileContent = fileContent ?? File.ReadAllText(FileName, GetEncoding());
 
                 ParsePart parseFunc = ReadUnknown;
 

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -12,7 +12,7 @@ namespace GitCommands.Config
     {
         public string FileName { get; }
 
-        public bool Local { get; private set; }
+        public bool Local { get; }
 
         public ConfigFile(string fileName, bool local)
         {
@@ -31,7 +31,7 @@ namespace GitCommands.Config
             }
         }
 
-        public IList<IConfigSection> ConfigSections { get; private set; }
+        public IList<IConfigSection> ConfigSections { get; }
 
         public IEnumerable<IConfigSection> GetConfigSections(string sectionName)
         {

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -515,7 +515,7 @@ namespace GitCommands.Config
                         case '"':
                             if (_quotedValue)
                             {
-                                _token.Append(_valueToken.ToString());
+                                _token.Append(_valueToken);
                             }
                             else
                             {

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -54,7 +54,7 @@ namespace GitCommands.Config
             parser.Parse();
         }
 
-        public static readonly char[] CommentChars = new char[] { ';', '#' };
+        public static readonly char[] CommentChars = new[] { ';', '#' };
 
         public void LoadFromString(string str)
         {

--- a/GitCommands/Core/SimpleStructured.cs
+++ b/GitCommands/Core/SimpleStructured.cs
@@ -76,25 +76,23 @@ namespace GitCommands.Core
             {
                 return indent + "[null]";
             }
-            else
+
+            if (!(obj is string))
             {
-                if (!(obj is string))
+                IEnumerable eo = obj as IEnumerable;
+                if (eo != null)
                 {
-                    IEnumerable eo = obj as IEnumerable;
-                    if (eo != null)
-                    {
-                        return eo.Cast<object>().Select(o => ToString(o, indent + "  ")).Join("\n");
-                    }
+                    return eo.Cast<object>().Select(o => ToString(o, indent + "  ")).Join("\n");
                 }
-
-                SimpleStructured ss = obj as SimpleStructured;
-                if (ss != null)
-                {
-                    return ToString(ss.InlinedStructure(), indent);
-                }
-
-                return indent + obj.ToString();
             }
+
+            SimpleStructured ss = obj as SimpleStructured;
+            if (ss != null)
+            {
+                return ToString(ss.InlinedStructure(), indent);
+            }
+
+            return indent + obj.ToString();
         }
     }
 }

--- a/GitCommands/Core/SimpleStructured.cs
+++ b/GitCommands/Core/SimpleStructured.cs
@@ -92,7 +92,7 @@ namespace GitCommands.Core
                 return ToString(ss.InlinedStructure(), indent);
             }
 
-            return indent + obj.ToString();
+            return indent + obj;
         }
     }
 }

--- a/GitCommands/EnvironmentPathsProvider.cs
+++ b/GitCommands/EnvironmentPathsProvider.cs
@@ -49,7 +49,7 @@ namespace GitCommands
 
                 // Usually, paths with spaces are not quoted on %PATH%, but it's well possible, and .NET won't consume a quoted path
                 // This does not handle the full grammar of the %PATH%, but at least prevents Illegal Characters in Path exceptions (see #2924)
-                dir = dir.Trim(new[] { ' ', '"', '\t' });
+                dir = dir.Trim(' ', '"', '\t');
                 if (dir.Length == 0)
                 {
                     continue;

--- a/GitCommands/EnvironmentPathsProvider.cs
+++ b/GitCommands/EnvironmentPathsProvider.cs
@@ -49,7 +49,7 @@ namespace GitCommands
 
                 // Usually, paths with spaces are not quoted on %PATH%, but it's well possible, and .NET won't consume a quoted path
                 // This does not handle the full grammar of the %PATH%, but at least prevents Illegal Characters in Path exceptions (see #2924)
-                dir = dir.Trim(new char[] { ' ', '"', '\t' });
+                dir = dir.Trim(new[] { ' ', '"', '\t' });
                 if (dir.Length == 0)
                 {
                     continue;

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -70,7 +70,7 @@ namespace GitCommands
             string[] diffvals = { "set", "astextplain", "ada", "bibtext", "cpp", "csharp", "fortran", "html", "java", "matlab", "objc", "pascal", "perl", "php", "python", "ruby", "tex" };
             string cmd = "check-attr -z diff text crlf eol -- " + fileName.Quote();
             string result = module.RunGitCmd(cmd);
-            var lines = result.Split(new[] { '\n', '\0' });
+            var lines = result.Split('\n', '\0');
             var attributes = new Dictionary<string, string>();
             for (int i = 0; i < lines.Length - 2; i += 3)
             {

--- a/GitCommands/Git/Extensions/GitRevisionExtensions.cs
+++ b/GitCommands/Git/Extensions/GitRevisionExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace GitCommands.Git.Extensions
+﻿namespace GitCommands.Git.Extensions
 {
     public static class GitRevisionExtensions
     {

--- a/GitCommands/Git/GitBlame.cs
+++ b/GitCommands/Git/GitBlame.cs
@@ -14,8 +14,8 @@ namespace GitCommands
             Lines = new List<GitBlameLine>();
         }
 
-        public IList<GitBlameHeader> Headers { get; private set; }
-        public IList<GitBlameLine> Lines { get; private set; }
+        public IList<GitBlameHeader> Headers { get; }
+        public IList<GitBlameLine> Lines { get; }
 
         public GitBlameHeader FindHeaderForCommitGuid(string commitGuid)
         {

--- a/GitCommands/Git/GitBlame.cs
+++ b/GitCommands/Git/GitBlame.cs
@@ -93,12 +93,12 @@ namespace GitCommands
 
         public static bool operator ==(GitBlameHeader x, GitBlameHeader y)
         {
-            if (object.ReferenceEquals(x, y))
+            if (ReferenceEquals(x, y))
             {
                 return true;
             }
 
-            if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null))
+            if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
             {
                 return false;
             }

--- a/GitCommands/Git/GitBlame.cs
+++ b/GitCommands/Git/GitBlame.cs
@@ -61,7 +61,7 @@ namespace GitCommands
             int number = 0;
             foreach (char c in text)
             {
-                number += (int)c;
+                number += c;
             }
 
             return number;

--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -96,7 +96,7 @@ namespace GitCommands.Git
 
             // rule #2 is not applicable
             // rule #6 runs as second last to ensure no consecutive '/' are left after previous normalisations
-            branchName = Rule06(branchName, options);
+            branchName = Rule06(branchName);
             branchName = Rule01(branchName, options);
 
             return branchName;
@@ -188,9 +188,8 @@ namespace GitCommands.Git
         /// Branch name begin or end with a slash '/' or contain multiple consecutive slashes.
         /// </summary>
         /// <param name="branchName">Name of the branch.</param>
-        /// <param name="options">The options.</param>
         /// <returns>Normalised branch name.</returns>
-        internal string Rule06(string branchName, GitBranchNameOptions options)
+        internal string Rule06(string branchName)
         {
             branchName = Regex.Replace(branchName, @"(\/{2,})", "/");
             if (branchName.StartsWith("/"))

--- a/GitCommands/Git/GitBranchNameOptions.cs
+++ b/GitCommands/Git/GitBranchNameOptions.cs
@@ -29,6 +29,6 @@ namespace GitCommands.Git
         /// Gets the character which will replace all invalid characters in git branch name.
         /// </summary>
         /// <seealso cref="GitBranchNameNormaliser"/>.
-        public string ReplacementToken { get; private set; }
+        public string ReplacementToken { get; }
     }
 }

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1150,7 +1150,7 @@ namespace GitCommands
             IList<string> submodules = module.GetSubmodulesLocalPaths();
 
             // Split all files on '\0' (WE NEED ALL COMMANDS TO BE RUN WITH -z! THIS IS ALSO IMPORTANT FOR ENCODING ISSUES!)
-            var files = trimmedStatus.Split(new char[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+            var files = trimmedStatus.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
             for (int n = 0; n < files.Length; n++)
             {
                 if (string.IsNullOrEmpty(files[n]))
@@ -1158,7 +1158,7 @@ namespace GitCommands
                     continue;
                 }
 
-                int splitIndex = files[n].IndexOfAny(new char[] { '\0', '\t', ' ' }, 1);
+                int splitIndex = files[n].IndexOfAny(new[] { '\0', '\t', ' ' }, 1);
 
                 string status = string.Empty;
                 string fileName = string.Empty;

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1160,8 +1160,8 @@ namespace GitCommands
 
                 int splitIndex = files[n].IndexOfAny(new[] { '\0', '\t', ' ' }, 1);
 
-                string status = string.Empty;
-                string fileName = string.Empty;
+                string status;
+                string fileName;
 
                 if (splitIndex < 0)
                 {
@@ -1180,7 +1180,7 @@ namespace GitCommands
 
                 if (x != '?' && x != '!' && x != ' ')
                 {
-                    GitItemStatus gitItemStatusX = null;
+                    GitItemStatus gitItemStatusX;
                     if (x == 'R' || x == 'C')
                     {
                         // Find renamed files...

--- a/GitCommands/Git/GitCommandsInstance.cs
+++ b/GitCommands/Git/GitCommandsInstance.cs
@@ -11,7 +11,7 @@ namespace GitCommands
         private Process _myProcess;
         private readonly object _processLock = new object();
 
-        public string WorkingDirectory { get; private set; }
+        public string WorkingDirectory { get; }
 
         public GitCommandsInstance(string workingDirectory)
         {

--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -146,7 +146,7 @@ namespace GitCommands.Gpg
             TagStatus tagStatus = TagStatus.NoTag;
 
             /* No Tag present, exit */
-            var usefulTagRefs = revision.Refs.Where(x => x.IsTag && x.IsDereference).ToList<IGitRef>();
+            var usefulTagRefs = revision.Refs.Where(x => x.IsTag && x.IsDereference).ToList();
             if (usefulTagRefs.Count == 0)
             {
                 return tagStatus;
@@ -228,7 +228,7 @@ namespace GitCommands.Gpg
                 throw new ArgumentNullException(nameof(revision));
             }
 
-            var usefulTagRefs = revision.Refs.Where(x => x.IsTag && x.IsDereference).ToList<IGitRef>();
+            var usefulTagRefs = revision.Refs.Where(x => x.IsTag && x.IsDereference).ToList();
             return EvaluateTagVerifyMessage(usefulTagRefs);
         }
 

--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -240,7 +240,7 @@ namespace GitCommands.Gpg
                 return null;
             }
 
-            string rawFlag = raw == true ? "--raw" : "";
+            string rawFlag = raw ? "--raw" : "";
 
             var module = GetModule();
             return module.RunGitCmd($"verify-tag {rawFlag} {tagName}");

--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -105,7 +105,7 @@ namespace GitCommands
 
         public override string ToString()
         {
-            string toString = string.Empty;
+            string toString;
             if (IsRenamed)
             {
                 toString = string.Concat("Renamed\n   ", OldName, "\nto\n   ", Name, "");

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1385,7 +1385,7 @@ namespace GitCommands
             if (localPath.Contains("("))
             {
                 gitSubmodule.LocalPath = localPath.Substring(0, localPath.IndexOf("(")).TrimEnd();
-                gitSubmodule.Branch = localPath.Substring(localPath.IndexOf("(")).Trim(new[] { '(', ')', ' ' });
+                gitSubmodule.Branch = localPath.Substring(localPath.IndexOf("(")).Trim('(', ')', ' ');
             }
             else
             {
@@ -3176,7 +3176,7 @@ namespace GitCommands
         public string[] GetFullTree(string id)
         {
             string tree = RunCacheableCmd(AppSettings.GitCommand, string.Format("ls-tree -z -r --name-only {0}", id), SystemEncoding);
-            return tree.Split(new[] { '\0', '\n' });
+            return tree.Split('\0', '\n');
         }
 
         public IEnumerable<IGitItem> GetTree(string id, bool full)
@@ -3239,7 +3239,7 @@ namespace GitCommands
                     if (line.StartsWith("\t"))
                     {
                         blameLine.LineText = line.Substring(1) // trim ONLY first tab
-                                                 .Trim(new[] { '\r' }); // trim \r, this is a workaround for a \r\n bug
+                                                 .Trim('\r'); // trim \r, this is a workaround for a \r\n bug
                         blameLine.LineText = ReEncodeStringFromLossless(blameLine.LineText, encoding);
                     }
                     else if (line.StartsWith("author-mail"))
@@ -3329,7 +3329,7 @@ namespace GitCommands
             {
                 // index
                 string blob = RunGitCmd(string.Format("ls-files -s \"{0}\"", fileName));
-                string[] s = blob.Split(new[] { ' ', '\t' });
+                string[] s = blob.Split(' ', '\t');
                 if (s.Length >= 2)
                 {
                     return s[1];
@@ -3338,7 +3338,7 @@ namespace GitCommands
             else
             {
                 string blob = RunGitCmd(string.Format("ls-tree -r {0} \"{1}\"", revision, fileName));
-                string[] s = blob.Split(new[] { ' ', '\t' });
+                string[] s = blob.Split(' ', '\t');
                 if (s.Length >= 3)
                 {
                     return s[2];

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -28,7 +28,7 @@ namespace GitCommands
             GitModule = gitModule;
         }
 
-        public GitModule GitModule { get; private set; }
+        public GitModule GitModule { get; }
     }
 
     public enum SubmoduleStatus

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2113,7 +2113,7 @@ namespace GitCommands
         public IList<PatchFile> GetInteractiveRebasePatchFiles()
         {
             string todoFile = GetRebaseDir() + "git-rebase-todo";
-            string[] todoCommits = File.Exists(todoFile) ? File.ReadAllText(todoFile).Trim().Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries) : null;
+            string[] todoCommits = File.Exists(todoFile) ? File.ReadAllText(todoFile).Trim().Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries) : null;
 
             IList<PatchFile> patchFiles = new List<PatchFile>();
 
@@ -2353,7 +2353,7 @@ namespace GitCommands
         public string[] GetRemotes(bool allowEmpty)
         {
             string remotes = RunGitCmd("remote show");
-            return allowEmpty ? remotes.Split('\n') : remotes.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            return allowEmpty ? remotes.Split('\n') : remotes.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public IEnumerable<string> GetSettings(string setting)
@@ -3178,7 +3178,7 @@ namespace GitCommands
         public string[] GetFullTree(string id)
         {
             string tree = RunCacheableCmd(AppSettings.GitCommand, string.Format("ls-tree -z -r --name-only {0}", id), SystemEncoding);
-            return tree.Split(new char[] { '\0', '\n' });
+            return tree.Split(new[] { '\0', '\n' });
         }
 
         public IEnumerable<IGitItem> GetTree(string id, bool full)
@@ -3241,7 +3241,7 @@ namespace GitCommands
                     if (line.StartsWith("\t"))
                     {
                         blameLine.LineText = line.Substring(1) // trim ONLY first tab
-                                                 .Trim(new char[] { '\r' }); // trim \r, this is a workaround for a \r\n bug
+                                                 .Trim(new[] { '\r' }); // trim \r, this is a workaround for a \r\n bug
                         blameLine.LineText = ReEncodeStringFromLossless(blameLine.LineText, encoding);
                     }
                     else if (line.StartsWith("author-mail"))
@@ -3331,7 +3331,7 @@ namespace GitCommands
             {
                 // index
                 string blob = RunGitCmd(string.Format("ls-files -s \"{0}\"", fileName));
-                string[] s = blob.Split(new char[] { ' ', '\t' });
+                string[] s = blob.Split(new[] { ' ', '\t' });
                 if (s.Length >= 2)
                 {
                     return s[1];
@@ -3340,7 +3340,7 @@ namespace GitCommands
             else
             {
                 string blob = RunGitCmd(string.Format("ls-tree -r {0} \"{1}\"", revision, fileName));
-                string[] s = blob.Split(new char[] { ' ', '\t' });
+                string[] s = blob.Split(new[] { ' ', '\t' });
                 if (s.Length >= 3)
                 {
                     return s[2];
@@ -3394,11 +3394,11 @@ namespace GitCommands
         {
             string sep = "d3fb081b9000598e658da93657bf822cc87b2bf6";
             string output = RunGitCmd("log -n " + count + " " + revision + " --pretty=format:" + sep + "%e%n%s%n%n%b", LosslessEncoding);
-            string[] messages = output.Split(new string[] { sep }, StringSplitOptions.RemoveEmptyEntries);
+            string[] messages = output.Split(new[] { sep }, StringSplitOptions.RemoveEmptyEntries);
 
             if (messages.Length == 0)
             {
-                return new string[] { string.Empty };
+                return new[] { string.Empty };
             }
 
             return messages.Select(cm =>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1747,8 +1747,6 @@ namespace GitCommands
 
                 branchArguments = " +" + FormatBranchName(remoteBranch);
 
-                var remoteUrl = GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
-
                 if (!string.IsNullOrEmpty(localBranch))
                 {
                     branchArguments += ":" + GitCommandHelpers.GetFullBranchName(localBranch);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2446,7 +2446,7 @@ namespace GitCommands
             return GetPatch(patchManager, fileName, oldFileName);
         }
 
-        private Patch GetPatch(PatchApply.PatchManager patchManager, string fileName, string oldFileName)
+        private Patch GetPatch(PatchManager patchManager, string fileName, string oldFileName)
         {
             foreach (Patch p in patchManager.Patches)
             {

--- a/GitCommands/Git/GitPushAction.cs
+++ b/GitCommands/Git/GitPushAction.cs
@@ -10,10 +10,10 @@ namespace GitCommands
     public class GitPush
     {
         /// <summary>Gets the name or URL of the remote repo to push to.</summary>
-        public string Remote { get; private set; }
+        public string Remote { get; }
 
         /// <summary>Gets the set of LocalBranch:RemoteBranch actions.</summary>
-        public IEnumerable<GitPushAction> PushActions { get; private set; }
+        public IEnumerable<GitPushAction> PushActions { get; }
 
         /// <summary>Indicates whether to report progress during the push operation.</summary>
         public bool ReportProgress { get; set; }

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -26,7 +26,7 @@ namespace GitCommands
         /// <summary>"^{}"</summary>
         public static readonly string TagDereferenceSuffix = "^{}";
 
-        public IGitModule Module { get; private set; }
+        public IGitModule Module { get; }
 
         public GitRef(IGitModule module, string guid, string completeName)
             : this(module, guid, completeName, string.Empty)
@@ -57,26 +57,26 @@ namespace GitCommands
             return new GitRef(module, guid, RefsHeadsPrefix + name);
         }
 
-        public string CompleteName { get; private set; }
+        public string CompleteName { get; }
         public bool Selected { get; set; }
         public bool SelectedHeadMergeSource { get; set; }
-        public bool IsTag { get; private set; }
-        public bool IsHead { get; private set; }
-        public bool IsRemote { get; private set; }
-        public bool IsBisect { get; private set; }
+        public bool IsTag { get; }
+        public bool IsHead { get; }
+        public bool IsRemote { get; }
+        public bool IsBisect { get; }
 
         /// <summary>
         /// True when Guid is a checksum of an object (e.g. commit) to which another object
         /// with Name (e.g. annotated tag) is applied.
         /// <para>False when Name and Guid are denoting the same object.</para>
         /// </summary>
-        public bool IsDereference { get; private set; }
+        public bool IsDereference { get; }
 
         public bool IsOther => !IsHead && !IsRemote && !IsTag;
 
         public string LocalName => IsRemote ? Name.Substring(Remote.Length + 1) : Name;
 
-        public string Remote { get; private set; }
+        public string Remote { get; }
 
         public string TrackingRemote
         {
@@ -149,7 +149,7 @@ namespace GitCommands
 
         #region IGitItem Members
 
-        public string Guid { get; private set; }
+        public string Guid { get; }
         public string Name { get; private set; }
 
         #endregion

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -122,7 +122,7 @@ namespace GitCommands
 
         public static bool IsFullSha1Hash(string id)
         {
-            return Regex.IsMatch(id, GitRevision.Sha1HashPattern);
+            return Regex.IsMatch(id, Sha1HashPattern);
         }
     }
 }

--- a/GitCommands/Git/GitSubmoduleInfo.cs
+++ b/GitCommands/Git/GitSubmoduleInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GitUIPluginInterfaces;
+﻿using GitUIPluginInterfaces;
 
 namespace GitCommands
 {

--- a/GitCommands/LockableNotifier.cs
+++ b/GitCommands/LockableNotifier.cs
@@ -6,8 +6,8 @@ namespace GitCommands
 {
     public abstract class LockableNotifier : ILockableNotifier
     {
-        private int _lockCount = 0;
-        private bool _notifyRequested = false;
+        private int _lockCount;
+        private bool _notifyRequested;
 
         protected abstract void InternalNotify();
 

--- a/GitCommands/Logging/CommandLogEntry.cs
+++ b/GitCommands/Logging/CommandLogEntry.cs
@@ -4,9 +4,9 @@ namespace GitCommands.Logging
 {
   public class CommandLogEntry
   {
-    public string Command { get; private set; }
-    public DateTime ExecutionStartTimestamp { get; private set; }
-    public DateTime ExecutionEndTimestamp { get; private set; }
+    public string Command { get; }
+    public DateTime ExecutionStartTimestamp { get; }
+    public DateTime ExecutionEndTimestamp { get; }
 
     public CommandLogEntry(string command, DateTime executionStartTimestamp, DateTime executionEndTimestamp)
     {

--- a/GitCommands/Patch/Patch.cs
+++ b/GitCommands/Patch/Patch.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
 

--- a/GitCommands/Patch/Patch.cs
+++ b/GitCommands/Patch/Patch.cs
@@ -76,13 +76,10 @@ namespace PatchApply
             if (Type == PatchType.NewFile)
             {
                 HandleNewFilePatchType();
-                return;
             }
-
-            if (Type == PatchType.ChangeFile)
+            else if (Type == PatchType.ChangeFile)
             {
                 HandleChangeFilePatchType(filesContentEncoding);
-                return;
             }
         }
 

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -167,7 +167,7 @@ namespace PatchApply
         public string GetMD5Hash(string input)
         {
             IEnumerable<byte> bs = GetUTF8EncodedBytes(input);
-            var s = new System.Text.StringBuilder();
+            var s = new StringBuilder();
             foreach (byte b in bs)
             {
                 s.Append(b.ToString("x2").ToLower());
@@ -179,7 +179,7 @@ namespace PatchApply
         private static IEnumerable<byte> GetUTF8EncodedBytes(string input)
         {
             var x = new System.Security.Cryptography.MD5CryptoServiceProvider();
-            byte[] bs = System.Text.Encoding.UTF8.GetBytes(input);
+            byte[] bs = Encoding.UTF8.GetBytes(input);
             bs = x.ComputeHash(bs);
             return bs;
         }

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -19,7 +19,7 @@ namespace PatchApply
 
         public static byte[] GetResetUnstagedLinesAsPatch(GitModule module, string text, int selectionPosition, int selectionLength, bool staged, Encoding fileContentEncoding)
         {
-            ChunkList selectedChunks = ChunkList.GetSelectedChunks(text, selectionPosition, selectionLength, staged, out var header);
+            ChunkList selectedChunks = ChunkList.GetSelectedChunks(text, selectionPosition, selectionLength, out var header);
 
             if (selectedChunks == null)
             {
@@ -45,9 +45,9 @@ namespace PatchApply
             }
         }
 
-        public static byte[] GetSelectedLinesAsPatch(GitModule module, string text, int selectionPosition, int selectionLength, bool staged, Encoding fileContentEncoding, bool isNewFile)
+        public static byte[] GetSelectedLinesAsPatch(string text, int selectionPosition, int selectionLength, bool staged, Encoding fileContentEncoding, bool isNewFile)
         {
-            ChunkList selectedChunks = ChunkList.GetSelectedChunks(text, selectionPosition, selectionLength, staged, out var header);
+            ChunkList selectedChunks = ChunkList.GetSelectedChunks(text, selectionPosition, selectionLength, out var header);
 
             if (selectedChunks == null)
             {
@@ -659,7 +659,7 @@ namespace PatchApply
 
     internal class ChunkList : List<Chunk>
     {
-        public static ChunkList GetSelectedChunks(string text, int selectionPosition, int selectionLength, bool staged, out string header)
+        public static ChunkList GetSelectedChunks(string text, int selectionPosition, int selectionLength, out string header)
         {
             header = null;
 

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -244,8 +244,8 @@ namespace PatchApply
         public List<PatchLine> RemovedLines = new List<PatchLine>();
         public List<PatchLine> AddedLines = new List<PatchLine>();
         public List<PatchLine> PostContext = new List<PatchLine>();
-        public string WasNoNewLineAtTheEnd = null;
-        public string IsNoNewLineAtTheEnd = null;
+        public string WasNoNewLineAtTheEnd;
+        public string IsNoNewLineAtTheEnd;
 
         public string ToStagePatch(ref int addedCount, ref int removedCount, ref bool wereSelectedLines, bool staged, bool isWholeFile)
         {
@@ -434,7 +434,7 @@ namespace PatchApply
     {
         private int _startLine;
         private List<SubChunk> _subChunks = new List<SubChunk>();
-        private SubChunk _currentSubChunk = null;
+        private SubChunk _currentSubChunk;
 
         public SubChunk CurrentSubChunk
         {

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -72,7 +72,7 @@ namespace PatchApply
 
         private static string CorrectHeaderForNewFile(string header)
         {
-            string[] headerLines = header.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            string[] headerLines = header.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
             string pppLine = null;
             foreach (string line in headerLines)
             {
@@ -580,7 +580,7 @@ namespace PatchApply
 
             int eolLength = eol.Length;
 
-            string[] lines = fileText.Split(new string[] { eol }, StringSplitOptions.None);
+            string[] lines = fileText.Split(new[] { eol }, StringSplitOptions.None);
             int i = 0;
 
             while (i < lines.Length)
@@ -680,7 +680,7 @@ namespace PatchApply
             header = text.Substring(0, patchPos);
             string diff = text.Substring(patchPos - 1);
 
-            string[] chunks = diff.Split(new string[] { "\n@@" }, StringSplitOptions.RemoveEmptyEntries);
+            string[] chunks = diff.Split(new[] { "\n@@" }, StringSplitOptions.RemoveEmptyEntries);
             ChunkList selectedChunks = new ChunkList();
             int i = 0;
             int currentPos = patchPos - 1;

--- a/GitCommands/Patch/PatchProcessor.cs
+++ b/GitCommands/Patch/PatchProcessor.cs
@@ -319,8 +319,7 @@ namespace PatchApply
 
         private static bool IsStartOfANewPatch(string input)
         {
-            bool combinedDiff;
-            return IsStartOfANewPatch(input, out combinedDiff);
+            return IsStartOfANewPatch(input, out _);
         }
 
         private static bool SetPatchType(string input, Patch patch)

--- a/GitCommands/Patch/PatchProcessor.cs
+++ b/GitCommands/Patch/PatchProcessor.cs
@@ -8,7 +8,7 @@ namespace PatchApply
 {
     public class PatchProcessor
     {
-        public Encoding FilesContentEncoding { get; private set; }
+        public Encoding FilesContentEncoding { get; }
 
         public PatchProcessor(Encoding filesContentEncoding)
         {

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -106,7 +106,7 @@ namespace GitCommands
             if (repositoryUrl != null)
             {
                 const string standardRepositorySuffix = ".git";
-                string path = repositoryUrl.TrimEnd(new[] { '\\', '/' });
+                string path = repositoryUrl.TrimEnd('\\', '/');
 
                 if (path.EndsWith(standardRepositorySuffix))
                 {

--- a/GitCommands/Remote/GitRemoteSaveResult.cs
+++ b/GitCommands/Remote/GitRemoteSaveResult.cs
@@ -14,11 +14,11 @@ namespace GitCommands.Remote
         /// <summary>
         /// Indicates whether the "remote update" is desirable after the save operation.
         /// </summary>
-        public bool ShouldUpdateRemote { get; private set; }
+        public bool ShouldUpdateRemote { get; }
 
         /// <summary>
         /// Gets the output of the save operation (if any).
         /// </summary>
-        public string UserMessage { get; private set; }
+        public string UserMessage { get; }
     }
 }

--- a/GitCommands/Repository/RecentRepoInfo.cs
+++ b/GitCommands/Repository/RecentRepoInfo.cs
@@ -269,9 +269,8 @@ namespace GitCommands.Repository
                 string root = null;
                 string company = null;
                 string repository = null;
-                string workingDir = null;
+                var workingDir = dirInfo.Name;
 
-                workingDir = dirInfo.Name;
                 dirInfo = dirInfo.Parent;
                 if (dirInfo != null)
                 {

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -103,7 +103,7 @@ namespace GitCommands
         public string BranchFilter = string.Empty;
         public RevisionGraphInMemFilter InMemFilter;
         private string _selectedBranchName;
-        private static char[] ShellGlobCharacters = new[] { '?', '*', '[' };
+        private static char[] ShellGlobCharacters = { '?', '*', '[' };
 
         public void Execute()
         {

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -239,7 +239,7 @@ namespace GitCommands
                 }
 
                 string bufferString = new string(buffer, 0, bytesRead);
-                string[] dataBlocks = bufferString.Split(new[] { '\0' });
+                string[] dataBlocks = bufferString.Split('\0');
 
                 if (dataBlocks.Length > 1)
                 {
@@ -362,7 +362,7 @@ namespace GitCommands
                 case ReadStep.Commit:
                     data = GitModule.ReEncodeString(data, GitModule.LosslessEncoding, _module.LogOutputEncoding);
 
-                    string[] lines = data.Split(new[] { '\n' });
+                    string[] lines = data.Split('\n');
                     Debug.Assert(lines.Length == 11, "lines.Length == 11");
                     Debug.Assert(lines[0] == CommitBegin, "lines[0] == CommitBegin");
 
@@ -415,7 +415,7 @@ namespace GitCommands
                         // Git adds \n between the format string (ends with \0 in our case)
                         // and the first file name. So, we need to remove it from the file name.
                         data = GitModule.ReEncodeFileNameFromLossless(data);
-                        _revision.Name = data.TrimStart(new[] { '\n' });
+                        _revision.Name = data.TrimStart('\n');
                     }
 
                     break;

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -239,7 +239,7 @@ namespace GitCommands
                 }
 
                 string bufferString = new string(buffer, 0, bytesRead);
-                string[] dataBlocks = bufferString.Split(new char[] { '\0' });
+                string[] dataBlocks = bufferString.Split(new[] { '\0' });
 
                 if (dataBlocks.Length > 1)
                 {
@@ -362,7 +362,7 @@ namespace GitCommands
                 case ReadStep.Commit:
                     data = GitModule.ReEncodeString(data, GitModule.LosslessEncoding, _module.LogOutputEncoding);
 
-                    string[] lines = data.Split(new char[] { '\n' });
+                    string[] lines = data.Split(new[] { '\n' });
                     Debug.Assert(lines.Length == 11, "lines.Length == 11");
                     Debug.Assert(lines[0] == CommitBegin, "lines[0] == CommitBegin");
 
@@ -377,7 +377,7 @@ namespace GitCommands
                     }
 
                     // RemoveEmptyEntries is required for root commits. They should have empty list of parents.
-                    _revision.ParentGuids = lines[2].Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    _revision.ParentGuids = lines[2].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     _revision.TreeGuid = lines[3];
 
                     _revision.Author = lines[4];
@@ -415,7 +415,7 @@ namespace GitCommands
                         // Git adds \n between the format string (ends with \0 in our case)
                         // and the first file name. So, we need to remove it from the file name.
                         data = GitModule.ReEncodeFileNameFromLossless(data);
-                        _revision.Name = data.TrimStart(new char[] { '\n' });
+                        _revision.Name = data.TrimStart(new[] { '\n' });
                     }
 
                     break;

--- a/GitCommands/RevisionGraph.cs
+++ b/GitCommands/RevisionGraph.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -473,7 +473,7 @@ namespace GitCommands
                 {
                     return CultureInfo.GetCultureInfo(CurrentLanguageCode);
                 }
-                catch (System.Globalization.CultureNotFoundException)
+                catch (CultureNotFoundException)
                 {
                     Debug.WriteLine("Culture {0} not found", CurrentLanguageCode);
                     return CultureInfo.GetCultureInfo("en");

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1016,7 +1016,7 @@ namespace GitCommands
             set => SetBool("StartWithRecentWorkingDir", value);
         }
 
-        public static CommandLogger GitLog { get; private set; }
+        public static CommandLogger GitLog { get; }
 
         public static string Plink
         {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -742,7 +742,7 @@ namespace GitCommands
         public static PullAction? AutoPullOnPushRejectedAction
         {
             get => GetNullableEnum<PullAction>("AutoPullOnPushRejectedAction");
-            set => SetNullableEnum<PullAction>("AutoPullOnPushRejectedAction", value);
+            set => SetNullableEnum("AutoPullOnPushRejectedAction", value);
         }
 
         public static bool DontConfirmPushNewBranch

--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -17,7 +17,7 @@ namespace GitCommands.Settings
         private System.Timers.Timer _saveTimer = new System.Timers.Timer(SaveTime);
         private readonly bool _autoSave;
 
-        public string SettingsFilePath { get; private set; }
+        public string SettingsFilePath { get; }
 
         public FileSettingsCache(string settingsFilePath, bool autoSave = true)
         {

--- a/GitCommands/Settings/GitExtSettingsCache.cs
+++ b/GitCommands/Settings/GitExtSettingsCache.cs
@@ -42,7 +42,7 @@ namespace GitCommands.Settings
 
         protected override void WriteSettings(string fileName)
         {
-            using (System.Xml.XmlTextWriter xtw = new System.Xml.XmlTextWriter(fileName, Encoding.UTF8))
+            using (XmlTextWriter xtw = new XmlTextWriter(fileName, Encoding.UTF8))
             {
                 xtw.Formatting = Formatting.Indented;
                 xtw.WriteStartDocument();
@@ -61,7 +61,7 @@ namespace GitCommands.Settings
                 CheckCharacters = false
             };
 
-            using (System.Xml.XmlReader xr = XmlReader.Create(fileName, readerSettings))
+            using (XmlReader xr = XmlReader.Create(fileName, readerSettings))
             {
                 _encodedNameMap.ReadXml(xr);
             }

--- a/GitCommands/Settings/SettingsCache.cs
+++ b/GitCommands/Settings/SettingsCache.cs
@@ -7,10 +7,6 @@ namespace GitCommands
     {
         private readonly Dictionary<string, object> _byNameMap = new Dictionary<string, object>();
 
-        public SettingsCache()
-        {
-        }
-
         public void Dispose()
         {
             Dispose(true);

--- a/GitCommands/Settings/SettingsCache.cs
+++ b/GitCommands/Settings/SettingsCache.cs
@@ -112,7 +112,7 @@ namespace GitCommands
 
         private string GetValue(string name)
         {
-            return LockedAction<string>(() =>
+            return LockedAction(() =>
             {
                 EnsureSettingsAreUpToDate();
                 return GetValueImpl(name);
@@ -137,7 +137,7 @@ namespace GitCommands
                 s = encode(value);
             }
 
-            return LockedAction<bool>(() =>
+            return LockedAction(() =>
             {
                 string inMemValue = GetValue(name);
                 return inMemValue != null && !string.Equals(inMemValue, s);
@@ -176,7 +176,7 @@ namespace GitCommands
             object o;
             T val = defaultValue;
 
-            bool result = LockedAction<bool>(() =>
+            bool result = LockedAction(() =>
             {
                 EnsureSettingsAreUpToDate();
 

--- a/GitCommands/Settings/SettingsContainer.cs
+++ b/GitCommands/Settings/SettingsContainer.cs
@@ -5,8 +5,8 @@ namespace GitCommands.Settings
 {
     public class SettingsContainer<TLowerPriority, TCache> : ISettingsSource where TLowerPriority : SettingsContainer<TLowerPriority, TCache> where TCache : SettingsCache
     {
-        public TLowerPriority LowerPriority { get; private set; }
-        public TCache SettingsCache { get; private set; }
+        public TLowerPriority LowerPriority { get; }
+        public TCache SettingsCache { get; }
 
         public SettingsContainer(TLowerPriority lowerPriority, TCache settingsCache)
         {

--- a/GitCommands/Settings/SettingsContainer.cs
+++ b/GitCommands/Settings/SettingsContainer.cs
@@ -58,7 +58,7 @@ namespace GitCommands.Settings
 
         public virtual bool TryGetValue<T>(string name, T defaultValue, Func<string, T> decode, out T value)
         {
-            if (SettingsCache.TryGetValue<T>(name, defaultValue, decode, out value))
+            if (SettingsCache.TryGetValue(name, defaultValue, decode, out value))
             {
                 return true;
             }

--- a/GitCommands/Statistics/ImpactLoader.cs
+++ b/GitCommands/Statistics/ImpactLoader.cs
@@ -16,7 +16,7 @@ namespace GitCommands.Statistics
                 Commit = commit;
             }
 
-            public Commit Commit { get; private set; }
+            public Commit Commit { get; }
         }
 
         /// <summary>

--- a/GitCommands/Statistics/ImpactLoader.cs
+++ b/GitCommands/Statistics/ImpactLoader.cs
@@ -183,7 +183,7 @@ namespace GitCommands.Statistics
                 DateTime date = DateTime.Parse(header[0]).Date;
 
                 // Calculate first day of the commit week
-                date = commit.week = date.AddDays(-(int)date.DayOfWeek);
+                commit.week = date.AddDays(-(int)date.DayOfWeek);
 
                 // Reset commit data
                 commit.data.Commits = 1;

--- a/GitCommands/SynchronizedProcessReader.cs
+++ b/GitCommands/SynchronizedProcessReader.cs
@@ -9,7 +9,7 @@ namespace GitCommands
 {
     public class SynchronizedProcessReader
     {
-        public Process Process { get; private set; }
+        public Process Process { get; }
         public byte[] Output { get; private set; }
         public byte[] Error { get; private set; }
 

--- a/GitCommands/SynchronizedProcessReader.cs
+++ b/GitCommands/SynchronizedProcessReader.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -8,7 +8,7 @@ namespace System
     public static class StringExtensions
     {
         /// <summary>'\n'</summary>
-        private static readonly char[] NewLineSeparator = new[] { '\n' };
+        private static readonly char[] NewLineSeparator = { '\n' };
 
         public static string SkipStr(this string str, string toSkip)
         {

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -8,7 +8,7 @@ namespace System
     public static class StringExtensions
     {
         /// <summary>'\n'</summary>
-        private static readonly char[] NewLineSeparator = new char[] { '\n' };
+        private static readonly char[] NewLineSeparator = new[] { '\n' };
 
         public static string SkipStr(this string str, string toSkip)
         {

--- a/GitCommands/Utils/EnvUtils.cs
+++ b/GitCommands/Utils/EnvUtils.cs
@@ -67,14 +67,14 @@ namespace GitCommands.Utils
 
         public static bool IsNet4FullOrHigher()
         {
-            if (System.Environment.Version.Major > 4)
+            if (Environment.Version.Major > 4)
             {
                 return true;
             }
 
-            if (System.Environment.Version.Major == 4)
+            if (Environment.Version.Major == 4)
             {
-                if (System.Environment.Version.Minor >= 5)
+                if (Environment.Version.Minor >= 5)
                 {
                     return true;
                 }

--- a/GitCommands/Utils/RFC2047Decoder.cs
+++ b/GitCommands/Utils/RFC2047Decoder.cs
@@ -27,7 +27,7 @@ namespace GitCommands
                         {
                             if (!hasSeenAtLeastOneWord || currentSurroundingText.ToString().Trim().Length > 0)
                             {
-                                sb.Append(currentSurroundingText.ToString());
+                                sb.Append(currentSurroundingText);
                             }
 
                             currentSurroundingText = new StringBuilder();
@@ -69,7 +69,7 @@ namespace GitCommands
                 }
             }
 
-            sb.Append(currentSurroundingText.ToString());
+            sb.Append(currentSurroundingText);
             return sb.ToString();
         }
 

--- a/GitCommands/Utils/WeakRefCache.cs
+++ b/GitCommands/Utils/WeakRefCache.cs
@@ -48,7 +48,7 @@ namespace GitCommands.Utils
             return (T)cached;
         }
 
-        private void OnClearTimer(object source, System.Timers.ElapsedEventArgs e)
+        private void OnClearTimer(object source, ElapsedEventArgs e)
         {
             lock (_weakMap)
             {

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -240,7 +240,7 @@ namespace GitExtensions
                     MessageBox.Show(ce.ToString(), "Configuration Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
-                System.Environment.Exit(1);
+                Environment.Exit(1);
             }
         }
     }

--- a/GitExtensionsVSIX/GitExtCommandTable.cs
+++ b/GitExtensionsVSIX/GitExtCommandTable.cs
@@ -10,7 +10,7 @@ namespace GitExtensionsVSIX
     /// <summary>
     /// Helper class that exposes all GUIDs used across VS Package.
     /// </summary>
-    internal sealed partial class PackageGuids
+    internal sealed class PackageGuids
     {
         public const string guidGitExtensionsPackageString = "14f45fb8-a093-48af-a2a2-a7bb404cb357";
         public const string guidGitExtensionsPackageCmdSetString = "8bd71b0f-f446-442d-a92a-bbefd8e60202";
@@ -22,7 +22,7 @@ namespace GitExtensionsVSIX
     /// <summary>
     /// Helper class that encapsulates all CommandIDs uses across VS Package.
     /// </summary>
-    internal sealed partial class PackageIds
+    internal sealed class PackageIds
     {
         public const int gitExtMenu = 0x1000;
         public const int gitExtMenuGlobalGroup = 0x1010;

--- a/GitPluginShared/Commands/Blame.cs
+++ b/GitPluginShared/Commands/Blame.cs
@@ -11,7 +11,7 @@ namespace GitPluginShared.Commands
             var textSelection = item.DTE.ActiveDocument.Selection as TextSelection;
             if (textSelection != null)
             {
-                arguments = new string[] { textSelection.CurrentLine.ToString() };
+                arguments = new[] { textSelection.CurrentLine.ToString() };
             }
 
             RunGitEx("blame", fileName, arguments);

--- a/GitPluginShared/Commands/Commit.cs
+++ b/GitPluginShared/Commands/Commit.cs
@@ -10,10 +10,6 @@ namespace GitPluginShared.Commands
         private static string lastFile;
         private static string _lastUpdatedCaption;
 
-        public Commit()
-        {
-        }
-
         public override bool IsEnabled(EnvDTE80.DTE2 application)
         {
             bool enabled = base.IsEnabled(application);

--- a/GitUI/AutoCompletion/AutoCompleteWord.cs
+++ b/GitUI/AutoCompletion/AutoCompleteWord.cs
@@ -5,7 +5,7 @@ namespace GitUI.AutoCompletion
 {
     public class AutoCompleteWord : IEquatable<AutoCompleteWord>
     {
-        public string Word { get; private set; }
+        public string Word { get; }
         private readonly string _camelHumps;
 
         public AutoCompleteWord(string word)

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -89,7 +89,7 @@ namespace GitUI.AutoCompletion
 
             using (var sr = new StreamReader(s))
             {
-                return sr.ReadToEnd().Split(new char[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+                return sr.ReadToEnd().Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
             }
         }
 

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -44,9 +44,9 @@ namespace GitUI.AutoCompletion
                                 foreach (Match match in matches)
                                 {
                                     // Skip first group since it always contains the entire matched string (regardless of capture groups)
-                                    foreach (Group @group in match.Groups.OfType<Group>().Skip(1))
+                                    foreach (Group group in match.Groups.OfType<Group>().Skip(1))
                                     {
-                                        foreach (Capture capture in @group.Captures)
+                                        foreach (Capture capture in group.Captures)
                                         {
                                             autoCompleteWords.Add(capture.Value);
                                         }

--- a/GitUI/BuildServerIntegration/BuildInfoDrawingLogic.cs
+++ b/GitUI/BuildServerIntegration/BuildInfoDrawingLogic.cs
@@ -9,7 +9,7 @@ namespace GitUI.BuildServerIntegration
 {
     internal static class BuildInfoDrawingLogic
     {
-        public static void BuildStatusImageColumnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, Brush foreBrush, Font rowFont)
+        public static void BuildStatusImageColumnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision)
         {
             if (revision.BuildStatus != null)
             {

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -309,7 +309,7 @@ namespace GitUI.BuildServerIntegration
                         var canBeLoaded = export.Metadata.CanBeLoaded;
                         if (!canBeLoaded.IsNullOrEmpty())
                         {
-                            System.Diagnostics.Debug.Write(export.Metadata.BuildServerType + " adapter could not be loaded: " + canBeLoaded);
+                            Debug.Write(export.Metadata.BuildServerType + " adapter could not be loaded: " + canBeLoaded);
                             return null;
                         }
 

--- a/GitUI/CommandsDialogs/AboutBox.cs
+++ b/GitUI/CommandsDialogs/AboutBox.cs
@@ -10,11 +10,7 @@ namespace GitUI.CommandsDialogs
     {
         public AboutBox()
         {
-            _contributersList = string.Join(", ", new[]
-            {
-                Coders, Translators,
-                Designers, Other
-            })
+            _contributersList = string.Join(", ", Coders, Translators, Designers, Other)
                 .Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
 
             InitializeComponent();

--- a/GitUI/CommandsDialogs/AboutBox.cs
+++ b/GitUI/CommandsDialogs/AboutBox.cs
@@ -77,8 +77,7 @@ namespace GitUI.CommandsDialogs
         {
             using (FormContributors formContributors = new FormContributors())
             {
-                formContributors.LoadContributors(Coders, Translators,
-                    Designers, Other);
+                formContributors.LoadContributors(Coders, Translators, Designers);
                 formContributors.ShowDialog(this);
             }
         }

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -6,10 +6,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
 {
     public class FormContributors : GitExtensionsForm
     {
-        private static readonly string[] tabCaptions = new[]
-        {
-            "The Coders", "The Translators", "The Designers"
-        };
+        private static readonly string[] tabCaptions = { "The Coders", "The Translators", "The Designers" };
 
         private readonly TextBox[] _textboxes = new TextBox[tabCaptions.Length];
         private readonly TabPage[] _tabPages = new TabPage[tabCaptions.Length];

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -27,10 +27,10 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
             tb.BackColor = Color.White;
             tb.Dock = DockStyle.Fill;
             tb.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point, (byte)0);
-            tb.Margin = new System.Windows.Forms.Padding(0);
+            tb.Margin = new Padding(0);
             tb.Multiline = true;
             tb.ReadOnly = true;
-            tb.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            tb.ScrollBars = ScrollBars.Vertical;
             tb.TabStop = false;
             return tb;
         }
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
         private TabPage GetNewTabPage(TextBox tb, string caption)
         {
             TabPage tp = new TabPage();
-            tp.Margin = new System.Windows.Forms.Padding(0);
+            tp.Margin = new Padding(0);
             tp.Text = caption;
             tp.Controls.Add(tb);
             return tp;

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -6,7 +6,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
 {
     public class FormContributors : GitExtensionsForm
     {
-        private static readonly string[] tabCaptions = new string[]
+        private static readonly string[] tabCaptions = new[]
         {
             "The Coders", "The Translators", "The Designers"
         };

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -26,7 +26,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
             TextBox tb = new TextBox();
             tb.BackColor = Color.White;
             tb.Dock = DockStyle.Fill;
-            tb.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point, (byte)0);
+            tb.Font = new Font("Segoe UI", 9.75F, FontStyle.Regular, GraphicsUnit.Point, 0);
             tb.Margin = new Padding(0);
             tb.Multiline = true;
             tb.ReadOnly = true;
@@ -48,7 +48,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
         {
             TabControl tc = new TabControl();
             tc.Dock = DockStyle.Fill;
-            tc.Font = new Font("Segoe UI", 10F, FontStyle.Bold, GraphicsUnit.Point, (byte)0);
+            tc.Font = new Font("Segoe UI", 10F, FontStyle.Bold, GraphicsUnit.Point, 0);
             tc.ItemSize = new Size(150, 26);
             tc.Margin = new Padding(0);
             tc.Padding = new Point(0, 0);

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -86,7 +86,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
             ResumeLayout(false);
         }
 
-        public void LoadContributors(string coders, string translators, string designers, string others)
+        public void LoadContributors(string coders, string translators, string designers)
         {
             const string NEWLINES = @"\r\n?|\n";
             _textboxes[0].Text = Regex.Replace(coders, NEWLINES, " ");

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -114,7 +114,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             //
             var showCurrentBranchMenuItem = new ToolStripMenuItem(_showCurrentBranch.Text);
             showCurrentBranchMenuItem.Click += showCurrentBranchMenuItem_Click;
-            showCurrentBranchMenuItem.Checked = GitCommands.AppSettings.DashboardShowCurrentBranch;
+            showCurrentBranchMenuItem.Checked = AppSettings.DashboardShowCurrentBranch;
 
             var menuStrip = FindControl<MenuStrip>(Parent.Parent.Parent, p => true); // TODO: improve: Parent.Parent.Parent == FormBrowse
             var dashboardMenu = (ToolStripMenuItem)menuStrip.Items.Cast<ToolStripItem>().SingleOrDefault(p => p.Name == "dashboardToolStripMenuItem");
@@ -244,8 +244,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void showCurrentBranchMenuItem_Click(object sender, EventArgs e)
         {
-            bool newValue = !GitCommands.AppSettings.DashboardShowCurrentBranch;
-            GitCommands.AppSettings.DashboardShowCurrentBranch = newValue;
+            bool newValue = !AppSettings.DashboardShowCurrentBranch;
+            AppSettings.DashboardShowCurrentBranch = newValue;
             ((ToolStripMenuItem)sender).Checked = newValue;
             Refresh();
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardCategory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardCategory.cs
@@ -254,7 +254,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 Repository = repository;
             }
 
-            public Repository Repository { get; private set; }
+            public Repository Repository { get; }
         }
 
         public event EventHandler<RepositoryEventArgs> RepositoryRemoved;

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardItem.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardItem.cs
@@ -37,7 +37,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 _branchNameLoader = new AsyncLoader();
                 _branchNameLoader.Load(() =>
                 {
-                    if (!GitCommands.GitModule.IsBareRepository(repository.Path))
+                    if (!GitModule.IsBareRepository(repository.Path))
                     {
                         return GitModule.GetSelectedBranchFast(repository.Path);
                     }
@@ -144,7 +144,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private void DashboardItem_MouseLeave(object sender, EventArgs e)
         {
             if ((sender == Icon || sender == _NO_TRANSLATE_Title) &&
-                ClientRectangle.Contains(PointToClient(Control.MousePosition)))
+                ClientRectangle.Contains(PointToClient(MousePosition)))
             {
                 return;
             }
@@ -152,7 +152,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             BackColor = SystemColors.Control;
         }
 
-        private void DashboardItem_VisibleChanged(object sender, System.EventArgs e)
+        private void DashboardItem_VisibleChanged(object sender, EventArgs e)
         {
             if (!Visible)
             {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenuCommands.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenuCommands.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using GitUI.CommandsDialogs.BrowseDialog;
 
 namespace GitUI.CommandsDialogs
@@ -9,7 +10,7 @@ namespace GitUI.CommandsDialogs
         private GitUICommands UICommands => _formBrowse.UICommands;
 
         // must be created only once because of translation
-        private IEnumerable<MenuCommand> _navigateMenuCommands;
+        private IReadOnlyList<MenuCommand> _navigateMenuCommands;
 
         public FormBrowseMenuCommands(FormBrowse formBrowse)
         {
@@ -23,7 +24,7 @@ namespace GitUI.CommandsDialogs
         {
             if (_navigateMenuCommands == null)
             {
-                _navigateMenuCommands = CreateNavigateMenuCommands();
+                _navigateMenuCommands = CreateNavigateMenuCommands().ToList();
             }
 
             return _navigateMenuCommands;

--- a/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.cs
@@ -12,7 +12,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             : base(commands)
         {
             InitializeComponent();
-            Loading.Image = global::GitUI.Properties.Resources.loadingpanel;
+            Loading.Image = Properties.Resources.loadingpanel;
             Translate();
         }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -68,7 +68,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void Go()
         {
-            DialogResult = System.Windows.Forms.DialogResult.OK;
+            DialogResult = DialogResult.OK;
             Close();
         }
 
@@ -77,7 +77,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             Go();
         }
 
-        private void linkGitRevParse_LinkClicked(object sender, System.Windows.Forms.LinkLabelLinkClickedEventArgs e)
+        private void linkGitRevParse_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start(@"https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html#_specifying_revisions");
         }
@@ -206,19 +206,19 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             Go();
         }
 
-        private void comboBoxTags_KeyUp(object sender, System.Windows.Forms.KeyEventArgs e)
+        private void comboBoxTags_KeyUp(object sender, KeyEventArgs e)
         {
             GoIfEnterKey(sender, e);
         }
 
-        private void comboBoxBranches_KeyUp(object sender, System.Windows.Forms.KeyEventArgs e)
+        private void comboBoxBranches_KeyUp(object sender, KeyEventArgs e)
         {
             GoIfEnterKey(sender, e);
         }
 
-        private void GoIfEnterKey(object sender, System.Windows.Forms.KeyEventArgs e)
+        private void GoIfEnterKey(object sender, KeyEventArgs e)
         {
-            if (e.KeyCode == System.Windows.Forms.Keys.Enter)
+            if (e.KeyCode == Keys.Enter)
             {
                 Go();
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -17,7 +17,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private readonly TranslationString _warningOpenFailedCaption =
             new TranslationString("Error");
 
-        private GitModule _choosenModule = null;
+        private GitModule _choosenModule;
 
         public FormOpenDirectory(GitModule currentModule)
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             {
                 Process.Start(UpdateUrl);
             }
-            catch (System.ComponentModel.Win32Exception)
+            catch (Win32Exception)
             {
             }
         }
@@ -179,7 +179,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
             catch (Exception e)
             {
-                System.Diagnostics.Debug.WriteLine(e);
+                Debug.WriteLine(e);
                 return null;
             }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -190,7 +190,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 DownloadPage = section.GetValue("DownloadPage")
             };
 
-            Enum.TryParse<ReleaseType>(section.GetValue("ReleaseType"), true, out version.ReleaseType);
+            Enum.TryParse(section.GetValue("ReleaseType"), true, out version.ReleaseType);
 
             return version;
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -28,28 +28,26 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             {
                 return new ToolStripSeparator();
             }
-            else
-            {
-                var toolStripMenuItem = new ToolStripMenuItem();
-                toolStripMenuItem.Name = menuCommand.Name;
-                toolStripMenuItem.Text = menuCommand.Text;
-                toolStripMenuItem.Image = menuCommand.Image;
-                toolStripMenuItem.ShortcutKeys = menuCommand.ShortcutKeys;
-                toolStripMenuItem.ShortcutKeyDisplayString = menuCommand.ShortcutKeyDisplayString;
-                toolStripMenuItem.Click += (obj, sender) =>
-                    {
-                        if (menuCommand.ExecuteAction != null)
-                        {
-                            menuCommand.ExecuteAction();
-                        }
-                        else
-                        {
-                            MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.");
-                        }
-                    };
 
-                return toolStripMenuItem;
-            }
+            var toolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem.Name = menuCommand.Name;
+            toolStripMenuItem.Text = menuCommand.Text;
+            toolStripMenuItem.Image = menuCommand.Image;
+            toolStripMenuItem.ShortcutKeys = menuCommand.ShortcutKeys;
+            toolStripMenuItem.ShortcutKeyDisplayString = menuCommand.ShortcutKeyDisplayString;
+            toolStripMenuItem.Click += (obj, sender) =>
+            {
+                if (menuCommand.ExecuteAction != null)
+                {
+                    menuCommand.ExecuteAction();
+                }
+                else
+                {
+                    MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.");
+                }
+            };
+
+            return toolStripMenuItem;
         }
 
         private IList<ToolStripMenuItem> _registeredMenuItems = new List<ToolStripMenuItem>();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -865,7 +865,7 @@ namespace GitUI.CommandsDialogs
                     _pullButton.Click += PullToolStripMenuItemClick;
 
                     _toolbarButtonsCreated = true;
-                    ThumbnailToolBarButton[] buttons = new[] { _commitButton, _pullButton, _pushButton };
+                    ThumbnailToolBarButton[] buttons = { _commitButton, _pullButton, _pushButton };
 
                     // Call this method using reflection.  This is a workaround to *not* reference WPF libraries, becuase of how the WindowsAPICodePack was implimented.
                     TaskbarManager.Instance.ThumbnailToolBars.AddButtons(Handle, buttons);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2316,9 +2316,8 @@ namespace GitUI.CommandsDialogs
             }
 
             RefreshPullIcon();
-            bool pullCompelted;
 
-            UICommands.StartPullDialog(this, true, out pullCompelted, true);
+            UICommands.StartPullDialog(this, true, out _, true);
 
             // restore AppSettings.FormPullAction value
             if (!AppSettings.SetNextPullActionAsDefault)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2143,7 +2143,7 @@ namespace GitUI.CommandsDialogs
             base.OnClosed(e);
         }
 
-        private void CommandsToolStripMenuItem_DropDownOpening(object sender, System.EventArgs e)
+        private void CommandsToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
             // Most options do not make sense for artificial commits or no revision selected at all
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -59,13 +59,11 @@ namespace GitUI.CommandsDialogs
             {
                 return null;
             }
-            else
-            {
-                // 1. get all lines from text box which are not empty
-                // 2. wrap lines with ""
-                // 3. join together with space as separator
-                return string.Join(" ", textBoxPaths.Lines.Where(a => !a.IsNullOrEmpty()).Select(a => string.Format("\"{0}\"", a)));
-            }
+
+            // 1. get all lines from text box which are not empty
+            // 2. wrap lines with ""
+            // 3. join together with space as separator
+            return string.Join(" ", textBoxPaths.Lines.Where(a => !a.IsNullOrEmpty()).Select(a => string.Format("\"{0}\"", a)));
         }
 
         private void Cancel_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -422,8 +422,7 @@ namespace GitUI.CommandsDialogs
             }
             else if (branchList.AuthenticationFail)
             {
-                string loadedKey;
-                if (FormPuttyError.AskForKey(this, out loadedKey))
+                if (FormPuttyError.AskForKey(this, out _))
                 {
                     LoadBranches();
                 }

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -354,7 +354,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                destinationPath += _NO_TRANSLATE_To.Text.TrimEnd(new[] { '\\', '/' });
+                destinationPath += _NO_TRANSLATE_To.Text.TrimEnd('\\', '/');
             }
 
             destinationPath += "\\";

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2177,8 +2177,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            bool wereErrors;
-            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.ToList(), true, out wereErrors);
+            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.ToList(), true, out _);
 
             Initialize();
         }
@@ -2192,8 +2191,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            bool wereErrors;
-            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.ToList(), false, out wereErrors);
+            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.ToList(), false, out _);
 
             Initialize();
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -588,7 +588,8 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                patch = PatchManager.GetSelectedLinesAsPatch(Module, SelectedDiff.GetText(),
+                patch = PatchManager.GetSelectedLinesAsPatch(
+                    SelectedDiff.GetText(),
                     SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
                     _currentItemStaged, SelectedDiff.Encoding, _currentItem.IsNew);
             }
@@ -677,7 +678,8 @@ namespace GitUI.CommandsDialogs
 
             if (_currentItemStaged)
             {
-                patch = PatchManager.GetSelectedLinesAsPatch(Module, SelectedDiff.GetText(),
+                patch = PatchManager.GetSelectedLinesAsPatch(
+                    SelectedDiff.GetText(),
                     SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
                     _currentItemStaged, SelectedDiff.Encoding, _currentItem.IsNew);
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -312,7 +312,7 @@ namespace GitUI.CommandsDialogs
             // a special meaning, and can be dangerous if used inappropriately.
             if (_commitKind == CommitKind.Normal)
             {
-                GitCommands.CommitHelper.SetCommitMessage(Module, Message.Text, Amend.Checked);
+                CommitHelper.SetCommitMessage(Module, Message.Text, Amend.Checked);
             }
 
             _splitterManager.SaveSplitters();
@@ -1796,11 +1796,11 @@ namespace GitUI.CommandsDialogs
                                     Directory.Delete(path, true);
                                 }
                             }
-                            catch (System.IO.IOException)
+                            catch (IOException)
                             {
                                 filesInUse.Add(item.Name);
                             }
-                            catch (System.UnauthorizedAccessException)
+                            catch (UnauthorizedAccessException)
                             {
                             }
                         }
@@ -2723,11 +2723,11 @@ namespace GitUI.CommandsDialogs
             // Change the icon for commit button
             if (gpgSignCommitToolStripComboBox.SelectedIndex > 0)
             {
-                Commit.Image = GitUI.Properties.Resources.IconKey;
+                Commit.Image = Properties.Resources.IconKey;
             }
             else
             {
-                Commit.Image = GitUI.Properties.Resources.IconClean;
+                Commit.Image = Properties.Resources.IconClean;
             }
 
             toolStripGpgKeyTextBox.Visible = gpgSignCommitToolStripComboBox.SelectedIndex == 2;
@@ -2864,10 +2864,10 @@ namespace GitUI.CommandsDialogs
                                 Directory.Delete(path, true);
                             }
                         }
-                        catch (System.IO.IOException)
+                        catch (IOException)
                         {
                         }
-                        catch (System.UnauthorizedAccessException)
+                        catch (UnauthorizedAccessException)
                         {
                         }
                     }
@@ -3009,7 +3009,6 @@ namespace GitUI.CommandsDialogs
             }
             catch
             {
-                return;
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1181,7 +1181,7 @@ namespace GitUI.CommandsDialogs
         {
             if (AppSettings.CommitValidationMaxCntCharsFirstLine > 0)
             {
-                var firstLine = Message.Text.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)[0];
+                var firstLine = Message.Text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)[0];
                 if (firstLine.Length > AppSettings.CommitValidationMaxCntCharsFirstLine)
                 {
                     if (MessageBox.Show(this, _commitMsgFirstLineInvalid.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
@@ -1193,7 +1193,7 @@ namespace GitUI.CommandsDialogs
 
             if (AppSettings.CommitValidationMaxCntCharsPerLine > 0)
             {
-                var lines = Message.Text.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                var lines = Message.Text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var line in lines)
                 {
                     if (line.Length > AppSettings.CommitValidationMaxCntCharsPerLine)
@@ -1208,7 +1208,7 @@ namespace GitUI.CommandsDialogs
 
             if (AppSettings.CommitValidationSecondLineMustBeEmpty)
             {
-                var lines = Message.Text.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
+                var lines = Message.Text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
                 if (lines.Length > 2)
                 {
                     if (lines[1].Length != 0)
@@ -2052,7 +2052,7 @@ namespace GitUI.CommandsDialogs
 
             if (!prevMsgs.Contains(msg))
             {
-                prevMsgs = new string[] { msg }.Concat(prevMsgs).Take(AppSettings.CommitDialogNumberOfPreviousMessages);
+                prevMsgs = new[] { msg }.Concat(prevMsgs).Take(AppSettings.CommitDialogNumberOfPreviousMessages);
             }
 
             foreach (var localLastCommitMessage in prevMsgs)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2236,8 +2236,7 @@ namespace GitUI.CommandsDialogs
 
         private void OpenToolStripMenuItemClick(object sender, EventArgs e)
         {
-            FileStatusList list = sender as FileStatusList;
-            if (!SenderToFileStatusList(sender, out list))
+            if (!SenderToFileStatusList(sender, out var list))
             {
                 return;
             }
@@ -2382,9 +2381,10 @@ namespace GitUI.CommandsDialogs
         private void UpdateAuthorInfo()
         {
             GetUserSettings();
-            string author = "";
+
             string committer = string.Format("{0} {1} <{2}>", _commitCommitterInfo.Text, _userName, _userEmail);
 
+            string author;
             if (string.IsNullOrEmpty(toolAuthor.Text) || string.IsNullOrEmpty(toolAuthor.Text.Trim()))
             {
                 author = string.Format("{0} {1} <{2}>", _commitAuthorInfo.Text, _userName, _userEmail);

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -128,28 +128,28 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            GitUI.RevisionDiffKind diffKind;
+            RevisionDiffKind diffKind;
 
             if (sender == aLocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffALocal;
+                diffKind = RevisionDiffKind.DiffALocal;
             }
             else if (sender == bLocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffBLocal;
+                diffKind = RevisionDiffKind.DiffBLocal;
             }
             else if (sender == parentOfALocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffAParentLocal;
+                diffKind = RevisionDiffKind.DiffAParentLocal;
             }
             else if (sender == parentOfBLocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffBParentLocal;
+                diffKind = RevisionDiffKind.DiffBParentLocal;
             }
             else
             {
                 Debug.Assert(sender == aBToolStripMenuItem, "Not implemented DiffWithRevisionKind: " + sender);
-                diffKind = GitUI.RevisionDiffKind.DiffAB;
+                diffKind = RevisionDiffKind.DiffAB;
             }
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -110,8 +110,6 @@ namespace GitUI.CommandsDialogs
                     case DialogResult.No:
                         needToClose = true;
                         break;
-                    default:
-                        break;
                 }
             }
             else

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -21,8 +21,10 @@ namespace GitUI.CommandsDialogs
         private string _originalGitIgnoreFileContent = string.Empty;
 
         #region default patterns
+
         private static readonly string DefaultIgnorePatternsFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GitExtensions/DefaultIgnorePatterns.txt");
-        private static readonly string[] DefaultIgnorePatterns = new[]
+
+        private static readonly string[] DefaultIgnorePatterns =
         {
             "#Ignore thumbnails created by Windows",
             "Thumbs.db",
@@ -57,9 +59,9 @@ namespace GitUI.CommandsDialogs
             "packages/"
         };
 
-        private IGitIgnoreDialogModel _dialogModel;
-
         #endregion
+
+        private IGitIgnoreDialogModel _dialogModel;
 
         public FormGitIgnore(GitUICommands commands, bool localExclude)
             : base(commands)

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -169,13 +169,12 @@ namespace GitUI.CommandsDialogs
                         if (!SaveGitIgnore())
                         {
                             e.Cancel = true;
-                            return;
                         }
 
                         break;
                     case DialogResult.Cancel:
                         e.Cancel = true;
-                        return;
+                        break;
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -112,8 +112,6 @@ namespace GitUI.CommandsDialogs
                     case DialogResult.No:
                         needToClose = true;
                         break;
-                    default:
-                        break;
                 }
             }
             else

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -13,8 +13,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _strategyTooltipText = new TranslationString("resolve " + Environment.NewLine + "This can only resolve two heads (i.e. the current branch and another branch you pulled from) using a 3-way merge algorithm." + Environment.NewLine + "It tries to carefully detect criss-cross merge ambiguities and is considered generally safe and fast. " + Environment.NewLine + "" + Environment.NewLine + "recursive " + Environment.NewLine + "This can only resolve two heads using a 3-way merge algorithm. When there is more than one common ancestor that can be " + Environment.NewLine + "used for 3-way merge, it creates a merged tree of the common ancestors and uses that as the reference tree for the 3-way" + Environment.NewLine + "merge. Additionally this can detect and handle merges involving renames. This is the default merge strategy when pulling or " + Environment.NewLine + "merging one branch. " + Environment.NewLine + "" + Environment.NewLine + "octopus " + Environment.NewLine + "This resolves cases with more than two heads, but refuses to do a complex merge that needs manual resolution. It is " + Environment.NewLine + "primarily meant to be used for bundling topic branch heads together. This is the default merge strategy when pulling or " + Environment.NewLine + "merging more than one branch. " + Environment.NewLine + "" + Environment.NewLine + "ours " + Environment.NewLine + "This resolves any number of heads, but the resulting tree of the merge is always that of the current branch head, effectively " + Environment.NewLine + "ignoring all changes from all other branches. It is meant to be used to supersede old development history of side branches." + Environment.NewLine + "" + Environment.NewLine + "subtree " + Environment.NewLine + "This is a modified recursive strategy. When merging trees A and B, if B corresponds to a subtree of A, B is first adjusted to " + Environment.NewLine + "match the tree structure of A, instead of reading the trees at the same level. This adjustment is also done to the common " + Environment.NewLine + "ancestor tree.");
         private readonly TranslationString _formMergeBranchHoverShowImageLabelText = new TranslationString("Hover to see scenario when fast forward is possible.");
         private readonly string _defaultBranch;
-        private readonly int _rowBranchComboHeight;
-        private readonly int _groupBoxWidth;
 
         /// <summary>Initializes <see cref="FormMergeBranch"/>.</summary>
         /// <param name="defaultBranch">Branch to merge into the current branch.</param>
@@ -23,9 +21,6 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             Translate();
-
-            _rowBranchComboHeight = Branches.Height;
-            _groupBoxWidth = groupBox1.Width;
 
             currentBranchLabel.Font = new Font(currentBranchLabel.Font, FontStyle.Bold);
             noCommit.Checked = AppSettings.DontCommitMerge;

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -595,7 +595,7 @@ namespace GitUI.CommandsDialogs
                     int idx = _mergetoolCmd.IndexOf(executablePattern);
                     if (idx >= 0)
                     {
-                        _mergetoolPath = _mergetoolCmd.Substring(0, idx + executablePattern.Length + 1).Trim(new[] { '\"', ' ' });
+                        _mergetoolPath = _mergetoolCmd.Substring(0, idx + executablePattern.Length + 1).Trim('\"', ' ');
                         _mergetoolCmd = _mergetoolCmd.Substring(idx + executablePattern.Length + 1);
                     }
                 }

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -265,7 +265,7 @@ namespace GitUI.CommandsDialogs
             /// <summary>
             /// Empty rule set vs. got some stuff there
             /// </summary>
-            public bool IsCurrentRuleSetEmpty { get; private set; }
+            public bool IsCurrentRuleSetEmpty { get; }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -35,7 +35,7 @@ namespace GitUI.CommandsDialogs
             : base(commands)
         {
             InitializeComponent();
-            Loading.Image = global::GitUI.Properties.Resources.loadingpanel;
+            Loading.Image = Properties.Resources.loadingpanel;
             Translate();
             View.ExtraDiffArgumentsChanged += ViewExtraDiffArgumentsChanged;
         }
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs
         {
             if (chkIncludeUntrackedFiles.Checked && !GitCommandHelpers.VersionInUse.StashUntrackedFilesSupported)
             {
-                if (MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == System.Windows.Forms.DialogResult.Cancel)
+                if (MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == DialogResult.Cancel)
                 {
                     return;
                 }
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs
         {
             if (chkIncludeUntrackedFiles.Checked && !GitCommandHelpers.VersionInUse.StashUntrackedFilesSupported)
             {
-                if (MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == System.Windows.Forms.DialogResult.Cancel)
+                if (MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == DialogResult.Cancel)
                 {
                     return;
                 }

--- a/GitUI/CommandsDialogs/FormSvnClone.cs
+++ b/GitUI/CommandsDialogs/FormSvnClone.cs
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs
         private void _NO_TRANSLATE_svnRepositoryComboBox_TextUpdate(object sender, EventArgs e)
         {
             var path = _NO_TRANSLATE_SvnFrom.Text;
-            path = path.TrimEnd(new[] { '\\', '/' });
+            path = path.TrimEnd('\\', '/');
 
             if (path.Contains("\\") || path.Contains("/"))
             {

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -287,7 +287,7 @@ namespace GitUI.CommandsDialogs
             {
                 currentTag++;
                 var createTagArgs = new GitCreateTagArgs($"{RestoredObjectsTagPrefix}{currentTag}", lostObject.Hash);
-                var success = _gitTagController.CreateTag(createTagArgs, this);
+                _gitTagController.CreateTag(createTagArgs, this);
             }
 
             return currentTag;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -204,7 +204,7 @@ namespace GitUI.CommandsDialogs
             _lostObjects.AddRange(dialogResult
                 .Split('\r', '\n')
                 .Where(s => !string.IsNullOrEmpty(s))
-                .Select<string, LostObject>((s) => LostObject.TryParse(Module, s))
+                .Select((s) => LostObject.TryParse(Module, s))
                 .Where(parsedLostObject => parsedLostObject != null));
 
             UpdateFilteredLostObjects();

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -409,8 +409,7 @@ namespace GitUI.CommandsDialogs
                 files.Add(item);
             }
 
-            bool err;
-            Module.StageFiles(files, out err);
+            Module.StageFiles(files, out _);
             RefreshArtificial();
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -499,27 +499,27 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            GitUI.RevisionDiffKind diffKind;
+            RevisionDiffKind diffKind;
 
             if (sender == aLocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffALocal;
+                diffKind = RevisionDiffKind.DiffALocal;
             }
             else if (sender == bLocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffBLocal;
+                diffKind = RevisionDiffKind.DiffBLocal;
             }
             else if (sender == parentOfALocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffAParentLocal;
+                diffKind = RevisionDiffKind.DiffAParentLocal;
             }
             else if (sender == parentOfBLocalToolStripMenuItem)
             {
-                diffKind = GitUI.RevisionDiffKind.DiffBParentLocal;
+                diffKind = RevisionDiffKind.DiffBParentLocal;
             }
             else
             {
-                diffKind = GitUI.RevisionDiffKind.DiffAB;
+                diffKind = RevisionDiffKind.DiffAB;
             }
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)

--- a/GitUI/CommandsDialogs/RevisionGpgInfo.cs
+++ b/GitUI/CommandsDialogs/RevisionGpgInfo.cs
@@ -49,7 +49,7 @@ namespace GitUI.CommandsDialogs
 
         private void ApplyLayout()
         {
-            var heightRowCommit = 0f;
+            float heightRowCommit;
             var heightRowTag = 0f;
 
             if (txtTagGpgInfo.Visible)

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -211,8 +211,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public static bool CheckIfFileIsInPath(string fileName)
         {
-            string foo;
-            return PathUtil.TryFindFullPath(fileName, out foo);
+            return PathUtil.TryFindFullPath(fileName, out _);
         }
 
         public bool SolveMergeToolForKDiff()
@@ -290,8 +289,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public void AutoConfigMergeToolCmd()
         {
-            string exeName;
-            string exeFile = MergeToolsHelper.FindMergeToolFullPath(CommonLogic.ConfigFileSettingsSet, GetGlobalMergeToolText(), out exeName);
+            string exeFile = MergeToolsHelper.FindMergeToolFullPath(CommonLogic.ConfigFileSettingsSet, GetGlobalMergeToolText(), out _);
+
             if (string.IsNullOrEmpty(exeFile))
             {
                 SetMergetoolPathText("");

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using GitCommands;
 using JetBrains.Annotations;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 ListIncludedEncodings.EndUpdate();
             }
 
-            var availableEncoding = System.Text.Encoding.GetEncodings()
+            var availableEncoding = Encoding.GetEncodings()
                 .Select(ei => ei.GetEncoding())
                 .Where(e => !includedEncoding.ContainsKey(e.HeaderName))
                 .ToList();

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -411,7 +411,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 return exeName;
             }
 
-            var vsVersions = new string[] { "14.0", "12.0", "11.0" };
+            var vsVersions = new[] { "14.0", "12.0", "11.0" };
 
             foreach (var version in vsVersions)
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -58,8 +58,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _populateBuildServerTypeTask.ContinueWith(
                 task =>
                 {
-                    checkBoxEnableBuildServerIntegration.SetNullableChecked((bool?)CurrentSettings.BuildServer.EnableIntegration.Value);
-                    checkBoxShowBuildSummary.SetNullableChecked((bool?)CurrentSettings.BuildServer.ShowBuildSummaryInGrid.Value);
+                    checkBoxEnableBuildServerIntegration.SetNullableChecked(CurrentSettings.BuildServer.EnableIntegration.Value);
+                    checkBoxShowBuildSummary.SetNullableChecked(CurrentSettings.BuildServer.ShowBuildSummaryInGrid.Value);
 
                     BuildServerType.SelectedItem = CurrentSettings.BuildServer.Type.Value ?? _noneItem.Text;
                 },

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -131,7 +131,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             return (string)BuildServerType.SelectedItem;
         }
 
-        private void BuildServerType_SelectedIndexChanged(object sender, System.EventArgs e)
+        private void BuildServerType_SelectedIndexChanged(object sender, EventArgs e)
         {
             ActivateBuildServerSettingsControl();
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -335,7 +335,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             SaveAndRescan_Click(null, null);
         }
 
-        private readonly string[] _autoConfigMergeTools = new[] { "p4merge", "TortoiseMerge", "meld", "beyondcompare3", "beyondcompare4", "diffmerge", "semanticmerge", "vscode", "vsdiffmerge" };
+        private readonly string[] _autoConfigMergeTools = { "p4merge", "TortoiseMerge", "meld", "beyondcompare3", "beyondcompare4", "diffmerge", "semanticmerge", "vscode", "vsdiffmerge" };
         private void MergeToolFix_Click(object sender, EventArgs e)
         {
             if (string.IsNullOrEmpty(CommonLogic.GetGlobalMergeTool()))

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -50,11 +50,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
     public static class CheckboxExtension
     {
-        public static CheckState ToCheckboxState(this bool booleanValue)
-        {
-            return booleanValue.ToCheckboxState();
-        }
-
         public static CheckState ToCheckboxState(this bool? booleanValue)
         {
             if (!booleanValue.HasValue)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -194,7 +194,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)));
                     otherHome.Checked = true;
                     otherHomeDir.Text = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-                    return;
                 }
             }
             catch

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
@@ -75,7 +75,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.FollowRenamesInFileHistoryExactOnly = chkFollowRenamesInFileHistoryExact.Checked;
         }
 
-        private void chkUseSSL_CheckedChanged(object sender, System.EventArgs e)
+        private void chkUseSSL_CheckedChanged(object sender, EventArgs e)
         {
             if (!chkUseSSL.Checked)
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitExtensionsSettingsPage.cs
@@ -15,7 +15,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Translate();
         }
 
-        private bool _loadedDefaultClone = false;
+        private bool _loadedDefaultClone;
         private void defaultCloneDropDown(object sender, EventArgs e)
         {
             if (!_loadedDefaultClone)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -339,7 +339,7 @@ Current Branch:
         {
             var helpDisplayDialog = new SimpleHelpDisplayDialog();
             helpDisplayDialog.DialogTitle = _scriptSettingsPageHelpDisplayArgumentsHelp.Text;
-            helpDisplayDialog.ContentText = @_scriptSettingsPageHelpDisplayContent.Text.Replace("\n", Environment.NewLine);
+            helpDisplayDialog.ContentText = _scriptSettingsPageHelpDisplayContent.Text.Replace("\n", Environment.NewLine);
 
             helpDisplayDialog.ShowDialog();
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -314,7 +314,7 @@ Current Branch:
             }
 
             Bitmap result = new Bitmap(width, height);
-            using (Graphics g = Graphics.FromImage((Image)result))
+            using (Graphics g = Graphics.FromImage(result))
             {
                 g.DrawImage(b, 0, 0, width, height);
             }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
@@ -58,11 +58,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 if (chlMenuEntries.GetItemChecked(i))
                 {
-                    cascaded += "       " + chlMenuEntries.Items[i].ToString() + "\r\n";
+                    cascaded += "       " + chlMenuEntries.Items[i] + "\r\n";
                 }
                 else
                 {
-                    topLevel += "GitExt " + chlMenuEntries.Items[i].ToString() + "\r\n";
+                    topLevel += "GitExt " + chlMenuEntries.Items[i] + "\r\n";
                 }
             }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
         public static PluginSettingsPage CreateSettingsPageFromPlugin(ISettingsPageHost pageHost, IGitPlugin gitPlugin)
         {
-            var result = SettingsPageBase.Create<PluginSettingsPage>(pageHost);
+            var result = Create<PluginSettingsPage>(pageHost);
             result.Init(gitPlugin);
             return result;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -184,7 +184,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         }
     }
 
-    public class StringComboBoxAdapter : GitUIPluginInterfaces.ChoiceSetting
+    public class StringComboBoxAdapter : ChoiceSetting
     {
         public StringComboBoxAdapter(GitCommands.Settings.StringSetting setting, ComboBox comboBox)
             : base(setting.FullPath, comboBox.Items.Cast<string>().ToList(), setting.DefaultValue)
@@ -193,7 +193,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         }
     }
 
-    public class IntTextBoxAdapter : GitUIPluginInterfaces.NumberSetting<int>
+    public class IntTextBoxAdapter : NumberSetting<int>
     {
         public IntTextBoxAdapter(IntNullableSetting setting, TextBox control)
             : base(setting.FullPath, setting.DefaultValue.Value)

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageHeader.cs
@@ -21,7 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         void SetRepoDistSettings();
     }
 
-    public partial class SettingsPageHeader : GitExtensionsControl
+    public partial class SettingsPageHeader
     {
         private readonly SettingsPageWithHeader _page;
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.Designer.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.Designer.cs
@@ -31,9 +31,9 @@
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // createWorktreeButton
-            // 
+            //
             this.createWorktreeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.createWorktreeButton.AutoSize = true;
             this.createWorktreeButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
@@ -47,18 +47,18 @@
             this.createWorktreeButton.Text = "Create the new worktree";
             this.createWorktreeButton.UseVisualStyleBackColor = true;
             this.createWorktreeButton.Click += new System.EventHandler(this.createWorktreeButton_Click);
-            // 
+            //
             // textBoxNewBranchName
-            // 
+            //
             this.textBoxNewBranchName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxNewBranchName.Location = new System.Drawing.Point(174, 34);
             this.textBoxNewBranchName.Name = "textBoxNewBranchName";
             this.textBoxNewBranchName.Size = new System.Drawing.Size(419, 21);
             this.textBoxNewBranchName.TabIndex = 11;
             this.textBoxNewBranchName.TextChanged += new System.EventHandler(this.UpdateWorktreePathAndValidateWorktreeOptions);
-            // 
+            //
             // radioButtonCreateNewBranch
-            // 
+            //
             this.radioButtonCreateNewBranch.AutoSize = true;
             this.radioButtonCreateNewBranch.Location = new System.Drawing.Point(3, 30);
             this.radioButtonCreateNewBranch.Name = "radioButtonCreateNewBranch";
@@ -68,9 +68,9 @@
             this.radioButtonCreateNewBranch.Text = "Create a new branch:\r\n (from current commit) ";
             this.radioButtonCreateNewBranch.UseVisualStyleBackColor = true;
             this.radioButtonCreateNewBranch.Click += new System.EventHandler(this.UpdateWorktreePathAndValidateWorktreeOptions);
-            // 
+            //
             // radioButtonCheckoutExistingBranch
-            // 
+            //
             this.radioButtonCheckoutExistingBranch.AutoSize = true;
             this.radioButtonCheckoutExistingBranch.Location = new System.Drawing.Point(3, 3);
             this.radioButtonCheckoutExistingBranch.Name = "radioButtonCheckoutExistingBranch";
@@ -80,9 +80,9 @@
             this.radioButtonCheckoutExistingBranch.Text = "Checkout an existing branch:";
             this.radioButtonCheckoutExistingBranch.UseVisualStyleBackColor = true;
             this.radioButtonCheckoutExistingBranch.Click += new System.EventHandler(this.UpdateWorktreePathAndValidateWorktreeOptions);
-            // 
+            //
             // openWorktreeCheckBox
-            // 
+            //
             this.openWorktreeCheckBox.AutoSize = true;
             this.openWorktreeCheckBox.Checked = true;
             this.openWorktreeCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
@@ -93,9 +93,9 @@
             this.openWorktreeCheckBox.TabIndex = 9;
             this.openWorktreeCheckBox.Text = "Open the new worktree after the creation";
             this.openWorktreeCheckBox.UseVisualStyleBackColor = true;
-            // 
+            //
             // newWorktreeDirectory
-            // 
+            //
             this.newWorktreeDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.newWorktreeDirectory.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.newWorktreeDirectory.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystemDirectories;
@@ -104,9 +104,9 @@
             this.newWorktreeDirectory.Size = new System.Drawing.Size(356, 21);
             this.newWorktreeDirectory.TabIndex = 7;
             this.newWorktreeDirectory.TextChanged += new System.EventHandler(this.ValidateWorktreeOptions);
-            // 
+            //
             // label2
-            // 
+            //
             this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(3, 98);
@@ -114,10 +114,10 @@
             this.label2.Size = new System.Drawing.Size(124, 13);
             this.label2.TabIndex = 6;
             this.label2.Text = "New worktree directory:";
-            // 
+            //
             // comboBoxBranches
-            // 
-            this.comboBoxBranches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.comboBoxBranches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxBranches.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.comboBoxBranches.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
@@ -128,22 +128,20 @@
             this.comboBoxBranches.Size = new System.Drawing.Size(419, 21);
             this.comboBoxBranches.TabIndex = 2;
             this.comboBoxBranches.SelectedIndexChanged += new System.EventHandler(this.UpdateWorktreePathAndValidateWorktreeOptions);
-            this.comboBoxBranches.SelectionChangeCommitted += new System.EventHandler(this.comboBoxBranches_SelectionChangeCommitted);
-            this.comboBoxBranches.TextChanged += new System.EventHandler(this.comboBoxBranches_TextChanged);
             this.comboBoxBranches.KeyUp += new System.Windows.Forms.KeyEventHandler(this.comboBoxBranches_KeyUp);
-            // 
+            //
             // folderBrowserButton1
-            // 
+            //
             this.folderBrowserButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.folderBrowserButton1.Location = new System.Drawing.Point(495, 92);
             this.folderBrowserButton1.Name = "folderBrowserButton1";
             this.folderBrowserButton1.PathShowingControl = this.newWorktreeDirectory;
             this.folderBrowserButton1.Size = new System.Drawing.Size(110, 25);
             this.folderBrowserButton1.TabIndex = 8;
-            // 
+            //
             // groupBoxWhatToCheckout
-            // 
-            this.groupBoxWhatToCheckout.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.groupBoxWhatToCheckout.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxWhatToCheckout.AutoSize = true;
             this.groupBoxWhatToCheckout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
@@ -155,9 +153,9 @@
             this.groupBoxWhatToCheckout.TabIndex = 12;
             this.groupBoxWhatToCheckout.TabStop = false;
             this.groupBoxWhatToCheckout.Text = "What to checkout: ";
-            // 
+            //
             // tableLayoutPanel2
-            // 
+            //
             this.tableLayoutPanel2.AutoSize = true;
             this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel2.ColumnCount = 2;
@@ -175,9 +173,9 @@
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.Size = new System.Drawing.Size(596, 63);
             this.tableLayoutPanel2.TabIndex = 14;
-            // 
+            //
             // tableLayoutPanel1
-            // 
+            //
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -198,9 +196,9 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.Size = new System.Drawing.Size(608, 208);
             this.tableLayoutPanel1.TabIndex = 13;
-            // 
+            //
             // FormCreateWorktree
-            // 
+            //
             this.AcceptButton = this.createWorktreeButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -70,20 +70,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         public IList<IGitRef> ExistingBranches { get; set; }
 
-        private void comboBoxBranches_TextChanged(object sender, EventArgs e)
-        {
-            if (comboBoxBranches.DataSource == null)
-            {
-            }
-        }
-
-        private void comboBoxBranches_SelectionChangeCommitted(object sender, EventArgs e)
-        {
-            if (comboBoxBranches.SelectedValue == null)
-            {
-            }
-        }
-
         private void comboBoxBranches_KeyUp(object sender, KeyEventArgs e)
         {
             GoIfEnterKey(sender, e);

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -86,12 +86,12 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             }
         }
 
-        private void comboBoxBranches_KeyUp(object sender, System.Windows.Forms.KeyEventArgs e)
+        private void comboBoxBranches_KeyUp(object sender, KeyEventArgs e)
         {
             GoIfEnterKey(sender, e);
         }
 
-        private void GoIfEnterKey(object sender, System.Windows.Forms.KeyEventArgs e)
+        private void GoIfEnterKey(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
             {

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -74,7 +74,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         {
             if (comboBoxBranches.DataSource == null)
             {
-                return;
             }
         }
 
@@ -82,7 +81,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         {
             if (comboBoxBranches.SelectedValue == null)
             {
-                return;
             }
         }
 
@@ -173,7 +171,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             if (createWorktreeButton.Enabled)
             {
                 createWorktreeButton.Enabled = IsTargetFolderValid();
-                return;
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -153,7 +153,7 @@ namespace GitUI.CommitInfo
         private List<string> _branches;
         private string _branchInfo;
         private IList<string> _sortedRefs;
-        private System.Drawing.Rectangle _headerResize; // Cache desired size for commit header
+        private Rectangle _headerResize; // Cache desired size for commit header
 
         private void ReloadCommitInfo()
         {
@@ -364,8 +364,8 @@ namespace GitUI.CommitInfo
             int gravatarIndex, revInfoIndex, gravatarSpan, revInfoSpan;
             if (right)
             {
-                tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-                tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+                tableLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+                tableLayout.ColumnStyles.Add(new ColumnStyle());
                 gravatarIndex = 1;
                 revInfoIndex = 0;
                 gravatarSpan = 1;
@@ -373,8 +373,8 @@ namespace GitUI.CommitInfo
             }
             else
             {
-                tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-                tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+                tableLayout.ColumnStyles.Add(new ColumnStyle());
+                tableLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
                 gravatarIndex = 0;
                 revInfoIndex = 1;
                 gravatarSpan = 2;

--- a/GitUI/Editor/ColorHelper.cs
+++ b/GitUI/Editor/ColorHelper.cs
@@ -58,7 +58,7 @@ namespace GitUI.Editor
 
         public static int GetColorBrightnessDifference(Color a, Color b)
         {
-            return System.Math.Abs(GetColorBrightnessIndex(a) - GetColorBrightnessIndex(b));
+            return Math.Abs(GetColorBrightnessIndex(a) - GetColorBrightnessIndex(b));
         }
     }
 }

--- a/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
@@ -30,12 +30,12 @@ namespace GitUI.Editor.Diff
 
         protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
         {
-            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new string[] { "+", " +" }, ref found);
+            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new[] { "+", " +" }, ref found);
         }
 
         protected override List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
         {
-            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new string[] { "-", " -" }, ref found);
+            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new[] { "-", " -" }, ref found);
         }
     }
 }

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -15,7 +15,7 @@ namespace GitUI.Editor.Diff
         public class Result
         {
             public Dictionary<int, DiffLineNum> LineNumbers = new Dictionary<int, DiffLineNum>();
-            public int MaxLineNumber = 0;
+            public int MaxLineNumber;
         }
 
         private void AddToResult(Result result, DiffLineNum diffLine)

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -40,10 +40,8 @@ namespace GitUI.Editor.Diff
                     {
                         break;
                     }
-                    else
-                    {
-                        beginIndex++;
-                    }
+
+                    beginIndex++;
                 }
             }
 

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -16,7 +16,7 @@ namespace GitUI.Editor.Diff
 
         public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string prefixStr, ref bool found)
         {
-            return GetLinesStartingWith(document, ref beginIndex, new string[] { prefixStr }, ref found);
+            return GetLinesStartingWith(document, ref beginIndex, new[] { prefixStr }, ref found);
         }
 
         public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string[] prefixStrs, ref bool found)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1172,7 +1172,7 @@ namespace GitUI.Editor
                 // if header is selected then don't remove diff extra chars
                 if (hpos <= pos)
                 {
-                    char[] specials = new[] { ' ', '-', '+' };
+                    char[] specials = { ' ', '-', '+' };
                     lines = lines.Select(s => s.Length > 0 && specials.Any(c => c == s[0]) ? s.Substring(1) : s);
                 }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -962,7 +962,7 @@ namespace GitUI.Editor
 
             // go to the top of change block
             while (firstVisibleLine > 0 &&
-                _internalFileViewer.GetLineText(firstVisibleLine).StartsWithAny(new string[] { "+", "-" }))
+                _internalFileViewer.GetLineText(firstVisibleLine).StartsWithAny(new[] { "+", "-" }))
             {
                 firstVisibleLine--;
             }
@@ -971,8 +971,8 @@ namespace GitUI.Editor
             {
                 var lineContent = _internalFileViewer.GetLineText(line);
 
-                if (lineContent.StartsWithAny(new string[] { "+", "-" })
-                    && !lineContent.StartsWithAny(new string[] { "++", "--" }))
+                if (lineContent.StartsWithAny(new[] { "+", "-" })
+                    && !lineContent.StartsWithAny(new[] { "++", "--" }))
                 {
                     emptyLineCheck = true;
                 }
@@ -1173,7 +1173,7 @@ namespace GitUI.Editor
                 // if header is selected then don't remove diff extra chars
                 if (hpos <= pos)
                 {
-                    char[] specials = new char[] { ' ', '-', '+' };
+                    char[] specials = new[] { ' ', '-', '+' };
                     lines = lines.Select(s => s.Length > 0 && specials.Any(c => c == s[0]) ? s.Substring(1) : s);
                 }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -25,7 +25,6 @@ namespace GitUI.Editor
         private int _currentScrollPos = -1;
         private bool _currentViewIsPatch;
         private readonly IFileViewer _internalFileViewer;
-        private GetNextFileFnc _fileLoader;
         private readonly IFullPathResolver _fullPathResolver;
 
         public FileViewer()
@@ -1089,7 +1088,6 @@ namespace GitUI.Editor
         public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _internalFileViewer.SetFileLoader(fileLoader);
-            _fileLoader = fileLoader;
         }
 
         private void encodingToolStripComboBox_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1092,8 +1092,7 @@ namespace GitUI.Editor
 
         private void encodingToolStripComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            Encoding encod = null;
-
+            Encoding encod;
             if (string.IsNullOrEmpty(encodingToolStripComboBox.Text))
             {
                 encod = Module.FilesEncoding;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1211,15 +1211,17 @@ namespace GitUI.Editor
 
             if (reverse)
             {
-                patch = PatchManager.GetResetUnstagedLinesAsPatch(Module, GetText(),
-                selectionStart, selectionLength,
-                false, Encoding);
+                patch = PatchManager.GetResetUnstagedLinesAsPatch(
+                    Module, GetText(),
+                    selectionStart, selectionLength,
+                    false, Encoding);
             }
             else
             {
-                patch = PatchManager.GetSelectedLinesAsPatch(Module, GetText(),
-                selectionStart, selectionLength,
-                false, Encoding, false);
+                patch = PatchManager.GetSelectedLinesAsPatch(
+                    GetText(),
+                    selectionStart, selectionLength,
+                    false, Encoding, false);
             }
 
             if (patch != null && patch.Length > 0)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -61,12 +61,12 @@ namespace GitUI.Editor
 
             IgnoreWhitespaceChanges = AppSettings.IgnoreWhitespaceChanges;
             ignoreWhiteSpaces.Checked = IgnoreWhitespaceChanges;
-            ignoreWhiteSpaces.Image = GitUI.Properties.Resources.ignore_whitespaces;
+            ignoreWhiteSpaces.Image = Properties.Resources.ignore_whitespaces;
             ignoreWhitespaceChangesToolStripMenuItem.Checked = IgnoreWhitespaceChanges;
             ignoreWhitespaceChangesToolStripMenuItem.Image = ignoreWhiteSpaces.Image;
 
             ignoreAllWhitespaces.Checked = AppSettings.IgnoreAllWhitespaceChanges;
-            ignoreAllWhitespaces.Image = GitUI.Properties.Resources.ignore_all_whitespaces;
+            ignoreAllWhitespaces.Image = Properties.Resources.ignore_all_whitespaces;
             ignoreAllWhitespaceChangesToolStripMenuItem.Checked = ignoreAllWhitespaces.Checked;
             ignoreAllWhitespaceChangesToolStripMenuItem.Image = ignoreAllWhitespaces.Image;
 
@@ -229,7 +229,7 @@ namespace GitUI.Editor
             Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
         }
 
-        private void ContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        private void ContextMenu_Opening(object sender, CancelEventArgs e)
         {
             copyToolStripMenuItem.Enabled = _internalFileViewer.GetSelectionLength() > 0;
             ContextMenuOpening?.Invoke(sender, e);

--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -157,7 +157,7 @@ namespace GitUI
 
             int startIdx = -1;
             int currentIdx = -1;
-            TextRange range = null;
+            TextRange range;
             do
             {
                 Caret caret = _editor.ActiveTextAreaControl.Caret;

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -11,7 +11,7 @@ namespace GitUI.Editor
             SelectedLine = selectedLine;
         }
 
-        public int SelectedLine { get; private set; }
+        public int SelectedLine { get; }
     }
 
     public interface IFileViewer

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -760,10 +760,9 @@ namespace GitUI.Editor.RichTextBoxExtension
             bool fontSet = false;
             string strFont = "";
             int crFont = 0;
-            Color color = new Color();
             int yHeight = 0;
 
-            int i = 0;
+            int i;
             int pos = 0;
             int k = rtb.TextLength;
             char[] chtrim = { ' ', '\x0000' };
@@ -809,7 +808,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     int fsize = yHeight / (20 * 5);
 
                     // color object from COLORREF
-                    color = GetColor(crFont);
+                    var color = GetColor(crFont);
 
                     // add <font> tag
                     string strcolor = string.Concat("#", (color.ToArgb() & 0x00FFFFFF).ToString("X6"));

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1274,8 +1274,6 @@ namespace GitUI.Editor.RichTextBoxExtension
                     break;
                 case XmlNodeType.Comment:
                     break;
-                default:
-                    break;
             }
         }
 
@@ -1519,8 +1517,6 @@ namespace GitUI.Editor.RichTextBoxExtension
                             case XmlNodeType.ProcessingInstruction:
                                 break;
                             case XmlNodeType.Comment:
-                                break;
-                            default:
                                 break;
                         }
                     }

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -649,7 +649,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static string GetUrl(this LinkClickedEventArgs e)
         {
-            var v = e.LinkText.Split(new char[] { '#' }, 2);
+            var v = e.LinkText.Split(new[] { '#' }, 2);
             if (v.Length == 0)
             {
                 return "";
@@ -666,7 +666,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void GetLinkText(this LinkClickedEventArgs e, out string url, out string text)
         {
-            var v = e.LinkText.Split(new char[] { '#' }, 2);
+            var v = e.LinkText.Split(new[] { '#' }, 2);
             if (v.Length == 0)
             {
                 url = "";

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1195,7 +1195,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     }
                 }
             }
-            catch (System.Xml.XmlException ex)
+            catch (XmlException ex)
             {
                 Debug.WriteLine(ex.Message);
             }
@@ -1527,7 +1527,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     }
                 }
             }
-            catch (System.Xml.XmlException ex)
+            catch (XmlException ex)
             {
                 Debug.WriteLine(ex.Message);
             }

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -19,9 +19,9 @@ namespace GitUI
 
         public FilterBranchHelper()
         {
-            _localToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            _tagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            _remoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            _localToolStripMenuItem = new ToolStripMenuItem();
+            _tagsToolStripMenuItem = new ToolStripMenuItem();
+            _remoteToolStripMenuItem = new ToolStripMenuItem();
 
             //
             // localToolStripMenuItem

--- a/GitUI/FilterRevisionsHelper.cs
+++ b/GitUI/FilterRevisionsHelper.cs
@@ -22,11 +22,11 @@ namespace GitUI
 
         public FilterRevisionsHelper()
         {
-            _commitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            _committerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            _authorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            _diffContainsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            _hashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            _commitToolStripMenuItem = new ToolStripMenuItem();
+            _committerToolStripMenuItem = new ToolStripMenuItem();
+            _authorToolStripMenuItem = new ToolStripMenuItem();
+            _diffContainsToolStripMenuItem = new ToolStripMenuItem();
+            _hashToolStripMenuItem = new ToolStripMenuItem();
 
             //
             // commitToolStripMenuItem1

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -61,7 +61,7 @@ namespace GitUI
 
         public static bool ShowDialog(GitModuleForm owner, string arguments)
         {
-            return ShowDialog(owner, (string)null, arguments);
+            return ShowDialog(owner, null, arguments);
         }
 
         public static bool ShowDialog(GitModuleForm owner, string process, string arguments)

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -266,7 +266,7 @@ namespace GitUI
             // FormProcess
             //
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new System.Drawing.Size(565, 326);
             Name = "FormProcess";
             ResumeLayout(false);

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -27,7 +27,6 @@ namespace GitUI
 
         // only for translation
         protected FormRemoteProcess()
-            : base()
         {
         }
 

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -36,7 +36,7 @@ namespace GitUI
             Translate();
             if (_useDialogSettings)
             {
-                KeepDialogOpen.Checked = !GitCommands.AppSettings.CloseProcessDialog;
+                KeepDialogOpen.Checked = !AppSettings.CloseProcessDialog;
             }
             else
             {
@@ -159,11 +159,11 @@ namespace GitUI
 
                 if (isSuccess)
                 {
-                    picBoxSuccessFail.Image = GitUI.Properties.Resources.success;
+                    picBoxSuccessFail.Image = Properties.Resources.success;
                 }
                 else
                 {
-                    picBoxSuccessFail.Image = GitUI.Properties.Resources.error;
+                    picBoxSuccessFail.Image = Properties.Resources.error;
                 }
 
                 _errorOccurred = !isSuccess;

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -11,7 +11,8 @@ namespace GitUI
 {
     public partial class FormStatus : GitExtensionsForm
     {
-        private readonly bool _useDialogSettings = true;
+        private readonly bool _useDialogSettings;
+
         private DispatcherFrameModalControler _modalControler;
 
         public FormStatus() : this(true)

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -32,7 +32,6 @@ namespace GitUI
         /// <param name="enablePositionRestore">Indicates whether the <see cref="Form"/>'s position
         /// will be restored upon being re-opened.</param>
         public GitExtensionsForm(bool enablePositionRestore)
-            : base()
         {
             _enablePositionRestore = enablePositionRestore;
 

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -13,7 +13,7 @@ namespace GitUI
         private readonly object _lock = new object();
 
         [Browsable(false)]
-        public bool UICommandsSourceParentSearch { get; private set; }
+        public bool UICommandsSourceParentSearch { get; }
 
         /// <summary>Occurs after the <see cref="UICommandsSource"/> is changed.</summary>
         [Browsable(false)]

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -908,8 +908,7 @@ namespace GitUI
 
         public bool StartPullDialog(IWin32Window owner, bool pullOnShow)
         {
-            bool errorOccurred;
-            return StartPullDialog(owner, pullOnShow, out errorOccurred, false);
+            return StartPullDialog(owner, pullOnShow, out _, false);
         }
 
         public bool StartPullDialog(bool pullOnShow, out bool pullCompleted)
@@ -929,14 +928,12 @@ namespace GitUI
 
         public bool StartPullDialog(bool pullOnShow, string remoteBranch)
         {
-            bool errorOccurred;
-            return StartPullDialog(pullOnShow, remoteBranch, out errorOccurred);
+            return StartPullDialog(pullOnShow, remoteBranch, out _);
         }
 
         public bool StartPullDialog(IWin32Window owner)
         {
-            bool errorOccurred;
-            return StartPullDialog(owner, false, out errorOccurred, false);
+            return StartPullDialog(owner, false, out _, false);
         }
 
         public bool StartPullDialog()

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1118,10 +1118,10 @@ namespace GitUI
                         Directory.Delete(path, true);
                     }
                 }
-                catch (System.IO.IOException)
+                catch (IOException)
                 {
                 }
-                catch (System.UnauthorizedAccessException)
+                catch (UnauthorizedAccessException)
                 {
                 }
             }
@@ -1619,7 +1619,7 @@ namespace GitUI
 
         public bool StartRepoSettingsDialog(IWin32Window owner)
         {
-            return StartSettingsDialog(owner, GitUI.CommandsDialogs.SettingsDialog.Pages.GitConfigSettingsPage.GetPageReference());
+            return StartSettingsDialog(owner, CommandsDialogs.SettingsDialog.Pages.GitConfigSettingsPage.GetPageReference());
         }
 
         public bool StartBrowseDialog(IWin32Window owner, string filter, string selectedCommit)
@@ -2083,7 +2083,7 @@ namespace GitUI
                 case "fileeditor":  // filename
                     if (!StartFileEditorDialog(args[2]))
                     {
-                        System.Environment.ExitCode = -1;
+                        Environment.ExitCode = -1;
                     }
 
                     return;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1751,8 +1751,7 @@ namespace GitUI
 
         public bool StartPushDialog(IWin32Window owner, bool pushOnShow)
         {
-            bool pushCompleted;
-            return StartPushDialog(owner, pushOnShow, out pushCompleted);
+            return StartPushDialog(owner, pushOnShow, out _);
         }
 
         public bool StartPushDialog(bool pushOnShow)
@@ -2239,7 +2238,7 @@ namespace GitUI
             {
                 if (File.Exists(args[2]))
                 {
-                    string path = File.ReadAllText(args[2]).Trim().Split(new char[] { '\n' }, 1).FirstOrDefault();
+                    string path = File.ReadAllText(args[2]).Trim().Split(new[] { '\n' }, 1).FirstOrDefault();
                     if (Directory.Exists(path))
                     {
                         c = new GitUICommands(path);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -180,7 +180,7 @@ namespace GitUI
 
         public event GitUIEventHandler PostRegisterPlugin;
 
-        public ILockableNotifier RepoChangedNotifier { get; private set; }
+        public ILockableNotifier RepoChangedNotifier { get; }
         public IBrowseRepo BrowseRepo { get; set; }
 
         #endregion

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -37,7 +37,7 @@ namespace GitUI.HelperDialogs
             }
         }
 
-        public GitCommands.GitRevision SelectedRevision { get; private set; }
+        public GitRevision SelectedRevision { get; private set; }
         private Dictionary<string, string> _parents;
 
         protected override void OnLoad(EventArgs e)

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -333,7 +333,6 @@ namespace GitUI.Hotkey
         {
             var curScripts = Script.ScriptManager.GetScripts();
 
-            HotkeyCommand[] scriptKeys = new HotkeyCommand[curScripts.Count];
             /* define unusable int for identifying a shortcut for a custom script is pressed
              * all integers above 9000 represent a scripthotkey
              * these integers are never matched in the 'switch' routine on a form and

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -331,7 +331,7 @@ namespace GitUI.Hotkey
 
         public static HotkeyCommand[] LoadScriptHotkeys()
         {
-            var curScripts = GitUI.Script.ScriptManager.GetScripts();
+            var curScripts = Script.ScriptManager.GetScripts();
 
             HotkeyCommand[] scriptKeys = new HotkeyCommand[curScripts.Count];
             /* define unusable int for identifying a shortcut for a custom script is pressed

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -341,7 +341,7 @@ namespace GitUI.Hotkey
 
             return curScripts.
                 Where(s => !s.Name.IsNullOrEmpty()).
-                Select(s => new HotkeyCommand((int)s.HotkeyCommandIdentifier, s.Name) { KeyData = Keys.None })
+                Select(s => new HotkeyCommand(s.HotkeyCommandIdentifier, s.Name) { KeyData = Keys.None })
             .ToArray();
         }
     }

--- a/GitUI/IGitUICommandsSource.cs
+++ b/GitUI/IGitUICommandsSource.cs
@@ -9,7 +9,7 @@ namespace GitUI
             OldCommands = oldCommands;
         }
 
-        public GitUICommands OldCommands { get; private set; }
+        public GitUICommands OldCommands { get; }
     }
 
     public class GitUICommandsSourceEventArgs : EventArgs
@@ -19,7 +19,7 @@ namespace GitUI
             GitUICommandsSource = gitUiCommandsSource;
         }
 
-        public IGitUICommandsSource GitUICommandsSource { get; private set; }
+        public IGitUICommandsSource GitUICommandsSource { get; }
     }
 
     /// <summary>Provides <see cref="GitUICommands"/> and a change notification.</summary>

--- a/GitUI/Lemmings.cs
+++ b/GitUI/Lemmings.cs
@@ -17,16 +17,14 @@ namespace GitUI
                     // X-Mass
                     return Resources.Cow_xmass;
                 }
-                else
-                    if (currentDate.Month == 6 && currentDate.Day == 21)
-                    {
-                        // summer
-                        return Resources.Cow_sunglass;
-                    }
-                    else
-                    {
-                        return Resources.Cow;
-                    }
+
+                if (currentDate.Month == 6 && currentDate.Day == 21)
+                {
+                    // summer
+                    return Resources.Cow_sunglass;
+                }
+
+                return Resources.Cow;
             }
 
             return null;

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -89,7 +89,7 @@ namespace GitUI
 
         public static bool CacheHostkey(IWin32Window owner)
         {
-            return MessageBox.Show(owner, Instance._serverHostkeyNotCachedText.Text, "SSH", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.Yes;
+            return MessageBox.Show(owner, Instance._serverHostkeyNotCachedText.Text, "SSH", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
         }
 
         public static bool ConfirmUpdateSubmodules(IWin32Window win)

--- a/GitUI/MouseWheelRedirector.cs
+++ b/GitUI/MouseWheelRedirector.cs
@@ -94,12 +94,12 @@ namespace GitUI
                     Y = y;
                 }
 
-                public static implicit operator System.Drawing.Point(POINT p)
+                public static implicit operator Point(POINT p)
                 {
-                    return new System.Drawing.Point(p.X, p.Y);
+                    return new Point(p.X, p.Y);
                 }
 
-                public static implicit operator POINT(System.Drawing.Point p)
+                public static implicit operator POINT(Point p)
                 {
                     return new POINT(p.X, p.Y);
                 }

--- a/GitUI/RepoHosts.cs
+++ b/GitUI/RepoHosts.cs
@@ -7,7 +7,7 @@ namespace GitUI
 {
     public class RepoHosts
     {
-        public static List<IRepositoryHostPlugin> GitHosters { get; private set; }
+        public static List<IRepositoryHostPlugin> GitHosters { get; }
         static RepoHosts()
         {
             GitHosters = new List<IRepositoryHostPlugin>();

--- a/GitUI/Script/SplitButton.cs
+++ b/GitUI/Script/SplitButton.cs
@@ -453,7 +453,7 @@ namespace GitUI.Script
             // if the width is odd - favor pushing it over one pixel right.
             middle.X += dropDownRect.Width % 2;
 
-            Point[] arrow = new[] { new Point(middle.X - 2, middle.Y - 1), new Point(middle.X + 3, middle.Y - 1), new Point(middle.X, middle.Y + 2) };
+            Point[] arrow = { new Point(middle.X - 2, middle.Y - 1), new Point(middle.X + 3, middle.Y - 1), new Point(middle.X, middle.Y + 2) };
 
             if (Enabled)
             {

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -442,7 +442,7 @@ namespace GitUI.SpellChecker
                     foreach (var suggestion in _spelling.Suggestions)
                     {
                         var si = AddContextMenuItem(suggestion, SuggestionToolStripItemClick);
-                        si.Font = new System.Drawing.Font(si.Font, FontStyle.Bold);
+                        si.Font = new Font(si.Font, FontStyle.Bold);
                     }
 
                     AddContextMenuItem(_addToDictionaryText.Text, AddToDictionaryClick)

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -56,7 +56,7 @@ namespace GitUI.SpellChecker
         public Font TextBoxFont { get; set; }
 
         public EventHandler TextAssigned;
-        public bool IsUndoInProgress = false;
+        public bool IsUndoInProgress;
 
         public EditNetSpell()
         {
@@ -649,7 +649,7 @@ namespace GitUI.SpellChecker
             OnKeyUp(e);
         }
 
-        private bool _skipSelectionUndo = false;
+        private bool _skipSelectionUndo;
 
         private void UndoHighlighting()
         {

--- a/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/GitUI/SpellChecker/TextBoxHelper.cs
@@ -194,16 +194,13 @@ namespace GitUI.SpellChecker
         ///   area of the control.</returns>
         private static Point PosFromChar(TextBoxBase textBoxBase, int charIndex)
         {
-            unchecked
-            {
-                var xy =
-                    NativeMethods.SendMessageInt(
-                        textBoxBase.Handle,
-                        NativeMethods.EM_POSFROMCHAR,
-                        new IntPtr(charIndex),
-                        IntPtr.Zero).ToInt32();
-                return new Point(xy);
-            }
+            var xy =
+                NativeMethods.SendMessageInt(
+                    textBoxBase.Handle,
+                    NativeMethods.EM_POSFROMCHAR,
+                    new IntPtr(charIndex),
+                    IntPtr.Zero).ToInt32();
+            return new Point(xy);
         }
 
         private static int GetFirstVisibleLine(TextBoxBase txt)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -255,7 +255,7 @@ namespace GitUI.Blame
                 {
                     blameCommitter.AppendLine(
                         (blameHeader.Author + " - " + blameHeader.AuthorTime + " - " + blameHeader.FileName +
-                         new string(' ', 100)).Trim(new[] { '\r', '\n' }));
+                         new string(' ', 100)).Trim('\r', '\n'));
                 }
 
                 if (blameLine.LineText == null)
@@ -264,7 +264,7 @@ namespace GitUI.Blame
                 }
                 else
                 {
-                    blameFile.AppendLine(blameLine.LineText.Trim(new[] { '\r', '\n' }));
+                    blameFile.AppendLine(blameLine.LineText.Trim('\r', '\n'));
                 }
             }
 

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -45,7 +45,7 @@ namespace GitUI
 
         public IEnumerable<IGitRef> GetSelectedBranches()
         {
-            foreach (string branch in branches.Text.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string branch in branches.Text.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 var gitHead = _branchesToSelect.FirstOrDefault(g => g.Name == branch);
                 if (gitHead == null)

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -133,7 +133,7 @@ namespace GitUI.UserControls
     {
         private Action<TextEventArgs> _fireDataReceived;
         private int _commandLineCharsInOutput;
-        private string _lineChunk = null;
+        private string _lineChunk;
 
         public ConsoleCommandLineOutputProcessor(int commandLineCharsInOutput, Action<TextEventArgs> fireDataReceived)
         {

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -104,7 +104,7 @@ namespace GitUI.UserControls
                 process.ErrorDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.Exited += delegate
                 {
-                    this.InvokeAsync(new Action(() =>
+                    this.InvokeAsync(() =>
                     {
                         if (_process == null)
                         {
@@ -129,7 +129,7 @@ namespace GitUI.UserControls
                         _process = null;
                         _timer.Stop(true);
                         FireProcessExited();
-                    }));
+                    });
                 };
 
                 process.Exited += (sender, args) =>

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -388,7 +388,7 @@ namespace GitUI
                 FileStatusListView.ContextMenuStrip = value;
                 if (FileStatusListView.ContextMenuStrip != null)
                 {
-                    FileStatusListView.ContextMenuStrip.Opening += new CancelEventHandler(FileStatusListView_ContextMenu_Opening);
+                    FileStatusListView.ContextMenuStrip.Opening += FileStatusListView_ContextMenu_Opening;
                 }
             }
         }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -170,8 +170,6 @@ namespace GitUI
                 ListViewItem currentItem = FileStatusListView.Items[curIdx];
                 var currentGroup = currentItem.Group;
 
-                int maxIdx = GitItemStatuses.Count() - 1;
-
                 if (searchBackward)
                 {
                     var nextItem = FindPrevItemInGroups(curIdx, currentGroup);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1174,7 +1174,7 @@ namespace GitUI
                 {
                     if (!AppSettings.ShowDiffForAllParents)
                     {
-                        parentRevs = new GitRevision[] { parentRevs[0] };
+                        parentRevs = new[] { parentRevs[0] };
                     }
 
                     foreach (var rev in parentRevs)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -892,7 +892,7 @@ namespace GitUI
                 ListViewGroup group = null;
                 if (pair.Key != null)
                 {
-                    var groupName = "";
+                    string groupName;
                     if (pair.Key.Guid == CombinedDiff.Text)
                     {
                         groupName = CombinedDiff.Text;

--- a/GitUI/UserControls/GotoUserManualControl.cs
+++ b/GitUI/UserControls/GotoUserManualControl.cs
@@ -15,7 +15,7 @@ namespace GitUI.UserControls
             Translate();
         }
 
-        private bool _isLoaded = false;
+        private bool _isLoaded;
 
         private void GotoUserManualControl_Load(object sender, EventArgs e)
         {

--- a/GitUI/UserControls/HelpImageDisplayUserControl.cs
+++ b/GitUI/UserControls/HelpImageDisplayUserControl.cs
@@ -197,8 +197,8 @@ namespace GitUI.Help
 
             // apply size to control
             var form = TopLevelControl as Form;
-            var s = new System.Drawing.Size();
-            var ms = new System.Drawing.Size();
+            var s = new Size();
+            var ms = new Size();
             if (form != null)
             {
                 s = form.Size;
@@ -207,7 +207,7 @@ namespace GitUI.Help
                 if (!ms.IsEmpty)
                 {
                     ms.Width -= Size.Width;
-                    form.MinimumSize = new System.Drawing.Size();
+                    form.MinimumSize = new Size();
                 }
             }
 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2144,7 +2144,7 @@ namespace GitUI
             NotFilled
         }
 
-        private static readonly float[] dashPattern = new float[] { 4, 4 };
+        private static readonly float[] dashPattern = { 4, 4 };
 
         private float DrawHeadBackground(bool isSelected, Graphics graphics, Color color,
             float x, float y, float width, float height, float radius, ArrowType arrowType, bool dashedLine, bool fill)

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -205,7 +205,7 @@ namespace GitUI
         {
             foreach (var menuCommand in menuCommands)
             {
-                var toolStripItem = (ToolStripItem)MenuCommand.CreateToolStripItem(menuCommand);
+                var toolStripItem = MenuCommand.CreateToolStripItem(menuCommand);
                 var toolStripMenuItem = toolStripItem as ToolStripMenuItem;
                 if (toolStripMenuItem != null)
                 {
@@ -1505,7 +1505,7 @@ namespace GitUI
 
             if (AppSettings.MaxRevisionGraphCommits > 0)
             {
-                revListParams += string.Format("--max-count=\"{0}\" ", (int)AppSettings.MaxRevisionGraphCommits);
+                revListParams += string.Format("--max-count=\"{0}\" ", AppSettings.MaxRevisionGraphCommits);
             }
 
             return Module.ReadGitOutputLines(revListParams + initRevision).ToArray();

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1913,7 +1913,7 @@ namespace GitUI
                 }
                 else if (columnIndex == BuildServerWatcher.BuildStatusImageColumnIndex)
                 {
-                    BuildInfoDrawingLogic.BuildStatusImageColumnCellPainting(e, revision, foreBrush, rowFont);
+                    BuildInfoDrawingLogic.BuildStatusImageColumnCellPainting(e, revision);
                 }
                 else if (columnIndex == BuildServerWatcher.BuildStatusMessageColumnIndex)
                 {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -94,7 +94,7 @@ namespace GitUI
         private readonly NavigationHistory _navigationHistory = new NavigationHistory();
         private readonly AuthorEmailBasedRevisionHighlighting _revisionHighlighting;
 
-        private GitRevision _baseCommitToCompare = null;
+        private GitRevision _baseCommitToCompare;
 
         // tracks status for the artificial commits while the revision graph is reloading
         private IList<GitItemStatus> _artificialStatus;
@@ -366,7 +366,7 @@ namespace GitUI
             _initialSelectedRevision = initialSelectedRevision;
         }
 
-        private bool _isRefreshingRevisions = false;
+        private bool _isRefreshingRevisions;
         private bool _isLoading;
         private void RevisionsLoading(object sender, DvcsGraph.LoadingEventArgs e)
         {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -125,7 +125,7 @@ namespace GitUI
             _parentChildNavigationHistory = new ParentChildNavigationHistory(revision => SetSelectedRevision(revision));
             _revisionHighlighting = new AuthorEmailBasedRevisionHighlighting();
 
-            Loading.Image = global::GitUI.Properties.Resources.loadingpanel;
+            Loading.Image = Resources.loadingpanel;
 
             Translate();
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Junction.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Junction.cs
@@ -65,11 +65,11 @@ namespace GitUI.RevisionGridClasses
                     }
                     else
                     {
-                        throw new ArgumentException("Parent has no children:\n" + parent.ToString());
+                        throw new ArgumentException("Parent has no children:\n" + parent);
                     }
                 }
 
-                throw new ArgumentException("Junction:\n" + ToString() + "\ndoesn't contain this parent:\n" + parent.ToString());
+                throw new ArgumentException("Junction:\n" + ToString() + "\ndoesn't contain this parent:\n" + parent);
             }
 
             public int NodesCount => _nodes.Count;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Lanes.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Lanes.cs
@@ -900,7 +900,7 @@ namespace GitUI.RevisionGridClasses
 
                 #region LaneRow Members
 
-                public int NodeLane { get; } = -1;
+                public int NodeLane { get; }
 
                 public Node Node { get; }
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1414,7 +1414,7 @@ namespace GitUI.RevisionGridClasses
             {
                 if (Data == null)
                 {
-                    string name = Id.ToString();
+                    string name = Id;
                     if (name.Length > 8)
                     {
                         name = name.Substring(0, 4) + ".." + name.Substring(name.Length - 4, 4);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1206,7 +1206,7 @@ namespace GitUI.RevisionGridClasses
                     }
                     finally
                     {
-                        ((IDisposable)brushLineColorPen)?.Dispose();
+                        brushLineColorPen?.Dispose();
                         ((IDisposable)brushLineColor)?.Dispose();
                     }
                 }

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -23,7 +23,7 @@ namespace GitUI.RevisionGridClasses
                 IsLoading = isLoading;
             }
 
-            public bool IsLoading { get; private set; }
+            public bool IsLoading { get; }
         }
 
         #endregion

--- a/GitUI/UserControls/RevisionGridClasses/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGridClasses/IndexWatcher.cs
@@ -11,7 +11,7 @@ namespace GitUI.UserControls.RevisionGridClasses
             IsIndexChanged = isIndexChanged;
         }
 
-        public bool IsIndexChanged { get; private set; }
+        public bool IsIndexChanged { get; }
     }
 
     public sealed class IndexWatcher : IDisposable
@@ -101,8 +101,8 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         private bool _enabled;
         private string _gitDirPath;
-        private FileSystemWatcher GitIndexWatcher { get; set; }
-        private FileSystemWatcher RefsWatcher { get; set; }
+        private FileSystemWatcher GitIndexWatcher { get; }
+        private FileSystemWatcher RefsWatcher { get; }
 
         private void fileSystemWatcher_Changed(object sender, FileSystemEventArgs e)
         {

--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -87,16 +87,16 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "GotoCurrentRevision",
                     Text = "Go to current revision",
-                    Image = global::GitUI.Properties.Resources.IconGotoCurrentRevision,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.SelectCurrentRevision),
+                    Image = Properties.Resources.IconGotoCurrentRevision,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.SelectCurrentRevision),
                     ExecuteAction = SelectCurrentRevisionExecute
                 },
                 new MenuCommand
                 {
                     Name = "GotoCommit",
                     Text = "Go to commit...",
-                    Image = global::GitUI.Properties.Resources.IconGotoCommit,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.GoToCommit),
+                    Image = Properties.Resources.IconGotoCommit,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.GoToCommit),
                     ExecuteAction = GotoCommitExcecute
                 },
                 MenuCommand.CreateSeparator(),
@@ -104,15 +104,15 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "GotoChildCommit",
                     Text = "Go to child commit",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.GoToChild),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.GoToChild)
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.GoToChild),
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.GoToChild)
                 },
                 new MenuCommand
                 {
                     Name = "GotoParentCommit",
                     Text = "Go to parent commit",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.GoToParent),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.GoToParent)
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.GoToParent),
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.GoToParent)
                 },
                 MenuCommand.CreateSeparator(),
                 new MenuCommand
@@ -120,14 +120,14 @@ namespace GitUI.UserControls.RevisionGridClasses
                     Name = "NavigateBackward",
                     Text = "Navigate backward",
                     ShortcutKeyDisplayString = (Keys.Alt | Keys.Left).ToShortcutKeyDisplayString(),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.NavigateBackward)
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.NavigateBackward)
                 },
                 new MenuCommand
                 {
                     Name = "NavigateForward",
                     Text = "Navigate forward",
                     ShortcutKeyDisplayString = (Keys.Alt | Keys.Right).ToShortcutKeyDisplayString(),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.NavigateForward)
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.NavigateForward)
                 },
                 MenuCommand.CreateSeparator(),
                 new MenuCommand
@@ -140,15 +140,15 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "PrevQuickSearch",
                     Text = "Quick search previous",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.PrevQuickSearch),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.PrevQuickSearch)
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.PrevQuickSearch),
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.PrevQuickSearch)
                 },
                 new MenuCommand
                 {
                     Name = "NextQuickSearch",
                     Text = "Quick search next",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.NextQuickSearch),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.NextQuickSearch)
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.NextQuickSearch),
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.NextQuickSearch)
                 }
             };
         }
@@ -156,7 +156,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         /// <summary>
         /// this is needed because _revsionGrid is null when TranslationApp is called
         /// </summary>
-        private string GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands revGridCommands)
+        private string GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands revGridCommands)
         {
             return _revisionGrid?.GetShortcutKeys(revGridCommands).ToShortcutKeyDisplayString();
         }
@@ -174,7 +174,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "ShowAllBranches",
                     Text = "Show all branches",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ShowAllBranches),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ShowAllBranches),
                     ExecuteAction = () => _revisionGrid.ShowAllBranches_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => _revisionGrid.ShowAllBranches_ToolStripMenuItemChecked
                 },
@@ -182,7 +182,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "ShowCurrentBranchOnly",
                     Text = "Show current branch only",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ShowCurrentBranchOnly),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ShowCurrentBranchOnly),
                     ExecuteAction = () => _revisionGrid.ShowCurrentBranchOnly_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => _revisionGrid.ShowCurrentBranchOnly_ToolStripMenuItemChecked
                 },
@@ -190,7 +190,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "ShowFilteredBranches",
                     Text = "Show filtered branches",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ShowFilteredBranches),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ShowFilteredBranches),
                     ExecuteAction = () => _revisionGrid.ShowFilteredBranches_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => _revisionGrid.ShowFilteredBranches_ToolStripMenuItemChecked
                 },
@@ -201,7 +201,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "ShowRemoteBranches",
                     Text = "Show remote branches",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ShowRemoteBranches),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ShowRemoteBranches),
                     ExecuteAction = () => _revisionGrid.ShowRemoteBranches_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => AppSettings.ShowRemoteBranches
                 },
@@ -278,7 +278,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "showMergeCommitsToolStripMenuItem",
                     Text = "Show merge commits",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleShowMergeCommits),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ToggleShowMergeCommits),
                     ExecuteAction = () => _revisionGrid.ShowMergeCommits_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => AppSettings.ShowMergeCommits
                 },
@@ -286,7 +286,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "showTagsToolStripMenuItem",
                     Text = "Show tags",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleShowTags),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ToggleShowTags),
                     ExecuteAction = () => _revisionGrid.ShowTags_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => AppSettings.ShowTags
                 },
@@ -322,14 +322,14 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "ToggleHighlightSelectedBranch",
                     Text = "Highlight selected branch (until refresh)",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleHighlightSelectedBranch),
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.ToggleHighlightSelectedBranch)
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ToggleHighlightSelectedBranch),
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGrid.Commands.ToggleHighlightSelectedBranch)
                 },
                 new MenuCommand
                 {
                     Name = "ToggleRevisionCardLayout",
                     Text = "Change commit view layout",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ToggleRevisionCardLayout),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ToggleRevisionCardLayout),
                     ExecuteAction = () => _revisionGrid.ToggleRevisionCardLayout()
                 },
 
@@ -339,8 +339,8 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "showFirstParent",
                     Text = "Show first parents",
-                    Image = global::GitUI.Properties.Resources.IconShowFirstParent,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.ShowFirstParent),
+                    Image = Properties.Resources.IconShowFirstParent,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.ShowFirstParent),
                     ExecuteAction = () => _revisionGrid.ShowFirstParent_ToolStripMenuItemClick(null, null),
                     IsCheckedFunc = () => AppSettings.ShowFirstParent
                 },
@@ -348,8 +348,8 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "filterToolStripMenuItem",
                     Text = "Set advanced filter",
-                    Image = global::GitUI.Properties.Resources.IconFilter,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(GitUI.RevisionGrid.Commands.RevisionFilter),
+                    Image = Properties.Resources.IconFilter,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGrid.Commands.RevisionFilter),
                     ExecuteAction = () => _revisionGrid.FilterToolStripMenuItemClick(null, null)
                 }
             };
@@ -389,7 +389,7 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         public void SelectCurrentRevisionExecute()
         {
-            _revisionGrid.ExecuteCommand(GitUI.RevisionGrid.Commands.SelectCurrentRevision);
+            _revisionGrid.ExecuteCommand(RevisionGrid.Commands.SelectCurrentRevision);
         }
 
         public void GotoCommitExcecute()

--- a/GitUI/UserManual/SingleHtmlUserManual.cs
+++ b/GitUI/UserManual/SingleHtmlUserManual.cs
@@ -14,7 +14,7 @@ namespace GitUI.UserManual
                 if (_location == null)
                 {
                     var path = Path.Combine(AppSettings.GetInstallDir(), "help");
-                    var uri = new System.Uri(path);
+                    var uri = new Uri(path);
                     _location = uri.AbsolutePath;
                 }
 

--- a/GitUI/WebBrowserEmulationMode.cs
+++ b/GitUI/WebBrowserEmulationMode.cs
@@ -37,7 +37,7 @@ namespace GitUI
             emulationMode = 11000; // Internet Explorer 11. Webpages containing standards-based !DOCTYPE directives are displayed in IE11 Standards mode.
             try
             {
-                int browserVersion = 0;
+                int browserVersion;
                 using (var ieKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Internet Explorer",
                     RegistryKeyPermissionCheck.ReadSubTree,
                     System.Security.AccessControl.RegistryRights.QueryValues))

--- a/GitUI/WebBrowserEmulationMode.cs
+++ b/GitUI/WebBrowserEmulationMode.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Microsoft.Win32;
 
 namespace GitUI

--- a/NetSpell.SpellChecker/Dictionary/Affix/AffixUtility.cs
+++ b/NetSpell.SpellChecker/Dictionary/Affix/AffixUtility.cs
@@ -224,7 +224,6 @@ namespace NetSpell.SpellChecker.Dictionary.Affix
             } // foreach char
 
             entry.ConditionCount = num;
-            return;
         }
 
         /// <summary>

--- a/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
+++ b/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
@@ -20,11 +20,11 @@ namespace NetSpell.SpellChecker.Dictionary
     /// <summary>
     /// The WordDictionary class contains all the logic for managing the word list.
     /// </summary>
-    [ToolboxBitmap(typeof(NetSpell.SpellChecker.Dictionary.WordDictionary), "Dictionary.bmp")]
-    public class WordDictionary : System.ComponentModel.Component
+    [ToolboxBitmap(typeof(WordDictionary), "Dictionary.bmp")]
+    public class WordDictionary : Component
     {
         private string _dictionaryFile = Thread.CurrentThread.CurrentCulture.Name + ".dic";
-        private System.ComponentModel.Container _components;
+        private Container _components;
 
         /// <summary>
         ///     Initializes a new instance of the class
@@ -37,7 +37,7 @@ namespace NetSpell.SpellChecker.Dictionary
         /// <summary>
         ///     Initializes a new instance of the class
         /// </summary>
-        public WordDictionary(System.ComponentModel.IContainer container)
+        public WordDictionary(IContainer container)
         {
             container.Add(this);
             InitializeComponent();

--- a/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
+++ b/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
@@ -546,13 +546,12 @@ namespace NetSpell.SpellChecker.Dictionary
         public string PhoneticCode(string word)
         {
             string tempWord = word.ToUpper();
-            string prevWord = "";
             StringBuilder code = new StringBuilder();
 
             while (tempWord.Length > 0)
             {
                 // save previous word
-                prevWord = tempWord;
+                var prevWord = tempWord;
                 foreach (PhoneticRule rule in PhoneticRules)
                 {
                     bool begining = tempWord.Length == word.Length ? true : false;

--- a/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
+++ b/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
@@ -554,8 +554,8 @@ namespace NetSpell.SpellChecker.Dictionary
                 var prevWord = tempWord;
                 foreach (PhoneticRule rule in PhoneticRules)
                 {
-                    bool begining = tempWord.Length == word.Length ? true : false;
-                    bool ending = rule.ConditionCount == tempWord.Length ? true : false;
+                    bool begining = tempWord.Length == word.Length;
+                    bool ending = rule.ConditionCount == tempWord.Length;
 
                     if ((rule.BeginningOnly == begining || !rule.BeginningOnly)
                         && (rule.EndOnly == ending || !rule.EndOnly)

--- a/NetSpell.SpellChecker/Spelling.cs
+++ b/NetSpell.SpellChecker/Spelling.cs
@@ -16,8 +16,8 @@ namespace NetSpell.SpellChecker
     ///     The Spelling class encapsulates the functions necessary to check
     ///     the spelling of inputted text.
     /// </summary>
-    [ToolboxBitmap(typeof(NetSpell.SpellChecker.Spelling), "Spelling.bmp")]
-    public class Spelling : System.ComponentModel.Component
+    [ToolboxBitmap(typeof(Spelling), "Spelling.bmp")]
+    public class Spelling : Component
     {
         #region Global Regex
         // Regex are class scope and compiled to improve performance on reuse
@@ -32,7 +32,7 @@ namespace NetSpell.SpellChecker
         #endregion
 
         #region private variables
-        private System.ComponentModel.Container _components;
+        private Container _components;
         #endregion
 
         #region Events
@@ -91,7 +91,7 @@ namespace NetSpell.SpellChecker
         ///     This represents the delegate method prototype that
         ///     event receivers must implement
         /// </summary>
-        public delegate void EndOfTextEventHandler(object sender, System.EventArgs e);
+        public delegate void EndOfTextEventHandler(object sender, EventArgs e);
 
         /// <summary>
         ///     This represents the delegate method prototype that
@@ -133,7 +133,7 @@ namespace NetSpell.SpellChecker
         ///     This is the method that is responsible for notifying
         ///     receivers that the event occurred
         /// </summary>
-        protected virtual void OnEndOfText(System.EventArgs e)
+        protected virtual void OnEndOfText(EventArgs e)
         {
             EndOfText?.Invoke(this, e);
         }
@@ -180,7 +180,7 @@ namespace NetSpell.SpellChecker
         /// <summary>
         ///     Required for Windows.Forms Class Composition Designer support
         /// </summary>
-        public Spelling(System.ComponentModel.IContainer container)
+        public Spelling(IContainer container)
         {
             container.Add(this);
             InitializeComponent();
@@ -874,7 +874,7 @@ namespace NetSpell.SpellChecker
             if (startWordIndex > endWordIndex || _words == null || _words.Count == 0)
             {
                 // make sure end index is not greater then word count
-                OnEndOfText(System.EventArgs.Empty);    // raise event
+                OnEndOfText(EventArgs.Empty);    // raise event
                 return false;
             }
 
@@ -918,7 +918,7 @@ namespace NetSpell.SpellChecker
 
             if (_wordIndex >= _words.Count - 1 && !misspelledWord)
             {
-                OnEndOfText(System.EventArgs.Empty);    // raise event
+                OnEndOfText(EventArgs.Empty);    // raise event
             }
 
             return misspelledWord;

--- a/NetSpell.SpellChecker/Spelling.cs
+++ b/NetSpell.SpellChecker/Spelling.cs
@@ -880,13 +880,12 @@ namespace NetSpell.SpellChecker
 
             Initialize();
 
-            string currentWord = "";
             bool misspelledWord = false;
 
             for (int i = startWordIndex; i <= endWordIndex; i++)
             {
                 WordIndex = i; // saving the current word index
-                currentWord = CurrentWord;
+                var currentWord = CurrentWord;
 
                 if (CheckString(currentWord))
                 {

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -75,7 +75,7 @@ namespace Bitbucket
                         ddlRepositoryTarget.Enabled = true;
                     });
                 }
-                catch (System.InvalidOperationException)
+                catch (InvalidOperationException)
                 {
                 }
             });
@@ -99,9 +99,8 @@ namespace Bitbucket
                         lbxPullRequests.DisplayMember = "DisplayName";
                     });
                 }
-                catch (System.InvalidOperationException)
+                catch (InvalidOperationException)
                 {
-                    return;
                 }
             });
         }

--- a/Plugins/Bitbucket/BitbucketRequestBase.cs
+++ b/Plugins/Bitbucket/BitbucketRequestBase.cs
@@ -19,7 +19,7 @@ namespace Bitbucket
 
     internal abstract class BitbucketRequestBase<T>
     {
-        protected Settings Settings { get; private set; }
+        protected Settings Settings { get; }
 
         protected BitbucketRequestBase(Settings settings)
         {

--- a/Plugins/Bitbucket/BitbucketRequestBase.cs
+++ b/Plugins/Bitbucket/BitbucketRequestBase.cs
@@ -85,7 +85,7 @@ namespace Bitbucket
 
         private static BitbucketResponse<T> ParseErrorResponse(string jsonString)
         {
-            var json = new JObject();
+            JObject json;
             try
             {
                 System.Console.WriteLine(jsonString);

--- a/Plugins/Bitbucket/GetPullRequest.cs
+++ b/Plugins/Bitbucket/GetPullRequest.cs
@@ -37,7 +37,7 @@ namespace Bitbucket
             }
             else
             {
-                reviewers.ForEach(r => request.Reviewers += r["user"]["displayName"] + " (" + r["approved"] + ")" + System.Environment.NewLine);
+                reviewers.ForEach(r => request.Reviewers += r["user"]["displayName"] + " (" + r["approved"] + ")" + Environment.NewLine);
                 if (request.Reviewers.EndsWith(", "))
                 {
                     request.Reviewers = request.Reviewers.Substring(0, request.Reviewers.Length - 2);
@@ -50,7 +50,7 @@ namespace Bitbucket
             }
             else
             {
-                participants.ForEach(r => request.Reviewers += r["user"]["displayName"] + " (" + r["approved"] + ")" + System.Environment.NewLine);
+                participants.ForEach(r => request.Reviewers += r["user"]["displayName"] + " (" + r["approved"] + ")" + Environment.NewLine);
                 if (request.Reviewers.EndsWith(", "))
                 {
                     request.Reviewers = request.Reviewers.Substring(0, request.Reviewers.Length - 2);

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -414,13 +414,12 @@ namespace AppVeyorIntegration
                 buildDetails.Duration = GetBuildDuration(buildData);
             }
 
-            string testResults = string.Empty;
             int testCount = buildDescription["testsCount"].ToObject<int>();
             if (testCount != 0)
             {
                 int failedTestCount = buildDescription["failedTestsCount"].ToObject<int>();
                 int skippedTestCount = testCount - buildDescription["passedTestsCount"].ToObject<int>();
-                testResults = " : " + testCount + " tests";
+                var testResults = " : " + testCount + " tests";
                 if (failedTestCount != 0 || skippedTestCount != 0)
                 {
                     testResults += string.Format(" ( {0} failed, {1} skipped )", failedTestCount, skippedTestCount);

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -81,7 +81,7 @@ namespace JenkinsIntegration
 
                 UpdateHttpClientOptions(buildServerCredentials);
 
-                string[] projectUrls = projectName.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] projectUrls = projectName.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var projectUrl in projectUrls.Select(s => baseAdress + "job/" + s.Trim() + "/"))
                 {
                     AddGetBuildUrl(projectUrl);

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -110,7 +110,7 @@ namespace TeamCityIntegration
 
             _buildServerWatcher = buildServerWatcher;
 
-            ProjectNames = config.GetString("ProjectName", "").Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            ProjectNames = config.GetString("ProjectName", "").Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
 
             var buildIdFilerSetting = config.GetString("BuildIdFilter", "");
             if (!BuildServerSettingsHelper.IsRegexValid(buildIdFilerSetting))

--- a/Plugins/BuildServerIntegration/TfsIntegration/Properties/AssemblyInfo.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/Properties/AssemblyInfo.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion(Properties.Version)]
 [assembly: AssemblyFileVersion(Properties.Version)]
 
-partial class Properties
+internal static class Properties
 {
     public const string Version = "0.0.1";
 }

--- a/Plugins/BuildServerIntegration/TfsInterop.Common/Properties/AssemblyInfo.cs
+++ b/Plugins/BuildServerIntegration/TfsInterop.Common/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion(Properties.Version)]
 [assembly: AssemblyFileVersion(Properties.Version)]
 
-partial class Properties
+internal static class Properties
 {
     public const string Version = "0.0.1";
 }

--- a/Plugins/BuildServerIntegration/TfsInterop.Common/TfsHelper.cs
+++ b/Plugins/BuildServerIntegration/TfsInterop.Common/TfsHelper.cs
@@ -74,7 +74,7 @@ namespace TfsInterop
                 {
                     _buildDefinitions = string.IsNullOrWhiteSpace(buildDefinitionNameFilter.ToString())
                         ? buildDefs
-                        : buildDefs.Where(b => buildDefinitionNameFilter.IsMatch(b.Name)).Cast<IBuildDefinition>().ToArray();
+                        : buildDefs.Where(b => buildDefinitionNameFilter.IsMatch(b.Name)).ToArray();
                 }
             }
             catch (Exception ex)

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsHelper2015.cs
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsHelper2015.cs
@@ -80,7 +80,7 @@ namespace TfsInterop
                 {
                     _buildDefinitions = string.IsNullOrWhiteSpace(buildDefinitionNameFilter.ToString())
                         ? buildDefs
-                        : buildDefs.Where(b => buildDefinitionNameFilter.IsMatch(b.Name)).Cast<IBuildDefinition>().ToArray();
+                        : buildDefs.Where(b => buildDefinitionNameFilter.IsMatch(b.Name)).ToArray();
                 }
 
                 ConnectToTfsServer2015(hostname, teamCollection, projectName, buildDefinitionNameFilter);

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsHelper2015.cs
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsHelper2015.cs
@@ -34,7 +34,6 @@ namespace TfsInterop
         private string _urlPrefix;
         private IBuildServer _buildServer;
         private TfsTeamProjectCollection _tfsCollection;
-        private VssConnection _connection;
         private BuildHttpClient _buildClient;
         private string _projectName;
 
@@ -282,7 +281,6 @@ namespace TfsInterop
 
                 _buildDefinitions2015 = buildDefs.ToArray();
                 _buildClient = buildClient;
-                _connection = connection;
                 _projectName = projectName;
             }
             catch (Exception ex)
@@ -487,7 +485,6 @@ namespace TfsInterop
             _tfsCollection?.Dispose();
             _buildDefinitions = null;
             _buildDefinitions2015 = null;
-            _connection = null;
             _buildClient = null;
             GC.Collect();
         }

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsHelper2015.cs
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsHelper2015.cs
@@ -42,7 +42,7 @@ namespace TfsInterop
             try
             {
                 Trace.WriteLine("Test if Microsoft.TeamFoundation.Build assemblies dependencies are present : " + Microsoft.TeamFoundation.Build.Client.BuildStatus.Succeeded.ToString("G"));
-                return true && IsDependencyOk2015();
+                return IsDependencyOk2015();
             }
             catch (Exception)
             {

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
@@ -16,7 +16,7 @@ namespace CreateLocalBranches
         {
             using (var frm = new CreateLocalBranchesForm(gitUiCommands))
             {
-                frm.ShowDialog(gitUiCommands.OwnerForm as IWin32Window);
+                frm.ShowDialog(gitUiCommands.OwnerForm);
             }
 
             return true;

--- a/Plugins/DeleteUnusedBranches/Branch.cs
+++ b/Plugins/DeleteUnusedBranches/Branch.cs
@@ -13,10 +13,10 @@ namespace DeleteUnusedBranches
             Delete = delete;
         }
 
-        public string Name { get; private set; }
-        public DateTime Date { get; private set; }
+        public string Name { get; }
+        public DateTime Date { get; }
         public bool Delete { get; set; }
-        public string Author { get; private set; }
-        public string Message { get; private set; }
+        public string Author { get; }
+        public string Message { get; }
     }
 }

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesFormSettings.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesFormSettings.cs
@@ -24,14 +24,14 @@
             IncludeUnmergedBranchesFlag = includeUnmergedBranchesFlag;
         }
 
-        public string MergedInBranch { get; private set; }
-        public int DaysOlderThan { get; private set; }
-        public bool DeleteRemoteBranchesFromFlag { get; private set; }
-        public string RemoteName { get; private set; }
-        public bool UseRegexToFilterBranchesFlag { get; private set; }
-        public string RegexFilter { get; private set; }
-        public bool RegexCaseInsensitiveFlag { get; private set; }
-        public bool RegexInvertedFlag { get; private set; }
-        public bool IncludeUnmergedBranchesFlag { get; private set; }
+        public string MergedInBranch { get; }
+        public int DaysOlderThan { get; }
+        public bool DeleteRemoteBranchesFromFlag { get; }
+        public string RemoteName { get; }
+        public bool UseRegexToFilterBranchesFlag { get; }
+        public string RegexFilter { get; }
+        public bool RegexCaseInsensitiveFlag { get; }
+        public bool RegexInvertedFlag { get; }
+        public bool IncludeUnmergedBranchesFlag { get; }
     }
 }

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -81,7 +81,7 @@ namespace FindLargeFiles
                         pbRevisions.Invoke((Action)(() => pbRevisions.Value = pbRevisions.Value + (int)((_revList.Length * 0.1f) / packFiles.Length)));
                         foreach (var gitobj in objects.Where(x => x.Contains(" blob ")))
                         {
-                            string[] dataFields = gitobj.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                            string[] dataFields = gitobj.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                             if (_list.TryGetValue(dataFields[0], out var curGitObject))
                             {
                                 if (int.TryParse(dataFields[3], out var compressedSize))
@@ -105,7 +105,7 @@ namespace FindLargeFiles
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            _revList = _gitCommands.RunGitCmd("rev-list HEAD").Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            _revList = _gitCommands.RunGitCmd("rev-list HEAD").Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
             pbRevisions.Maximum = (int)(_revList.Length * 1.1f);
             BranchesGrid.DataSource = _gitObjects;
             Thread thread = new Thread(FindLargeFilesFunction);
@@ -119,12 +119,12 @@ namespace FindLargeFiles
             {
                 pbRevisions.Invoke((Action)(() => pbRevisions.Value = i));
                 string rev = _revList[i];
-                string[] objects = _gitCommands.RunGitCmd(string.Concat("ls-tree -zrl ", rev)).Split(new char[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] objects = _gitCommands.RunGitCmd(string.Concat("ls-tree -zrl ", rev)).Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string objData in objects)
                 {
                     // "100644 blob b17a497cdc6140aa3b9a681344522f44768165ac 2120195\tBin/Dictionaries/de-DE.dic"
                     var dataPack = objData.Split('\t');
-                    var data = dataPack[0].Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    var data = dataPack[0].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                     if (data[1] == "blob")
                     {
                         int.TryParse(data[3], out var size);

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -153,8 +153,7 @@ namespace Gerrit
 
                 // Don't use the Gerrit change number as a topic branch.
 
-                int unused;
-                if (int.TryParse(branchName, out unused))
+                if (int.TryParse(branchName, out _))
                 {
                     branchName = null;
                 }

--- a/Plugins/Gerrit/FormGitReview.cs
+++ b/Plugins/Gerrit/FormGitReview.cs
@@ -127,13 +127,12 @@ namespace Gerrit
                         if (!SaveGitReview())
                         {
                             e.Cancel = true;
-                            return;
                         }
 
                         break;
                     case DialogResult.Cancel:
                         e.Cancel = true;
-                        return;
+                        break;
                 }
             }
         }

--- a/Plugins/Gerrit/GerritSettings.cs
+++ b/Plugins/Gerrit/GerritSettings.cs
@@ -98,7 +98,7 @@ namespace Gerrit
 
                     if (trimmed[0] == '[')
                     {
-                        inHeader = trimmed.Trim(new[] { '[', ']' }).Equals("gerrit", StringComparison.OrdinalIgnoreCase);
+                        inHeader = trimmed.Trim('[', ']').Equals("gerrit", StringComparison.OrdinalIgnoreCase);
                     }
                     else if (inHeader)
                     {

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -19,7 +19,7 @@ namespace GitFlow
 
         private readonly GitUIBaseEventArgs _gitUiCommands;
 
-        private Dictionary<string, List<string>> Branches { get; set; }
+        private Dictionary<string, List<string>> Branches { get; }
 
         private readonly AsyncLoader _task = new AsyncLoader();
 

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildServerAdapterMetadataAttribute.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildServerAdapterMetadataAttribute.cs
@@ -18,7 +18,7 @@ namespace GitUIPluginInterfaces.BuildServerIntegration
             BuildServerType = buildServerType;
         }
 
-        public string BuildServerType { get; private set; }
+        public string BuildServerType { get; }
 
         public virtual string CanBeLoaded => null;
     }

--- a/Plugins/GitUIPluginInterfaces/GitUIBaseEventArgs.cs
+++ b/Plugins/GitUIPluginInterfaces/GitUIBaseEventArgs.cs
@@ -18,12 +18,12 @@ namespace GitUIPluginInterfaces
             Arguments = arguments;
         }
 
-        public IGitUICommands GitUICommands { get; private set; }
+        public IGitUICommands GitUICommands { get; }
 
-        public IWin32Window OwnerForm { get; private set; }
+        public IWin32Window OwnerForm { get; }
 
         public IGitModule GitModule => GitUICommands.GitModule;
 
-        public string Arguments { get; private set; }
+        public string Arguments { get; }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/GitUIPostActionEventArgs.cs
+++ b/Plugins/GitUIPluginInterfaces/GitUIPostActionEventArgs.cs
@@ -4,7 +4,7 @@ namespace GitUIPluginInterfaces
 {
     public class GitUIPostActionEventArgs : GitUIBaseEventArgs
     {
-        public bool ActionDone { get; private set; }
+        public bool ActionDone { get; }
 
         public GitUIPostActionEventArgs(IWin32Window ownerForm, IGitUICommands gitUICommands, bool actionDone)
             : base(ownerForm, gitUICommands)

--- a/Plugins/GitUIPluginInterfaces/IGitRemoteCommand.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitRemoteCommand.cs
@@ -18,7 +18,7 @@ namespace GitUIPluginInterfaces
 
     public class GitRemoteCommandCompletedEventArgs : EventArgs
     {
-        public IGitRemoteCommand Command { get; private set; }
+        public IGitRemoteCommand Command { get; }
 
         public bool IsError { get; set; }
 

--- a/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
@@ -36,12 +36,12 @@ namespace GitUIPluginInterfaces
 
         public void SetBool(string name, bool? value)
         {
-            SetValue<bool?>(name, value, (bool? b) => b.HasValue ? (b.Value ? "true" : "false") : null);
+            SetValue(name, value, (bool? b) => b.HasValue ? (b.Value ? "true" : "false") : null);
         }
 
         public void SetInt(string name, int? value)
         {
-            SetValue<int?>(name, value, (int? b) => b.HasValue ? b.ToString() : null);
+            SetValue(name, value, (int? b) => b.HasValue ? b.ToString() : null);
         }
 
         public int? GetInt(string name)
@@ -59,7 +59,7 @@ namespace GitUIPluginInterfaces
 
         public void SetFloat(string name, float? value)
         {
-            SetValue<float?>(name, value, (float? b) => b.HasValue ? b.ToString() : null);
+            SetValue(name, value, (float? b) => b.HasValue ? b.ToString() : null);
         }
 
         public float? GetFloat(string name)
@@ -82,7 +82,7 @@ namespace GitUIPluginInterfaces
 
         public void SetDate(string name, DateTime? value)
         {
-            SetValue<DateTime?>(name, value, (DateTime? b) => b?.ToString("yyyy/M/dd", CultureInfo.InvariantCulture));
+            SetValue(name, value, (DateTime? b) => b?.ToString("yyyy/M/dd", CultureInfo.InvariantCulture));
         }
 
         public DateTime? GetDate(string name)
@@ -105,17 +105,17 @@ namespace GitUIPluginInterfaces
 
         public void SetFont(string name, Font value)
         {
-            SetValue<Font>(name, value, x => x.AsString());
+            SetValue(name, value, x => x.AsString());
         }
 
         public Font GetFont(string name, Font defaultValue)
         {
-            return GetValue<Font>(name, defaultValue, x => x.Parse(defaultValue));
+            return GetValue(name, defaultValue, x => x.Parse(defaultValue));
         }
 
         public void SetColor(string name, Color? value)
         {
-            SetValue<Color?>(name, value, x => x.HasValue ? ColorTranslator.ToHtml(x.Value) : null);
+            SetValue(name, value, x => x.HasValue ? ColorTranslator.ToHtml(x.Value) : null);
         }
 
         public Color? GetColor(string name)
@@ -130,12 +130,12 @@ namespace GitUIPluginInterfaces
 
         public void SetEnum<T>(string name, T value)
         {
-            SetValue<T>(name, value, x => x.ToString());
+            SetValue(name, value, x => x.ToString());
         }
 
         public T GetEnum<T>(string name, T defaultValue) where T : struct
         {
-            return GetValue<T>(name, defaultValue, x =>
+            return GetValue(name, defaultValue, x =>
             {
                 var val = x.ToString();
 
@@ -150,7 +150,7 @@ namespace GitUIPluginInterfaces
 
         public void SetNullableEnum<T>(string name, T? value) where T : struct
         {
-            SetValue<T?>(name, value, x => x.HasValue ? x.ToString() : string.Empty);
+            SetValue(name, value, x => x.HasValue ? x.ToString() : string.Empty);
         }
 
         public T? GetNullableEnum<T>(string name) where T : struct
@@ -175,12 +175,12 @@ namespace GitUIPluginInterfaces
 
         public void SetString(string name, string value)
         {
-            SetValue<string>(name, value, s => string.IsNullOrEmpty(s) ? null : s);
+            SetValue(name, value, s => string.IsNullOrEmpty(s) ? null : s);
         }
 
         public string GetString(string name, string defaultValue)
         {
-            return GetValue<string>(name, defaultValue, x => x);
+            return GetValue(name, defaultValue, x => x);
         }
     }
 

--- a/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -54,7 +54,7 @@ namespace GitUIPluginInterfaces
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceError("Failed to get exports, {0}", ex.ToString());
+                    Trace.TraceError("Failed to get exports, {0}", ex);
                 }
             }
 

--- a/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
@@ -17,8 +17,8 @@ namespace GitUIPluginInterfaces
             DefaultValue = defaultValue;
         }
 
-        public string Name { get; private set; }
-        public string Caption { get; private set; }
+        public string Name { get; }
+        public string Caption { get; }
         public bool DefaultValue { get; set; }
         public CheckBox CustomControl { get; set; }
 

--- a/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
@@ -23,8 +23,8 @@ namespace GitUIPluginInterfaces
             }
         }
 
-        public string Name { get; private set; }
-        public string Caption { get; private set; }
+        public string Name { get; }
+        public string Caption { get; }
         public string DefaultValue { get; set; }
         public IList<string> Values { get; set; }
         public ComboBox CustomControl { get; set; }

--- a/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
@@ -16,8 +16,8 @@ namespace GitUIPluginInterfaces
             DefaultValue = defaultValue;
         }
 
-        public string Name { get; private set; }
-        public string Caption { get; private set; }
+        public string Name { get; }
+        public string Caption { get; }
         public T DefaultValue { get; set; }
         public TextBox CustomControl { get; set; }
 

--- a/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
@@ -16,8 +16,8 @@ namespace GitUIPluginInterfaces
             DefaultValue = defaultValue;
         }
 
-        public string Name { get; private set; }
-        public string Caption { get; private set; }
+        public string Name { get; }
+        public string Caption { get; }
         public string DefaultValue { get; set; }
         public TextBox CustomControl { get; set; }
 

--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -17,8 +17,8 @@ namespace GitUIPluginInterfaces
             DefaultValue = defaultValue;
         }
 
-        public string Name { get; private set; }
-        public string Caption { get; private set; }
+        public string Name { get; }
+        public string Caption { get; }
         public string DefaultValue { get; set; }
         public TextBox CustomControl { get; set; }
 

--- a/Plugins/Github3/GithubHostedRemote.cs
+++ b/Plugins/Github3/GithubHostedRemote.cs
@@ -25,19 +25,19 @@ namespace Github3
         /// <summary>
         /// Local name of the remote, 'origin'
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Owner of the remote repository, in
         /// git@github.com:mabako/Git.hub.git this is 'mabako'
         /// </summary>
-        public string Owner { get; private set; }
+        public string Owner { get; }
 
         /// <summary>
         /// Name of the remote repository, in
         /// git@github.com:mabako/Git.hub.git this is 'Git.hub'
         /// </summary>
-        public string RemoteRepositoryName { get; private set; }
+        public string RemoteRepositoryName { get; }
 
         public string Data => Owner + "/" + RemoteRepositoryName;
         public string DisplayData => Data;

--- a/Plugins/Github3/OAuth.cs
+++ b/Plugins/Github3/OAuth.cs
@@ -75,7 +75,7 @@ namespace Github3
 
                     GithubLoginInfo.OAuthToken = token;
 
-                    MessageBox.Show(Owner as IWin32Window, "Successfully retrieved OAuth token.", "Github Authorization");
+                    MessageBox.Show(Owner, "Successfully retrieved OAuth token.", "Github Authorization");
                 }
             }
         }

--- a/Plugins/Github3/OAuth.cs
+++ b/Plugins/Github3/OAuth.cs
@@ -15,7 +15,7 @@ namespace Github3
             webBrowser1.ScriptErrorsSuppressed = true;
         }
 
-        protected override void OnLoad(System.EventArgs e)
+        protected override void OnLoad(EventArgs e)
         {
             try
             {

--- a/Plugins/Github3/OAuth.cs
+++ b/Plugins/Github3/OAuth.cs
@@ -30,7 +30,7 @@ namespace Github3
             }
         }
 
-        private bool _gotToken = false;
+        private bool _gotToken;
 
         public void web_Navigating(object sender, WebBrowserNavigatingEventArgs e)
         {

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -68,7 +68,7 @@ namespace Gource
                             string.Format(_resetConfigPath.Text, pathToGource), _gource.Text, MessageBoxButtons.YesNo) ==
                         DialogResult.Yes)
                     {
-                        Settings.SetValue<string>(_gourcePath.Name, _gourcePath.DefaultValue, s => s);
+                        Settings.SetValue(_gourcePath.Name, _gourcePath.DefaultValue, s => s);
                         pathToGource = _gourcePath.DefaultValue;
                     }
                 }
@@ -113,8 +113,8 @@ namespace Gource
             using (var gourceStart = new GourceStart(pathToGource, eventArgs, _gourceArguments.ValueOrDefault(Settings)))
             {
                 gourceStart.ShowDialog(ownerForm);
-                Settings.SetValue<string>(_gourceArguments.Name, gourceStart.GourceArguments, s => s);
-                Settings.SetValue<string>(_gourcePath.Name, gourceStart.PathToGource, s => s);
+                Settings.SetValue(_gourceArguments.Name, gourceStart.GourceArguments, s => s);
+                Settings.SetValue(_gourcePath.Name, gourceStart.PathToGource, s => s);
             }
 
             return true;

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -51,7 +51,7 @@ namespace Gource
         public override bool Execute(GitUIBaseEventArgs eventArgs)
         {
             IGitModule gitUiCommands = eventArgs.GitModule;
-            var ownerForm = eventArgs.OwnerForm as IWin32Window;
+            var ownerForm = eventArgs.OwnerForm;
             if (!gitUiCommands.IsValidGitWorkingDir())
             {
                 MessageBox.Show(ownerForm, _currentDirectoryIsNotValidGit.Text);

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -24,7 +24,7 @@ namespace Gource
             Arguments.Text = GourceArguments;
         }
 
-        private GitUIBaseEventArgs GitUIArgs { get; set; }
+        private GitUIBaseEventArgs GitUIArgs { get; }
 
         public string PathToGource { get; set; }
 

--- a/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
+++ b/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
@@ -112,7 +112,7 @@ namespace ReleaseNotesGenerator
 
                     // Optional Source URL, used for resolving relative links.
                     case "sourceurl":
-                        SourceUrl = new System.Uri(val);
+                        SourceUrl = new Uri(val);
                         break;
                 }
             } // end for
@@ -144,7 +144,7 @@ namespace ReleaseNotesGenerator
         /// <summary>
         /// Get the Source URL of the HTML. May be null if no SourceUrl is specified. This is useful for resolving relative urls.
         /// </summary>
-        public System.Uri SourceUrl { get; }
+        public Uri SourceUrl { get; }
 
         #endregion // Read and decode from clipboard
 

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -128,7 +128,7 @@ namespace ReleaseNotesGenerator
                 stringBuilder.AppendFormat("{0}{1}{2}{3}", logLine.Commit, colSeparatorFirstLine, message, Environment.NewLine);
             }
 
-            string result = headerText + Environment.NewLine + stringBuilder.ToString();
+            string result = headerText + Environment.NewLine + stringBuilder;
             return result;
         }
 

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -373,7 +373,7 @@ namespace GitImpact
                 }
 
                 // Pre-calculate height scale factor
-                double height_factor = 0.9 * (float)Height / (float)h_max;
+                double height_factor = 0.9 * Height / h_max;
 
                 // Scale week label coordinates
                 for (int i = 0; i < _weekLabels.Count; i++)

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -176,18 +176,18 @@ namespace GitImpact
 
         private void InitializeComponent()
         {
-            _scrollBar = new System.Windows.Forms.HScrollBar();
+            _scrollBar = new HScrollBar();
             SuspendLayout();
 
             //
             // scrollBar
             //
-            _scrollBar.Dock = System.Windows.Forms.DockStyle.Bottom;
+            _scrollBar.Dock = DockStyle.Bottom;
             _scrollBar.LargeChange = 0;
-            _scrollBar.Location = new System.Drawing.Point(0, 133);
+            _scrollBar.Location = new Point(0, 133);
             _scrollBar.Maximum = 0;
             _scrollBar.Name = "_scrollBar";
-            _scrollBar.Size = new System.Drawing.Size(150, 17);
+            _scrollBar.Size = new Size(150, 17);
             _scrollBar.SmallChange = 0;
             _scrollBar.TabIndex = 0;
             _scrollBar.Scroll += OnScroll;

--- a/Plugins/Statistics/GitStatistics/CodeFile.cs
+++ b/Plugins/Statistics/GitStatistics/CodeFile.cs
@@ -23,7 +23,7 @@ namespace GitStatistics
             IsTestFile = false;
         }
 
-        public FileInfo File { get; private set; }
+        public FileInfo File { get; }
 
         protected internal int NumberLines { get; protected set; }
 

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -33,7 +33,6 @@ namespace GitStatistics
         private readonly bool _countSubmodule;
 
         protected Color[] DecentColors =
-            new[]
                 {
                     Color.Red,
                     Color.Yellow,

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -53,9 +53,6 @@ namespace GitStatistics
         public string DirectoriesToIgnore { get; set; }
         private readonly SynchronizationContext _syncContext;
         private LineCounter _lineCounter;
-#pragma warning disable 0414
-        private Task _loadThread;
-#pragma warning restore 0414
         private readonly IGitModule _module;
 
         public FormGitStatistics(IGitModule module, string codeFilePattern, bool countSubmodule)
@@ -169,7 +166,7 @@ namespace GitStatistics
             _lineCounter = new LineCounter();
             _lineCounter.LinesOfCodeUpdated += lineCounter_LinesOfCodeUpdated;
 
-            _loadThread = Task.Factory.StartNew(LoadLinesOfCode);
+            Task.Factory.StartNew(LoadLinesOfCode);
         }
 
         public void LoadLinesOfCode()

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -21,7 +21,7 @@ namespace GitStatistics
         public int NumberBlankLines { get; private set; }
         public int NumberCodeLines { get; private set; }
 
-        public Dictionary<string, int> LinesOfCodePerExtension { get; private set; }
+        public Dictionary<string, int> LinesOfCodePerExtension { get; }
 
         private static bool DirectoryIsFiltered(FileSystemInfo dir, IEnumerable<string> directoryFilters)
         {

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -9,11 +9,6 @@ namespace GitStatistics
     {
         public event EventHandler LinesOfCodeUpdated;
 
-        public LineCounter()
-        {
-            LinesOfCodePerExtension = new Dictionary<string, int>();
-        }
-
         public int NumberCommentsLines { get; private set; }
         public int NumberLines { get; private set; }
         public int NumberLinesInDesignerFiles { get; private set; }
@@ -21,7 +16,7 @@ namespace GitStatistics
         public int NumberBlankLines { get; private set; }
         public int NumberCodeLines { get; private set; }
 
-        public Dictionary<string, int> LinesOfCodePerExtension { get; }
+        public Dictionary<string, int> LinesOfCodePerExtension { get; } = new Dictionary<string, int>();
 
         private static bool DirectoryIsFiltered(FileSystemInfo dir, IEnumerable<string> directoryFilters)
         {

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -31,8 +31,7 @@ namespace GitStatistics.PieChart
         ///   Array of colors used for rendering.
         /// </summary>
         protected Color[] SliceColors =
-            new[]
-                {
+            {
                     Color.Red,
                     Color.Green,
                     Color.Blue,
@@ -50,7 +49,7 @@ namespace GitStatistics.PieChart
         /// <summary>
         ///   Array of relative displacements from the common center.
         /// </summary>
-        protected float[] SliceRelativeDisplacements = new[] { 0F };
+        protected float[] SliceRelativeDisplacements = { 0F };
 
         /// <summary>
         ///   Slice relative height.
@@ -60,7 +59,7 @@ namespace GitStatistics.PieChart
         /// <summary>
         ///   Array of values to be presented by the chart.
         /// </summary>
-        protected decimal[] Values = new decimal[] { };
+        protected decimal[] Values = { };
 
         /// <summary>
         ///   Initializes an empty instance of <c>PieChart3D</c>.

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
@@ -22,7 +22,7 @@ namespace GitStatistics.PieChart
         private float _initialAngle;
         private float _leftMargin;
         private PieChart3D _pieChart;
-        private float[] _relativeSliceDisplacements = new[] { 0F };
+        private float[] _relativeSliceDisplacements = { 0F };
         private float _rightMargin;
         private ShadowStyle _shadowStyle = ShadowStyle.GradualShadow;
         private float _sliceRelativeHeight;

--- a/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
@@ -29,12 +29,12 @@ namespace GitStatistics.PieChart
         /// <summary>
         ///   Style used for shadow.
         /// </summary>
-        private readonly ShadowStyle _shadowStyle = ShadowStyle.NoShadow;
+        private readonly ShadowStyle _shadowStyle;
 
         /// <summary>
         ///   Color of the surface.
         /// </summary>
-        private readonly Color _surfaceColor = Color.Empty;
+        private readonly Color _surfaceColor;
 
         /// <summary>
         ///   <c>Brush</c> used to render slice ending cut side.

--- a/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
@@ -1163,13 +1163,13 @@ namespace GitStatistics.PieChart
                 EndPoint = endPoint;
             }
 
-            public float StartAngle { get; private set; }
+            public float StartAngle { get; }
 
-            public float EndAngle { get; private set; }
+            public float EndAngle { get; }
 
-            public PointF StartPoint { get; private set; }
+            public PointF StartPoint { get; }
 
-            public PointF EndPoint { get; private set; }
+            public PointF EndPoint { get; }
         }
 
         #endregion

--- a/Plugins/Statistics/GitStatistics/PieChart/Quadrilateral.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/Quadrilateral.cs
@@ -12,8 +12,7 @@ namespace GitStatistics.PieChart
         ///   <c>PathPointType</c>s describing the <c>GraphicsPath</c> points.
         /// </summary>
         private static readonly byte[] QuadrilateralPointTypes =
-            new[]
-                {
+            {
                     (byte)PathPointType.Start,
                     (byte)PathPointType.Line,
                     (byte)PathPointType.Line,

--- a/ResourceManager/GitExtensionsUserControl.cs
+++ b/ResourceManager/GitExtensionsUserControl.cs
@@ -83,7 +83,7 @@ namespace ResourceManager
         /// <summary>Translates the <see cref="UserControl"/>'s elements.</summary>
         protected void Translate()
         {
-            Translator.Translate(this, GitCommands.AppSettings.CurrentTranslation);
+            Translator.Translate(this, AppSettings.CurrentTranslation);
             _translated = true;
         }
 

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -151,8 +151,8 @@ namespace ResourceManager
                 if (oldCommitData != null)
                 {
                     sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, oldCommitData.CommitDate.UtcDateTime) + " (" + GetFullDateString(oldCommitData.CommitDate) + ")");
-                    var delim = new char[] { '\n', '\r' };
-                    var lines = oldCommitData.Body.Trim(delim).Split(new string[] { "\r\n" }, 0);
+                    var delim = new[] { '\n', '\r' };
+                    var lines = oldCommitData.Body.Trim(delim).Split(new[] { "\r\n" }, 0);
                     foreach (var curline in lines)
                     {
                         sb.AppendLine("\t\t" + curline);
@@ -179,8 +179,8 @@ namespace ResourceManager
                 if (commitData != null)
                 {
                     sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, commitData.CommitDate.UtcDateTime) + " (" + GetFullDateString(commitData.CommitDate) + ")");
-                    var delim = new char[] { '\n', '\r' };
-                    var lines = commitData.Body.Trim(delim).Split(new string[] { "\r\n" }, 0);
+                    var delim = new[] { '\n', '\r' };
+                    var lines = commitData.Body.Trim(delim).Split(new[] { "\r\n" }, 0);
                     foreach (var curline in lines)
                     {
                         sb.AppendLine("\t\t" + curline);

--- a/ResourceManager/TranslationString.cs
+++ b/ResourceManager/TranslationString.cs
@@ -13,7 +13,7 @@ namespace ResourceManager
         }
 
         /// <summary>Gets the translated text.</summary>
-        public string Text { get; private set; }
+        public string Text { get; }
 
         /// <summary>Returns <see cref="Text"/> value.</summary>
         public override string ToString()

--- a/TranslationApp/FormTranslate.cs
+++ b/TranslationApp/FormTranslate.cs
@@ -428,7 +428,7 @@ namespace TranslationApp
 
         private TranslationItemWithCategory _translationItemWithCategoryInEditing;
 
-        private void translatedText_Enter(object sender, System.EventArgs e)
+        private void translatedText_Enter(object sender, EventArgs e)
         {
             if (_translationItemWithCategoryInEditing != null)
             {
@@ -443,7 +443,7 @@ namespace TranslationApp
             }
         }
 
-        private void translatedText_Leave(object sender, System.EventArgs e)
+        private void translatedText_Leave(object sender, EventArgs e)
         {
             ////Debug.Assert(_translationItemWithCategoryInEditing != null);
 

--- a/UnitTests/GitCommandsTests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommandsTests/Config/ConfigFileTest.cs
@@ -810,7 +810,7 @@ namespace GitCommandsTests.Config
             ConfigFile cfg = new ConfigFile("", true);
             cfg.LoadFromString(configFileContent);
             IEnumerable<string> actual = cfg.GetValues("status.showUntrackedFiles");
-            IEnumerable<string> expected = new string[] { "yes", "no" };
+            IEnumerable<string> expected = new[] { "yes", "no" };
             Assert.True(expected.SequenceEqual(actual));
         }
 

--- a/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using GitCommands;
 using GitCommands.Git.Extensions;
 using NUnit.Framework;

--- a/UnitTests/GitCommandsTests/Git/GitBranchNameNormaliserTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitBranchNameNormaliserTest.cs
@@ -104,7 +104,7 @@ namespace GitCommandsTests.Git
         [TestCase("///test///test///", "test/test")]
         public void Normalise_rule06(string input, string expected)
         {
-            _gitBranchNameNormaliser.Rule06(input, _gitBranchNameOptions).Should().Be(expected);
+            _gitBranchNameNormaliser.Rule06(input).Should().Be(expected);
         }
 
         // Branch name end with a dot '.'.

--- a/UnitTests/GitCommandsTests/Git/GitCommandCacheTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandCacheTest.cs
@@ -19,8 +19,8 @@ namespace GitCommandsTests.Git
         [TestMethod]
         public void TestAdd()
         {
-            byte[] output = new byte[] { 11, 12 };
-            byte[] error = new byte[] { 13, 14 };
+            byte[] output = { 11, 12 };
+            byte[] error = { 13, 14 };
             string[] expectedCachedCommand = { "git command" };
 
             GitCommandCache.Add("git command", output, error);
@@ -38,8 +38,8 @@ namespace GitCommandsTests.Git
         [TestMethod]
         public void TestTryGet()
         {
-            byte[] originalOutput = new byte[] { 11, 12 };
-            byte[] originalError = new byte[] { 13, 14 };
+            byte[] originalOutput = { 11, 12 };
+            byte[] originalError = { 13, 14 };
 
             GitCommandCache.Add("git command", originalOutput, originalError);
 
@@ -51,8 +51,8 @@ namespace GitCommandsTests.Git
         [TestMethod]
         public void TestClean()
         {
-            byte[] output = new byte[] { 11, 12 };
-            byte[] error = new byte[] { 13, 14 };
+            byte[] output = { 11, 12 };
+            byte[] error = { 13, 14 };
             string[] expectedCachedCommand = { "git command" };
 
             GitCommandCache.Add("git command", output, error);

--- a/UnitTests/GitCommandsTests/Git/GitCommandCacheTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandCacheTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using GitCommands;
 using NUnit.Framework;

--- a/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
@@ -130,7 +130,7 @@ namespace GitCommandsTests.Git.Gpg
             GitRevision revision = new GitRevision(guid);
 
             GitRef gitRef;
-            string gitRefCompleteName = "";
+            string gitRefCompleteName;
             switch (usefulTagRefNumber)
             {
                 case 0:

--- a/UnitTests/GitCommandsTests/Helpers/FileInfoExtensions.cs
+++ b/UnitTests/GitCommandsTests/Helpers/FileInfoExtensions.cs
@@ -43,7 +43,6 @@ namespace GitCommandsTests.Helpers
                     {
                         areEqual = false;
                         state.Stop();
-                        return;
                     }
                 });
                 return areEqual;

--- a/UnitTests/GitCommandsTests/Helpers/FileInfoExtensionsTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/FileInfoExtensionsTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using NUnit.Framework;
 using TestClass = NUnit.Framework.TestFixtureAttribute;
 using TestCleanup = NUnit.Framework.TearDownAttribute;

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -153,8 +153,7 @@ namespace GitCommandsTests.Helpers
         [TestCaseSource(nameof(GetInvalidPaths))]
         public void TryFindFullPath_not_throw_if_file_not_exist(string fileName)
         {
-            string fullPath;
-            PathUtil.TryFindFullPath(fileName, out fullPath).Should().BeFalse();
+            PathUtil.TryFindFullPath(fileName, out _).Should().BeFalse();
         }
 
         private static IEnumerable<string> GetInvalidPaths()

--- a/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
+++ b/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
@@ -193,8 +193,8 @@ namespace GitCommandsTests.Patch
 
         public class TestPatch
         {
-            public PatchApply.Patch Patch { get; private set; }
-            public StringBuilder PatchOutput { get; private set; }
+            public PatchApply.Patch Patch { get; }
+            public StringBuilder PatchOutput { get; }
 
             public TestPatch()
             {

--- a/UnitTests/GitUITests/CommandsDialogs/BrowseDialog/FormUpdateFixture.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/BrowseDialog/FormUpdateFixture.cs
@@ -28,7 +28,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
             var availableVersions = ReleaseVersion.Parse(GetReleasesConfigFileText());
 
             var updates = ReleaseVersion.GetNewerVersions(currentVersion, true, availableVersions);
-            var expectedVersions = new Version[]
+            var expectedVersions = new[]
             {
                 new Version(2, 48),
                 new Version(2, 49),
@@ -44,7 +44,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
             var availableVersions = ReleaseVersion.Parse(GetReleasesConfigFileText());
 
             var updates = ReleaseVersion.GetNewerVersions(currentVersion, false, availableVersions);
-            var expectedVersions = new Version[]
+            var expectedVersions = new[]
             {
                 new Version(2, 48)
             };

--- a/UnitTests/GitUITests/Helpers/DiffKindRevisionTests.cs
+++ b/UnitTests/GitUITests/Helpers/DiffKindRevisionTests.cs
@@ -23,7 +23,7 @@ namespace GitUITests.Helpers
         public void DiffKindRevisionTests_AB_1p()
         {
             IList<GitRevision> revisions = new List<GitRevision> { new GitRevision("HEAD") };
-            revisions[0].ParentGuids = new string[] { "parent" };
+            revisions[0].ParentGuids = new[] { "parent" };
             Assert.AreEqual("", RevisionDiffInfoProvider.Get(revisions, RevisionDiffKind.DiffAB, out _, out var firstRevision, out var secondRevision), "null rev");
             Assert.AreEqual("parent", firstRevision, "first");
             Assert.AreEqual("HEAD", secondRevision, "second");

--- a/UnitTests/GitUITests/TranslationTest.cs
+++ b/UnitTests/GitUITests/TranslationTest.cs
@@ -34,7 +34,7 @@ namespace GitUITests
                         obj.AddTranslationItems(tranlation);
                         obj.TranslateItems(tranlation);
                     }
-                    catch (System.Exception)
+                    catch (Exception)
                     {
                         Trace.WriteLine("Problem with class: " + type.FullName);
                         throw;

--- a/UnitTests/GravatarTests/DirectoryImageCacheTests.cs
+++ b/UnitTests/GravatarTests/DirectoryImageCacheTests.cs
@@ -50,7 +50,7 @@ namespace GravatarTests
             var image = await _cache.GetImageAsync(fileName, null);
 
             image.Should().BeNull();
-            var not_used = _fileInfo.DidNotReceive().LastWriteTime;
+            _ = _fileInfo.DidNotReceive().LastWriteTime;
         }
 
         [Test]
@@ -183,7 +183,7 @@ namespace GravatarTests
         {
             await _cache.DeleteImageAsync(fileName);
 
-            var not_used = _fileInfo.DidNotReceive().LastWriteTime;
+            _ = _fileInfo.DidNotReceive().LastWriteTime;
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace GravatarTests
             var image = await _cache.GetImageAsync(null, null);
 
             image.Should().BeNull();
-            var not_used = _fileInfo.DidNotReceive().LastWriteTime;
+            _ = _fileInfo.DidNotReceive().LastWriteTime;
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace GravatarTests
             var image = await _cache.GetImageAsync(FileName, null);
 
             image.Should().BeNull();
-            var not_used = _fileInfo.DidNotReceive().LastWriteTime;
+            _ = _fileInfo.DidNotReceive().LastWriteTime;
         }
 
         [Test]
@@ -265,7 +265,7 @@ namespace GravatarTests
             var image = await _cache.GetImageAsync(FileName, null);
 
             image.Should().BeNull();
-            var not_used = _fileInfo.Received(1).LastWriteTime;
+            _ = _fileInfo.Received(1).LastWriteTime;
         }
 
         [Test]

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -40,13 +40,12 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_should_render_body_with_links()
         {
-            string fullSha1;
-            _module.IsExistingCommitHash("b3e7944792", out fullSha1).Returns(x =>
+            _module.IsExistingCommitHash("b3e7944792", out _).Returns(x =>
             {
                 x[1] = "b3e79447928051cfb3494c9c0ef1a1d0ecde56a8";
                 return true;
             });
-            _module.IsExistingCommitHash("11119447928051cfb3494c9c0ef1a1d0ecde56a8", out fullSha1).Returns(x =>
+            _module.IsExistingCommitHash("11119447928051cfb3494c9c0ef1a1d0ecde56a8", out _).Returns(x =>
             {
                 x[1] = "11119447928051cfb3494c9c0ef1a1d0ecde56a8";
                 return true;


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove redundant code
- Some changes improve safety (eg. get-only properties)
- Some changes improve expressiveness, mostly due to newer C# features
- Some changes reduce potential for confusion (eg. class with one part marked `partial`)
- Some changes improve performance (eg. redundant assignments/casts/calls)

Each type of change is in its own commit to aid reviewing and amendments. Feel free to squash merge.

What did I do to test the code and ensure quality:
 - Manual review of changes
 - Unit tests
 - Manual tests of app

Has been tested on
 - Windows 10
