### PR TITLE
Patches 1/3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,6 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+
+[*.{patch,diff}]
+trim_trailing_whitespace = false

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2420,7 +2420,7 @@ namespace GitCommands
                 patch = RunCmd(AppSettings.GitCommand, arguments, LosslessEncoding);
             }
 
-            patchManager.LoadPatch(patch, false, encoding);
+            patchManager.LoadPatch(patch, encoding);
 
             return GetPatch(patchManager, fileName, oldFileName);
         }
@@ -2682,7 +2682,7 @@ namespace GitCommands
 
             string result = RunGitCmd(args, LosslessEncoding);
             var patchManager = new PatchManager();
-            patchManager.LoadPatch(result, false, encoding);
+            patchManager.LoadPatch(result, encoding);
 
             return GetPatch(patchManager, fileName, oldFileName);
         }
@@ -3827,7 +3827,7 @@ namespace GitCommands
                 return "";
             }
 
-            patchManager.LoadPatch(patch, false, encoding);
+            patchManager.LoadPatch(patch, encoding);
             return GetPatch(patchManager, filePath, filePath).Text;
         }
 

--- a/GitCommands/Patch/Patch.cs
+++ b/GitCommands/Patch/Patch.cs
@@ -1,6 +1,3 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace PatchApply
@@ -11,8 +8,6 @@ namespace PatchApply
 
         public Patch()
         {
-            Apply = true;
-            Bookmarks = new List<int>();
             File = FileType.Text;
         }
 
@@ -35,13 +30,7 @@ namespace PatchApply
         public FileType File { get; set; }
         public string FileNameA { get; set; }
         public string FileNameB { get; set; }
-        public string FileTextB { get; set; }
-        public string DirToPatch { get; set; }
-        public int Rate { get; set; }
-        public bool Apply { get; set; }
         public bool CombinedDiff { get; set; }
-
-        public List<int> Bookmarks { get; set; }
 
         public PatchType Type { get; set; }
 
@@ -57,213 +46,9 @@ namespace PatchApply
             GetTextBuilder().Append(line).Append('\n');
         }
 
-        public void ApplyPatch(Encoding filesContentEncoding)
-        {
-            FileTextB = "";
-            Rate = 100;
-
-            if (Type == PatchType.DeleteFile)
-            {
-                HandleDeletePatchType();
-                return;
-            }
-
-            if (Text == null)
-            {
-                return;
-            }
-
-            if (Type == PatchType.NewFile)
-            {
-                HandleNewFilePatchType();
-            }
-            else if (Type == PatchType.ChangeFile)
-            {
-                HandleChangeFilePatchType(filesContentEncoding);
-            }
-        }
-
         private StringBuilder GetTextBuilder()
         {
             return _textBuilder ?? (_textBuilder = new StringBuilder());
-        }
-
-        private string LoadFile(string fileName, Encoding filesContentEncoding)
-        {
-            try
-            {
-                using (var streamReader = new StreamReader(DirToPatch + fileName, filesContentEncoding))
-                {
-                    string retval = "";
-                    string line;
-                    while ((line = streamReader.ReadLine()) != null)
-                    {
-                        retval += line + "\n";
-                    }
-
-                    if (retval.Length > 0 && retval[retval.Length - 1] == '\n')
-                    {
-                        retval = retval.Remove(retval.Length - 1, 1);
-                    }
-
-                    return retval;
-                }
-            }
-            catch
-            {
-                return "";
-            }
-        }
-
-        private void HandleChangeFilePatchType(Encoding filesContentEncoding)
-        {
-            var fileLines = LoadFile(FileNameA, filesContentEncoding).Split('\n').ToList();
-
-            int lineNumber = 0;
-            foreach (string line in Text.Split('\n'))
-            {
-                // Parse first line
-                // @@ -1,4 +1,4 @@
-                if (line.StartsWith("@@") && line.LastIndexOf("@@") > 0)
-                {
-                    string pos = line.Substring(3, line.LastIndexOf("@@") - 3).Trim();
-                    string[] addrem = pos.Split('+', '-');
-                    string[] oldLines = addrem[1].Split(',');
-
-                    lineNumber = int.Parse(oldLines[0]) - 1;
-                    continue;
-                }
-
-                if (line.StartsWith(" "))
-                {
-                    // Do some extra checks
-                    if (line.Length > 0)
-                    {
-                        if (fileLines.Count > lineNumber && fileLines[lineNumber].CompareTo(line.Substring(1)) != 0)
-                        {
-                            Rate -= 20;
-                        }
-                    }
-                    else
-                    {
-                        if (fileLines.Count > lineNumber && fileLines[lineNumber] != "")
-                        {
-                            Rate -= 20;
-                        }
-                    }
-
-                    lineNumber++;
-                }
-
-                if (line.StartsWith("-"))
-                {
-                    if (line.Length > 0)
-                    {
-                        if (fileLines.Count > lineNumber && fileLines[lineNumber].CompareTo(line.Substring(1)) != 0)
-                        {
-                            Rate -= 20;
-                        }
-                    }
-                    else
-                    {
-                        if (fileLines.Count > lineNumber && fileLines[lineNumber] != "")
-                        {
-                            Rate -= 20;
-                        }
-                    }
-
-                    Bookmarks.Add(lineNumber);
-
-                    if (fileLines.Count > lineNumber)
-                    {
-                        fileLines.RemoveAt(lineNumber);
-                    }
-                    else
-                    {
-                        Rate -= 20;
-                    }
-                }
-
-                if (line.StartsWith("+"))
-                {
-                    string insertLine = "";
-                    if (line.Length > 1)
-                    {
-                        insertLine = line.Substring(1);
-                    }
-
-                    // Is the patch allready applied?
-                    if (fileLines.Count > lineNumber && fileLines[lineNumber].CompareTo(insertLine) == 0)
-                    {
-                        Rate -= 20;
-                    }
-
-                    fileLines.Insert(lineNumber, insertLine);
-                    Bookmarks.Add(lineNumber);
-
-                    lineNumber++;
-                }
-            }
-
-            foreach (string patchedLine in fileLines)
-            {
-                FileTextB += patchedLine + "\n";
-            }
-
-            if (FileTextB.Length > 0 && FileTextB[FileTextB.Length - 1] == '\n')
-            {
-                FileTextB = FileTextB.Remove(FileTextB.Length - 1, 1);
-            }
-
-            if (Rate != 100)
-            {
-                Apply = false;
-            }
-        }
-
-        private void HandleNewFilePatchType()
-        {
-            foreach (string line in Text.Split('\n'))
-            {
-                if (line.Length > 0 && line.StartsWith("+"))
-                {
-                    if (line.Length > 4 && line.StartsWith("+ï»¿"))
-                    {
-                        AppendText(line.Substring(4));
-                    }
-                    else if (line.Length > 1)
-                    {
-                        FileTextB += line.Substring(1);
-                    }
-
-                    FileTextB += "\n";
-                }
-            }
-
-            if (FileTextB.Length > 0 && FileTextB[FileTextB.Length - 1] == '\n')
-            {
-                FileTextB = FileTextB.Remove(FileTextB.Length - 1, 1);
-            }
-
-            Rate = 100;
-
-            if (System.IO.File.Exists(DirToPatch + FileNameB))
-            {
-                Rate -= 40;
-                Apply = false;
-            }
-        }
-
-        private void HandleDeletePatchType()
-        {
-            FileTextB = "";
-            Rate = 100;
-
-            if (!System.IO.File.Exists(DirToPatch + FileNameA))
-            {
-                Rate -= 40;
-                Apply = false;
-            }
         }
     }
 }

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Settings;
@@ -483,12 +484,24 @@ namespace PatchApply
             }
         }
 
