### PR TITLE
Introduce WaitCursorScope

### DIFF
--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -151,40 +151,40 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Cursor.Current = Cursors.WaitCursor;
-            if (PatchFileMode.Checked)
+            using (new WaitCursorScope())
             {
-                if (IgnoreWhitespace.Checked)
+                if (PatchFileMode.Checked)
                 {
-                    FormProcess.ShowDialog(this, GitCommandHelpers.PatchCmdIgnoreWhitespace(PatchFile.Text));
+                    if (IgnoreWhitespace.Checked)
+                    {
+                        FormProcess.ShowDialog(this, GitCommandHelpers.PatchCmdIgnoreWhitespace(PatchFile.Text));
+                    }
+                    else
+                    {
+                        FormProcess.ShowDialog(this, GitCommandHelpers.PatchCmd(PatchFile.Text));
+                    }
                 }
                 else
                 {
-                    FormProcess.ShowDialog(this, GitCommandHelpers.PatchCmd(PatchFile.Text));
+                    if (IgnoreWhitespace.Checked)
+                    {
+                        Module.ApplyPatch(PatchDir.Text, GitCommandHelpers.PatchDirCmdIgnoreWhitespace());
+                    }
+                    else
+                    {
+                        Module.ApplyPatch(PatchDir.Text, GitCommandHelpers.PatchDirCmd());
+                    }
                 }
-            }
-            else
-            {
-                if (IgnoreWhitespace.Checked)
+
+                UICommands.RepoChangedNotifier.Notify();
+
+                EnableButtons();
+
+                if (!Module.InTheMiddleOfAction() && !Module.InTheMiddleOfPatch())
                 {
-                    Module.ApplyPatch(PatchDir.Text, GitCommandHelpers.PatchDirCmdIgnoreWhitespace());
-                }
-                else
-                {
-                    Module.ApplyPatch(PatchDir.Text, GitCommandHelpers.PatchDirCmd());
+                    Close();
                 }
             }
-
-            UICommands.RepoChangedNotifier.Notify();
-
-            EnableButtons();
-
-            if (!Module.InTheMiddleOfAction() && !Module.InTheMiddleOfPatch())
-            {
-                Close();
-            }
-
-            Cursor.Current = Cursors.Default;
         }
 
         private void Mergetool_Click(object sender, EventArgs e)
@@ -195,26 +195,29 @@ namespace GitUI.CommandsDialogs
 
         private void Skip_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            FormProcess.ShowDialog(this, GitCommandHelpers.SkipCmd());
-            EnableButtons();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                FormProcess.ShowDialog(this, GitCommandHelpers.SkipCmd());
+                EnableButtons();
+            }
         }
 
         private void Resolved_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            FormProcess.ShowDialog(this, GitCommandHelpers.ResolvedCmd());
-            EnableButtons();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                FormProcess.ShowDialog(this, GitCommandHelpers.ResolvedCmd());
+                EnableButtons();
+            }
         }
 
         private void Abort_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            FormProcess.ShowDialog(this, GitCommandHelpers.AbortCmd());
-            EnableButtons();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                FormProcess.ShowDialog(this, GitCommandHelpers.AbortCmd());
+                EnableButtons();
+            }
         }
 
         private void AddFiles_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 if (PatchFileMode.Checked)
                 {
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs
 
         private void Skip_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, GitCommandHelpers.SkipCmd());
                 EnableButtons();
@@ -204,7 +204,7 @@ namespace GitUI.CommandsDialogs
 
         private void Resolved_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, GitCommandHelpers.ResolvedCmd());
                 EnableButtons();
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs
 
         private void Abort_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, GitCommandHelpers.AbortCmd());
                 EnableButtons();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -430,7 +430,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.Load();
             _filterBranchHelper.InitToolStripBranchFilter();
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 LayoutRevisionInfo();
                 InternalInitialize(false);
@@ -552,7 +552,7 @@ namespace GitUI.CommandsDialogs
 
         private void InternalInitialize(bool hard)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 UICommands.RaisePreBrowseInitialize(this);
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -734,28 +734,28 @@ namespace GitUI.CommandsDialogs
             _initialized = true;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(() => UpdateBranchNameDisplayAsync());
-            Cursor.Current = Cursors.WaitCursor;
 
-            if (loadUnstaged)
+            using (new WaitCursorScope())
             {
-                Loading.Visible = true;
-                LoadingStaged.Visible = true;
+                if (loadUnstaged)
+                {
+                    Loading.Visible = true;
+                    LoadingStaged.Visible = true;
 
-                Commit.Enabled = false;
-                CommitAndPush.Enabled = false;
-                Amend.Enabled = false;
-                Reset.Enabled = false;
-                ResetUnStaged.Enabled = false;
-                EnableStageButtons(false);
+                    Commit.Enabled = false;
+                    CommitAndPush.Enabled = false;
+                    Amend.Enabled = false;
+                    Reset.Enabled = false;
+                    ResetUnStaged.Enabled = false;
+                    EnableStageButtons(false);
 
-                ComputeUnstagedFiles(LoadUnstagedOutput, true);
+                    ComputeUnstagedFiles(LoadUnstagedOutput, true);
+                }
+
+                UpdateMergeHead();
+
+                Message.TextBoxFont = AppSettings.CommitFont;
             }
-
-            UpdateMergeHead();
-
-            Message.TextBoxFont = AppSettings.CommitFont;
-
-            Cursor.Current = Cursors.Default;
         }
 
         private void UpdateMergeHead()
