### PR TITLE
Fix Dictionary.Text not accepting AppSettings.Dictionary

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -87,9 +87,22 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Dictionary.Items.Clear();
             Dictionary.Items.Add(_noDictFile.Text);
             if (AppSettings.Dictionary.Equals("none", StringComparison.InvariantCultureIgnoreCase))
+            {
                 Dictionary.SelectedIndex = 0;
+            }
             else
-                Dictionary.Text = AppSettings.Dictionary;
+            {
+                string dictionaryFile = string.Concat(Path.Combine(AppSettings.GetDictionaryDir(), AppSettings.Dictionary), ".dic");
+                if (File.Exists(dictionaryFile))
+                {
+                    Dictionary.Items.Add(AppSettings.Dictionary);
+                    Dictionary.Text = AppSettings.Dictionary;
+                }
+                else
+                {
+                    Dictionary.SelectedIndex = 0;
+                }
+            }
 
             chkShowRelativeDate.Checked = AppSettings.RelativeDate;
 
@@ -125,6 +138,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             try
             {
+                string currentDictionary = Dictionary.Text;
+
                 Dictionary.Items.Clear();
                 Dictionary.Items.Add(_noDictFile.Text);
                 foreach (
@@ -134,6 +149,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     var file = new FileInfo(fileName);
                     Dictionary.Items.Add(file.Name.Replace(".dic", ""));
                 }
+
+                Dictionary.Text = currentDictionary;
             }
             catch
             {


### PR DESCRIPTION
Dictionary.DropDownStyle became DropDownList in commit 310a55c3c2 so Dictionary.Items must contain what we want to set in Dictionary.Text.

Fixes #4443.

Changes proposed in this pull request:
 - Preload Dictionary.Items with the current AppSettings.Dictionary if that current dic file exists so that Dictionary.Text will accept the current dictionary.
 - Retain the current dictionary selection during Dictionary_DropDown where previously Dictionary.Items.Clear did make Dictionary.Text invalid and therefore automatically clear the current choice.

This all comes about because Dictionary.DropDownStyle became DropDownList in commit 310a55c3c2.
 
What did I do to test the code and ensure quality:
 - checked that current dictionary setting is shown when displaying the settings.
 - checked that "None" was shown when the current dic file was missing.
 - checked that current selection is retained when opening the drop down of the combo box.

Has been tested on (remove any that don't apply):
 - Git 2.16.2.windows.1
 - Windows 10
 - GitExtensions on master branch at 5047252f5e

This commit as it is based on release/2.51 will cause a conflict with later changes in master because master has introduced brackets on if statements.

The commit that was tested and will merge cleanly into master can be found in my branch fix-4443-future, which is based on 5047252f5e. I can edit the pull request to that branch if you would prefer to apply this fix to only the future release.