-        public bool ParseHeader(string header)
+        /// <summary>
+        /// Parses a header line, setting the start index.
+        /// </summary>
+        /// <remarks>
+        /// An example header line is:
+        /// <code>
+        ///  -116,12 +117,15 @@ private string LoadFile(string fileName, Encoding filesContentEncoding)
+        /// </code>
+        /// In which case the start line is <c>116</c>.
+        /// </remarks>
+        public void ParseHeader(string header)
         {
-            header = header.SkipStr("-");
-            header = header.TakeUntilStr(",");
+            var match = Regex.Match(header, @".*-(\d+),");
 
-            return int.TryParse(header, out _startLine);
+            if (match.Success)
+            {
+                _startLine = int.Parse(match.Groups[1].Value);
+            }
         }
 
         public static Chunk ParseChunk(string chunkStr, int currentPos, int selectionPosition, int selectionLength)

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -208,15 +208,8 @@ namespace PatchApply
 
         public void LoadPatchFile(bool applyPatch, Encoding filesContentEncoding)
         {
-            using (var re = new StreamReader(PatchFileName, GitModule.LosslessEncoding))
-            {
-                LoadPatchStream(re, applyPatch, filesContentEncoding);
-            }
-        }
-
-        private void LoadPatchStream(TextReader reader, bool applyPatch, Encoding filesContentEncoding)
-        {
-            LoadPatch(reader.ReadToEnd(), applyPatch, filesContentEncoding);
+            var text = File.ReadAllText(PatchFileName, GitModule.LosslessEncoding);
+            LoadPatch(text, applyPatch, filesContentEncoding);
         }
     }
 

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -12,11 +12,9 @@ namespace PatchApply
 {
     public class PatchManager
     {
-        public string DirToPatch { get; set; }
-
         public List<Patch> Patches { get; set; } = new List<Patch>();
 
-        public static byte[] GetResetUnstagedLinesAsPatch(GitModule module, string text, int selectionPosition, int selectionLength, bool staged, Encoding fileContentEncoding)
+        public static byte[] GetResetUnstagedLinesAsPatch(GitModule module, string text, int selectionPosition, int selectionLength, Encoding fileContentEncoding)
         {
             ChunkList selectedChunks = ChunkList.GetSelectedChunks(text, selectionPosition, selectionLength, out var header);
 
@@ -184,30 +182,17 @@ namespace PatchApply
         }
 
         // TODO encoding for each file in patch should be obtained separately from .gitattributes
-        public void LoadPatch(string text, bool applyPatch, Encoding filesContentEncoding)
+        public void LoadPatch(string text, Encoding filesContentEncoding)
         {
             PatchProcessor patchProcessor = new PatchProcessor(filesContentEncoding);
 
             Patches = patchProcessor.CreatePatchesFromString(text).ToList();
-
-            if (!applyPatch)
-            {
-                return;
-            }
-
-            foreach (Patch patchApply in Patches)
-            {
-                if (patchApply.Apply)
-                {
-                    patchApply.ApplyPatch(filesContentEncoding);
-                }
-            }
         }
 
-        public void LoadPatchFile(string path, bool applyPatch, Encoding filesContentEncoding)
+        public void LoadPatchFile(string path, Encoding filesContentEncoding)
         {
             var text = File.ReadAllText(path, GitModule.LosslessEncoding);
-            LoadPatch(text, applyPatch, filesContentEncoding);
+            LoadPatch(text, filesContentEncoding);
         }
     }
 

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -196,7 +196,7 @@ namespace PatchApply
         }
     }
 
-    internal class PatchLine
+    internal sealed class PatchLine
     {
         public string Text { get; private set; }
         public bool Selected { get; set; }
@@ -218,7 +218,7 @@ namespace PatchApply
         }
     }
 
