### PR TITLE
Use nameof for binding symbol members

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.Designer.cs
@@ -169,20 +169,17 @@
             // 
             // pathDataGridViewTextBoxColumn
             // 
-            this.pathDataGridViewTextBoxColumn.DataPropertyName = "Path";
             this.pathDataGridViewTextBoxColumn.HeaderText = "Path";
             this.pathDataGridViewTextBoxColumn.Name = "pathDataGridViewTextBoxColumn";
             // 
             // Title
             // 
-            this.Title.DataPropertyName = "Title";
             this.Title.HeaderText = "Title";
             this.Title.Name = "Title";
             // 
             // descriptionDataGridViewTextBoxColumn
             // 
             this.descriptionDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.descriptionDataGridViewTextBoxColumn.DataPropertyName = "Description";
             this.descriptionDataGridViewTextBoxColumn.HeaderText = "Description";
             this.descriptionDataGridViewTextBoxColumn.Name = "descriptionDataGridViewTextBoxColumn";
             // 

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
@@ -18,6 +18,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             Translate();
             Initialize();
+
+            pathDataGridViewTextBoxColumn.DataPropertyName = nameof(Repository.Path);
+            Title.DataPropertyName = nameof(Repository.Title);
+            descriptionDataGridViewTextBoxColumn.DataPropertyName = nameof(Repository.Description);
         }
 
         protected override void OnHandleDestroyed(EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
@@ -33,13 +33,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private bool _bChangingDataSource;
 
-        public void Initialize()
+        private void Initialize()
         {
             _bChangingDataSource = true;
             _NO_TRANSLATE_Categories.DataSource = null;
             _NO_TRANSLATE_Categories.DataSource = Repositories.RepositoryCategories;
             _bChangingDataSource = false;
-            _NO_TRANSLATE_Categories.DisplayMember = "Description";
+            _NO_TRANSLATE_Categories.DisplayMember = nameof(RepositoryCategory.Description);
         }
 
         private void Categories_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -84,8 +84,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     list =>
                     {
                         comboBoxTags.Text = string.Empty;
-                        GitRefsToDataSource(comboBoxTags, list);
-                        comboBoxTags.DisplayMember = "LocalName";
+                        comboBoxTags.DataSource = list;
+                        comboBoxTags.DisplayMember = nameof(IGitRef.LocalName);
                         SetSelectedRevisionByFocusedControl();
                     });
             });
@@ -101,16 +101,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     list =>
                     {
                         comboBoxBranches.Text = string.Empty;
-                        GitRefsToDataSource(comboBoxBranches, list);
-                        comboBoxBranches.DisplayMember = "LocalName";
+                        comboBoxBranches.DataSource = list;
+                        comboBoxBranches.DisplayMember = nameof(IGitRef.LocalName);
                         SetSelectedRevisionByFocusedControl();
                     });
             });
-        }
-
-        private static void GitRefsToDataSource(ComboBox cb, IReadOnlyList<IGitRef> refs)
-        {
-            cb.DataSource = refs;
         }
 
         private static IReadOnlyList<IGitRef> DataSourceToGitRefs(ComboBox cb)

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -105,7 +105,7 @@ namespace GitUI.CommandsDialogs
 
         private void RevisionPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "BuildStatus")
