### PR TITLE
JTF testing update

### DIFF
--- a/UnitTests/GitUITests/ThreadHelperTests.cs
+++ b/UnitTests/GitUITests/ThreadHelperTests.cs
@@ -216,6 +216,24 @@ namespace GitUITests
             Assert.AreEqual(1, actual.InnerExceptions.Count);
         }
 
+        [Test]
+        [Apartment(ApartmentState.MTA)]
+        public void JoinableTaskFactoryConfiguredForMTA()
+        {
+            Assert.AreEqual(ApartmentState.MTA, Thread.CurrentThread.GetApartmentState());
+            Assert.Null(SynchronizationContext.Current);
+            Assert.NotNull(ThreadHelper.JoinableTaskContext);
+            Assert.NotNull(ThreadHelper.JoinableTaskFactory);
+            Assert.False(ThreadHelper.JoinableTaskContext.IsOnMainThread);
+        }
+
+        [Test]
+        [Apartment(ApartmentState.MTA)]
+        public async Task AllowAwaitForAsynchronousMTATest()
+        {
+            await Task.Yield();
+        }
+
         private static void JoinPendingOperations()
         {
             // Since we are testing a FileAndForget method, we need to join all pending operations before continuing.


### PR DESCRIPTION
* Make sure `ThreadHelper.JoinableTaskFactory` is usable in tests not marked with `STA`, provided `SwitchToMainThreadAsync` is not used
* Make sure thread exceptions (e.g. from `FileAndForget`) cause tests to fail

:memo: This pull request is the first two commits originally from #4757, but was updated to avoid the need to use `IDisposable` or `SemaphoreSlim`.