### PR TITLE
Use Regex.IsMatch over Regex.Match().Success

### DIFF
--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -165,26 +165,21 @@ namespace GitCommands.Gpg
                     string rawGpgMessage = GetTagVerificationMessage(usefulTagRefs[0], true);
 
                     /* Look for icon to be shown */
-                    var goodSignatureMatch = GoodSignatureTagRegex.Match(rawGpgMessage);
-                    var validSignatureMatch = ValidSignatureTagRegex.Match(rawGpgMessage);
-
-                    if (goodSignatureMatch.Success && validSignatureMatch.Success)
+                    if (GoodSignatureTagRegex.IsMatch(rawGpgMessage) && ValidSignatureTagRegex.IsMatch(rawGpgMessage))
                     {
                         /* It's only one good tag */
                         tagStatus = TagStatus.OneGood;
                     }
                     else
                     {
-                        Match noSignature = NoSignatureFoundTagRegex.Match(rawGpgMessage);
-                        if (noSignature.Success)
+                        if (NoSignatureFoundTagRegex.IsMatch(rawGpgMessage))
                         {
                             /* One tag, but not signed */
                             tagStatus = TagStatus.TagNotSigned;
                         }
                         else
                         {
-                            Match noPubKeyMatch = NoPubKeyTagRegex.Match(rawGpgMessage);
-                            if (noPubKeyMatch.Success)
+                            if (NoPubKeyTagRegex.IsMatch(rawGpgMessage))
                             {
                                 /* One tag, signed, but user has not the public key */
                                 tagStatus = TagStatus.NoPubKey;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1089,7 +1089,7 @@ namespace GitUI
             private static bool CheckCondition(string filter, Regex regex, string value)
             {
                 return string.IsNullOrEmpty(filter) ||
-                       ((regex != null) && (value != null) && regex.Match(value).Success);
+                       ((regex != null) && (value != null) && regex.IsMatch(value));
             }
 
             public override bool PassThru(GitRevision rev)


### PR DESCRIPTION
If the fact that a string matches a regex is needed, there's no need to construct the entire `Match` objects. This PR addresses the places where `Match` was called but this full allocation could have been avoided via `IsMatch` instead.

Apologies for the formatting change in the second commit (1f29cea). The change from `Match` to `IsMatch` happens in 06e478e. I am massaging local commits into separate pull requests and this was the only way I could avoid conflicts and maintain separate PRs.

What did I do to test the code and ensure quality:
 - Manual review of change
 - Unit tests
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
