### PR TITLE
Add missing word to dialog text (#4691)

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _deleteFailed = new TranslationString("Delete file failed");
 
         private readonly TranslationString _deleteSelectedFiles =
-            new TranslationString("Are you sure you want delete the selected file(s)?");
+            new TranslationString("Are you sure you want to delete the selected file(s)?");
 
         private readonly TranslationString _deleteSelectedFilesCaption = new TranslationString("Delete");
 

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _saveFileFilterAllFiles = new TranslationString("All files");
         private readonly TranslationString _deleteSelectedFilesCaption = new TranslationString("Delete");
         private readonly TranslationString _deleteSelectedFiles =
-            new TranslationString("Are you sure you want delete the selected file(s)?");
+            new TranslationString("Are you sure you want to delete the selected file(s)?");
         private readonly TranslationString _deleteFailed = new TranslationString("Delete file failed");
         private readonly TranslationString _multipleDescription = new TranslationString("<multiple>");
         private readonly TranslationString _selectedRevision = new TranslationString("Selected");


### PR DESCRIPTION
Fixes the missing word observed in #4691.

![image](https://user-images.githubusercontent.com/350947/37829929-c4fb4526-2e98-11e8-98bc-304aaf08c87a.png)


QUESTION: Does the translation system rely on this string? Does this change require something more for translation to continue to work? I took a look through the code and decided it didn't, but it'd be good to confirm.
