### PR TITLE
Fix commit drop downs (#4698)

### DIFF
--- a/GitCommands/Git/GitDeleteBranchCmd.cs
+++ b/GitCommands/Git/GitDeleteBranchCmd.cs
@@ -7,17 +7,17 @@ namespace GitCommands
 {
     public sealed class GitDeleteBranchCmd : GitCommand
     {
-        private readonly ICollection<IGitRef> _branches;
+        private readonly IReadOnlyCollection<IGitRef> _branches;
         private readonly bool _force;
 
-        public GitDeleteBranchCmd(IEnumerable<IGitRef> branches, bool force)
+        public GitDeleteBranchCmd(IReadOnlyCollection<IGitRef> branches, bool force)
         {
             if (branches == null)
             {
                 throw new ArgumentNullException(nameof(branches));
             }
 
-            _branches = branches.ToArray();
+            _branches = branches;
             _force = force;
         }
 
@@ -32,6 +32,7 @@ namespace GitCommands
 
             var hasRemoteBranch = _branches.Any(branch => branch.IsRemote);
             var hasNonRemoteBranch = _branches.Any(branch => !branch.IsRemote);
+
             if (hasRemoteBranch)
             {
                 yield return hasNonRemoteBranch ? "-a" : "-r";

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3189,12 +3189,7 @@ namespace GitCommands
             return _gitTreeParser.Parse(tree);
         }
 
-        public GitBlame Blame(string filename, string from, Encoding encoding)
-        {
-            return Blame(filename, from, null, encoding);
-        }
-
-        public GitBlame Blame(string fileName, string from, string lines, Encoding encoding)
+        public GitBlame Blame(string fileName, string from, Encoding encoding, string lines = null)
         {
             from = from.ToPosixPath();
             fileName = fileName.ToPosixPath();
@@ -3480,12 +3475,7 @@ namespace GitCommands
             return null;
         }
 
-        public IEnumerable<string> GetPreviousCommitMessages(int count)
-        {
-            return GetPreviousCommitMessages("HEAD", count);
-        }
-
-        public IEnumerable<string> GetPreviousCommitMessages(string revision, int count)
+        public IEnumerable<string> GetPreviousCommitMessages(int count, string revision = "HEAD")
         {
             const string sep = "d3fb081b9000598e658da93657bf822cc87b2bf6";
             string output = RunGitCmd("log -n " + count + " " + revision + " --pretty=format:" + sep + "%e%n%s%n%n%b", LosslessEncoding);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2953,12 +2953,12 @@ namespace GitCommands
             ByCommitDateDescending
         }
 
-        public ICollection<string> GetMergedBranches(bool includeRemote = false)
+        public IReadOnlyList<string> GetMergedBranches(bool includeRemote = false)
         {
             return RunGitCmd(GitCommandHelpers.MergedBranches(includeRemote)).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public ICollection<string> GetMergedRemoteBranches()
+        public IReadOnlyList<string> GetMergedRemoteBranches()
         {
             const string remoteBranchPrefixForMergedBranches = "remotes/";
             const string refsPrefix = "refs/";
@@ -2971,7 +2971,8 @@ namespace GitCommands
                 .Select(b => b.Trim())
                 .Where(b => b.StartsWith(remoteBranchPrefixForMergedBranches))
                 .Select(b => string.Concat(refsPrefix, b))
-                .Where(b => !string.IsNullOrEmpty(GitCommandHelpers.GetRemoteName(b, remotes))).ToList();
+                .Where(b => !string.IsNullOrEmpty(GitCommandHelpers.GetRemoteName(b, remotes)))
+                .ToList();
         }
 
         private string GetTree(bool tags, bool branches)

--- a/GitCommands/Repository/RecentRepoInfo.cs
+++ b/GitCommands/Repository/RecentRepoInfo.cs
@@ -76,11 +76,11 @@ namespace GitCommands.Repository
             RecentReposComboMinWidth = AppSettings.RecentReposComboMinWidth;
         }
 
-        public void SplitRecentRepos(ICollection<Repository> recentRepositories, List<RecentRepoInfo> mostRecentRepoList, List<RecentRepoInfo> lessRecentRepoList)
+        public void SplitRecentRepos(IReadOnlyList<Repository> recentRepositories, List<RecentRepoInfo> mostRecentRepoList, List<RecentRepoInfo> lessRecentRepoList)
         {
-            SortedList<string, List<RecentRepoInfo>> orderedRepos = new SortedList<string, List<RecentRepoInfo>>();
-            List<RecentRepoInfo> mostRecentRepos = new List<RecentRepoInfo>();
-            List<RecentRepoInfo> lessRecentRepos = new List<RecentRepoInfo>();
+            var orderedRepos = new SortedList<string, List<RecentRepoInfo>>();
+            var mostRecentRepos = new List<RecentRepoInfo>();
+            var lessRecentRepos = new List<RecentRepoInfo>();
 
             bool middleDot = ShorteningStrategy == ShorteningStrategy_MiddleDots;
             bool signDir = ShorteningStrategy == ShorteningStrategy_MostSignDir;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -167,6 +167,7 @@ namespace GitUI.CommandsDialogs
             _useFormCommitMessage = AppSettings.UseFormCommitMessage;
 
             InitializeComponent();
+
             Message.TextChanged += Message_TextChanged;
             Message.TextAssigned += Message_TextAssigned;
 
@@ -228,6 +229,12 @@ namespace GitUI.CommandsDialogs
             {
                 gpgSignCommitToolStripComboBox.SelectedIndex = 0;
             }
+
+            ((ToolStripDropDownMenu)commitTemplatesToolStripMenuItem.DropDown).ShowImageMargin = false;
+            ((ToolStripDropDownMenu)commitTemplatesToolStripMenuItem.DropDown).ShowCheckMargin = false;
+
+            ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowImageMargin = false;
+            ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowCheckMargin = false;
         }
 
         private void ConfigureMessageBox()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2020,12 +2020,21 @@ namespace GitUI.CommandsDialogs
             commitMessageToolStripMenuItem.DropDownItems.Clear();
 
             var msg = AppSettings.LastCommitMessage;
+            var maxCount = AppSettings.CommitDialogNumberOfPreviousMessages;
 
-            var prevMsgs = Module.GetPreviousCommitMessages(AppSettings.CommitDialogNumberOfPreviousMessages);
+            var prevMsgs = Module.GetPreviousCommitMessages(maxCount).ToList();
 
             if (!prevMsgs.Contains(msg))
             {
-                prevMsgs = new[] { msg }.Concat(prevMsgs).Take(AppSettings.CommitDialogNumberOfPreviousMessages);
+                // If the list is already full
+                if (prevMsgs.Count == maxCount)
+                {
+                    // Remove the last item
+                    prevMsgs.RemoveAt(maxCount - 1);
+                }
+
+                // Insert the last commit message as the first entry
+                prevMsgs.Insert(0, msg);
             }
 
             foreach (var localLastCommitMessage in prevMsgs)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2039,9 +2039,9 @@ namespace GitUI.CommandsDialogs
 
             commitMessageToolStripMenuItem.DropDownItems.Clear();
 
-            foreach (var localLastCommitMessage in prevMsgs)
+            foreach (var prevMsg in prevMsgs)
             {
-                AddCommitMessageToMenu(localLastCommitMessage);
+                AddCommitMessageToMenu(prevMsg);
             }
 
             commitMessageToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[]
@@ -2049,29 +2049,37 @@ namespace GitUI.CommandsDialogs
                 toolStripMenuItem1,
                 generateListOfChangesInSubmodulesChangesToolStripMenuItem
             });
-        }
 
