### PR TITLE
Update unit test packages

### DIFF
--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>CommonTestUtils</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,8 +45,8 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -86,5 +89,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
   </Target>
 </Project>

--- a/UnitTests/CommonTestUtils/packages.config
+++ b/UnitTests/CommonTestUtils/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
-  <package id="NUnit" version="3.9.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
@@ -50,7 +50,7 @@ namespace GitCommandsTests
             _module.WorkingDir.Returns(_workingDir);
             _module.GetEffectiveSetting("commit.template").Returns(template);
 
-            ((Action)(() => _manager.LoadGitCommitTemplate())).ShouldThrow<FileNotFoundException>();
+            ((Action)(() => _manager.LoadGitCommitTemplate())).Should().Throw<FileNotFoundException>();
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/ExternalLinks/ConfiguredLinkDefinitionsProviderTests.cs
+++ b/UnitTests/GitCommandsTests/ExternalLinks/ConfiguredLinkDefinitionsProviderTests.cs
@@ -58,7 +58,7 @@ namespace GitCommandsTests.ExternalLinks
         [Test]
         public void Get_should_throw_if_data_null()
         {
-            ((Action)(() => _provider.Get(null))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _provider.Get(null))).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/FullPathResolverTests.cs
+++ b/UnitTests/GitCommandsTests/FullPathResolverTests.cs
@@ -23,7 +23,7 @@ namespace GitCommandsTests
         [TestCase(" ")]
         public void Resolve_should_throw_if_path_null_or_empty(string path)
         {
-            ((Action)(() => _resolver.Resolve(path))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _resolver.Resolve(path))).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(@"c:\")]
@@ -35,7 +35,7 @@ namespace GitCommandsTests
         [TestCase("folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\folder\\filename.txt")]
         public void Resolve_should_throw_PathTooLongException(string path)
         {
-            ((Action)(() => _resolver.Resolve(path))).ShouldThrow<PathTooLongException>();
+            ((Action)(() => _resolver.Resolve(path))).Should().Throw<PathTooLongException>();
         }
 
         [TestCase(@"file")]

--- a/UnitTests/GitCommandsTests/Git/GitBranchNameOptionsTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitBranchNameOptionsTest.cs
@@ -22,7 +22,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void ReplacementToken_cant_be_multichar()
         {
-            ((Action)(() => new GitBranchNameOptions("aaa"))).ShouldThrow<ArgumentOutOfRangeException>()
+            ((Action)(() => new GitBranchNameOptions("aaa"))).Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage("Replacement token must be a single character\r\nParameter name: replacementToken");
         }
 
@@ -32,7 +32,7 @@ namespace GitCommandsTests.Git
         [TestCase(":", ':')]
         public void ReplacementToken_cant_be_invalid(string token, char expected)
         {
-            ((Action)(() => new GitBranchNameOptions(token))).ShouldThrow<ArgumentOutOfRangeException>()
+            ((Action)(() => new GitBranchNameOptions(token))).Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage(string.Format("Replacement token invalid: '{0}'\r\nParameter name: replacementToken", expected));
         }
     }

--- a/UnitTests/GitCommandsTests/Git/GitDirectoryResolverTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitDirectoryResolverTests.cs
@@ -41,7 +41,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void Resolve_should_throw_if_path_is_null()
         {
-            ((Action)(() => _resolver.Resolve(null))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _resolver.Resolve(null))).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase("")]

--- a/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
@@ -46,13 +46,13 @@ namespace GitCommandsTests.Git.Gpg
         [TestCase]
         public void Validate_GetRevisionCommitSignatureStatusAsync_null_revision()
         {
-            ((Func<Task>)(async () => await _gpgController.GetRevisionCommitSignatureStatusAsync(null))).ShouldThrow<ArgumentNullException>();
+            ((Func<Task>)(async () => await _gpgController.GetRevisionCommitSignatureStatusAsync(null))).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase]
         public void Validate_GetRevisionTagSignatureStatusAsync_null_revision()
         {
-            ((Func<Task>)(async () => await _gpgController.GetRevisionTagSignatureStatusAsync(null))).ShouldThrow<ArgumentNullException>();
+            ((Func<Task>)(async () => await _gpgController.GetRevisionTagSignatureStatusAsync(null))).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(TagStatus.NoTag, 0)]

