### PR TITLE
[wip] Remove unused 'browse repo' code

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -31,7 +31,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public partial class FormBrowse : GitModuleForm, IBrowseRepo
+    public partial class FormBrowse : GitModuleForm
     {
         #region Translation
 
@@ -262,14 +262,11 @@ namespace GitUI.CommandsDialogs
                 RefreshPullIcon();
                 oldcommands.PostRepositoryChanged -= UICommands_PostRepositoryChanged;
                 UICommands.PostRepositoryChanged += UICommands_PostRepositoryChanged;
-                oldcommands.BrowseRepo = null;
-                UICommands.BrowseRepo = this;
             };
             if (commands != null)
             {
                 RefreshPullIcon();
                 UICommands.PostRepositoryChanged += UICommands_PostRepositoryChanged;
-                UICommands.BrowseRepo = this;
                 _controller = new FormBrowseController(new GitGpgController(() => Module));
                 _commitDataManager = new CommitDataManager(() => Module);
                 _longShaProvider = new LongShaProvider(() => Module);
@@ -364,14 +361,6 @@ namespace GitUI.CommandsDialogs
                 InternalInitialize(true);
             }
         }
-
-        #region IBrowseRepo
-        public void GoToRef(string refName, bool showNoRevisionMsg)
-        {
-            RevisionGrid.GoToRef(refName, showNoRevisionMsg);
-        }
-
-        #endregion
 
         private void ShowDashboard()
         {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -181,7 +181,6 @@ namespace GitUI
         public event GitUIEventHandler PostRegisterPlugin;
 
         public ILockableNotifier RepoChangedNotifier { get; }
-        public IBrowseRepo BrowseRepo { get; set; }
 
         #endregion
 
@@ -2419,11 +2418,6 @@ namespace GitUI
         internal void RaisePostRegisterPlugin(IWin32Window owner)
         {
             InvokeEvent(owner, PostRegisterPlugin);
-        }
-
-        public void BrowseGoToRef(string refName, bool showNoRevisionMsg)
-        {
-            BrowseRepo?.GoToRef(refName, showNoRevisionMsg);
         }
 
         public IGitRemoteCommand CreateRemoteCommand()

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3727,19 +3727,6 @@ namespace GitUI
             }
         }
 
-        public void GoToRef(string refName, bool showNoRevisionMsg)
-        {
-            string revisionGuid = Module.RevParse(refName);
-            if (!string.IsNullOrEmpty(revisionGuid))
-            {
-                SetSelectedRevision(new GitRevision(revisionGuid));
-            }
-            else if (showNoRevisionMsg)
-            {
-                MessageBox.Show((ParentForm as IWin32Window) ?? this, _noRevisionFoundError.Text);
-            }
-        }
-
         internal Keys GetShortcutKeys(Commands cmd)
         {
             return GetShortcutKeys((int)cmd);

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -84,7 +84,6 @@
     <Compile Include="BuildServerIntegration\IBuildServerWatcher.cs" />
     <Compile Include="GitCmdResult.cs" />
     <Compile Include="GitUIPostActionEventArgs.cs" />
-    <Compile Include="IBrowseRepo.cs" />
     <Compile Include="IConfigFileSettings.cs" />
     <Compile Include="IConfigSection.cs" />
     <Compile Include="IGitCommand.cs" />

--- a/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
+++ b/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
@@ -1,7 +1,0 @@
-﻿namespace GitUIPluginInterfaces
-{
-    public interface IBrowseRepo
-    {
-        void GoToRef(string refName, bool showNoRevisionMsg);
-    }
-}

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -104,7 +104,6 @@ namespace GitUIPluginInterfaces
         IGitRemoteCommand CreateRemoteCommand();
         void CacheAvatar(string email);
         Icon FormIcon { get; }
-        IBrowseRepo BrowseRepo { get; }
 
         /// <summary>
         /// RepoChangedNotifier.Notify() should be called after each action that changess repo state


### PR DESCRIPTION
Looking through the code I found a small island of unused functionality. Perhaps it can be removed.

Changes proposed in this pull request:
 - Remove unused `IBrowseRepo` interface and implementation within `FormBrowse`
 - Remove unused `GitUICommands.BrowseGoToRef` and field
 - Remove unused `RevisionGrid.GoToRef`
 
What did I do to test the code and ensure quality:
 - Checked thoroughly to ensure this code wasn't invoked by some non-obvious mechanism.
