### PR TITLE
Allow ArgumentBuilder enum extensions to accept null

### DIFF
--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -98,11 +98,17 @@ namespace GitCommands
         /// <summary>
         /// Adds the git argument syntax for members of the <see cref="ForcePushOptions"/> enum.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="option"/> is <c>null</c> then no argument is added.
+        /// </remarks>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-        /// <param name="option">The enum member to add to the builder.</param>
-        public static void Add(this ArgumentBuilder builder, ForcePushOptions option)
+        /// <param name="option">The enum member to add to the builder, or <c>null</c>.</param>
+        public static void Add(this ArgumentBuilder builder, ForcePushOptions? option)
         {
-            builder.Add(GetArgument());
+            if (option.HasValue)
+            {
+                builder.Add(GetArgument());
+            }
 
             string GetArgument()
             {
@@ -123,11 +129,17 @@ namespace GitCommands
         /// <summary>
         /// Adds the git argument syntax for members of the <see cref="UntrackedFilesMode"/> enum.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="mode"/> is <c>null</c> then no argument is added.
+        /// </remarks>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-        /// <param name="mode">The enum member to add to the builder.</param>
-        public static void Add(this ArgumentBuilder builder, UntrackedFilesMode mode)
+        /// <param name="mode">The enum member to add to the builder, or <c>null</c>.</param>
+        public static void Add(this ArgumentBuilder builder, UntrackedFilesMode? mode)
         {
-            builder.Add(GetArgument());
+            if (mode.HasValue)
+            {
+                builder.Add(GetArgument());
+            }
 
             string GetArgument()
             {
@@ -150,11 +162,17 @@ namespace GitCommands
         /// <summary>
         /// Adds the git argument syntax for members of the <see cref="IgnoreSubmodulesMode"/> enum.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="mode"/> is <c>null</c> then no argument is added.
+        /// </remarks>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-        /// <param name="mode">The enum member to add to the builder.</param>
-        public static void Add(this ArgumentBuilder builder, IgnoreSubmodulesMode mode)
+        /// <param name="mode">The enum member to add to the builder, or <c>null</c>.</param>
+        public static void Add(this ArgumentBuilder builder, IgnoreSubmodulesMode? mode)
         {
-            builder.Add(GetArgument());
+            if (mode.HasValue)
+            {
+                builder.Add(GetArgument());
+            }
 
             string GetArgument()
             {
@@ -179,11 +197,17 @@ namespace GitCommands
         /// <summary>
         /// Adds the git argument syntax for members of the <see cref="GitBisectOption"/> enum.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="option"/> is <c>null</c> then no argument is added.
+        /// </remarks>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-        /// <param name="option">The enum member to add to the builder.</param>
-        public static void Add(this ArgumentBuilder builder, GitBisectOption option)
+        /// <param name="option">The enum member to add to the builder, or <c>null</c>.</param>
+        public static void Add(this ArgumentBuilder builder, GitBisectOption? option)
         {
-            builder.Add(GetArgument());
+            if (option.HasValue)
+            {
+                builder.Add(GetArgument());
+            }
 
             string GetArgument()
             {

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -729,7 +729,7 @@ namespace GitCommands
             return args.ToString();
         }
 
-        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = 0)
+        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode? ignoreSubmodules = null)
         {
             var args = new ArgumentBuilder
             {

--- a/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
@@ -205,14 +205,14 @@ namespace GitCommandsTests
             Test<IgnoreSubmodulesMode>();
             Test<GitBisectOption>();
 
-            void Test<T>()
+            void Test<T>() where T : struct
             {
                 var method = typeof(ArgumentBuilderExtensions).GetMethod(
                     nameof(ArgumentBuilderExtensions.Add),
                     new[]
                     {
                         typeof(ArgumentBuilder),
-                        typeof(T)
+                        typeof(T?)
                     });
 
                 Assert.NotNull(method);
@@ -221,6 +221,11 @@ namespace GitCommandsTests
                 {
                     var args = new ArgumentBuilder();
 
+                    // Passing null should not modify the arguments
+                    method.Invoke(null, new object[] { args, default(T?) });
+                    Assert.AreEqual("", args.ToString());
+
+                    // Passing a member should not throw (though might not modify the arguments)
                     Assert.DoesNotThrow(() => method.Invoke(null, new object[] { args, member }));
                 }
             }

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -641,6 +641,9 @@ namespace GitCommandsTests.Git
             Assert.AreEqual(
                 "status --porcelain -z --untracked-files --ignore-submodules=all",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.All));
+            Assert.AreEqual(
+                "status --porcelain -z --untracked-files",
+                GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4754.

This one made my head hurt for a few reasons.

- There are multiple fields in `FormBrowse` related to commit toolstrip items, and the names are not straightforward: `toolStripButton1`, `commitToolStripMenuItem`, `_toolStripGitStatus` (hint: it's the last one.)
- The actual problem was an exception that was swallowed in `GitStatusMonitor.OnUpdateStatusError`, resulting in `GitStatusMonitor` turning off, which then hides the commit button. It'd be useful to have some kind of error logging within GE for diagnosing issues. If this already exists, would someone please point it out?

The exception was:

> The value of argument 'mode' (0) is invalid for Enum type 'IgnoreSubmodulesMode'.
Parameter name: mode

It's a consequence of the new strictness added around unknown enum members. This behavioural change was requested during review.

`GitCommandHelpers.GetAllChangedFilesCmd` has parameter `IgnoreSubmodulesMode ignoreSubmodules = 0`. The previous logic was that `0` meant "I don't want this argument". I've changed it to a nullable argument, and everything works again.

The tests I added for `GetAllChangedFilesCmd` didn't have a case that covered the default value. This is fixed in this PR as well.

In general `ArgumentBuilder` accepts `null` as meaning _I don't want to add anything_. I've made all the enum extension methods accept `null` for this reason. It fixes the bug and feels more consistent with the rest of the API.

As an aside it would have been faster to bisect the issue if the PR hadn't been so squashed. The actual issue was originally introduced in a very small commit, one of nine that were squashed.