### PR TITLE
Add the current process id to the tmpFile name.

### DIFF
--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -131,7 +131,13 @@ namespace GitCommands.Settings
                     return;
                 }
 
-                var tmpFile = SettingsFilePath + ".tmp";
+                int currentProcessId;
+                using (var currentProcess = Process.GetCurrentProcess())
+                {
+                    currentProcessId = currentProcess.Id;
+                }
+
+                var tmpFile = SettingsFilePath + currentProcessId + ".tmp";
                 WriteSettings(tmpFile);
 
                 if (File.Exists(SettingsFilePath))


### PR DESCRIPTION
This ensures an unique file name among processes that save settings at the same time.
Fixes a possible root cause of #3929.

What did I do to test the code and ensure quality:

Tested manually.

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
