### PR TITLE
Enhanced logging: Save log to file, log start of CommandsChanged

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -84,6 +84,14 @@ namespace GitCommands
 
             var executionStartTimestamp = DateTime.Now;
 
+            string quotedCmd = fileName;
+            if (quotedCmd.IndexOf(' ') != -1)
+            {
+                quotedCmd = quotedCmd.Quote();
+            }
+
+            var startCmd = AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
+
             var startInfo = CreateProcessStartInfo(fileName, arguments, workingDirectory, outputEncoding);
             var startProcess = Process.Start(startInfo);
             startProcess.EnableRaisingEvents = true;
@@ -92,14 +100,8 @@ namespace GitCommands
             {
                 startProcess.Exited -= ProcessExited;
 
-                string quotedCmd = fileName;
-                if (quotedCmd.IndexOf(' ') != -1)
-                {
-                    quotedCmd = quotedCmd.Quote();
-                }
-
                 var executionEndTimestamp = DateTime.Now;
-                AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp);
+                AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
             }
 
             startProcess.Exited += ProcessExited;

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -82,15 +82,7 @@ namespace GitCommands
         {
             EnvironmentConfiguration.SetEnvironmentVariables();
 
-            var executionStartTimestamp = DateTime.Now;
-
-            string quotedCmd = fileName;
-            if (quotedCmd.IndexOf(' ') != -1)
-            {
-                quotedCmd = quotedCmd.Quote();
-            }
-
-            var startCmd = AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
+            var startCmd = AppSettings.GitLog.Log(fileName, arguments);
 
             var startInfo = CreateProcessStartInfo(fileName, arguments, workingDirectory, outputEncoding);
             var startProcess = Process.Start(startInfo);
@@ -99,9 +91,7 @@ namespace GitCommands
             void ProcessExited(object sender, EventArgs args)
             {
                 startProcess.Exited -= ProcessExited;
-
-                var executionEndTimestamp = DateTime.Now;
-                AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
+                startCmd.LogEnd();
             }
 
             startProcess.Exited += ProcessExited;

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -531,12 +531,13 @@ namespace GitCommands
                 startInfo.CreateNoWindow = true;
             }
 
+            var startCmd = AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
             var startProcess = Process.Start(startInfo);
 
             startProcess.Exited += (sender, args) =>
             {
                 var executionEndTimestamp = DateTime.Now;
-                AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp);
+                AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
             };
 
             return startProcess;
@@ -3152,7 +3153,7 @@ namespace GitCommands
             {
                 // Catch all parser errors, and ignore them all!
                 // We should never get here...
-                AppSettings.GitLog.Log("Error parsing output from command: " + args + "\n\nPlease report a bug!", DateTime.Now, DateTime.Now);
+                AppSettings.GitLog.Log("Error parsing output from command: " + args + "\n\nPlease report a bug!", DateTime.Now, DateTime.Now, isStart: true);
 
                 return new GitBlame(Array.Empty<GitBlameLine>());
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -511,14 +511,6 @@ namespace GitCommands
         {
             EnvironmentConfiguration.SetEnvironmentVariables();
 
-            string quotedCmd = fileName;
-            if (quotedCmd.IndexOf(' ') != -1)
-            {
-                quotedCmd = quotedCmd.Quote();
-            }
-
-            var executionStartTimestamp = DateTime.Now;
-
             var startInfo = new ProcessStartInfo
             {
                 FileName = fileName,
@@ -531,13 +523,12 @@ namespace GitCommands
                 startInfo.CreateNoWindow = true;
             }
 
-            var startCmd = AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
+            var startCmd = AppSettings.GitLog.Log(fileName, arguments);
             var startProcess = Process.Start(startInfo);
 
             startProcess.Exited += (sender, args) =>
             {
-                var executionEndTimestamp = DateTime.Now;
-                AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
+                startCmd.LogEnd();
             };
 
             return startProcess;
@@ -3153,7 +3144,7 @@ namespace GitCommands
             {
                 // Catch all parser errors, and ignore them all!
                 // We should never get here...
-                AppSettings.GitLog.Log("Error parsing output from command: " + args + "\n\nPlease report a bug!", DateTime.Now, DateTime.Now, isStart: true);
+                AppSettings.GitLog.Log("Error parsing output from command: " + args + "\n\nPlease report a bug!");
 
                 return new GitBlame(Array.Empty<GitBlameLine>());
             }

--- a/GitCommands/Logging/CommandLogEntry.cs
+++ b/GitCommands/Logging/CommandLogEntry.cs
@@ -7,19 +7,16 @@ namespace GitCommands.Logging
         private string Command { get; }
         private DateTime Timestamp { get; }
         public TimeSpan? Duration { get; set;  }
-        private int CmdId { get; }
 
         /// <summary>
         /// Create a new log entry
         /// </summary>
         /// <param name="command">The (Git) command to log</param>
-        /// <param name="counter">The log entry for the start command, to be able to identify start/end pairs</param>
         /// <param name="timestamp">The time for the log</param>
-        public CommandLogEntry(string command, int counter, DateTime timestamp)
+        public CommandLogEntry(string command, DateTime timestamp)
         {
             Command = command;
             Timestamp = timestamp;
-            CmdId = counter;
 
             Duration = null;
         }
@@ -27,10 +24,10 @@ namespace GitCommands.Logging
         public override string ToString()
         {
             string duration = Duration == null ?
-                "(start)" :
+                "started" :
                 string.Format("{0:0}ms", ((TimeSpan)Duration).TotalMilliseconds);
 
-            return $"{Timestamp:O} {duration:0,7} #{CmdId} {Command}";
+            return $"{Timestamp:HH:mm:ss.fffffff} {duration,7} {Command}";
         }
     }
 }

