### PR TITLE
Remove duplicate exclusion from codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,8 +7,6 @@ coverage:
       default: false
     patch:
       default: false
-  ignore:
-    - "*.Designer.cs"
 
 comment:
   layout: "diff"


### PR DESCRIPTION
This exclusion is aleady covered during coverage collection via an argument to OpenCover.

Implements the change requested in https://github.com/gitextensions/gitextensions/pull/4803#discussion_r180220633.