### PR TITLE
Parsing improvements

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -324,39 +324,6 @@ namespace GitCommands
             return cherryPickCmd + " " + arguments + " \"" + cherry + "\"";
         }
 
-        /// <summary>
-        /// Check if a string represents a commit hash
-        /// </summary>
-        private static bool IsCommitHash(string value)
-        {
-            return GitRevision.Sha1HashRegex.IsMatch(value);
-        }
-
-        [ContractAnnotation("branch:null=>null")]
-        public static string GetFullBranchName(string branch)
-        {
-            if (branch == null)
-            {
-                return null;
-            }
-
-            branch = branch.Trim();
-
-            if (string.IsNullOrEmpty(branch) || branch.StartsWith("refs/"))
-            {
-                return branch;
-            }
-
-            // If the branch represents a commit hash, return it as-is without appending refs/heads/ (fix issue #2240)
-            // NOTE: We can use `String.IsNullOrEmpty(Module.RevParse(srcRev))` instead
-            if (IsCommitHash(branch))
-            {
-                return branch;
-            }
-
-            return "refs/heads/" + branch;
-        }
-
         public static string DeleteTagCmd(string tagName)
         {
             return "tag -d \"" + tagName + "\"";
@@ -1047,45 +1014,6 @@ namespace GitCommands
                 IsIgnored = x == '!',
                 IsConflict = x == 'U'
             };
-        }
-
-        [NotNull]
-        public static string GetRemoteName([NotNull] string refName)
-        {
-            var regex = new Regex("^refs/remotes/([^/]+)");
-
-            var match = regex.Match(refName);
-
-            if (match.Success)
-            {
-                return match.Groups[1].Value;
-            }
-
-            // This method requires the full form of the ref path, which begins with "refs/".
-            // The overload which accepts multiple remote names can be used when the format might
-            // be abbreviated to "remote/branch".
-            Debug.Assert(refName.StartsWith("refs/"), "Must begin with \"refs/\".");
-
-            return string.Empty;
-        }
-
-        [NotNull]
-        public static string GetRemoteName([NotNull] string refName, [NotNull, ItemNotNull] IEnumerable<string> remotes)
-        {
-            if (refName.StartsWith("refs/"))
-            {
-                return GetRemoteName(refName);
-            }
-
-            foreach (var remote in remotes)
-            {
-                if (refName.StartsWith(remote) && refName.Length > remote.Length && refName[remote.Length] == '/')
-                {
-                    return remote;
-                }
-            }
-
-            return string.Empty;
         }
 
         public static string MergeBranchCmd(string branch, bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories, string message, int? log)

--- a/GitCommands/Git/GitPushAction.cs
+++ b/GitCommands/Git/GitPushAction.cs
@@ -95,8 +95,8 @@ namespace GitCommands
         /// ref even when the update is not a fast-forward.</param>
         public GitPushAction(string source, string destination, bool force = false)
         {
-            _localBranch = GitCommandHelpers.GetFullBranchName(source);
-            _remoteBranch = GitCommandHelpers.GetFullBranchName(destination);
+            _localBranch = GitRefName.GetFullBranchName(source);
+            _remoteBranch = GitRefName.GetFullBranchName(destination);
             _force = force;
         }
 
@@ -104,7 +104,7 @@ namespace GitCommands
         /// <param name="branch">Remote branch to delete.</param>
         public static GitPushAction DeleteRemoteBranch(string branch)
         {
-            branch = GitCommandHelpers.GetFullBranchName(branch);
+            branch = GitRefName.GetFullBranchName(branch);
             return new GitPushAction(null, branch);
         }
 

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GitCommands.Config;
 using GitUIPluginInterfaces;
