### PR TITLE
Hide watermark label when clicked on it.

### DIFF
--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -102,6 +102,7 @@ namespace GitUI
             this.FilterWatermarkLabel.Size = new System.Drawing.Size(65, 13);
             this.FilterWatermarkLabel.TabIndex = 3;
             this.FilterWatermarkLabel.Text = "Filter files...";
+            this.FilterWatermarkLabel.Click += new System.EventHandler(this.FilterWatermarkLabel_Click);
             // 
             // FilterToolTip
             // 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1304,9 +1304,15 @@ namespace GitUI
             }
         }
 
+        private void FilterWatermarkLabel_Click(object sender, EventArgs e)
+        {
+            FilterComboBox.Focus();
+        }
+
         private Regex _filter;
 
         #endregion Filtering
+
     }
 
     public class GitItemStatusWithParent


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/issues/4683#issuecomment-375118791

Changes proposed in this pull request:
 - Hide watermark label when clicked on it.
 - Focus FilterComboBox.
 
What did I do to test the code and ensure quality:
 - Tested manually.

Has been tested on (remove any that don't apply):
 - Windows 10