--- a/UnitTests/GitCommandsTests/Git/LongShaProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Git/LongShaProviderTests.cs
@@ -37,7 +37,7 @@ namespace GitCommandsTests.Git
         {
             _module = null;
 
-            ((Action)(() => _provider.Get("xx"))).ShouldThrow<ArgumentException>();
+            ((Action)(() => _provider.Get("xx"))).Should().Throw<ArgumentException>();
         }
 
         [TestCase("0123", true)]

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,13 +40,11 @@
     <DocumentationFile>bin\Release\GitCommandsTests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=5.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.5.2.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
@@ -55,19 +54,25 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Abstractions, Version=2.0.0.144, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Abstractions.2.0.0.144\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
@@ -174,8 +179,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
 </Project>

--- a/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommandsTests/GitRevisionInfoProviderTests.cs
@@ -25,7 +25,7 @@ namespace GitCommandsTests
         [Test]
         public void LoadChildren_should_throw_if_null()
         {
-            ((Action)(() => _provider.LoadChildren(null))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _provider.LoadChildren(null))).Should().Throw<ArgumentNullException>();
         }
 
         [TestCase(null)]
@@ -36,7 +36,7 @@ namespace GitCommandsTests
             var item = Substitute.For<IGitItem>();
             item.Guid.Returns(guid);
 
-            ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
+            ((Action)(() => _provider.LoadChildren(item))).Should().Throw<ArgumentException>();
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace GitCommandsTests
 
             _provider = new GitRevisionInfoProvider(() => null);
 
