### PR TITLE
Exclude FluentAssertions and SmartFormat assemblies from code coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ test_script:
         -register:user `
         -returntargetcode `
         -hideskipped:All `
-        -filter:"+[*]*" `
+        -filter:"+[*]* -[FluentAssertions*]* -[SmartFormat*]*" `
         -excludebyattribute:*.ExcludeFromCodeCoverage* `
         -excludebyfile:*\*Designer.cs `
         -output:"OpenCover.GitExtensions.xml" `


### PR DESCRIPTION
Excludes a few third-party libraries from code coverage that are producing noise during the CI build due to missing source files.

📝 If accepted, please do not rebase or squash this pull request during the merge.