### PR TITLE
Use Enumerable.Empty and Array.Empty

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -225,7 +225,7 @@ namespace GitCommands.Config
 
             if (configSection == null)
             {
-                return new List<string>();
+                return Array.Empty<string>();
             }
 
             return configSection.GetValues(keyName);

--- a/GitCommands/ExternalLinks/ExternalLinksLoader.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksLoader.cs
@@ -72,7 +72,7 @@ namespace GitCommands.ExternalLinks
         {
             if (string.IsNullOrWhiteSpace(xmlString))
             {
-                return new List<ExternalLinkDefinition>();
+                return Array.Empty<ExternalLinkDefinition>();
             }
 
             try
@@ -91,7 +91,7 @@ namespace GitCommands.ExternalLinks
                 Debug.WriteLine(ex.Message);
             }
 
-            return new List<ExternalLinkDefinition>();
+            return Array.Empty<ExternalLinkDefinition>();
         }
     }
 }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2119,11 +2119,9 @@ namespace GitCommands
 
             int.TryParse(nextFile, out var next);
 
-            var files = new string[0];
-            if (Directory.Exists(GetRebaseDir()))
-            {
-                files = Directory.GetFiles(GetRebaseDir());
-            }
+            var files = Directory.Exists(GetRebaseDir())
+                ? Directory.GetFiles(GetRebaseDir())
+                : Array.Empty<string>();
 
             foreach (var fullFileName in files)
             {
@@ -3037,7 +3035,7 @@ namespace GitCommands
             string info = RunGitCmd("branch " + args);
             if (info.Trim().StartsWith("fatal") || info.Trim().StartsWith("error:"))
             {
-                return new List<string>();
+                return Enumerable.Empty<string>();
             }
 
             string[] result = info.Split(new[] { '\r', '\n', '*' }, StringSplitOptions.RemoveEmptyEntries);
@@ -3068,7 +3066,7 @@ namespace GitCommands
 
             if (info.Trim().StartsWith("fatal") || info.Trim().StartsWith("error:"))
             {
-                return new List<string>();
+                return Enumerable.Empty<string>();
             }
 
             return info.Split(new[] { '\r', '\n', '*', ' ' }, StringSplitOptions.RemoveEmptyEntries);

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -140,7 +140,7 @@ namespace GitUI.CommandsDialogs
 
         private IEnumerable<Tuple<string, object>> GetAdditionalMainMenuItemsForTranslation()
         {
-            var list = new List<ToolStripMenuItem> { _navigateToolStripMenuItem, _viewToolStripMenuItem };
+            var list = new[] { _navigateToolStripMenuItem, _viewToolStripMenuItem };
             return list.Select(menuItem => new Tuple<string, object>(menuItem.Name, menuItem));
         }
 
@@ -199,7 +199,7 @@ namespace GitUI.CommandsDialogs
         {
             if (_navigateMenuCommands == null && _viewMenuCommands == null)
             {
-                return new List<MenuCommand>();
+                return Enumerable.Empty<MenuCommand>();
             }
             else if (_navigateMenuCommands != null && _viewMenuCommands != null)
             {

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -52,8 +52,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _gitHoster = gitHoster;
         }
 
-        private List<IHostedRemote> _hostedRemotes;
-        private List<IPullRequestInformation> _pullRequestsInfo;
+        private IReadOnlyList<IHostedRemote> _hostedRemotes;
+        private IReadOnlyList<IPullRequestInformation> _pullRequestsInfo;
         private IPullRequestInformation _currentPullRequestInfo;
 
         private void ViewPullRequestsForm_Load(object sender, EventArgs e)
@@ -118,7 +118,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                                        _strError.Text));
         }
 
-        private void SetPullRequestsData(List<IPullRequestInformation> infos)
+        private void SetPullRequestsData(IReadOnlyList<IPullRequestInformation> infos)
         {
             if (_isFirstLoad)
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1440,7 +1440,7 @@ namespace GitUI
         private void SelectInitialRevision()
         {
             string filtredCurrentCheckout = _filtredCurrentCheckout;
-            string[] lastSelectedRows = LastSelectedRows ?? new string[0];
+            string[] lastSelectedRows = LastSelectedRows ?? Array.Empty<string>();
 
             // filter out all unavailable commits from LastSelectedRows.
             lastSelectedRows = lastSelectedRows.Where(revision => FindRevisionIndex(revision) >= 0).ToArray();

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -19,7 +19,7 @@ namespace GitFlow
 
         private readonly GitUIBaseEventArgs _gitUiCommands;
 
-        private Dictionary<string, List<string>> Branches { get; }
+        private Dictionary<string, IReadOnlyList<string>> Branches { get; } = new Dictionary<string, IReadOnlyList<string>>();
 
         private readonly AsyncLoader _task = new AsyncLoader();
 
@@ -50,8 +50,6 @@ namespace GitFlow
             Translate();
 
             _gitUiCommands = gitUiCommands;
-
-            Branches = new Dictionary<string, List<string>>();
 
             lblPrefixManage.Text = string.Empty;
             ttGitFlow.SetToolTip(lnkGitFlow, _gitFlowTooltip.Text);
@@ -128,15 +126,17 @@ namespace GitFlow
             }
         }
 
-        private List<string> GetBranches(string typeBranch)
+        private IReadOnlyList<string> GetBranches(string typeBranch)
         {
             var result = _gitUiCommands.GitModule.RunGitCmdResult("flow " + typeBranch);
+
             if (result.ExitCode != 0)
             {
-                return new List<string>();
+                return Array.Empty<string>();
             }
 
             string[] references = result.StdOutput.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
             return references.Select(e => e.Trim('*', ' ', '\n', '\r')).ToList();
         }
 
