### PR TITLE
Various high DPI fixes

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -47,7 +47,9 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="GitUI\CancellationTokenSequence.cs" />
+    <Compile Include="GitUI\ControlDpiExtensions.cs" />
     <Compile Include="GitUI\ControlThreadingExtensions.cs" />
+    <Compile Include="GitUI\DpiUtil.cs" />
     <Compile Include="GitUI\ThreadHelper.cs" />
     <Compile Include="GitUI\UIExtensions.cs" />
     <Compile Include="Linq\LinqExtensions.cs" />
@@ -58,6 +60,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=15.6.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.6.46\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
       <Private>True</Private>

--- a/GitExtUtils/GitUI/ControlDpiExtensions.cs
+++ b/GitExtUtils/GitUI/ControlDpiExtensions.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using JetBrains.Annotations;
+
+namespace GitUI
+{
+    public static class ControlDpiExtensions
+    {
+        public static void AdjustForDpiScaling([NotNull] this Control control)
+        {
+            if (control == null)
+            {
+                throw new ArgumentNullException(nameof(control));
+            }
+
+            if (!DpiUtil.IsNonStandard)
+            {
+                return;
+            }
+
+            var queue = new Queue<Control>();
+            queue.Enqueue(control);
+
+            while (queue.Count != 0)
+            {
+                var next = queue.Dequeue();
+
+                // NOTE we can't automatically scale TreeView or ListView here as
+                // adjustment must be done before images are added to the
+                // ImageList otherwise they're all removed.
+
+                switch (next)
+                {
+                    case ButtonBase button:
+                    {
+                        if (button.Image != null)
+                        {
+                            button.Image = DpiUtil.Scale(button.Image);
+                        }
+
+                        break;
+                    }
+
+                    case PictureBox pictureBox:
+                    {
+                        if (pictureBox.Image != null)
+                        {
+                            pictureBox.Image = DpiUtil.Scale(pictureBox.Image);
+                        }
+
+                        break;
+                    }
+
+                    default:
+                    {
+                        foreach (Control child in next.Controls)
+                        {
+                            queue.Enqueue(child);
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GitExtUtils/GitUI/ControlDpiExtensions.cs
+++ b/GitExtUtils/GitUI/ControlDpiExtensions.cs
@@ -52,14 +52,25 @@ namespace GitUI
                         break;
                     }
 
+                    case TabControl tabControl:
+                    {
+                        tabControl.Padding = DpiUtil.Scale(tabControl.Padding);
+                        EnqueueChildren();
+                        break;
+                    }
+
                     default:
                     {
-                        foreach (Control child in next.Controls)
-                        {
-                            queue.Enqueue(child);
-                        }
-
+                        EnqueueChildren();
                         break;
+                    }
+                }
+
+                void EnqueueChildren()
+                {
+                    foreach (Control child in next.Controls)
+                    {
+                        queue.Enqueue(child);
                     }
                 }
             }

--- a/GitExtUtils/packages.config
+++ b/GitExtUtils/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="11.1.0" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.6.46" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -249,7 +249,7 @@ namespace GitUI.BuildServerIntegration
                 var buildStatusImageColumn = new DataGridViewImageColumn
                 {
                     AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
-                    Width = 16,
+                    Width = DpiUtil.Scale(16),
                     ReadOnly = true,
                     Resizable = DataGridViewTriState.False,
                     SortMode = DataGridViewColumnSortMode.NotSortable

--- a/GitUI/CommandsDialogs/AboutBox.cs
+++ b/GitUI/CommandsDialogs/AboutBox.cs
@@ -15,6 +15,7 @@ namespace GitUI.CommandsDialogs
 
             InitializeComponent();
             Translate();
+            this.AdjustForDpiScaling();
         }
 
         private static string Coders => Resources.Coders.Replace(Environment.NewLine, " ");
@@ -40,7 +41,7 @@ namespace GitUI.CommandsDialogs
             Bitmap image = Lemmings.GetPictureBoxImage(DateTime.Now);
             if (image != null)
             {
-                logoPictureBox.Image = image;
+                logoPictureBox.Image = DpiUtil.Scale(image);
             }
 
             thanksTimer_Tick(null, null);

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -16,6 +16,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
         {
             SetupForm();
             Translate();
+            this.AdjustForDpiScaling();
         }
 
         private static TextBox GetNewTextBox()
@@ -50,11 +51,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
             {
                 Dock = DockStyle.Fill,
                 Font = new Font("Segoe UI", 10F, FontStyle.Bold, GraphicsUnit.Point, 0),
-                ItemSize = new Size(150, 26),
-                Margin = new Padding(0),
-                Padding = new Point(0, 0),
                 SelectedIndex = 0,
-                SizeMode = TabSizeMode.Fixed
             };
         }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.Designer.cs
@@ -172,14 +172,12 @@
             this.pathDataGridViewTextBoxColumn.DataPropertyName = "Path";
             this.pathDataGridViewTextBoxColumn.HeaderText = "Path";
             this.pathDataGridViewTextBoxColumn.Name = "pathDataGridViewTextBoxColumn";
-            this.pathDataGridViewTextBoxColumn.Width = 150;
             // 
             // Title
             // 
             this.Title.DataPropertyName = "Title";
             this.Title.HeaderText = "Title";
             this.Title.Name = "Title";
-            this.Title.Width = 150;
             // 
             // descriptionDataGridViewTextBoxColumn
             // 

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
@@ -12,6 +12,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         public DashboardEditor()
         {
             InitializeComponent();
+
+            pathDataGridViewTextBoxColumn.Width = DpiUtil.Scale(150);
+            Title.Width = DpiUtil.Scale(150);
+
             Translate();
             Initialize();
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
@@ -12,6 +12,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             InitializeComponent();
             Translate();
+            this.AdjustForDpiScaling();
         }
 
         private void PictureBox1Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -38,6 +38,8 @@ namespace GitUI.CommandsDialogs
             }
 
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
+
+            this.AdjustForDpiScaling();
         }
 
         private string ExcludeFile

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -589,10 +589,7 @@ namespace GitUI.CommandsDialogs
             this.CommitInfoTabControl.Controls.Add(this.DiffTabPage);
             this.CommitInfoTabControl.Controls.Add(this.GpgInfoTabPage);
             this.CommitInfoTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CommitInfoTabControl.ItemSize = new System.Drawing.Size(47, 24);
-            this.CommitInfoTabControl.Location = new System.Drawing.Point(0, 0);
             this.CommitInfoTabControl.Name = "CommitInfoTabControl";
-            this.CommitInfoTabControl.Padding = new System.Drawing.Point(8, 4);
             this.CommitInfoTabControl.SelectedIndex = 0;
             this.CommitInfoTabControl.Size = new System.Drawing.Size(923, 290);
             this.CommitInfoTabControl.TabIndex = 0;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -163,19 +163,22 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
 
             // set tab page images
+            CommitInfoTabControl.ImageList = new ImageList
             {
-                var imageList = new ImageList();
-                CommitInfoTabControl.ImageList = imageList;
-                imageList.ColorDepth = ColorDepth.Depth8Bit;
-                imageList.Images.Add(Resources.IconCommit);
-                imageList.Images.Add(Resources.IconFileTree);
-                imageList.Images.Add(Resources.IconDiff);
-                imageList.Images.Add(Resources.IconKey);
-                CommitInfoTabControl.TabPages[0].ImageIndex = 0;
-                CommitInfoTabControl.TabPages[1].ImageIndex = 1;
-                CommitInfoTabControl.TabPages[2].ImageIndex = 2;
-                CommitInfoTabControl.TabPages[3].ImageIndex = 3;
-            }
+                ColorDepth = ColorDepth.Depth8Bit,
+                ImageSize = DpiUtil.Scale(new Size(16, 16)),
+                Images =
+                {
+                    Resources.IconCommit,
+                    Resources.IconFileTree,
+                    Resources.IconDiff,
+                    Resources.IconKey
+                }
+            };
+            CommitInfoTabControl.TabPages[0].ImageIndex = 0;
+            CommitInfoTabControl.TabPages[1].ImageIndex = 1;
+            CommitInfoTabControl.TabPages[2].ImageIndex = 2;
+            CommitInfoTabControl.TabPages[3].ImageIndex = 3;
 
             if (!AppSettings.ShowGpgInformation.ValueOrDefault)
             {
@@ -302,6 +305,8 @@ namespace GitUI.CommandsDialogs
 
             FillTerminalTab();
             ManageWorktreeSupport();
+
+            this.AdjustForDpiScaling();
         }
 
         private void LayoutRevisionInfo()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -235,6 +234,8 @@ namespace GitUI.CommandsDialogs
 
             ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowImageMargin = false;
             ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowCheckMargin = false;
