### PR TITLE
Linq tweaks

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -286,15 +286,7 @@ namespace GitCommands.Config
 
         private IConfigSection FindConfigSection(IConfigSection configSectionToFind)
         {
-            foreach (var configSection in ConfigSections)
-            {
-                if (configSectionToFind.Equals(configSection))
-                {
-                    return configSection;
-                }
-            }
-
-            return null;
+            return ConfigSections.FirstOrDefault(configSectionToFind.Equals);
         }
 
         #region ConfigFileParser

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -99,18 +99,18 @@ namespace GitCommands.ExternalLinks
 
             if (definition.SearchInParts.Contains(ExternalLinkDefinition.RevisionPart.LocalBranches))
             {
-                foreach (var head in revision.Refs.Where(b => !b.IsRemote))
-                {
-                    links.Add(ParseRevisionPart(revision, definition, remoteMatch, head.LocalName));
-                }
+                links.AddRange(
+                    revision.Refs
+                        .Where(b => !b.IsRemote)
+                        .Select(head => ParseRevisionPart(revision, definition, remoteMatch, head.LocalName)));
             }
 
             if (definition.SearchInParts.Contains(ExternalLinkDefinition.RevisionPart.RemoteBranches))
             {
-                foreach (var head in revision.Refs.Where(b => b.IsRemote))
-                {
-                    links.Add(ParseRevisionPart(revision, definition, remoteMatch, head.LocalName));
-                }
+                links.AddRange(
+                    revision.Refs
+                        .Where(b => b.IsRemote)
+                        .Select(head => ParseRevisionPart(revision, definition, remoteMatch, head.LocalName)));
             }
 
             if (definition.SearchInParts.Contains(ExternalLinkDefinition.RevisionPart.Message))

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3766,16 +3766,15 @@ namespace GitCommands
         {
             var fileList = RunGitCmd("diff-tree --name-only -z --cc --no-commit-id " + shaOfMergeCommit);
 
-            var ret = new List<GitItemStatus>();
             if (string.IsNullOrWhiteSpace(fileList))
             {
-                return ret;
+                return Array.Empty<GitItemStatus>();
             }
 
             var files = fileList.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var file in files)
