### PR TITLE
Remove the two-argument form of AsyncLoader.DoAsync<T>

### DIFF
--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -10,7 +10,7 @@ namespace GitCommands
     public sealed class AsyncLoader : IDisposable
     {
         /// <summary>
-        /// Invokes <paramref name="loadContent"/> on the thread pool, then executes <paramref name="continueWith"/> on the current synchronisation context.
+        /// Invokes <paramref name="loadContent"/> on the thread pool, then executes <paramref name="continueWith"/> on the main thread.
         /// </summary>
         /// <remarks>
         /// Note this method does not perform any cancellation of prior loads, nor does it support cancellation upon disposal.
@@ -18,14 +18,14 @@ namespace GitCommands
         /// </remarks>
         /// <typeparam name="T">Type of data returned by <paramref name="loadContent"/> and accepted by <paramref name="continueWith"/>.</typeparam>
         /// <param name="loadContent">A function to invoke on the thread pool that returns a value to be passed to <paramref name="continueWith"/>.</param>
-        /// <param name="continueWith">An action to invoke on the original synchronisation context with the return value from <paramref name="loadContent"/>.</param>
+        /// <param name="continueWith">An action to invoke on the main thread with the return value from <paramref name="loadContent"/>.</param>
         /// <param name="onError">
-        /// An optional callback for notification of exceptions from <paramref name="loadContent"/>.
+        /// A callback for notification of exceptions from <paramref name="loadContent"/>.
         /// Invoked on the original synchronisation context.
         /// Invoked once per exception, so may be called multiple times.
         /// Handlers must set <see cref="AsyncErrorEventArgs.Handled"/> to <c>true</c> to prevent any exceptions being re-thrown and faulting the async operation.
         /// </param>
-        public static async Task<T> DoAsync<T>(Func<T> loadContent, Action<T> continueWith, Action<AsyncErrorEventArgs> onError = null)
+        public static async Task<T> DoAsync<T>(Func<T> loadContent, Action<T> continueWith, Action<AsyncErrorEventArgs> onError)
         {
             using (var loader = new AsyncLoader())
             {

--- a/GitExtUtils/GitUI/ControlThreadingExtensions.cs
+++ b/GitExtUtils/GitUI/ControlThreadingExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Windows.Forms;
@@ -9,8 +10,7 @@ namespace GitUI
     public static class ControlThreadingExtensions
     {
         private static readonly CancellationToken _preCancelledToken;
-        private static readonly ConditionalWeakTable<Control, StrongBox<CancellationToken>> _controlDisposed;
-        private static readonly ConditionalWeakTable<Control, StrongBox<CancellationToken>>.CreateValueCallback _controlDisposedCancellationTokenFactory;
+        private static readonly ConditionalWeakTable<IComponent, StrongBox<CancellationToken>> _controlDisposed;
 
         static ControlThreadingExtensions()
         {
@@ -20,51 +20,19 @@ namespace GitUI
                 _preCancelledToken = cts.Token;
             }
 
-            _controlDisposed = new ConditionalWeakTable<Control, StrongBox<CancellationToken>>();
-            _controlDisposedCancellationTokenFactory = control =>
+            _controlDisposed = new ConditionalWeakTable<IComponent, StrongBox<CancellationToken>>();
+        }
+
+        public static ControlMainThreadAwaitable SwitchToMainThreadAsync(this ToolStripItem control)
+        {
+            if (control.IsDisposed)
             {
-                if (control.IsDisposed)
-                {
-                    return new StrongBox<CancellationToken>(_preCancelledToken);
-                }
-
-                var cts = new CancellationTokenSource();
-
-                // Get a copy of the CancellationToken before the source can be disposed. After the source is cancelled
-                // and disposed, the CancellationToken will continue to behave properly, but
-                // CancellationTokenSource.Token will start to throw an ObjectDisposedException.
-                var token = cts.Token;
-
-                control.Disposed += delegate
-                {
-                    CancelAndDispose(cts);
-                };
-
-                if (control.IsDisposed)
-                {
-                    // Handle control disposed on another thread while registering event handler
-                    CancelAndDispose(cts);
-                }
-
-                return new StrongBox<CancellationToken>(token);
-            };
-
-            return;
-
-            // Local functions
-            void CancelAndDispose(CancellationTokenSource cancellationTokenSource)
-            {
-                try
-                {
-                    cancellationTokenSource.Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                    // This can occur in race conditions
-                }
-
-                cancellationTokenSource.Dispose();
+                return new ControlMainThreadAwaitable(ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_preCancelledToken), _preCancelledToken);
             }
+
+            var disposedCancellationToken = ToolStripItemDisposedCancellationFactory.Instance.GetOrCreateCancellationToken(control);
+            var mainThreadAwaiter = ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(disposedCancellationToken);
+            return new ControlMainThreadAwaitable(mainThreadAwaiter, disposedCancellationToken);
         }
 
         public static ControlMainThreadAwaitable SwitchToMainThreadAsync(this Control control)
@@ -74,7 +42,7 @@ namespace GitUI
                 return new ControlMainThreadAwaitable(ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_preCancelledToken), _preCancelledToken);
             }
 
