### PR TITLE
Fix bug in GitRevision.IsFullSha1Hash

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -120,9 +120,17 @@ namespace GitCommands
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
+        /// <summary>
+        /// Returns a value indicating whether <paramref name="id"/> is a valid SHA-1 hash.
+        /// </summary>
+        /// <remarks>
+        /// To be valid the string must contain exactly 40 lower-case hexadecimal characters.
+        /// </remarks>
+        /// <param name="id">The string to validate.</param>
+        /// <returns><c>true</c> if <paramref name="id"/> is a valid SHA-1 hash, otherwise <c>false</c>.</returns>
         public static bool IsFullSha1Hash(string id)
         {
-            return Regex.IsMatch(id, Sha1HashPattern);
+            return Sha1HashRegex.IsMatch(id);
         }
     }
 }

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="FullPathResolverTests.cs" />
     <Compile Include="GitModuleTest.cs" />
     <Compile Include="GitRevisionInfoProviderTests.cs" />
+    <Compile Include="GitRevisionTests.cs" />
     <Compile Include="Git\EncodingHelperTest.cs" />
     <Compile Include="Git\GitBlameHeaderTest.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensionsTests.cs" />

--- a/UnitTests/GitCommandsTests/GitRevisionTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionTests.cs
@@ -1,0 +1,23 @@
+﻿using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    public sealed class GitRevisionTests
+    {
+        [Test]
+        public void Should_validate_full_sha1_correctly()
+        {
+            Assert.True(GitRevision.IsFullSha1Hash("0000000000000000000000000000000000000000"));
+            Assert.True(GitRevision.IsFullSha1Hash("1111111111111111111111111111111111111111"));
+            Assert.True(GitRevision.IsFullSha1Hash("0123456789abcdefa0123456789abcdefa012345"));
+
+            Assert.False(GitRevision.IsFullSha1Hash("0123456789ABCDEFA0123456789ABCDEFA012345"));
+            Assert.False(GitRevision.IsFullSha1Hash("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
+            Assert.False(GitRevision.IsFullSha1Hash("00000000000000000000000000000000000000000"));
+            Assert.False(GitRevision.IsFullSha1Hash("000000000000000000000000000000000000000"));
+            Assert.False(GitRevision.IsFullSha1Hash("0000000000000000000000000000000000000000 "));
+            Assert.False(GitRevision.IsFullSha1Hash(" 0000000000000000000000000000000000000000"));
+        }
+    }
+}


### PR DESCRIPTION
Method previously accepted any string that contained a SHA-1 anywhere in its body. With this change, the string must be exactly 40 characters in length and contain only lower-case hex characters.

Added unit test and XML documentation.

What did I do to test the code and ensure quality:
 - Add failing unit test then make it pass
 - Review usages of this method to ensure they won't break
 - Add API documentation
