### PR TITLE
Disable CLS compliance

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -26,3 +27,8 @@ using System.Reflection;
 
 // Disable CLS compliance. See https://github.com/gitextensions/gitextensions/issues/4710
 [assembly: CLSCompliant(isCompliant: false)]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -22,3 +23,6 @@
 [assembly: AssemblyVersion("2.51.00")]
 [assembly: AssemblyFileVersion("2.51.00")]
 [assembly: AssemblyInformationalVersion("2.51")]
+
+// Disable CLS compliance. See https://github.com/gitextensions/gitextensions/issues/4710
+[assembly: CLSCompliant(isCompliant: false)]

--- a/GitCommands/Properties/AssemblyInfo.cs
+++ b/GitCommands/Properties/AssemblyInfo.cs
@@ -5,6 +5,5 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GitCommandsTests")]

--- a/GitCommands/Properties/AssemblyInfo.cs
+++ b/GitCommands/Properties/AssemblyInfo.cs
@@ -1,9 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("GitCommandsTests")]

--- a/GitCommands/Properties/AssemblyInfo.cs
+++ b/GitCommands/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GitCommandsTests")]

--- a/GitExtUtils/Properties/AssemblyInfo.cs
+++ b/GitExtUtils/Properties/AssemblyInfo.cs
@@ -1,10 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 [assembly: InternalsVisibleTo("GitExtensions")]
 [assembly: InternalsVisibleTo("CommonTestUtils")]

--- a/GitExtUtils/Properties/AssemblyInfo.cs
+++ b/GitExtUtils/Properties/AssemblyInfo.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GitExtensions")]
 [assembly: InternalsVisibleTo("CommonTestUtils")]

--- a/GitExtUtils/Properties/AssemblyInfo.cs
+++ b/GitExtUtils/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GitExtensions")]
 [assembly: InternalsVisibleTo("CommonTestUtils")]

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -91,7 +91,6 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
@@ -187,13 +186,11 @@
       <PluginProjects Include="..\Plugins\*\*.csproj;..\Plugins\*\*\*.csproj" />
       <PluginDirectory Include="@(PluginProjects->'%(RelativeDir)')" />
     </ItemGroup>
-
     <PropertyGroup>
       <PluginBinariesExpression>@(PluginDirectory->'%(Identity)bin\$(Configuration)\*.dll')</PluginBinariesExpression>
       <PluginSymbolsExpression>@(PluginDirectory->'%(Identity)bin\$(Configuration)\*.pdb')</PluginSymbolsExpression>
       <PluginSatelliteBinariesExpression>@(PluginDirectory->'%(Identity)bin\$(Configuration)\*\*.dll')</PluginSatelliteBinariesExpression>
     </PropertyGroup>
-
     <ItemGroup>
       <PluginBinary Include="$(PluginBinariesExpression)" />
       <!-- Plugin symbols-->
@@ -201,7 +198,6 @@
       <!-- Plugin satellite assemblies -->
       <PluginSatelliteBinary Include="$(PluginSatelliteBinariesExpression)" />
     </ItemGroup>
-
     <ItemGroup>
       <None Include="@(PluginBinary)" Condition="'%(Filename)' != 'Microsoft.TeamFoundation.WorkItemTracking.Client.DataStoreLoader' AND '%(Filename)' != 'Microsoft.WITDataStore'">
         <Link>Plugins\%(Filename)%(Extension)</Link>

--- a/GitExtensions/Properties/AssemblyInfo.cs
+++ b/GitExtensions/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/GitExtensions/Properties/AssemblyInfo.cs
+++ b/GitExtensions/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/GitExtensions/Properties/AssemblyInfo.cs
+++ b/GitExtensions/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/GitExtensionsVSIX/Properties/AssemblyInfo.cs
+++ b/GitExtensionsVSIX/Properties/AssemblyInfo.cs
@@ -3,4 +3,3 @@
 [assembly: AssemblyDelaySign(false)]
 [assembly: AssemblyKeyFile("")]
 [assembly: AssemblyKeyName("")]
-[assembly: System.CLSCompliant(false)]

--- a/GitPlugin/Properties/AssemblyInfo.cs
+++ b/GitPlugin/Properties/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 
-[assembly: System.CLSCompliant(false)]
 [assembly: InternalsVisibleTo("GitExtensionsVSIX")]

--- a/GitPluginShared/Properties/AssemblyInfo.cs
+++ b/GitPluginShared/Properties/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 
-[assembly: System.CLSCompliant(false)]
 [assembly: InternalsVisibleTo("GitPluginShared")]

--- a/GitUI/Properties/AssemblyInfo.cs
+++ b/GitUI/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GitUITests")]

--- a/GitUI/Properties/AssemblyInfo.cs
+++ b/GitUI/Properties/AssemblyInfo.cs
@@ -5,6 +5,5 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GitUITests")]

