### PR TITLE
Equality operators

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -69,7 +69,7 @@ namespace GitCommands.Config
             value = value.Replace("\n", "\\n");
             value = value.Replace("\t", "\\t");
 
-            if (value.IndexOfAny(CommentChars) != -1 || !value.Trim().Equals(value))
+            if (value.IndexOfAny(CommentChars) != -1 || value.Trim() != value)
             {
                 value = value.Quote();
             }

--- a/GitCommands/ExternalLinks/ExternalLinksManager.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksManager.cs
@@ -57,7 +57,7 @@ namespace GitCommands.ExternalLinks
         /// <returns><see langword="true"/> if a definition already exists; otherwise <see langword="false"/>.</returns>
         public bool Contains(string definitionName)
         {
-            return _definitions.Any(linkDef => linkDef.Name.Equals(definitionName));
+            return _definitions.Any(linkDef => linkDef.Name == definitionName);
         }
 
         /// <summary>

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -565,11 +565,11 @@ namespace PatchApply
             int currentPos = 0;
             string gitEol = module.GetEffectiveSetting("core.eol");
             string eol;
-            if ("crlf".Equals(gitEol))
+            if (gitEol == "crlf")
             {
                 eol = "\r\n";
             }
-            else if ("native".Equals(gitEol))
+            else if (gitEol == "native")
             {
                 eol = Environment.NewLine;
             }