+            if (e.PropertyName == nameof(GitRevision.BuildStatus))
             {
                 // Refresh the selected Git revision
                 FillBuildReport(_selectedGitRevision);

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Windows.Forms;
 using GitUI.Script;
+using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs
 {
@@ -17,7 +18,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormDeleteTagLoad(object sender, EventArgs e)
         {
-            Tags.DisplayMember = "Name";
+            Tags.DisplayMember = nameof(IGitRef.Name);
             Tags.DataSource = Module.GetRefs(true, false);
             Tags.Text = Tag as string;
             remotesComboboxControl1.SelectedRemote = Module.GetCurrentRemote();

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs
         private void DirectoryDropDown(object sender, EventArgs e)
         {
             Directory.DataSource = Repositories.RepositoryHistory.Repositories;
-            Directory.DisplayMember = "Path";
+            Directory.DisplayMember = nameof(Repository.Path);
         }
 
         private void InitClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs
 
             _NO_TRANSLATE_Remotes.Sorted = false;
             _NO_TRANSLATE_Remotes.DataSource = new[] { new GitRemote { Name = AllRemotes } }.Union(remotes).ToList();
-            _NO_TRANSLATE_Remotes.DisplayMember = "Name";
+            _NO_TRANSLATE_Remotes.DisplayMember = nameof(GitRemote.Name);
             _NO_TRANSLATE_Remotes.SelectedIndex = -1;
             _NO_TRANSLATE_Remotes.ResizeComboBoxDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
@@ -262,7 +262,7 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                Branches.DisplayMember = "LocalName";
+                Branches.DisplayMember = nameof(IGitRef.LocalName);
 
                 ////_heads.Insert(0, GitHead.AllHeads); --> disable this because it is only for expert users
                 _heads.Insert(0, GitRef.NoHead(Module));
@@ -804,7 +804,7 @@ namespace GitUI.CommandsDialogs
         {
             string prevUrl = comboBoxPullSource.Text;
             comboBoxPullSource.DataSource = Repositories.RemoteRepositoryHistory.Repositories;
-            comboBoxPullSource.DisplayMember = "Path";
+            comboBoxPullSource.DisplayMember = nameof(Repository.Path);
             comboBoxPullSource.Text = prevUrl;
         }
 

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -444,21 +444,18 @@
             // LocalColumn
             // 
             this.LocalColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.LocalColumn.DataPropertyName = "Local";
             this.LocalColumn.HeaderText = "Local Branch";
             this.LocalColumn.Name = "LocalColumn";
             // 
             // RemoteColumn
             // 
             this.RemoteColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.RemoteColumn.DataPropertyName = "Remote";
             this.RemoteColumn.HeaderText = "Remote Branch";
             this.RemoteColumn.Name = "RemoteColumn";
             // 
             // NewColumn
             // 
             this.NewColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.NewColumn.DataPropertyName = "New";
             this.NewColumn.HeaderText = "New at Remote";
             this.NewColumn.Name = "NewColumn";
             this.NewColumn.ReadOnly = true;
@@ -466,21 +463,18 @@
             // PushColumn
             // 
             this.PushColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.PushColumn.DataPropertyName = "Push";
             this.PushColumn.HeaderText = "Push";
             this.PushColumn.Name = "PushColumn";
             // 
             // ForceColumn
             // 
             this.ForceColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.ForceColumn.DataPropertyName = "Force";
             this.ForceColumn.HeaderText = "Push (Force Rewind)";
             this.ForceColumn.Name = "ForceColumn";
             // 
             // DeleteColumn
             // 
             this.DeleteColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.DeleteColumn.DataPropertyName = "Delete";
             this.DeleteColumn.HeaderText = "Delete Remote Branch";
             this.DeleteColumn.Name = "DeleteColumn";
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -208,7 +208,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.TextUpdate -= RemotesUpdated;
             _NO_TRANSLATE_Remotes.Sorted = false;
             _NO_TRANSLATE_Remotes.DataSource = UserGitRemotes;
-            _NO_TRANSLATE_Remotes.DisplayMember = "Name";
+            _NO_TRANSLATE_Remotes.DisplayMember = nameof(GitRemote.Name);
             _NO_TRANSLATE_Remotes.SelectedIndex = -1;
 
             _NO_TRANSLATE_Remotes.SelectedIndexChanged += RemotesUpdated;
@@ -639,7 +639,7 @@ namespace GitUI.CommandsDialogs
         {
             string prevUrl = PushDestination.Text;
             PushDestination.DataSource = Repositories.RemoteRepositoryHistory.Repositories;
-            PushDestination.DisplayMember = "Path";
+            PushDestination.DisplayMember = nameof(Repository.Path);
             PushDestination.Text = prevUrl;
         }
 
@@ -647,7 +647,7 @@ namespace GitUI.CommandsDialogs
         {
             var curBranch = _NO_TRANSLATE_Branch.Text;
 
-            _NO_TRANSLATE_Branch.DisplayMember = "Name";
+            _NO_TRANSLATE_Branch.DisplayMember = nameof(IGitRef.Name);
             _NO_TRANSLATE_Branch.Items.Clear();
             _NO_TRANSLATE_Branch.Items.Add(AllRefs);
             _NO_TRANSLATE_Branch.Items.Add(HeadText);

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -21,6 +21,12 @@ namespace GitUI.CommandsDialogs
     {
         private const string HeadText = "HEAD";
         private const string AllRefs = "[ All ]";
+        private const string LocalColumnName = "Local";
+        private const string RemoteColumnName = "Remote";
+        private const string NewColumnName = "New";
+        private const string PushColumnName = "Push";
+        private const string ForceColumnName = "Force";
+        private const string DeleteColumnName = "Delete";
         private string _currentBranchName;
         private GitRemote _currentBranchRemote;
         private bool _candidateForRebasingMergeCommit;
@@ -399,17 +405,17 @@ namespace GitUI.CommandsDialogs
                 var pushActions = new List<GitPushAction>();
                 foreach (DataRow row in _branchTable.Rows)
                 {
-                    var push = Convert.ToBoolean(row["Push"]);
-                    var force = Convert.ToBoolean(row["Force"]);
-                    var delete = Convert.ToBoolean(row["Delete"]);
+                    var push = Convert.ToBoolean(row[PushColumnName]);
+                    var force = Convert.ToBoolean(row[ForceColumnName]);
+                    var delete = Convert.ToBoolean(row[DeleteColumnName]);
 
                     if (push || force)
                     {
-                        pushActions.Add(new GitPushAction(row["Local"].ToString(), row["Remote"].ToString(), force));
+                        pushActions.Add(new GitPushAction(row[LocalColumnName].ToString(), row[RemoteColumnName].ToString(), force));
                     }
                     else if (delete)
                     {
-                        pushActions.Add(GitPushAction.DeleteRemoteBranch(row["Remote"].ToString()));
+                        pushActions.Add(GitPushAction.DeleteRemoteBranch(row[RemoteColumnName].ToString()));
                     }
                 }
 
@@ -891,15 +897,20 @@ namespace GitUI.CommandsDialogs
         private void UpdateMultiBranchView()
         {
             _branchTable = new DataTable();
-            _branchTable.Columns.Add("Local", typeof(string));
-            _branchTable.Columns.Add("Remote", typeof(string));
-            _branchTable.Columns.Add("New", typeof(string));
-            _branchTable.Columns.Add("Push", typeof(bool));
-            _branchTable.Columns.Add("Force", typeof(bool));
-            _branchTable.Columns.Add("Delete", typeof(bool));
+            _branchTable.Columns.Add(LocalColumnName, typeof(string));
+            _branchTable.Columns.Add(RemoteColumnName, typeof(string));
+            _branchTable.Columns.Add(NewColumnName, typeof(string));
+            _branchTable.Columns.Add(PushColumnName, typeof(bool));
+            _branchTable.Columns.Add(ForceColumnName, typeof(bool));
+            _branchTable.Columns.Add(DeleteColumnName, typeof(bool));
             _branchTable.ColumnChanged += BranchTable_ColumnChanged;
-            var bs = new BindingSource { DataSource = _branchTable };
-            BranchGrid.DataSource = bs;
+            LocalColumn.DataPropertyName = LocalColumnName;
+            RemoteColumn.DataPropertyName = RemoteColumnName;
+            NewColumn.DataPropertyName = NewColumnName;
+            PushColumn.DataPropertyName = PushColumnName;
+            ForceColumn.DataPropertyName = ForceColumnName;
+            DeleteColumn.DataPropertyName = DeleteColumnName;
+            BranchGrid.DataSource = new BindingSource { DataSource = _branchTable };
 
             if (_selectedRemote == null)
             {
@@ -976,9 +987,9 @@ namespace GitUI.CommandsDialogs
             foreach (var head in localHeads)
             {
                 DataRow row = _branchTable.NewRow();
-                row["Force"] = false;
-                row["Delete"] = false;
-                row["Local"] = head.Name;
+                row[ForceColumnName] = false;
+                row[DeleteColumnName] = false;
+                row[LocalColumnName] = head.Name;
 
                 string remoteName;
                 if (head.Remote == remote)
@@ -990,10 +1001,10 @@ namespace GitUI.CommandsDialogs
                     remoteName = head.Name;
                 }
 
-                row["Remote"] = remoteName;
+                row[RemoteColumnName] = remoteName;
                 bool knownAtRemote = remoteBranches.Contains(remoteName);
-                row["New"] = knownAtRemote ? _no.Text : _yes.Text;
-                row["Push"] = knownAtRemote;
+                row[NewColumnName] = knownAtRemote ? _no.Text : _yes.Text;
+                row[PushColumnName] = knownAtRemote;
 
                 _branchTable.Rows.Add(row);
             }
@@ -1005,12 +1016,12 @@ namespace GitUI.CommandsDialogs
                 if (localHeads.All(h => h.Name != head.LocalName))
                 {
                     DataRow row = _branchTable.NewRow();
-                    row["Local"] = null;
-                    row["Remote"] = remoteHead.LocalName;
-                    row["New"] = _no.Text;
-                    row["Push"] = false;
-                    row["Force"] = false;
-                    row["Delete"] = false;
+                    row[LocalColumnName] = null;
+                    row[RemoteColumnName] = remoteHead.LocalName;
+                    row[NewColumnName] = _no.Text;
+                    row[PushColumnName] = false;
+                    row[ForceColumnName] = false;
+                    row[DeleteColumnName] = false;
                     _branchTable.Rows.Add(row);
                 }
             }
@@ -1020,22 +1031,40 @@ namespace GitUI.CommandsDialogs
 
         private static void BranchTable_ColumnChanged(object sender, DataColumnChangeEventArgs e)
         {
-            if (e.Column.ColumnName == "Push" && (bool)e.ProposedValue)
+            switch (e.Column.ColumnName)
             {
-                e.Row["Force"] = false;
-                e.Row["Delete"] = false;
-            }
+                case PushColumnName:
+                {
+                    if ((bool)e.ProposedValue)
+                    {
+                        e.Row[ForceColumnName] = false;
+                        e.Row[DeleteColumnName] = false;
+                    }
 
-            if (e.Column.ColumnName == "Force" && (bool)e.ProposedValue)
-            {
-                e.Row["Push"] = false;
-                e.Row["Delete"] = false;
-            }
+                    break;
+                }
 
-            if (e.Column.ColumnName == "Delete" && (bool)e.ProposedValue)
-            {
-                e.Row["Push"] = false;
-                e.Row["Force"] = false;
+                case ForceColumnName:
+                {
+                    if ((bool)e.ProposedValue)
+                    {
+                        e.Row[PushColumnName] = false;
+                        e.Row[DeleteColumnName] = false;
+                    }
+
+                    break;
+                }
+
+                case DeleteColumnName:
+                {
+                    if ((bool)e.ProposedValue)
+                    {
+                        e.Row[PushColumnName] = false;
+                        e.Row[ForceColumnName] = false;
+                    }
+
+                    break;
+                }
             }
         }
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -69,7 +69,7 @@ namespace GitUI.CommandsDialogs
 
             var refs = Module.GetRefs(true, true).OfType<GitRef>().ToList();
             Branches.DataSource = refs;
-            Branches.DisplayMember = "Name";
+            Branches.DisplayMember = nameof(GitRef.Name);
 
             if (_defaultBranch != null)
             {
@@ -80,7 +80,7 @@ namespace GitUI.CommandsDialogs
 
             refs = Module.GetRefs(false, true).OfType<GitRef>().ToList();
             cboTo.DataSource = refs;
-            cboTo.DisplayMember = "Name";
+            cboTo.DisplayMember = nameof(GitRef.Name);
 
             cboTo.Text = _defaultToBranch ?? selectedHead;
 

--- a/GitUI/CommandsDialogs/FormReflog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormReflog.Designer.cs
@@ -187,7 +187,6 @@ namespace GitUI.CommandsDialogs
             // 
             // Sha
             // 
-            this.Sha.DataPropertyName = "Sha";
             this.Sha.HeaderText = "SHA-1";
             this.Sha.Name = "Sha";
             this.Sha.ReadOnly = true;
@@ -195,7 +194,6 @@ namespace GitUI.CommandsDialogs
             // 
             // Ref
             // 
-            this.Ref.DataPropertyName = "Ref";
             this.Ref.HeaderText = "Ref";
             this.Ref.Name = "Ref";
             this.Ref.ReadOnly = true;
@@ -203,7 +201,6 @@ namespace GitUI.CommandsDialogs
             // 
             // Action
             // 
-            this.Action.DataPropertyName = "Action";
             this.Action.HeaderText = "Action";
             this.Action.Name = "Action";
             this.Action.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -25,6 +25,10 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             Translate();
+
+            Sha.DataPropertyName = nameof(RefLine.Sha);
+            Ref.DataPropertyName = nameof(RefLine.Ref);
+            Action.DataPropertyName = nameof(RefLine.Action);
         }
 
         private void FormReflog_Load(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -637,21 +637,18 @@ namespace GitUI.CommandsDialogs
             // 
             // BranchName
             // 
-            this.BranchName.DataPropertyName = "LocalName";
             this.BranchName.HeaderText = "Local branch name";
             this.BranchName.Name = "BranchName";
             this.BranchName.ReadOnly = true;
             // 
             // RemoteCombo
             // 
-            this.RemoteCombo.DataPropertyName = "TrackingRemote";
             this.RemoteCombo.HeaderText = "Remote repository";
             this.RemoteCombo.Name = "RemoteCombo";
             this.RemoteCombo.ReadOnly = true;
             // 
             // MergeWith
             // 
-            this.MergeWith.DataPropertyName = "MergeWith";
             this.MergeWith.HeaderText = "Default merge with";
             this.MergeWith.Name = "MergeWith";
             this.MergeWith.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -83,9 +83,6 @@ namespace GitUI.CommandsDialogs
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.UpdateBranch = new System.Windows.Forms.Button();
             this.Prune = new System.Windows.Forms.Button();
-            this.nameDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.BName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.flpnlRemoteManagement.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
@@ -767,26 +764,6 @@ namespace GitUI.CommandsDialogs
             this.Prune.UseVisualStyleBackColor = true;
             this.Prune.Click += new System.EventHandler(this.PruneClick);
             // 
-            // nameDataGridViewTextBoxColumn
-            // 
-            this.nameDataGridViewTextBoxColumn.DataPropertyName = "Name";
-            this.nameDataGridViewTextBoxColumn.HeaderText = "Branch";
-            this.nameDataGridViewTextBoxColumn.Name = "nameDataGridViewTextBoxColumn";
-            this.nameDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // BName
-            // 
-            this.BName.DataPropertyName = "Name";
-            this.BName.HeaderText = "Name";
-            this.BName.Name = "BName";
-            this.BName.ReadOnly = true;
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Name";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Name";
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            // 
             // FormRemotes
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -842,9 +819,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabPage1;
         private System.Windows.Forms.TabPage tabPage2;
-        private System.Windows.Forms.DataGridViewTextBoxColumn nameDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn BName;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.Button UpdateBranch;
         private System.Windows.Forms.Button Prune;
         private System.Windows.Forms.Button LoadSSHKey;

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -204,11 +204,11 @@ Inactive remote is completely invisible to git.");
                 Remotes.BeginUpdate();
 
                 Url.DataSource = repos.ToList();
-                Url.DisplayMember = "Path";
+                Url.DisplayMember = nameof(Repository.Path);
                 Url.SelectedItem = null;
 
                 comboBoxPushUrl.DataSource = repos.ToList();
-                comboBoxPushUrl.DisplayMember = "Path";
+                comboBoxPushUrl.DisplayMember = nameof(Repository.Path);
                 comboBoxPushUrl.SelectedItem = null;
 
                 BindRemotes(preselectRemote);
@@ -227,7 +227,7 @@ Inactive remote is completely invisible to git.");
 
             RemoteRepositoryCombo.Sorted = false;
             RemoteRepositoryCombo.DataSource = new[] { new GitRemote() }.Union(UserGitRemotes).ToList();
-            RemoteRepositoryCombo.DisplayMember = "Name";
+            RemoteRepositoryCombo.DisplayMember = nameof(GitRemote.Name);
 
             RemoteBranches.AutoGenerateColumns = false;
             RemoteBranches.SelectionChanged -= RemoteBranchesSelectionChanged;

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -99,6 +99,10 @@ Inactive remote is completely invisible to git.");
 
             Application.Idle += application_Idle;
 
+            BranchName.DataPropertyName = nameof(IGitRef.LocalName);
+            RemoteCombo.DataPropertyName = nameof(IGitRef.TrackingRemote);
+            MergeWith.DataPropertyName = nameof(IGitRef.MergeWith);
+
             this.AdjustForDpiScaling();
         }
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -126,14 +126,12 @@ namespace GitUI.CommandsDialogs
             // FileName
             // 
             this.FileName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.FileName.DataPropertyName = "FileName";
             this.FileName.HeaderText = "Filename";
             this.FileName.Name = "FileName";
             this.FileName.ReadOnly = true;
             // 
             // authorDataGridViewTextBoxColumn1
             // 
-            this.authorDataGridViewTextBoxColumn1.DataPropertyName = "Author";
             this.authorDataGridViewTextBoxColumn1.HeaderText = "Author";
             this.authorDataGridViewTextBoxColumn1.Name = "authorDataGridViewTextBoxColumn1";
             this.authorDataGridViewTextBoxColumn1.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -71,14 +71,6 @@ namespace GitUI.CommandsDialogs
             this.openMergeToolBtn = new System.Windows.Forms.Button();
             this.Rescan = new System.Windows.Forms.Button();
             this.Reset = new System.Windows.Forms.Button();
-            this.guidDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.commitGuidDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.itemTypeDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.nameDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.authorDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dateDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.fileNameDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.modeDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
@@ -486,62 +478,6 @@ namespace GitUI.CommandsDialogs
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.Reset_Click);
             // 
-            // guidDataGridViewTextBoxColumn
-            // 
-            this.guidDataGridViewTextBoxColumn.DataPropertyName = "Guid";
-            this.guidDataGridViewTextBoxColumn.HeaderText = "Guid";
-            this.guidDataGridViewTextBoxColumn.Name = "guidDataGridViewTextBoxColumn";
-            this.guidDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // commitGuidDataGridViewTextBoxColumn
-            // 
-            this.commitGuidDataGridViewTextBoxColumn.DataPropertyName = "CommitGuid";
-            this.commitGuidDataGridViewTextBoxColumn.HeaderText = "CommitGuid";
-            this.commitGuidDataGridViewTextBoxColumn.Name = "commitGuidDataGridViewTextBoxColumn";
-            this.commitGuidDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // itemTypeDataGridViewTextBoxColumn
-            // 
-            this.itemTypeDataGridViewTextBoxColumn.DataPropertyName = "ItemType";
-            this.itemTypeDataGridViewTextBoxColumn.HeaderText = "ItemType";
-            this.itemTypeDataGridViewTextBoxColumn.Name = "itemTypeDataGridViewTextBoxColumn";
-            this.itemTypeDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // nameDataGridViewTextBoxColumn
-            // 
-            this.nameDataGridViewTextBoxColumn.DataPropertyName = "Name";
-            this.nameDataGridViewTextBoxColumn.HeaderText = "Name";
-            this.nameDataGridViewTextBoxColumn.Name = "nameDataGridViewTextBoxColumn";
-            this.nameDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // authorDataGridViewTextBoxColumn
-            // 
-            this.authorDataGridViewTextBoxColumn.DataPropertyName = "Author";
-            this.authorDataGridViewTextBoxColumn.HeaderText = "Author";
-            this.authorDataGridViewTextBoxColumn.Name = "authorDataGridViewTextBoxColumn";
-            this.authorDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // dateDataGridViewTextBoxColumn
-            // 
-            this.dateDataGridViewTextBoxColumn.DataPropertyName = "Date";
-            this.dateDataGridViewTextBoxColumn.HeaderText = "Date";
-            this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
-            this.dateDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // fileNameDataGridViewTextBoxColumn
-            // 
-            this.fileNameDataGridViewTextBoxColumn.DataPropertyName = "FileName";
-            this.fileNameDataGridViewTextBoxColumn.HeaderText = "FileName";
-            this.fileNameDataGridViewTextBoxColumn.Name = "fileNameDataGridViewTextBoxColumn";
-            this.fileNameDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // modeDataGridViewTextBoxColumn
-            // 
-            this.modeDataGridViewTextBoxColumn.DataPropertyName = "Mode";
-            this.modeDataGridViewTextBoxColumn.HeaderText = "Mode";
-            this.modeDataGridViewTextBoxColumn.Name = "modeDataGridViewTextBoxColumn";
-            this.modeDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
             // tableLayoutPanel4
             // 
             this.tableLayoutPanel4.ColumnCount = 2;
@@ -644,7 +580,6 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel5.ResumeLayout(false);
             this.tableLayoutPanel5.PerformLayout();
             this.ResumeLayout(false);
-
         }
 
         #endregion
@@ -666,14 +601,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem ContextSaveLocalAs;
         private System.Windows.Forms.ToolStripMenuItem ContextSaveRemoteAs;
         private System.Windows.Forms.ToolStripMenuItem ContextMarkAsSolved;
-        private System.Windows.Forms.DataGridViewTextBoxColumn guidDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn commitGuidDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn itemTypeDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn nameDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn authorDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dateDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn fileNameDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn modeDataGridViewTextBoxColumn;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -101,6 +101,9 @@ namespace GitUI.CommandsDialogs
             Translate();
             _offerCommit = offerCommit;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
+
+            FileName.DataPropertyName = nameof(ConflictData.Filename);
+            authorDataGridViewTextBoxColumn1.DataPropertyName = "Author"; // TODO this property does not exist on the target type
         }
 
         private FormResolveConflicts()
@@ -148,7 +151,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 ConflictedFiles.DataSource = Module.GetConflicts();
-                ConflictedFiles.Columns[0].DataPropertyName = "Filename";
+                ConflictedFiles.Columns[0].DataPropertyName = nameof(ConflictData.Filename);
                 if (ConflictedFiles.Rows.Count > oldSelectedRow)
                 {
                     ConflictedFiles.Rows[oldSelectedRow].Selected = true;

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -73,7 +73,7 @@ namespace GitUI.CommandsDialogs
             Stashes.Text = "";
             StashMessage.Text = "";
             Stashes.SelectedItem = null;
-            Stashes.ComboBox.DisplayMember = "Message";
+            Stashes.ComboBox.DisplayMember = nameof(GitStash.Message);
             Stashes.Items.Clear();
             foreach (GitStash stashedItem in stashedItems)
             {

--- a/GitUI/CommandsDialogs/FormSubmodules.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.Designer.cs
@@ -147,7 +147,6 @@
             // nameDataGridViewTextBoxColumn
             // 
             this.nameDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.nameDataGridViewTextBoxColumn.DataPropertyName = "Name";
             this.nameDataGridViewTextBoxColumn.HeaderText = "Name";
             this.nameDataGridViewTextBoxColumn.Name = "nameDataGridViewTextBoxColumn";
             this.nameDataGridViewTextBoxColumn.ReadOnly = true;
@@ -155,7 +154,6 @@
             // Status
             // 
             this.Status.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Status.DataPropertyName = "Status";
             this.Status.HeaderText = "Status";
             this.Status.Name = "Status";
             this.Status.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -24,6 +24,8 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             Translate();
+            nameDataGridViewTextBoxColumn.DataPropertyName = nameof(GitSubmoduleInfo.Name);
+            Status.DataPropertyName = nameof(GitSubmoduleInfo.Status);
             gitSubmoduleBindingSource.DataSource = _modules;
         }
 

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -282,7 +282,6 @@
             // columnIsLostObjectSelected
             // 
             this.columnIsLostObjectSelected.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.columnIsLostObjectSelected.DataPropertyName = "IsSelected";
             this.columnIsLostObjectSelected.HeaderText = "";
             this.columnIsLostObjectSelected.MinimumWidth = 20;
             this.columnIsLostObjectSelected.Name = "columnIsLostObjectSelected";
@@ -290,7 +289,6 @@
             // columnDate
             // 
             this.columnDate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.columnDate.DataPropertyName = "Date";
             this.columnDate.HeaderText = "Date";
             this.columnDate.Name = "columnDate";
             this.columnDate.ReadOnly = true;
@@ -298,7 +296,6 @@
             // columnType
             // 
             this.columnType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.columnType.DataPropertyName = "RawType";
             this.columnType.HeaderText = "Type";
             this.columnType.Name = "columnType";
             this.columnType.ReadOnly = true;
@@ -306,7 +303,6 @@
             // columnSubject
             // 
             this.columnSubject.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.columnSubject.DataPropertyName = "Subject";
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.columnSubject.DefaultCellStyle = dataGridViewCellStyle1;
@@ -316,14 +312,12 @@
             // 
             // columnAuthor
             // 
-            this.columnAuthor.DataPropertyName = "Author";
             this.columnAuthor.HeaderText = "Author";
             this.columnAuthor.Name = "columnAuthor";
             this.columnAuthor.ReadOnly = true;
             // 
             // columnHash
             // 
-            this.columnHash.DataPropertyName = "Hash";
             this.columnHash.HeaderText = "Hash";
             this.columnHash.Name = "columnHash";
             this.columnHash.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -51,6 +51,13 @@ namespace GitUI.CommandsDialogs
             Translate();
             Warnings.AutoGenerateColumns = false;
 
+            columnIsLostObjectSelected.DataPropertyName = "IsSelected"; // TODO this property is not on the bound type
+            columnDate.DataPropertyName = nameof(LostObject.Date);
+            columnType.DataPropertyName = nameof(LostObject.RawType);
+            columnSubject.DataPropertyName = nameof(LostObject.Subject);
+            columnAuthor.DataPropertyName = nameof(LostObject.Author);
+            columnHash.DataPropertyName = nameof(LostObject.Hash);
+
             if (commands != null)
             {
                 _gitTagController = new GitTagController(commands);

--- a/GitUI/CommandsDialogs/FormViewPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.Designer.cs
@@ -101,7 +101,6 @@ namespace GitUI.CommandsDialogs
             // FileNameA
             // 
             this.FileNameA.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.FileNameA.DataPropertyName = "FileNameA";
             this.FileNameA.HeaderText = "Filename";
             this.FileNameA.Name = "FileNameA";
             this.FileNameA.ReadOnly = true;

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -27,6 +27,7 @@ namespace GitUI.CommandsDialogs
 
             typeDataGridViewTextBoxColumn.DataPropertyName = nameof(Patch.ChangeType);
             File.DataPropertyName = nameof(Patch.FileType);
+            FileNameA.DataPropertyName = nameof(Patch.FileNameA);
         }
 
         public void LoadPatch(string patch)

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.Designer.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.Designer.cs
@@ -87,7 +87,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // 
             // _pullReqTargetsCB
             // 
-            this._pullReqTargetsCB.DisplayMember = "DisplayData";
             this._pullReqTargetsCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._pullReqTargetsCB.FormattingEnabled = true;
             this._pullReqTargetsCB.Location = new System.Drawing.Point(141, 12);

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -37,14 +37,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
             InitializeComponent();
             Translate();
             _prevTitle = _titleTB.Text;
+            _pullReqTargetsCB.DisplayMember = nameof(IHostedRemote.DisplayData);
         }
 
         private void CreatePullRequestForm_Load(object sender, EventArgs e)
-        {
-            Init();
-        }
-
-        private void Init()
         {
             _createBtn.Enabled = false;
             _yourBranchesCB.Text = _strLoading.Text;
@@ -57,7 +53,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     if (foreignHostedRemotes.Length == 0)
                     {
                         MessageBox.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +
-                            _strPleaseCloneGitHubRep.Text, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                              _strPleaseCloneGitHubRep.Text, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         Close();
                         return;
                     }

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
@@ -124,7 +124,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // 
             // _selectHostedRepoCB
             // 
-            this._selectHostedRepoCB.DisplayMember = "DisplayData";
             this._selectHostedRepoCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._selectHostedRepoCB.FormattingEnabled = true;
             this._selectHostedRepoCB.Location = new System.Drawing.Point(144, 4);

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -39,6 +39,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             InitializeComponent();
             Translate();
+            _selectHostedRepoCB.DisplayMember = nameof(IHostedRemote.DisplayData);
             _loader.LoadingError += (sender, ex) =>
                 {
                     MessageBox.Show(this, ex.Exception.ToString(), _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -62,11 +63,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _fileStatusList.SelectedIndexChanged += _fileStatusList_SelectedIndexChanged;
             _discussionWB.DocumentCompleted += _discussionWB_DocumentCompleted;
 
-            Init();
-        }
-
-        private void Init()
-        {
             _isFirstLoad = true;
 
             this.Mask();

--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -141,7 +141,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public void FillEncodings(ComboBox combo)
         {
             combo.Items.AddRange(AppSettings.AvailableEncodings.Values.ToArray());
-            combo.DisplayMember = "EncodingName";
+            combo.DisplayMember = nameof(Encoding.EncodingName);
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             try
             {
                 ListIncludedEncodings.Items.AddRange(includedEncoding.Values.ToArray());
-                ListIncludedEncodings.DisplayMember = "EncodingName";
+                ListIncludedEncodings.DisplayMember = nameof(Encoding.EncodingName);
             }
             finally
             {
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             try
             {
                 ListAvailableEncodings.Items.AddRange(availableEncoding.ToArray());
-                ListAvailableEncodings.DisplayMember = "EncodingName";
+                ListAvailableEncodings.DisplayMember = nameof(Encoding.EncodingName);
             }
             finally
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
@@ -259,7 +259,6 @@
             // 
             // cboAutoNormaliseSymbol
             // 
-            this.cboAutoNormaliseSymbol.DisplayMember = "Key";
             this.cboAutoNormaliseSymbol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboAutoNormaliseSymbol.Enabled = false;
             this.cboAutoNormaliseSymbol.FormattingEnabled = true;
@@ -267,7 +266,6 @@
             this.cboAutoNormaliseSymbol.Name = "cboAutoNormaliseSymbol";
             this.cboAutoNormaliseSymbol.Size = new System.Drawing.Size(81, 21);
             this.cboAutoNormaliseSymbol.TabIndex = 8;
-            this.cboAutoNormaliseSymbol.ValueMember = "Value";
             // 
             // tooltip
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
@@ -16,6 +16,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 new { Key = "-", Value = "-" },
                 new { Key = "(none)", Value = "" },
             };
+            cboAutoNormaliseSymbol.DisplayMember = "Key";
+            cboAutoNormaliseSymbol.ValueMember = "Value";
             cboAutoNormaliseSymbol.DataSource = autoNormaliseSymbols;
             cboAutoNormaliseSymbol.SelectedIndex = 0;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.Designer.cs
@@ -126,7 +126,6 @@
             // 
             this.cmbSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.cmbSettings.DisplayMember = "Name";
             this.cmbSettings.FormattingEnabled = true;
             this.cmbSettings.IntegralHeight = false;
             this.cmbSettings.ItemHeight = 15;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
@@ -61,6 +61,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             InitializeComponent();
             Translate();
+
+            cmbSettings.DisplayMember = nameof(HotkeySettings.Name);
         }
 
         #region Methods

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -199,14 +199,12 @@
             // 
             // CaptionCol
             // 
-            this.CaptionCol.DataPropertyName = "Caption";
             this.CaptionCol.HeaderText = "Caption";
             this.CaptionCol.Name = "CaptionCol";
             // 
             // URICol
             // 
             this.URICol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.URICol.DataPropertyName = "Format";
             this.URICol.HeaderText = "URI";
             this.URICol.Name = "URICol";
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -159,7 +159,6 @@
             // 
             // _NO_TRANSLATE_Categories
             // 
-            this._NO_TRANSLATE_Categories.DisplayMember = "Name";
             this._NO_TRANSLATE_Categories.Dock = System.Windows.Forms.DockStyle.Fill;
             this._NO_TRANSLATE_Categories.FormattingEnabled = true;
             this._NO_TRANSLATE_Categories.IntegralHeight = false;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -14,6 +14,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Text = "Revision links";
             Translate();
             LinksGrid.AutoGenerateColumns = false;
+            CaptionCol.DataPropertyName = nameof(ExternalLinkFormat.Caption);
+            URICol.DataPropertyName = nameof(ExternalLinkFormat.Format);
         }
 
         protected override void SettingsToPage()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -49,7 +49,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             var effectiveLinkDefinitions = _externalLinksManager.GetEffectiveSettings();
 
             _NO_TRANSLATE_Categories.DataSource = null;
-            _NO_TRANSLATE_Categories.DisplayMember = "Name";
+            _NO_TRANSLATE_Categories.DisplayMember = nameof(ExternalLinkDefinition.Name);
             _NO_TRANSLATE_Categories.DataSource = effectiveLinkDefinitions;
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -119,28 +119,24 @@
             // HotkeyCommandIdentifier
             // 
             this.HotkeyCommandIdentifier.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.HotkeyCommandIdentifier.DataPropertyName = "HotkeyCommandIdentifier";
             this.HotkeyCommandIdentifier.HeaderText = "#";
             this.HotkeyCommandIdentifier.Name = "HotkeyCommandIdentifier";
             this.HotkeyCommandIdentifier.ReadOnly = true;
             // 
             // EnabledColumn
             // 
-            this.EnabledColumn.DataPropertyName = "Enabled";
             this.EnabledColumn.HeaderText = "Enabled";
             this.EnabledColumn.Name = "EnabledColumn";
             this.EnabledColumn.ReadOnly = true;
             // 
             // OnEvent
             // 
-            this.OnEvent.DataPropertyName = "OnEvent";
             this.OnEvent.HeaderText = "OnEvent";
             this.OnEvent.Name = "OnEvent";
             this.OnEvent.ReadOnly = true;
             // 
             // AskConfirmation
             // 
-            this.AskConfirmation.DataPropertyName = "AskConfirmation";
             this.AskConfirmation.HeaderText = "Confirmation";
             this.AskConfirmation.Name = "AskConfirmation";
             this.AskConfirmation.ReadOnly = true;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -61,6 +61,11 @@ Current Branch:
             HotkeyCommandIdentifier.Width = DpiUtil.Scale(39);
             Text = "Scripts";
             Translate();
+
+            HotkeyCommandIdentifier.DataPropertyName = nameof(ScriptInfo.HotkeyCommandIdentifier);
+            EnabledColumn.DataPropertyName = nameof(ScriptInfo.Enabled);
+            OnEvent.DataPropertyName = nameof(ScriptInfo.OnEvent);
+            AskConfirmation.DataPropertyName = nameof(ScriptInfo.AskConfirmation);
         }
 
         public override bool IsInstantSavePage => true;

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
         private void FormAddSubmoduleShown(object sender, EventArgs e)
         {
             Directory.DataSource = Repositories.RemoteRepositoryHistory.Repositories;
-            Directory.DisplayMember = "Path";
+            Directory.DisplayMember = nameof(Repository.Path);
             Directory.Text = "";
             LocalPath.Text = "";
         }
@@ -74,7 +74,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
                 heads.AddRange(module.GetRefs(false));
             }
 
-            Branch.DisplayMember = "Name";
+            Branch.DisplayMember = nameof(IGitRef.Name);
             Branch.DataSource = heads;
         }
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -51,7 +51,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                     {
                         comboBoxBranches.Text = string.Empty;
                         comboBoxBranches.DataSource = list;
-                        comboBoxBranches.DisplayMember = "LocalName";
+                        comboBoxBranches.DisplayMember = nameof(IGitRef.LocalName);
                     });
 
                 await this.SwitchToMainThreadAsync();

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
@@ -85,7 +85,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // Path
             // 
             this.Path.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Path.DataPropertyName = "Path";
             this.Path.HeaderText = "Path";
             this.Path.Name = "Path";
             this.Path.ReadOnly = true;