-        private void AddCommitMessageToMenu(string commitMessage)
-        {
-            if (string.IsNullOrEmpty(commitMessage))
+            void AddCommitMessageToMenu(string commitMessage)
             {
-                return;
-            }
+                const int maxLabelLength = 50;
 
-            var toolStripItem =
-                new ToolStripMenuItem
+                string label;
+
+                if (commitMessage.Length <= maxLabelLength)
+                {
+                    label = commitMessage;
+                }
+                else
+                {
+                    var newlineIndex = commitMessage.IndexOf('\n');
+
+                    if (newlineIndex != -1 && newlineIndex <= maxLabelLength)
+                    {
+                        label = commitMessage.Substring(0, newlineIndex);
+                    }
+                    else
+                    {
+                        label = commitMessage.ShortenTo(maxLabelLength);
+                    }
+                }
+
+                commitMessageToolStripMenuItem.DropDownItems.Add(new ToolStripMenuItem
                 {
                     Tag = commitMessage,
-                    Text =
-                        commitMessage.Substring(
-                            0,
-                            Math.Min(
-                                                    Math.Min(50, commitMessage.Length),
-                                                    commitMessage.Contains("\n") ? commitMessage.IndexOf('\n') : 99)) +
-                        "..."
-                };
-
-            commitMessageToolStripMenuItem.DropDownItems.Add(toolStripItem);
+                    Text = label
+                });
+            }
         }
 
         private void CommitMessageToolStripMenuItemDropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2017,12 +2017,12 @@ namespace GitUI.CommandsDialogs
 
         private void CommitMessageToolStripMenuItemDropDownOpening(object sender, EventArgs e)
         {
-            commitMessageToolStripMenuItem.DropDownItems.Clear();
-
             var msg = AppSettings.LastCommitMessage;
             var maxCount = AppSettings.CommitDialogNumberOfPreviousMessages;
 
-            var prevMsgs = Module.GetPreviousCommitMessages(maxCount).ToList();
+            var prevMsgs = Module.GetPreviousCommitMessages(maxCount)
+                .Select(message => message.TrimEnd('\n'))
+                .ToList();
 
             if (!prevMsgs.Contains(msg))
             {
@@ -2036,6 +2036,8 @@ namespace GitUI.CommandsDialogs
                 // Insert the last commit message as the first entry
                 prevMsgs.Insert(0, msg);
             }
+
+            commitMessageToolStripMenuItem.DropDownItems.Clear();
 
             foreach (var localLastCommitMessage in prevMsgs)
             {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2978,6 +2978,8 @@ namespace GitUI.CommandsDialogs
             // Add a settings item
             AddSettingsItem();
 
+            return;
+
             void CreateToolStripItem(CommitTemplateItem item)
             {
                 if (string.IsNullOrEmpty(item.Name))

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -173,7 +173,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             if (_prevTitle == _titleTB.Text && !_yourBranchesCB.Text.IsNullOrWhiteSpace() && MyRemote != null)
             {
-                var lastMsg = Module.GetPreviousCommitMessages(MyRemote.Name.Combine("/", _yourBranchesCB.Text), 1).FirstOrDefault();
+                var lastMsg = Module.GetPreviousCommitMessages(1, MyRemote.Name.Combine("/", _yourBranchesCB.Text)).FirstOrDefault();
                 _titleTB.Text = lastMsg.TakeUntilStr("\n");
                 _prevTitle = _titleTB.Text;
             }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -376,7 +376,7 @@ namespace GitUI.Blame
 
             string commit = _blame.Lines[line].Commit.ObjectId;
             int originalLine = _blame.Lines[line].OriginLineNumber;
-            GitBlame blame = Module.Blame(_fileName, commit + "^", originalLine + ",+1", _encoding);
+            GitBlame blame = Module.Blame(_fileName, commit + "^", _encoding, originalLine + ",+1");
             if (blame.Lines.Count > 0)
             {
                 var revision = blame.Lines[0].Commit.ObjectId;


### PR DESCRIPTION
Fixes #4698.

## Changes proposed in this pull request:

- Fix duplicate entry in commit message drop down list
- Fix truncation of commit message drop down labels
- Fix position of separator in commit templates drop down list
- Remove margin from these two drop down lists
- Misc tidying
 
## Screenshots before and after:

### Before

![image](https://user-images.githubusercontent.com/350947/37853558-2aa2f676-2edf-11e8-9bb9-bc6c8d58de3a.png)

![image](https://user-images.githubusercontent.com/350947/37854476-fd8ab54e-2ee2-11e8-8040-6979bb3bf1e0.png)

### After

![image](https://user-images.githubusercontent.com/350947/37855514-8a8b56a2-2ee7-11e8-9b37-019c57d34024.png)

![image](https://user-images.githubusercontent.com/350947/37855523-91331b66-2ee7-11e8-919a-cb02be62f840.png)

## What did I do to test the code and ensure quality:
 - Lots of manual testing and code review

### Has been tested on:
 - GIT 2.16
 - Windows 10