+
+            this.AdjustForDpiScaling();
         }
 
         private void ConfigureMessageBox()

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -28,6 +28,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             Translate();
             _defaultBranch = defaultBranch;
+            this.AdjustForDpiScaling();
         }
 
         private void FormDeleteBranchLoad(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -26,6 +26,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             Translate();
             _defaultRemoteBranch = defaultRemoteBranch;
+            this.AdjustForDpiScaling();
         }
 
         private void FormDeleteRemoteBranchLoad(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
@@ -36,20 +37,22 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
             _asyncLoader = new AsyncLoader();
 
-            // set tab page images
+            tabControl1.ImageList = new ImageList
             {
-                var imageList = new ImageList();
-                tabControl1.ImageList = imageList;
-                imageList.ColorDepth = ColorDepth.Depth8Bit;
-                imageList.Images.Add(Properties.Resources.IconCommit);
-                imageList.Images.Add(Properties.Resources.IconViewFile);
-                imageList.Images.Add(Properties.Resources.IconDiff);
-                imageList.Images.Add(Properties.Resources.IconBlame);
-                tabControl1.TabPages[0].ImageIndex = 0;
-                tabControl1.TabPages[1].ImageIndex = 1;
-                tabControl1.TabPages[2].ImageIndex = 2;
-                tabControl1.TabPages[3].ImageIndex = 3;
-            }
+                ColorDepth = ColorDepth.Depth8Bit,
+                ImageSize = DpiUtil.Scale(new Size(16, 16)),
+                Images =
+                {
+                    Properties.Resources.IconCommit,
+                    Properties.Resources.IconViewFile,
+                    Properties.Resources.IconDiff,
+                    Properties.Resources.IconBlame
+                }
+            };
+            tabControl1.TabPages[0].ImageIndex = 0;
+            tabControl1.TabPages[1].ImageIndex = 1;
+            tabControl1.TabPages[2].ImageIndex = 2;
+            tabControl1.TabPages[3].ImageIndex = 3;
 
             _filterBranchHelper = new FilterBranchHelper(toolStripBranchFilterComboBox, toolStripBranchFilterDropDownButton, FileChanges);
             _filterRevisionsHelper = new FilterRevisionsHelper(toolStripRevisionFilterTextBox, toolStripRevisionFilterDropDownButton, FileChanges, toolStripRevisionFilterLabel, ShowFirstParent, form: this);
@@ -63,6 +66,8 @@ namespace GitUI.CommandsDialogs
             _commitDataManager = new CommitDataManager(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _longShaProvider = new LongShaProvider(() => Module);
+
+            this.AdjustForDpiScaling();
         }
 
         public FormFileHistory(GitUICommands commands, string fileName, GitRevision revision = null, bool filterByRevision = false)

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -156,10 +156,7 @@
             this.TabControlTagBranch.Controls.Add(this.BranchTab);
             this.TabControlTagBranch.Controls.Add(this.TagTab);
             this.TabControlTagBranch.Controls.Add(this.MultipleBranchTab);
-            this.TabControlTagBranch.HotTrack = true;
-            this.TabControlTagBranch.ItemSize = new System.Drawing.Size(57, 18);
             this.TabControlTagBranch.Location = new System.Drawing.Point(12, 98);
-            this.TabControlTagBranch.Multiline = true;
             this.TabControlTagBranch.Name = "TabControlTagBranch";
             this.TabControlTagBranch.SelectedIndex = 0;
             this.TabControlTagBranch.ShowToolTips = true;

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -465,7 +465,6 @@
             this.NewColumn.HeaderText = "New at Remote";
             this.NewColumn.Name = "NewColumn";
             this.NewColumn.ReadOnly = true;
-            this.NewColumn.Width = 97;
             // 
             // PushColumn
             // 
@@ -473,7 +472,6 @@
             this.PushColumn.DataPropertyName = "Push";
             this.PushColumn.HeaderText = "Push";
             this.PushColumn.Name = "PushColumn";