-    internal class SubChunk
+    internal sealed class SubChunk
     {
         public List<PatchLine> PreContext { get; } = new List<PatchLine>();
         public List<PatchLine> RemovedLines { get; } = new List<PatchLine>();
@@ -410,13 +410,13 @@ namespace PatchApply
 
     internal delegate string SubChunkToPatchFnc(SubChunk subChunk, ref int addedCount, ref int removedCount, ref bool wereSelectedLines);
 
-    internal class Chunk
+    internal sealed class Chunk
     {
         private int _startLine;
         private readonly List<SubChunk> _subChunks = new List<SubChunk>();
         private SubChunk _currentSubChunk;
 
-        public SubChunk CurrentSubChunk
+        private SubChunk CurrentSubChunk
         {
             get
             {
@@ -430,7 +430,7 @@ namespace PatchApply
             }
         }
 
-        public void AddContextLine(PatchLine line, bool preContext)
+        private void AddContextLine(PatchLine line, bool preContext)
         {
             if (preContext)
             {
@@ -442,7 +442,7 @@ namespace PatchApply
             }
         }
 
-        public void AddDiffLine(PatchLine line, bool removed)
+        private void AddDiffLine(PatchLine line, bool removed)
         {
             // if postContext is not empty @line comes from next SubChunk
             if (CurrentSubChunk.PostContext.Count > 0)
@@ -470,7 +470,7 @@ namespace PatchApply
         /// </code>
         /// In which case the start line is <c>116</c>.
         /// </remarks>
-        public void ParseHeader(string header)
+        private void ParseHeader(string header)
         {
             var match = Regex.Match(header, @".*-(\d+),");
 
@@ -728,7 +728,7 @@ namespace PatchApply
             return ToPatch(SubChunkToPatch);
         }
 
-        protected string ToPatch(SubChunkToPatchFnc subChunkToPatch)
+        private string ToPatch(SubChunkToPatchFnc subChunkToPatch)
         {
             string result = null;
 

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -12,8 +12,6 @@ namespace PatchApply
 {
     public class PatchManager
     {
-        public string PatchFileName { get; set; }
-
         public string DirToPatch { get; set; }
 
         public List<Patch> Patches { get; set; } = new List<Patch>();
@@ -206,9 +204,9 @@ namespace PatchApply
             }
         }
 
-        public void LoadPatchFile(bool applyPatch, Encoding filesContentEncoding)
+        public void LoadPatchFile(string path, bool applyPatch, Encoding filesContentEncoding)
         {
-            var text = File.ReadAllText(PatchFileName, GitModule.LosslessEncoding);
+            var text = File.ReadAllText(path, GitModule.LosslessEncoding);
             LoadPatch(text, applyPatch, filesContentEncoding);
         }
     }

--- a/GitCommands/Patch/PatchProcessor.cs
+++ b/GitCommands/Patch/PatchProcessor.cs
@@ -109,18 +109,12 @@ namespace PatchApply
                     }
 
                     patch.File = Patch.FileType.Binary;
-
-                    // TODO: NOT SUPPORTED!
-                    patch.Apply = false;
                     state = PatchProcessorState.OutsidePatch;
                     break;
                 }
                 else if (IsBinaryPatch(input))
                 {
                     patch.File = Patch.FileType.Binary;
-
-                    // TODO: NOT SUPPORTED!
-                    patch.Apply = false;
                     state = PatchProcessorState.OutsidePatch;
                     break;
                 }

--- a/GitCommands/Utils/EncodingHelper.cs
+++ b/GitCommands/Utils/EncodingHelper.cs
@@ -36,10 +36,11 @@ namespace GitCommands
             return sb.ToString();
         }
 
-        public static byte[] ConvertTo(Encoding encoding, string filename)
+        public static byte[] ConvertTo(Encoding encoding, string s)
         {
-            byte[] bytesunicode = Encoding.Unicode.GetBytes(filename);
-            return Encoding.Convert(Encoding.Unicode, encoding, bytesunicode);
+            byte[] unicodeBytes = Encoding.Unicode.GetBytes(s);
+
+            return Encoding.Convert(Encoding.Unicode, encoding, unicodeBytes);
         }
 
         public static string DecodeString(byte[] output, byte[] error, ref Encoding encoding)

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -4,34 +4,17 @@ namespace System.Linq
 {
     public static class LinqExtensions
     {
-        //
-        // Summary:
-        //     Creates a System.Collections.Generic.Dictionary<TKey,List<TValue>> from an System.Collections.Generic.IEnumerable<T>
-        //     according to a specified key selector function.
-        //
-        // Parameters:
-        //   source:
-        //     An System.Collections.Generic.IEnumerable<T> to create a System.Collections.Generic.Dictionary<TKey,List<TValue>>
-        //     from.
-        //
-        //   keySelector:
-        //     A function to extract a key from each element.
-        //
-        // Type parameters:
-        //   TSource:
-        //     The type of the elements of source.
-        //
-        //   TKey:
-        //     The type of the key returned by keySelector.
-        //
-        // Returns:
-        //     A System.Collections.Generic.Dictionary<TKey,List<TValue>> that contains keys and
-        //     values.
-        //
-        // Exceptions:
-        //   System.ArgumentNullException:
-        //     source or keySelector is null.  -or- keySelector produces a key that is null.
-
+        /// <summary>
+        /// Creates a <see cref="Dictionary{TKey,TValue}"/> from an <see cref="IEnumerable{T}"/> according to a specified
+        /// <paramref name="keySelector"/> function.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by keySelector.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> to create a <see cref="Dictionary{TKey,TValue}"/> from.</param>
+        /// <param name="keySelector">A function to extract a key from each element.</param>
+        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> that contains keys and values.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <c>null</c>
+        /// or <paramref name="keySelector"/> produces a key that is <c>null</c>.</exception>
         public static Dictionary<TKey, List<TSource>> ToDictionaryOfList<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
             if (keySelector == null)
@@ -95,35 +78,16 @@ namespace System.Linq
             return string.Join(separator, source);
         }
 
-        //
-        // Summary:
-        //     Sorts the elements of a sequence in ascending order by using a specified
-        //     comparer.
-        //
-        // Parameters:
-        //   source:
-        //     A sequence of values to order.
-        //
-        //   keySelector:
-        //     A function to extract a key from an element.
-        //
-        //   comparer:
-        //     A function to compare keys.
-        //
-        // Type parameters:
-        //   TSource:
-        //     The type of the elements of source.
-        //
-        //   TKey:
-        //     The type of the key returned by keySelector.
-        //
-        // Returns:
-        //     An System.Linq.IOrderedEnumerable<TElement> whose elements are sorted according
-        //     to a key.
-        //
-        // Exceptions:
-        //   System.ArgumentNullException:
-        //     source or keySelector is null.
+        /// <summary>
+        /// Sorts the elements of a sequence in ascending order by using a specified <paramref name="comparer"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by keySelector.</typeparam>
+        /// <param name="source">A sequence of values to order.</param>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        /// <param name="comparer">A function to compare keys.</param>
+        /// <returns>An <see cref="IOrderedEnumerable{TElement}"/> whose elements are sorted according to a key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="keySelector"/> is <c>null</c>.</exception>
         public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, TKey, int> comparer)
         {
             FuncComparer<TKey> fc = new FuncComparer<TKey>(comparer);
@@ -146,24 +110,13 @@ namespace System.Linq
             }
         }
 