--- a/GitCommands/Logging/CommandLogEntry.cs
+++ b/GitCommands/Logging/CommandLogEntry.cs
@@ -2,23 +2,62 @@ using System;
 
 namespace GitCommands.Logging
 {
-  public class CommandLogEntry
-  {
-    public string Command { get; }
-    public DateTime ExecutionStartTimestamp { get; }
-    public DateTime ExecutionEndTimestamp { get; }
-
-    public CommandLogEntry(string command, DateTime executionStartTimestamp, DateTime executionEndTimestamp)
+    public class CommandLogEntry
     {
-      Command = command;
-      ExecutionStartTimestamp = executionStartTimestamp;
-      ExecutionEndTimestamp = executionEndTimestamp;
-    }
+        private string Command { get; }
+        private DateTime ExecutionStartTimestamp { get; }
+        private DateTime ExecutionEndTimestamp { get; }
+        private bool IsStart { get; }
+        private uint CmdId { get; }
+        private bool _enhanced;
 
-    public override string ToString()
-    {
-      var durationInMillis = (long)ExecutionEndTimestamp.Subtract(ExecutionStartTimestamp).TotalMilliseconds;
-      return string.Format("{0}    {1}    #(took {2} ms)", ExecutionStartTimestamp.ToString("O"), Command, durationInMillis);
+        private static uint counter = 0;
+
+        /// <summary>
+        /// Create a new log entry
+        /// </summary>
+        /// <param name="command">The (Git) command to log</param>
+        /// <param name="executionStartTimestamp">The start time for the command</param>
+        /// <param name="executionEndTimestamp">The end time for the command, ignored if this is start of a command</param>
+        /// <param name="startCmd">The log entry for the start command, to be able to identify start/end pairs</param>
+        /// <param name="isStart">Set if this is start of a command</param>
+        public CommandLogEntry(string command, DateTime executionStartTimestamp, DateTime executionEndTimestamp, CommandLogEntry startCmd = null, bool isStart = false)
+        {
+            Command = command;
+            ExecutionStartTimestamp = executionStartTimestamp;
+            ExecutionEndTimestamp = executionEndTimestamp;
+            IsStart = isStart;
+
+            // Start of commands will only be logged if enhanced logging is set,
+            // so cmdNo (with reference to start) will only be not null for ends with enhanced logging
+            _enhanced = isStart || startCmd != null;
+
+            if (isStart)
+            {
+                counter++;
+            }
+
+            // If there is no previous log entry, use the counter
+            CmdId = startCmd == null ?
+                counter :
+                startCmd.CmdId;
+        }
+
+        public override string ToString()
+        {
+            string cmd = !_enhanced ? "" : "#" + CmdId.ToString() + " ";
+            string end;
+            if (IsStart)
+            {
+                end = "#(start)";
+            }
+            else
+            {
+                var durationInMillis = (long)ExecutionEndTimestamp.Subtract(ExecutionStartTimestamp).TotalMilliseconds;
+                end = string.Format("#(took {0} ms)", durationInMillis);
+            }
+
+            return string.Format("{0}    {1}{2}    {3}", ExecutionStartTimestamp.ToString("O"), cmd, Command, end);
+        }
     }
-  }
 }

