### PR TITLE
fix: FormRemotes is messed up on HiDPI

### DIFF
--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -287,9 +287,9 @@ Inactive remote is completely invisible to git.");
             // this may be necessary if the translated labels require more space than English versions
             // the longest label is likely to be lebel3 (Private key file), so use it as a guide
             var widestLabelMinSize = new Size(label3.Width, 0);
-            label1.MinimumSize = widestLabelMinSize;        // Name
-            label2.MinimumSize = widestLabelMinSize;        // Url
-            labelPushUrl.MinimumSize = widestLabelMinSize;  // Push URL
+            label1.MinimumSize = label1.MaximumSize = widestLabelMinSize;        // Name
+            label2.MinimumSize = label2.MaximumSize = widestLabelMinSize;        // Url
+            labelPushUrl.MinimumSize = labelPushUrl.MaximumSize = widestLabelMinSize;  // Push URL
 
             if (Module == null)
             {


### PR DESCRIPTION
Relates to #4099

Screenshots before and after (if PR changes UI):
100% scaling
![image](https://user-images.githubusercontent.com/4403806/37896821-6bd3557a-3130-11e8-8835-cc9defd493ca.png)
150% scaling
![image](https://user-images.githubusercontent.com/4403806/37897478-fe3b9296-3131-11e8-96bc-fcf3ea52ff4b.png)

What did I do to test the code and ensure quality:
 - run it manually at various scaling

Has been tested on (remove any that don't apply):
 - Windows 10
 - 34" 4K monitor
