### PR TITLE
[WIP] Make a few GitCommands methods asynchronous

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -192,7 +192,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             if (EnvUtils.RunningOnWindows())
             {
                 var command = (from cmd in GetWindowsCommandLocations(possibleNewPath)
-                               let output = Module.RunCmd(cmd, string.Empty)
+                               let output = ThreadHelper.JoinableTaskFactory.Run(() => Module.RunCmdAsync(cmd, string.Empty))
                                where !string.IsNullOrEmpty(output)
                                select cmd).FirstOrDefault();
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void Initialize()
         {
-            var listWorktree = UICommands.CommandLineCommand("git", "worktree list --porcelain");
+            var listWorktree = ThreadHelper.JoinableTaskFactory.Run(() => UICommands.CommandLineCommandAsync("git", "worktree list --porcelain"));
             var worktreesLines = listWorktree.Split('\n').GetEnumerator();
             _worktrees = new List<WorkTree>();
             WorkTree currentWorktree = null;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Settings;
@@ -178,9 +179,9 @@ namespace GitUI
             return Module.RunGitCmd(arguments);
         }
 
-        public string CommandLineCommand(string cmd, string arguments)
+        public async Task<string> CommandLineCommandAsync(string cmd, string arguments)
         {
-            return Module.RunCmd(cmd, arguments);
+            return await Module.RunCmdAsync(cmd, arguments).ConfigureAwait(false);
         }
 
         private bool RequiresValidWorkingDir(object owner)

--- a/Plugins/Gerrit/FormGerritDownload.cs
+++ b/Plugins/Gerrit/FormGerritDownload.cs
@@ -32,17 +32,6 @@ namespace Gerrit
             Translate();
         }
 
-        public async Task PushAndShowDialogWhenFailedAsync(IWin32Window owner = null)
-        {
-            await this.SwitchToMainThreadAsync();
-
-            if (!(await DownloadChangeAsync(owner)))
-            {
-                await this.SwitchToMainThreadAsync();
-                ShowDialog(owner);
-            }
-        }
-
         private void DownloadClick(object sender, EventArgs e)
         {
             if (ThreadHelper.JoinableTaskFactory.Run(() => DownloadChangeAsync(this)))

--- a/Plugins/Gerrit/Gerrit.csproj
+++ b/Plugins/Gerrit/Gerrit.csproj
@@ -114,6 +114,10 @@
       <Name>GitCommands</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\GitUI\GitUI.csproj">
       <Project>{CF5B22E7-230F-4E50-BE88-C4F7023CED2C}</Project>
       <Name>GitUI</Name>

--- a/Plugins/Gerrit/GerritPlugin.cs
+++ b/Plugins/Gerrit/GerritPlugin.cs
@@ -5,7 +5,9 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitUI;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -280,14 +282,16 @@ namespace Gerrit
 
             if (result == DialogResult.Yes)
             {
-                InstallCommitMsgHook();
+                ThreadHelper.JoinableTaskFactory.Run(InstallCommitMsgHookAsync);
             }
 
             _gitUiCommands.RepoChangedNotifier.Notify();
         }
 
