### PR TITLE
Plugins/FindLargeFiles: Fix a bug when files to be deleted have spaces in its name

### DIFF
--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -144,7 +144,7 @@ namespace FindLargeFiles
                 StringBuilder sb = new StringBuilder();
                 foreach (GitObject gitObject in _gitObjects.Where(gitObject => gitObject.Delete))
                 {
-                    sb.AppendLine(string.Format("\"{0}\" filter-branch --index-filter \"git rm -r -f --cached --ignore-unmatch {1}\" --prune-empty -- --all",
+                    sb.AppendLine(string.Format("\"{0}\" filter-branch --index-filter \"git rm -r -f --cached --ignore-unmatch \\\"{1}\\\"\" --prune-empty -- --all",
                         _gitCommands.GitCommand, gitObject.Path));
                 }
 


### PR DESCRIPTION
Fixes #2245.

Changes proposed in this pull request:
 - Fix a bug when files to be deleted have spaces in its name

I didn't have a chance yet to test this locally.