-            var disposedCancellationToken = _controlDisposed.GetValue(control, _controlDisposedCancellationTokenFactory).Value;
+            var disposedCancellationToken = ControlIsDisposedCancellationFactory.Instance.GetOrCreateCancellationToken(control);
             var mainThreadAwaiter = ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(disposedCancellationToken);
             return new ControlMainThreadAwaitable(mainThreadAwaiter, disposedCancellationToken);
         }
@@ -119,6 +87,78 @@ namespace GitUI
                 // ensures we always cancel the continuation if we somehow reach the UI thread after the control was
                 // disposed.
                 _cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        private sealed class ControlIsDisposedCancellationFactory : IsDisposedCancellationFactory<Control>
+        {
+            public static readonly ControlIsDisposedCancellationFactory Instance = new ControlIsDisposedCancellationFactory();
+
+            protected override bool IsDisposed(Control component) => component.IsDisposed;
+        }
+
+        private sealed class ToolStripItemDisposedCancellationFactory : IsDisposedCancellationFactory<ToolStripItem>
+        {
+            public static readonly ToolStripItemDisposedCancellationFactory Instance = new ToolStripItemDisposedCancellationFactory();
+
+            protected override bool IsDisposed(ToolStripItem component) => component.IsDisposed;
+        }
+
+        private abstract class IsDisposedCancellationFactory<T>
+            where T : class, IComponent
+        {
+            private readonly ConditionalWeakTable<IComponent, StrongBox<CancellationToken>>.CreateValueCallback _disposedCancellationTokenFactory;
+
+            protected IsDisposedCancellationFactory()
+            {
+                _disposedCancellationTokenFactory = control =>
+                {
+                    if (IsDisposed((T)control))
+                    {
+                        return new StrongBox<CancellationToken>(_preCancelledToken);
+                    }
+
+                    var cts = new CancellationTokenSource();
+
+                    // Get a copy of the CancellationToken before the source can be disposed. After the source is cancelled
+                    // and disposed, the CancellationToken will continue to behave properly, but
+                    // CancellationTokenSource.Token will start to throw an ObjectDisposedException.
+                    var token = cts.Token;
+
+                    control.Disposed += delegate
+                    {
+                        CancelAndDispose(cts);
+                    };
+
+                    if (IsDisposed((T)control))
+                    {
+                        // Handle control disposed on another thread while registering event handler
+                        CancelAndDispose(cts);
+                    }
+
+                    return new StrongBox<CancellationToken>(token);
+                };
+            }
+
+            public CancellationToken GetOrCreateCancellationToken(T component)
+            {
+                return _controlDisposed.GetValue(component, _disposedCancellationTokenFactory).Value;
+            }
+
+            protected abstract bool IsDisposed(T component);
+
+            private static void CancelAndDispose(CancellationTokenSource cancellationTokenSource)
+            {
+                try
+                {
+                    cancellationTokenSource.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // This can occur in race conditions
+                }
+
+                cancellationTokenSource.Dispose();
             }
         }
     }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -944,14 +944,21 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateStashCount()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (AppSettings.ShowStashCount)
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(() =>
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    return AsyncLoader.DoAsync(() => Module.GetStashes().Count,
-                        (result) => toolStripSplitStash.Text = string.Format(_stashCount.Text, result,
-                            result != 1 ? _stashPlural.Text : _stashSingular.Text));
-                });
+                    await TaskScheduler.Default;
+
+                    var result = Module.GetStashes().Count;
+
+                    await this.SwitchToMainThreadAsync();
+
+                    toolStripSplitStash.Text = string.Format(_stashCount.Text, result,
+                            result != 1 ? _stashPlural.Text : _stashSingular.Text);
+                }).FileAndForget();
             }
             else
             {
@@ -961,6 +968,8 @@ namespace GitUI.CommandsDialogs
 
         private void CheckForMergeConflicts()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             bool validWorkingDir = Module.IsValidGitWorkingDir();
 
             if (validWorkingDir && Module.InTheMiddleOfBisect())
@@ -1007,44 +1016,46 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(() =>
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                return AsyncLoader.DoAsync(
-                    () => validWorkingDir && Module.InTheMiddleOfConflictedMerge() &&
-                            !Directory.Exists(Module.WorkingDirGitDir + "rebase-apply\\"),
-                    (result) =>
-                    {
-                        if (result)
-                        {
-                            if (_warning == null)
-                            {
-                                _warning = new WarningToolStripItem { Text = _hintUnresolvedMergeConflicts.Text };
-                                _warning.Click += WarningClick;
-                                statusStrip.Items.Add(_warning);
-                            }
-                        }
-                        else
-                        {
-                            if (_warning != null)
-                            {
-                                _warning.Click -= WarningClick;
-                                statusStrip.Items.Remove(_warning);
-                                _warning = null;
-                            }
-                        }
+                await TaskScheduler.Default;
 
-                        // Only show status strip when there are status items on it.
-                        // There is always a close (x) button, do not count first item.
-                        if (statusStrip.Items.Count > 1)
-                        {
-                            statusStrip.Show();
-                        }
-                        else
-                        {
-                            statusStrip.Hide();
-                        }
-                    });
-            });
+                var result = validWorkingDir
+                    && Module.InTheMiddleOfConflictedMerge()
+                    && !Directory.Exists(Module.WorkingDirGitDir + "rebase-apply\\");
+
+                await this.SwitchToMainThreadAsync();
+
+                if (result)
+                {
+                    if (_warning == null)
+                    {
+                        _warning = new WarningToolStripItem { Text = _hintUnresolvedMergeConflicts.Text };
+                        _warning.Click += WarningClick;
+                        statusStrip.Items.Add(_warning);
+                    }
+                }
+                else
+                {
+                    if (_warning != null)
+                    {
+                        _warning.Click -= WarningClick;
+                        statusStrip.Items.Remove(_warning);
+                        _warning = null;
+                    }
+                }
+
+                // Only show status strip when there are status items on it.
+                // There is always a close (x) button, do not count first item.
+                if (statusStrip.Items.Count > 1)
+                {
+                    statusStrip.Show();
+                }
+                else
+                {
+                    statusStrip.Hide();
+                }
+            }).FileAndForget();
         }
 
         private void RebaseClick(object sender, EventArgs e)


### PR DESCRIPTION
The two-argument form of `DoAsync<T>` didn't seem to provide substantial advantages over JTF. This pull request converts the few uses to a more direct JTF approach and requires `DoAsync<T>` users pass the third argument.

📝 If accepted, please do not rebase or squash this pull request during the merge.