### PR TITLE
Editor syntax highlighting for commit and interactive rebase

### DIFF
--- a/GitCommands/Git/GitDirectoryResolver.cs
+++ b/GitCommands/Git/GitDirectoryResolver.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace GitCommands.Git
 {
@@ -15,7 +16,8 @@ namespace GitCommands.Git
         /// </summary>
         /// <param name="repositoryPath">The repository working folder.</param>
         /// <returns>The resolved location of .git folder.</returns>
-        string Resolve(string repositoryPath);
+        [NotNull]
+        string Resolve([NotNull] string repositoryPath);
     }
 
     /// <summary>
@@ -25,7 +27,7 @@ namespace GitCommands.Git
     {
         private readonly IFileSystem _fileSystem;
 
-        public GitDirectoryResolver(IFileSystem fileSystem)
+        public GitDirectoryResolver([NotNull] IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
         }

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -14,20 +14,21 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _cannotSaveFile = new TranslationString("Cannot save file:");
         private readonly TranslationString _error = new TranslationString("Error");
 
-        [CanBeNull] private string _fileName;
+        [CanBeNull] private readonly string _fileName;
 
         private bool _hasChanges;
 
         public FormEditor([NotNull] GitUICommands commands, [CanBeNull] string fileName, bool showWarning)
             : base(commands)
         {
+            _fileName = fileName;
             InitializeComponent();
             Translate();
 
             // for translation form
-            if (fileName != null)
+            if (_fileName != null)
             {
-                OpenFile(fileName);
+                OpenFile();
             }
 
             fileViewer.TextChanged += (s, e) => HasChanges = true;
@@ -45,11 +46,10 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void OpenFile(string fileName)
+        private void OpenFile()
         {
             try
             {
-                _fileName = fileName;
                 fileViewer.ViewFileAsync(_fileName);
                 fileViewer.IsReadOnly = false;
                 fileViewer.SetVisibilityDiffContextMenu(false, false);
@@ -61,7 +61,6 @@ namespace GitUI.CommandsDialogs
             catch (Exception ex)
             {
                 MessageBox.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, _error.Text);
-                _fileName = string.Empty;
                 Close();
             }
         }

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Windows.Forms;
+using JetBrains.Annotations;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -12,10 +13,12 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _cannotOpenFile = new TranslationString("Cannot open file:");
         private readonly TranslationString _cannotSaveFile = new TranslationString("Cannot save file:");
         private readonly TranslationString _error = new TranslationString("Error");
-        private bool _hasChanges;
-        private string _fileName;
 
-        public FormEditor(GitUICommands commands, string fileName, bool showWarning)
+        [CanBeNull] private string _fileName;
+
+        private bool _hasChanges;
+
+        public FormEditor([NotNull] GitUICommands commands, [CanBeNull] string fileName, bool showWarning)
             : base(commands)
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -43,6 +43,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         private bool SolveEditor()
         {
             string editor = CommonLogic.GetGlobalEditor();
+
             if (string.IsNullOrEmpty(editor))
             {
                 GlobalConfigFileSettings.SetPathValue("core.editor", "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor");

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using GitCommands;
 using GitCommands.Settings;
 using GitCommands.Utils;
+using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using Microsoft.Win32;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
@@ -46,7 +47,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             if (string.IsNullOrEmpty(editor))
             {
-                GlobalConfigFileSettings.SetPathValue("core.editor", "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor");
+                GlobalConfigFileSettings.SetPathValue("core.editor", EditorHelper.FileEditorCommand);
             }
 
             return true;

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -6,11 +6,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     public static class EditorHelper
     {
         [NotNull]
-        public static object[] GetEditors()
+        public static string FileEditorCommand
+            => $"\"{AppSettings.GetGitExtensionsFullPath()}\" fileeditor";
+
+        [NotNull]
+        public static string[] GetEditors()
         {
-            return new object[]
+            return new[]
             {
-                "\"" + AppSettings.GetGitExtensionsFullPath() + "\" fileeditor",
+                FileEditorCommand,
                 "vi",
                 "notepad",
                 GetNotepadPP(),

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -15,7 +15,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 "notepad",
                 GetNotepadPP(),
                 GetSublimeText3(),
-                GetVsCode(),
+                GetVsCode()
             };
         }
 
@@ -41,13 +41,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private static string GetEditorCommandLine(string editorName, string executableName, string commandLineParameter, params string[] installFolders)
         {
             string exec = MergeToolsHelper.FindFileInFolders(executableName, installFolders);
+
             if (string.IsNullOrEmpty(exec))
             {
                 exec = editorName;
             }
             else
             {
-                exec = "\"" + exec + "\"";
+                exec = $"\"{exec}\"";
             }
 
             return exec + commandLineParameter;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -39,29 +39,21 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         public override void OnPageShown()
         {
-            {
-                bool canFindGitCmd = CheckSettingsLogic.CanFindGitCmd();
+            bool canFindGitCmd = CheckSettingsLogic.CanFindGitCmd();
 
-                GlobalUserName.Enabled = canFindGitCmd;
-                GlobalUserEmail.Enabled = canFindGitCmd;
-                GlobalEditor.Enabled = canFindGitCmd;
-                CommitTemplatePath.Enabled = canFindGitCmd;
-                _NO_TRANSLATE_GlobalMergeTool.Enabled = canFindGitCmd;
-                MergetoolPath.Enabled = canFindGitCmd;
-                MergeToolCmd.Enabled = canFindGitCmd;
-                GlobalKeepMergeBackup.Enabled = canFindGitCmd;
-                InvalidGitPathGlobal.Visible = !canFindGitCmd;
-            }
+            GlobalUserName.Enabled = canFindGitCmd;
+            GlobalUserEmail.Enabled = canFindGitCmd;
+            GlobalEditor.Enabled = canFindGitCmd;
+            CommitTemplatePath.Enabled = canFindGitCmd;
+            _NO_TRANSLATE_GlobalMergeTool.Enabled = canFindGitCmd;
+            MergetoolPath.Enabled = canFindGitCmd;
+            MergeToolCmd.Enabled = canFindGitCmd;
+            GlobalKeepMergeBackup.Enabled = canFindGitCmd;
+            InvalidGitPathGlobal.Visible = !canFindGitCmd;
 
-            if (_NO_TRANSLATE_GlobalMergeTool.Text.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase)
-                && string.IsNullOrEmpty(MergeToolCmd.Text))
-            {
-                MergeToolCmd.Enabled = false;
-            }
-            else
-            {
-                MergeToolCmd.Enabled = true;
-            }
+            var isKdiff3 = _NO_TRANSLATE_GlobalMergeTool.Text.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase);
+
+            MergeToolCmd.Enabled = !isKdiff3 || !string.IsNullOrEmpty(MergeToolCmd.Text);
         }
 
         protected override void SettingsToPage()
@@ -98,44 +90,46 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             CurrentSettings.FilesEncoding = CommonLogic.ComboToEncoding(Global_FilesEncoding);
 
-            if (CheckSettingsLogic.CanFindGitCmd())
+            if (!CheckSettingsLogic.CanFindGitCmd())
             {
-                CurrentSettings.SetValue(SettingKeyString.UserName, GlobalUserName.Text);
-                CurrentSettings.SetValue(SettingKeyString.UserEmail, GlobalUserEmail.Text);
-                CurrentSettings.SetValue("commit.template", CommitTemplatePath.Text);
-                CurrentSettings.SetPathValue("core.editor", GlobalEditor.Text);
+                return;
+            }
 
-                CheckSettingsLogic.SetDiffToolToConfig(CurrentSettings, _NO_TRANSLATE_GlobalDiffTool.Text);
+            CurrentSettings.SetValue(SettingKeyString.UserName, GlobalUserName.Text);
+            CurrentSettings.SetValue(SettingKeyString.UserEmail, GlobalUserEmail.Text);
+            CurrentSettings.SetValue("commit.template", CommitTemplatePath.Text);
+            CurrentSettings.SetPathValue("core.editor", GlobalEditor.Text);
 
-                CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text), DifftoolPath.Text);
-                CurrentSettings.SetPathValue(string.Format("difftool.{0}.cmd", _NO_TRANSLATE_GlobalDiffTool.Text), DifftoolCmd.Text);
+            CheckSettingsLogic.SetDiffToolToConfig(CurrentSettings, _NO_TRANSLATE_GlobalDiffTool.Text);
 
-                CurrentSettings.SetValue("merge.tool", _NO_TRANSLATE_GlobalMergeTool.Text);
+            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text), DifftoolPath.Text);
+            CurrentSettings.SetPathValue(string.Format("difftool.{0}.cmd", _NO_TRANSLATE_GlobalDiffTool.Text), DifftoolCmd.Text);
 