@@ -766,10 +766,11 @@ namespace GitUI.CommandsDialogs
 
         private void InitializedStaged()
         {
-            Cursor.Current = Cursors.WaitCursor;
-            SolveMergeconflicts.Visible = Module.InTheMiddleOfConflictedMerge();
-            Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), Module.GetStagedFilesWithSubmodulesStatus());
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                SolveMergeconflicts.Visible = Module.InTheMiddleOfConflictedMerge();
+                Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), Module.GetStagedFilesWithSubmodulesStatus());
+            }
         }
 
         private event Action OnStageAreaLoaded;
@@ -1377,118 +1378,119 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Cursor.Current = Cursors.WaitCursor;
-            EnableStageButtons(false);
-            try
+            using (new WaitCursorScope())
             {
-                var lastSelection = new List<GitItemStatus>();
-                if (_currentFilesList != null)
+                EnableStageButtons(false);
+                try
                 {
-                    lastSelection = _currentSelection;
-                }
+                    var lastSelection = new List<GitItemStatus>();
+                    if (_currentFilesList != null)
+                    {
+                        lastSelection = _currentSelection;
+                    }
 
-                toolStripProgressBar1.Visible = true;
-                toolStripProgressBar1.Maximum = Staged.SelectedItems.Count() * 2;
-                toolStripProgressBar1.Value = 0;
-                Staged.StoreNextIndexToSelect();
+                    toolStripProgressBar1.Visible = true;
+                    toolStripProgressBar1.Maximum = Staged.SelectedItems.Count() * 2;
+                    toolStripProgressBar1.Value = 0;
+                    Staged.StoreNextIndexToSelect();
 
-                var files = new List<GitItemStatus>();
-                var allFiles = new List<GitItemStatus>();
+                    var files = new List<GitItemStatus>();
+                    var allFiles = new List<GitItemStatus>();
 
-                foreach (var item in Staged.SelectedItems)
-                {
-                    toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
-                    if (!item.IsNew)
+                    foreach (var item in Staged.SelectedItems)
                     {
                         toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
-                        Module.UnstageFileToRemove(item.Name);
+                        if (!item.IsNew)
+                        {
+                            toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
+                            Module.UnstageFileToRemove(item.Name);
+
+                            if (item.IsRenamed)
+                            {
+                                Module.UnstageFileToRemove(item.OldName);
+                            }
+                        }
+                        else
+                        {
+                            files.Add(item);
+                        }
+
+                        allFiles.Add(item);
+                    }
+
+                    Module.UnstageFiles(files);
+
+                    _skipUpdate = true;
+                    InitializedStaged();
+                    var stagedFiles = Staged.GitItemStatuses.ToList();
+                    var unstagedFiles = Unstaged.GitItemStatuses.ToList();
+                    foreach (var item in allFiles)
+                    {
+                        var item1 = item;
+                        if (stagedFiles.Exists(i => i.Name == item1.Name))
+                        {
+                            continue;
+                        }
+
+                        var item2 = item;
+                        if (unstagedFiles.Exists(i => i.Name == item2.Name))
+                        {
+                            continue;
+                        }
+
+                        if (item.IsNew && !item.IsChanged && !item.IsDeleted)
+                        {
+                            item.IsTracked = false;
+                        }
+                        else
+                        {
+                            item.IsTracked = true;
+                        }
 
                         if (item.IsRenamed)
                         {
-                            Module.UnstageFileToRemove(item.OldName);
+                            var clone = new GitItemStatus
+                            {
+                                Name = item.OldName,
+                                IsDeleted = true,
+                                IsTracked = true,
+                                IsStaged = false
+                            };
+                            unstagedFiles.Add(clone);
+
+                            item.IsRenamed = false;
+                            item.IsNew = true;
+                            item.IsTracked = false;
+                            item.OldName = string.Empty;
                         }
+
+                        item.IsStaged = false;
+                        unstagedFiles.Add(item);
                     }
-                    else
+
+                    Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unstagedFiles);
+                    Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), stagedFiles);
+                    _skipUpdate = false;
+                    Staged.SelectStoredNextIndex();
+
+                    toolStripProgressBar1.Value = toolStripProgressBar1.Maximum;
+
+                    toolStripProgressBar1.Visible = false;
+
+                    if (Staged.IsEmpty)
                     {
-                        files.Add(item);
+                        _currentFilesList = Unstaged;
+                        RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
+                        Unstaged.Focus();
                     }
-
-                    allFiles.Add(item);
                 }
-
-                Module.UnstageFiles(files);
-
-                _skipUpdate = true;
-                InitializedStaged();
-                var stagedFiles = Staged.GitItemStatuses.ToList();
-                var unstagedFiles = Unstaged.GitItemStatuses.ToList();
-                foreach (var item in allFiles)
+                catch (Exception ex)
                 {
-                    var item1 = item;
-                    if (stagedFiles.Exists(i => i.Name == item1.Name))
-                    {
-                        continue;
-                    }
-
-                    var item2 = item;
-                    if (unstagedFiles.Exists(i => i.Name == item2.Name))
-                    {
-                        continue;
-                    }
-
-                    if (item.IsNew && !item.IsChanged && !item.IsDeleted)
-                    {
-                        item.IsTracked = false;
-                    }
-                    else
-                    {
-                        item.IsTracked = true;
-                    }
-
-                    if (item.IsRenamed)
-                    {
-                        var clone = new GitItemStatus
-                        {
-                            Name = item.OldName,
-                            IsDeleted = true,
-                            IsTracked = true,
-                            IsStaged = false
-                        };
-                        unstagedFiles.Add(clone);
-
-                        item.IsRenamed = false;
-                        item.IsNew = true;
-                        item.IsTracked = false;
-                        item.OldName = string.Empty;
-                    }
-
-                    item.IsStaged = false;
-                    unstagedFiles.Add(item);
+                    Trace.WriteLine(ex.Message);
                 }
 