--- a/GitCommands/Logging/CommandLogEntry.cs
+++ b/GitCommands/Logging/CommandLogEntry.cs
@@ -5,59 +5,32 @@ namespace GitCommands.Logging
     public class CommandLogEntry
     {
         private string Command { get; }
-        private DateTime ExecutionStartTimestamp { get; }
-        private DateTime ExecutionEndTimestamp { get; }
-        private bool IsStart { get; }
-        private uint CmdId { get; }
-        private bool _enhanced;
-
-        private static uint counter = 0;
+        private DateTime Timestamp { get; }
+        public TimeSpan? Duration { get; set;  }
+        private int CmdId { get; }
 
         /// <summary>
         /// Create a new log entry
         /// </summary>
         /// <param name="command">The (Git) command to log</param>
-        /// <param name="executionStartTimestamp">The start time for the command</param>
-        /// <param name="executionEndTimestamp">The end time for the command, ignored if this is start of a command</param>
-        /// <param name="startCmd">The log entry for the start command, to be able to identify start/end pairs</param>
-        /// <param name="isStart">Set if this is start of a command</param>
-        public CommandLogEntry(string command, DateTime executionStartTimestamp, DateTime executionEndTimestamp, CommandLogEntry startCmd = null, bool isStart = false)
+        /// <param name="counter">The log entry for the start command, to be able to identify start/end pairs</param>
+        /// <param name="timestamp">The time for the log</param>
+        public CommandLogEntry(string command, int counter, DateTime timestamp)
         {
             Command = command;
-            ExecutionStartTimestamp = executionStartTimestamp;
-            ExecutionEndTimestamp = executionEndTimestamp;
-            IsStart = isStart;
+            Timestamp = timestamp;
+            CmdId = counter;
 
-            // Start of commands will only be logged if enhanced logging is set,
-            // so cmdNo (with reference to start) will only be not null for ends with enhanced logging
-            _enhanced = isStart || startCmd != null;
-
-            if (isStart)
-            {
-                counter++;
-            }
-
-            // If there is no previous log entry, use the counter
-            CmdId = startCmd == null ?
-                counter :
-                startCmd.CmdId;
+            Duration = null;
         }
 
         public override string ToString()
         {
-            string cmd = !_enhanced ? "" : "#" + CmdId.ToString() + " ";
-            string end;
-            if (IsStart)
-            {
-                end = "#(start)";
-            }
-            else
-            {
-                var durationInMillis = (long)ExecutionEndTimestamp.Subtract(ExecutionStartTimestamp).TotalMilliseconds;
-                end = string.Format("#(took {0} ms)", durationInMillis);
-            }
+            string duration = Duration == null ?
+                "(start)" :
+                string.Format("{0:0}ms", ((TimeSpan)Duration).TotalMilliseconds);
 
-            return string.Format("{0}    {1}{2}    {3}", ExecutionStartTimestamp.ToString("O"), cmd, Command, end);
+            return $"{Timestamp:O} {duration:0,7} #{CmdId} {Command}";
         }
     }
 }

--- a/GitCommands/Logging/CommandLogger.cs
+++ b/GitCommands/Logging/CommandLogger.cs
@@ -25,10 +25,9 @@ namespace GitCommands.Logging
         /// Add the command to the log fifo queue
         /// </summary>
         /// <param name="command">The (Git) command to log</param>
-        /// <param name="counter">The log entry for the start command, to be able to identify start/end pairs</param>
         /// <param name="timestamp">The time for the log</param>
         /// <returns>The log entry reference, null if not added</returns>
-        public CommandLogEntry LogEntry(string command, int counter, DateTime timestamp)
+        public CommandLogEntry LogEntry(string command, DateTime timestamp)
         {
             CommandLogEntry commandLogEntry = null;
             lock (_logQueue)
@@ -38,7 +37,7 @@ namespace GitCommands.Logging
                     _logQueue.Dequeue();
                 }
 
-                commandLogEntry = new CommandLogEntry(command, counter, timestamp);
+                commandLogEntry = new CommandLogEntry(command, timestamp);
                 _logQueue.Enqueue(commandLogEntry);
             }
 
@@ -51,16 +50,20 @@ namespace GitCommands.Logging
             CommandsChanged?.Invoke(this, EventArgs.Empty);
         }
 
