### PR TITLE
Show the computed merge base commit sha.

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -57,6 +57,7 @@ namespace GitUI.CommandsDialogs
             _baseRevision = new GitRevision(baseCommitSha);
             _headRevision = new GitRevision(headCommitSha);
             _mergeBase = new GitRevision(Module.GetMergeBase(_baseRevision.Guid, _headRevision.Guid));
+            ckCompareToMergeBase.Text += $" ({GitRevision.ToShortSha(_mergeBase.Guid)})";
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _findFilePredicateProvider = new FindFilePredicateProvider();
             _revisionTester = new GitRevisionTester(_fullPathResolver);


### PR DESCRIPTION
Changes proposed in this pull request:
 - Show what commit git has chosen as a merge base.
 
Screenshots before and after (if PR changes UI):
Before
![qr](https://user-images.githubusercontent.com/1003909/38466894-669db50a-3b30-11e8-9c47-7fe082d5f466.png)

After
![gitext](https://user-images.githubusercontent.com/1003909/38466896-6e814642-3b30-11e8-9739-8803441d2b66.png)

Has been tested on (remove any that don't apply):
 - GIT 2.15
 - Windows 10