-            {
-                var item = new GitItemStatus
+
+            return files.Select(
+                file => new GitItemStatus
                 {
                     IsChanged = true,
                     IsConflict = true,
@@ -3784,11 +3783,7 @@ namespace GitCommands
                     IsStaged = false,
                     IsNew = false,
                     Name = file,
-                };
-                ret.Add(item);
-            }
-
-            return ret;
+                }).ToList();
         }
 
         public string GetCombinedDiffContent(GitRevision revisionOfMergeCommit, string filePath,

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3506,17 +3506,17 @@ namespace GitCommands
             const string arguments = "x";
             var output = RunCmd(cmd, arguments);
             var lines = output.Split('\n');
-            if (lines.Count() >= 2)
+            if (lines.Length >= 2)
             {
                 return false;
             }
 
             var headers = lines[0].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             var commandIndex = Array.IndexOf(headers, "COMMAND");
-            for (int i = 1; i < lines.Count(); i++)
+            for (int i = 1; i < lines.Length; i++)
             {
                 var columns = lines[i].Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (commandIndex < columns.Count())
+                if (commandIndex < columns.Length)
                 {
                     var command = columns[commandIndex];
                     if (command.EndsWith("/git"))

--- a/GitCommands/Patch/Patch.cs
+++ b/GitCommands/Patch/Patch.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace PatchApply
@@ -116,11 +117,7 @@ namespace PatchApply
 
         private void HandleChangeFilePatchType(Encoding filesContentEncoding)
         {
-            var fileLines = new List<string>();
-            foreach (string s in LoadFile(FileNameA, filesContentEncoding).Split('\n'))
-            {
-                fileLines.Add(s);
-            }
+            var fileLines = LoadFile(FileNameA, filesContentEncoding).Split('\n').ToList();
 
             int lineNumber = 0;
             foreach (string line in Text.Split('\n'))

--- a/GitCommands/Repository/RecentRepoInfo.cs
+++ b/GitCommands/Repository/RecentRepoInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 
 namespace GitCommands.Repository
 {
@@ -131,25 +132,16 @@ namespace GitCommands.Repository
 
             void AddSortedRepos(bool mostRecent, List<RecentRepoInfo> addToList)
             {
-                foreach (string caption in orderedRepos.Keys)
-                {
-                    List<RecentRepoInfo> list = orderedRepos[caption];
-                    foreach (RecentRepoInfo repo in list)
-                    {
-                        if (repo.MostRecent == mostRecent)
-                        {
-                            addToList.Add(repo);
-                        }
-                    }
-                }
+                addToList.AddRange(
+                    from caption in orderedRepos.Keys
+                    from repo in orderedRepos[caption]
+                    where repo.MostRecent == mostRecent
+                    select repo);
             }
 
             void AddNotSortedRepos(List<RecentRepoInfo> list, List<RecentRepoInfo> addToList)
             {
-                foreach (RecentRepoInfo repo in list)
-                {
-                    addToList.Add(repo);
-                }
+                addToList.AddRange(list);
             }
 
             if (SortMostRecentRepos)

--- a/GitCommands/Repository/Repositories.cs
+++ b/GitCommands/Repository/Repositories.cs
@@ -125,15 +125,9 @@ namespace GitCommands.Repository
 
         private static Repository FindFirstCategoryRepository(string path)
         {
-            foreach (Repository repo in RepositoryCategories.SelectMany(category => category.Repositories))
-            {
-                if (repo.Path != null && repo.Path.Equals(path, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    return repo;
-                }
-            }
-
-            return null;
+            return RepositoryCategories
+                .SelectMany(category => category.Repositories)
+                .FirstOrDefault(repo => repo.Path != null && repo.Path.Equals(path, StringComparison.CurrentCultureIgnoreCase));
         }
 
         public static BindingList<RepositoryCategory> RepositoryCategories

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -70,7 +70,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     return;
                 }
 
-                var releases = tree.Tree.Where(entry => "GitExtensions.releases".Equals(entry.Path, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
+                var releases = tree.Tree.FirstOrDefault(entry => "GitExtensions.releases".Equals(entry.Path, StringComparison.InvariantCultureIgnoreCase));
 
                 if (releases?.Blob.Value != null)
                 {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1586,7 +1586,7 @@ namespace GitUI.CommandsDialogs
 
         private void FileToolStripMenuItemDropDownOpening(object sender, EventArgs e)
         {
-            if (Repositories.RepositoryHistory.Repositories.Count() == 0)
+            if (Repositories.RepositoryHistory.Repositories.Count == 0)
             {
                 recentToolStripMenuItem.Enabled = false;
                 return;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1367,8 +1367,8 @@ namespace GitUI.CommandsDialogs
             }
 
             if (canUseUnstageAll &&
-                Staged.GitItemStatuses.Count() > 10 &&
-                Staged.SelectedItems.Count() == Staged.GitItemStatuses.Count())
+                Staged.GitItemStatuses.Count > 10 &&
+                Staged.SelectedItems.Count() == Staged.GitItemStatuses.Count)
             {
                 UnstageAllToolStripMenuItemClick(null, null);
                 return;
@@ -1587,7 +1587,7 @@ namespace GitUI.CommandsDialogs
                 Cursor.Current = Cursors.WaitCursor;
                 Unstaged.StoreNextIndexToSelect();
                 toolStripProgressBar1.Visible = true;
-                toolStripProgressBar1.Maximum = gitItemStatuses.Count() * 2;
+                toolStripProgressBar1.Maximum = gitItemStatuses.Count * 2;
                 toolStripProgressBar1.Value = 0;
 
                 var files = new List<GitItemStatus>();

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs
             var baseCommit = ckCompareToMergeBase.Checked ? _mergeBase : _baseRevision;
 
             IList<GitRevision> items = new List<GitRevision> { _headRevision, baseCommit };
-            if (items.Count() == 1)
+            if (items.Count == 1)
             {
                 items.Add(DiffFiles.SelectedItemParent);
             }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -518,17 +518,9 @@ namespace GitUI.CommandsDialogs
         private bool IsSubmodulesInitialized()
         {
             // Fast submodules check
-            var submodules = Module.GetSubmodulesLocalPaths();
-            foreach (var submoduleName in submodules)
-            {
-                GitModule submodule = Module.GetSubmodule(submoduleName);
-                if (!submodule.IsValidGitWorkingDir())
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Module.GetSubmodulesLocalPaths()
+                .Select(submoduleName => Module.GetSubmodule(submoduleName))
+                .All(submodule => submodule.IsValidGitWorkingDir());
         }
 
         private FormProcess CreateFormProcess(string source, string curLocalBranch, string curRemoteBranch)

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -146,8 +146,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             var currentRemote = Module.GetCurrentRemote();
             var hostedRemote = _selectHostedRepoCB.Items.
                 Cast<IHostedRemote>().
-                Where(remote => remote.Name.Equals(currentRemote, StringComparison.OrdinalIgnoreCase)).
-                FirstOrDefault();
+                FirstOrDefault(remote => remote.Name.Equals(currentRemote, StringComparison.OrdinalIgnoreCase));
 
             if (hostedRemote == null)
             {

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -451,14 +451,11 @@ namespace GitUI.CommandsDialogs
 
         private void StageFileToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var files = new List<GitItemStatus>();
-
             // IsStaged is set by default, so that cannot be trusted, must be limited when selecting
-            var workDirFiles = DiffFiles.SelectedItemsWithParent.Where(it => it.ParentRevision.Guid == GitRevision.IndexGuid);
-            foreach (var item in workDirFiles)
-            {
-                files.Add(item.Item);
-            }
+            var files = DiffFiles.SelectedItemsWithParent
+                .Where(it => it.ParentRevision.Guid == GitRevision.IndexGuid)
+                .Select(it => it.Item)
+                .ToList();
 
             Module.StageFiles(files, out _);
             RefreshArtificial();

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -35,7 +35,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 .ToList();
 
             // If exists utf-8, then replace to utf-8 without BOM
-            var utf8 = availableEncoding.Where(e => typeof(UTF8Encoding) == e.GetType()).FirstOrDefault();
+            var utf8 = availableEncoding.FirstOrDefault(e => typeof(UTF8Encoding) == e.GetType());
             if (utf8 != null)
             {
                 availableEncoding.Remove(utf8);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using GitCommands;
 using GitCommands.Utils;
 using GitUI.Editor;
@@ -137,15 +138,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return false;
             }
 
-            foreach (var path in GetPuttyLocations())
-            {
-                if (AutoFindPuttyPathsInDir(path))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return GetPuttyLocations().Any(AutoFindPuttyPathsInDir);
         }
 
         private bool AutoFindPuttyPathsInDir(string installdir)

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -397,7 +397,7 @@ namespace GitUI.CommitInfo
             if (_sortedRefs != null)
             {
                 if (_annotatedTagsMessages != null &&
-                    _annotatedTagsMessages.Count() > 0 &&
+                    _annotatedTagsMessages.Count > 0 &&
                     string.IsNullOrEmpty(_annotatedTagsInfo) &&
                     Revision != null)
                 {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1081,8 +1081,8 @@ namespace GitUI.Editor
             else
             {
                 encod = AppSettings.AvailableEncodings.Values
-                      .Where(en => en.EncodingName == encodingToolStripComboBox.Text)
-                      .FirstOrDefault() ?? Module.FilesEncoding;
+                    .FirstOrDefault(en => en.EncodingName == encodingToolStripComboBox.Text)
+                        ?? Module.FilesEncoding;
             }
 
             if (!encod.Equals(Encoding))

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1147,14 +1147,8 @@ namespace GitUI
                 GitRevision[] parentRevs;
                 if (revisions.Count == 1)
                 {
-                    var list = new List<GitRevision>();
-                    foreach (var item in Revision.ParentGuids)
-                    {
-                        // Note: RevisionGrid could in some forms be used to get the parent guids
-                        list.Add(new GitRevision(item));
-                    }
-
-                    parentRevs = list.ToArray();
+                    // Note: RevisionGrid could in some forms be used to get the parent guids
+                    parentRevs = Revision.ParentGuids.Select(item => new GitRevision(item)).ToArray();
                 }
                 else
                 {

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -488,7 +488,7 @@ namespace GitUI
             }
             else
             {
-                return GitItemStatusesWithParents.SelectMany(pair => pair.Value).Count();
+                return GitItemStatusesWithParents.Sum(pair => pair.Value.Count);
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3003,7 +3003,7 @@ namespace GitUI
         private void UpdateArtificialCommitCount(IList<GitItemStatus> status, GitRevision unstagedRev, GitRevision stagedRev)
         {
             int staged = status.Count(item => item.IsStaged);
-            int unstaged = status.Count() - staged;
+            int unstaged = status.Count - staged;
             if (unstagedRev != null)
             {
                 unstagedRev.SubjectCount = "(" + unstaged + ") ";

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -776,11 +776,7 @@ namespace GitUI.RevisionGridClasses
 
         private List<Color> GetJunctionColors(IEnumerable<Junction> junction)
         {
-            List<Color> colors = new List<Color>();
-            foreach (Junction j in junction)
-            {
-                colors.Add(GetJunctionColor(j));
-            }
+            var colors = junction.Select(GetJunctionColor).ToList();
 
             if (colors.Count == 0)
             {

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -20,15 +20,8 @@ namespace GitStatistics
 
         private static bool DirectoryIsFiltered(FileSystemInfo dir, IEnumerable<string> directoryFilters)
         {
-            foreach (var directoryFilter in directoryFilters)
-            {
-                if (dir.FullName.EndsWith(directoryFilter, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return directoryFilters.Any(
+                filter => dir.FullName.EndsWith(filter, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private static IEnumerable<FileInfo> GetFiles(List<string> filesToCheck, string[] codeFilePatterns)

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Linq;
 
 namespace GitStatistics.PieChart
 {
@@ -640,11 +641,7 @@ namespace GitStatistics.PieChart
         {
             // calculates the sum of values required to evaluate sweep angles
             // for individual pies
-            double sum = 0;
-            foreach (var itemValue in Values)
-            {
-                sum += (double)itemValue;
-            }
+            double sum = Values.Sum(itemValue => (double)itemValue);
 
             // some values and indices that will be used in the loop
             var topEllipeSize = TopEllipseSize;
@@ -984,15 +981,7 @@ namespace GitStatistics.PieChart
         /// </returns>
         private static bool AreDisplacementsValid(IEnumerable<float> displacements)
         {
-            foreach (var value in displacements)
-            {
-                if (!IsDisplacementValid(value))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return displacements.All(IsDisplacementValid);
         }
 
         /// <summary>

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChartControl.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace GitStatistics.PieChart
@@ -244,15 +245,7 @@ namespace GitStatistics.PieChart
 
         private bool HasNonZeroValue()
         {
-            foreach (var value in _values)
-            {
-                if (value != 0)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return _values.Any(value => value != 0);
         }
 
         protected override void OnMouseEnter(EventArgs e)

--- a/TranslationApp/FormTranslate.cs
+++ b/TranslationApp/FormTranslate.cs
@@ -76,7 +76,7 @@ namespace TranslationApp
         private void UpdateProgress()
         {
             int translatedCount = _translationItems.Sum(p => p.Value.Count(translateItem => !string.IsNullOrEmpty(translateItem.TranslatedValue)));
-            int totalCount = _translationItems.Count();
+            int totalCount = _translationItems.Count;
             var progresMsg = string.Format(_translateProgressText.Text, translatedCount, totalCount);
             if (translateProgress.Text != progresMsg)
             {

--- a/UnitTests/GitUITests/Editor/Diff/LinePrefixHelperFixture.cs
+++ b/UnitTests/GitUITests/Editor/Diff/LinePrefixHelperFixture.cs
@@ -93,7 +93,7 @@ namespace GitUITests.Editor.Diff
         {
             var doc = Substitute.For<IDocument>();
             doc.GetCharAt(Arg.Any<int>()).Returns(args => diffText[(int)args[0]]);
-            doc.TotalNumberOfLines.Returns(diffText.Split('\n').Count());
+            doc.TotalNumberOfLines.Returns(diffText.Split('\n').Length);
             doc.TextLength.Returns(diffText.Length);
             return doc;
         }


### PR DESCRIPTION
Various linq-related improvements

Changes proposed in this pull request:
 - Simplify `Where`/`First` style expressions
 - Simplify `SelectMany`/`Count` expression (potentially much fewer iterations required)
 - Don't use `Count()` if `Count`/`Length` available
 - Replace loops with linq expressions
 
What did I do to test the code and ensure quality:
 - Careful review
 - Manual testing
 - 

Has been tested on:
 - GIT 2.16
 - Windows 10
