### PR TITLE
Start with dashboard also if started from valid Git repo

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -16,6 +16,10 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Default debugging command starts GitExtensions browsing this repository -->
+    <StartArguments>browse "$(MSBuildThisFileDirectory).."</StartArguments>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -167,15 +167,6 @@ namespace GitExtensions
                 }
             }
 
-            if (string.IsNullOrEmpty(workingDir))
-            {
-                string findWorkingDir = GitModule.FindGitWorkingDir(Directory.GetCurrentDirectory());
-                if (GitModule.IsValidGitWorkingDir(findWorkingDir))
-                {
-                    workingDir = findWorkingDir;
-                }
-            }
-
             return workingDir;
         }
 


### PR DESCRIPTION
Resolves #4739

Changes proposed in this pull request:
 - Show dashboard also when starting with debugger
(see issue for a longer explanation)

What did I do to test the code and ensure quality:
 - Start with/without setting 
 - Test vsix plugin
 - Test shell extension - browse

Has been tested on (remove any that don't apply):
 - Windows 10
