### PR TITLE
#4554 added a new Commit tab but did not adjust the tab icons

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -41,12 +41,14 @@ namespace GitUI.CommandsDialogs
                 var imageList = new ImageList();
                 tabControl1.ImageList = imageList;
                 imageList.ColorDepth = ColorDepth.Depth8Bit;
+                imageList.Images.Add(Properties.Resources.IconCommit);
                 imageList.Images.Add(Properties.Resources.IconViewFile);
                 imageList.Images.Add(Properties.Resources.IconDiff);
                 imageList.Images.Add(Properties.Resources.IconBlame);
                 tabControl1.TabPages[0].ImageIndex = 0;
                 tabControl1.TabPages[1].ImageIndex = 1;
                 tabControl1.TabPages[2].ImageIndex = 2;
+                tabControl1.TabPages[3].ImageIndex = 3;
             }
 
             _filterBranchHelper = new FilterBranchHelper(toolStripBranchFilterComboBox, toolStripBranchFilterDropDownButton, FileChanges);


### PR DESCRIPTION
Regression from #4554

Changes proposed in this pull request:
 - Incorrect tab icons
 
Screenshots before and after (if PR changes UI):
-                 imageList.Images.Add(Properties.Resources.IconViewFile);
![image](https://user-images.githubusercontent.com/6248932/37434547-32397596-27e0-11e8-99bc-703bfb00defc.png)


- 
![image](https://user-images.githubusercontent.com/6248932/37434468-f5db287e-27df-11e8-98e3-f87286cb86a9.png)



What did I do to test the code and ensure quality:
 - View form

Has been tested on (remove any that don't apply):
 - Windows 10