--- a/GitUI/Properties/AssemblyInfo.cs
+++ b/GitUI/Properties/AssemblyInfo.cs
@@ -1,9 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("GitUITests")]

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -129,7 +129,6 @@ namespace GitUI.UserControls
         }
     }
 
-    [CLSCompliant(false)]
     public class ConsoleCommandLineOutputProcessor
     {
         private readonly Action<TextEventArgs> _fireDataReceived;

--- a/GitUI/UserControls/ExListView.cs
+++ b/GitUI/UserControls/ExListView.cs
@@ -6,7 +6,6 @@ using GitCommands.Utils;
 
 namespace GitUI.UserControls
 {
-    [CLSCompliant(false)]
     public enum ListViewGroupState : uint
     {
         /// <summary>

--- a/Gravatar/Gravatar.csproj
+++ b/Gravatar/Gravatar.csproj
@@ -83,7 +83,6 @@
     <Compile Include="DefaultImageType.cs" />
     <Compile Include="GravatarService.cs" />
     <Compile Include="MD5.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rating.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Gravatar/Properties/AssemblyInfo.cs
+++ b/Gravatar/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Gravatar/Properties/AssemblyInfo.cs
+++ b/Gravatar/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Gravatar/Properties/AssemblyInfo.cs
+++ b/Gravatar/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/NetSpell.SpellChecker/Properties/AssemblyInfo.cs
+++ b/NetSpell.SpellChecker/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("2.1.7.35462")]
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 [assembly: ComVisible(false)]
 
 namespace NetSpell.SpellChecker

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubmodules.csproj
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubmodules.csproj
@@ -75,7 +75,6 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AutoCompileSubModulesPlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">

--- a/Plugins/AutoCompileSubmodules/Properties/AssemblyInfo.cs
+++ b/Plugins/AutoCompileSubmodules/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/AutoCompileSubmodules/Properties/AssemblyInfo.cs
+++ b/Plugins/AutoCompileSubmodules/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/AutoCompileSubmodules/Properties/AssemblyInfo.cs
+++ b/Plugins/AutoCompileSubmodules/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/BackgroundFetch/BackgroundFetch.csproj
+++ b/Plugins/BackgroundFetch/BackgroundFetch.csproj
@@ -76,7 +76,6 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="BackgroundFetchPlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">

--- a/Plugins/BackgroundFetch/Properties/AssemblyInfo.cs
+++ b/Plugins/BackgroundFetch/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/BackgroundFetch/Properties/AssemblyInfo.cs
+++ b/Plugins/BackgroundFetch/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/BackgroundFetch/Properties/AssemblyInfo.cs
+++ b/Plugins/BackgroundFetch/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/Bitbucket/Bitbucket.csproj
+++ b/Plugins/Bitbucket/Bitbucket.csproj
@@ -79,7 +79,6 @@
     <Compile Include="GetRepoRequest.cs" />
     <Compile Include="GetUserRequest.cs" />
     <Compile Include="BitbucketPlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="BitbucketPullRequestForm.cs">
       <SubType>Form</SubType>

--- a/Plugins/Bitbucket/Properties/AssemblyInfo.cs
+++ b/Plugins/Bitbucket/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/Bitbucket/Properties/AssemblyInfo.cs
+++ b/Plugins/Bitbucket/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/Bitbucket/Properties/AssemblyInfo.cs
+++ b/Plugins/Bitbucket/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/CreateLocalBranches/CreateLocalBranches.csproj
+++ b/Plugins/CreateLocalBranches/CreateLocalBranches.csproj
@@ -64,7 +64,6 @@
       <DependentUpon>CreateLocalBranchesForm.cs</DependentUpon>
     </Compile>
     <Compile Include="CreateLocalBranchesPlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">

--- a/Plugins/CreateLocalBranches/Properties/AssemblyInfo.cs
+++ b/Plugins/CreateLocalBranches/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/CreateLocalBranches/Properties/AssemblyInfo.cs
+++ b/Plugins/CreateLocalBranches/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/CreateLocalBranches/Properties/AssemblyInfo.cs
+++ b/Plugins/CreateLocalBranches/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
@@ -70,7 +70,6 @@
     <Compile Include="DeleteUnusedBranchesForm.Designer.cs">
       <DependentUpon>DeleteUnusedBranchesForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Plugins/DeleteUnusedBranches/Properties/AssemblyInfo.cs
+++ b/Plugins/DeleteUnusedBranches/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/DeleteUnusedBranches/Properties/AssemblyInfo.cs
+++ b/Plugins/DeleteUnusedBranches/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/DeleteUnusedBranches/Properties/AssemblyInfo.cs
+++ b/Plugins/DeleteUnusedBranches/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/FindLargeFiles/FindLargeFiles.csproj
+++ b/Plugins/FindLargeFiles/FindLargeFiles.csproj
@@ -69,7 +69,6 @@
     <Compile Include="FindLargeFilesForm.Designer.cs">
       <DependentUpon>FindLargeFilesForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SortableObjectsList.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Plugins/FindLargeFiles/Properties/AssemblyInfo.cs
+++ b/Plugins/FindLargeFiles/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/FindLargeFiles/Properties/AssemblyInfo.cs
+++ b/Plugins/FindLargeFiles/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/FindLargeFiles/Properties/AssemblyInfo.cs
+++ b/Plugins/FindLargeFiles/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/Gerrit/Gerrit.csproj
+++ b/Plugins/Gerrit/Gerrit.csproj
@@ -101,7 +101,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Plugins/Gerrit/Properties/AssemblyInfo.cs
+++ b/Plugins/Gerrit/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/Gerrit/Properties/AssemblyInfo.cs
+++ b/Plugins/Gerrit/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/Gerrit/Properties/AssemblyInfo.cs
+++ b/Plugins/Gerrit/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/GitFlow/GitFlow.csproj
+++ b/Plugins/GitFlow/GitFlow.csproj
@@ -64,7 +64,6 @@
       <DependentUpon>GitFlowForm.cs</DependentUpon>
     </Compile>
     <Compile Include="GitFlowPlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resource.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Plugins/GitFlow/Properties/AssemblyInfo.cs
+++ b/Plugins/GitFlow/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/GitFlow/Properties/AssemblyInfo.cs
+++ b/Plugins/GitFlow/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/GitFlow/Properties/AssemblyInfo.cs
+++ b/Plugins/GitFlow/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -108,7 +108,6 @@
     <Compile Include="ISetting.cs" />
     <Compile Include="ISettingsSource.cs" />
     <Compile Include="ManagedExtensibility.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepositoryHosts\IRepositoryHostPlugin.cs" />
     <Compile Include="IGitPlugin.cs" />
     <Compile Include="IGitPluginSettingsContainer.cs" />

--- a/Plugins/GitUIPluginInterfaces/Properties/AssemblyInfo.cs
+++ b/Plugins/GitUIPluginInterfaces/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/GitUIPluginInterfaces/Properties/AssemblyInfo.cs
+++ b/Plugins/GitUIPluginInterfaces/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/GitUIPluginInterfaces/Properties/AssemblyInfo.cs
+++ b/Plugins/GitUIPluginInterfaces/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/Github3/Github3.csproj
+++ b/Plugins/Github3/Github3.csproj
@@ -69,7 +69,6 @@
     <Compile Include="OAuth.Designer.cs">
       <DependentUpon>OAuth.cs</DependentUpon>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Externals\Git.hub\Git.hub\Git.hub.csproj">

--- a/Plugins/Github3/Properties/AssemblyInfo.cs
+++ b/Plugins/Github3/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/Github3/Properties/AssemblyInfo.cs
+++ b/Plugins/Github3/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/Gource/Gource.csproj
+++ b/Plugins/Gource/Gource.csproj
@@ -86,7 +86,6 @@
     <Compile Include="GourceStart.Designer.cs">
       <DependentUpon>GourceStart.cs</DependentUpon>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">

--- a/Plugins/Gource/Properties/AssemblyInfo.cs
+++ b/Plugins/Gource/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/Gource/Properties/AssemblyInfo.cs
+++ b/Plugins/Gource/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/Gource/Properties/AssemblyInfo.cs
+++ b/Plugins/Gource/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/ProxySwitcher/Properties/AssemblyInfo.cs
+++ b/Plugins/ProxySwitcher/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/ProxySwitcher/Properties/AssemblyInfo.cs
+++ b/Plugins/ProxySwitcher/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/ProxySwitcher/Properties/AssemblyInfo.cs
+++ b/Plugins/ProxySwitcher/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/ProxySwitcher/ProxySwitcher.csproj
+++ b/Plugins/ProxySwitcher/ProxySwitcher.csproj
@@ -57,7 +57,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProxySwitcherForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Plugins/ReleaseNotesGenerator/Properties/AssemblyInfo.cs
+++ b/Plugins/ReleaseNotesGenerator/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("ReleaseNotesGeneratorTests")]

--- a/Plugins/ReleaseNotesGenerator/Properties/AssemblyInfo.cs
+++ b/Plugins/ReleaseNotesGenerator/Properties/AssemblyInfo.cs
@@ -5,6 +5,5 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("ReleaseNotesGeneratorTests")]