@@ -94,7 +93,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // Type
             // 
             this.Type.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Type.DataPropertyName = "Type";
             this.Type.HeaderText = "Type";
             this.Type.Name = "Type";
             this.Type.ReadOnly = true;
@@ -103,7 +101,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // Branch
             // 
             this.Branch.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Branch.DataPropertyName = "Branch";
             this.Branch.HeaderText = "Branch";
             this.Branch.Name = "Branch";
             this.Branch.ReadOnly = true;
@@ -112,7 +109,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // Sha1
             // 
             this.Sha1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Sha1.DataPropertyName = "Sha1";
             this.Sha1.HeaderText = "SHA-1";
             this.Sha1.Name = "Sha1";
             this.Sha1.ReadOnly = true;
@@ -121,7 +117,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // IsDeleted
             // 
             this.IsDeleted.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.IsDeleted.DataPropertyName = "IsDeleted";
             this.IsDeleted.HeaderText = "Deleted";
             this.IsDeleted.Name = "IsDeleted";
             this.IsDeleted.ReadOnly = true;

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
@@ -41,15 +41,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Delete = new System.Windows.Forms.DataGridViewImageColumn();
             this.buttonClose = new System.Windows.Forms.Button();
             this.buttonPruneWorktrees = new System.Windows.Forms.Button();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewCheckBoxColumn1 = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.dataGridViewImageColumn1 = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dataGridViewImageColumn2 = new System.Windows.Forms.DataGridViewImageColumn();
