### PR TITLE
Fix separator in file name within File History form

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -192,7 +192,7 @@ namespace GitUI.CommandsDialogs
                 NativeMethods.GetLongPathName(shortPath.ToString(), longPath, longPath.Capacity);
 
                 // remove the working directory and now we have a properly cased file name.
-                fileName = longPath.ToString().Substring(Module.WorkingDir.Length);
+                fileName = longPath.ToString().Substring(Module.WorkingDir.Length).ToPosixPath();
             }
 
             if (fileName.StartsWith(Module.WorkingDir, StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
Following generalization of use of IFullPathResolver, the separator used in the
File History form ends up as the native one, while it should be the posix '/'
for later git commands to work properly (via right-click command for instance).