--- a/Plugins/ReleaseNotesGenerator/Properties/AssemblyInfo.cs
+++ b/Plugins/ReleaseNotesGenerator/Properties/AssemblyInfo.cs
@@ -1,9 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("ReleaseNotesGeneratorTests")]

--- a/Plugins/Statistics/GitImpact/GitImpact.csproj
+++ b/Plugins/Statistics/GitImpact/GitImpact.csproj
@@ -67,7 +67,6 @@
     <Compile Include="ImpactControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">

--- a/Plugins/Statistics/GitImpact/Properties/AssemblyInfo.cs
+++ b/Plugins/Statistics/GitImpact/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/Statistics/GitImpact/Properties/AssemblyInfo.cs
+++ b/Plugins/Statistics/GitImpact/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/Statistics/GitImpact/Properties/AssemblyInfo.cs
+++ b/Plugins/Statistics/GitImpact/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/Plugins/Statistics/GitStatistics/GitStatistics.csproj
+++ b/Plugins/Statistics/GitStatistics/GitStatistics.csproj
@@ -96,7 +96,6 @@
     <Compile Include="PieChart\Quadrilateral.cs" />
     <Compile Include="PieChart\SliceSelectedArgs.cs" />
     <Compile Include="PieChart\ShadowStyle.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">