-            this.nameDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.BName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.Worktrees)).BeginInit();
             this.SuspendLayout();
@@ -178,83 +169,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.buttonPruneWorktrees.UseVisualStyleBackColor = true;
             this.buttonPruneWorktrees.Click += new System.EventHandler(this.buttonPruneWorktrees_Click);
             // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Name";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Name";
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "Type";
-            this.dataGridViewTextBoxColumn2.HeaderText = "Type";
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "Branch";
-            this.dataGridViewTextBoxColumn3.HeaderText = "Branch";
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "Sha1";
-            this.dataGridViewTextBoxColumn4.HeaderText = "SHA-1";
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            // 
-            // dataGridViewCheckBoxColumn1
-            // 
-            this.dataGridViewCheckBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewCheckBoxColumn1.DataPropertyName = "IsDeleted";
-            this.dataGridViewCheckBoxColumn1.HeaderText = "Deleted";
-            this.dataGridViewCheckBoxColumn1.Name = "dataGridViewCheckBoxColumn1";
-            this.dataGridViewCheckBoxColumn1.ReadOnly = true;
-            this.dataGridViewCheckBoxColumn1.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // dataGridViewImageColumn1
-            // 
-            this.dataGridViewImageColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewImageColumn1.HeaderText = "Open";
-            this.dataGridViewImageColumn1.Image = global::GitUI.Properties.Resources.IconBrowseFileExplorer;
-            this.dataGridViewImageColumn1.Name = "dataGridViewImageColumn1";
-            this.dataGridViewImageColumn1.ReadOnly = true;
-            this.dataGridViewImageColumn1.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // dataGridViewImageColumn2
-            // 
-            this.dataGridViewImageColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewImageColumn2.HeaderText = "Delete";
-            this.dataGridViewImageColumn2.Image = global::GitUI.Properties.Resources.Delete;
-            this.dataGridViewImageColumn2.Name = "dataGridViewImageColumn2";
-            this.dataGridViewImageColumn2.ReadOnly = true;
-            this.dataGridViewImageColumn2.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // nameDataGridViewTextBoxColumn
-            // 
-            this.nameDataGridViewTextBoxColumn.DataPropertyName = "Name";
-            this.nameDataGridViewTextBoxColumn.HeaderText = "Branch";
-            this.nameDataGridViewTextBoxColumn.Name = "nameDataGridViewTextBoxColumn";
-            this.nameDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // BName
-            // 
-            this.BName.DataPropertyName = "Name";
-            this.BName.HeaderText = "Name";
-            this.BName.Name = "BName";
-            this.BName.ReadOnly = true;
-            // 
             // FormManageWorktree
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -277,19 +191,10 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         }
 
         #endregion
