### PR TITLE
Remove .cmd to let Windows find and run either .exe or .cmd for gitk.…

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1049,9 +1049,9 @@ namespace GitCommands
             }
             else
             {
-                RunExternalCmdDetached("cmd.exe", "/c \"\"" + AppSettings.GitCommand.Replace("git.cmd", "gitk.cmd")
-                                                              .Replace("bin\\git.exe", "cmd\\gitk.cmd")
-                                                              .Replace("bin/git.exe", "cmd/gitk.cmd") + "\" --branches --tags --remotes\"");
+                RunExternalCmdDetached("cmd.exe", "/c \"\"" + AppSettings.GitCommand.Replace("git.cmd", "gitk")
+                                                              .Replace("bin\\git.exe", "cmd\\gitk")
+                                                              .Replace("bin/git.exe", "cmd/gitk") + "\" --branches --tags --remotes\"");
             }
         }
 


### PR DESCRIPTION
Fixes #4510.

Changes proposed in this pull request:
 - Removed the file extension ".cmd" when invoking gitk. This allows Windows to find and run either gitk.exe or gitk.cmd, whichever is present.

What did I do to test the code and ensure quality:
 - Ran gitk from inside GE on git 2.16.2.windows.1, which installs gitk.exe. gitk would start after my change.
 - Tested in a standard command prompt that I could execute either a "cmd" or "exe" file using just the name without the extension.

Has been tested on (remove any that don't apply):
 - GIT 2.16.2.windows.1
 - Windows 10
 - GE master branch

This PR provides #4674 on master - with manual testing.