--- a/Plugins/Statistics/GitStatistics/Properties/AssemblyInfo.cs
+++ b/Plugins/Statistics/GitStatistics/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/Plugins/Statistics/GitStatistics/Properties/AssemblyInfo.cs
+++ b/Plugins/Statistics/GitStatistics/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/Plugins/Statistics/GitStatistics/Properties/AssemblyInfo.cs
+++ b/Plugins/Statistics/GitStatistics/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/ResourceManager/Properties/AssemblyInfo.cs
+++ b/ResourceManager/Properties/AssemblyInfo.cs
@@ -5,5 +5,5 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]
 [assembly: InternalsVisibleTo("ResourceManagerTests")]

--- a/ResourceManager/Properties/AssemblyInfo.cs
+++ b/ResourceManager/Properties/AssemblyInfo.cs
@@ -1,8 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("ResourceManagerTests")]

--- a/ResourceManager/Properties/AssemblyInfo.cs
+++ b/ResourceManager/Properties/AssemblyInfo.cs
@@ -5,5 +5,4 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]
 [assembly: InternalsVisibleTo("ResourceManagerTests")]

--- a/TranslationApp/Properties/AssemblyInfo.cs
+++ b/TranslationApp/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]

--- a/TranslationApp/Properties/AssemblyInfo.cs
+++ b/TranslationApp/Properties/AssemblyInfo.cs
@@ -4,4 +4,3 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(false)]

--- a/TranslationApp/Properties/AssemblyInfo.cs
+++ b/TranslationApp/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: System.CLSCompliant(true)]
+[assembly: System.CLSCompliant(false)]

--- a/TranslationApp/TranslationApp.csproj
+++ b/TranslationApp/TranslationApp.csproj
@@ -104,7 +104,6 @@
       <DependentUpon>FormTranslate.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -186,13 +185,11 @@
       <PluginProjects Include="..\Plugins\*\*.csproj;..\Plugins\*\*\*.csproj" />
       <PluginDirectory Include="@(PluginProjects->'%(RelativeDir)')" />
     </ItemGroup>
-
     <PropertyGroup>
       <PluginBinariesExpression>@(PluginDirectory->'%(Identity)bin\$(Configuration)\*.dll')</PluginBinariesExpression>
       <PluginSymbolsExpression>@(PluginDirectory->'%(Identity)bin\$(Configuration)\*.pdb')</PluginSymbolsExpression>
       <PluginSatelliteBinariesExpression>@(PluginDirectory->'%(Identity)bin\$(Configuration)\*\*.dll')</PluginSatelliteBinariesExpression>
     </PropertyGroup>
-
     <ItemGroup>
       <PluginBinary Include="$(PluginBinariesExpression)" />
       <!-- Plugin symbols-->
@@ -200,7 +197,6 @@
       <!-- Plugin satellite assemblies -->
       <PluginSatelliteBinary Include="$(PluginSatelliteBinariesExpression)" />
     </ItemGroup>
-
     <ItemGroup>
       <None Include="@(PluginBinary)" Condition="'%(Filename)' != 'Microsoft.TeamFoundation.WorkItemTracking.Client.DataStoreLoader' AND '%(Filename)' != 'Microsoft.WITDataStore'">
         <Link>Plugins\%(Filename)%(Extension)</Link>


### PR DESCRIPTION
Following discussion in #4710, here's a PR that disables CLS compliance for all projects.

---

@sharwell pointed out that CLS checking is extra work for the compiler and slows the build. I wondered by how much, so ran some tests.

```base
$ time msbuild GitExtensions.sln /target:rebuild
```

### Before this PR

51.216s
51.640s
52.049s

### After this PR

47.102s
47.043s
47.101s