+using JetBrains.Annotations;
 
 namespace GitCommands
 {
@@ -10,21 +11,6 @@ namespace GitCommands
     {
         private readonly string _mergeSettingName;
         private readonly string _remoteSettingName;
-
-        /// <summary>"refs/tags/"</summary>
-        public static readonly string RefsTagsPrefix = "refs/tags/";
-
-        /// <summary>"refs/heads/"</summary>
-        public static readonly string RefsHeadsPrefix = "refs/heads/";
-
-        /// <summary>"refs/remotes/"</summary>
-        public static readonly string RefsRemotesPrefix = "refs/remotes/";
-
-        /// <summary>"refs/bisect/"</summary>
-        public static readonly string RefsBisectPrefix = "refs/bisect/";
-
-        /// <summary>"^{}"</summary>
-        public static readonly string TagDereferenceSuffix = "^{}";
 
         public IGitModule Module { get; }
 
@@ -40,11 +26,12 @@ namespace GitCommands
             Selected = false;
             CompleteName = completeName;
             Remote = remote;
-            IsTag = CompleteName.StartsWith(RefsTagsPrefix);
-            IsDereference = CompleteName.EndsWith(TagDereferenceSuffix);
-            IsHead = CompleteName.StartsWith(RefsHeadsPrefix);
-            IsRemote = CompleteName.StartsWith(RefsRemotesPrefix);
-            IsBisect = CompleteName.StartsWith(RefsBisectPrefix);
+
+            IsTag = CompleteName.StartsWith(GitRefName.RefsTagsPrefix);
+            IsDereference = CompleteName.EndsWith(GitRefName.TagDereferenceSuffix);
+            IsHead = CompleteName.StartsWith(GitRefName.RefsHeadsPrefix);
+            IsRemote = CompleteName.StartsWith(GitRefName.RefsRemotesPrefix);
+            IsBisect = CompleteName.StartsWith(GitRefName.RefsBisectPrefix);
 
             var name = ParseName();
             Name = name.IsNullOrWhiteSpace() ? CompleteName : name;
@@ -122,7 +109,7 @@ namespace GitCommands
                 }
                 else
                 {
-                    Module.SetSetting(_mergeSettingName, GitCommandHelpers.GetFullBranchName(value));
+                    Module.SetSetting(_mergeSettingName, GitRefName.GetFullBranchName(value));
                 }
             }
         }
@@ -135,7 +122,7 @@ namespace GitCommands
         public string GetMergeWith(ISettingsValueGetter configFile)
         {
             string merge = configFile.GetValue(_mergeSettingName);
-            return merge.StartsWith(RefsHeadsPrefix) ? merge.Substring(11) : merge;
+            return merge.StartsWith(GitRefName.RefsHeadsPrefix) ? merge.Substring(11) : merge;
         }
 
         public static GitRef NoHead(GitModule module)
@@ -167,8 +154,8 @@ namespace GitCommands
             {
                 // we need the one containing ^{}, because it contains the reference
                 var temp =
-                    CompleteName.Contains(TagDereferenceSuffix)
-                        ? CompleteName.Substring(0, CompleteName.Length - TagDereferenceSuffix.Length)
+                    CompleteName.Contains(GitRefName.TagDereferenceSuffix)
+                        ? CompleteName.Substring(0, CompleteName.Length - GitRefName.TagDereferenceSuffix.Length)
                         : CompleteName;
 
                 return temp.Substring(CompleteName.LastIndexOf("tags/") + 5);

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -52,11 +52,6 @@ namespace GitCommands
             _mergeSettingName = string.Format("branch.{0}.merge", Name);
         }
 
-        public static GitRef CreateBranchRef(GitModule module, string guid, string name)
-        {
-            return new GitRef(module, guid, RefsHeadsPrefix + name);
-        }
-
         public string CompleteName { get; }
         public bool Selected { get; set; }
         public bool SelectedHeadMergeSource { get; set; }