+        public GitLogEntry Log(string fileName, string arguments = "")
+        {
+            return new GitLogEntry(this, fileName, arguments);
+        }
+
         public class GitLogEntry
         {
             public GitLogEntry(CommandLogger log, string fileName, string arguments)
             {
                 string command = System.IO.Path.GetFileName(fileName) + " " + arguments;
-                int counter = Interlocked.Increment(ref globalCounter);
                 _log = log;
 
                 _stopwatch = new Stopwatch();
-                _entry = _log.LogEntry(command, counter, DateTime.Now);
+                _entry = _log.LogEntry(command, DateTime.Now);
                 _stopwatch.Start();
             }
 
@@ -74,18 +77,11 @@ namespace GitCommands.Logging
             private CommandLogger _log;
             private Stopwatch _stopwatch;
             private CommandLogEntry _entry;
-
-            private static int globalCounter = 0;
         }
 
         public override string ToString()
         {
             return string.Join(Environment.NewLine, GetCommands().Select(cle => cle.ToString()));
-        }
-
-        public GitLogEntry Log(string fileName, string arguments = "")
-        {
-            return new GitLogEntry(this, fileName, arguments);
         }
     }
 }

--- a/GitCommands/Logging/CommandLogger.cs
+++ b/GitCommands/Logging/CommandLogger.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 
 namespace GitCommands.Logging
 {
@@ -23,22 +25,11 @@ namespace GitCommands.Logging
         /// Add the command to the log fifo queue
         /// </summary>
         /// <param name="command">The (Git) command to log</param>
-        /// <param name="executionStartTimestamp">The start time for the command</param>
-        /// <param name="executionEndTimestamp">The end time for the command, ignored if this is start of a command</param>
-        /// <param name="startCmd">The log entry for the start command, to be able to identify start/end pairs</param>
+        /// <param name="counter">The log entry for the start command, to be able to identify start/end pairs</param>
+        /// <param name="timestamp">The time for the log</param>
         /// <returns>The log entry reference, null if not added</returns>
-        public CommandLogEntry Log(string command, DateTime executionStartTimestamp, DateTime executionEndTimestamp, CommandLogEntry startCmd = null, bool isStart = false)
+        public CommandLogEntry LogEntry(string command, int counter, DateTime timestamp)
         {
-            if (!AppSettings.EnhancedGitLog)
-            {
-                if (isStart)
-                {
-                    return null;
-                }
-
-                startCmd = null;
-            }
-
             CommandLogEntry commandLogEntry = null;
             lock (_logQueue)
             {
@@ -47,7 +38,7 @@ namespace GitCommands.Logging
                     _logQueue.Dequeue();
                 }
 
-                commandLogEntry = new CommandLogEntry(command, executionStartTimestamp, executionEndTimestamp, startCmd, isStart);
+                commandLogEntry = new CommandLogEntry(command, counter, timestamp);
                 _logQueue.Enqueue(commandLogEntry);
             }
 
@@ -55,9 +46,46 @@ namespace GitCommands.Logging
             return commandLogEntry;
         }
 
+        public void LogEnd()
+        {
+            CommandsChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public class GitLogEntry
+        {
+            public GitLogEntry(CommandLogger log, string fileName, string arguments)
+            {
+                string command = System.IO.Path.GetFileName(fileName) + " " + arguments;
+                int counter = Interlocked.Increment(ref globalCounter);
+                _log = log;
+
+                _stopwatch = new Stopwatch();
+                _entry = _log.LogEntry(command, counter, DateTime.Now);
+                _stopwatch.Start();
+            }
+
+            public void LogEnd()
+            {
+                _stopwatch.Stop();
+                _entry.Duration = _stopwatch.Elapsed;
+                _log.LogEnd();
+            }
+
+            private CommandLogger _log;
+            private Stopwatch _stopwatch;
+            private CommandLogEntry _entry;
+
+            private static int globalCounter = 0;
+        }
+
         public override string ToString()
         {
             return string.Join(Environment.NewLine, GetCommands().Select(cle => cle.ToString()));
+        }
+
+        public GitLogEntry Log(string fileName, string arguments = "")
+        {
+            return new GitLogEntry(this, fileName, arguments);
         }
     }
 }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1472,12 +1472,6 @@ namespace GitCommands
             set => SetEnum("BranchOrderingCriteria", value);
         }
 