-        private void InstallCommitMsgHook()
+        private async Task InstallCommitMsgHookAsync()
         {
+            await _mainForm.SwitchToMainThreadAsync();
+
             var settings = GerritSettings.Load(_mainForm, _gitUiCommands.GitModule);
 
             if (settings == null)
@@ -303,13 +307,14 @@ namespace Gerrit
 
             try
             {
-                content = DownloadFromScp(settings);
+                content = await DownloadFromScpAsync(settings);
             }
             catch
             {
                 content = null;
             }
 
+            await _mainForm.SwitchToMainThreadAsync();
             if (content == null)
             {
                 MessageBox.Show(
@@ -329,18 +334,18 @@ namespace Gerrit
             }
         }
 
-        private string DownloadFromScp(GerritSettings settings)
+        private async Task<string> DownloadFromScpAsync(GerritSettings settings)
         {
             // This is a very quick and dirty "implementation" of the scp
             // protocol. By sending the 0's as input, we trigger scp to
             // send the file.
 
-            string content = GerritUtil.RunGerritCommand(
+            string content = await GerritUtil.RunGerritCommandAsync(
                 _mainForm,
                 _gitUiCommands.GitModule,
                 "scp -f hooks/commit-msg",
                 settings.DefaultRemote,
-                new byte[] { 0, 0, 0, 0, 0, 0, 0 });
+                new byte[] { 0, 0, 0, 0, 0, 0, 0 }).ConfigureAwait(false);
 
             // The first line of the output contains the file we're receiving
             // in a format like "C0755 4248 commit-msg".

--- a/Plugins/Gerrit/GerritUtil.cs
+++ b/Plugins/Gerrit/GerritUtil.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI;
@@ -14,11 +15,11 @@ namespace Gerrit
     {
         private static readonly ISshPathLocator SshPathLocatorInstance = new SshPathLocator();
 
-        public static string RunGerritCommand([NotNull] IWin32Window owner, [NotNull] IGitModule module, [NotNull] string command, [NotNull] string remote, byte[] stdIn)
+        public static async Task<string> RunGerritCommandAsync([NotNull] IWin32Window owner, [NotNull] IGitModule module, [NotNull] string command, [NotNull] string remote, byte[] stdIn)
         {
             var fetchUrl = GetFetchUrl(module, remote);
 
-            return RunGerritCommand(owner, module, command, fetchUrl, remote, stdIn);
+            return await RunGerritCommandAsync(owner, module, command, fetchUrl, remote, stdIn).ConfigureAwait(false);
         }
 
         public static Uri GetFetchUrl(IGitModule module, string remote)
@@ -30,7 +31,7 @@ namespace Gerrit
             return new Uri(fetchUrlLine.Split(new[] { ':' }, 2)[1].Trim());
         }
 
-        public static string RunGerritCommand([NotNull] IWin32Window owner, [NotNull] IGitModule module, [NotNull] string command, [NotNull] Uri fetchUrl, [NotNull] string remote, byte[] stdIn)
+        public static async Task<string> RunGerritCommandAsync([NotNull] IWin32Window owner, [NotNull] IGitModule module, [NotNull] string command, [NotNull] Uri fetchUrl, [NotNull] string remote, byte[] stdIn)
         {
             if (owner == null)
             {
@@ -99,11 +100,11 @@ namespace Gerrit
             sb.Append(command);
             sb.Append("\"");
 
-            return module.RunCmd(
+            return await module.RunCmdAsync(
                 sshCmd,
                 sb.ToString(),
-                null,
-                stdIn);
+                encoding: null,
+                stdIn).ConfigureAwait(false);
         }
 
         public static void StartAgent([NotNull] IWin32Window owner, [NotNull] IGitModule module, [NotNull] string remote)

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace GitUIPluginInterfaces
 {
@@ -48,14 +49,14 @@ namespace GitUIPluginInterfaces
         /// <summary>
         /// Run command, console window is hidden, wait for exit, redirect output
         /// </summary>
-        string RunCmd(string cmd, string arguments, Encoding encoding = null, byte[] stdIn = null);
+        Task<string> RunCmdAsync(string cmd, string arguments, Encoding encoding = null, byte[] stdIn = null);
 
         /// <summary>
         /// Run command, console window is hidden, wait for exit, redirect output
         /// </summary>
         CmdResult RunCmdResult(string cmd, string arguments, Encoding encoding = null, byte[] stdInput = null);
 
-        string RunBatchFile(string batchFile);
+        Task<string> RunBatchFileAsync(string batchFile);
 
         /// <summary>
         /// Determines whether the given repository has index.lock file.

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GitUIPluginInterfaces
@@ -87,7 +88,7 @@ namespace GitUIPluginInterfaces
 
         IGitModule GitModule { get; }
         string GitCommand(string arguments);
-        string CommandLineCommand(string cmd, string arguments);
+        Task<string> CommandLineCommandAsync(string cmd, string arguments);
         IGitRemoteCommand CreateRemoteCommand();
         void CacheAvatar(string email);
         Icon FormIcon { get; }


### PR DESCRIPTION
This pull request incrementally changes GitCommands methods to use JTF. In each iteration, a "primary" method was selected for conversion, and then additional methods were selected when a caller was not used in a large number of places.

* `GitModule.RunCmd`
* ~~`GitModule.RunBash`~~ (removed from this PR)
* ~~`SynchronizedProcessReader`~~ (removed from this PR)
* ~~`GitModule.RunCacheableCmdAsync`~~ (removed from this PR)

:memo: The rule in #4751 was established early in this work, and should be followed at each step.