-                CurrentSettings.SetPathValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text), MergetoolPath.Text);
-                CurrentSettings.SetPathValue(string.Format("mergetool.{0}.cmd", _NO_TRANSLATE_GlobalMergeTool.Text), MergeToolCmd.Text);
+            CurrentSettings.SetValue("merge.tool", _NO_TRANSLATE_GlobalMergeTool.Text);
 
-                CurrentSettings.mergetool.keepBackup.Value = GlobalKeepMergeBackup.GetNullableChecked();
+            CurrentSettings.SetPathValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text), MergetoolPath.Text);
+            CurrentSettings.SetPathValue(string.Format("mergetool.{0}.cmd", _NO_TRANSLATE_GlobalMergeTool.Text), MergeToolCmd.Text);
 
-                if (globalAutoCrlfFalse.Checked)
-                {
-                    CurrentSettings.core.autocrlf.Value = AutoCRLFType.@false;
-                }
+            CurrentSettings.mergetool.keepBackup.Value = GlobalKeepMergeBackup.GetNullableChecked();
 
-                if (globalAutoCrlfInput.Checked)
-                {
-                    CurrentSettings.core.autocrlf.Value = AutoCRLFType.input;
-                }
+            if (globalAutoCrlfFalse.Checked)
+            {
+                CurrentSettings.core.autocrlf.Value = AutoCRLFType.@false;
+            }
 