-                Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unstagedFiles);
-                Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), stagedFiles);
-                _skipUpdate = false;
-                Staged.SelectStoredNextIndex();
-
-                toolStripProgressBar1.Value = toolStripProgressBar1.Maximum;
-
-                toolStripProgressBar1.Visible = false;
-
-                if (Staged.IsEmpty)
-                {
-                    _currentFilesList = Unstaged;
-                    RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
-                    Unstaged.Focus();
-                }
+                EnableStageButtons(true);
             }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex.Message);
-            }
-
-            EnableStageButtons(true);
-            Cursor.Current = Cursors.Default;
 
             if (AppSettings.RevisionGraphShowWorkingDirChanges)
             {
@@ -1578,120 +1580,123 @@ namespace GitUI.CommandsDialogs
 
         private void Stage(IReadOnlyList<GitItemStatus> gitItemStatuses)
         {
-            EnableStageButtons(false);
-            try
+            using (new WaitCursorScope())
             {
-                var lastSelection = new List<GitItemStatus>();
-                if (_currentFilesList != null)
+                EnableStageButtons(false);
+                try
                 {
-                    lastSelection = _currentSelection;
-                }
-
-                Cursor.Current = Cursors.WaitCursor;
-                Unstaged.StoreNextIndexToSelect();
-                toolStripProgressBar1.Visible = true;
-                toolStripProgressBar1.Maximum = gitItemStatuses.Count * 2;
-                toolStripProgressBar1.Value = 0;
-
-                var files = new List<GitItemStatus>();
-
-                foreach (var gitItemStatus in gitItemStatuses)
-                {
-                    toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
-                    if (gitItemStatus.Name.EndsWith("/"))
+                    var lastSelection = new List<GitItemStatus>();
+                    if (_currentFilesList != null)
                     {
-                        gitItemStatus.Name = gitItemStatus.Name.TrimEnd('/');
+                        lastSelection = _currentSelection;
                     }
 
-                    files.Add(gitItemStatus);
-                }
+                    Unstaged.StoreNextIndexToSelect();
+                    toolStripProgressBar1.Visible = true;
+                    toolStripProgressBar1.Maximum = gitItemStatuses.Count * 2;
+                    toolStripProgressBar1.Value = 0;
 
-                bool wereErrors = false;
-                if (AppSettings.ShowErrorsWhenStagingFiles)
-                {
-                    void ProcessStart(FormStatus form)
-                    {
-                        form.AppendMessageCrossThread(
-                            string.Format(
-                                _stageFiles.Text + "\n", files.Count));
-                        var output = Module.StageFiles(files, out wereErrors);
-                        form.AppendMessageCrossThread(output);
-                        form.Done(string.IsNullOrEmpty(output));
-                    }
+                    var files = new List<GitItemStatus>();
 
-                    using (var process = new FormStatus(ProcessStart, null) { Text = _stageDetails.Text })
+                    foreach (var gitItemStatus in gitItemStatuses)
                     {
-                        process.ShowDialogOnError(this);
-                    }
-                }
-                else
-                {
-                    Module.StageFiles(files, out wereErrors);
-                }
-
-                if (wereErrors)
-                {
-                    RescanChanges();
-                }
-                else
-                {
-                    InitializedStaged();
-                    var unstagedFiles = Unstaged.GitItemStatuses.ToList();
-                    _skipUpdate = true;
-                    var names = new HashSet<string>();
-                    foreach (var item in files)
-                    {
-                        names.Add(item.Name);
-                        names.Add(item.OldName);
-                    }
-
-                    var unstagedItems = new HashSet<GitItemStatus>();
-                    foreach (var item in unstagedFiles)
-                    {
-                        if (names.Contains(item.Name))
+                        toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
+                        if (gitItemStatus.Name.EndsWith("/"))
                         {
-                            unstagedItems.Add(item);
+                            gitItemStatus.Name = gitItemStatus.Name.TrimEnd('/');
+                        }
+
+                        files.Add(gitItemStatus);
+                    }
+
+                    bool wereErrors = false;
+                    if (AppSettings.ShowErrorsWhenStagingFiles)
+                    {
+                        void ProcessStart(FormStatus form)
+                        {
+                            form.AppendMessageCrossThread(
+                                string.Format(
+                                    _stageFiles.Text + "\n", files.Count));
+                            var output = Module.StageFiles(files, out wereErrors);
+                            form.AppendMessageCrossThread(output);
+                            form.Done(string.IsNullOrEmpty(output));
+                        }
+
+                        using (var process = new FormStatus(ProcessStart, null) { Text = _stageDetails.Text })
+                        {
+                            process.ShowDialogOnError(this);
                         }
                     }
-
-                    unstagedFiles.RemoveAll(item => !item.IsSubmodule && unstagedItems.Contains(item));
-                    unstagedFiles.RemoveAll(item => item.IsSubmodule && item.GetSubmoduleStatusAsync().IsCompleted &&
-                        (item.GetSubmoduleStatusAsync().CompletedResult() == null ||
-                        (!item.GetSubmoduleStatusAsync().CompletedResult().IsDirty && unstagedItems.Contains(item))));
-                    foreach (var item in unstagedItems.Where(item => item.IsSubmodule &&
-                        (ThreadHelper.JoinableTaskFactory.Run(() => item.GetSubmoduleStatusAsync()) == null ||
-                        (item.GetSubmoduleStatusAsync().IsCompleted && item.GetSubmoduleStatusAsync().CompletedResult().IsDirty))))
+                    else
                     {
-                        item.GetSubmoduleStatusAsync().CompletedResult().Status = SubmoduleStatus.Unknown;
+                        Module.StageFiles(files, out wereErrors);
                     }
 
-                    Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unstagedFiles);
-                    Unstaged.ClearSelected();
-                    _skipUpdate = false;
-                    Unstaged.SelectStoredNextIndex();
+                    if (wereErrors)
+                    {
+                        RescanChanges();
+                    }
+                    else
+                    {
+                        InitializedStaged();
+                        var unstagedFiles = Unstaged.GitItemStatuses.ToList();
+                        _skipUpdate = true;
+                        var names = new HashSet<string>();
+                        foreach (var item in files)
+                        {
+                            names.Add(item.Name);
+                            names.Add(item.OldName);
+                        }
+
+                        var unstagedItems = new HashSet<GitItemStatus>();
+                        foreach (var item in unstagedFiles)
+                        {
+                            if (names.Contains(item.Name))
+                            {
+                                unstagedItems.Add(item);
+                            }
+                        }
+
+                        unstagedFiles.RemoveAll(item => !item.IsSubmodule && unstagedItems.Contains(item));
+                        unstagedFiles.RemoveAll(
+                            item => item.IsSubmodule && item.GetSubmoduleStatusAsync().IsCompleted &&
+                                    (item.GetSubmoduleStatusAsync().CompletedResult() == null ||
+                                     (!item.GetSubmoduleStatusAsync().CompletedResult().IsDirty && unstagedItems.Contains(item))));
+                        foreach (var item in unstagedItems.Where(
+                            item => item.IsSubmodule &&
+                                    (ThreadHelper.JoinableTaskFactory.Run(() => item.GetSubmoduleStatusAsync()) == null ||
+                                     (item.GetSubmoduleStatusAsync().IsCompleted && item.GetSubmoduleStatusAsync().CompletedResult().IsDirty))))
+                        {
+                            item.GetSubmoduleStatusAsync().CompletedResult().Status = SubmoduleStatus.Unknown;
+                        }
+
+                        Unstaged.SetDiffs(new GitRevision(GitRevision.UnstagedGuid), new GitRevision(GitRevision.IndexGuid), unstagedFiles);
+                        Unstaged.ClearSelected();
+                        _skipUpdate = false;
+                        Unstaged.SelectStoredNextIndex();
+                    }
+
+                    toolStripProgressBar1.Value = toolStripProgressBar1.Maximum;
+
+                    toolStripProgressBar1.Visible = false;
+
+                    if (Unstaged.IsEmpty)
+                    {
+                        _currentFilesList = Staged;
+                        RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
+                    }
                 }
-
-                toolStripProgressBar1.Value = toolStripProgressBar1.Maximum;
-
-                toolStripProgressBar1.Visible = false;
-
-                if (Unstaged.IsEmpty)
+                catch (Exception ex)
                 {
-                    _currentFilesList = Staged;
-                    RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
+                    Trace.WriteLine(ex.Message);
                 }
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex.Message);
-            }
 
