### PR TITLE
Provide more information to contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,11 @@
-I was not able to find an [open](https://github.com/gitextensions/gitextensions/issues?q=is%3Aopen) or [closed](https://github.com/gitextensions/gitextensions/issues?q=is%3Aclosed) issue matching what I'm seeing
+<!--
+IMPORTANT
+
+Before creating an issue, be sure to search existing issues, both open AND closed,
+to see whether someone else has already reported your issue.
+
+Please also read CONTRIBUTING.md.
+-->
 
 **Do you want to request a *feature* or report a *bug*?**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
-Fixes # .
+<!-- Please read CONTRIBUTING.md before submitting a pull request -->
+
+Fixes #
 
 Changes proposed in this pull request:
- - 
- - 
- - 
+- 
+- 
+- 
  
 Screenshots before and after (if PR changes UI):
 -
@@ -11,10 +13,10 @@ Screenshots before and after (if PR changes UI):
 -
 
 What did I do to test the code and ensure quality:
- - 
- - 
- - 
+- 
+- 
+- 
 
 Has been tested on (remove any that don't apply):
- - GIT 2.10 and above
- - Windows 7 and above
+- GIT 2.10 and above
+- Windows 7 and above

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,56 @@
-# Contributing to Git Extensions
+﻿# Contributing to Git Extensions
 
-## How to contribute code
+GitExtensions is a project with a long history, made possible by [hundreds of contributors](https://github.com/gitextensions/gitextensions/graphs/contributors).
 
-* Login in github (you need an account)
-* Fork the main repository from [github](http://github.com/gitextensions/gitextensions)
-* Read [Project workflow](https://github.com/gitextensions/gitextensions/wiki/Project-Workflow) and [Coding guide](https://github.com/gitextensions/gitextensions/wiki#coding-guide)
-* Push your changes to your fork
-* Create a pull request
+We welcome contributions including:
 
-## How to debug GitExtensions
+- Ideas for improvements
+- Bug reports
+- Bug fixes
+- New features
 
-The installer is build using WiX. You need to install WiX when you want to build the installer. This can be downloaded here: [http://wixtoolset.org/](http://wixtoolset.org/). If you do not want to build the installer, just open the solution and ignore the warning.
+To help the project maintainers be as effective as possible, please follow some simple guidelines.
 
-* Open the solution file (GitExtensions.sln)
-* Hit F5 to compile and run GitExtensions
+## Reporting Issues
 
-## How to create the installer
+[Search the issue tracker](https://github.com/gitextensions/gitextensions/issues?&q=) for an
+existing or closely related issue before creating a new one. Be sure to include closed issues
+in your search.
 
-* Download and install WiX [http://wixtoolset.org/](http://wixtoolset.org/)
-* Run Setup\\BuildInstallers.cmd to build the installers
+If an open issue already exists, read through the discussion. If you can add something helpful, do so.
+Add a 👍 if you'd like to see it prioritised. Subscribe to the issue for updates.
 
+If a closed issue already exists and the issue was addressed, you may like to try one of the
+[CI builds](https://github.com/gitextensions/gitextensions/wiki/CI-Builds).
+
+If no issue exists, create one. Complete the template, and add any further information that
+could be relevant.
+
+## Pull Requests
+
+Want to contribute some code? Great! In addition to the regular GitHub Pull Request workflow,
+you'll want to browse the [wiki](https://github.com/gitextensions/gitextensions/wiki).
+
+Good places to start contributing include:
+
+- Open [bugs](https://github.com/gitextensions/gitextensions/labels/bugs)
+- Open issues marked [good first issue](https://github.com/gitextensions/gitextensions/labels/good%20first%20issue)
+- Open issues marked [help wanted](https://github.com/gitextensions/gitextensions/labels/help%20wanted)
+
+It's a good idea to mention that you're picking something up by commenting on its issue.
+
+If no issue exists, create one before making a PR. This creates the opportunity to discuss
+the issue before you spend time on its implementation. You will likely be more effective
+this way, and have a greater chance of satisfaction in the end.
+
+Pull requests will be reviewed by one or more team members. To improve the chance of your
+pull request being merged, your contribution should be as easy to review as possible.
+Specifically:
+
+- Be focussed in scope
+- Be comprised of clear commits (use interactive rebase to tidy things up if needed)
+- Include a clear description of the changes and why they should be made
+- Be consistent with the current code style
+
+When filing a pull request, you should be prepared to answer questions about your changes
+and to perform additional work on the changes in response to review feedback.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We welcome contributions including:
 - Bug fixes
 - New features
 
-To help the project maintainers be as effective as possible, please follow some simple guidelines.
+To help the project maintainers be as effective as possible, please follow the simple guidelines below.
 
 ## Reporting Issues
 
@@ -24,12 +24,12 @@ If a closed issue already exists and the issue was addressed, you may like to tr
 [CI builds](https://github.com/gitextensions/gitextensions/wiki/CI-Builds).
 
 If no issue exists, create one. Complete the template, and add any further information that
-could be relevant.
+could be relevant such as steps to reproduce, stack traces, screenshots, git/OS version, etc.
 
 ## Pull Requests
 
 Want to contribute some code? Great! In addition to the regular GitHub Pull Request workflow,
-you'll want to browse the [wiki](https://github.com/gitextensions/gitextensions/wiki).
+you'll want to browse our [wiki](https://github.com/gitextensions/gitextensions/wiki).
 
 Good places to start contributing include:
 
@@ -50,6 +50,7 @@ Specifically:
 - Be focussed in scope
 - Be comprised of clear commits (use interactive rebase to tidy things up if needed)
 - Include a clear description of the changes and why they should be made
+- Be accompanied by unit tests
 - Be consistent with the current code style
 
 When filing a pull request, you should be prepared to answer questions about your changes

--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -166,7 +166,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		GitExtensions.ruleset = GitExtensions.ruleset
 		GitExtensionsTest.ruleset = GitExtensionsTest.ruleset
+		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		LICENSE.md = LICENSE.md
+		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -176,6 +178,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{472B72D9
 		Build\vs-threading.MainThreadAssertingMethods.txt = Build\vs-threading.MainThreadAssertingMethods.txt
 		Build\vs-threading.MainThreadSwitchingMethods.txt = Build\vs-threading.MainThreadSwitchingMethods.txt
 		Build\vs-threading.TypesRequiringMainThread.txt = Build\vs-threading.TypesRequiringMainThread.txt
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{17FD2A6B-4005-41DC-BFAC-59F936DF33AA}"
+	ProjectSection(SolutionItems) = preProject
+		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
+		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 	EndProjectSection
 EndProject
 Global
@@ -754,6 +762,7 @@ Global
 		{626CA9EB-DB83-4BEB-87D5-15E3B397EF57} = {3D5CA0E0-EF51-4488-A8B7-86CC330D7AD8}
 		{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548} = {020F800B-9170-4BB3-83C9-FCF83596D83C}
 		{472B72D9-9336-4C8B-A199-300F0CA7669E} = {C5855184-8571-4AD0-A373-B98215BA56CA}
+		{17FD2A6B-4005-41DC-BFAC-59F936DF33AA} = {C5855184-8571-4AD0-A373-B98215BA56CA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ECECB7EA-BCCF-44AD-B63E-C2FA45589FB0}


### PR DESCRIPTION
Following the discussion in #4783...

The [current CONTRIBUTING.md](https://github.com/gitextensions/gitextensions/blob/master/CONTRIBUTING.md) file doesn't directly tell contributors what's required of them. I typed out some notes that I think should make that a bit clearer. My goal is to be inclusive and welcoming, yet to lay out the ground rules and set appropriate expectations.

The wiki also has some contributor guidelines which overlap with the below. It's the norm on GitHub at least for contributor guidelines to go in `CONTRIBUTING.md`, which is linked to in a banner for first-time contributors.

It also turns out that GitHub flavoured markdown allows HTML-style comments, so we can put the notes reminding issue creators to search for existing issues there.

I moved the information about building the installer from `CONTRIBUTING.md` to the wiki. I found the section on debugging GE confusing so I removed it entirely.

Not particularly attached to any of the text here so don't hesitate to give feedback.