--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+
+namespace GitCommands
+{
+    public static class GitRefName
+    {
+        private static readonly Regex _remoteHeadRegex = new Regex("^refs/remotes/[^/]+/HEAD$", RegexOptions.Compiled);
+        private static readonly Regex _remoteNameRegex = new Regex("^refs/remotes/([^/]+)", RegexOptions.Compiled);
+
+        /// <summary>"refs/tags/"</summary>
+        public static string RefsTagsPrefix { get; } = "refs/tags/";
+
+        /// <summary>"refs/heads/"</summary>
+        public static string RefsHeadsPrefix { get; } = "refs/heads/";
+
+        /// <summary>"refs/remotes/"</summary>
+        public static string RefsRemotesPrefix { get; } = "refs/remotes/";
+
+        /// <summary>"refs/bisect/"</summary>
+        public static string RefsBisectPrefix { get; } = "refs/bisect/";
+
+        /// <summary>"^{}"</summary>
+        public static string TagDereferenceSuffix { get; } = "^{}";
+
+        [Pure, NotNull]
+        public static string GetRemoteName([NotNull] string refName)
+        {
+            var match = _remoteNameRegex.Match(refName);
+
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+
+            // This method requires the full form of the ref path, which begins with "refs/".
+            // The overload which accepts multiple remote names can be used when the format might
+            // be abbreviated to "remote/branch".
+            Debug.Assert(refName.StartsWith("refs/"), "Must begin with \"refs/\".");
+
+            return string.Empty;
+        }
+
+        [Pure, NotNull]
+        public static string GetRemoteName([NotNull] string refName, [NotNull, ItemNotNull] IEnumerable<string> remotes)
+        {
+            if (refName.StartsWith("refs/"))
+            {
+                return GetRemoteName(refName);
+            }
+
+            foreach (var remote in remotes)
+            {
+                if (refName.StartsWith(remote) && refName.Length > remote.Length && refName[remote.Length] == '/')
+                {
+                    return remote;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        [Pure, CanBeNull]
+        public static string GetFullBranchName([CanBeNull] string branch)
+        {
+            if (branch == null)
+            {
+                return null;
+            }
+
+            branch = branch.Trim();
+
+            if (string.IsNullOrEmpty(branch) || branch.StartsWith("refs/"))
+            {
+                return branch;
+            }
+
+            // If the branch represents a commit hash, return it as-is without appending refs/heads/ (fix issue #2240)
+            // NOTE: We can use `String.IsNullOrEmpty(Module.RevParse(srcRev))` instead
+            if (GitRevision.Sha1HashRegex.IsMatch(branch))
+            {
+                return branch;
+            }
+
+            return "refs/heads/" + branch;
+        }
+
+        [Pure]
+        public static bool IsRemoteHead([NotNull] string refName)
+        {
+            return _remoteHeadRegex.IsMatch(refName);
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Git\Extensions\GitRevisionExtensions.cs" />
     <Compile Include="Git\LongShaProvider.cs" />
     <Compile Include="Git\GitRevisionTester.cs" />
+    <Compile Include="Git\GitRefName.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDeleteRemoteBranchesCmd.cs" />

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -443,7 +443,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                _remoteName = GitCommandHelpers.GetRemoteName(branch, Module.GetRemotes(false));
+                _remoteName = GitRefName.GetRemoteName(branch, Module.GetRemotes(false));
                 _localBranchName = Module.GetLocalTrackingBranchName(_remoteName, branch);
                 var remoteBranchName = _remoteName.Length > 0 ? branch.Substring(_remoteName.Length + 1) : branch;
                 _newLocalBranchName = string.Concat(_remoteName, "_", remoteBranchName);

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2564,7 +2564,7 @@ namespace GitUI
             }
 
             // For now there is no action that could be done on currentBranch
-            string currentBranchRef = GitRef.RefsHeadsPrefix + Module.GetSelectedBranch();
+            string currentBranchRef = GitRefName.RefsHeadsPrefix + Module.GetSelectedBranch();
             var branchesWithNoIdenticalRemotes = gitRefListsForRevision.BranchesWithNoIdenticalRemotes;
 
             bool currentBranchPointsToRevision = false;

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -40,7 +40,7 @@ namespace Gerrit
         {
             remote = remote.ToPosixPath();
 
-            toBranch = GitCommandHelpers.GetFullBranchName(toBranch);
+            toBranch = GitRefName.GetFullBranchName(toBranch);
 
             const string fromBranch = "HEAD";
 

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -702,5 +702,18 @@ namespace GitCommandsTests.Git
                 "am --3way --signoff --ignore-whitespace",
                 GitCommandHelpers.ApplyMailboxPatchCmd(true));
         }
+
+        [Test]
+        public void GetRemoteName()
+        {
+            Assert.AreEqual("foo", GitCommandHelpers.GetRemoteName("refs/remotes/foo/master"));
+            Assert.AreEqual("", GitCommandHelpers.GetRemoteName("refs/tags/1.0.0"));
+
+            var remotes = new[] { "foo", "bar" };
+
+            Assert.AreEqual("foo", GitCommandHelpers.GetRemoteName("foo/master", remotes));
+            Assert.AreEqual("", GitCommandHelpers.GetRemoteName("food/master", remotes));
+            Assert.AreEqual("", GitCommandHelpers.GetRemoteName("refs/tags/1.0.0", remotes));
+        }
     }
 }

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -161,20 +161,6 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void GetFullBranchNameTest()
-        {
-            Assert.AreEqual(null, GitCommandHelpers.GetFullBranchName(null));
-            Assert.AreEqual("", GitCommandHelpers.GetFullBranchName(""));
-            Assert.AreEqual("", GitCommandHelpers.GetFullBranchName("    "));
-            Assert.AreEqual("4e0f0fe3f6add43557913c354de02560b8faec32", GitCommandHelpers.GetFullBranchName("4e0f0fe3f6add43557913c354de02560b8faec32"));
-            Assert.AreEqual("refs/heads/master", GitCommandHelpers.GetFullBranchName("master"));
-            Assert.AreEqual("refs/heads/master", GitCommandHelpers.GetFullBranchName(" master "));
-            Assert.AreEqual("refs/heads/master", GitCommandHelpers.GetFullBranchName("refs/heads/master"));
-            Assert.AreEqual("refs/heads/release/2.48", GitCommandHelpers.GetFullBranchName("refs/heads/release/2.48"));
-            Assert.AreEqual("refs/tags/my-tag", GitCommandHelpers.GetFullBranchName("refs/tags/my-tag"));
-        }
-
-        [Test]
         public void TestGetPlinkCompatibleUrl_Incompatible()
         {
             // Test urls that are incompatible and need to be changed
@@ -701,19 +687,6 @@ namespace GitCommandsTests.Git
             Assert.AreEqual(
                 "am --3way --signoff --ignore-whitespace",
                 GitCommandHelpers.ApplyMailboxPatchCmd(true));
-        }
-
-        [Test]
-        public void GetRemoteName()
-        {
-            Assert.AreEqual("foo", GitCommandHelpers.GetRemoteName("refs/remotes/foo/master"));
-            Assert.AreEqual("", GitCommandHelpers.GetRemoteName("refs/tags/1.0.0"));
-
-            var remotes = new[] { "foo", "bar" };
-
-            Assert.AreEqual("foo", GitCommandHelpers.GetRemoteName("foo/master", remotes));
-            Assert.AreEqual("", GitCommandHelpers.GetRemoteName("food/master", remotes));
-            Assert.AreEqual("", GitCommandHelpers.GetRemoteName("refs/tags/1.0.0", remotes));
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Git/GitRefNameTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitRefNameTests.cs
@@ -1,0 +1,71 @@
+﻿using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    public sealed class GitRefNameTests
+    {
+        [Test]
+        public void GetFullBranchNameTest()
+        {
+            Assert.AreEqual(null, GitRefName.GetFullBranchName(null));
+            Assert.AreEqual("", GitRefName.GetFullBranchName(""));
+            Assert.AreEqual("", GitRefName.GetFullBranchName("    "));
+            Assert.AreEqual("4e0f0fe3f6add43557913c354de02560b8faec32", GitRefName.GetFullBranchName("4e0f0fe3f6add43557913c354de02560b8faec32"));
+            Assert.AreEqual("refs/heads/master", GitRefName.GetFullBranchName("master"));
+            Assert.AreEqual("refs/heads/master", GitRefName.GetFullBranchName(" master "));
+            Assert.AreEqual("refs/heads/master", GitRefName.GetFullBranchName("refs/heads/master"));
+            Assert.AreEqual("refs/heads/release/2.48", GitRefName.GetFullBranchName("refs/heads/release/2.48"));
+            Assert.AreEqual("refs/tags/my-tag", GitRefName.GetFullBranchName("refs/tags/my-tag"));
+        }
+
+        [Test]
+        public void GetRemoteName()
+        {
+            Assert.AreEqual("foo", GitRefName.GetRemoteName("refs/remotes/foo/master"));
+            Assert.AreEqual("", GitRefName.GetRemoteName("refs/tags/1.0.0"));
+
+            var remotes = new[] { "foo", "bar" };
+
+            Assert.AreEqual("foo", GitRefName.GetRemoteName("foo/master", remotes));
+            Assert.AreEqual("", GitRefName.GetRemoteName("food/master", remotes));
+            Assert.AreEqual("", GitRefName.GetRemoteName("refs/tags/1.0.0", remotes));
+        }
+
+        [Test]
+        public void GetFullBranchName()
+        {
+            Assert.AreEqual("refs/heads/foo", GitRefName.GetFullBranchName("foo"));
+
+            Assert.AreEqual("refs/foo", GitRefName.GetFullBranchName("refs/foo"));
+
+            Assert.AreEqual(
+                "4e0f0fe3f6add43557913c354de02560b8faec32",
+                GitRefName.GetFullBranchName("4e0f0fe3f6add43557913c354de02560b8faec32"));
+
+            Assert.AreEqual("", GitRefName.GetFullBranchName(""));
+            Assert.AreEqual("", GitRefName.GetFullBranchName("    "));
+
+            Assert.IsNull(GitRefName.GetFullBranchName(null));
+        }
+
+        [Test]
+        public void IsRemoteHead()
+        {
+            Assert.IsTrue(GitRefName.IsRemoteHead("refs/remotes/origin/HEAD"));
+            Assert.IsTrue(GitRefName.IsRemoteHead("refs/remotes/upstream/HEAD"));
+
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/remotes/ori/gin/HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/remotes//HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/remotes/HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/origin/HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("ref/remotes/origin/HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("remotes/origin/HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("wat/refs/remotes/origin/HEAD"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/remotes/origin/HEADZ"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/remotes/origin/HEAD/wat"));
+            Assert.IsFalse(GitRefName.IsRemoteHead("refs/remotes/origin/HEAD  "));
+            Assert.IsFalse(GitRefName.IsRemoteHead("  refs/remotes/origin/HEAD"));
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
     <Compile Include="ArgumentBuilderTests.cs" />
+    <Compile Include="Git\GitRefNameTests.cs" />
     <Compile Include="RepoNameExtractorTest.cs" />
     <Compile Include="GitModuleTest.cs" />
     <Compile Include="GitRevisionInfoProviderTests.cs" />

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -190,5 +190,58 @@ namespace GitCommandsTests
                 "commit -Skey -F \"COMMITMESSAGE\"",
                 _gitModule.CommitCmd(amend: false, gpgSign: true, gpgKeyId: "key"));
         }
+
+        [Test]
+        public void GetTreeRefs()
+        {
+            Assert.IsEmpty(_gitModule.GetTreeRefs(""));
+            Assert.IsEmpty(_gitModule.GetTreeRefs("Foo"));
+
+            const string tree =
+                "69a7c7a40230346778e7eebed809773a6bc45268 refs/heads/master\n" +
+                "69a7c7a40230346778e7eebed809773a6bc45268 refs/remotes/origin/master\n" +
+                "5303e7114f1896c639dea0231fac522752cc44a2 refs/remotes/upstream/mono\n" +
+                "366dfba1abf6cb98d2934455713f3d190df2ba34 refs/tags/2.51\n";
+
+            var refs = _gitModule.GetTreeRefs(tree);
+
+            Assert.AreEqual(4, refs.Count);
+
+            Assert.AreEqual("69a7c7a40230346778e7eebed809773a6bc45268", refs[0].Guid);
+            Assert.AreEqual("refs/heads/master", refs[0].CompleteName);
+            Assert.AreEqual("master", refs[0].LocalName);
+            Assert.AreEqual("", refs[0].Remote);
+            Assert.IsTrue(refs[0].IsHead);
+            Assert.IsFalse(refs[0].IsRemote);
+            Assert.IsFalse(refs[0].IsTag);
+            Assert.AreSame(_gitModule, refs[0].Module);
+
+            Assert.AreEqual("69a7c7a40230346778e7eebed809773a6bc45268", refs[1].Guid);
+            Assert.AreEqual("refs/remotes/origin/master", refs[1].CompleteName);
+            Assert.AreEqual("master", refs[1].LocalName);
+            Assert.AreEqual("origin", refs[1].Remote);
+            Assert.IsFalse(refs[1].IsHead);
+            Assert.IsTrue(refs[1].IsRemote);
+            Assert.IsFalse(refs[1].IsTag);
+            Assert.AreSame(_gitModule, refs[1].Module);
+
+            Assert.AreEqual("5303e7114f1896c639dea0231fac522752cc44a2", refs[2].Guid);
+            Assert.AreEqual("refs/remotes/upstream/mono", refs[2].CompleteName);
+            Assert.AreEqual("mono", refs[2].LocalName);
+            Assert.AreEqual("upstream", refs[2].Remote);
+            Assert.IsFalse(refs[2].IsHead);
+            Assert.IsTrue(refs[2].IsRemote);
+            Assert.IsFalse(refs[2].IsTag);
+            Assert.AreSame(_gitModule, refs[2].Module);
+
+            Assert.AreEqual("366dfba1abf6cb98d2934455713f3d190df2ba34", refs[3].Guid);
+            Assert.AreEqual("refs/tags/2.51", refs[3].CompleteName);
+            Assert.AreEqual("2.51", refs[3].LocalName);
+            Assert.AreEqual("", refs[3].Remote);
+            Assert.IsFalse(refs[3].IsHead);
+            Assert.IsFalse(refs[3].IsRemote);
+            Assert.IsTrue(refs[3].IsTag);
+            Assert.AreSame(_gitModule, refs[3].Module);
+        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add faster overload of `GetRemoteName` (used O(N) from `GitModule.GetTreeRefs`) which avoids additional git process execution to obtain remote names (`git remote show`)
- Add tests for `GitModule.GetTreeRefs`
- Use regex in `GitModule.GetTreeRefs` and reduce allocations
- Make `GitRef.Name` immutable
- Create `RefName` class for all utilities relating to ref names (i.e. `refs/remotes/origin/master` etc), moving several existing methods/constants to it, and adding unit tests

What did I do to test the code and ensure quality:
 - Added unit tests to modified code
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