-            EnableStageButtons(true);
+                EnableStageButtons(true);
 
-            Commit.Enabled = true;
-            Amend.Enabled = true;
-            AcceptButton = Commit;
-            Cursor.Current = Cursors.Default;
+                Commit.Enabled = true;
+                Amend.Enabled = true;
+                AcceptButton = Commit;
+            }
 
             if (AppSettings.RevisionGraphShowWorkingDirChanges)
             {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -735,7 +735,7 @@ namespace GitUI.CommandsDialogs
 
             ThreadHelper.JoinableTaskFactory.RunAsync(() => UpdateBranchNameDisplayAsync());
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 if (loadUnstaged)
                 {
@@ -766,7 +766,7 @@ namespace GitUI.CommandsDialogs
 
         private void InitializedStaged()
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 SolveMergeconflicts.Visible = Module.InTheMiddleOfConflictedMerge();
                 Staged.SetDiffs(new GitRevision(GitRevision.IndexGuid), new GitRevision("HEAD"), Module.GetStagedFilesWithSubmodulesStatus());
@@ -1378,7 +1378,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 EnableStageButtons(false);
                 try
@@ -1580,7 +1580,7 @@ namespace GitUI.CommandsDialogs
 
         private void Stage(IReadOnlyList<GitItemStatus> gitItemStatuses)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 EnableStageButtons(false);
                 try

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -44,7 +44,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 diffViewer.ViewChangesAsync(RevisionGrid.GetSelectedRevisions(), DiffFiles.SelectedItem, string.Empty);
             }
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
 
         private void RevisionGridSelectionChanged(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
             }

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -44,16 +44,18 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Cursor.Current = Cursors.WaitCursor;
-            diffViewer.ViewChangesAsync(RevisionGrid.GetSelectedRevisions(), DiffFiles.SelectedItem, string.Empty);
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                diffViewer.ViewChangesAsync(RevisionGrid.GetSelectedRevisions(), DiffFiles.SelectedItem, string.Empty);
+            }
         }
 
         private void RevisionGridSelectionChanged(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
+            }
         }
 
         private void DiffViewerExtraDiffArgumentsChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -228,48 +228,48 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Cursor.Current = Cursors.WaitCursor;
