### PR TITLE
"Filter files..." label was visible when combobox lost Focus

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1194,7 +1194,6 @@ namespace GitUI
             if (_filterVisible)
             {
                 FilterComboBox.Visible = filesPresent;
-                FilterWatermarkLabel.Visible = filesPresent;
             }
         }
 


### PR DESCRIPTION
Fixes #4683
Regression from #4562

What did I do to test the code and ensure quality:
 - Type in the filter
 - focus outside the combo box
 - Verify that the label does not cover the text

Has been tested on (remove any that don't apply):
 - Windows 10