-        public static bool EnhancedGitLog
-        {
-            get => GetBool("EnhancedGitLog", false);
-            set => SetBool("EnhancedGitLog", value);
-        }
-
         public static string GetGitExtensionsFullPath()
         {
             return Application.ExecutablePath;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -54,7 +54,7 @@ namespace GitCommands
                 }
                 else
                 {
-                    // Make applicationdatapath version independent
+                    // Make ApplicationDataPath version independent
                     return Application.UserAppDataPath.Replace(Application.ProductVersion, string.Empty);
                 }
             });
@@ -1470,6 +1470,12 @@ namespace GitCommands
         {
             get => GetEnum("BranchOrderingCriteria", GitRefsOrder.ByLastAccessDate);
             set => SetEnum("BranchOrderingCriteria", value);
+        }
+
+        public static bool EnhancedGitLog
+        {
+            get => GetBool("EnhancedGitLog", false);
+            set => SetBool("EnhancedGitLog", value);
         }
 
         public static string GetGitExtensionsFullPath()

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.Designer.cs
@@ -30,6 +30,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.TabControl = new System.Windows.Forms.TabControl();
             this.tabPageCommandLog = new System.Windows.Forms.TabPage();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
@@ -40,21 +41,21 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.CommandCacheItems = new System.Windows.Forms.ListBox();
             this.commandCacheOutput = new System.Windows.Forms.RichTextBox();
             this.alwaysOnTopCheckBox = new System.Windows.Forms.CheckBox();
+            this.enhancedLogCheckBox = new System.Windows.Forms.CheckBox();
+            this.logContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.saveToFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.TabControl.SuspendLayout();
             this.tabPageCommandLog.SuspendLayout();
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
-
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
             this.tabPageCommandCache.SuspendLayout();
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            this.logContextMenuStrip.SuspendLayout();
             this.SuspendLayout();
             // 
             // TabControl
@@ -75,10 +76,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             this.tabPageCommandLog.BackColor = System.Drawing.SystemColors.ControlLight;
             this.tabPageCommandLog.Controls.Add(this.splitContainer2);
-            this.tabPageCommandLog.Location = new System.Drawing.Point(4, 24);
+            this.tabPageCommandLog.Location = new System.Drawing.Point(4, 22);
             this.tabPageCommandLog.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageCommandLog.Name = "tabPageCommandLog";
-            this.tabPageCommandLog.Size = new System.Drawing.Size(651, 414);
+            this.tabPageCommandLog.Size = new System.Drawing.Size(651, 416);
             this.tabPageCommandLog.TabIndex = 0;
             this.tabPageCommandLog.Text = "Command log";
             // 
@@ -98,21 +99,21 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.LogOutput);
-            this.splitContainer2.Size = new System.Drawing.Size(651, 414);
-            this.splitContainer2.SplitterDistance = 332;
+            this.splitContainer2.Size = new System.Drawing.Size(651, 416);
+            this.splitContainer2.SplitterDistance = 334;
             this.splitContainer2.TabIndex = 1;
             // 
             // LogItems
             // 
             this.LogItems.Dock = System.Windows.Forms.DockStyle.Fill;
             this.LogItems.FormattingEnabled = true;
-            this.LogItems.ItemHeight = 15;
             this.LogItems.Location = new System.Drawing.Point(0, 0);
             this.LogItems.Margin = new System.Windows.Forms.Padding(0);
             this.LogItems.Name = "LogItems";
-            this.LogItems.Size = new System.Drawing.Size(651, 332);
+            this.LogItems.Size = new System.Drawing.Size(651, 334);
             this.LogItems.TabIndex = 0;
             this.LogItems.SelectedIndexChanged += new System.EventHandler(this.LogItems_SelectedIndexChanged);
+            this.LogItems.ContextMenuStrip = logContextMenuStrip;
             // 
             // LogOutput
             // 
@@ -130,10 +131,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             this.tabPageCommandCache.BackColor = System.Drawing.SystemColors.ControlLight;
             this.tabPageCommandCache.Controls.Add(this.splitContainer1);
-            this.tabPageCommandCache.Location = new System.Drawing.Point(4, 24);
+            this.tabPageCommandCache.Location = new System.Drawing.Point(4, 22);
             this.tabPageCommandCache.Margin = new System.Windows.Forms.Padding(0);
             this.tabPageCommandCache.Name = "tabPageCommandCache";
