### PR TITLE
Fix for blank file history

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3606,12 +3606,12 @@ namespace GitCommands
         /// </example>
         /// <param name="s">The string to unescape.</param>
         /// <returns>The unescaped string, or <paramref name="s"/> if no escaped values were present, or <c>""</c> if <paramref name="s"/> is <c>null</c>.</returns>
-        [NotNull]
+        [ContractAnnotation("s:null=>null")]
         public static string UnescapeOctalCodePoints([CanBeNull] string s)
         {
-            if (string.IsNullOrWhiteSpace(s))
+            if (s == null)
             {
-                return s ?? string.Empty;
+                return null;
             }
 
             return _escapedOctalCodePointRegex.Replace(

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3635,30 +3635,30 @@ namespace GitCommands
                 });
         }
 
-        public static string ReEncodeFileNameFromLossless(string fileName)
+        [ContractAnnotation("fileName:null=>null")]
+        public static string ReEncodeFileNameFromLossless([CanBeNull] string fileName)
         {
             fileName = ReEncodeStringFromLossless(fileName, SystemEncoding);
             return UnescapeOctalCodePoints(fileName);
         }
 
-        public static string ReEncodeString(string s, Encoding fromEncoding, Encoding toEncoding)
+        [ContractAnnotation("s:null=>null")]
+        public static string ReEncodeString([CanBeNull] string s, [NotNull] Encoding fromEncoding, [NotNull] Encoding toEncoding)
         {
-            if (s == null || fromEncoding.HeaderName.Equals(toEncoding.HeaderName))
+            if (s == null || fromEncoding.HeaderName == toEncoding.HeaderName)
             {
                 return s;
             }
-            else
-            {
-                byte[] bytes = fromEncoding.GetBytes(s);
-                s = toEncoding.GetString(bytes);
-                return s;
-            }
+
+            var bytes = fromEncoding.GetBytes(s);
+            return toEncoding.GetString(bytes);
         }
 
         /// <summary>
         /// reencodes string from GitCommandHelpers.LosslessEncoding to toEncoding
         /// </summary>