-            LoadPuttyKey();
-
-            if (_heads == null)
+            using (new WaitCursorScope())
             {
-                if (PullFromUrl.Checked)
-                {
-                    _heads = Module.GetRefs(false, true).ToList();
-                }
-                else
-                {
-                    // The line below is the most reliable way to get a list containing
-                    // all remote branches but it is also the slowest.
-                    // Heads = GitCommands.GitCommands.GetRemoteHeads(Remotes.Text, false, true);
+                LoadPuttyKey();
 
-                    // The code below is a quick way to get a list contains all remote branches.
-                    // It only returns the heads that are already known to the repository. This
-                    // doesn't return heads that are new on the server. This can be updated using
-                    // update branch info in the manage remotes dialog.
-                    _heads = new List<IGitRef>();
-                    foreach (var head in Module.GetRefs(true, true))
+                if (_heads == null)
+                {
+                    if (PullFromUrl.Checked)
                     {
-                        if (!head.IsRemote ||
-                            !head.Name.StartsWith(_NO_TRANSLATE_Remotes.Text, StringComparison.CurrentCultureIgnoreCase))
-                        {
-                            continue;
-                        }
+                        _heads = Module.GetRefs(false, true).ToList();
+                    }
+                    else
+                    {
+                        // The line below is the most reliable way to get a list containing
+                        // all remote branches but it is also the slowest.
+                        // Heads = GitCommands.GitCommands.GetRemoteHeads(Remotes.Text, false, true);
 
-                        _heads.Insert(0, head);
+                        // The code below is a quick way to get a list contains all remote branches.
+                        // It only returns the heads that are already known to the repository. This
+                        // doesn't return heads that are new on the server. This can be updated using
+                        // update branch info in the manage remotes dialog.
+                        _heads = new List<IGitRef>();
+                        foreach (var head in Module.GetRefs(true, true))
+                        {
+                            if (!head.IsRemote ||
+                                !head.Name.StartsWith(_NO_TRANSLATE_Remotes.Text, StringComparison.CurrentCultureIgnoreCase))
+                            {
+                                continue;
+                            }
+
+                            _heads.Insert(0, head);
+                        }
                     }
                 }
+
+                Branches.DisplayMember = "LocalName";
+
+                ////_heads.Insert(0, GitHead.AllHeads); --> disable this because it is only for expert users
+                _heads.Insert(0, GitRef.NoHead(Module));
+                Branches.DataSource = _heads;
+
+                ComboBoxHelper.ResizeComboBoxDropDownWidth(Branches, AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
             }
-
-            Branches.DisplayMember = "LocalName";
-
-            ////_heads.Insert(0, GitHead.AllHeads); --> disable this because it is only for expert users
-            _heads.Insert(0, GitRef.NoHead(Module));
-            Branches.DataSource = _heads;
-
-            ComboBoxHelper.ResizeComboBoxDropDownWidth(Branches, AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
-
-            Cursor.Current = Cursors.Default;
         }
 
         private void PullClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -228,7 +228,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 LoadPuttyKey();
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResolvedClick(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, GitCommandHelpers.ContinueRebaseCmd());
 
@@ -192,7 +192,7 @@ namespace GitUI.CommandsDialogs
 
         private void SkipClick(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, GitCommandHelpers.SkipRebaseCmd());
 
@@ -208,7 +208,7 @@ namespace GitUI.CommandsDialogs
 
         private void AbortClick(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, GitCommandHelpers.AbortRebaseCmd());
 
@@ -224,7 +224,7 @@ namespace GitUI.CommandsDialogs
 
         private void OkClick(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 if (string.IsNullOrEmpty(Branches.Text))
                 {

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -176,89 +176,95 @@ namespace GitUI.CommandsDialogs
 
         private void ResolvedClick(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            FormProcess.ShowDialog(this, GitCommandHelpers.ContinueRebaseCmd());
-
-            if (!Module.InTheMiddleOfRebase())
+            using (new WaitCursorScope())
             {
-                Close();
-            }
+                FormProcess.ShowDialog(this, GitCommandHelpers.ContinueRebaseCmd());
 
-            EnableButtons();
-            patchGrid1.Initialize();
-            Cursor.Current = Cursors.Default;
+                if (!Module.InTheMiddleOfRebase())
+                {
+                    Close();
+                }
+
+                EnableButtons();
+                patchGrid1.Initialize();
+            }
         }
 
         private void SkipClick(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            FormProcess.ShowDialog(this, GitCommandHelpers.SkipRebaseCmd());
-
-            if (!Module.InTheMiddleOfRebase())
+            using (new WaitCursorScope())
             {
-                Close();
-            }
+                FormProcess.ShowDialog(this, GitCommandHelpers.SkipRebaseCmd());
 
-            EnableButtons();
-            patchGrid1.Initialize();
-            Cursor.Current = Cursors.Default;
+                if (!Module.InTheMiddleOfRebase())
+                {
+                    Close();
+                }
+
+                EnableButtons();
+                patchGrid1.Initialize();
+            }
         }
 
         private void AbortClick(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            FormProcess.ShowDialog(this, GitCommandHelpers.AbortRebaseCmd());
-
-            if (!Module.InTheMiddleOfRebase())
+            using (new WaitCursorScope())
             {
-                Close();
-            }
+                FormProcess.ShowDialog(this, GitCommandHelpers.AbortRebaseCmd());
 
-            EnableButtons();
-            patchGrid1.Initialize();
-            Cursor.Current = Cursors.Default;
+                if (!Module.InTheMiddleOfRebase())
+                {
+                    Close();
+                }
+
+                EnableButtons();
+                patchGrid1.Initialize();
+            }
         }
 
         private void OkClick(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            if (string.IsNullOrEmpty(Branches.Text))
+            using (new WaitCursorScope())
             {
-                MessageBox.Show(this, _noBranchSelectedText.Text);
-                return;
-            }
+                if (string.IsNullOrEmpty(Branches.Text))
+                {
+                    MessageBox.Show(this, _noBranchSelectedText.Text);
+                    return;
+                }
 
-            AppSettings.RebaseAutoStash = chkStash.Checked;
+                AppSettings.RebaseAutoStash = chkStash.Checked;
 
-            string rebaseCmd;
-            if (chkSpecificRange.Checked && !string.IsNullOrWhiteSpace(txtFrom.Text) && !string.IsNullOrWhiteSpace(cboTo.Text))
-            {
-                rebaseCmd = GitCommandHelpers.RebaseRangeCmd(txtFrom.Text, cboTo.Text, Branches.Text,
-                                                             chkInteractive.Checked, chkPreserveMerges.Checked,
-                                                             chkAutosquash.Checked, chkStash.Checked);
-            }
-            else
-            {
-                rebaseCmd = GitCommandHelpers.RebaseCmd(Branches.Text, chkInteractive.Checked,
-                                                        chkPreserveMerges.Checked, chkAutosquash.Checked,
-                                                        chkStash.Checked);
-            }
+                string rebaseCmd;
+                if (chkSpecificRange.Checked && !string.IsNullOrWhiteSpace(txtFrom.Text) && !string.IsNullOrWhiteSpace(cboTo.Text))
+                {
+                    rebaseCmd = GitCommandHelpers.RebaseRangeCmd(
+                        txtFrom.Text, cboTo.Text, Branches.Text,
+                        chkInteractive.Checked, chkPreserveMerges.Checked,
+                        chkAutosquash.Checked, chkStash.Checked);
+                }
+                else
+                {
+                    rebaseCmd = GitCommandHelpers.RebaseCmd(
+                        Branches.Text, chkInteractive.Checked,
+                        chkPreserveMerges.Checked, chkAutosquash.Checked,
+                        chkStash.Checked);
+                }
 
-            var dialogResult = FormProcess.ReadDialog(this, rebaseCmd);
-            if (dialogResult.Trim() == "Current branch a is up to date.")
-            {
-                MessageBox.Show(this, _branchUpToDateText.Text, _branchUpToDateCaption.Text);
-            }
+                var dialogResult = FormProcess.ReadDialog(this, rebaseCmd);
+                if (dialogResult.Trim() == "Current branch a is up to date.")
+                {
+                    MessageBox.Show(this, _branchUpToDateText.Text, _branchUpToDateCaption.Text);
+                }
 
-            if (!Module.InTheMiddleOfAction() &&
-                !Module.InTheMiddleOfPatch())
-            {
-                Close();
-            }
+                if (!Module.InTheMiddleOfAction() &&
+                    !Module.InTheMiddleOfPatch())
+                {
+                    Close();
+                }
 
-            EnableButtons();
-            patchGrid1.Initialize();
-            Cursor.Current = Cursors.Default;
+                EnableButtons();
+                patchGrid1.Initialize();
+            }
         }
 
         private void SolveMergeconflictsClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -121,7 +121,7 @@ namespace GitUI.CommandsDialogs
 
         private void Mergetool_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 Directory.SetCurrentDirectory(Module.WorkingDir);
                 Module.RunExternalCmdShowConsole(AppSettings.GitCommand, "mergetool");
