### PR TITLE
Use Regex in GitItemParser

### DIFF
--- a/GitCommands/Git/GitItem.cs
+++ b/GitCommands/Git/GitItem.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using GitUIPluginInterfaces;
 
 namespace GitCommands.Git
@@ -7,11 +6,10 @@ namespace GitCommands.Git
     [DebuggerDisplay("GitItem( {" + nameof(FileName) + "} )")]
     public class GitItem : IGitItem
     {
-        public GitItem(string mode, string objectType, string guid, string name)
+        public GitItem(int mode, GitObjectType objectType, string guid, string name)
         {
             Mode = mode;
-            Enum.TryParse(objectType, true, out GitObjectType type);
-            ObjectType = type;
+            ObjectType = objectType;
             Guid = guid;
             FileName = Name = name;
         }
@@ -20,7 +18,7 @@ namespace GitCommands.Git
         public GitObjectType ObjectType { get; }
         public string Name { get; }
         public string FileName { get; set; }
-        public string Mode { get; }
+        public int Mode { get; }
     }
 
     public enum GitObjectType

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -10,7 +10,7 @@ namespace GitCommands.Git
     {
         [NotNull]
         [ItemNotNull]
-        IEnumerable<IGitItem> Parse([CanBeNull] string tree);
+        IEnumerable<GitItem> Parse([CanBeNull] string tree);
 
         [CanBeNull]
         GitItem ParseSingle([CanBeNull] string rawItem);
@@ -22,11 +22,11 @@ namespace GitCommands.Git
             @"^(?<mode>\d{6}) (?<type>(blob|tree|commit)+) (?<objectid>[0-9a-f]{40})\s+(?<name>.+)$",
             RegexOptions.Compiled);
 
-        public IEnumerable<IGitItem> Parse(string tree)
+        public IEnumerable<GitItem> Parse(string tree)
         {
             if (string.IsNullOrWhiteSpace(tree))
             {
-                return Enumerable.Empty<IGitItem>();
+                return Enumerable.Empty<GitItem>();
             }
 
             // $ git ls-tree HEAD

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -1,7 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitCommands.Git
@@ -59,15 +59,14 @@ namespace GitCommands.Git
                 return null;
             }
 
-            // TODO would be more compact to save mode as an Int32
-            // TODO should parse GitObjectType here
-
-            var mode = match.Groups["mode"].Value;
-            var itemType = match.Groups["type"].Value;
+            var mode = int.Parse(match.Groups["mode"].Value);
+            var typeName = match.Groups["type"].Value;
             var guid = match.Groups["objectid"].Value;
             var name = match.Groups["name"].Value;
 
-            return new GitItem(mode, itemType, guid, name);
+            Enum.TryParse(typeName, ignoreCase: true, out GitObjectType type);
+
+            return new GitItem(mode, type, guid, name);
         }
     }
 }

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
 using System.Linq;
 using GitUIPluginInterfaces;
+using JetBrains.Annotations;
 
 namespace GitCommands.Git
 {
     public interface IGitTreeParser
     {
-        IEnumerable<IGitItem> Parse(string tree);
-        GitItem ParseSingle(string rawItem);
+        [NotNull]
+        [ItemNotNull]
+        IEnumerable<IGitItem> Parse([CanBeNull] string tree);
+
+        [CanBeNull]
+        GitItem ParseSingle([CanBeNull] string rawItem);
     }
 
     public sealed class GitTreeParser : IGitTreeParser

--- a/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
@@ -29,17 +29,15 @@ namespace GitCommandsTests.Git
 
             items.Count.Should().Be(10);
 
-            var item = (GitItem)items[3];
-            item.Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
-            item.Mode.Should().Be("100644");
-            item.Name.Should().Be(".gitignore");
-            item.ObjectType.Should().Be(GitObjectType.Blob);
+            items[3].Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
+            items[3].Mode.Should().Be("100644");
+            items[3].Name.Should().Be(".gitignore");
+            items[3].ObjectType.Should().Be(GitObjectType.Blob);
 
-            item = (GitItem)items[8];
-            item.Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
-            item.Mode.Should().Be("040000");
-            item.Name.Should().Be("Bin");
-            item.ObjectType.Should().Be(GitObjectType.Tree);
+            items[8].Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
+            items[8].Mode.Should().Be("040000");
+            items[8].Name.Should().Be("Bin");
+            items[8].ObjectType.Should().Be(GitObjectType.Tree);
         }
 
         [TestCase(null)]

--- a/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
@@ -28,6 +28,7 @@ namespace GitCommandsTests.Git
             var items = _parser.Parse(GetLsTreeOutput()).ToList();
 
             items.Count.Should().Be(10);
+
             var item = (GitItem)items[3];
             item.Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
             item.Mode.Should().Be("100644");
@@ -41,17 +42,18 @@ namespace GitCommandsTests.Git
             item.ObjectType.Should().Be(GitObjectType.Tree);
         }
 
