### PR TITLE
Fix string.Format bug in GitFlow pull command

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -239,7 +239,7 @@ namespace GitFlow
         private void btnPull_Click(object sender, EventArgs e)
         {
             var branchType = cbType.SelectedValue.ToString();
-            RunCommand(string.Format("flow {0} pull {1} {2}" + branchType, cbRemote.SelectedValue, cbBranches.SelectedValue));
+            RunCommand(string.Format("flow {0} pull {1} {2}", branchType, cbRemote.SelectedValue, cbBranches.SelectedValue));
         }
 
         private void btnFinish_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes bug in `string.Format` in `GitFlowForm.btnPull_Click`.

The old code would have thrown an exception as there was no value for index 2.

What did I do to test the code and ensure quality:
 - Comparison with other git flow commands (adjacent methods)
