### PR TITLE
Make GitStash immutable and use regex parsing

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2370,15 +2370,15 @@ namespace GitCommands
 
         public IReadOnlyList<GitStash> GetStashes()
         {
-            var list = RunGitCmd("stash list").Split('\n');
+            var lines = RunGitCmd("stash list").Split('\n');
 
-            var stashes = new List<GitStash>();
-            for (int i = 0; i < list.Length; i++)
+            var stashes = new List<GitStash>(lines.Length);
+
+            foreach (var line in lines)
             {
-                string stashString = list[i];
-                if (stashString.IndexOf(':') > 0 && !stashString.StartsWith("fatal: "))
+                if (GitStash.TryParse(line, out var stash))
                 {
-                    stashes.Add(new GitStash(stashString, i));
+                    stashes.Add(stash);
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -65,11 +65,7 @@ namespace GitUI.CommandsDialogs
         {
             var stashedItems = Module.GetStashes().ToList();
 
-            _currentWorkingDirStashItem = new GitStash("currentWorkingDirStashItem")
-            {
-                Name = _currentWorkingDirChanges.Text,
-                Message = _currentWorkingDirChanges.Text
-            };
+            _currentWorkingDirStashItem = new GitStash(-1, _currentWorkingDirChanges.Text);
 
             stashedItems.Insert(0, _currentWorkingDirStashItem);
 

--- a/UnitTests/GitCommandsTests/Git/GitStashTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitStashTests.cs
@@ -1,11 +1,10 @@
-﻿using FluentAssertions;
-using GitCommands.Git;
+﻿using GitCommands.Git;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Git
 {
     [TestFixture]
-    public class GitStashTests
+    public sealed class GitStashTests
     {
         [TestCase("stash@{0}: Very descriptive message", 0, "stash@{0}", "Very descriptive message")]
         [TestCase("stash@{1}: On 4263_View_Stash_AOORE: Testing things", 1, "stash@{1}", "On 4263_View_Stash_AOORE: Testing things")]
@@ -13,11 +12,25 @@ namespace GitCommandsTests.Git
         [TestCase("stash@{3}: WIP on master: Test", 3, "stash@{3}", "WIP on master: Test")]
         public void Can_parse_stash_names(string rawStash, int index, string name, string message)
         {
-            var stash = new GitStash(rawStash, index);
+            Assert.IsTrue(GitStash.TryParse(rawStash, out var stash));
 
-            stash.Index.Should().Be(index);
-            stash.Message.Should().Be(message);
-            stash.Name.Should().Be(name);
+            Assert.NotNull(stash);
+            Assert.AreEqual(index, stash.Index);
+            Assert.AreEqual(message, stash.Message);
+            Assert.AreEqual(name, stash.Name);
+        }
+
+        [TestCase("stash@{0}:Very descriptive message")]
+        [TestCase("stash@{-1}: Very descriptive message")]
+        [TestCase("stash{0}: Very descriptive message")]
+        [TestCase(" stash@{0}: Very descriptive message")]
+        [TestCase("stash@{0}: ")]
+        [TestCase("")]
+        [TestCase("  ")]
+        public void Identifies_invalid_stash_strings(string rawStash)
+        {
+            Assert.IsFalse(GitStash.TryParse(rawStash, out var stash));
+            Assert.Null(stash);
         }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - `GitStash` has fewer fields
 - Parsing is more robust, via regex
 - Add more test cases

What did I do to test the code and ensure quality:
 - Added tests
 - Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
