### PR TITLE
Invert if/else to bring precondition early and reduce nesting

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -633,14 +633,12 @@ namespace GitCommands
             }
 
             byte[] cmdout, cmderr;
-            if (GitCommandCache.TryGet(arguments, out cmdout, out cmderr))
+            if (!GitCommandCache.TryGet(arguments, out cmdout, out cmderr))
             {
-                return StripAnsiCodes(EncodingHelper.DecodeString(cmdout, cmderr, ref encoding));
+                GitCommandHelpers.RunCmdByte(cmd, arguments, WorkingDir, null, out cmdout, out cmderr);
+
+                GitCommandCache.Add(arguments, cmdout, cmderr);
             }
-
-            GitCommandHelpers.RunCmdByte(cmd, arguments, WorkingDir, null, out cmdout, out cmderr);
-
-            GitCommandCache.Add(arguments, cmdout, cmderr);
 
             return StripAnsiCodes(EncodingHelper.DecodeString(cmdout, cmderr, ref encoding));
         }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -671,22 +671,12 @@ namespace GitUI.Editor
                 return null;
             }
 
-            // StreamReader disposes of 'fileStream'.
-            // see: https://msdn.microsoft.com/library/ms182334.aspx
-            var fileStream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            try
+            using (var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = new StreamReader(stream, Module.FilesEncoding))
             {
-                using (var reader = new StreamReader(fileStream, Module.FilesEncoding))
-                {
-                    fileStream = null;
-                    var content = reader.ReadToEnd();
-                    FilePreamble = reader.CurrentEncoding.GetPreamble();
-                    return content;
-                }
-            }
-            finally
-            {
-                fileStream?.Dispose();
+                var content = reader.ReadToEnd();
+                FilePreamble = reader.CurrentEncoding.GetPreamble();
+                return content;
             }
         }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -666,29 +666,27 @@ namespace GitUI.Editor
                 path = _fullPathResolver.Resolve(fileName);
             }
 
-            if (File.Exists(path))
-            {
-                // StreamReader disposes of 'fileStream'.
-                // see: https://msdn.microsoft.com/library/ms182334.aspx
-                var fileStream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                try
-                {
-                    using (var reader = new StreamReader(fileStream, Module.FilesEncoding))
-                    {
-                        fileStream = null;
-                        var content = reader.ReadToEnd();
-                        FilePreamble = reader.CurrentEncoding.GetPreamble();
-                        return content;
-                    }
-                }
-                finally
-                {
-                    fileStream?.Dispose();
-                }
-            }
-            else
+            if (!File.Exists(path))
             {
                 return null;
+            }
+
+            // StreamReader disposes of 'fileStream'.
+            // see: https://msdn.microsoft.com/library/ms182334.aspx
+            var fileStream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            try
+            {
+                using (var reader = new StreamReader(fileStream, Module.FilesEncoding))
+                {
+                    fileStream = null;
+                    var content = reader.ReadToEnd();
+                    FilePreamble = reader.CurrentEncoding.GetPreamble();
+                    return content;
+                }
+            }
+            finally
+            {
+                fileStream?.Dispose();
             }
         }
 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -165,35 +165,34 @@ namespace GitUI
         public int GetNextIndex(bool searchBackward, bool loop)
         {
             int curIdx = SelectedIndex;
-            if (curIdx >= 0)
+
+            if (curIdx < 0)
             {
-                ListViewItem currentItem = FileStatusListView.Items[curIdx];
-                var currentGroup = currentItem.Group;
+                return -1;
+            }
 
-                if (searchBackward)
+            ListViewItem currentItem = FileStatusListView.Items[curIdx];
+            var currentGroup = currentItem.Group;
+
+            if (searchBackward)
+            {
+                var nextItem = FindPrevItemInGroups(curIdx, currentGroup);
+                if (nextItem == null)
                 {
-                    var nextItem = FindPrevItemInGroups(curIdx, currentGroup);
-                    if (nextItem == null)
-                    {
-                        return loop ? GetLastIndex() : curIdx;
-                    }
-
-                    return nextItem.Index;
+                    return loop ? GetLastIndex() : curIdx;
                 }
-                else
-                {
-                    var nextItem = FindNextItemInGroups(curIdx, currentGroup);
-                    if (nextItem == null)
-                    {
-                        return loop ? 0 : curIdx;
-                    }
 
-                    return nextItem.Index;
-                }
+                return nextItem.Index;
             }
             else
             {
-                return -1;
+                var nextItem = FindNextItemInGroups(curIdx, currentGroup);
+                if (nextItem == null)
+                {
+                    return loop ? 0 : curIdx;
+                }
+
+                return nextItem.Index;
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1105,20 +1105,19 @@ namespace GitUI
                                                                  string messageFilter,
                                                                  bool ignoreCase)
             {
-                if (!(string.IsNullOrEmpty(authorFilter) &&
-                      string.IsNullOrEmpty(committerFilter) &&
-                      string.IsNullOrEmpty(messageFilter) &&
-                      !MessageFilterCouldBeSHA(messageFilter)))
-                {
-                    return new RevisionGridInMemFilter(authorFilter,
-                                                       committerFilter,
-                                                       messageFilter,
-                                                       ignoreCase);
-                }
-                else
+                if (string.IsNullOrEmpty(authorFilter) &&
+                    string.IsNullOrEmpty(committerFilter) &&
+                    string.IsNullOrEmpty(messageFilter) &&
+                    !MessageFilterCouldBeSHA(messageFilter))
                 {
                     return null;
                 }
+
+                return new RevisionGridInMemFilter(
+                    authorFilter,
+                    committerFilter,
+                    messageFilter,
+                    ignoreCase);
             }
         }
 

--- a/GitUI/UserControls/RevisionGridClasses/NavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGridClasses/NavigationHistory.cs
@@ -36,17 +36,15 @@ namespace GitUI.UserControls.RevisionGridClasses
         /// <exception cref="InvalidOperationException">When no previous history is available.</exception>
         public string NavigateBackward()
         {
-            if (CanNavigateBackward)
-            {
-                string curr = _prevItems.Pop();
-                string prev = _prevItems.Peek();
-                _nextItems.Push(curr);
-                return prev;
-            }
-            else
+            if (!CanNavigateBackward)
             {
                 throw new InvalidOperationException();
             }
+
+            string curr = _prevItems.Pop();
+            string prev = _prevItems.Peek();
+            _nextItems.Push(curr);
+            return prev;
         }
 
         /// <summary>
@@ -60,16 +58,14 @@ namespace GitUI.UserControls.RevisionGridClasses
         /// <exception cref="InvalidOperationException">When no forward history is available.</exception>
         public string NavigateForward()
         {
-            if (CanNavigateForward)
-            {
-                string next = _nextItems.Pop();
-                _prevItems.Push(next);
-                return next;
-            }
-            else
+            if (!CanNavigateForward)
             {
                 throw new InvalidOperationException();
             }
+
+            string next = _nextItems.Pop();
+            _prevItems.Push(next);
+            return next;
         }
 
         /// <summary>


### PR DESCRIPTION
Following [this comment](https://github.com/gitextensions/gitextensions/pull/4615#discussion_r173673944) from @sharwell, this PR inverts a few if/else statements in order to return early from methods and reduce nesting.

What did I do to test the code and ensure quality:
 - Manual review of automated changes
 - Unit tests
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