-        //
-        // Summary:
-        //     Transforms each element of an array into a new form.
-        //
-        // Parameters:
-        //   source:
-        //     A sequence of values to invoke a transform function on.
-        //
-        //   transformer:
-        //     A transform function to apply to each element.
-        //
-        // Type parameters:
-        //   TSource:
-        //     The type of the elements of source.
-        //
-        // Exceptions:
-        //   System.ArgumentNullException:
-        //     source or selector is null.
+        /// <summary>
+        /// Transforms each element of an array into a new form.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <param name="source">A sequence of values to invoke a transform function on.</param>
+        /// <param name="transformer">A transform function to apply to each element.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="transformer"/> is <c>null</c>.</exception>
         public static void Transform<TSource>(this TSource[] source, Func<TSource, TSource> transformer)
         {
             if (source == null)

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -92,7 +92,7 @@ namespace System.Linq
 
         public static string Join(this IEnumerable<string> source, string separator)
         {
-            return string.Join(separator, source.ToArray());
+            return string.Join(separator, source);
         }
 
         //
@@ -143,44 +143,6 @@ namespace System.Linq
             public int Compare(T x, T y)
             {
                 return _comparer(x, y);
-            }
-        }
-
-        //
-        // Summary:
-        //     Transforms each element of an array into a new form by incorporating the
-        //     element's index.
-        //
-        // Parameters:
-        //   source:
-        //     A sequence of values to invoke a transform function on.
-        //
-        //   transformer:
-        //     A transform function to apply to each source element; the second parameter
-        //     of the function represents the index of the source element.
-        //
-        // Type parameters:
-        //   TSource:
-        //     The type of the elements of source.
-        //
-        // Exceptions:
-        //   System.ArgumentNullException:
-        //     source or selector is null.
-        public static void Select<TSource>(this TSource[] source, Func<TSource, int, TSource> transformer)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (transformer == null)
-            {
-                throw new ArgumentNullException(nameof(transformer));
-            }
-
-            for (int i = 0; i < source.Length; i++)
-            {
-                source[i] = transformer(source[i], i);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -685,8 +685,7 @@ namespace GitUI.CommandsDialogs
             else
             {
                 patch = PatchManager.GetResetUnstagedLinesAsPatch(Module, SelectedDiff.GetText(),
-                    SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
-                    _currentItemStaged, SelectedDiff.Encoding);
+                    SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(), SelectedDiff.Encoding);
             }
 
             if (patch != null && patch.Length > 0)

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -72,8 +72,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                PatchManager.PatchFileName = PatchFileNameEdit.Text;
-                PatchManager.LoadPatchFile(false, Module.FilesEncoding);
+                PatchManager.LoadPatchFile(PatchFileNameEdit.Text, false, Module.FilesEncoding);
 
                 GridChangedFiles.DataSource = PatchManager.Patches;
             }

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -25,11 +25,10 @@ namespace GitUI.CommandsDialogs
         public void LoadPatch(string patch)
         {
             PatchFileNameEdit.Text = patch;
-            LoadButton_Click(null, null);
+            LoadPatchFile();
         }
 
         public PatchManager PatchManager { get; set; }
-        public Patch CurrentPatch { get; set; }
 
         private void GridChangedFiles_SelectionChanged(object sender, EventArgs e)
         {
@@ -39,7 +38,6 @@ namespace GitUI.CommandsDialogs
             }
 
             var patch = (Patch)GridChangedFiles.SelectedRows[0].DataBoundItem;
-            CurrentPatch = patch;
 
             if (patch == null)
             {
@@ -58,21 +56,21 @@ namespace GitUI.CommandsDialogs
                 Title = _patchFileFilterTitle.Text
             })
             {
-                return (dialog.ShowDialog(this) == DialogResult.OK) ? dialog.FileName : PatchFileNameEdit.Text;
+                return dialog.ShowDialog(this) == DialogResult.OK ? dialog.FileName : PatchFileNameEdit.Text;
             }
         }
 
         private void BrowsePatch_Click(object sender, EventArgs e)
         {
             PatchFileNameEdit.Text = SelectPatchFile(@".");
-            LoadButton_Click(sender, e);
+            LoadPatchFile();
         }
 
