### PR TITLE
Remove .cmd to let Windows find and run either .exe or .cmd for gitk.…

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1029,9 +1029,9 @@ namespace GitCommands
             }
             else
             {
-                RunExternalCmdDetached("cmd.exe", "/c \"\"" + AppSettings.GitCommand.Replace("git.cmd", "gitk.cmd")
-                                                              .Replace("bin\\git.exe", "cmd\\gitk.cmd")
-                                                              .Replace("bin/git.exe", "cmd/gitk.cmd") + "\" --branches --tags --remotes\"");
+                RunExternalCmdDetached("cmd.exe", "/c \"\"" + AppSettings.GitCommand.Replace("git.cmd", "gitk")
+                                                              .Replace("bin\\git.exe", "cmd\\gitk")
+                                                              .Replace("bin/git.exe", "cmd/gitk") + "\" --branches --tags --remotes\"");
             }
         }
 


### PR DESCRIPTION
For review or discussion if this is an appropriate fix for #4510.
Fixes #4510.

Changes proposed in this pull request:
 - Removed the file extension ".cmd" when invoking gitk. This allows Windows to find and run either gitk.exe or gitk.cmd, whichever is present.
 
What did I do to test the code and ensure quality:
 - Ran gitk from inside GE on git 2.13.3, which installs gitk.exe. gitk would start after my change.
 - Tested in a standard command prompt that I could execute either a "cmd" or "exe" file using just the name without the extension.

Has been tested on (remove any that don't apply):
 - GIT 2.13.3.windows.1
 - Windows 7
 - GE version 2.51 at the latest position of the release/2.51 branch