-        private System.Windows.Forms.DataGridViewTextBoxColumn nameDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn BName;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.Button buttonClose;
         private System.Windows.Forms.DataGridView Worktrees;
         private System.Windows.Forms.Button buttonPruneWorktrees;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn2;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn3;
-        private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn4;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn dataGridViewCheckBoxColumn1;
-        private System.Windows.Forms.DataGridViewImageColumn dataGridViewImageColumn1;
-        private System.Windows.Forms.DataGridViewImageColumn dataGridViewImageColumn2;
         private System.Windows.Forms.DataGridViewTextBoxColumn Path;
         private System.Windows.Forms.DataGridViewTextBoxColumn Type;
         private System.Windows.Forms.DataGridViewTextBoxColumn Branch;

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -24,6 +24,12 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             Delete.Width = DpiUtil.Scale(44);
             Worktrees.AutoGenerateColumns = false;
             Translate();
+
+            Path.DataPropertyName = nameof(WorkTree.Path);
+            Type.DataPropertyName = nameof(WorkTree.Type);
+            Branch.DataPropertyName = nameof(WorkTree.Branch);
+            Sha1.DataPropertyName = nameof(WorkTree.Sha1);
+            IsDeleted.DataPropertyName = nameof(WorkTree.IsDeleted);
         }
 
         private void FormManageWorktree_Load(object sender, EventArgs e)