-        private void LoadButton_Click(object sender, EventArgs e)
+        private void LoadPatchFile()
         {
             try
             {
-                PatchManager.LoadPatchFile(PatchFileNameEdit.Text, false, Module.FilesEncoding);
+                PatchManager.LoadPatchFile(PatchFileNameEdit.Text, Module.FilesEncoding);
 
                 GridChangedFiles.DataSource = PatchManager.Patches;
             }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1190,8 +1190,7 @@ namespace GitUI.Editor
             {
                 patch = PatchManager.GetResetUnstagedLinesAsPatch(
                     Module, GetText(),
-                    selectionStart, selectionLength,
-                    false, Encoding);
+                    selectionStart, selectionLength, Encoding);
             }
             else
             {

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -46,7 +46,7 @@ namespace GitUI
                     diffArgs, encoding, true, isTracked);
         }
 
-        public static string GetSelectedPatch(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file)
+        private static string GetSelectedPatch(this FileViewer diffViewer, string firstRevision, string secondRevision, GitItemStatus file)
         {
             if (!file.IsTracked)
             {
@@ -176,7 +176,7 @@ namespace GitUI
             return null;
         }
 
-        public class MaskPanel : PictureBox
+        private class MaskPanel : PictureBox
         {
             public MaskPanel()
             {
@@ -191,7 +191,7 @@ namespace GitUI
             return tree.Nodes.AllNodes();
         }
 
-        public static IEnumerable<TreeNode> AllNodes(this TreeNodeCollection nodes)
+        private static IEnumerable<TreeNode> AllNodes(this TreeNodeCollection nodes)
         {
             foreach (TreeNode node in nodes)
             {

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -144,18 +145,17 @@ namespace GitUI
 
         public static void Mask(this Control control)
         {
-            if (control.FindMaskPanel() == null)
+            if (FindMaskPanel(control) == null)
             {
-                MaskPanel panel = new MaskPanel();
+                var panel = new MaskPanel { Dock = DockStyle.Fill };
                 control.Controls.Add(panel);
-                panel.Dock = DockStyle.Fill;
                 panel.BringToFront();
             }
         }
 
         public static void UnMask(this Control control)
         {
-            MaskPanel panel = control.FindMaskPanel();
+            MaskPanel panel = FindMaskPanel(control);
             if (panel != null)
             {
                 control.Controls.Remove(panel);
@@ -163,17 +163,9 @@ namespace GitUI
             }
         }
 
-        private static MaskPanel FindMaskPanel(this Control control)
+        private static MaskPanel FindMaskPanel(Control control)
         {
-            foreach (var c in control.Controls)
-            {
-                if (c is MaskPanel)
-                {
-                    return c as MaskPanel;
-                }
-            }
-
-            return null;
+            return control.Controls.Cast<Control>().OfType<MaskPanel>().FirstOrDefault();
         }
 
         private class MaskPanel : PictureBox

--- a/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
+++ b/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
@@ -41,14 +41,13 @@ namespace GitCommandsTests.PatchApply
             var manager = new PatchManager();
             TestPatch expectedPatch = CreateSmallPatchExample();
 
-            manager.LoadPatch(expectedPatch.PatchOutput.ToString(), false, Encoding.UTF8);
+            manager.LoadPatch(expectedPatch.PatchOutput.ToString(), Encoding.UTF8);
 
             Patch createdPatch = manager.Patches.First();
 
             Assert.AreEqual(expectedPatch.Patch.PatchHeader, createdPatch.PatchHeader);
             Assert.AreEqual(expectedPatch.Patch.FileNameA, createdPatch.FileNameA);
             Assert.AreEqual(expectedPatch.Patch.PatchIndex, createdPatch.PatchIndex);
-            Assert.AreEqual(expectedPatch.Patch.Rate, createdPatch.Rate);
             Assert.AreEqual(expectedPatch.Patch.Type, createdPatch.Type);
             Assert.AreEqual(expectedPatch.Patch.Text, createdPatch.Text);
         }
@@ -59,14 +58,13 @@ namespace GitCommandsTests.PatchApply
             var manager = new PatchManager();
             TestPatch expectedPatch = CreateSmallPatchExample(true);
 
-            manager.LoadPatch(expectedPatch.PatchOutput.ToString(), false, Encoding.UTF8);
+            manager.LoadPatch(expectedPatch.PatchOutput.ToString(), Encoding.UTF8);
 
             Patch createdPatch = manager.Patches.First();
 
             Assert.AreEqual(expectedPatch.Patch.PatchHeader, createdPatch.PatchHeader, "header");
             Assert.AreEqual(expectedPatch.Patch.FileNameB, createdPatch.FileNameA, "fileA");
             Assert.AreEqual(expectedPatch.Patch.PatchIndex, createdPatch.PatchIndex);
-            Assert.AreEqual(expectedPatch.Patch.Rate, createdPatch.Rate);
             Assert.AreEqual(expectedPatch.Patch.Type, createdPatch.Type);
             Assert.AreEqual(expectedPatch.Patch.Text, createdPatch.Text);
         }
@@ -75,7 +73,7 @@ namespace GitCommandsTests.PatchApply
         public void TestCorrectlyLoadsTheRightNumberOfDiffsInAPatchFile()
         {
             var manager = new PatchManager();
-            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
+            manager.LoadPatch(_bigPatch, Encoding.UTF8);
 
             Assert.AreEqual(17, manager.Patches.Count);
         }
@@ -84,7 +82,7 @@ namespace GitCommandsTests.PatchApply
         public void TestCorrectlyLoadsTheRightFilenamesInAPatchFile()
         {
             var manager = new PatchManager();
-            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
+            manager.LoadPatch(_bigPatch, Encoding.UTF8);
 
             Assert.AreEqual(17, manager.Patches.Select(p => p.FileNameA).Distinct().Count());
             Assert.AreEqual(17, manager.Patches.Select(p => p.FileNameB).Distinct().Count());
@@ -94,7 +92,7 @@ namespace GitCommandsTests.PatchApply
         public void TestCorrectlyLoadsBinaryPatch()
         {
             var manager = new PatchManager();
-            manager.LoadPatch(_bigBinPatch, false, Encoding.UTF8);
+            manager.LoadPatch(_bigBinPatch, Encoding.UTF8);
 
             Assert.AreEqual(248, manager.Patches.Count(p => p.File == Patch.FileType.Binary));
         }
@@ -103,7 +101,7 @@ namespace GitCommandsTests.PatchApply
         public void TestCorrectlyLoadsOneNewFile()
         {
             var manager = new PatchManager();
-            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
+            manager.LoadPatch(_bigPatch, Encoding.UTF8);
 
             Assert.AreEqual(1, manager.Patches.Count(p => p.Type == Patch.PatchType.NewFile));
         }
@@ -112,7 +110,7 @@ namespace GitCommandsTests.PatchApply
         public void TestCorrectlyLoadsOneDeleteFile()
         {
             var manager = new PatchManager();
-            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
+            manager.LoadPatch(_bigPatch, Encoding.UTF8);
 
             Assert.AreEqual(1, manager.Patches.Count(p => p.Type == Patch.PatchType.DeleteFile));
         }
@@ -123,10 +121,10 @@ namespace GitCommandsTests.PatchApply
             var manager = new PatchManager();
             var testSmallPatch = CreateSmallPatchExample();
 
-            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
+            manager.LoadPatch(_bigPatch, Encoding.UTF8);
             Assert.AreEqual(15, manager.Patches.Count(p => p.Type == Patch.PatchType.ChangeFile));
 
-            manager.LoadPatch(testSmallPatch.PatchOutput.ToString(), false, Encoding.UTF8);
+            manager.LoadPatch(testSmallPatch.PatchOutput.ToString(), Encoding.UTF8);
             Assert.AreEqual(1, manager.Patches.Count(p => p.Type == Patch.PatchType.ChangeFile));
         }
 
@@ -134,7 +132,7 @@ namespace GitCommandsTests.PatchApply
         public void TestCorrectlyLoadsRebaseDiff()
         {
             var manager = new PatchManager();
-            manager.LoadPatch(_rebaseDiff, false, Encoding.UTF8);
+            manager.LoadPatch(_rebaseDiff, Encoding.UTF8);
 
             Assert.AreEqual(13, manager.Patches.Count);
             Assert.AreEqual(3, manager.Patches.Count(p => p.CombinedDiff));
@@ -147,7 +145,6 @@ namespace GitCommandsTests.PatchApply
                 Patch =
                 {
                     Type = Patch.PatchType.ChangeFile,
-                    Apply = true,
                     PatchHeader = reverse ? "diff --git b/thisisatestb.txt a/thisisatesta.txt" : "diff --git a/thisisatesta.txt b/thisisatestb.txt",
                     PatchIndex = "index 5e4dce2..5eb1e6f 100644",
                     FileNameA = "thisisatesta.txt",

--- a/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
+++ b/UnitTests/GitCommandsTests/Patch/PatchManagerTest.cs
@@ -5,82 +5,45 @@ using GitCommands;
 using NUnit.Framework;
 using PatchApply;
 
-namespace GitCommandsTests.Patch
+namespace GitCommandsTests.PatchApply
 {
     [TestFixture]
-    public class PatchManagerTest
+    public sealed class PatchManagerTest
     {
-        private readonly string _bigPatchFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"Patch/testdata/big.patch");
-        private readonly string _bigBinPatchFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"Patch/testdata/bigBin.patch");
-        private readonly string _rebaseDiffFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"Patch/testdata/rebase.diff");
+        private readonly string _bigPatch;
+        private readonly string _bigBinPatch;
+        private readonly string _rebaseDiff;
+
+        public PatchManagerTest()
+        {
+            _bigPatch = LoadPatch("big.patch");
+            _bigBinPatch = LoadPatch("bigBin.patch");
+            _rebaseDiff = LoadPatch("rebase.diff");
+
+            string LoadPatch(string fileName)
+            {
+                var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Patch/testdata", fileName);
+                var bytes = File.ReadAllBytes(path);
+                return GitModule.LosslessEncoding.GetString(bytes);
+            }
+        }
 
         [Test]
         public void TestPatchManagerInstanceNotNull()
         {
-            PatchManager manager = NewManager();
+            var manager = new PatchManager();
             Assert.IsNotNull(manager);
-        }
-
-        public byte[] LoadTestPatchDataBytes(string fileName)
-        {
-            byte[] patchBytes;
-
-            using (var reader = new StreamReader(fileName))
-            {
-                patchBytes = new BinaryReader(reader.BaseStream).ReadBytes((int)reader.BaseStream.Length);
-            }
-
-            return patchBytes;
-        }
-
-        public TestPatch CreateSmallPatchExample(bool reverse = false)
-        {
-            TestPatch testPatch = new TestPatch();
-            Encoding fileEncoding = Encoding.UTF8;
-            testPatch.Patch.Type = PatchApply.Patch.PatchType.ChangeFile;
-            testPatch.Patch.Apply = true;
-            if (reverse)
-            {
-                testPatch.Patch.PatchHeader = "diff --git b/thisisatestb.txt a/thisisatesta.txt";
-            }
-            else
-            {
-                testPatch.Patch.PatchHeader = "diff --git a/thisisatesta.txt b/thisisatestb.txt";
-            }
-
-            testPatch.Patch.PatchIndex = "index 5e4dce2..5eb1e6f 100644";
-            testPatch.Patch.FileNameA = "thisisatesta.txt";
-            testPatch.Patch.FileNameB = "thisisatestb.txt";
-            testPatch.AppendHeaderLine(testPatch.Patch.PatchHeader);
-            testPatch.AppendHeaderLine(testPatch.Patch.PatchIndex);
-            if (reverse)
-            {
-                testPatch.AppendHeaderLine("--- b/" + testPatch.Patch.FileNameB);
-                testPatch.AppendHeaderLine("+++ a/" + testPatch.Patch.FileNameA);
-            }
-            else
-            {
-                testPatch.AppendHeaderLine("--- a/" + testPatch.Patch.FileNameA);
-                testPatch.AppendHeaderLine("+++ b/" + testPatch.Patch.FileNameB);
-            }
-
-            testPatch.AppendDiffLine("@@ -1,2 +1,2 @@", fileEncoding);
-            testPatch.AppendDiffLine(" iiiiii", fileEncoding);
-            testPatch.AppendDiffLine("-ąśdkjaldskjlaksd", fileEncoding);
-            testPatch.AppendDiffLine("+changed again€", fileEncoding);
-
-            return testPatch;
         }
 
         [Test]
         public void TestCorrectlyLoadPatch()
         {
-            PatchManager manager = NewManager();
+            var manager = new PatchManager();
             TestPatch expectedPatch = CreateSmallPatchExample();
 
             manager.LoadPatch(expectedPatch.PatchOutput.ToString(), false, Encoding.UTF8);
 
-            PatchApply.Patch createdPatch = manager.Patches.First();
+            Patch createdPatch = manager.Patches.First();
 
             Assert.AreEqual(expectedPatch.Patch.PatchHeader, createdPatch.PatchHeader);
             Assert.AreEqual(expectedPatch.Patch.FileNameA, createdPatch.FileNameA);
@@ -93,12 +56,12 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestCorrectlyLoadReversePatch()
         {
-            PatchManager manager = NewManager();
+            var manager = new PatchManager();
             TestPatch expectedPatch = CreateSmallPatchExample(true);
 
             manager.LoadPatch(expectedPatch.PatchOutput.ToString(), false, Encoding.UTF8);
 
-            PatchApply.Patch createdPatch = manager.Patches.First();
+            Patch createdPatch = manager.Patches.First();
 
             Assert.AreEqual(expectedPatch.Patch.PatchHeader, createdPatch.PatchHeader, "header");
             Assert.AreEqual(expectedPatch.Patch.FileNameB, createdPatch.FileNameA, "fileA");
@@ -111,9 +74,8 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestCorrectlyLoadsTheRightNumberOfDiffsInAPatchFile()
         {
-            PatchManager manager = NewManager();
-            var testPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_bigPatchFile));
-            manager.LoadPatch(testPatch, false, Encoding.UTF8);
+            var manager = new PatchManager();
+            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
 
             Assert.AreEqual(17, manager.Patches.Count);
         }
@@ -121,9 +83,8 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestCorrectlyLoadsTheRightFilenamesInAPatchFile()
         {
-            PatchManager manager = NewManager();
-            var testPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_bigPatchFile));
-            manager.LoadPatch(testPatch, false, Encoding.UTF8);
+            var manager = new PatchManager();
+            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
 
             Assert.AreEqual(17, manager.Patches.Select(p => p.FileNameA).Distinct().Count());
             Assert.AreEqual(17, manager.Patches.Select(p => p.FileNameB).Distinct().Count());
@@ -132,73 +93,96 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestCorrectlyLoadsBinaryPatch()
         {
-            PatchManager manager = NewManager();
-            var testPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_bigBinPatchFile));
-            manager.LoadPatch(testPatch, false, Encoding.UTF8);
+            var manager = new PatchManager();
+            manager.LoadPatch(_bigBinPatch, false, Encoding.UTF8);
 
-            Assert.AreEqual(248, manager.Patches.Count(p => p.File == PatchApply.Patch.FileType.Binary));
+            Assert.AreEqual(248, manager.Patches.Count(p => p.File == Patch.FileType.Binary));
         }
 
         [Test]
         public void TestCorrectlyLoadsOneNewFile()
         {
-            PatchManager manager = NewManager();
-            var testPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_bigPatchFile));
-            manager.LoadPatch(testPatch, false, Encoding.UTF8);
+            var manager = new PatchManager();
+            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
 