-        [Test]
-        public void ParseSingle_should_return_null_for_null()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("Hello World")]
+        [TestCase("ZZZZZZ blob 0000000000000000000000000000000000000000    README.md")]
+        [TestCase("100644 blob 000000000000000000000000000000000000000    README.md")]
+        [TestCase("100644 blob 00000000000000000000000000000000000000000    README.md")]
+        [TestCase("100644 ZZZZ 00000000000000000000000000000000000000000    README.md")]
+        [TestCase("1006444 blob 0000000000000000000000000000000000000000    README.md")]
+        [TestCase("10064 blob 0000000000000000000000000000000000000000    README.md")]
+        public void ParseSingle_should_return_null_if_input_invalid(string s)
         {
-            _parser.ParseSingle(null).Should().BeNull();
-        }
-
-        [Test]
-        public void ParseSingle_should_return_null_if_input_shorter_than_required()
-        {
-            _parser.ParseSingle("").Should().BeNull();
-            _parser.ParseSingle(new string('c', GitTreeParser.MinimumStringLength - 1)).Should().BeNull();
+            _parser.ParseSingle(s).Should().BeNull();
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitTreeParserTests.cs
@@ -30,12 +30,12 @@ namespace GitCommandsTests.Git
             items.Count.Should().Be(10);
 
             items[3].Guid.Should().Be("46cccae116d2e5a1a2f818b0b31adde4ab3800a9");
-            items[3].Mode.Should().Be("100644");
+            items[3].Mode.Should().Be(100644);
             items[3].Name.Should().Be(".gitignore");
             items[3].ObjectType.Should().Be(GitObjectType.Blob);
 
             items[8].Guid.Should().Be("58d57013ed2ef925fc1b3f6fe72ead258c522e75");
-            items[8].Mode.Should().Be("040000");
+            items[8].Mode.Should().Be(040000);
             items[8].Name.Should().Be("Bin");
             items[8].ObjectType.Should().Be(GitObjectType.Tree);
         }
@@ -61,7 +61,7 @@ namespace GitCommandsTests.Git
             var item = _parser.ParseSingle(s);
 
             item.Guid.Should().Be("25d7b5d771e84982a3dfd8bd537531d8fb45d491");
-            item.Mode.Should().Be("100644");
+            item.Mode.Should().Be(100644);
             item.Name.Should().Be(".editorconfig");
             item.ObjectType.Should().Be(GitObjectType.Blob);
         }

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -71,9 +71,9 @@ namespace GitCommandsTests
         public void LoadChildren_should_return_shallow_tree_for_GitItem_with_updated_FileName()
         {
             var guid = Guid.NewGuid().ToString("N");
-            var item = new GitItem("", "", guid, "folder");
+            var item = new GitItem(0, GitObjectType.Tree, guid, "folder");
 
-            var items = new[] { Substitute.For<IGitItem>(), new GitItem("", "", "", "file2"), new GitItem("", "", "", "file3") };
+            var items = new[] { Substitute.For<IGitItem>(), new GitItem(0, GitObjectType.Blob, "", "file2"), new GitItem(0, GitObjectType.Blob, "", "file3") };
             _module.GetTree(guid, false).Returns(items);
 
             var children = _provider.LoadChildren(item);

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows.Forms;
 using FluentAssertions;
@@ -42,7 +43,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_not_add_nods_if_no_children()
         {
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(x => null);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -75,8 +76,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_add_IsTree_as_folders()
         {
-            var items = new[] { CreateGitItem("file1", true, false, false), CreateGitItem("file2", true, false, false) };
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var items = new[] { new GitItem(0, GitObjectType.Tree, "", "file1"), new GitItem(0, GitObjectType.Tree, "", "file2") };
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -96,8 +97,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_add_IsCommit_as_submodue()
         {
-            var items = new[] { CreateGitItem("file1", false, true, false), CreateGitItem("file2", false, true, false) };
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var items = new[] { new GitItem(0, GitObjectType.Commit, "", "file1"), new GitItem(0, GitObjectType.Commit, "", "file2") };
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -117,8 +118,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_add_IsBlob_as_file()
         {
-            var items = new[] { CreateGitItem("file1", false, false, true), CreateGitItem("file2", false, false, true) };
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var items = new[] { new GitItem(0, GitObjectType.Blob, "", "file1"), new GitItem(0, GitObjectType.Blob, "", "file2") };
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -134,8 +135,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_not_load_icons_for_file_without_extension()
         {
-            var items = new[] { CreateGitItem("file1.", false, false, true), CreateGitItem("file2", false, false, true) };
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var items = new[] { new GitItem(0, GitObjectType.Blob, "", "file1."), new GitItem(0, GitObjectType.Blob, "", "file2") };
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -156,8 +157,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_not_add_icons_for_file_if_none_provided()
         {
-            var items = new[] { CreateGitItem("file1.foo", false, false, true), CreateGitItem("file2.txt", false, false, true) };
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var items = new[] { new GitItem(0, GitObjectType.Blob, "", "file1.foo"), new GitItem(0, GitObjectType.Blob, "", "file2.txt") };
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -178,8 +179,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_add_icon_for_file_extension_only_once()
         {
-            var items = new[] { CreateGitItem("file1.txt", false, false, true), CreateGitItem("file2.txt", false, false, true) };
-            var item = new GitItem("", "", System.Guid.NewGuid().ToString("N"), "folder");
+            var items = new[] { new GitItem(0, GitObjectType.Blob, "", "file1.txt"), new GitItem(0, GitObjectType.Blob, "", "file2.txt") };
+            var item = new GitItem(0, GitObjectType.Tree, Guid.NewGuid().ToString("N"), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
             var image = Resources.cow_head;
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(image);
@@ -197,12 +198,6 @@ namespace GitUITests.CommandsDialogs
             }
 
             _imageList.Images.Count.Should().Be(1);
-        }
-
-        private IGitItem CreateGitItem(string name, bool isTree, bool isCommit, bool isBlol)
-        {
-            var item = new GitItem("", isTree ? "tree" : isBlol ? "blob" : isCommit ? "commit" : "", "", name);
-            return item;
         }
 
         [SuppressMessage("ReSharper", "UnusedMember.Local")]


### PR DESCRIPTION
Changes proposed in this pull request:
 - Use Regex for clearer and more robust parsing of ls-tree output
 - GitItem class uses `int` to store `mode` for reduced allocation
 - GitItem no longer parses type string in ctor
 - Annotate `IGitItemParser` interface
 
What did I do to test the code and ensure quality:
 - Unit tests (added more tests)
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