@@ -139,7 +139,7 @@ namespace GitUI.CommandsDialogs
 
         private void Initialize()
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 int oldSelectedRow = 0;
                 if (ConflictedFiles.SelectedRows.Count > 0)
@@ -385,7 +385,7 @@ namespace GitUI.CommandsDialogs
 
         private void ConflictedFiles_DoubleClick(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 try
                 {
@@ -562,7 +562,7 @@ namespace GitUI.CommandsDialogs
                 return false;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 _mergetoolCmd = Module.GetEffectiveSetting($"mergetool.{_mergetool}.cmd");
                 _mergetoolPath = Module.GetEffectiveSetting($"mergetool.{_mergetool}.path");
@@ -619,7 +619,7 @@ namespace GitUI.CommandsDialogs
 
         private void Reset_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 if (ShowAbortMessage())
                 {
@@ -744,7 +744,7 @@ namespace GitUI.CommandsDialogs
 
         private void ContextChooseBase_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var conflictItems = GetConflicts();
                 StartProgressBarWithMaxValue(conflictItems.Length);
@@ -773,7 +773,7 @@ namespace GitUI.CommandsDialogs
 
         private void ContextChooseLocal_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var conflictItems = GetConflicts();
                 StartProgressBarWithMaxValue(conflictItems.Length);
@@ -802,7 +802,7 @@ namespace GitUI.CommandsDialogs
 
         private void ContextChooseRemote_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var conflictItems = GetConflicts();
                 StartProgressBarWithMaxValue(conflictItems.Length);
@@ -988,7 +988,7 @@ namespace GitUI.CommandsDialogs
 
         private void OpenMergetool_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 ConflictedFiles_DoubleClick(sender, e);
             }
@@ -1006,7 +1006,7 @@ namespace GitUI.CommandsDialogs
 
         private void OpenSideWith(string side)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var conflictData = GetConflict();
                 string fileName = conflictData.Filename;
@@ -1053,7 +1053,7 @@ namespace GitUI.CommandsDialogs
 
         private void SaveAs(string side)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var conflictData = GetConflict();
                 string fileName = conflictData.Filename;
@@ -1098,7 +1098,7 @@ namespace GitUI.CommandsDialogs
 
         private void ContextMarkAsSolved_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 StageFile(GetFileName());
                 Initialize();

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormSettings_Shown(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 LoadSettings();
             }
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs
                 Text = _translatedTitle + " - " + title;
                 Application.DoEvents();
 
-                using (new WaitCursorScope())
+                using (WaitCursorScope.Enter())
                 {
                     settingsPage.OnPageShown();
                 }
@@ -221,7 +221,7 @@ namespace GitUI.CommandsDialogs
 
         private void Ok_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 if (Save())
                 {
@@ -292,7 +292,7 @@ namespace GitUI.CommandsDialogs
 
         private void buttonDiscard_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 LoadSettings();
             }
@@ -300,7 +300,7 @@ namespace GitUI.CommandsDialogs
 
         private void buttonApply_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 Save();
             }

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -151,9 +151,10 @@ namespace GitUI.CommandsDialogs
 
         private void FormSettings_Shown(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            LoadSettings();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                LoadSettings();
+            }
         }
 
         private void settingsTreeViewUserControl1_SettingsPageSelected(object sender, SettingsPageSelectedEventArgs e)