-            Assert.AreEqual(1, manager.Patches.Count(p => p.Type == PatchApply.Patch.PatchType.NewFile));
+            Assert.AreEqual(1, manager.Patches.Count(p => p.Type == Patch.PatchType.NewFile));
         }
 
         [Test]
         public void TestCorrectlyLoadsOneDeleteFile()
         {
-            PatchManager manager = NewManager();
-            var testPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_bigPatchFile));
-            manager.LoadPatch(testPatch, false, Encoding.UTF8);
+            var manager = new PatchManager();
+            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
 
-            Assert.AreEqual(1, manager.Patches.Count(p => p.Type == PatchApply.Patch.PatchType.DeleteFile));
+            Assert.AreEqual(1, manager.Patches.Count(p => p.Type == Patch.PatchType.DeleteFile));
         }
 
         [Test]
         public void TestCorrectlyLoadsChangeFiles()
         {
-            PatchManager manager = NewManager();
-            var testBigPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_bigPatchFile));
+            var manager = new PatchManager();
             var testSmallPatch = CreateSmallPatchExample();
 
-            manager.LoadPatch(testBigPatch, false, Encoding.UTF8);
-            Assert.AreEqual(15, manager.Patches.Count(p => p.Type == PatchApply.Patch.PatchType.ChangeFile));
+            manager.LoadPatch(_bigPatch, false, Encoding.UTF8);
+            Assert.AreEqual(15, manager.Patches.Count(p => p.Type == Patch.PatchType.ChangeFile));
 
             manager.LoadPatch(testSmallPatch.PatchOutput.ToString(), false, Encoding.UTF8);
