### PR TITLE
Fix bug in FormViewPatch

### DIFF
--- a/GitUI/CommandsDialogs/FormViewPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.Designer.cs
@@ -108,7 +108,6 @@ namespace GitUI.CommandsDialogs
             // 
             // typeDataGridViewTextBoxColumn
             // 
-            this.typeDataGridViewTextBoxColumn.DataPropertyName = "Type";
             this.typeDataGridViewTextBoxColumn.HeaderText = "Change";
             this.typeDataGridViewTextBoxColumn.Name = "typeDataGridViewTextBoxColumn";
             this.typeDataGridViewTextBoxColumn.ReadOnly = true;
@@ -116,7 +115,6 @@ namespace GitUI.CommandsDialogs
             // 
             // File
             // 
-            this.File.DataPropertyName = "File";
             this.File.HeaderText = "Type";
             this.File.Name = "File";
             this.File.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -20,6 +20,9 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             Translate();
+
+            typeDataGridViewTextBoxColumn.DataPropertyName = nameof(Patch.ChangeType);
+            File.DataPropertyName = nameof(Patch.FileType);
         }
 
         public void LoadPatch(string patch)


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes a binding issue in `FormViewPatch` where `DataPropertyName` ended up with an incorrect string after a refactor
- Use `nameof(...)` to prevent this happening again
 
What did I do to test the code and ensure quality:
 - Manual testing