-            this.tabPageCommandCache.Size = new System.Drawing.Size(651, 414);
+            this.tabPageCommandCache.Size = new System.Drawing.Size(651, 416);
             this.tabPageCommandCache.TabIndex = 1;
             this.tabPageCommandCache.Text = "Command cache";
             // 
@@ -151,7 +152,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.commandCacheOutput);
-            this.splitContainer1.Size = new System.Drawing.Size(651, 414);
+            this.splitContainer1.Size = new System.Drawing.Size(651, 416);
             this.splitContainer1.SplitterDistance = 183;
             this.splitContainer1.TabIndex = 0;
             // 
@@ -159,7 +160,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             this.CommandCacheItems.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CommandCacheItems.FormattingEnabled = true;
-            this.CommandCacheItems.ItemHeight = 15;
             this.CommandCacheItems.Location = new System.Drawing.Point(0, 0);
             this.CommandCacheItems.Margin = new System.Windows.Forms.Padding(0);
             this.CommandCacheItems.Name = "CommandCacheItems";
@@ -175,7 +175,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.commandCacheOutput.Location = new System.Drawing.Point(0, 0);
             this.commandCacheOutput.Margin = new System.Windows.Forms.Padding(0);
             this.commandCacheOutput.Name = "commandCacheOutput";
-            this.commandCacheOutput.Size = new System.Drawing.Size(651, 227);
+            this.commandCacheOutput.Size = new System.Drawing.Size(651, 229);
             this.commandCacheOutput.TabIndex = 0;
             this.commandCacheOutput.Text = "";
             // 
@@ -183,19 +183,46 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             this.alwaysOnTopCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.alwaysOnTopCheckBox.AutoSize = true;
-            this.alwaysOnTopCheckBox.Location = new System.Drawing.Point(4, 449);
+            this.alwaysOnTopCheckBox.Location = new System.Drawing.Point(4, 451);
             this.alwaysOnTopCheckBox.Name = "alwaysOnTopCheckBox";
-            this.alwaysOnTopCheckBox.Size = new System.Drawing.Size(101, 19);
+            this.alwaysOnTopCheckBox.Size = new System.Drawing.Size(94, 17);
             this.alwaysOnTopCheckBox.TabIndex = 2;
             this.alwaysOnTopCheckBox.Text = "Always on top";
             this.alwaysOnTopCheckBox.UseVisualStyleBackColor = true;
             this.alwaysOnTopCheckBox.CheckedChanged += new System.EventHandler(this.alwaysOnTopCheckBox_CheckedChanged);
+            // 
+            // enhancedLogCheckBox
+            // 
+            this.enhancedLogCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.enhancedLogCheckBox.AutoSize = true;
+            this.enhancedLogCheckBox.Location = new System.Drawing.Point(104, 451);
+            this.enhancedLogCheckBox.Name = "enhancedLogCheckBox";
+            this.enhancedLogCheckBox.Size = new System.Drawing.Size(110, 17);
+            this.enhancedLogCheckBox.TabIndex = 3;
+            this.enhancedLogCheckBox.Text = "Enhanced logging";
+            this.enhancedLogCheckBox.UseVisualStyleBackColor = true;
+            this.enhancedLogCheckBox.CheckedChanged += new System.EventHandler(this.enhancedLogCheckBox_CheckedChanged);
+            // 
+            // logContextMenuStrip
+            // 
+            this.logContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.saveToFileToolStripMenuItem});
+            this.logContextMenuStrip.Name = "logContextMenuStrip";
+            this.logContextMenuStrip.Size = new System.Drawing.Size(132, 26);
+            // 
+            // saveToFileToolStripMenuItem
+            // 
+            this.saveToFileToolStripMenuItem.Name = "saveToFileToolStripMenuItem";
+            this.saveToFileToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
+            this.saveToFileToolStripMenuItem.Text = "Save to file";
+            this.saveToFileToolStripMenuItem.Click += SaveToFileToolStripMenuItem_Click;
             // 
             // FormGitLog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(659, 470);
+            this.Controls.Add(this.enhancedLogCheckBox);
             this.Controls.Add(this.alwaysOnTopCheckBox);
             this.Controls.Add(this.TabControl);
             this.Name = "FormGitLog";
@@ -206,17 +233,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.tabPageCommandLog.ResumeLayout(false);
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel2.ResumeLayout(false);
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
-
             this.splitContainer2.ResumeLayout(false);
             this.tabPageCommandCache.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
