### PR TITLE
Defer JIT compile of bulk of Program.Main

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -50,6 +50,14 @@ namespace GitExtensions
                 }
             }
 
+            // NOTE we perform the rest of the application's startup in another method to defer
+            // the JIT processing more types than required to configure NBug.
+            // In this way, there's more chance we can handle startup exceptions correctly.
+            RunApplication();
+        }
+
+        private static void RunApplication()
+        {
             string[] args = Environment.GetCommandLineArgs();
 
             // This form created for obtain UI synchronization context only

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,9 +44,9 @@ namespace GitExtensions
                 // is this exception caused by the configuration?
                 if (tie.InnerException != null
                     && tie.InnerException.GetType()
-                        .IsSubclassOf(typeof(System.Configuration.ConfigurationException)))
+                        .IsSubclassOf(typeof(ConfigurationException)))
                 {
-                    HandleConfigurationException((System.Configuration.ConfigurationException)tie.InnerException);
+                    HandleConfigurationException((ConfigurationException)tie.InnerException);
                 }
             }
 
@@ -176,7 +177,7 @@ namespace GitExtensions
         /// <summary>
         /// Used in the rare event that the configuration file for the application is corrupted
         /// </summary>
-        private static void HandleConfigurationException(System.Configuration.ConfigurationException ce)
+        private static void HandleConfigurationException(ConfigurationException ce)
         {
             bool exceptionHandled = false;
             try


### PR DESCRIPTION
The JIT must load all types used in a method when the method is loaded.

`Program.Main` attempts to hook type initialisation exceptions via NBug.

Loading fewer types in `Main` increases the chance of catching such exceptions.

Other than that, there is no change to program behaviour.

What did I do to test the code and ensure quality:
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
