### PR TITLE
Difference for initial commit of a file were presented as a diff to the working directory

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -172,7 +172,7 @@ namespace GitUI.CommandsDialogs
         private bool GetNextPatchFile(bool searchBackward, bool loop, out int fileIndex, out Task loadFileContent)
         {
             fileIndex = -1;
-            loadFileContent = Task.FromResult<string>(null);
+            loadFileContent = Task.CompletedTask;
             var revisions = _revisionGrid.GetSelectedRevisions();
             if (revisions.Count == 0)
                 return false;

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -75,7 +75,9 @@ namespace GitUI
         public static Task ViewChanges(this FileViewer diffViewer, IList<GitRevision> revisions, GitItemStatus file, string defaultText)
         {
             if (revisions.Count == 0)
-                return Task.FromResult(string.Empty);
+            {
+                return Task.CompletedTask;
+            }
 
             var selectedRevision = revisions[0];
             string secondRevision = selectedRevision?.Guid;
@@ -87,11 +89,31 @@ namespace GitUI
 
         public static Task ViewChanges(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file, string defaultText)
         {
-            return diffViewer.ViewPatch(() =>
+            if (firstRevision == null)
             {
-                string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
-                return selectedPatch ?? defaultText;
-            });
+                // The previous commit does not exist, nothing to compare with
+                if (file.TreeGuid.IsNullOrEmpty())
+                {
+                    if (secondRevision.IsNullOrWhiteSpace())
+                    {
+                        throw new ArgumentException(nameof(secondRevision));
+                    }
+
+                    return diffViewer.ViewGitItemRevision(file.Name, secondRevision);
+                }
+                else
+                {
+                    return diffViewer.ViewGitItem(file.Name, file.TreeGuid);
+                }
+            }
+            else
+            {
+                return diffViewer.ViewPatch(() =>
+                {
+                    string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
+                    return selectedPatch ?? defaultText;
+                });
+            }
         }
 
         public static void RemoveIfExists(this TabControl tabControl, TabPage page)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -96,7 +96,8 @@ namespace GitUI
                 {
                     if (secondRevision.IsNullOrWhiteSpace())
                     {
-                        throw new ArgumentException(nameof(secondRevision));
+                        // Revision unexpectedly is not set, just return for 2.51 update
+                        return Task.CompletedTask;
                     }
 
                     return diffViewer.ViewGitItemRevision(file.Name, secondRevision);

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -96,8 +96,7 @@ namespace GitUI
                 {
                     if (secondRevision.IsNullOrWhiteSpace())
                     {
-                        // Revision unexpectedly is not set, just return for 2.51 update
-                        return Task.CompletedTask;
+                        throw new ArgumentException(nameof(secondRevision));
                     }
 
                     return diffViewer.ViewGitItemRevision(file.Name, secondRevision);

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 
@@ -42,24 +43,34 @@ namespace GitUI.HelperDialogs
             }
         }
 
-        private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
+        private async void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ViewSelectedDiff();
-        }
-
-        private void ViewSelectedDiff()
-        {
-            if (DiffFiles.SelectedItem != null && _revision != null)
+            try
             {
-                Cursor.Current = Cursors.WaitCursor;
-                DiffText.ViewChanges(DiffFiles.SelectedItemParent, _revision.Guid, DiffFiles.SelectedItem, String.Empty);
-                Cursor.Current = Cursors.Default;
+                await ViewSelectedDiff();
+            }
+            catch (OperationCanceledException)
+            {
             }
         }
 
-        void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        private async Task ViewSelectedDiff()
         {
-            ViewSelectedDiff();
+            if (DiffFiles.SelectedItem != null && _revision != null)
+            {
+                await DiffText.ViewChanges(DiffFiles.SelectedItemParent, DiffFiles.Revision?.Guid, DiffFiles.SelectedItem, string.Empty);
+            }
+        }
+
+        private async void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                await ViewSelectedDiff();
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Difference for initial commit of a file were presented as a diff to the working directory (#4585)

Fixes #4580
Regression from #4313

Non-existing commits are handled with the "revision" null which is mostly handled as a working directory file.
The compare options for working directory files were limited in 2.50. In 2.51 the changes are presented with git-diff if possible and the non-existing parent were incorrectly handled.
Also some async/await changes

Don't indicate "in progress" async actions with WaitCursor.
If needed, the "awaiting" status should be displayed by the control that is awaiting the async action.
This should be done only if the load time is significant.

Cherry-pick of 7f7b26499bce424864ada3c05d15bd9ab6534581 from #4585  with one change: Suppress exception for patch release

The arguments to ViewChanges() is not fully investigated for the 2.51 release, use same behavior as in 2.50 and do not throw exceptions


Has been tested on (remove any that don't apply):
 - Windows 10
