### PR TITLE
Fix avatar under high DPI

### DIFF
--- a/GitUI/DpiUtil.cs
+++ b/GitUI/DpiUtil.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace GitUI
+{
+    /// <summary>
+    /// Utility class related to DPI settings, primarily used for scaling dimensions on high-DPI displays.
+    /// </summary>
+    public static class DpiUtil
+    {
+        public static int DpiX { get; }
+        public static int DpiY { get; }
+
+        public static double ScaleX { get; }
+        public static double ScaleY { get; }
+
+        static DpiUtil()
+        {
+            var hdc = GetDC(IntPtr.Zero);
+
+            try
+            {
+                const int LOGPIXELSX = 88;
+                const int LOGPIXELSY = 90;
+
+                DpiX = GetDeviceCaps(hdc, LOGPIXELSX);
+                DpiY = GetDeviceCaps(hdc, LOGPIXELSY);
+
+                ScaleX = DpiX / 96.0;
+                ScaleY = DpiY / 96.0;
+            }
+            catch
+            {
+                DpiX = 96;
+                DpiY = 96;
+
+                ScaleX = 1.0;
+                ScaleY = 1.0;
+            }
+            finally
+            {
+                ReleaseDC(IntPtr.Zero, hdc);
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the current pixel density is not 96 DPI.
+        /// </summary>
+        public static bool IsNonStandard => DpiX != 96 || DpiY != 96;
+
+        /// <summary>
+        /// Returns a scaled copy of <paramref name="size"/> which takes equivalent
+        /// screen space at the current DPI as the original would at 96 DPI.
+        /// </summary>
+        public static Size Scale(Size size)
+        {
+            Scale(ref size);
+            return size;
+        }
+
+        /// <summary>
+        /// Modifies <paramref name="size"/> in place so that it takes equivalent screen
+        /// space at the current DPI as the original value would at 96 DPI.
+        /// </summary>
+        public static void Scale(ref Size size)
+        {
+            size.Width = (int)(size.Width * ScaleX);
+            size.Height = (int)(size.Height * ScaleY);
+        }
+
+        [DllImport("gdi32.dll")]
+        private static extern int GetDeviceCaps(IntPtr hdc, int index);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetDC(IntPtr hwnd);
+
+        [DllImport("user32.dll")]
+        private static extern int ReleaseDC(IntPtr hwnd, IntPtr deviceContextHandle);
+    }
+}

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -236,8 +236,7 @@ namespace GitUI
                 return;
             }
 
-            int deviceDpi = GetCurrentDeviceDpi();
-            float scale = 1.0f * deviceDpi / position.DeviceDpi;
+            float scale = (float)DpiUtil.DpiX / position.DeviceDpi;
 
             StartPosition = FormStartPosition.Manual;
             if (FormBorderStyle == FormBorderStyle.Sizable ||
@@ -303,20 +302,6 @@ namespace GitUI
             }
         }
 
-        public int GetCurrentDeviceDpi()
-        {
-#if TARGETING_DOTNET47
-            int deviceDpi = DeviceDpi;
-#else
-            int deviceDpi;
-            using (Graphics g = CreateGraphics())
-            {
-                deviceDpi = (int)g.DpiX;
-            }
-#endif
-            return deviceDpi;
-        }
-
         private static WindowPositionList _windowPositionList;
 
         /// <summary>
@@ -356,8 +341,7 @@ namespace GitUI
                     }
                 }
 
-                int deviceDpi = GetCurrentDeviceDpi();
-                var position = new WindowPosition(rectangle, deviceDpi, formWindowState, name);
+                var position = new WindowPosition(rectangle, DpiUtil.DpiX, formWindowState, name);
                 _windowPositionList.AddOrUpdate(position);
                 _windowPositionList.Save();
             }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -391,6 +391,7 @@
     <Compile Include="UserControls\ConsoleOutputControl.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="DpiUtil.cs" />
     <Compile Include="UserControls\EditboxBasedConsoleOutputControl.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GitUI/UserControls/GravatarControl.cs
+++ b/GitUI/UserControls/GravatarControl.cs
@@ -58,6 +58,9 @@ namespace GitUI
 
             // resize our control (I'm not using AutoSize for a reason)
             var size = new Size(AppSettings.AuthorImageSize, AppSettings.AuthorImageSize);
+
+            DpiUtil.Scale(ref size);
+
             Size = _gravatarImg.Size = size;
 
             if (!AppSettings.ShowAuthorGravatar || string.IsNullOrEmpty(Email))
@@ -66,7 +69,8 @@ namespace GitUI
                 return;
             }
 
-            var image = await _gravatarService.GetAvatarAsync(Email, AppSettings.AuthorImageSize, AppSettings.GravatarDefaultImageType);
+            var image = await _gravatarService.GetAvatarAsync(Email, Math.Max(size.Width, size.Height), AppSettings.GravatarDefaultImageType);
+
             RefreshImage(image);
         }
 

--- a/ResourceManager/GitExtensionsUserControl.cs
+++ b/ResourceManager/GitExtensionsUserControl.cs
@@ -18,20 +18,6 @@ namespace ResourceManager
             Load += GitExtensionsControl_Load;
         }
 
-        public int GetCurrentDeviceDpi()
-        {
-#if TARGETING_DOTNET47
-            int deviceDpi = DeviceDpi;
-#else
-            int deviceDpi;
-            using (Graphics g = CreateGraphics())
-            {
-                deviceDpi = (int)g.DpiX;
-            }
-#endif
-            return deviceDpi;
-        }
-
         [Browsable(false)] // because we always read from settings
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font


### PR DESCRIPTION
Relates to #4099.

### Changes proposed in this pull request:
 - Introduce `DpiUtil` for DPI related operations
 - Update `GraavatarControl` to scale such that it looks correct at high DPI (see screenshot)
 
### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/350947/37880305-f5270b0e-307d-11e8-8f1c-0df137695f1a.png)

#### After

![image](https://user-images.githubusercontent.com/350947/37880281-a5ad6dfc-307d-11e8-9962-3033638dfe32.png)

### What did I do to test the code and ensure quality:
 - Lots of testing
 - Code defensively, so any issue obtaining the DPI setting falls back to the old behaviour

### Has been tested on:
 - GIT 2.16
 - Windows 10