-            ((Action)(() => _provider.LoadChildren(item))).ShouldThrow<ArgumentException>();
+            ((Action)(() => _provider.LoadChildren(item))).Should().Throw<ArgumentException>();
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -35,7 +35,7 @@ namespace GitCommandsTests.Remote
         {
             _module = null;
 
-            ((Action)(() => _controller.LoadRemotes(true))).ShouldNotThrow();
+            ((Action)(() => _controller.LoadRemotes(true))).Should().NotThrow();
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace GitCommandsTests.Remote
         [Test]
         public void RemoveRemote_should_throw_if_remote_is_null()
         {
-            ((Action)(() => _controller.RemoveRemote(null))).ShouldThrow<ArgumentNullException>()
+            ((Action)(() => _controller.RemoveRemote(null))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null.\r\nParameter name: remote");
         }
 
@@ -112,11 +112,11 @@ namespace GitCommandsTests.Remote
         [Test]
         public void SaveRemote_should_throw_if_remoteName_is_null_or_empty()
         {
-            ((Action)(() => _controller.SaveRemote(null, null, "b", "c", "d"))).ShouldThrow<ArgumentNullException>()
+            ((Action)(() => _controller.SaveRemote(null, null, "b", "c", "d"))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null.\r\nParameter name: remoteName");
-            ((Action)(() => _controller.SaveRemote(null, "", "b", "c", "d"))).ShouldThrow<ArgumentNullException>()
+            ((Action)(() => _controller.SaveRemote(null, "", "b", "c", "d"))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null.\r\nParameter name: remoteName");
-            ((Action)(() => _controller.SaveRemote(null, "  ", "b", "c", "d"))).ShouldThrow<ArgumentNullException>()
+            ((Action)(() => _controller.SaveRemote(null, "  ", "b", "c", "d"))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null.\r\nParameter name: remoteName");
         }
 
@@ -217,7 +217,7 @@ namespace GitCommandsTests.Remote
         [Test]
         public void SetRemoteState_should_throw_if_remote_is_null()
         {
-            ((Action)(() => _controller.ToggleRemoteState(null, false))).ShouldThrow<ArgumentNullException>()
+            ((Action)(() => _controller.ToggleRemoteState(null, false))).Should().Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null.\r\nParameter name: remoteName");
         }
 

--- a/UnitTests/GitCommandsTests/packages.config
+++ b/UnitTests/GitCommandsTests/packages.config
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.2.0" targetFramework="net461" />
+  <package id="FluentAssertions" version="5.2.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
-  <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
-  <package id="NUnit" version="3.9.0" targetFramework="net461" />
-  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
   <package id="System.IO.Abstractions" version="2.0.0.144" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
+++ b/UnitTests/GitUITests/FindFilePredicateProviderTest.cs
@@ -23,7 +23,7 @@ namespace GitUITests
         public void Get_should_throw_if_pattern_is_null(string pattern)
         {
             Action predicate = () => { _provider.Get(pattern, workingDirDefault); };
-            predicate.ShouldThrow<ArgumentNullException>();
+            predicate.Should().Throw<ArgumentNullException>();
         }
 
         [TestCase("")]
@@ -31,14 +31,14 @@ namespace GitUITests
         public void Get_should_not_throw_if_pattern_is_empty(string pattern)
         {
             Action predicate = () => { _provider.Get(pattern, workingDirDefault); };
-            predicate.ShouldNotThrow<ArgumentNullException>();
+            predicate.Should().NotThrow<ArgumentNullException>();
         }
 
         [TestCase(null)]
         public void Get_should_throw_if_workingDir_is_null(string workingDir)
         {
             Action predicate = () => { _provider.Get(patternDefault, workingDir); };
-            predicate.ShouldThrow<ArgumentNullException>();
+            predicate.Should().Throw<ArgumentNullException>();
         }
 
         [TestCase("")]
@@ -46,7 +46,7 @@ namespace GitUITests
         public void Get_should_throw_if_workingDir_is_empty(string workingDir)
         {
             Action predicate = () => { _provider.Get(patternDefault, workingDir); };
-            predicate.ShouldNotThrow<ArgumentNullException>();
+            predicate.Should().NotThrow<ArgumentNullException>();
         }
 
         [TestCase(@"test2/t", "test1/test2/test3")]
@@ -61,7 +61,7 @@ namespace GitUITests
         public void Get_should_not_throw_then_workingDir_lenght_greater_that_pattern_length(string pattern, string workingDir)
         {
             Action predicate = () => { _provider.Get(pattern, workingDir); };
-            predicate.ShouldNotThrow<ArgumentNullException>();
+            predicate.Should().NotThrow<ArgumentNullException>();
         }
 
         [TestCase(@"D:\test1", @"D:/", "test1/test2/test3/")]
@@ -110,7 +110,7 @@ namespace GitUITests
             var predicate = _provider.Get(patternDefault, workingDirDefault);
 
             Action executor = () => { predicate(filePath); };
-            executor.ShouldNotThrow<ArgumentNullException>();
+            executor.Should().NotThrow<ArgumentNullException>();
         }
     }
 }

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,13 +40,11 @@
     <DocumentationFile>bin\Release\GitUITests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=5.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.5.2.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.TextEditor">
       <HintPath>..\..\Bin\ICSharpCode.TextEditor.dll</HintPath>
@@ -58,18 +57,24 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Abstractions, Version=2.0.0.144, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Abstractions.2.0.0.144\lib\net40\System.IO.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
@@ -158,8 +163,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
 </Project>

--- a/UnitTests/GitUITests/packages.config
+++ b/UnitTests/GitUITests/packages.config
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.2.0" targetFramework="net461" />
+  <package id="FluentAssertions" version="5.2.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
-  <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
-  <package id="NUnit" version="3.9.0" targetFramework="net461" />
-  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
   <package id="System.IO.Abstractions" version="2.0.0.144" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/UnitTests/GravatarTests/DirectoryImageCacheTests.cs
+++ b/UnitTests/GravatarTests/DirectoryImageCacheTests.cs
@@ -170,7 +170,7 @@ namespace GravatarTests
             {
                 await _cache.ClearAsync();
             };
-            act.ShouldNotThrow();
+            act.Should().NotThrow();
         }
 
         [TestCase(null)]
@@ -227,7 +227,7 @@ namespace GravatarTests
             {
                 await _cache.DeleteImageAsync(FileName);
             };
-            act.ShouldNotThrow();
+            act.Should().NotThrow();
         }
 
         [Test]
