### PR TITLE
Cease checking if git-log output contains commitId - fixes #4745

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -187,7 +187,7 @@ namespace GitCommands
             // Do not cache this command, since notes can be added
             data = GetModule().RunGitCmd(arguments, GitModule.LosslessEncoding);
 
-            if (GitModule.IsGitErrorMessage(data) || !data.Contains(commitId))
+            if (GitModule.IsGitErrorMessage(data))
             {
                 error = "Cannot find commit " + commitId;
                 return false;


### PR DESCRIPTION
commitId may be a branch or tag name but the output from git-log will contain only the commit's sha1, thus it cannot verify that it found the commit simply by checking for the commitId.

Fixes #4745.

Changes proposed in this pull request:
 - When finding a commit using CommitDataManager.TryGetCommit, cease checking if git-log output contains commitId

The code in v2.51.01 attempted to make the same check but was failing, thus letting it use the output from ``git log`` even though the original commitId was not found in the output. 
By removing the check from the post-2.51 code, I have restored the original functionality with no loss in protection from invalid data returned from ``git log``.
 
What did I do to test the code and ensure quality:
 - Tested manually clicking on branch and tag links and ensuring they now changed to the correct revision in the revision grid.

Has been tested on (remove any that don't apply):
 - GIT 2.16.2.windows.1
 - Windows 10
 - GitExtensions master