--- a/GitUI/HelperDialogs/FormSelectMultipleBranches.cs
+++ b/GitUI/HelperDialogs/FormSelectMultipleBranches.cs
@@ -25,7 +25,7 @@ namespace GitUI.HelperDialogs
                 Branches.MultiColumn = true;
             }
 
-            Branches.DisplayMember = "Name";
+            Branches.DisplayMember = nameof(IGitRef.Name);
             Branches.Items.AddRange(branchesToSelect.ToArray());
         }
 

--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -67,7 +67,6 @@
             // AutoComplete
             // 
             this.AutoComplete.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.AutoComplete.DisplayMember = "Word";
             this.AutoComplete.FormattingEnabled = true;
             this.AutoComplete.ItemHeight = 15;
             this.AutoComplete.Location = new System.Drawing.Point(167, 243);

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -67,6 +67,8 @@ namespace GitUI.SpellChecker
             MistakeFont = new Font(TextBox.Font, FontStyle.Underline);
             TextBoxFont = TextBox.Font;
 
+            AutoComplete.DisplayMember = nameof(AutoCompleteWord.Word);
+
             _wordAtCursorExtractor = new WordAtCursorExtractor();
         }
 

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -18,7 +18,7 @@ namespace GitUI
             InitializeComponent();
             Translate();
 
-            branches.DisplayMember = "Name";
+            branches.DisplayMember = nameof(IGitRef.Name);
         }
 
         private IReadOnlyList<IGitRef> _branchesToSelect;

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -72,14 +72,12 @@
             // FileName
             // 
             this.FileName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.FileName.DataPropertyName = "Name";
             this.FileName.HeaderText = "Name";
             this.FileName.Name = "FileName";
             this.FileName.ReadOnly = true;
             // 
             // subjectDataGridViewTextBoxColumn
             // 
-            this.subjectDataGridViewTextBoxColumn.DataPropertyName = "Subject";
             this.subjectDataGridViewTextBoxColumn.HeaderText = "Subject";
             this.subjectDataGridViewTextBoxColumn.Name = "subjectDataGridViewTextBoxColumn";
             this.subjectDataGridViewTextBoxColumn.ReadOnly = true;
@@ -87,7 +85,6 @@
             // authorDataGridViewTextBoxColumn
             // 
             this.authorDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.authorDataGridViewTextBoxColumn.DataPropertyName = "Author";
             this.authorDataGridViewTextBoxColumn.HeaderText = "Author";
             this.authorDataGridViewTextBoxColumn.Name = "authorDataGridViewTextBoxColumn";
             this.authorDataGridViewTextBoxColumn.ReadOnly = true;
@@ -95,7 +92,6 @@
             // dateDataGridViewTextBoxColumn
             // 
             this.dateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dateDataGridViewTextBoxColumn.DataPropertyName = "Date";
             this.dateDataGridViewTextBoxColumn.HeaderText = "Date";
             this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
             this.dateDataGridViewTextBoxColumn.ReadOnly = true;