-            this.PushColumn.Width = 36;
             // 
             // ForceColumn
             // 
@@ -481,7 +479,6 @@
             this.ForceColumn.DataPropertyName = "Force";
             this.ForceColumn.HeaderText = "Push (Force Rewind)";
             this.ForceColumn.Name = "ForceColumn";
-            this.ForceColumn.Width = 101;
             // 
             // DeleteColumn
             // 
@@ -489,7 +486,6 @@
             this.DeleteColumn.DataPropertyName = "Delete";
             this.DeleteColumn.HeaderText = "Delete Remote Branch";
             this.DeleteColumn.Name = "DeleteColumn";
-            this.DeleteColumn.Width = 108;
             // 
             // LoadSSHKey
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -111,6 +111,8 @@ namespace GitUI.CommandsDialogs
                 _remoteManager = new GitRemoteManager(() => Module);
                 Init();
             }
+
+            this.AdjustForDpiScaling();
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -83,6 +83,12 @@ namespace GitUI.CommandsDialogs
             : base(commands)
         {
             InitializeComponent();
+
+            NewColumn.Width = DpiUtil.Scale(97);
+            PushColumn.Width = DpiUtil.Scale(36);
+            ForceColumn.Width = DpiUtil.Scale(101);
+            DeleteColumn.Width = DpiUtil.Scale(108);
+
             Translate();
 
             if (!GitCommandHelpers.VersionInUse.SupportPushForceWithLease)

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -506,7 +506,6 @@ namespace GitUI.CommandsDialogs
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl1.ItemSize = new System.Drawing.Size(117, 24);
             this.tabControl1.Location = new System.Drawing.Point(0, 0);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -98,6 +98,8 @@ Inactive remote is completely invisible to git.");
             Remotes.Groups.AddRange(new[] { _lvgEnabled, _lvgDisabled });
 
             Application.Idle += application_Idle;
+
+            this.AdjustForDpiScaling();
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -122,6 +122,8 @@ namespace GitUI.CommandsDialogs
 
             settingsTreeView.GotoPage(initalPage);
             settingsTreeView.ResumeLayout();
+
+            this.AdjustForDpiScaling();
         }
 
         public static DialogResult ShowSettingsDialog(GitUICommands uiCommands, IWin32Window owner, SettingsPageReference initalPage = null)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -38,6 +38,7 @@ namespace GitUI.CommandsDialogs
             Loading.Image = Properties.Resources.loadingpanel;
             Translate();
             View.ExtraDiffArgumentsChanged += ViewExtraDiffArgumentsChanged;
+            this.AdjustForDpiScaling();
         }
 
         private void ViewExtraDiffArgumentsChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -286,7 +286,6 @@
             this.columnIsLostObjectSelected.HeaderText = "";
             this.columnIsLostObjectSelected.MinimumWidth = 20;
             this.columnIsLostObjectSelected.Name = "columnIsLostObjectSelected";
-            this.columnIsLostObjectSelected.Width = 20;
             // 
             // columnDate
             // 
@@ -295,7 +294,6 @@
             this.columnDate.HeaderText = "Date";
             this.columnDate.Name = "columnDate";
             this.columnDate.ReadOnly = true;
-            this.columnDate.Width = 56;
             // 
             // columnType
             // 
@@ -304,7 +302,6 @@
             this.columnType.HeaderText = "Type";
             this.columnType.Name = "columnType";
             this.columnType.ReadOnly = true;
-            this.columnType.Width = 58;
             // 
             // columnSubject
             // 
@@ -323,7 +320,6 @@
             this.columnAuthor.HeaderText = "Author";
             this.columnAuthor.Name = "columnAuthor";
             this.columnAuthor.ReadOnly = true;
-            this.columnAuthor.Width = 150;
             // 
             // columnHash
             // 
@@ -331,7 +327,6 @@
             this.columnHash.HeaderText = "Hash";
             this.columnHash.Name = "columnHash";
             this.columnHash.ReadOnly = true;