-            Assert.AreEqual(1, manager.Patches.Count(p => p.Type == PatchApply.Patch.PatchType.ChangeFile));
+            Assert.AreEqual(1, manager.Patches.Count(p => p.Type == Patch.PatchType.ChangeFile));
         }
 
         [Test]
         public void TestCorrectlyLoadsRebaseDiff()
         {
-            PatchManager manager = NewManager();
-            var testPatch = GitModule.LosslessEncoding.GetString(LoadTestPatchDataBytes(_rebaseDiffFile));
-            manager.LoadPatch(testPatch, false, Encoding.UTF8);
+            var manager = new PatchManager();
+            manager.LoadPatch(_rebaseDiff, false, Encoding.UTF8);
 
             Assert.AreEqual(13, manager.Patches.Count);
             Assert.AreEqual(3, manager.Patches.Count(p => p.CombinedDiff));
         }
 
-        private static PatchManager NewManager()
+        private static TestPatch CreateSmallPatchExample(bool reverse = false)
         {
-            return new PatchManager();
+            var testPatch = new TestPatch
+            {
+                Patch =
+                {
+                    Type = Patch.PatchType.ChangeFile,
+                    Apply = true,
+                    PatchHeader = reverse ? "diff --git b/thisisatestb.txt a/thisisatesta.txt" : "diff --git a/thisisatesta.txt b/thisisatestb.txt",
+                    PatchIndex = "index 5e4dce2..5eb1e6f 100644",
+                    FileNameA = "thisisatesta.txt",
+                    FileNameB = "thisisatestb.txt"
+                }
+            };
+
+            testPatch.AppendHeaderLine(testPatch.Patch.PatchHeader);
+            testPatch.AppendHeaderLine(testPatch.Patch.PatchIndex);
+
+            if (reverse)
+            {
+                testPatch.AppendHeaderLine("--- b/" + testPatch.Patch.FileNameB);
+                testPatch.AppendHeaderLine("+++ a/" + testPatch.Patch.FileNameA);
+            }
+            else
+            {
+                testPatch.AppendHeaderLine("--- a/" + testPatch.Patch.FileNameA);
+                testPatch.AppendHeaderLine("+++ b/" + testPatch.Patch.FileNameB);
+            }
+
+            var fileEncoding = Encoding.UTF8;
+
+            testPatch.AppendDiffLine("@@ -1,2 +1,2 @@", fileEncoding);
+            testPatch.AppendDiffLine(" iiiiii", fileEncoding);
+            testPatch.AppendDiffLine("-ąśdkjaldskjlaksd", fileEncoding);
+            testPatch.AppendDiffLine("+changed again€", fileEncoding);
+
+            return testPatch;
         }
 
