### PR TITLE
Fix Dictionary.Text not accepting AppSettings.Dictionary

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -91,7 +91,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             else
             {
-                Dictionary.Text = AppSettings.Dictionary;
+                string dictionaryFile = string.Concat(Path.Combine(AppSettings.GetDictionaryDir(), AppSettings.Dictionary), ".dic");
+                if (File.Exists(dictionaryFile))
+                {
+                    Dictionary.Items.Add(AppSettings.Dictionary);
+                    Dictionary.Text = AppSettings.Dictionary;
+                }
+                else
+                {
+                    Dictionary.SelectedIndex = 0;
+                }
             }
 
             chkShowRelativeDate.Checked = AppSettings.RelativeDate;
@@ -128,6 +137,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             try
             {
+                string currentDictionary = Dictionary.Text;
+
                 Dictionary.Items.Clear();
                 Dictionary.Items.Add(_noDictFile.Text);
                 foreach (
@@ -137,6 +148,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     var file = new FileInfo(fileName);
                     Dictionary.Items.Add(file.Name.Replace(".dic", ""));
                 }
+
+                Dictionary.Text = currentDictionary;
             }
             catch
             {


### PR DESCRIPTION
Dictionary.DropDownStyle became DropDownList in commit 310a55c3c2 so Dictionary.Items must contain what we want to set in Dictionary.Text.

Fixes #4443.

Changes proposed in this pull request:
 - Preload Dictionary.Items with the current AppSettings.Dictionary if that current dic file exists so that Dictionary.Text will accept the current dictionary.
 - Retain the current dictionary selection during Dictionary_DropDown where previously Dictionary.Items.Clear did make Dictionary.Text invalid and therefore automatically clear the current choice.

I intentionally chose to retain the existing behaviour of loading of the list at the time the drop-down button is clicked rather than loading it as a fixed list at the time the form is created. This enables a user to copy in a new dic file then choose that file from the list while the Settings > Appearance form remains open.

This all comes about because Dictionary.DropDownStyle became DropDownList in commit 310a55c3c2.
 
What did I do to test the code and ensure quality:
 - checked that current dictionary setting is shown when displaying the settings.
 - checked that "None" was shown when the current dic file was missing.
 - checked that current selection is retained when opening the drop down of the combo box.

Has been tested on (remove any that don't apply):
 - Git 2.16.2.windows.1
 - Windows 10
 - GitExtensions on master branch at 5047252f5e

**NOTE:** This pull request (for master) replaces #4626, because that previous pull request was for release/2.51. 