-            this.columnHash.Width = 80;
             // 
             // FormVerify
             // 

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -39,6 +39,13 @@ namespace GitUI.CommandsDialogs
             : base(commands)
         {
             InitializeComponent();
+
+            columnIsLostObjectSelected.Width = DpiUtil.Scale(20);
+            columnDate.Width = DpiUtil.Scale(56);
+            columnType.Width = DpiUtil.Scale(58);
+            columnAuthor.Width = DpiUtil.Scale(150);
+            columnHash.Width = DpiUtil.Scale(80);
+
             _selectedItemsHeader.AttachTo(columnIsLostObjectSelected);
 
             Translate();

--- a/GitUI/CommandsDialogs/FormViewPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.Designer.cs
@@ -112,7 +112,6 @@ namespace GitUI.CommandsDialogs
             this.typeDataGridViewTextBoxColumn.HeaderText = "Change";
             this.typeDataGridViewTextBoxColumn.Name = "typeDataGridViewTextBoxColumn";
             this.typeDataGridViewTextBoxColumn.ReadOnly = true;
-            this.typeDataGridViewTextBoxColumn.Width = 70;
             // 
             // File
             // 
@@ -120,7 +119,6 @@ namespace GitUI.CommandsDialogs
             this.File.HeaderText = "Type";
             this.File.Name = "File";
             this.File.ReadOnly = true;
-            this.File.Width = 50;
             // 
             // patchBindingSource
             // 

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -19,6 +19,10 @@ namespace GitUI.CommandsDialogs
             : base(commands)
         {
             InitializeComponent();
+
+            typeDataGridViewTextBoxColumn.Width = DpiUtil.Scale(70);
+            File.Width = DpiUtil.Scale(50);
+
             Translate();
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -43,6 +43,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _gitHoster = gitHoster;
             InitializeComponent();
             Translate();
+            this.AdjustForDpiScaling();
         }
 
         private void ForkAndCloneForm_Load(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -44,6 +44,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     MessageBox.Show(this, ex.Exception.ToString(), _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     this.UnMask();
                 };
+            this.AdjustForDpiScaling();
         }
 
         public ViewPullRequestsForm(GitUICommands commands, IRepositoryHostPlugin gitHoster)

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -222,11 +222,15 @@ See the changes in the commit form.");
 
             tvGitTree.ImageList = new ImageList(components)
             {
-                ColorDepth = ColorDepth.Depth32Bit
+                ColorDepth = ColorDepth.Depth32Bit,
+                ImageSize = DpiUtil.Scale(new Size(16, 16)), // Scale ImageSize and images scale automatically
+                Images =
+                {
+                    Properties.Resources.New, // File
+                    Properties.Resources.Folder, // Folder
+                    Properties.Resources.IconFolderSubmodule // Submodule
+                }
             };
-            tvGitTree.ImageList.Images.Add(Properties.Resources.New); // File
-            tvGitTree.ImageList.Images.Add(Properties.Resources.Folder); // Folder
-            tvGitTree.ImageList.Images.Add(Properties.Resources.IconFolderSubmodule); // Submodule
 
             GotFocus += (s, e1) => tvGitTree.Focus();
 

--- a/GitUI/CommandsDialogs/RevisionGpgInfo.cs
+++ b/GitUI/CommandsDialogs/RevisionGpgInfo.cs
@@ -16,6 +16,7 @@ namespace GitUI.CommandsDialogs
             Translate();
 
             DisplayGpgInfo(null);
+            this.AdjustForDpiScaling();
         }
 
         public void DisplayGpgInfo(GpgInfo info)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -211,28 +211,39 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void ShowIconPreview()
         {
-            Icon icon;
             switch (IconStyle.SelectedIndex)
             {
                 case 0:
-                    IconPreview.Image = new Icon(GitExtensionsForm.GetApplicationIcon("Large", GetSelectedApplicationIconColor()), 32, 32).ToBitmap();
-                    IconPreviewSmall.Image = new Icon(GitExtensionsForm.GetApplicationIcon("Small", GetSelectedApplicationIconColor()), 16, 16).ToBitmap();
+                    IconPreview.Image = GetIcon("Large", 32);
+                    IconPreviewSmall.Image = GetIcon("Small", 16);
                     break;
                 case 1:
-                    icon = GitExtensionsForm.GetApplicationIcon("Small", GetSelectedApplicationIconColor());
-                    IconPreview.Image = new Icon(icon, 32, 32).ToBitmap();
-                    IconPreviewSmall.Image = new Icon(icon, 16, 16).ToBitmap();
+                    IconPreview.Image = GetIcon("Small", 32);
+                    IconPreviewSmall.Image = GetIcon("Small", 16);
                     break;
                 case 2:
-                    icon = GitExtensionsForm.GetApplicationIcon("Large", GetSelectedApplicationIconColor());
-                    IconPreview.Image = new Icon(icon, 32, 32).ToBitmap();
-                    IconPreviewSmall.Image = new Icon(icon, 16, 16).ToBitmap();
+                    IconPreview.Image = GetIcon("Large", 32);
+                    IconPreviewSmall.Image = GetIcon("Large", 16);
                     break;
                 case 3:
-                    icon = GitExtensionsForm.GetApplicationIcon("Cow", GetSelectedApplicationIconColor());
-                    IconPreview.Image = new Icon(icon, 32, 32).ToBitmap();
-                    IconPreviewSmall.Image = new Icon(icon, 16, 16).ToBitmap();
+                    IconPreview.Image = GetIcon("Cow", 32);
+                    IconPreviewSmall.Image = GetIcon("Cow", 16);
                     break;
+            }
+
+            Image GetIcon(string name, int size)
+            {
+                var icon = GitExtensionsForm.GetApplicationIcon(name, GetSelectedApplicationIconColor());
+
+                var targetWidth = (int)(DpiUtil.ScaleX * size);
+                var targetHeight = (int)(DpiUtil.ScaleY * size);
+
+                if (icon.Width != targetWidth && icon.Height != targetHeight)
+                {
+                    icon = new Icon(icon, targetWidth, targetHeight);
+                }
+
+                return icon.ToBitmap();
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -204,7 +204,6 @@
             this.CaptionCol.DataPropertyName = "Caption";
             this.CaptionCol.HeaderText = "Caption";
             this.CaptionCol.Name = "CaptionCol";
-            this.CaptionCol.Width = 150;
             // 
             // URICol
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -69,7 +69,6 @@
             this._NO_TRANSLATE_Name = new System.Windows.Forms.TextBox();
             this.EnabledChx = new System.Windows.Forms.CheckBox();
             this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -619,13 +618,6 @@
             this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 21);
             this.gotoUserManualControl1.TabIndex = 26;
             // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Title";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Title";
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.Width = 150;
-            // 
             // RevisionLinksSettingsPage
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -677,7 +669,6 @@
         private System.Windows.Forms.Label CategoriesLabel;
         private System.Windows.Forms.Panel detailPanel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.DataGridViewTextBoxColumn CaptionCol;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -10,7 +10,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public RevisionLinksSettingsPage()
         {
             InitializeComponent();
-            Text = @"Revision links";
+            CaptionCol.Width = DpiUtil.Scale(150);
+            Text = "Revision links";
             Translate();
             LinksGrid.AutoGenerateColumns = false;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -123,7 +123,6 @@
             this.HotkeyCommandIdentifier.HeaderText = "#";
             this.HotkeyCommandIdentifier.Name = "HotkeyCommandIdentifier";
             this.HotkeyCommandIdentifier.ReadOnly = true;
-            this.HotkeyCommandIdentifier.Width = 39;
             // 
             // EnabledColumn
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -58,6 +58,7 @@ Current Branch:
         public ScriptsSettingsPage()
         {
             InitializeComponent();
+            HotkeyCommandIdentifier.Width = DpiUtil.Scale(39);
             Text = "Scripts";
             Translate();
         }

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
@@ -99,7 +99,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Path.Name = "Path";
             this.Path.ReadOnly = true;
             this.Path.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.Path.Width = 35;
             // 
             // Type
             // 
@@ -109,7 +108,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Type.Name = "Type";
             this.Type.ReadOnly = true;
             this.Type.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.Type.Width = 37;
             // 
             // Branch
             // 
@@ -119,7 +117,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Branch.Name = "Branch";
             this.Branch.ReadOnly = true;
             this.Branch.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.Branch.Width = 46;
             // 
             // Sha1
             // 
@@ -129,7 +126,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Sha1.Name = "Sha1";
             this.Sha1.ReadOnly = true;
             this.Sha1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.Sha1.Width = 37;
             // 
             // IsDeleted
             // 
@@ -139,7 +135,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.IsDeleted.Name = "IsDeleted";
             this.IsDeleted.ReadOnly = true;
             this.IsDeleted.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.IsDeleted.Width = 50;
             // 
             // Open
             // 
@@ -149,7 +144,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Open.Name = "Open";
             this.Open.ReadOnly = true;
             this.Open.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.Open.Width = 39;
             // 
             // Delete
             // 
@@ -161,7 +155,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Delete.Name = "Delete";
             this.Delete.ReadOnly = true;
             this.Delete.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.Delete.Width = 44;
             // 
             // buttonClose
             // 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -15,6 +15,13 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             : base(commands)
         {
             InitializeComponent();
+            Path.Width = DpiUtil.Scale(35);
+            Type.Width = DpiUtil.Scale(37);
+            Branch.Width = DpiUtil.Scale(46);
+            Sha1.Width = DpiUtil.Scale(37);
+            IsDeleted.Width = DpiUtil.Scale(50);
+            Open.Width = DpiUtil.Scale(39);
+            Delete.Width = DpiUtil.Scale(44);
             Worktrees.AutoGenerateColumns = false;
             Translate();
         }

--- a/GitUI/DpiUtil.cs
+++ b/GitUI/DpiUtil.cs
@@ -69,6 +69,16 @@ namespace GitUI
             size.Height = (int)(size.Height * ScaleY);
         }
 
+        /// <summary>
+        /// Returns a scaled copy of measurement <paramref name="i"/> which has
+        /// equivalent length on screen at the current DPI at the original would
+        /// at 96 DPI.
+        /// </summary>
+        public static int Scale(int i)
+        {
+            return (int)Math.Round(i * ScaleX);
+        }
+
         [DllImport("gdi32.dll")]
         private static extern int GetDeviceCaps(DeviceContextSafeHandle hdc, int index);
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -561,6 +561,7 @@ namespace GitUI.Editor
                                 ResetForImage();
                                 if (image != null)
                                 {
+                                    // TODO review whether we need DPI scaling here
                                     if (image.Size.Height > PictureBox.Size.Height ||
                                         image.Size.Width > PictureBox.Size.Width)
                                     {

--- a/GitUI/FormPuttyError.cs
+++ b/GitUI/FormPuttyError.cs
@@ -25,6 +25,7 @@ namespace GitUI
         {
             InitializeComponent();
             Translate();
+            this.AdjustForDpiScaling();
         }
 
         private void LoadSSHKey_Click(object sender, EventArgs e)

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -43,6 +43,8 @@ namespace GitUI
             {
                 KeepDialogOpen.Hide();
             }
+
+            this.AdjustForDpiScaling();
         }
 
         public FormStatus(Action<FormStatus> process, Action<FormStatus> abort)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -373,7 +373,6 @@
     <Compile Include="UserControls\ConsoleOutputControl.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="DpiUtil.cs" />
     <Compile Include="UserControls\EditboxBasedConsoleOutputControl.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -187,7 +187,7 @@ namespace GitUI
         {
             public MaskPanel()
             {
-                Image = Properties.Resources.loadingpanel;
+                Image = DpiUtil.Scale(Properties.Resources.loadingpanel);
                 SizeMode = PictureBoxSizeMode.CenterImage;
                 BackColor = SystemColors.AppWorkspace;
             }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -52,24 +52,31 @@ namespace GitUI
             SelectFirstItemOnSetItems = true;
             FileStatusListView.MouseMove += FileStatusListView_MouseMove;
             FileStatusListView.MouseDown += FileStatusListView_MouseDown;
+
             if (_images == null)
             {
-                _images = new ImageList();
-                _images.Images.Add(Resources.Removed); // 0
-                _images.Images.Add(Resources.Added); // 1
-                _images.Images.Add(Resources.Modified); // 2
-                _images.Images.Add(Resources.Renamed); // 3
-                _images.Images.Add(Resources.Copied); // 4
-                _images.Images.Add(Resources.IconSubmoduleDirty); // 5
-                _images.Images.Add(Resources.IconSubmoduleRevisionUp); // 6
-                _images.Images.Add(Resources.IconSubmoduleRevisionUpDirty); // 7
-                _images.Images.Add(Resources.IconSubmoduleRevisionDown); // 8
-                _images.Images.Add(Resources.IconSubmoduleRevisionDownDirty); // 9
-                _images.Images.Add(Resources.IconSubmoduleRevisionSemiUp); // 10
-                _images.Images.Add(Resources.IconSubmoduleRevisionSemiUpDirty); // 11
-                _images.Images.Add(Resources.IconSubmoduleRevisionSemiDown); // 12
-                _images.Images.Add(Resources.IconSubmoduleRevisionSemiDownDirty); // 13
-                _images.Images.Add(Resources.IconFileStatusUnknown); // 14
+                _images = new ImageList
+                {
+                    ImageSize = DpiUtil.Scale(new Size(16, 16)), // Scale ImageSize and images scale automatically
+                    Images =
+                    {
+                        Resources.Removed, // 0
+                        Resources.Added, // 1
+                        Resources.Modified, // 2
+                        Resources.Renamed, // 3
+                        Resources.Copied, // 4
+                        Resources.IconSubmoduleDirty, // 5
+                        Resources.IconSubmoduleRevisionUp, // 6
+                        Resources.IconSubmoduleRevisionUpDirty, // 7
+                        Resources.IconSubmoduleRevisionDown, // 8
+                        Resources.IconSubmoduleRevisionDownDirty, // 9
+                        Resources.IconSubmoduleRevisionSemiUp, // 10
+                        Resources.IconSubmoduleRevisionSemiUpDirty, // 11
+                        Resources.IconSubmoduleRevisionSemiDown, // 12
+                        Resources.IconSubmoduleRevisionSemiDownDirty, // 13
+                        Resources.IconFileStatusUnknown // 14
+                    }
+                };
             }
 
             FileStatusListView.SmallImageList = _images;

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -64,7 +64,6 @@
             this.Patches.Size = new System.Drawing.Size(675, 406);
             this.Patches.TabIndex = 0;
             this.Patches.DoubleClick += new System.EventHandler(this.Patches_DoubleClick);
-            this.Patches.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(dataGridView1_CellContentClick);
             // 
             // patchFileBindingSource
             // 

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -77,7 +77,6 @@
             this.FileName.HeaderText = "Name";
             this.FileName.Name = "FileName";
             this.FileName.ReadOnly = true;
-            this.FileName.Width = 50;
             // 
             // subjectDataGridViewTextBoxColumn
             // 
@@ -93,7 +92,6 @@
             this.authorDataGridViewTextBoxColumn.HeaderText = "Author";
             this.authorDataGridViewTextBoxColumn.Name = "authorDataGridViewTextBoxColumn";
             this.authorDataGridViewTextBoxColumn.ReadOnly = true;
-            this.authorDataGridViewTextBoxColumn.Width = 140;
             // 
             // dateDataGridViewTextBoxColumn
             // 
@@ -102,7 +100,6 @@
             this.dateDataGridViewTextBoxColumn.HeaderText = "Date";
             this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
             this.dateDataGridViewTextBoxColumn.ReadOnly = true;
-            this.dateDataGridViewTextBoxColumn.Width = 160;
             // 
             // Status
             // 
@@ -111,7 +108,6 @@
             this.Status.HeaderText = "Status";
             this.Status.Name = "Status";
             this.Status.ReadOnly = true;
-            this.Status.Width = 80;
             // 
             // PatchGrid
             // 

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -16,6 +16,10 @@ namespace GitUI
             InitializeComponent();
             Translate();
             Patches.CellPainting += Patches_CellPainting;
+            FileName.Width = DpiUtil.Scale(50);
+            authorDataGridViewTextBoxColumn.Width = DpiUtil.Scale(140);
+            dateDataGridViewTextBoxColumn.Width = DpiUtil.Scale(160);
+            Status.Width = DpiUtil.Scale(80);
         }
 
         private static void Patches_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -15,19 +15,11 @@ namespace GitUI
         {
             InitializeComponent();
             Translate();
-            Patches.CellPainting += Patches_CellPainting;
+
             FileName.Width = DpiUtil.Scale(50);
             authorDataGridViewTextBoxColumn.Width = DpiUtil.Scale(140);
             dateDataGridViewTextBoxColumn.Width = DpiUtil.Scale(160);
             Status.Width = DpiUtil.Scale(80);
-        }
-
-        private static void Patches_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
-        {
-        }
-
-        private static void dataGridView1_CellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
         }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -230,7 +230,6 @@ namespace GitUI
             this.GraphDataGridViewColumn.Name = "Graph";
             this.GraphDataGridViewColumn.ReadOnly = true;
             this.GraphDataGridViewColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.GraphDataGridViewColumn.Width = 70;
             // 
             // Message
             // 
@@ -255,7 +254,6 @@ namespace GitUI
             this.AuthorDataGridViewColumn.Name = "Author";
             this.AuthorDataGridViewColumn.ReadOnly = true;
             this.AuthorDataGridViewColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.AuthorDataGridViewColumn.Width = 150;
             // 
             // Date
             // 
@@ -263,7 +261,6 @@ namespace GitUI
             this.DateDataGridViewColumn.Name = "Date";
             this.DateDataGridViewColumn.ReadOnly = true;
             this.DateDataGridViewColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.DateDataGridViewColumn.Width = 135;
             //
             // Id
             //

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -131,9 +131,6 @@ namespace GitUI
             this.showMergeCommitsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.runScriptToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openBuildReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.SelectionTimer = new System.Windows.Forms.Timer(this.components);
             this.NoCommits = new System.Windows.Forms.Panel();
             this.NoGit = new System.Windows.Forms.Panel();
@@ -644,33 +641,6 @@ namespace GitUI
             this.showMergeCommitsToolStripMenuItem.Name = "showMergeCommitsToolStripMenuItem";
             this.showMergeCommitsToolStripMenuItem.Size = new System.Drawing.Size(32, 19);
             // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.Frozen = true;
-            this.dataGridViewTextBoxColumn3.HeaderText = "";
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.dataGridViewTextBoxColumn3.Width = 70;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.Frozen = true;
-            this.dataGridViewTextBoxColumn2.HeaderText = "";
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.dataGridViewTextBoxColumn2.Width = 70;
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.Frozen = true;
-            this.dataGridViewTextBoxColumn1.HeaderText = "";
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.dataGridViewTextBoxColumn1.Width = 70;
-            // 
             // SelectionTimer
             // 
             this.SelectionTimer.Interval = 200;
@@ -882,9 +852,7 @@ namespace GitUI
         private System.Windows.Forms.ToolStripMenuItem rebaseOnToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem rebaseToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem rebaseInteractivelyToolStripMenuItem;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.ToolStripMenuItem copyToClipboardToolStripMenuItem;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
         private System.Windows.Forms.ToolStripMenuItem branchNameCopyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem tagNameCopyToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem messageCopyToolStripMenuItem;
@@ -896,7 +864,6 @@ namespace GitUI
         private System.Windows.Forms.ToolStripMenuItem markRevisionAsGoodToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem stopBisectToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator bisectSeparator;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn3;
         private System.Windows.Forms.ToolStripMenuItem runScriptToolStripMenuItem;
         private System.Windows.Forms.Button InitRepository;
         private System.Windows.Forms.Button CloneRepository;

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -185,9 +185,13 @@ namespace GitUI
             Revisions.ColumnHeadersVisible = false;
             Revisions.IdColumn.Visible = AppSettings.ShowIds;
 
-            IsMessageMultilineDataGridViewColumn.Width = 25;
+            IsMessageMultilineDataGridViewColumn.Width = DpiUtil.Scale(25);
             IsMessageMultilineDataGridViewColumn.DisplayIndex = 2;
             IsMessageMultilineDataGridViewColumn.Resizable = DataGridViewTriState.False;
+
+            GraphDataGridViewColumn.Width = DpiUtil.Scale(70);
+            AuthorDataGridViewColumn.Width = DpiUtil.Scale(150);
+            DateDataGridViewColumn.Width = DpiUtil.Scale(135);
 
             HotkeysEnabled = true;
             try

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -52,9 +52,9 @@ namespace GitUI.RevisionGridClasses
 
         #endregion
 
-        private int _nodeDimension = 10;
-        private int _laneWidth = 13;
-        private int _laneLineWidth = 2;
+        private int _nodeDimension = DpiUtil.Scale(10);
+        private int _laneWidth = DpiUtil.Scale(13);
+        private int _laneLineWidth = DpiUtil.Scale(2);
         private const int MaxLanes = 40;
 
         private Pen _whiteBorderPen;
@@ -99,9 +99,9 @@ namespace GitUI.RevisionGridClasses
         public void SetDimensions(int nodeDimension, int laneWidth, int laneLineWidth, int rowHeight)
         {
             RowTemplate.Height = rowHeight;
-            _nodeDimension = nodeDimension;
-            _laneWidth = laneWidth;
-            _laneLineWidth = laneLineWidth;
+            _nodeDimension = DpiUtil.Scale(nodeDimension);
+            _laneWidth = DpiUtil.Scale(laneWidth);
+            _laneLineWidth = DpiUtil.Scale(laneLineWidth);
 
             dataGrid_Resize(null, null);
         }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -48,6 +47,8 @@ namespace Bitbucket
             lblLinkViewPull.Text = string.Format("{0}/projects/{1}/repos/{2}/pull-requests",
                 _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
             toolTipLink.SetToolTip(lblLinkViewPull, _linkLabelToolTip.Text);
+
+            this.AdjustForDpiScaling();
         }
 
         private void BitbucketPullRequestFormLoad(object sender, EventArgs e)

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
@@ -79,6 +79,10 @@
       <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
       <Name>GitExtUtils</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitUI\GitUI.csproj">
+      <Project>{CF5B22E7-230F-4E50-BE88-C4F7023CED2C}</Project>
+      <Name>GitUI</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{d3440fd7-afc5-4351-8741-6cdbf15ce944}</Project>
       <Name>ResourceManager</Name>

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
@@ -139,7 +139,6 @@
             this.deleteDataGridViewCheckBoxColumn.FillWeight = 20F;
             this.deleteDataGridViewCheckBoxColumn.HeaderText = "Delete";
             this.deleteDataGridViewCheckBoxColumn.Name = "deleteDataGridViewCheckBoxColumn";
-            this.deleteDataGridViewCheckBoxColumn.Width = 50;
             // 
             // nameDataGridViewTextBoxColumn
             // 
@@ -161,7 +160,6 @@
             this.dateDataGridViewTextBoxColumn.HeaderText = "Last activity";
             this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
             this.dateDataGridViewTextBoxColumn.ReadOnly = true;
-            this.dateDataGridViewTextBoxColumn.Width = 175;
             // 
             // Author
             // 
@@ -173,7 +171,6 @@
             this.Author.HeaderText = "Last author";
             this.Author.Name = "Author";
             this.Author.ReadOnly = true;
-            this.Author.Width = 91;
             // 
             // Message
             // 

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -35,8 +35,13 @@ namespace DeleteUnusedBranches
         private readonly IGitPlugin _gitPlugin;
         private CancellationTokenSource _refreshCancellation;
 
-        public DeleteUnusedBranchesForm()
+        public DeleteUnusedBranchesForm(DeleteUnusedBranchesFormSettings settings, IGitModule gitCommands, IGitUICommands gitUiCommands, IGitPlugin gitPlugin)
         {
+            _settings = settings;
+            _gitCommands = gitCommands;
+            _gitUiCommands = gitUiCommands;
+            _gitPlugin = gitPlugin;
+
             InitializeComponent();
 
             deleteDataGridViewCheckBoxColumn.Width = DpiUtil.Scale(50);
@@ -44,16 +49,10 @@ namespace DeleteUnusedBranches
             Author.Width = DpiUtil.Scale(91);
 
             Translate();
-        }
-
-        public DeleteUnusedBranchesForm(DeleteUnusedBranchesFormSettings settings, IGitModule gitCommands, IGitUICommands gitUiCommands, IGitPlugin gitPlugin)
-            : this()
-        {
-            _settings = settings;
-            _gitCommands = gitCommands;
-            _gitUiCommands = gitUiCommands;
-            _gitPlugin = gitPlugin;
             imgLoading.Image = Resources.loadingpanel;
+
+            this.AdjustForDpiScaling();
+
             ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
         }
 

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -38,6 +38,11 @@ namespace DeleteUnusedBranches
         public DeleteUnusedBranchesForm()
         {
             InitializeComponent();
+
+            deleteDataGridViewCheckBoxColumn.Width = DpiUtil.Scale(50);
+            dateDataGridViewTextBoxColumn.Width = DpiUtil.Scale(175);
+            Author.Width = DpiUtil.Scale(91);
+
             Translate();
         }
 

--- a/Plugins/FindLargeFiles/FindLargeFiles.csproj
+++ b/Plugins/FindLargeFiles/FindLargeFiles.csproj
@@ -73,6 +73,10 @@
       <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
       <Name>GitExtUtils</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitUI\GitUI.csproj">
+      <Project>{CF5B22E7-230F-4E50-BE88-C4F7023CED2C}</Project>
+      <Name>GitUI</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{d3440fd7-afc5-4351-8741-6cdbf15ce944}</Project>
       <Name>ResourceManager</Name>

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.Designer.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.Designer.cs
@@ -83,7 +83,6 @@
             this.sHADataGridViewTextBoxColumn.HeaderText = "SHA";
             this.sHADataGridViewTextBoxColumn.Name = "sHADataGridViewTextBoxColumn";
             this.sHADataGridViewTextBoxColumn.ReadOnly = true;
-            this.sHADataGridViewTextBoxColumn.Width = 54;
             // 
             // pathDataGridViewTextBoxColumn
             // 
@@ -100,7 +99,6 @@
             this.sizeDataGridViewTextBoxColumn.HeaderText = "Size";
             this.sizeDataGridViewTextBoxColumn.Name = "sizeDataGridViewTextBoxColumn";
             this.sizeDataGridViewTextBoxColumn.ReadOnly = true;
-            this.sizeDataGridViewTextBoxColumn.Width = 52;
             // 
             // CompressedSize
             // 
@@ -116,7 +114,6 @@
             this.commitCountDataGridViewTextBoxColumn.HeaderText = "Commit count";
             this.commitCountDataGridViewTextBoxColumn.Name = "commitCountDataGridViewTextBoxColumn";
             this.commitCountDataGridViewTextBoxColumn.ReadOnly = true;
-            this.commitCountDataGridViewTextBoxColumn.Width = 88;
             // 
             // lastCommitDateDataGridViewTextBoxColumn
             // 
@@ -125,7 +122,6 @@
             this.lastCommitDateDataGridViewTextBoxColumn.HeaderText = "Last commit date";
             this.lastCommitDateDataGridViewTextBoxColumn.Name = "lastCommitDateDataGridViewTextBoxColumn";
             this.lastCommitDateDataGridViewTextBoxColumn.ReadOnly = true;
-            this.lastCommitDateDataGridViewTextBoxColumn.Width = 103;
             // 
             // dataGridViewCheckBoxColumn1
             // 

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -26,6 +26,12 @@ namespace FindLargeFiles
         public FindLargeFilesForm(float threshold, GitUIBaseEventArgs gitUiEventArgs)
         {
             InitializeComponent();
+
+            sHADataGridViewTextBoxColumn.Width = DpiUtil.Scale(54);
+            sizeDataGridViewTextBoxColumn.Width = DpiUtil.Scale(52);
+            commitCountDataGridViewTextBoxColumn.Width = DpiUtil.Scale(88);
+            lastCommitDateDataGridViewTextBoxColumn.Width = DpiUtil.Scale(103);
+
             Translate();
 
             _threshold = threshold;

--- a/Plugins/GitFlow/GitFlow.csproj
+++ b/Plugins/GitFlow/GitFlow.csproj
@@ -77,6 +77,10 @@
       <Name>GitCommands</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
       <Project>{27559302-F35E-4B62-A6EC-11FF21A5FA6F}</Project>
       <Name>GitUIPluginInterfaces</Name>

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GitCommands;
 using GitFlow.Properties;
+using GitUI;
 using GitUIPluginInterfaces;
 using ResourceManager;
 
@@ -249,7 +250,7 @@ namespace GitFlow
 
         private bool RunCommand(string commandText)
         {
-            pbResultCommand.Image = Resource.StatusHourglass;
+            pbResultCommand.Image = DpiUtil.Scale(Resource.StatusHourglass);
             ShowToolTip(pbResultCommand, "running command : git " + commandText);
             ForceRefresh(pbResultCommand);
             lblRunCommand.Text = "git " + commandText;
@@ -267,14 +268,14 @@ namespace GitFlow
             var resultText = Regex.Replace(result.GetString(), @"\r\n?|\n", Environment.NewLine);
             if (result.ExitCode == 0)
             {
-                pbResultCommand.Image = Resource.success;
+                pbResultCommand.Image = DpiUtil.Scale(Resource.success);
                 ShowToolTip(pbResultCommand, resultText);
                 DisplayHead();
                 txtResult.Text = resultText;
             }
             else
             {
-                pbResultCommand.Image = Resource.error;
+                pbResultCommand.Image = DpiUtil.Scale(Resource.error);
                 ShowToolTip(pbResultCommand, "error: " + resultText);
                 txtResult.Text = resultText;
             }

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -69,6 +69,8 @@ namespace GitStatistics
             TotalLinesOfTestCode.Font = TotalLinesOfCode.Font;
             TotalCommits.Font = TotalLinesOfCode.Font;
             LoadingLabel.Font = TotalLinesOfCode.Font;
+
+            this.AdjustForDpiScaling();
         }
 
         private void FormGitStatisticsSizeChanged(object sender, EventArgs e)


### PR DESCRIPTION
Relates to #4775.

Changes proposed in this pull request:
- Explicitly scale `DataGridViewColumn.Width` for high DPI support
- Fix button icon sizes on `FormCommit`
- Fix list item icon sizes on `FileStatusList`
- Remove some unused code

What did I do to test the code and ensure quality:
- Lots of manual testing at different scaling factors.

Has been tested on:
 - Windows 10

---

## Screenshots (before / after)

### Revision grid

- Fixes sizing of nodes in graph.
- Fixes width of columns in grid. Especially noticeable for multi-line indicator and date/time.

Before

![image](https://user-images.githubusercontent.com/350947/38310903-a2b095bc-3815-11e8-813d-322947841ba6.png)

After

![image](https://user-images.githubusercontent.com/350947/38310920-ae63212c-3815-11e8-94ad-4088c18410a9.png)

---

### File Tree

Before

![image](https://user-images.githubusercontent.com/350947/38341815-6c5394ee-3872-11e8-94e0-12df3f88ee57.png)

After 

![image](https://user-images.githubusercontent.com/350947/38341825-784d2a8a-3872-11e8-8674-ebbb731e3ec5.png)


---

### FormCommit

Before

![image](https://user-images.githubusercontent.com/350947/38341730-f00850be-3871-11e8-8cb9-9f6dcd0f3382.png)

After

![image](https://user-images.githubusercontent.com/350947/38341715-df956b36-3871-11e8-973c-c132b1ac4cf9.png)

---

### Patch form

Before

![image](https://user-images.githubusercontent.com/350947/38311038-0127c99e-3816-11e8-8709-3b49a67163bc.png)

After

![image](https://user-images.githubusercontent.com/350947/38311052-105cd9c2-3816-11e8-9dfd-ad95cea9b269.png)

---

### Dashboard settings

Before

![image](https://user-images.githubusercontent.com/350947/38311085-2ef9d59c-3816-11e8-9966-c7555a9db95a.png)

After

![image](https://user-images.githubusercontent.com/350947/38311096-3ce853e0-3816-11e8-9e05-766dd0771615.png)

---

### Revision links

Before

![image](https://user-images.githubusercontent.com/350947/38311832-02e8ead6-3818-11e8-80aa-06e5c9939b63.png)

After

![image](https://user-images.githubusercontent.com/350947/38311845-0cbc9256-3818-11e8-8a76-ed2f4ba1400e.png)


---

### Verify form

Before

![image](https://user-images.githubusercontent.com/350947/38311584-720a59dc-3817-11e8-8f39-7aeecef18402.png)

After

![image](https://user-images.githubusercontent.com/350947/38311621-8d6aa164-3817-11e8-8e0f-8622ba43ceb9.png)

---

### View patch

Before

![image](https://user-images.githubusercontent.com/350947/38311301-bed201b2-3816-11e8-9c7e-d655d72b6ef9.png)

After

![image](https://user-images.githubusercontent.com/350947/38314682-b68714ea-381e-11e8-949b-d7bfa9734460.png)

---

### Delete unused branches

Before

![image](https://user-images.githubusercontent.com/350947/38311226-92cf5f74-3816-11e8-87ed-3a71e3cdf29c.png)

After

![image](https://user-images.githubusercontent.com/350947/38311233-99a4e88c-3816-11e8-8e86-98bcb71bab7f.png)