-        public static string ReEncodeStringFromLossless(string s, Encoding toEncoding)
+        [ContractAnnotation("s:null=>null")]
+        public static string ReEncodeStringFromLossless([CanBeNull] string s, [CanBeNull] Encoding toEncoding)
         {
             if (toEncoding == null)
             {
@@ -3668,7 +3668,8 @@ namespace GitCommands
             return ReEncodeString(s, LosslessEncoding, toEncoding);
         }
 
-        public string ReEncodeStringFromLossless(string s)
+        [ContractAnnotation("s:null=>null")]
+        public string ReEncodeStringFromLossless([CanBeNull] string s)
         {
             return ReEncodeStringFromLossless(s, LogOutputEncoding);
         }
@@ -3676,7 +3677,7 @@ namespace GitCommands
         // there was a bug: Git before v1.8.4 did not recode commit message when format is given
         // Lossless encoding is used, because LogOutputEncoding might not be lossless and not recoded
         // characters could be replaced by replacement character while reencoding to LogOutputEncoding
-        public string ReEncodeCommitMessage(string s, string toEncodingName)
+        public string ReEncodeCommitMessage(string s, [CanBeNull] string toEncodingName)
         {
             bool isABug = !GitCommandHelpers.VersionInUse.LogFormatRecodesCommitMessage;
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -142,13 +142,13 @@ namespace GitUI.CommandsDialogs
         {
             FileChanges.Visible = true;
 
+            if (string.IsNullOrEmpty(FileName))
+            {
+                return;
+            }
+
             _asyncLoader.LoadAsync(() => BuildFilter(FileName), (filter) =>
             {
-                if (filter == null)
-                {
-                    return;
-                }
-
                 FileChanges.FixedRevisionFilter = filter.RevisionFilter;
                 FileChanges.FixedPathFilter = filter.PathFilter;
                 FileChanges.FiltredFileName = FileName;
@@ -165,11 +165,6 @@ namespace GitUI.CommandsDialogs
 
         private FixedFilterTuple BuildFilter(string fileName)
         {
-            if (string.IsNullOrEmpty(fileName))
-            {
-                return null;
-            }
-
             // Replace windows path separator to Linux path separator.
             // This is needed to keep the file history working when started from file tree in
             // browse dialog.

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -147,23 +147,22 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            _asyncLoader.LoadAsync(() => BuildFilter(FileName), (filter) =>
-            {
-                FileChanges.FixedRevisionFilter = filter.RevisionFilter;
-                FileChanges.FixedPathFilter = filter.PathFilter;
-                FileChanges.FiltredFileName = FileName;
-                FileChanges.AllowGraphWithFilter = true;
-                FileChanges.Load();
-            });
+            _asyncLoader.LoadAsync(
+                () => BuildFilter(FileName),
+                filter =>
+                {
+                    var (revisionFilter, pathFilter) = BuildFilter(FileName);
+
+                    FileChanges.FixedRevisionFilter = revisionFilter;
+                    FileChanges.FixedPathFilter = pathFilter;
+                    FileChanges.FiltredFileName = FileName;
+                    FileChanges.AllowGraphWithFilter = true;
+
+                    FileChanges.Load();
+                });
         }
 
-        private class FixedFilterTuple
-        {
-            public string RevisionFilter;
-            public string PathFilter;
-        }
-
-        private FixedFilterTuple BuildFilter(string fileName)
+        private (string revisionFilter, string pathFilter) BuildFilter(string fileName)
         {
             // Replace windows path separator to Linux path separator.
             // This is needed to keep the file history working when started from file tree in
@@ -197,7 +196,7 @@ namespace GitUI.CommandsDialogs
 
             FileName = fileName;
 
-            var res = new FixedFilterTuple { PathFilter = $" \"{fileName}\"" };
+            var res = (revisionFilter: (string)null, pathFilter: $" \"{fileName}\"");
 
             if (AppSettings.FollowRenamesInFileHistory && !Directory.Exists(fullFilePath))
             {
@@ -237,24 +236,24 @@ namespace GitUI.CommandsDialogs
                 while (line != null);
 
                 // here we need --name-only to get the previous filenames in the revision graph
-                res.PathFilter = listOfFileNames.ToString();
-                res.RevisionFilter += " --name-only --parents" + GitCommandHelpers.FindRenamesAndCopiesOpts();
+                res.pathFilter = listOfFileNames.ToString();
+                res.revisionFilter += " --name-only --parents" + GitCommandHelpers.FindRenamesAndCopiesOpts();
             }
             else if (AppSettings.FollowRenamesInFileHistory)
             {
                 // history of a directory
                 // --parents doesn't work with --follow enabled, but needed to graph a filtered log
-                res.RevisionFilter = " " + GitCommandHelpers.FindRenamesOpt() + " --follow --parents";
+                res.revisionFilter = " " + GitCommandHelpers.FindRenamesOpt() + " --follow --parents";
             }
             else
             {
                 // rename following disabled
-                res.RevisionFilter = " --parents";
+                res.revisionFilter = " --parents";
             }
 
             if (AppSettings.FullHistoryInFileHistory)
             {
-                res.RevisionFilter = string.Concat(" --full-history --simplify-merges ", res.RevisionFilter);
+                res.revisionFilter = string.Concat(" --full-history --simplify-merges ", res.revisionFilter);
             }
 
             return res;

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -65,7 +65,7 @@ namespace GitCommandsTests
             Assert.AreEqual("", result.Lines.Last().Text);
         }
 
-        [TestCase(null, "")]
+        [TestCase(null, null)]
         [TestCase("", "")]
         [TestCase(" ", " ")]
         [TestCase("Hello, World!", "Hello, World!")]


### PR DESCRIPTION
Fixes #4793.

Changes proposed in this pull request:
 - Fix cause of bug in 4793
 - As bug was null-related, annotate some methods in this area
- Replace custom tuple type with `ValueTuple`
 
The bug was caused when we modified `UnescapeOctalCodePoints` to promote `null` to `""`. This caused a loop in `FormFileHistory` to never terminate:

```c#
string line;
do
{
    line = p.StandardOutput.ReadLine();
    line = GitModule.ReEncodeFileNameFromLossless(line); // null converted to ""

    // ...
}
while (line != null); // this condition never met
```

That loop was being run via `AsyncLoader` in the background, which is why the UI remained responsive, however we would have had one core pinned at 100%.

Has been tested on:
 - GIT 2.16
 - Windows 10