-
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-
             this.splitContainer1.ResumeLayout(false);
+            this.logContextMenuStrip.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -234,5 +258,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private System.Windows.Forms.ListBox LogItems;
         private System.Windows.Forms.RichTextBox LogOutput;
         private CheckBox alwaysOnTopCheckBox;
+        private CheckBox enhancedLogCheckBox;
+        private ContextMenuStrip logContextMenuStrip;
+        private ToolStripMenuItem saveToFileToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.Designer.cs
@@ -41,7 +41,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.CommandCacheItems = new System.Windows.Forms.ListBox();
             this.commandCacheOutput = new System.Windows.Forms.RichTextBox();
             this.alwaysOnTopCheckBox = new System.Windows.Forms.CheckBox();
-            this.enhancedLogCheckBox = new System.Windows.Forms.CheckBox();
             this.logContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.saveToFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.TabControl.SuspendLayout();
@@ -191,18 +190,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.alwaysOnTopCheckBox.UseVisualStyleBackColor = true;
             this.alwaysOnTopCheckBox.CheckedChanged += new System.EventHandler(this.alwaysOnTopCheckBox_CheckedChanged);
             // 
-            // enhancedLogCheckBox
-            // 
-            this.enhancedLogCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.enhancedLogCheckBox.AutoSize = true;
-            this.enhancedLogCheckBox.Location = new System.Drawing.Point(104, 451);
-            this.enhancedLogCheckBox.Name = "enhancedLogCheckBox";
-            this.enhancedLogCheckBox.Size = new System.Drawing.Size(110, 17);
-            this.enhancedLogCheckBox.TabIndex = 3;
-            this.enhancedLogCheckBox.Text = "Enhanced logging";
-            this.enhancedLogCheckBox.UseVisualStyleBackColor = true;
-            this.enhancedLogCheckBox.CheckedChanged += new System.EventHandler(this.enhancedLogCheckBox_CheckedChanged);
-            // 
             // logContextMenuStrip
             // 
             this.logContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -222,7 +209,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(659, 470);
-            this.Controls.Add(this.enhancedLogCheckBox);
             this.Controls.Add(this.alwaysOnTopCheckBox);
             this.Controls.Add(this.TabControl);
             this.Name = "FormGitLog";
@@ -258,7 +244,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private System.Windows.Forms.ListBox LogItems;
         private System.Windows.Forms.RichTextBox LogOutput;
         private CheckBox alwaysOnTopCheckBox;
-        private CheckBox enhancedLogCheckBox;
         private ContextMenuStrip logContextMenuStrip;
         private ToolStripMenuItem saveToFileToolStripMenuItem;
     }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.cs
@@ -17,9 +17,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             ShowInTaskbar = true;
             InitializeComponent();
             Translate();
-            enhancedLogCheckBox.CheckedChanged -= new System.EventHandler(enhancedLogCheckBox_CheckedChanged);
-            enhancedLogCheckBox.Checked = AppSettings.EnhancedGitLog;
-            enhancedLogCheckBox.CheckedChanged += new System.EventHandler(enhancedLogCheckBox_CheckedChanged);
         }
 
         private void GitLogFormLoad(object sender, EventArgs e)
@@ -123,12 +120,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             TopMost = !TopMost;
             alwaysOnTopCheckBox.Checked = TopMost;
-        }
-
-        private void enhancedLogCheckBox_CheckedChanged(object sender, EventArgs e)
-        {
-            AppSettings.EnhancedGitLog = !AppSettings.EnhancedGitLog;
-            enhancedLogCheckBox.Checked = AppSettings.EnhancedGitLog;
         }
 
         private void SaveToFileToolStripMenuItem_Click(object sender, System.EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -16,6 +17,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             ShowInTaskbar = true;
             InitializeComponent();
             Translate();
+            enhancedLogCheckBox.CheckedChanged -= new System.EventHandler(enhancedLogCheckBox_CheckedChanged);
+            enhancedLogCheckBox.Checked = AppSettings.EnhancedGitLog;
+            enhancedLogCheckBox.CheckedChanged += new System.EventHandler(enhancedLogCheckBox_CheckedChanged);
         }
 
         private void GitLogFormLoad(object sender, EventArgs e)
@@ -119,6 +123,30 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             TopMost = !TopMost;
             alwaysOnTopCheckBox.Checked = TopMost;