@@ -597,7 +597,7 @@ namespace PatchApply
 
                 if (i == lines.Length - 1)
                 {
-                    if (!line.Equals(string.Empty))
+                    if (line != string.Empty)
                     {
                         result.CurrentSubChunk.IsNoNewLineAtTheEnd = GitModule.NoNewLineAtTheEnd;
                         result.AddDiffLine(patchLine, reset);

--- a/GitCommands/Repository/RecentRepoInfo.cs
+++ b/GitCommands/Repository/RecentRepoInfo.cs
@@ -82,8 +82,8 @@ namespace GitCommands.Repository
             List<RecentRepoInfo> mostRecentRepos = new List<RecentRepoInfo>();
             List<RecentRepoInfo> lessRecentRepos = new List<RecentRepoInfo>();
 
-            bool middleDot = ShorteningStrategy_MiddleDots.Equals(ShorteningStrategy);
-            bool signDir = ShorteningStrategy_MostSignDir.Equals(ShorteningStrategy);
+            bool middleDot = ShorteningStrategy == ShorteningStrategy_MiddleDots;
+            bool signDir = ShorteningStrategy == ShorteningStrategy_MostSignDir;
 
             int n = Math.Min(MaxRecentRepositories, recentRepositories.Count);
 

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -143,7 +143,8 @@ namespace GitCommands
             if (gitExtDir.Length > len)
             {
                 var path = gitExtDir.Substring(gitExtDir.Length - len);
-                if (debugPath.ToPosixPath().Equals(path.ToPosixPath()))
+
+                if (debugPath.ToPosixPath() == path.ToPosixPath())
                 {
                     string projectPath = gitExtDir.Substring(0, gitExtDir.Length - len);
                     return Path.Combine(projectPath, "Bin");

--- a/GitCommands/Utils/EnvUtils.cs
+++ b/GitCommands/Utils/EnvUtils.cs
@@ -75,7 +75,7 @@ namespace GitCommands.Utils
                         using (registryKey)
                         {
                             var v = registryKey.GetValue("Install");
-                            return v != null && v.ToString().Equals("1");
+                            return v != null && v.ToString() == "1";
                         }
                     }
                 }

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -86,7 +86,7 @@ namespace GitExtensions
 
             try
             {
-                if (!(args.Length >= 2 && args[1].Equals("uninstall"))
+                if (!(args.Length >= 2 && args[1] == "uninstall")
                     && (AppSettings.CheckSettings
                     || string.IsNullOrEmpty(AppSettings.GitCommandValue)
                     || !File.Exists(AppSettings.GitCommandValue)))
@@ -194,7 +194,7 @@ namespace GitExtensions
                 var in3 = ce.InnerException.InnerException;
 
                 // saves having to have a reference to System.Xml just to check that we have an XmlException
-                if (in3.GetType().Name.Equals("XmlException"))
+                if (in3.GetType().Name == "XmlException")
                 {
                     var localSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GitExtensions");
 

--- a/GitPluginShared/PluginHelpers.cs
+++ b/GitPluginShared/PluginHelpers.cs
@@ -47,7 +47,7 @@ namespace GitPluginShared
         {
             return commandBar.Controls
                 .Cast<CommandBarControl>()
-                .Where(control => control.TooltipText.Trim().Equals(tooltipText))
+                .Where(control => control.TooltipText.Trim() == tooltipText)
                 .Cast<CommandBarButton>()
                 .FirstOrDefault();
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardCategory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardCategory.cs
@@ -295,7 +295,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             {
                 foreach (RepositoryCategory newRepositoryCategory in Repositories.RepositoryCategories)
                 {
-                    if (newRepositoryCategory.Description.Equals(toolStripItem.Text))
+                    if (newRepositoryCategory.Description == toolStripItem.Text)
                     {
                         RepositoryCategory.RemoveRepository(_repository);
                         _repository.RepositoryType = RepositoryType.Repository;

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -68,15 +68,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void SetShorteningStrategy(string strategy)
         {
-            if (RecentRepoSplitter.ShorteningStrategy_None.Equals(strategy))
+            if (strategy == RecentRepoSplitter.ShorteningStrategy_None)
             {
                 dontShortenRB.Checked = true;
             }
-            else if (RecentRepoSplitter.ShorteningStrategy_MostSignDir.Equals(strategy))
+            else if (strategy == RecentRepoSplitter.ShorteningStrategy_MostSignDir)
             {
                 mostSigDirRB.Checked = true;
             }
-            else if (RecentRepoSplitter.ShorteningStrategy_MiddleDots.Equals(strategy))
+            else if (strategy == RecentRepoSplitter.ShorteningStrategy_MiddleDots)
             {
                 middleDotRB.Checked = true;
             }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1712,7 +1712,7 @@ namespace GitUI.CommandsDialogs
 
             toolStripItem.Click += (hs, he) => ChangeWorkingDir(repo.Path);
 
-            if (repo.Title != null || !repo.Path.Equals(caption))
+            if (repo.Title != null || repo.Path != caption)
             {
                 toolStripItem.ToolTipText = repo.Path;
             }

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -281,7 +281,7 @@ namespace GitUI.CommandsDialogs
                     if (localBranchRef != null && remoteBranchRef != null)
                     {
                         string mergeBaseGuid = Module.GetMergeBase(localBranchRef.Guid, remoteBranchRef.Guid);
-                        bool isResetFastForward = localBranchRef.Guid.Equals(mergeBaseGuid);
+                        bool isResetFastForward = localBranchRef.Guid == mergeBaseGuid;
                         if (!isResetFastForward)
                         {
                             string mergeBaseText = mergeBaseGuid.IsNullOrWhiteSpace()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs
             ResetUnStaged.Visible = AppSettings.ShowResetUnstagedChanges;
             CommitAndPush.Visible = AppSettings.ShowCommitAndPush;
             AdjustCommitButtonPanelHeight();
-            showUntrackedFilesToolStripMenuItem.Checked = !Module.EffectiveConfigFile.GetValue("status.showUntrackedFiles").Equals("no");
+            showUntrackedFilesToolStripMenuItem.Checked = Module.EffectiveConfigFile.GetValue("status.showUntrackedFiles") != "no";
             MinimizeBox = Owner == null;
         }
 
@@ -625,7 +625,7 @@ namespace GitUI.CommandsDialogs
             {
                 void TextLoaded(object a, EventArgs b)
                 {
-                    if (_currentItem != null && _currentItem.Name.Equals(selectedFileName))
+                    if (_currentItem != null && _currentItem.Name == selectedFileName)
                     {
                         SelectedDiff.GoToLine(selectedDifflineToSelect);
                         SelectedDiff.ScrollPos = scrollPosition;

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -281,7 +281,8 @@ namespace GitUI.CommandsDialogs
         private void SetTitle(string fileName)
         {
             Text = string.Format("File History - {0}", FileName);
-            if (!fileName.IsNullOrEmpty() && !fileName.Equals(FileName))
+
+            if (!fileName.IsNullOrEmpty() && fileName != FileName)
             {
                 Text = Text + string.Format(" ({0})", fileName);
             }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -605,7 +605,7 @@ namespace GitUI.CommandsDialogs
 
             if (_branch == localBranch.Text)
             {
-                if (remote.Equals(currentBranchRemote.Value) || currentBranchRemote.Value.IsNullOrEmpty())
+                if (remote == currentBranchRemote.Value || currentBranchRemote.Value.IsNullOrEmpty())
                 {
                     curLocalBranch = Branches.Text.IsNullOrEmpty() ? null : _branch;
                 }
@@ -620,7 +620,7 @@ namespace GitUI.CommandsDialogs
             }
 
             if (Branches.Text.IsNullOrEmpty() && !curLocalBranch.IsNullOrEmpty()
-                && !remote.Equals(currentBranchRemote.Value) && !Fetch.Checked)
+                && remote != currentBranchRemote.Value && !Fetch.Checked)
             {
                 int idx = PSTaskDialog.cTaskDialog.ShowCommandBox(this,
                                                         _noRemoteBranchCaption.Text,
@@ -745,7 +745,7 @@ namespace GitUI.CommandsDialogs
                 IEnumerable<GitRemote> remotes = (IEnumerable<GitRemote>)_NO_TRANSLATE_Remotes.DataSource;
                 foreach (var r in remotes)
                 {
-                    if (!r.Name.IsNullOrWhiteSpace() && !r.Name.Equals(AllRemotes))
+                    if (!r.Name.IsNullOrWhiteSpace() && r.Name != AllRemotes)
                     {
                         yield return r.Name;
                     }
@@ -984,7 +984,7 @@ namespace GitUI.CommandsDialogs
 
         private void localBranch_Leave(object sender, EventArgs e)
         {
-            if (!_branch.Equals(localBranch.Text.Trim()) && Branches.Text.IsNullOrWhiteSpace())
+            if (_branch != localBranch.Text.Trim() && Branches.Text.IsNullOrWhiteSpace())
             {
                 Branches.Text = localBranch.Text;
             }

--- a/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -46,7 +46,8 @@ namespace GitUI.CommandsDialogs
             Ok.Focus();
 
             var newName = BranchNameTextBox.Text;
-            if (newName.Equals(_oldName))
+
+            if (newName == _oldName)
             {
                 DialogResult = DialogResult.Cancel;
                 return;

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void _yourBranchCB_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (_prevTitle.Equals(_titleTB.Text) && !_yourBranchesCB.Text.IsNullOrWhiteSpace() && MyRemote != null)
+            if (_prevTitle == _titleTB.Text && !_yourBranchesCB.Text.IsNullOrWhiteSpace() && MyRemote != null)
             {
                 var lastMsg = Module.GetPreviousCommitMessages(MyRemote.Name.Combine("/", _yourBranchesCB.Text), 1).FirstOrDefault();
                 _titleTB.Text = lastMsg.TakeUntilStr("\n");

--- a/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
@@ -77,7 +77,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     var props = typeof(SystemColors).GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty).ToList();
 
                     var kvps = from prop in props
-                               where prop.PropertyType.Equals(typeof(Color))
+                               where prop.PropertyType == typeof(Color)
                                let c = (Color)prop.GetValue(null, null)
                                select new KeyValuePair<string, string>("SC." + prop.Name, string.Format("#{0:X2}{1:X2}{2:X2}", c.R, c.G, c.B));
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -11,9 +11,9 @@
 
         protected override void SettingsToPage()
         {
-            checkBoxPullRebase.Checked = CurrentSettings.GetValue("pull.rebase").Equals("true");
-            checkBoxFetchPrune.Checked = CurrentSettings.GetValue("fetch.prune").Equals("true");
-            checkBoxRebaseAutostash.Checked = CurrentSettings.GetValue("rebase.autoStash").Equals("true");
+            checkBoxPullRebase.Checked = CurrentSettings.GetValue("pull.rebase") == "true";
+            checkBoxFetchPrune.Checked = CurrentSettings.GetValue("fetch.prune") == "true";
+            checkBoxRebaseAutostash.Checked = CurrentSettings.GetValue("rebase.autoStash") == "true";
         }
 
         protected override void PageToSettings()

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1874,31 +1874,32 @@ namespace GitUI
             }
 
             var command = args[1];
-            if (command.Equals("blame") && args.Length <= 2)
+
+            if (command == "blame" && args.Length <= 2)
             {
                 MessageBox.Show("Cannot open blame, there is no file selected.", "Blame");
                 return;
             }
 
-            if (command.Equals("difftool") && args.Length <= 2)
+            if (command == "difftool" && args.Length <= 2)
             {
                 MessageBox.Show("Cannot open difftool, there is no file selected.", "Difftool");
                 return;
             }
 
-            if (command.Equals("filehistory") && args.Length <= 2)
+            if (command == "filehistory" && args.Length <= 2)
             {
                 MessageBox.Show("Cannot open file history, there is no file selected.", "File history");
                 return;
             }
 
-            if (command.Equals("fileeditor") && args.Length <= 2)
+            if (command == "fileeditor" && args.Length <= 2)
             {
                 MessageBox.Show("Cannot open file editor, there is no file selected.", "File editor");
                 return;
             }
 
-            if (command.Equals("revert") && args.Length <= 2)
+            if (command == "revert" && args.Length <= 2)
             {
                 MessageBox.Show("Cannot open revert, there is no file selected.", "Revert");
                 return;

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -641,7 +641,7 @@ namespace GitUI.SpellChecker
             }
 
             IsUndoInProgress = true;
-            while (TextBox.UndoActionName.Equals("Unknown"))
+            while (TextBox.UndoActionName == "Unknown")
             {
                 TextBox.Undo();
             }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -214,9 +214,10 @@ namespace GitUI.Blame
 
         public void LoadBlame(GitRevision revision, List<string> children, string fileName, RevisionGrid revGrid, Control controlToMask, Encoding encoding, int? initialLine = null, bool force = false)
         {
-            // refresh only when something changed
             string guid = revision.Guid;
-            if (!force && guid.Equals(_blameHash) && fileName == _fileName && revGrid == _revGrid && encoding == _encoding)
+
+            // refresh only when something changed
+            if (!force && guid == _blameHash && fileName == _fileName && revGrid == _revGrid && encoding == _encoding)
             {
                 return;
             }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -470,7 +470,7 @@ namespace GitUI
                     // Use width-itemheight because the icon drawn in front of the text is the itemheight
                     if (textWidth > (FileStatusListView.Width - FileStatusListView.GetItemRect(hoveredItem.Index).Height))
                     {
-                        if (!hoveredItem.ToolTipText.Equals(gitItemStatus.ToString()))
+                        if (hoveredItem.ToolTipText != gitItemStatus.ToString())
                         {
                             hoveredItem.ToolTipText = gitItemStatus.ToString();
                         }

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -70,7 +70,7 @@ namespace GitUI
         {
             string truncatePathMethod = AppSettings.TruncatePathMethod;
 
-            if (truncatePathMethod.Equals("fileNameOnly"))
+            if (truncatePathMethod == "fileNameOnly")
             {
                 return FormatTextForFileNameOnly(name, oldName);
             }
@@ -108,7 +108,7 @@ namespace GitUI
             var fileName = Path.GetFileName(name);
             var oldFileName = Path.GetFileName(oldName);
 
-            if (fileName.Equals(oldFileName))
+            if (fileName == oldFileName)
             {
                 oldFileName = null;
             }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -753,12 +753,12 @@ namespace GitUI
 
         public bool SetAndApplyBranchFilter(string filter)
         {
-            if (filter.Equals(_revisionFilter.GetBranchFilter()))
+            if (filter == _revisionFilter.GetBranchFilter())
             {
                 return false;
             }
 
-            if (filter.Equals(""))
+            if (filter == "")
             {
                 AppSettings.BranchFilterEnabled = false;
                 AppSettings.ShowCurrentBranchOnly = true;
@@ -998,9 +998,10 @@ namespace GitUI
         {
             var revision = Module.GetRevision(CurrentCheckout, true);
             var refs = Module.GetRefs(true, true);
+
             foreach (var gitRef in refs)
             {
-                if (gitRef.Guid.Equals(revision.Guid))
+                if (gitRef.Guid == revision.Guid)
                 {
                     revision.Refs.Add(gitRef);
                 }
@@ -2563,7 +2564,7 @@ namespace GitUI
             bool currentBranchPointsToRevision = false;
             foreach (var head in branchesWithNoIdenticalRemotes)
             {
-                if (head.CompleteName.Equals(currentBranchRef))
+                if (head.CompleteName == currentBranchRef)
                 {
                     currentBranchPointsToRevision = !revision.IsArtificial;
                 }
@@ -2623,7 +2624,7 @@ namespace GitUI
                 // skip remote branches - they can not be deleted this way
                 if (!head.IsRemote)
                 {
-                    if (!head.CompleteName.Equals(currentBranchRef))
+                    if (head.CompleteName != currentBranchRef)
                     {
                         toolStripItem = new ToolStripMenuItem(head.Name);
                         toolStripItem.Tag = head.Name;
@@ -2637,7 +2638,7 @@ namespace GitUI
                     renameDropDown.Items.Add(toolStripItem); // Add to rename branch
                 }
 
-                if (!head.CompleteName.Equals(currentBranchRef))
+                if (head.CompleteName != currentBranchRef)
                 {
                     toolStripItem = new ToolStripMenuItem(head.Name);
                     if (head.IsRemote)

--- a/GitUI/UserControls/RevisionGridClasses/GitRefListsForRevision.cs
+++ b/GitUI/UserControls/RevisionGridClasses/GitRefListsForRevision.cs
@@ -49,7 +49,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         /// </summary>
         public IGitRef[] GetDeletableLocalRefs(string currentBranch)
         {
-            return _localBranches.Where(b => !b.Name.Equals(currentBranch)).Union(_tags).ToArray();
+            return _localBranches.Where(b => b.Name != currentBranch).Union(_tags).ToArray();
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGridClasses/NavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGridClasses/NavigationHistory.cs
@@ -18,7 +18,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         /// </summary>
         public void Push(string curr)
         {
-            if ((_prevItems.Count == 0) || !_prevItems.Peek().Equals(curr))
+            if (_prevItems.Count == 0 || _prevItems.Peek() != curr)
             {
                 _prevItems.Push(curr);
                 _nextItems.Clear();

--- a/Plugins/Gerrit/GerritSettings.cs
+++ b/Plugins/Gerrit/GerritSettings.cs
@@ -121,7 +121,7 @@ namespace Gerrit
                             case "project": result.Project = parts[1]; break;
                             case "defaultbranch": result.DefaultBranch = parts[1]; break;
                             case "defaultremote": result.DefaultRemote = parts[1]; break;
-                            case "defaultrebase": result.DefaultRebase = !parts[1].Equals("0"); break;
+                            case "defaultrebase": result.DefaultRebase = parts[1] != "0"; break;
 
                             case "port":
                                 if (!int.TryParse(parts[1], out var value))

--- a/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
@@ -211,7 +211,7 @@ namespace GitUIPluginInterfaces
             try
             {
                 string fontSize;
-                if (parts.Length == 3 && InvariantCultureId.Equals(parts[2]))
+                if (parts.Length == 3 && parts[2] == InvariantCultureId)
                 {
                     fontSize = parts[1];
                 }

--- a/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
@@ -56,9 +56,10 @@ namespace GitUIPluginInterfaces
             public override void SaveSetting(ISettingsSource settings, bool areSettingsEffective, TextBox control)
             {
                 var controlValue = control.Text;
+
                 if (areSettingsEffective)
                 {
-                    if (ConvertToString(Setting.ValueOrDefault(settings)).Equals(controlValue))
+                    if (ConvertToString(Setting.ValueOrDefault(settings)) == controlValue)
                     {
                         return;
                     }

--- a/ResourceManager/Translator.cs
+++ b/ResourceManager/Translator.cs
@@ -20,7 +20,7 @@ namespace ResourceManager
             {
                 _translation = new Dictionary<string, TranslationFile>();
             }
-            else if (!translationName.Equals(_name))
+            else if (translationName != _name)
             {
                 _translation = new Dictionary<string, TranslationFile>();
                 string translationsDir = GetTranslationDir();

--- a/TranslationApp/FormTranslate.cs
+++ b/TranslationApp/FormTranslate.cs
@@ -131,7 +131,7 @@ namespace TranslationApp
         private IEnumerable<TranslationItemWithCategory> GetCategoryItems(TranslationCategory filter)
         {
             var filteredByCategory = _translationItems.SelectMany(p => p.Value).Where(
-                translateItem => filter == null || filter.Name.Equals(translateItem.Category));
+                translateItem => filter == null || filter.Name == translateItem.Category);
             var filteredItems = filteredByCategory.Where(
                 translateItem => !hideTranslatedItems.Checked);
             return filteredItems;


### PR DESCRIPTION
Changes proposed in this pull request:
 - Use equality operator for comparing strings and types

The code used `Equals` in some places and `==` in others when comparing strings.

This PR makes all code use `==` for regular string comparison.
 
This doesn't effect perf but it does make the code more readable and consistent. This is C#, not Java!

What did I do to test the code and ensure quality:
 - Manual review of automated refactoring
 - Unit tests
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