@@ -155,7 +155,7 @@ namespace GitFlow
             var isThereABranch = branches.Any();
 
             cbManageType.Enabled = true;
-            cbBranches.DataSource = isThereABranch ? branches : new List<string> { string.Format(_noBranchExist.Text, branchType) };
+            cbBranches.DataSource = isThereABranch ? branches : new[] { string.Format(_noBranchExist.Text, branchType) };
             cbBranches.Enabled = isThereABranch;
             if (isThereABranch && CurrentBranch != null)
             {

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
@@ -29,7 +29,7 @@ namespace GitUIPluginInterfaces.RepositoryHosts
         /// <returns>The new repo, owne by me.</returns>
         IHostedRepository Fork();
 
-        List<IPullRequestInformation> GetPullRequests();
+        IReadOnlyList<IPullRequestInformation> GetPullRequests();
 
         /// <returns>Pull request number</returns>
         int CreatePullRequest(string myBranch, string remoteBranch, string title, string body);

--- a/Plugins/Github3/GithubRepo.cs
+++ b/Plugins/Github3/GithubRepo.cs
@@ -83,22 +83,24 @@ namespace Github3
             return new GithubRepo(_repo.CreateFork());
         }
 
-        public List<IPullRequestInformation> GetPullRequests()
+        public IReadOnlyList<IPullRequestInformation> GetPullRequests()
         {
             var pullRequests = _repo?.GetPullRequests();
+
             if (pullRequests != null)
             {
                 return pullRequests
-                    .Select(pr => (IPullRequestInformation)new GithubPullRequest(pr))
+                    .Select(pr => new GithubPullRequest(pr))
                     .ToList();
             }
 
-            return new List<IPullRequestInformation>();
+            return Array.Empty<IPullRequestInformation>();
         }
 
         public int CreatePullRequest(string myBranch, string remoteBranch, string title, string body)
         {
             var pullrequest = _repo.CreatePullRequest(GithubLoginInfo.Username + ":" + myBranch, remoteBranch, title, body);
+
             if (pullrequest == null || pullrequest.Number == 0)
             {
                 throw new Exception("Failed to create pull request.");

--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using GitCommands;
 using GitUIPluginInterfaces;
 
@@ -22,7 +23,7 @@ namespace ResourceManager
 
         public virtual IEnumerable<ISetting> GetSettings()
         {
-            return new List<ISetting>();
+            return Enumerable.Empty<ISetting>();
         }
 
         public virtual void Register(IGitUICommands gitUiCommands)

--- a/ResourceManager/Translator.cs
+++ b/ResourceManager/Translator.cs
@@ -56,7 +56,7 @@ namespace ResourceManager
                 string translationDir = GetTranslationDir();
                 if (!Directory.Exists(translationDir))
                 {
-                    return new string[0];
+                    return Array.Empty<string>();
                 }
 
                 foreach (string fileName in Directory.GetFiles(translationDir, "*.xlf"))

--- a/UnitTests/GitUITests/UserControls/AuthorEmailBasedRevisionHighlightingFixture.cs
+++ b/UnitTests/GitUITests/UserControls/AuthorEmailBasedRevisionHighlightingFixture.cs
@@ -134,7 +134,7 @@ namespace GitUITests.UserControls
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            var action = sut.ProcessRevisionSelectionChange(currentModule, new GitRevision[0]);
+            var action = sut.ProcessRevisionSelectionChange(currentModule, Array.Empty<GitRevision>());
 
             action.Should().Be(AuthorEmailBasedRevisionHighlighting.SelectionChangeAction.RefreshUserInterface);
         }
@@ -147,7 +147,7 @@ namespace GitUITests.UserControls
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
-            sut.ProcessRevisionSelectionChange(currentModule, new GitRevision[0]);
+            sut.ProcessRevisionSelectionChange(currentModule, Array.Empty<GitRevision>());
 
             sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail2);
         }

--- a/UnitTests/GitUITests/UserControls/ToolStripClasses/CommitIconProviderTests.cs
+++ b/UnitTests/GitUITests/UserControls/ToolStripClasses/CommitIconProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System;
+using GitCommands;
 using GitUI.UserControls.ToolStripClasses;
 using NUnit.Framework;
 
@@ -31,7 +32,7 @@ namespace GitUITests.UserControls.ToolStripClasses
         [Test]
         public void ReturnsIconCleanWhenThereIsNoChangedFiles()
         {
-            var commitIcon = _commitIconProvider.GetCommitIcon(new GitItemStatus[0]);
+            var commitIcon = _commitIconProvider.GetCommitIcon(Array.Empty<GitItemStatus>());
 
             Assert.AreEqual(CommitIconProvider.IconClean, commitIcon);
         }


### PR DESCRIPTION
`Enumerable.Empty` and `Array.Empty` return singleton instances, so reduce overall allocations.

Also use `new [] { ... }` over `new List<T> { ... }` in a few places, for lesser allocations. The latter allocates an over-sized array (capacity 16) as well as the overhead of `List<T>`.
 
In a few places I substitute in `IReadOnlyList<T>`. I feel like GE could use this interface more broadly, though understand the interface itself is newer than much of the codebase. I will use it more in future.

What did I do to test the code and ensure quality:
 - Manual review of straightforward changes. The compiler does the checking here.