-        public class TestPatch
+        private sealed class TestPatch
         {
-            public PatchApply.Patch Patch { get; }
-            public StringBuilder PatchOutput { get; }
-
-            public TestPatch()
-            {
-                Patch = new PatchApply.Patch();
-                PatchOutput = new StringBuilder();
-            }
+            public Patch Patch { get; } = new Patch();
+            public StringBuilder PatchOutput { get; } = new StringBuilder();
 
             public void AppendHeaderLine(string line)
             {

--- a/UnitTests/GitCommandsTests/Patch/PatchTest.cs
+++ b/UnitTests/GitCommandsTests/Patch/PatchTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
+using PatchApply;
 
-namespace GitCommandsTests.Patch
+namespace GitCommandsTests.PatchApply
 {
     [TestFixture]
     internal class PatchTest
@@ -8,7 +9,7 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestPatchConstructor()
         {
-            PatchApply.Patch patch = new PatchApply.Patch();
+            Patch patch = new Patch();
 
             Assert.IsNotNull(patch);
         }
@@ -16,7 +17,7 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestAppendText()
         {
-            PatchApply.Patch patch = new PatchApply.Patch();
+            Patch patch = new Patch();
             patch.AppendText("text1");
             patch.AppendText("text2");
 
@@ -26,7 +27,7 @@ namespace GitCommandsTests.Patch
         [Test]
         public void TestAppendTextLine()
         {
-            PatchApply.Patch patch = new PatchApply.Patch();
+            Patch patch = new Patch();
 
             patch.AppendTextLine("text1");
             patch.AppendTextLine("text2");


### PR DESCRIPTION
This PR contains the first third of the commits from my `patches` branch, which ultimately makes `Patch` immutable, `PatchProcessor`/`PatchManager` stateless, and reduces the amount of string manipulation in the handling of patches.

I've squashed some of the commits and can squash more. Right now it's pretty easy to follow each commit. The first 7 commits are all related to patch unit tests and could be squashed.

Changes proposed in this pull request:
- Make `PatchManager` stateless
- Remove unused code (~300 LOC)
- Fix conflict between type and namespace names
- Miscellaneous tidying and admin
 
What did I do to test the code and ensure quality:
- Manual testing
- Unit tests

Has been tested on:
 - GIT 2.16
 - Windows 10
