### PR TITLE
Remove GitModule.StreamCopy

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3313,18 +3313,6 @@ namespace GitCommands
             return string.Empty;
         }
 
-        public static void StreamCopy(Stream input, Stream output)
-        {
-            int read;
-            var buffer = new byte[2048];
-            do
-            {
-                read = input.Read(buffer, 0, buffer.Length);
-                output.Write(buffer, 0, read);
-            }
-            while (read > 0);
-        }
-
         public Stream GetFileStream(string blob)
         {
             try
@@ -3333,7 +3321,7 @@ namespace GitCommands
 
                 using (var process = RunGitCmdDetached("cat-file blob " + blob))
                 {
-                    StreamCopy(process.StandardOutput.BaseStream, newStream);
+                    process.StandardOutput.BaseStream.CopyTo(newStream);
                     newStream.Position = 0;
 
                     process.WaitForExit();


### PR DESCRIPTION
This method exists in the framework as `Stream.CopyTo`.

https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.copyto?view=netframework-4.7.1