### PR TITLE
Delete TAGMESSAGE after tag command completes

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
 
             if (aCommands != null)
             {
-                _gitTagController = new GitTagController(() => aCommands.Module.WorkingDir);
+                _gitTagController = new GitTagController(aCommands);
             }
         }
 
@@ -87,8 +87,8 @@ namespace GitUI.CommandsDialogs
                                                      tagMessage.Text,
                                                      textBoxGpgKey.Text,
                                                      ForceTag.Checked);
-            var cmd = _gitTagController.GetCreateTagCommand(createTagArgs);
-            if (!UICommands.StartCommandLineProcessDialog(cmd, this))
+            var success = _gitTagController.CreateTag(createTagArgs, this);
+            if (!success)
             {
                 return string.Empty;
             }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -47,7 +47,7 @@ namespace GitUI.CommandsDialogs
 
             if (aCommands != null)
             {
-                _gitTagController = new GitTagController(() => aCommands.Module.WorkingDir);
+                _gitTagController = new GitTagController(aCommands);
             }
         }
 
@@ -261,8 +261,7 @@ namespace GitUI.CommandsDialogs
             {
                 currentTag++;
                 var createTagArgs = new GitCreateTagArgs($"{RestoredObjectsTagPrefix}{currentTag}", lostObject.Hash);
-                var cmd = _gitTagController.GetCreateTagCommand(createTagArgs);
-                UICommands.StartCommandLineProcessDialog(cmd, this);
+                var success = _gitTagController.CreateTag(createTagArgs, this);
             }
 
             return currentTag;

--- a/UnitTests/GitCommandsTests/Git/Tag/GitTagControllerTest.cs
+++ b/UnitTests/GitCommandsTests/Git/Tag/GitTagControllerTest.cs
@@ -1,6 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.IO.Abstractions;
+using System.Windows.Forms;
 using GitCommands.Git.Tag;
+using GitUIPluginInterfaces;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -13,6 +16,7 @@ namespace GitCommandsTests.Git.Tag
         private string _tagMessageFile;
         private IGitTagController _controller;
         private IFileSystem _fileSystem;
+        private IGitUICommands _uiCommands;
 
         [SetUp]
         public void Setup()
@@ -22,18 +26,68 @@ namespace GitCommandsTests.Git.Tag
             _fileSystem = Substitute.For<IFileSystem>();
             _fileSystem.File.Returns(Substitute.For<FileBase>());
 
-            _controller = new GitTagController(() => _workingDir, _fileSystem);
+            _uiCommands = Substitute.For<IGitUICommands>();
+            _uiCommands.GitModule.WorkingDir.Returns(_workingDir);
+
+            _controller = new GitTagController(_uiCommands, _fileSystem);
         }
 
+        [Test]
+        public void CreateTagWithMessageThrowsIfTheWindowIsNull()
+        {
+            var args = CreateAnnotatedTagArgs();
+            Assert.Throws<ArgumentNullException>(() => _controller.CreateTag(args, null));
+        }
 
         [Test]
         public void CreateTagWithMessageWritesTagMessageFile()
         {
-            var args = new GitCreateTagArgs("tagname", "00000", TagOperation.Annotate, "hello world");
+            var args = CreateAnnotatedTagArgs();
 
-            _controller.GetCreateTagCommand(args);
+            _controller.CreateTag(args, CreateTestingWindow());
 
             _fileSystem.File.Received(1).WriteAllText(_tagMessageFile, "hello world");
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CreateTagWithMessageDeletesTheTemporaryFileForUiResult(bool uiResult)
+        {
+            var args = CreateAnnotatedTagArgs();
+
+            _fileSystem.File.Exists(Arg.Is<string>(s => s != null)).Returns(true);
+
+            _uiCommands.StartCommandLineProcessDialog(Arg.Any<GitCreateTagCmd>(), Arg.Any<IWin32Window>())
+                .Returns(uiResult);
+
+            Assert.AreEqual(uiResult,  _controller.CreateTag(args, CreateTestingWindow()));
+
+            _fileSystem.File.Received(1).Delete(_tagMessageFile);
+        }
+
+        [Test]
+        public void PassesCreatedArgsAndWindowToCommands()
+        {
+            var args = CreateAnnotatedTagArgs();
+            var window = CreateTestingWindow();
+
+            _controller.CreateTag(args, window);
+
+            _uiCommands.Received(1).StartCommandLineProcessDialog(
+                Arg.Is<GitCreateTagCmd>(c => c.Arguments == args),
+                window);
+
+        }
+
+        private static IWin32Window CreateTestingWindow()
+        {
+            return Substitute.For<IWin32Window>();
+        }
+
+        private static GitCreateTagArgs CreateAnnotatedTagArgs()
+        {
+            return new GitCreateTagArgs("tagname", "00000", TagOperation.Annotate, "hello world");
         }
     }
 }


### PR DESCRIPTION
UI is never aware of the create tag command
Simplified the construction of the GitTagController too.

Issue: #4358
(cherry picked from commit 79136af7a4a2ee9f0f4ea78d1a1ba686c2558665)

