### PR TITLE
String extensions

### DIFF
--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -171,7 +171,7 @@ namespace System
             {
                 if (!shouldRemoveLine(line))
                 {
-                    sb.Append(line + '\n');
+                    sb.Append(line).Append('\n');
                 }
             }
 

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -178,49 +178,10 @@ namespace System
             return sb.ToString();
         }
 
-        /// <summary>Split a string, removing empty entries, then trim whitespace.</summary>
-        public static IEnumerable<string> SplitThenTrim(this string value, params string[] separator)
-        {
-            return value
-                .Split(separator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(s => s.Trim());
-        }
-
-        /// <summary>Split a string, removing empty entries, then trim whitespace.</summary>
-        public static IEnumerable<string> SplitThenTrim(this string value, params char[] separator)
-        {
-            return value
-                .Split(separator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(s => s.Trim());
-        }
-
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
         public static string[] SplitLines(this string value)
         {
             return value.Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
-        }
-
-        /// <summary>Split a string, delimited by line-breaks, excluding empty entries; then trim whitespace.</summary>
-        public static IEnumerable<string> SplitLinesThenTrim(this string value)
-        {
-            return value.SplitThenTrim(NewLineSeparator);
-        }
-
-        /// <summary>Gets the text after the last separator.
-        /// If NO separator OR ends with separator, returns the original value.</summary>
-        public static string SubstringAfterLastSafe(this string value, string separator)
-        {// ex: "origin/master" -> "master"
-            if (value.EndsWith(separator) || !value.Contains(separator))
-            {// "origin/master/" OR "master" -> return original
-                return value;
-            }
-
-            return value.Substring(1 + value.LastIndexOf(separator, StringComparison.InvariantCultureIgnoreCase));
-        }
-
-        public static string SubstringAfterFirst(this string value, string separator)
-        {
-            return value.Substring(1 + value.IndexOf(separator, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -92,17 +92,9 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes string if it is not null
-        /// </summary>
-        public static string Quote(this string s)
-        {
-            return s.Quote("\"");
-        }
-
-        /// <summary>
         /// Quotes this string with the specified <paramref name="quotationMark"/>
         /// </summary>
-        public static string Quote(this string s, string quotationMark)
+        public static string Quote(this string s, string quotationMark = "\"")
         {
             if (s == null)
             {
@@ -117,7 +109,7 @@ namespace System
         /// </summary>
         public static string QuoteNE(this string s)
         {
-            return s.IsNullOrEmpty() ? s : s.Quote("\"");
+            return s.IsNullOrEmpty() ? s : s.Quote();
         }
 
         /// <summary>

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -209,9 +209,8 @@ namespace System
         }
 
         /// <summary>
-        /// Shortens this string, that it will be no longer than the specified <paramref name="maxLength"/>.
-        /// If this string is longer than the specified <paramref name="maxLength"/>, it'll be truncated to the length of <paramref name="maxLength"/>-3
-        /// and the "..." will be appended to the end of the resulting string.
+        /// Shortens <paramref name="str"/> if necessary, so that the resulting string has fewer than <paramref name="maxLength"/> characters.
+        /// If shortened, ellipsis are appended to the truncated string.
         /// </summary>
         [NotNull]
         public static string ShortenTo([CanBeNull] this string str, int maxLength)
@@ -225,10 +224,13 @@ namespace System
             {
                 return str;
             }
-            else
+
+            if (maxLength < 3)
             {
-                return str.Substring(0, maxLength - 3) + "...";
+                return str.Substring(0, maxLength);
             }
+
+            return str.Substring(0, maxLength - 3) + "...";
         }
     }
 

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -10,7 +10,9 @@ namespace System
         /// <summary>'\n'</summary>
         private static readonly char[] NewLineSeparator = { '\n' };
 
-        public static string SkipStr(this string str, string toSkip)
+        [Pure]
+        [CanBeNull]
+        public static string SkipStr([CanBeNull] this string str, [NotNull] string toSkip)
         {
             if (str == null)
             {
@@ -29,7 +31,9 @@ namespace System
             }
         }
 
-        public static string TakeUntilStr(this string str, string untilStr)
+        [Pure]
+        [CanBeNull]
+        public static string TakeUntilStr([CanBeNull] this string str, [NotNull] string untilStr)
         {
             if (str == null)
             {
@@ -48,7 +52,9 @@ namespace System
             }
         }
 
-        public static string CommonPrefix(this string s, string other)
+        [Pure]
+        [NotNull]
+        public static string CommonPrefix([CanBeNull] this string s, [CanBeNull] string other)
         {
             if (s.IsNullOrEmpty() || other.IsNullOrEmpty())
             {
@@ -70,12 +76,15 @@ namespace System
             return s;
         }
 
-        public static bool IsNullOrEmpty(this string s)
+        [Pure]
+        [ContractAnnotation("s:null=>true")]
+        public static bool IsNullOrEmpty([CanBeNull] this string s)
         {
             return string.IsNullOrEmpty(s);
         }
 
-        public static string Combine(this string left, string sep, string right)
+        [Pure]
+        public static string Combine([CanBeNull] this string left, [NotNull] string sep, [CanBeNull] string right)
         {
             if (left.IsNullOrEmpty())
             {
@@ -94,7 +103,9 @@ namespace System
         /// <summary>
         /// Quotes this string with the specified <paramref name="quotationMark"/>
         /// </summary>
-        public static string Quote(this string s, string quotationMark = "\"")
+        [Pure]
+        [NotNull]
+        public static string Quote([CanBeNull] this string s, [NotNull] string quotationMark = "\"")
         {
             if (s == null)
             {
@@ -107,7 +118,9 @@ namespace System
         /// <summary>
         /// Quotes this string if it is not null and not empty
         /// </summary>
-        public static string QuoteNE(this string s)
+        [Pure]
+        [ContractAnnotation("s:null=>null")]
+        public static string QuoteNE([CanBeNull] this string s)
         {
             return s.IsNullOrEmpty() ? s : s.Quote();
         }
@@ -115,7 +128,9 @@ namespace System
         /// <summary>
         /// Adds parentheses if string is not null and not empty
         /// </summary>
-        public static string AddParenthesesNE(this string s)
+        [Pure]
+        [ContractAnnotation("s:null=>null")]
+        public static string AddParenthesesNE([CanBeNull] this string s)
         {
             return s.IsNullOrEmpty() ? s : "(" + s + ")";
         }
@@ -131,15 +146,18 @@ namespace System
         /// true if the value parameter is null or <see cref="string.Empty"/>, or if value consists exclusively of white-space characters.
         /// </returns>
         [Pure]
+        [ContractAnnotation("value:null=>true")]
         public static bool IsNullOrWhiteSpace([CanBeNull] this string value)
         {
             return string.IsNullOrWhiteSpace(value);
         }
 
         /// <summary>Indicates whether the specified string is neither null, nor empty, nor has only whitespace.</summary>
+        [Pure]
+        [ContractAnnotation("value:null=>false")]
         public static bool IsNotNullOrWhitespace([CanBeNull] this string value)
         {
-            return !value.IsNullOrWhiteSpace();
+            return !string.IsNullOrWhiteSpace(value);
         }
 
         /// <summary>
@@ -147,12 +165,16 @@ namespace System
         /// </summary>
         /// <param name="starts">array of strings to compare</param>
         /// <returns>true if any starts element matches the beginning of this string; otherwise, false.</returns>
-        public static bool StartsWithAny([CanBeNull] this string value, string[] starts)
+        [Pure]
+        [ContractAnnotation("value:null=>false")]
+        public static bool StartsWithAny([CanBeNull] this string value, [NotNull, ItemNotNull] IEnumerable<string> starts)
         {
             return value != null && starts.Any(s => value.StartsWith(s));
         }
 
-        public static string RemoveLines(this string value, Func<string, bool> shouldRemoveLine)
+        [Pure]
+        [ContractAnnotation("value:null=>null")]
+        public static string RemoveLines([CanBeNull] this string value, [NotNull] Func<string, bool> shouldRemoveLine)
         {
             if (value.IsNullOrEmpty())
             {
@@ -179,7 +201,9 @@ namespace System
         }
 
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
-        public static string[] SplitLines(this string value)
+        [Pure]
+        [NotNull]
+        public static string[] SplitLines([NotNull] this string value)
         {
             return value.Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
         }
@@ -189,7 +213,8 @@ namespace System
         /// If this string is longer than the specified <paramref name="maxLength"/>, it'll be truncated to the length of <paramref name="maxLength"/>-3
         /// and the "..." will be appended to the end of the resulting string.
         /// </summary>
-        public static string ShortenTo(this string str, int maxLength)
+        [NotNull]
+        public static string ShortenTo([CanBeNull] this string str, int maxLength)
         {
             if (str.IsNullOrEmpty())
             {
@@ -212,6 +237,7 @@ namespace System
         /// <summary>
         /// Translates this bool value to the git command line force flag
         /// </summary>
+        [NotNull]
         public static string AsForce(this bool force)
         {
             return force ? " -f " : string.Empty;

--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
@@ -102,8 +102,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
 
             if (!_commitTemplates[line].Name.IsNullOrEmpty())
             {
-                comboBoxText = _commitTemplates[line].Name.Substring(0, _commitTemplates[line].Name.Length > _maxShownCharsForName ? (_maxShownCharsForName - 3) : _commitTemplates[line].Name.Length);
-                comboBoxText += _commitTemplates[line].Name.Length > _maxShownCharsForName ? "..." : "";
+                comboBoxText = _commitTemplates[line].Name.ShortenTo(_maxShownCharsForName);
             }
             else
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3666,8 +3666,8 @@ namespace GitUI
             var r = LatestSelectedRevision;
             if (r != null)
             {
-                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(hashCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(r.Guid, 15));
-                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(messageCopyToolStripMenuItem, CopyToClipboardMenuHelper.StrLimitWithElipses(r.Subject, 30));
+                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(hashCopyToolStripMenuItem, r.Guid.ShortenTo(15));
+                CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(messageCopyToolStripMenuItem, r.Subject.ShortenTo(30));
                 CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(authorCopyToolStripMenuItem, r.Author);
                 CopyToClipboardMenuHelper.AddOrUpdateTextPostfix(dateCopyToolStripMenuItem, r.CommitDate.ToString());
             }

--- a/GitUI/UserControls/RevisionGridClasses/CopyToClipboardMenuHelper.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyToClipboardMenuHelper.cs
@@ -57,41 +57,5 @@ namespace GitUI.UserControls.RevisionGridClasses
 
             target.Text += string.Format("     ({0})", postfix);
         }
-
-        /// <summary>
-        /// Substring with elipses but OK if shorter, will take 3 characters off character count if necessary
-        /// from http://blog.abodit.com/2010/02/string-extension-methods-for-truncating-and-adding-ellipsis/
-        /// </summary>
-        public static string StrLimitWithElipses(string str, int characterCount)
-        {
-            if (characterCount < 5)
-            {
-                return StrLimit(str, characterCount); // Can’t do much with such a short limit
-            }
-
-            if (str.Length <= characterCount - 3)
-            {
-                return str;
-            }
-            else
-            {
-                return str.Substring(0, characterCount - 3) + "...";
-            }
-        }
-
-        /// <summary>
-        /// Substring but OK if shorter
-        /// </summary>
-        public static string StrLimit(string str, int characterCount)
-        {
-            if (str.Length <= characterCount)
-            {
-                return str;
-            }
-            else
-            {
-                return str.Substring(0, characterCount).TrimEnd(' ');
-            }
-        }
     }
 }

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Remote\GitRemoteManagerTests.cs" />
     <Compile Include="SshPathLocatorTest.cs" />
+    <Compile Include="StringExtensionTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ExternalLinks\MockData\level3_roaming_GitExtensions.settings.xml" />

--- a/UnitTests/GitCommandsTests/StringExtensionTests.cs
+++ b/UnitTests/GitCommandsTests/StringExtensionTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public sealed class StringExtensionTests
+    {
+        [TestCase(null, 10, "")]
+        [TestCase("Hello", 10, "Hello")]
+        [TestCase("Hello", 5, "Hello")]
+        [TestCase("Hello", 4, "H...")]
+        [TestCase("Hello", 3, "...")]
+        [TestCase("Hello", 2, "He")]
+        public void ShortenTo_works_as_expected(string s, int length, string expected)
+        {
+            Assert.AreEqual(expected, s.ShortenTo(length));
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
 - Consolidate all string shortening methods into one (`ShortenTo`)
 - Annotate `StringExtensions` and `BoolExtension` methods
 - Remove some unused methods

What did I do to test the code and ensure quality:
 - Manual testing
 - Unit testing

Has been tested on:
 - GIT 2.16
 - Windows 10
