### PR TITLE
Make LaunchBuildServerInfoFetchOperation async

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -97,7 +97,8 @@ namespace GitUI.BuildServerIntegration
                     };
 
                     _buildStatusCancellationToken = cancellationToken;
-                });
+                })
+                .FileAndForget();
         }
 
         public void CancelBuildStatusFetchOperation()

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1427,18 +1427,18 @@ namespace GitUI
             else
             {
                 // This has to happen on the UI thread
-                this.InvokeAsync(() =>
-                                      {
-                                          UpdateGraph(null);
-                                          Loading.Visible = false;
-                                          _isRefreshingRevisions = false;
-                                          SelectInitialRevision();
-                                          if (ShowBuildServerInfo)
-                                          {
-                                              BuildServerWatcher.LaunchBuildServerInfoFetchOperation();
-                                          }
-                                      })
-                    .FileAndForget();
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await this.SwitchToMainThreadAsync();
+                    UpdateGraph(null);
+                    Loading.Visible = false;
+                    _isRefreshingRevisions = false;
+                    SelectInitialRevision();
+                    if (ShowBuildServerInfo)
+                    {
+                        await BuildServerWatcher.LaunchBuildServerInfoFetchOperationAsync();
+                    }
+                }).FileAndForget();
             }
 
             DisposeRevisionGraphCommand();

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerWatcher.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerWatcher.cs
@@ -1,10 +1,12 @@
+using System.Threading.Tasks;
+
 namespace GitUIPluginInterfaces.BuildServerIntegration
 {
     public interface IBuildServerWatcher
     {
         IBuildServerCredentials GetBuildServerCredentials(IBuildServerAdapter buildServerAdapter, bool useStoredCredentialsIfExisting);
 
-        void LaunchBuildServerInfoFetchOperation();
+        Task LaunchBuildServerInfoFetchOperationAsync();
 
         void CancelBuildStatusFetchOperation();
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Move most of the LaunchBuildServerInfoFetchOperation logic to the background
- Use CancellationTokenSequence to cancel previously scheduled LaunchBuildServerInfoFetchOperationAsync

What did I do to test the code and ensure quality:
 - Manual tests with AppVeyor and Jenkins plugins.