+        }
+
+        private void enhancedLogCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            AppSettings.EnhancedGitLog = !AppSettings.EnhancedGitLog;
+            enhancedLogCheckBox.Checked = AppSettings.EnhancedGitLog;
+        }
+
+        private void SaveToFileToolStripMenuItem_Click(object sender, System.EventArgs e)
+        {
+            using (var fileDialog = new SaveFileDialog
+            {
+                Title = Name,
+                DefaultExt = ".txt",
+                AddExtension = true
+            })
+            {
+                fileDialog.Filter =
+                    "All files (*.*)|*.*";
+                if (fileDialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    File.WriteAllText(fileDialog.FileName, AppSettings.GitLog.ToString());
+                }
+            }
         }
 
         private void OnCommandsLogChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.resx
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitLog.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="logContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/GitUI/Script/PowerShellHelper.cs
+++ b/GitUI/Script/PowerShellHelper.cs
@@ -22,12 +22,13 @@ namespace GitUI.Script
                 UseShellExecute = false
             };
 
+            var startCmd = AppSettings.GitLog.Log(filename + " " + psarguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
             var startProcess = Process.Start(startInfo);
 
             startProcess.Exited += (sender, args) =>
             {
                 var executionEndTimestamp = DateTime.Now;
-                AppSettings.GitLog.Log(filename + " " + psarguments, executionStartTimestamp, executionEndTimestamp);
+                AppSettings.GitLog.Log(filename + " " + psarguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
             };
         }
     }

--- a/GitUI/Script/PowerShellHelper.cs
+++ b/GitUI/Script/PowerShellHelper.cs
@@ -12,8 +12,6 @@ namespace GitUI.Script
             var psarguments = (runInBackground ? "" : "-NoExit") + " -ExecutionPolicy Unrestricted -Command \"" + command + " " + argument + "\"";
             EnvironmentConfiguration.SetEnvironmentVariables();
 
-            var executionStartTimestamp = DateTime.Now;
-
             var startInfo = new ProcessStartInfo
             {
                 FileName = filename,
@@ -22,13 +20,12 @@ namespace GitUI.Script
                 UseShellExecute = false
             };
 
-            var startCmd = AppSettings.GitLog.Log(filename + " " + psarguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
+            var startCmd = AppSettings.GitLog.Log(filename, psarguments);
             var startProcess = Process.Start(startInfo);
 
             startProcess.Exited += (sender, args) =>
             {
-                var executionEndTimestamp = DateTime.Now;
-                AppSettings.GitLog.Log(filename + " " + psarguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
+                startCmd.LogEnd();
             };
         }
     }

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -132,10 +132,11 @@ namespace GitUI.UserControls
                     }).FileAndForget();
                 };
 
+                var startCmd = AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
                 process.Exited += (sender, args) =>
                 {
                     DateTime executionEndTimestamp = DateTime.Now;
-                    AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp);
+                    AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
                 };
 
                 process.Start();

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -80,14 +80,6 @@ namespace GitUI.UserControls
 
                 KillProcess();
 
-                string quotedCmd = command;
-                if (quotedCmd.IndexOf(' ') != -1)
-                {
-                    quotedCmd = quotedCmd.Quote();
-                }
-
-                DateTime executionStartTimestamp = DateTime.Now;
-
                 // process used to execute external commands
                 var process = new Process();
                 ProcessStartInfo startInfo = GitCommandHelpers.CreateProcessStartInfo(command, arguments, workdir, GitModule.SystemEncoding);
@@ -132,11 +124,10 @@ namespace GitUI.UserControls
                     }).FileAndForget();
                 };
 
-                var startCmd = AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionStartTimestamp, isStart: true);
+                var startCmd = AppSettings.GitLog.Log(command, arguments);
                 process.Exited += (sender, args) =>
                 {
-                    DateTime executionEndTimestamp = DateTime.Now;
-                    AppSettings.GitLog.Log(quotedCmd + " " + arguments, executionStartTimestamp, executionEndTimestamp, startCmd: startCmd);
+                    startCmd.LogEnd();
                 };
 
                 process.Start();


### PR DESCRIPTION
part of #4213 and #4753

Changes proposed in this pull request:
 - Save command log to file
 - Add "id" to commands, log start and stop
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/6248932/41070595-f6be2060-69f3-11e8-9329-1d66975d5966.png)

What did I do to test the code and ensure quality:
 - Manual testing
 
Has been tested on (remove any that don't apply):
 - Windows 10
