### PR TITLE
Fix double call to RefreshRevisions after creating a tag. Fixes #4495

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2321,13 +2321,12 @@ namespace GitUI
                 return;
             }
 
-            using (var frm = new FormCreateTag(UICommands, LatestSelectedRevision))
-            {
-                if (frm.ShowDialog(this) == DialogResult.OK)
+            UICommands.DoActionOnRepo(() =>
                 {
-                    RefreshRevisions();
-                }
-            }
+                    var frm = new FormCreateTag(UICommands, LatestSelectedRevision);
+
+                    return frm.ShowDialog(this) == DialogResult.OK;
+                });
         }
 
         private void ResetCurrentBranchToHereToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2323,9 +2323,10 @@ namespace GitUI
 
             UICommands.DoActionOnRepo(() =>
                 {
-                    var frm = new FormCreateTag(UICommands, LatestSelectedRevision);
-
-                    return frm.ShowDialog(this) == DialogResult.OK;
+                    using (var frm = new FormCreateTag(UICommands, LatestSelectedRevision))
+                    {
+                        return frm.ShowDialog(this) == DialogResult.OK;
+                    }
                 });
         }
 


### PR DESCRIPTION
Fixes #4495.

Changes proposed in this pull request:
 - Stopped RevisionGrid::CreateTagToolStripMenuItemClick calling RefreshRevisions itself as this will happen when the create tag form is disposed of. Running RefreshRevisions twice loses the last selected revision.
 - Made running FormCreateTag instead use DoActionOnRepo, which is now consistent with other forms (e.g. FormCreateBranch) and consistent with how it's run from the main menu.
 
What did I do to test the code and ensure quality:
 - created a tag and observed that the selected revision did not change after the create tag dialog was closed.
 - observed that the tag was created and appeared in GitExtensions UI.
 - ensured that a tag could be created on a different revision by changing the option "Create tag at this revision", yet the selected revision did not change after the create tag dialog was closed.

Has been tested on (remove any that don't apply):
 - GIT 2.16.2.windows.1
 - Windows 10