### PR TITLE
Coverage tweaks

### DIFF
--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -152,7 +152,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonTestUtils", "UnitTest
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C5855184-8571-4AD0-A373-B98215BA56CA}"
 	ProjectSection(SolutionItems) = preProject
-		.codecov.yml = .codecov.yml
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
@@ -160,6 +159,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.mailmap = .mailmap
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
+		codecov.yml = codecov.yml
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		CONTRIBUTING.md = CONTRIBUTING.md
 		CustomDictionary.xml = CustomDictionary.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,4 @@ coverage:
       default: false
 
 comment:
-  layout: "diff, flags, files, footer"
+  layout: "diff"

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,8 @@ coverage:
       default: false
     patch:
       default: false
+  ignore:
+    - "*.Designer.cs"
 
 comment:
   layout: "diff"


### PR DESCRIPTION
Fixes #4802.

Changes proposed in this pull request:
- Ignore some patterns from test coverage
  - ~~`UnitTests/*`~~
  - ~~`Externals/*`~~
  - `*.Designer.cs`
- Make PR comments from codecov bot much shorter on screen/email
- ~~Don't comment at all if coverage is unchanged (eg. changes to non-source files)~~
- Fix the solution reference to `codecov.yml`
 
What did I do to test the code and ensure quality:
- I don't know how to test these without committing them to master. It's possible that these changes will flag a need for further changes. I did read their documentation thoroughly and believe the changes will achieve the goals I had.

---

I find the comments from the bot way too long. They separate the PR's description from its discussion. The key info is whether coverage went up or down, and by how much. The rest is just a click away if needed. Less is more. This is my opinion, though [maybe not mine alone](https://github.com/gitextensions/gitextensions/pull/4801#issuecomment-379467566).

So instead of this:

![image](https://user-images.githubusercontent.com/350947/38458214-a1ec1ab8-3a93-11e8-8242-00c8e3380835.png)

We should see something more like this:

![image](https://user-images.githubusercontent.com/350947/38458240-d5c17d56-3a93-11e8-8f1a-7117e6b16fa5.png)

I believe there could be a superior middle ground, but it would require an extension to the codecov bot. codecov/support#491

---

Another discussion point is the testing of `*.Designer.cs` files. We definitely should be testing such partial classes, but for my taste it is enough to test the non-generated parts.

I'm sure some ideas will come out of discussion. I will update the PR accordingly, or close it if no consensus is reached.

@sharwell did you originally set this up? Can you provide a review please?