@@ -272,7 +272,7 @@ namespace GravatarTests
             {
                 await _cache.GetImageAsync(FileName, null);
             };
-            act.ShouldNotThrow();
+            act.Should().NotThrow();
         }
     }
 }

--- a/UnitTests/GravatarTests/GravatarTests.csproj
+++ b/UnitTests/GravatarTests/GravatarTests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,13 +40,11 @@
     <DocumentationFile>bin\Release\GravatarTests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=5.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.5.2.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
@@ -55,14 +54,14 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Abstractions, Version=2.0.0.144, Culture=neutral, processorArchitecture=MSIL">
@@ -72,6 +71,12 @@
     <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
@@ -135,8 +140,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
 </Project>

--- a/UnitTests/GravatarTests/packages.config
+++ b/UnitTests/GravatarTests/packages.config
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.2.0" targetFramework="net461" />
+  <package id="FluentAssertions" version="5.2.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
-  <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
-  <package id="NUnit" version="3.9.0" targetFramework="net461" />
-  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
   <package id="System.IO.Abstractions" version="2.0.0.144" targetFramework="net461" />
   <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -55,8 +56,8 @@
       <HintPath>..\..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -93,8 +94,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
 </Project>

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
@@ -40,9 +40,8 @@
     <DocumentationFile>bin\Release\ReleaseNotesGeneratorTests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=5.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\FluentAssertions.5.2.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
@@ -61,6 +60,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/packages.config
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="5.2.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="NUnit" version="3.10.1" targetFramework="net461" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/packages.config
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
-  <package id="NUnit" version="3.9.0" targetFramework="net461" />
-  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -34,7 +34,7 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_should_throw_if_data_null()
         {
-            ((Action)(() => _renderer.Render(null, true))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _renderer.Render(null, true))).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -80,7 +80,7 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_should_throw_if_data_null()
         {
-            ((Action)(() => _renderer.Render(null, true))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _renderer.Render(null, true))).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
@@ -255,7 +255,7 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void RenderPlain_should_throw_if_data_null()
         {
-            ((Action)(() => _renderer.RenderPlain(null))).ShouldThrow<ArgumentNullException>();
+            ((Action)(() => _renderer.RenderPlain(null))).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
+++ b/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,13 +40,11 @@
     <DocumentationFile>bin\Release\ResourceManagerTests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.19.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=5.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.5.2.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
@@ -55,16 +54,22 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -110,8 +115,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
 </Project>

--- a/UnitTests/ResourceManagerTests/packages.config
+++ b/UnitTests/ResourceManagerTests/packages.config
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.2.0" targetFramework="net461" />
+  <package id="FluentAssertions" version="5.2.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
-  <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
-  <package id="NUnit" version="3.9.0" targetFramework="net461" />
-  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta006" targetFramework="net461" developmentDependency="true" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Relates to #4426.

This PR updates NuGet packages used in unit test projects only.

- NUnit 3.9.0 -> 3.10.1
- FluentAssertions 4.19.3 -> 5.2.0
- NSubstitute 2.0.3 -> 3.1.0

`ShouldThrow` and `ShouldNotThrow` were removed. They are replaced by `Should().Throw` and `Should().NotThrow` respectively.

What did I do to test the code and ensure quality:
 - Verified tests still passed