-                if (globalAutoCrlfTrue.Checked)
-                {
-                    CurrentSettings.core.autocrlf.Value = AutoCRLFType.@true;
-                }
+            if (globalAutoCrlfInput.Checked)
+            {
+                CurrentSettings.core.autocrlf.Value = AutoCRLFType.input;
+            }
 
-                if (globalAutoCrlfNotSet.Checked)
-                {
-                    CurrentSettings.core.autocrlf.Value = null;
-                }
+            if (globalAutoCrlfTrue.Checked)
+            {
+                CurrentSettings.core.autocrlf.Value = AutoCRLFType.@true;
+            }
+
+            if (globalAutoCrlfNotSet.Checked)
+            {
+                CurrentSettings.core.autocrlf.Value = null;
             }
         }
 
@@ -149,15 +143,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             MergetoolPath.Text = CurrentSettings.GetValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()));
             MergeToolCmd.Text = CurrentSettings.GetValue(string.Format("mergetool.{0}.cmd", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()));
 
-            if (_NO_TRANSLATE_GlobalMergeTool.Text.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase) &&
-                string.IsNullOrEmpty(MergeToolCmd.Text))
-            {
-                MergeToolCmd.Enabled = false;
-            }
-            else
-            {
-                MergeToolCmd.Enabled = true;
-            }
+            var isKdiff3 = _NO_TRANSLATE_GlobalMergeTool.Text.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase);
+
+            MergeToolCmd.Enabled = !isKdiff3 || !string.IsNullOrEmpty(MergeToolCmd.Text);
 
             MergeToolCmdSuggest_Click(null, null);
         }