@@ -103,7 +99,6 @@
             // Status
             // 
             this.Status.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Status.DataPropertyName = "Status";
             this.Status.HeaderText = "Status";
             this.Status.Name = "Status";
             this.Status.ReadOnly = true;

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -15,6 +15,11 @@ namespace GitUI
         {
             InitializeComponent();
             Translate();
+            FileName.DataPropertyName = nameof(PatchFile.Name);
+            subjectDataGridViewTextBoxColumn.DataPropertyName = nameof(PatchFile.Subject);
+            authorDataGridViewTextBoxColumn.DataPropertyName = nameof(PatchFile.Author);
+            dateDataGridViewTextBoxColumn.DataPropertyName = nameof(PatchFile.Date);
+            Status.DataPropertyName = nameof(PatchFile.Status);
 
             FileName.Width = DpiUtil.Scale(50);
             authorDataGridViewTextBoxColumn.Width = DpiUtil.Scale(140);
@@ -29,16 +34,11 @@ namespace GitUI
 
         public void Initialize()
         {
-            IReadOnlyList<PatchFile> patchFiles;
+            var patchFiles = Module.InTheMiddleOfInteractiveRebase()
+                ? Module.GetInteractiveRebasePatchFiles()
+                : Module.GetRebasePatchFiles();
 
-            if (Module.InTheMiddleOfInteractiveRebase())
-            {
-                Patches.DataSource = patchFiles = Module.GetInteractiveRebasePatchFiles();
-            }
-            else
-            {
-                Patches.DataSource = patchFiles = Module.GetRebasePatchFiles();
-            }
+            Patches.DataSource = patchFiles;
 
             if (patchFiles.Any())
             {

--- a/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.Designer.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.Designer.cs
@@ -36,7 +36,6 @@
             // 
             // lbxRefs
             // 
-            this.lbxRefs.DisplayMember = "Label";
             this.lbxRefs.FormattingEnabled = true;
             this.lbxRefs.Items.AddRange(new object[] {
             "local1 (ref)",

--- a/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormQuickGitRefSelector.cs
@@ -19,6 +19,8 @@ namespace GitUI.UserControls.RevisionGridClasses
         {
             InitializeComponent();
             Translate();
+
+            lbxRefs.DisplayMember = nameof(DisplyGitRef.Label);
         }
 
         /// <summary>

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
@@ -209,7 +209,6 @@
             // 
             this.ddlRepositorySource.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.ddlRepositorySource.DisplayMember = "DisplayName";
             this.ddlRepositorySource.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ddlRepositorySource.Enabled = false;
             this.ddlRepositorySource.FormattingEnabled = true;
@@ -223,7 +222,6 @@
             // 
             this.ddlBranchSource.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.ddlBranchSource.DisplayMember = "DisplayName";
             this.ddlBranchSource.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ddlBranchSource.FormattingEnabled = true;
             this.ddlBranchSource.Location = new System.Drawing.Point(128, 58);
@@ -246,7 +244,6 @@
             // 
             this.ddlBranchTarget.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.ddlBranchTarget.DisplayMember = "DisplayName";
             this.ddlBranchTarget.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ddlBranchTarget.FormattingEnabled = true;
             this.ddlBranchTarget.Location = new System.Drawing.Point(127, 58);
@@ -274,7 +271,6 @@
             // 
             this.ddlRepositoryTarget.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.ddlRepositoryTarget.DisplayMember = "DisplayName";
             this.ddlRepositoryTarget.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ddlRepositoryTarget.Enabled = false;
             this.ddlRepositoryTarget.FormattingEnabled = true;

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.Designer.cs
@@ -34,7 +34,6 @@
             this.lblDescription = new System.Windows.Forms.Label();
             this.txtDescription = new System.Windows.Forms.TextBox();
             this.btnCreate = new System.Windows.Forms.Button();
-            this.GridColumnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.txtTitle = new System.Windows.Forms.TextBox();
             this.lblTitle = new System.Windows.Forms.Label();
             this.lblSourceRepository = new System.Windows.Forms.Label();
@@ -153,13 +152,6 @@
             this.btnCreate.Text = "Create";
             this.btnCreate.UseVisualStyleBackColor = true;
             this.btnCreate.Click += new System.EventHandler(this.BtnCreateClick);
-            // 
-            // GridColumnName
-            // 
-            this.GridColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.GridColumnName.DataPropertyName = "Slug";
-            this.GridColumnName.HeaderText = "Name";
-            this.GridColumnName.Name = "GridColumnName";
             // 
             // txtTitle
             // 
@@ -726,7 +718,6 @@
         private System.Windows.Forms.Button btnCreate;
         private System.Windows.Forms.TextBox txtTitle;
         private System.Windows.Forms.Label lblTitle;
-        private System.Windows.Forms.DataGridViewTextBoxColumn GridColumnName;
         private System.Windows.Forms.Label lblSourceRepository;
         private System.Windows.Forms.GroupBox groupBoxSource;
         private System.Windows.Forms.GroupBox groupBoxTarget;

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -29,6 +29,10 @@ namespace Bitbucket
             InitializeComponent();
             Translate();
 
+            // NOTE ddlBranchSource and ddlBranchTarget both have string items so do not need a display member
+            ddlRepositorySource.DisplayMember = nameof(Repository.DisplayName);
+            ddlRepositoryTarget.DisplayMember = nameof(Repository.DisplayName);
+
             _settings = Settings.Parse(gitUiCommands.GitModule, settings, plugin);
             if (_settings == null)
             {
@@ -85,7 +89,7 @@ namespace Bitbucket
 
                 await this.SwitchToMainThreadAsync();
                 lbxPullRequests.DataSource = pullReqs;
-                lbxPullRequests.DisplayMember = "DisplayName";
+                lbxPullRequests.DisplayMember = nameof(PullRequest.DisplayName);
             }).FileAndForget();
         }
 

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
@@ -135,7 +135,6 @@
             // deleteDataGridViewCheckBoxColumn
             // 
             this.deleteDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.deleteDataGridViewCheckBoxColumn.DataPropertyName = "Delete";
             this.deleteDataGridViewCheckBoxColumn.FillWeight = 20F;
             this.deleteDataGridViewCheckBoxColumn.HeaderText = "Delete";
             this.deleteDataGridViewCheckBoxColumn.Name = "deleteDataGridViewCheckBoxColumn";
@@ -143,7 +142,6 @@
             // nameDataGridViewTextBoxColumn
             // 
             this.nameDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.nameDataGridViewTextBoxColumn.DataPropertyName = "Name";
             dataGridViewCellStyle1.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.nameDataGridViewTextBoxColumn.DefaultCellStyle = dataGridViewCellStyle1;
             this.nameDataGridViewTextBoxColumn.FillWeight = 2F;
@@ -155,7 +153,6 @@
             // dateDataGridViewTextBoxColumn
             // 
             this.dateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dateDataGridViewTextBoxColumn.DataPropertyName = "Date";
             this.dateDataGridViewTextBoxColumn.FillWeight = 300F;
             this.dateDataGridViewTextBoxColumn.HeaderText = "Last activity";
             this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
@@ -164,7 +161,6 @@
             // Author
             // 
             this.Author.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Author.DataPropertyName = "Author";
             dataGridViewCellStyle2.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.Author.DefaultCellStyle = dataGridViewCellStyle2;
             this.Author.FillWeight = 2F;
@@ -175,7 +171,6 @@
             // Message
             // 
             this.Message.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.Message.DataPropertyName = "Message";
             this.Message.HeaderText = "Last message";
             this.Message.Name = "Message";
             this.Message.ReadOnly = true;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -51,6 +51,12 @@ namespace DeleteUnusedBranches
             Translate();
             imgLoading.Image = Resources.loadingpanel;
 
+            deleteDataGridViewCheckBoxColumn.DataPropertyName = nameof(Branch.Delete);
+            nameDataGridViewTextBoxColumn.DataPropertyName = nameof(Branch.Name);
+            dateDataGridViewTextBoxColumn.DataPropertyName = nameof(Branch.Date);
+            Author.DataPropertyName = nameof(Branch.Author);
+            Message.DataPropertyName = nameof(Branch.Message);
+
             this.AdjustForDpiScaling();
 
             ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.Designer.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.Designer.cs
@@ -79,7 +79,6 @@
             // sHADataGridViewTextBoxColumn
             // 
             this.sHADataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.sHADataGridViewTextBoxColumn.DataPropertyName = "SHA";
             this.sHADataGridViewTextBoxColumn.HeaderText = "SHA";
             this.sHADataGridViewTextBoxColumn.Name = "sHADataGridViewTextBoxColumn";
             this.sHADataGridViewTextBoxColumn.ReadOnly = true;
@@ -87,7 +86,6 @@
             // pathDataGridViewTextBoxColumn
             // 
             this.pathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.pathDataGridViewTextBoxColumn.DataPropertyName = "Path";
             this.pathDataGridViewTextBoxColumn.HeaderText = "Path";
             this.pathDataGridViewTextBoxColumn.Name = "pathDataGridViewTextBoxColumn";
             this.pathDataGridViewTextBoxColumn.ReadOnly = true;
@@ -95,14 +93,12 @@
             // sizeDataGridViewTextBoxColumn
             // 
             this.sizeDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.sizeDataGridViewTextBoxColumn.DataPropertyName = "Size";
             this.sizeDataGridViewTextBoxColumn.HeaderText = "Size";
             this.sizeDataGridViewTextBoxColumn.Name = "sizeDataGridViewTextBoxColumn";
             this.sizeDataGridViewTextBoxColumn.ReadOnly = true;
             // 
             // CompressedSize
             // 
-            this.CompressedSize.DataPropertyName = "CompressedSize";
             this.CompressedSize.HeaderText = "Compressed size";
             this.CompressedSize.Name = "CompressedSize";
             this.CompressedSize.ReadOnly = true;
@@ -110,7 +106,6 @@
             // commitCountDataGridViewTextBoxColumn
             // 
             this.commitCountDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.commitCountDataGridViewTextBoxColumn.DataPropertyName = "CommitCount";
             this.commitCountDataGridViewTextBoxColumn.HeaderText = "Commit count";
             this.commitCountDataGridViewTextBoxColumn.Name = "commitCountDataGridViewTextBoxColumn";
             this.commitCountDataGridViewTextBoxColumn.ReadOnly = true;
@@ -118,14 +113,12 @@
             // lastCommitDateDataGridViewTextBoxColumn
             // 
             this.lastCommitDateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.lastCommitDateDataGridViewTextBoxColumn.DataPropertyName = "LastCommitDate";
             this.lastCommitDateDataGridViewTextBoxColumn.HeaderText = "Last commit date";
             this.lastCommitDateDataGridViewTextBoxColumn.Name = "lastCommitDateDataGridViewTextBoxColumn";
             this.lastCommitDateDataGridViewTextBoxColumn.ReadOnly = true;
             // 
             // dataGridViewCheckBoxColumn1
             // 
-            this.dataGridViewCheckBoxColumn1.DataPropertyName = "Delete";
             this.dataGridViewCheckBoxColumn1.HeaderText = "Delete";
             this.dataGridViewCheckBoxColumn1.Name = "dataGridViewCheckBoxColumn1";
             this.dataGridViewCheckBoxColumn1.ReadOnly = true;

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -34,6 +34,14 @@ namespace FindLargeFiles
 
             Translate();
 
+            sHADataGridViewTextBoxColumn.DataPropertyName = nameof(GitObject.SHA);
+            pathDataGridViewTextBoxColumn.DataPropertyName = nameof(GitObject.Path);
+            sizeDataGridViewTextBoxColumn.DataPropertyName = nameof(GitObject.Size);
+            CompressedSize.DataPropertyName = nameof(GitObject.CompressedSize);
+            commitCountDataGridViewTextBoxColumn.DataPropertyName = nameof(GitObject.CommitCount);
+            lastCommitDateDataGridViewTextBoxColumn.DataPropertyName = nameof(GitObject.LastCommitDate);
+            dataGridViewCheckBoxColumn1.DataPropertyName = nameof(GitObject.Delete);
+
             _threshold = threshold;
             _gitUiCommands = gitUiEventArgs;
             _gitCommands = gitUiEventArgs?.GitModule;

--- a/TranslationApp/FormTranslate.Designer.cs
+++ b/TranslationApp/FormTranslate.Designer.cs
@@ -292,7 +292,6 @@ namespace TranslationApp
             // 
             // categoryDataGridViewTextBoxColumn
             // 
-            this.categoryDataGridViewTextBoxColumn.DataPropertyName = "Category";
             this.categoryDataGridViewTextBoxColumn.HeaderText = "Category";
             this.categoryDataGridViewTextBoxColumn.Name = "categoryDataGridViewTextBoxColumn";
             this.categoryDataGridViewTextBoxColumn.ReadOnly = true;
@@ -300,7 +299,6 @@ namespace TranslationApp
             // 
             // nameDataGridViewTextBoxColumn
             // 
-            this.nameDataGridViewTextBoxColumn.DataPropertyName = "Name";
             this.nameDataGridViewTextBoxColumn.HeaderText = "Name";
             this.nameDataGridViewTextBoxColumn.Name = "nameDataGridViewTextBoxColumn";
             this.nameDataGridViewTextBoxColumn.ReadOnly = true;
@@ -308,7 +306,6 @@ namespace TranslationApp
             // 
             // propertyDataGridViewTextBoxColumn
             // 
-            this.propertyDataGridViewTextBoxColumn.DataPropertyName = "Property";
             this.propertyDataGridViewTextBoxColumn.HeaderText = "Property";
             this.propertyDataGridViewTextBoxColumn.Name = "propertyDataGridViewTextBoxColumn";
             this.propertyDataGridViewTextBoxColumn.ReadOnly = true;
@@ -317,7 +314,6 @@ namespace TranslationApp
             // neutralValueDataGridViewTextBoxColumn
             // 
             this.neutralValueDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.neutralValueDataGridViewTextBoxColumn.DataPropertyName = "NeutralValue";
             this.neutralValueDataGridViewTextBoxColumn.HeaderText = "NeutralValue";
             this.neutralValueDataGridViewTextBoxColumn.Name = "neutralValueDataGridViewTextBoxColumn";
             this.neutralValueDataGridViewTextBoxColumn.ReadOnly = true;
@@ -326,7 +322,6 @@ namespace TranslationApp
             // translatedValueDataGridViewTextBoxColumn
             // 
             this.translatedValueDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.translatedValueDataGridViewTextBoxColumn.DataPropertyName = "TranslatedValue";
             this.translatedValueDataGridViewTextBoxColumn.HeaderText = "TranslatedValue";
             this.translatedValueDataGridViewTextBoxColumn.Name = "translatedValueDataGridViewTextBoxColumn";
             this.translatedValueDataGridViewTextBoxColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;

--- a/TranslationApp/FormTranslate.Designer.cs
+++ b/TranslationApp/FormTranslate.Designer.cs
@@ -232,7 +232,6 @@ namespace TranslationApp
             // 
             // translateCategories
             // 
-            this.translateCategories.DisplayMember = "Name";
             this.translateCategories.Dock = System.Windows.Forms.DockStyle.Fill;
             this.translateCategories.FormattingEnabled = true;
             this.translateCategories.ItemHeight = 23;

--- a/TranslationApp/FormTranslate.cs
+++ b/TranslationApp/FormTranslate.cs
@@ -37,6 +37,8 @@ namespace TranslationApp
         {
             InitializeComponent();
             Translate();
+
+            translateCategories.DisplayMember = nameof(TranslationCategory.Name);
         }
 
         private void FormTranslate_Load(object sender, EventArgs e)

--- a/TranslationApp/FormTranslate.cs
+++ b/TranslationApp/FormTranslate.cs
@@ -39,6 +39,12 @@ namespace TranslationApp
             Translate();
 
             translateCategories.DisplayMember = nameof(TranslationCategory.Name);
+
+            categoryDataGridViewTextBoxColumn.DataPropertyName = nameof(TranslationItemWithCategory.Category);
+            nameDataGridViewTextBoxColumn.DataPropertyName = nameof(TranslationItemWithCategory.Name);
+            propertyDataGridViewTextBoxColumn.DataPropertyName = nameof(TranslationItemWithCategory.Property);
+            neutralValueDataGridViewTextBoxColumn.DataPropertyName = nameof(TranslationItemWithCategory.NeutralValue);
+            translatedValueDataGridViewTextBoxColumn.DataPropertyName = nameof(TranslationItemWithCategory.TranslatedValue);
         }
 
         private void FormTranslate_Load(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #4795

Changes proposed in this pull request:
- Use `nameof` to prevent dynamic bindings between UI and GE types from breaking during automated refactoring
  - `DataGridViewColumn.DataPropertyName`
  - `ListControl.DisplayMember` (covers `ComboBox`, `ListBox`, ...)
  - `ListControl.ValueMember` (covers `ComboBox`, `ListBox`, ...)
- Remove a bunch of unused grid columns from `*.Designer.cs` files

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
 - GIT 2.16
 - Windows 10