@@ -176,9 +177,10 @@ namespace GitUI.CommandsDialogs
                 Text = _translatedTitle + " - " + title;
                 Application.DoEvents();
 
-                Cursor.Current = Cursors.WaitCursor;
-                settingsPage.OnPageShown();
-                Cursor.Current = Cursors.Default;
+                using (new WaitCursorScope())
+                {
+                    settingsPage.OnPageShown();
+                }
 
                 bool isInstantSavePage = settingsPage.IsInstantSavePage;
                 labelInstantSaveNotice.Visible = isInstantSavePage;
@@ -219,13 +221,13 @@ namespace GitUI.CommandsDialogs
 
         private void Ok_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            if (Save())
+            using (new WaitCursorScope())
             {
-                Close();
+                if (Save())
+                {
+                    Close();
+                }
             }
-
-            Cursor.Current = Cursors.Default;
         }
 
         private bool Save()
@@ -290,16 +292,18 @@ namespace GitUI.CommandsDialogs
 
         private void buttonDiscard_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            LoadSettings();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                LoadSettings();
+            }
         }
 
         private void buttonApply_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            Save();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                Save();
+            }
         }
 
         public void GotoPage(SettingsPageReference settingsPageReference)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
 
             EnablePartialStash();
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 if (stashedItem != null &&
                     gitStash == _currentWorkingDirStashItem)
@@ -198,7 +198,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var msg = toolStripButton_customMessage.Checked ? " " + StashMessage.Text.Trim() : string.Empty;
                 UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg);
@@ -216,7 +216,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var msg = toolStripButton_customMessage.Checked ? " " + StashMessage.Text.Trim() : string.Empty;
                 UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg, Stashed.SelectedItems.Select(i => i.Name));
@@ -277,7 +277,7 @@ namespace GitUI.CommandsDialogs
         {
             EnablePartialStash();
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 InitializeSoft();
 
@@ -310,7 +310,7 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshAll()
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 Initialize();
             }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -190,7 +190,7 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateLostObjects()
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var dialogResult = FormProcess.ReadDialog(this, "fsck-objects" + GetOptions());
 

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -190,25 +190,26 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateLostObjects()
         {
-            Cursor.Current = Cursors.WaitCursor;
-
-            var dialogResult = FormProcess.ReadDialog(this, "fsck-objects" + GetOptions());
-
-            if (FormProcess.IsOperationAborted(dialogResult))
+            using (new WaitCursorScope())
             {
-                DialogResult = DialogResult.Abort;
-                return;
+                var dialogResult = FormProcess.ReadDialog(this, "fsck-objects" + GetOptions());
+
+                if (FormProcess.IsOperationAborted(dialogResult))
+                {
+                    DialogResult = DialogResult.Abort;
+                    return;
+                }
+
+                _lostObjects.Clear();
+                _lostObjects.AddRange(
+                    dialogResult
+                        .Split('\r', '\n')
+                        .Where(s => !string.IsNullOrEmpty(s))
+                        .Select((s) => LostObject.TryParse(Module, s))
+                        .Where(parsedLostObject => parsedLostObject != null));
+
+                UpdateFilteredLostObjects();
             }
-
-            _lostObjects.Clear();
-            _lostObjects.AddRange(dialogResult
-                .Split('\r', '\n')
-                .Where(s => !string.IsNullOrEmpty(s))
-                .Select((s) => LostObject.TryParse(Module, s))
-                .Where(parsedLostObject => parsedLostObject != null));
-
-            UpdateFilteredLostObjects();
-            Cursor.Current = Cursors.Default;
         }
 
         private void UpdateFilteredLostObjects()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -413,11 +413,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void SaveAndRescan_Click(object sender, EventArgs e)
         {
-            Cursor.Current = Cursors.WaitCursor;
-            PageHost.SaveAll();
-            PageHost.LoadAll();
-            CheckSettings();
-            Cursor.Current = Cursors.Default;
+            using (new WaitCursorScope())
+            {
+                PageHost.SaveAll();
+                PageHost.LoadAll();
+                CheckSettings();
+            }
         }
 
         private void CheckAtStartup_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -413,7 +413,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void SaveAndRescan_Click(object sender, EventArgs e)
         {
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 PageHost.SaveAll();
                 PageHost.LoadAll();

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
                 return;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 var addSubmoduleCmd = GitCommandHelpers.AddSubmoduleCmd(Directory.Text, LocalPath.Text, Branch.Text, chkForce.Checked);
                 FormProcess.ShowDialog(this, addSubmoduleCmd);

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -38,12 +38,13 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
                 return;
             }
 
-            Cursor.Current = Cursors.WaitCursor;
-            var addSubmoduleCmd = GitCommandHelpers.AddSubmoduleCmd(Directory.Text, LocalPath.Text, Branch.Text, chkForce.Checked);
-            FormProcess.ShowDialog(this, addSubmoduleCmd);
+            using (new WaitCursorScope())
+            {
+                var addSubmoduleCmd = GitCommandHelpers.AddSubmoduleCmd(Directory.Text, LocalPath.Text, Branch.Text, chkForce.Checked);
+                FormProcess.ShowDialog(this, addSubmoduleCmd);
 
-            Close();
-            Cursor.Current = Cursors.Default;
+                Close();
+            }
         }
 
         private void DirectorySelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1135,6 +1135,7 @@
     <Compile Include="UserControls\WarningToolStripItem.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="WaitCursorScope.cs" />
     <Compile Include="WebBrowserEmulationMode.cs" />
     <Compile Include="WindowPositionList.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\WordWrapper.cs" />

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -907,7 +907,7 @@ namespace GitUI
                 return false;
             }
 