--- a/GitUI/Editor/CommitMessageHighlightingStrategy.cs
+++ b/GitUI/Editor/CommitMessageHighlightingStrategy.cs
@@ -1,0 +1,171 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands;
+using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor
+{
+    internal sealed class CommitMessageHighlightingStrategy : GitHighlightingStrategyBase
+    {
+        private static HighlightColor ColorSummary { get; } = new HighlightColor(Color.Black, bold: true, italic: false);
+
+        private readonly List<TextMarker> _overlengthDescriptionMarkers = new List<TextMarker>();
+
+        private readonly TextMarker _markerSummaryTooLong = new TextMarker(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "Summary line is too long." };
+        private readonly TextMarker _markerSpacerNeeded = new TextMarker(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "There must be a blank line after the summary." };
+
+        public CommitMessageHighlightingStrategy(GitModule module)
+            : base("GitCommitMessage", module)
+        {
+        }
+
+        // TODO pending issue is that when text is pasted into the editor, validation markers are not updated until their lines are modified (seems like a bug in the editor)
+
+        protected override void MarkTokens(IDocument document, IList<LineSegment> lines)
+        {
+            var summaryLineNumber = -1;
+            var seenDividingSpace = false;
+            var descriptionStartLineNumber = -1;
+
+            foreach (var line in document.LineSegmentCollection)
+            {
+                if (summaryLineNumber == -1)
+                {
+                    if (!IsEmptyOrWhiteSpace(document, line) && !IsComment(document, line))
+                    {
+                        summaryLineNumber = line.LineNumber;
+                    }
+                }
+                else if (!seenDividingSpace)
+                {
+                    if (IsEmptyOrWhiteSpace(document, line))
+                    {
+                        seenDividingSpace = true;
+                    }
+                    else if (!IsComment(document, line))
+                    {
+                        descriptionStartLineNumber = line.LineNumber;
+                        break;
+                    }
+                }
+                else if (descriptionStartLineNumber != -1)
+                {
+                    if (!IsEmptyOrWhiteSpace(document, line) && !IsComment(document, line))
+                    {
+                        descriptionStartLineNumber = line.LineNumber;
+                        break;
+                    }
+                }
+            }
+
+            const int maxSummaryLength = 50;
+            const int maxDescriptionLength = 80;
+
+            // NOTE the pattern of removing then adding markers might look suboptimal, but tracking their presence isn't reliable as they can be removed without warning
+
+            foreach (var line in lines)
+            {
+                var lineNumber = line.LineNumber;
+
+                if (TryHighlightComment(document, line))
+                {
+                }
+                else
+                {
+                    var color = lineNumber == summaryLineNumber ? ColorSummary : ColorNormal;
+
+                    line.Words = new List<TextWord>(capacity: 1)
+                        { new TextWord(document, line, 0, line.Length, color, hasDefaultColor: false) };
+
+                    if (lineNumber == summaryLineNumber)
+                    {
+                        document.MarkerStrategy.RemoveMarker(_markerSummaryTooLong);
+
+                        if (line.Length > maxSummaryLength)
+                        {
+                            _markerSummaryTooLong.Offset = line.Offset + maxSummaryLength;
+                            _markerSummaryTooLong.Length = line.Length - maxSummaryLength;
+                            document.MarkerStrategy.AddMarker(_markerSummaryTooLong);
+                        }
+                    }
+                    else if (lineNumber == descriptionStartLineNumber)
+                    {
+                        document.MarkerStrategy.RemoveMarker(_markerSpacerNeeded);
+
+                        if (!seenDividingSpace)
+                        {
+                            _markerSpacerNeeded.Offset = line.Offset;
+                            _markerSpacerNeeded.Length = line.Length;
+                            document.MarkerStrategy.AddMarker(_markerSpacerNeeded);
+                        }
+                    }
+                }
+
+                document.RequestUpdate(
+                    new TextAreaUpdate(TextAreaUpdateType.SingleLine, lineNumber));
+            }
+
+            if (descriptionStartLineNumber == -1)
+            {
+                if (_overlengthDescriptionMarkers.Count != 0)
+                {
+                    foreach (var marker in _overlengthDescriptionMarkers)
+                    {
+                        document.MarkerStrategy.RemoveMarker(marker);
+                    }
+
+                    _overlengthDescriptionMarkers.Clear();
+                }
+
+                return;
+            }
+
+            var markerIndex = 0;
+
+            foreach (var line in document.LineSegmentCollection)
+            {
+                if (line.LineNumber < descriptionStartLineNumber)
+                {
+                    continue;
+                }
+
+                if (line.Length > maxDescriptionLength)
+                {
+                    var markerOffset = line.Offset + maxDescriptionLength;
+                    var markerLength = line.Length - maxDescriptionLength;
+
+                    TextMarker overlengthMarker;
+                    if (markerIndex < _overlengthDescriptionMarkers.Count)
+                    {
+                        overlengthMarker = _overlengthDescriptionMarkers[markerIndex];
+                    }
+                    else
+                    {
+                        overlengthMarker = new TextMarker(markerOffset, markerLength, TextMarkerType.WaveLine, Color.Red) { ToolTip = "Line is too long." };
+                        _overlengthDescriptionMarkers.Add(overlengthMarker);
+                        document.MarkerStrategy.AddMarker(overlengthMarker);
+                    }
+
+                    overlengthMarker.Offset = markerOffset;
+                    overlengthMarker.Length = markerLength;
+
+                    markerIndex++;
+                }
+            }
+
+            var toRemove = _overlengthDescriptionMarkers.Count - markerIndex;
+
+            if (toRemove > 0)
+            {
+                for (var i = 0; i < toRemove; i++)
+                {
+                    var marker = _overlengthDescriptionMarkers[markerIndex + i];
+                    document.MarkerStrategy.RemoveMarker(marker);
+                }
+
+                _overlengthDescriptionMarkers.RemoveRange(markerIndex, toRemove);
+            }
+        }
+    }
+}

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -483,8 +483,7 @@ namespace GitUI.Editor
 
         public void ViewPatch([CanBeNull] Patch patch, [CanBeNull] Action openWithDifftool = null)
         {
-            string text = patch != null ? patch.Text : "";
-            ViewPatch(text, openWithDifftool);
+            ViewPatch(patch?.Text ?? "", openWithDifftool);
         }
 
         public void ViewPatch([NotNull] string text, [CanBeNull] Action openWithDifftool)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -38,7 +38,7 @@ namespace GitUI.Editor
 
             GitUICommandsSourceSet += FileViewer_GitUICommandsSourceSet;
 
