### PR TITLE
Ignore CS1712 warning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
-    <NoWarn>$(NoWarn);1573;1591</NoWarn>
+    <NoWarn>$(NoWarn);1573;1591;1712</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
As recommended by @sharwell at https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2630