-            using (new WaitCursorScope())
+            using (WaitCursorScope.Enter())
             {
                 // Reset all changes.
                 Module.ResetFile(fileName);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -907,35 +907,34 @@ namespace GitUI
                 return false;
             }
 
-            Cursor.Current = Cursors.WaitCursor;
-
-            // Reset all changes.
-            Module.ResetFile(fileName);
-
-            // Also delete new files, if requested.
-            if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)
+            using (new WaitCursorScope())
             {
-                try
+                // Reset all changes.
+                Module.ResetFile(fileName);
+
+                // Also delete new files, if requested.
+                if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    string path = _fullPathResolver.Resolve(fileName);
-                    if (File.Exists(path))
+                    try
                     {
-                        File.Delete(path);
+                        string path = _fullPathResolver.Resolve(fileName);
+                        if (File.Exists(path))
+                        {
+                            File.Delete(path);
+                        }
+                        else
+                        {
+                            Directory.Delete(path, true);
+                        }
                     }
-                    else
+                    catch (IOException)
                     {
-                        Directory.Delete(path, true);
                     }
-                }
-                catch (IOException)
-                {
-                }
-                catch (UnauthorizedAccessException)
-                {
+                    catch (UnauthorizedAccessException)
+                    {
+                    }
                 }
             }
-
-            Cursor.Current = Cursors.Default;
 
             return true;
         }

--- a/GitUI/WaitCursorScope.cs
+++ b/GitUI/WaitCursorScope.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace GitUI
+{
+    /// <summary>
+    /// Sets the mouse cursor to <see cref="Cursors.WaitCursor"/> to indicate UI activity over some lexical scope.
+    /// </summary>
+    /// <remarks>
+    /// Usage is:
+    /// <code>
+    /// using (new WaitCursorScope())
+    /// {
+    ///     // perform UI activity
+    /// }
+    /// </code>
+    /// This pattern ensures:
+    /// <list type="bullet">
+    /// <item>The cursor is always restored when the block exits, whether by fall-through, return or exception.</item>
+    /// <item>Nested scopes work properly. That is, an inner scope doesn't reset the mouse when it exits.
+    /// Only the top-most scope will fully restore the mouse cursor.</item>
+    /// </list>
+    /// </remarks>
+    public sealed class WaitCursorScope : IDisposable
+    {
+        private readonly Cursor _cursorAtStartOfScope;
+
+        /// <summary>
+        /// Starts a new scope, recording <see cref="Cursor.Current"/> and setting the mouse cursor to <see cref="Cursors.WaitCursor"/>.
+        /// </summary>
+        public WaitCursorScope()
+        {
+            _cursorAtStartOfScope = Cursor.Current;
+
+            Cursor.Current = Cursors.WaitCursor;
+        }
+
+        /// <summary>
+        /// Restores <see cref="Cursor.Current"/> to the value captured in the constructor.
+        /// </summary>
+        public void Dispose()
+        {
+            Cursor.Current = _cursorAtStartOfScope;
+        }
+    }
+}

--- a/GitUI/WaitCursorScope.cs
+++ b/GitUI/WaitCursorScope.cs
@@ -9,7 +9,7 @@ namespace GitUI
     /// <remarks>
     /// Usage is:
     /// <code>
-    /// using (new WaitCursorScope())
+    /// using (WaitCursorScope.Enter())
     /// {
     ///     // perform UI activity
     /// }
@@ -21,18 +21,25 @@ namespace GitUI
     /// Only the top-most scope will fully restore the mouse cursor.</item>
     /// </list>
     /// </remarks>
-    public sealed class WaitCursorScope : IDisposable
+    public readonly struct WaitCursorScope : IDisposable
     {
-        private readonly Cursor _cursorAtStartOfScope;
-
         /// <summary>
         /// Starts a new scope, recording <see cref="Cursor.Current"/> and setting the mouse cursor to <see cref="Cursors.WaitCursor"/>.
         /// </summary>
-        public WaitCursorScope()
+        public static WaitCursorScope Enter()
         {
-            _cursorAtStartOfScope = Cursor.Current;
+            var cursorAtStartOfScope = Cursor.Current;
 
             Cursor.Current = Cursors.WaitCursor;
+
+            return new WaitCursorScope(cursorAtStartOfScope);
+        }
+
+        private readonly Cursor _cursorAtStartOfScope;
+
+        private WaitCursorScope(Cursor cursorAtStartOfScope)
+        {
+            _cursorAtStartOfScope = cursorAtStartOfScope;
         }
 
         /// <summary>


### PR DESCRIPTION
`WaitCursorScope` allows setting the current mouse cursor as 'busy' within a given scope, and having it automatically restore at the end of that scope.

```c#
using (new WaitCursorScope())
{
    // ...
}
```

### Pros:

- Nests properly. If one scope exists within another, exiting the enclosed scope doesn't reset the cursor back to 'normal'. Exiting a scope restores the cursor to whatever it was when the scope was entered. A nested scope sets the wait cursor on both entry and exit, which makes sense as the outer scope is 'busy' throughout.
- Exception safe. No matter what happens within the `using` block, the (global, singleton) cursor will be restored properly.
- Refactor safe. No need to be mindful of two unrelated commands located potentially some distance apart. Introducing a return within the block won't leave your mouse busy.

### Cons:

- Code within the block must be indented.
- Requires scope to exist within one method. I found two cases where this didn't hold: `FormResolveConflicts` and `FormStash`, but the two approaches can co-exist just fine.

What did I do to test the code and ensure quality:
 - Manual testing
 - Manual review (changes are very simple -- [ignore white-space in diff](https://github.com/gitextensions/gitextensions/pull/4670/files?w=1))

Has been tested on:
 - GIT 2.16
 - Windows 10