-            _internalFileViewer = new FileViewerInternal();
+            _internalFileViewer = new FileViewerInternal(() => Module);
             _internalFileViewer.MouseEnter += _internalFileViewer_MouseEnter;
             _internalFileViewer.MouseLeave += _internalFileViewer_MouseLeave;
             _internalFileViewer.MouseMove += _internalFileViewer_MouseMove;

--- a/GitUI/Editor/GitHighlightingStrategyBase.cs
+++ b/GitUI/Editor/GitHighlightingStrategyBase.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using GitCommands;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor
+{
+    internal abstract class GitHighlightingStrategyBase : IHighlightingStrategy
+    {
+        protected static HighlightColor ColorNormal { get; } = new HighlightColor(Color.Black, bold: false, italic: false);
+
+        private static HighlightColor ColorComment { get; } = new HighlightColor(Color.DarkGreen, bold: false, italic: false);
+
+        private readonly DefaultHighlightingStrategy _defaultHighlightingStrategy = new DefaultHighlightingStrategy();
+
+        private readonly char _commentChar;
+
+        protected GitHighlightingStrategyBase(string name, GitModule module)
+        {
+            Name = name;
+
+            // By default, comments start with '#'.
+            //
+            // This can be overridden via the "core.commentChar" configuration setting.
+            //
+            // However, if "core.commentChar" is "auto", then git attempts to choose a
+            // character from "#;@!$%^&|:" which is not present in the message.
+            // In such cases it does not appear that the character is provided to the
+            // editor. The only way to determine the character is to inspect the message,
+            // potentially for a regex resembling "with '(.)' will be ignored", though
+            // this likely changes with locale.
+            //
+            // An alternative approach would be to tally counts for the known set of
+            // characters for each line[0] and take the character with most.
+            // That would work well in practice.
+
+            string commentCharSetting = module.EffectiveConfigFile.GetString("core.commentChar", "#");
+
+            _commentChar = commentCharSetting?.Length == 1 ? commentCharSetting[0] : '#';
+        }
+
+        protected abstract void MarkTokens(IDocument document, IList<LineSegment> lines);
+
+        protected bool TryHighlightComment(IDocument document, LineSegment line)
+        {
+            if (IsComment(document, line))
+            {
+                line.Words = new List<TextWord>(capacity: 1)
+                    { new TextWord(document, line, 0, line.Length, ColorComment, hasDefaultColor: false) };
+                return true;
+            }
+
+            return false;
+        }
+
+        #region IHighlightingStrategy
+
+        public string Name { get; }
+
+        public string[] Extensions => Array.Empty<string>();
+
+        public Dictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+
+        public HighlightColor GetColorFor(string name)
+        {
+            return _defaultHighlightingStrategy.GetColorFor(name);
+        }
+
+        public void MarkTokens(IDocument document)
+        {
+            MarkTokens(document, document.LineSegmentCollection);
+        }
+
+        public void MarkTokens(IDocument document, List<LineSegment> lines)
+        {
+            MarkTokens(document, (IList<LineSegment>)lines);
+        }
+
+        #endregion
+
+        #region Line classifiers
+
+        protected bool IsComment(IDocument document, LineSegment line)
+        {
+            for (var i = 0; i < line.Length; i++)
+            {
+                var c = document.GetCharAt(line.Offset + i);
+
+                if (char.IsWhiteSpace(c))
+                {
+                    continue;
+                }
+
+                return c == _commentChar;
+            }
+
+            return false;
+        }
+
+        protected static bool IsEmptyOrWhiteSpace(IDocument document, LineSegment line)
+        {
+            for (var i = 0; i < line.Length; i++)
+            {
+                var c = document.GetCharAt(line.Offset + i);
+
+                if (!char.IsWhiteSpace(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -34,7 +34,7 @@ namespace GitUI.Editor
 
         string GetText();
         void SetText([NotNull] string text, [CanBeNull] Action openWithDifftool, bool isDiff = false);
-        void SetHighlighting(string syntax);
+        void SetHighlighting([NotNull] string syntax);
         void SetHighlightingForFile(string filename);
         void HighlightLine(int line, Color color);
         void HighlightLines(int startLine, int endLine, Color color);

--- a/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
+++ b/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands;
+using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
+using JetBrains.Annotations;
+
+namespace GitUI.Editor
+{
+    internal sealed class RebaseTodoHighlightingStrategy : GitHighlightingStrategyBase
+    {
+        /*
+        Commands:
+        p, pick = use commit
+        r, reword = use commit, but edit the commit message
+        e, edit = use commit, but stop for amending
+        s, squash = use commit, but meld into previous commit
+        f, fixup = like "squash", but discard this commit's log message
+        x, exec = run command (the rest of the line) using shell
+        d, drop = remove commit
+        */
+
+        private static readonly Dictionary<char, (string longForm, HighlightColor color)> _commandByFirstChar = new Dictionary<char, (string longForm, HighlightColor color)>
+        {
+            { 'p', ("pick", new HighlightColor(Color.Black, bold: true, italic: false)) },
+            { 'r', ("reword", new HighlightColor(Color.Purple, bold: true, italic: false)) },
+            { 'e', ("edit", new HighlightColor(Color.Black, bold: true, italic: false)) },
+            { 's', ("squash", new HighlightColor(Color.DarkBlue, bold: true, italic: false)) },
+            { 'f', ("fixup", new HighlightColor(Color.LightCoral, bold: true, italic: false)) },
+            { 'x', ("exec", new HighlightColor(Color.Black, bold: true, italic: false)) },
+            { 'd', ("drop", new HighlightColor(Color.Red, bold: true, italic: false)) }
+        };
+
+        public RebaseTodoHighlightingStrategy([NotNull] GitModule module)
+            : base("GitRebaseTodo", module)
+        {
+        }
+
+        protected override void MarkTokens(IDocument document, IList<LineSegment> lines)
+        {
+            foreach (var line in lines)
+            {
+                if (!TryHighlightComment(document, line) &&
+                    !TryHighlightInteractiveRebaseCommand(document, line))
+                {
+                    line.Words = new List<TextWord>(capacity: 1)
+                        { new TextWord(document, line, 0, line.Length, ColorNormal, hasDefaultColor: true) };
+                }
+
+                document.RequestUpdate(
+                    new TextAreaUpdate(TextAreaUpdateType.SingleLine, line.LineNumber));
+            }
+        }
+
+        private enum State
+        {
+            Command,
+            SpacesAfterCommand,
+            Id
+        }
+
+        private static bool TryHighlightInteractiveRebaseCommand(IDocument document, LineSegment line)
+        {
+            if (line.Length < 1)
+            {
+                return false;
+            }
+
+            var c = document.GetCharAt(line.Offset);
+
+            if (!_commandByFirstChar.TryGetValue(c, out var cmd))
+            {
+                return false;
+            }
+
+            var state = State.Command;
+            var index = 1;
+            var idStartIndex = -1;
+
+            while (index < line.Length)
+            {
+                c = document.GetCharAt(line.Offset + index);
+
+                if (c == '\r' || c == '\n')
+                {
+                    return false;
+                }
+
+                switch (state)
+                {
+                    case State.Command:
+                    {
+                        if (index == 1 && char.IsWhiteSpace(c))
+                        {
+                            state = State.SpacesAfterCommand;
+                        }
+                        else if (index == cmd.longForm.Length && char.IsWhiteSpace(c))
+                        {
+                            state = State.SpacesAfterCommand;
+                        }
+                        else if (index >= cmd.longForm.Length || c != cmd.longForm[index])
+                        {
+                            return false;
+                        }
+
+                        break;
+                    }
+
+                    case State.SpacesAfterCommand:
+                    {
+                        if (IsHexChar())
+                        {
+                            idStartIndex = index;
+                            state = State.Id;
+                        }
+                        else if (!char.IsWhiteSpace(c))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    }
+
+                    case State.Id:
+                    {
+                        if (char.IsWhiteSpace(c))
+                        {
+                            var idLength = index - idStartIndex;
+
+                            if (idLength <= 5)
+                            {
+                                return false;
+                            }
+
+                            line.Words = new List<TextWord>(capacity: 3)
+                            {
+                                new TextWord(document, line, 0, idStartIndex, cmd.color, hasDefaultColor: false),
+                                new TextWord(document, line, idStartIndex, idLength, cmd.color, hasDefaultColor: false),
+                                new TextWord(document, line, index, line.Length - index, ColorNormal, hasDefaultColor: true)
+                            };
+
+                            return true;
+                        }
+
+                        if (!IsHexChar())
+                        {
+                            return false;
+                        }
+
+                        break;
+                    }
+                }
+
+                index++;
+            }
+
+            return false;
+
+            bool IsHexChar() => char.IsDigit(c) || (c >= 'a' && c <= 'f');
+        }
+    }
+}

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows.Forms;
 using GitCommands;
+using GitUI.Script;
 
 namespace GitUI
 {
@@ -58,12 +59,8 @@ namespace GitUI
 
         protected override bool ExecuteCommand(int command)
         {
-            if (Script.ScriptRunner.ExecuteScriptCommand(this, Module, command))
-            {
-                return true;
-            }
-
-            return base.ExecuteCommand(command);
+            return ScriptRunner.ExecuteScriptCommand(this, Module, command)
+                || base.ExecuteCommand(command);
         }
     }
 }

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -24,7 +24,6 @@ namespace GitUI
 
                 return _uiCommands;
             }
-
             protected set
             {
                 GitUICommands oldCommands = _uiCommands;
@@ -34,7 +33,7 @@ namespace GitUI
         }
 
         /// <summary>true if <see cref="UICommands"/> has been initialized.</summary>
-        public bool IsUICommandsInitialized => _uiCommands != null;
+        protected bool IsUICommandsInitialized => _uiCommands != null;
 
         /// <summary>Gets a <see cref="GitModule"/> reference.</summary>
         [Browsable(false)]
@@ -46,12 +45,12 @@ namespace GitUI
         {
         }
 
-        public GitModuleForm(GitUICommands commands)
+        protected GitModuleForm(GitUICommands commands)
             : this(true, commands)
         {
         }
 
-        public GitModuleForm(bool enablePositionRestore, GitUICommands commands)
+        protected GitModuleForm(bool enablePositionRestore, GitUICommands commands)
             : base(enablePositionRestore)
         {
             UICommands = commands;

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -59,17 +59,12 @@ namespace GitUI
 
         protected override bool ExecuteCommand(int command)
         {
-            if (ExecuteScriptCommand(command))
+            if (Script.ScriptRunner.ExecuteScriptCommand(this, Module, command))
             {
                 return true;
             }
 
             return base.ExecuteCommand(command);
-        }
-
-        protected bool ExecuteScriptCommand(int command)
-        {
-            return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command);
         }
     }
 }

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.Script;
+using JetBrains.Annotations;
 
 namespace GitUI
 {
@@ -12,7 +13,7 @@ namespace GitUI
     {
         private GitUICommands _uiCommands;
 
-        /// <summary>Gets a <see cref="GitUICommands"/> reference.</summary>
+        /// <inheritdoc />
         [Browsable(false)]
         public GitUICommands UICommands
         {
@@ -37,9 +38,11 @@ namespace GitUI
         protected bool IsUICommandsInitialized => _uiCommands != null;
 
         /// <summary>Gets a <see cref="GitModule"/> reference.</summary>
+        [CanBeNull]
         [Browsable(false)]
         public GitModule Module => _uiCommands?.Module;
 
+        /// <inheritdoc />
         public event EventHandler<GitUICommandsChangedEventArgs> GitUICommandsChanged;
 
         protected GitModuleForm()

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -249,6 +249,8 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="Editor\GitHighlightingStrategyBase.cs" />
+    <Compile Include="Editor\RebaseTodoHighlightingStrategy.cs" />
     <Compile Include="FindFilePredicateProvider.cs" />
     <Compile Include="Properties\MsVsImages.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -276,6 +278,7 @@
     <Compile Include="Editor\Diff\DiffViewerLineNumberCtrl.cs" />
     <Compile Include="Editor\Diff\LinePrefixHelper.cs" />
     <Compile Include="Editor\Diff\LineSegmentGetter.cs" />
+    <Compile Include="Editor\CommitMessageHighlightingStrategy.cs" />
     <Compile Include="HelperDialogs\FormBuildServerCredentials.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1675,7 +1675,7 @@ namespace GitUI
 
         private static Dictionary<string, string> InitializeArguments(string[] args)
         {
-            Dictionary<string, string> arguments = new Dictionary<string, string>();
+            var arguments = new Dictionary<string, string>();
 
             for (int i = 2; i < args.Length; i++)
             {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -29,7 +29,7 @@ namespace GitUI
         public ILockableNotifier RepoChangedNotifier { get; }
         public IBrowseRepo BrowseRepo { get; set; }
 
-        public GitUICommands(GitModule module)
+        public GitUICommands([NotNull] GitModule module)
         {
             Module = module;
             _commitTemplateManager = new CommitTemplateManager(module);

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI;
+using JetBrains.Annotations;
 
 namespace ResourceManager
 {
@@ -53,6 +54,7 @@ namespace ResourceManager
             return GetHotkeyCommand(commandCode)?.KeyData ?? Keys.None;
         }
 
+        [CanBeNull]
         protected HotkeyCommand GetHotkeyCommand(int commandCode)
         {
             return Hotkeys?.FirstOrDefault(h => h.CommandCode == commandCode);


### PR DESCRIPTION
Closes #3516

Changes proposed in this pull request:
- Add editor syntax highlighting for commit messages
  - Summary line bold
  - Summary line beyond 50 characters is flagged
  - Non-blank line after summary is flagged
  - Description lines beyond 72 characters are flagged
  - Comments are highlighted
- Add editor syntax highlighting for (interactive) rebase todo
  - Commands are bold, and coloured
  - Comments are highlighted

What did I do to test the code and ensure quality:
- Lots of manual testing
- Review feedback on @azarkevich's work on #3516 and address or avoid many concerns

Specific differences to #3516:
- Add support for commit messages
- Add support for `core.commentChar` setting
- Avoid need to modify argument processing (the file name indicates the highlight type needed)
- Avoid scanning types for implementations of `IHighlightingStrategy`

Has been tested on (remove any that don't apply):
 - GIT 2.16
 - Windows 10

---

## Screenshots

Note the use of a custom comment character in the _after_ shots. This works with any reasonable character via:

```
git config core.commentChar "%"
```

### Rebase

*Before*

![image](https://user-images.githubusercontent.com/350947/38474073-6ca1c62e-3b91-11e8-8790-00d3b3186207.png)

*After*

![image](https://user-images.githubusercontent.com/350947/38473985-09ace0fe-3b90-11e8-9bd7-f9019de21b45.png)


### Commit

*Before*

![image](https://user-images.githubusercontent.com/350947/38474055-34af525e-3b91-11e8-9bb7-a3472c62b1ee.png)

*After*

![image](https://user-images.githubusercontent.com/350947/38474022-c9bac014-3b90-11e8-8c87-9c61b1ed47c5.png)

---

To test this I found it handy to configure the locally compiled editor for use within the GE repo:

```
git config core.editor "\"C:\\somepath\\gitextensions\\GitExtensions\\bin\\Debug\\GitExtensions.exe\" fileeditor"
```

