### PR TITLE
FormCommitCount doesn't block UI thread

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.Designer.cs
@@ -81,7 +81,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.cbIncludeSubmodules.TabIndex = 0;
             this.cbIncludeSubmodules.Text = "Include submodules";
             this.cbIncludeSubmodules.UseVisualStyleBackColor = true;
-            this.cbIncludeSubmodules.CheckedChanged += new System.EventHandler(this.cbIncludeSubmodules_CheckedChanged);
             // 
             // panel2
             // 
@@ -103,7 +102,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.Name = "FormCommitCount";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Commit count";
-            this.Load += new System.EventHandler(this.FormCommitCountLoad);
             ((System.ComponentModel.ISupportInitialize)(this.Loading)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();

--- a/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.cs
@@ -21,16 +21,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             InitializeComponent();
             Loading.Image = Properties.Resources.loadingpanel;
             Translate();
-        }
 
-        private void FormCommitCountLoad(object sender, EventArgs e)
-        {
-            FetchData();
-        }
-
-        private void cbIncludeSubmodules_CheckedChanged(object sender, EventArgs e)
-        {
-            FetchData();
+            Load += delegate { FetchData(); };
+            cbIncludeSubmodules.CheckedChanged += delegate { FetchData(); };
         }
 
         private void FetchData()

--- a/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormCommitCount.cs
@@ -31,6 +31,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             ThreadHelper.ThrowIfNotOnUIThread();
 
             _backgroundLoaderTokenSource.Cancel();
+            _backgroundLoaderTokenSource.Dispose();
             _backgroundLoaderTokenSource = new CancellationTokenSource();
             var token = _backgroundLoaderTokenSource.Token;
 


### PR DESCRIPTION
Wanted to make a simple conversion using the new VS Threading stuff. It's nothing too exciting, but was satisfying to see how straightforward such a change was.

I actually did this a while back and it was the precursor to the ideas in #4735. 

Changes proposed in this pull request:
 - Query statistics and compose text on a background thread
 - Optimise string composition (many fewer allocations)
 
What did I do to test the code and ensure quality:
 - Lots of manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
