### PR TITLE
Back SearchControl with IEnumerable instead of IList.

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -73,11 +73,10 @@ namespace GitUI.BranchTreePanel
             _txtBranchCriterion.PreviewKeyDown += OnPreviewKeyDown;
         }
 
-        private IReadOnlyList<string> SearchForBranch(string arg)
+        private IEnumerable<string> SearchForBranch(string arg)
         {
             return _branchCriterionAutoCompletionSrc
-                .Where(r => r.IndexOf(arg, StringComparison.OrdinalIgnoreCase) != -1)
-                .ToList();
+                .Where(r => r.IndexOf(arg, StringComparison.OrdinalIgnoreCase) != -1);
         }
 
         private void OnPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -199,10 +199,10 @@ namespace GitUI.CommandsDialogs
         {
             var candidates = DiffFiles.GitItemStatuses;
 
-            IReadOnlyList<GitItemStatus> FindDiffFilesMatches(string name)
+            IEnumerable<GitItemStatus> FindDiffFilesMatches(string name)
             {
                 var predicate = _findFilePredicateProvider.Get(name, Module.WorkingDir);
-                return candidates.Where(item => predicate(item.Name) || predicate(item.OldName)).ToList();
+                return candidates.Where(item => predicate(item.Name) || predicate(item.OldName));
             }
 
             GitItemStatus selectedItem;

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -502,10 +502,10 @@ namespace GitUI.CommandsDialogs
         {
             var candidates = DiffFiles.GitItemStatuses;
 
-            IReadOnlyList<GitItemStatus> FindDiffFilesMatches(string name)
+            IEnumerable<GitItemStatus> FindDiffFilesMatches(string name)
             {
                 var predicate = _findFilePredicateProvider.Get(name, Module.WorkingDir);
-                return candidates.Where(item => predicate(item.Name) || predicate(item.OldName)).ToList();
+                return candidates.Where(item => predicate(item.Name) || predicate(item.OldName));
             }
 
             GitItemStatus selectedItem;

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -237,12 +237,12 @@ See the changes in the commit form.");
             base.OnRuntimeLoad(e);
         }
 
-        private IReadOnlyList<string> FindFileMatches(string name)
+        private IEnumerable<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree(_revision.TreeGuid);
             var predicate = _findFilePredicateProvider.Get(name, Module.WorkingDir);
 
-            return candidates.Where(predicate).ToList();
+            return candidates.Where(predicate);
         }
 
         private void OnItemActivated()

--- a/GitUI/CommandsDialogs/SearchControl.cs
+++ b/GitUI/CommandsDialogs/SearchControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using JetBrains.Annotations;
@@ -9,7 +10,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class SearchControl<T> : UserControl, IDisposable where T : class
     {
-        private readonly Func<string, IReadOnlyList<T>> _getCandidates;
+        private readonly Func<string, IEnumerable<T>> _getCandidates;
         private readonly Action<Size> _onSizeChanged;
         private readonly AsyncLoader _backgroundLoader = new AsyncLoader();
         private bool _isUpdatingTextFromCode = false;
@@ -22,7 +23,7 @@ namespace GitUI.CommandsDialogs
             set => txtSearchBox.Text = value;
         }
 
-        public SearchControl([NotNull]Func<string, IReadOnlyList<T>> getCandidates, Action<Size> onSizeChanged)
+        public SearchControl([NotNull]Func<string, IEnumerable<T>> getCandidates, Action<Size> onSizeChanged)
         {
             InitializeComponent();
             txtSearchBox.LostFocus += TxtSearchBoxOnLostFocus;
@@ -58,20 +59,20 @@ namespace GitUI.CommandsDialogs
             listBoxSearchResult.Visible = false;
         }
 
-        private void SearchForCandidates(IReadOnlyList<T> candidates)
+        private void SearchForCandidates(IEnumerable<T> candidates)
         {
             var selectionStart = txtSearchBox.SelectionStart;
             var selectionLength = txtSearchBox.SelectionLength;
             listBoxSearchResult.BeginUpdate();
             listBoxSearchResult.Items.Clear();
 
-            for (int i = 0; i < candidates.Count && i < 20; i++)
+            foreach (var candidate in candidates.Take(20))
             {
-                listBoxSearchResult.Items.Add(candidates[i]);
+                listBoxSearchResult.Items.Add(candidate);
             }
 
             listBoxSearchResult.EndUpdate();
-            if (candidates.Count > 0)
+            if (listBoxSearchResult.Items.Count > 0)
             {
                 listBoxSearchResult.SelectedIndex = 0;
             }

--- a/GitUI/CommandsDialogs/SearchWindow.cs
+++ b/GitUI/CommandsDialogs/SearchWindow.cs
@@ -8,7 +8,8 @@ namespace GitUI.CommandsDialogs
     public partial class SearchWindow<T> : Form where T : class
     {
         private readonly SearchControl<T> _searchControl;
-        public SearchWindow(Func<string, IReadOnlyList<T>> getCandidates)
+
+        public SearchWindow(Func<string, IEnumerable<T>> getCandidates)
         {
             InitializeComponent();
             _searchControl = new SearchControl<T>(getCandidates, OnChildSizeChanged);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -2136,13 +2136,13 @@ namespace GitUI
             return arguments;
         }
 
-        private IReadOnlyList<string> FindFileMatches(string name)
+        private IEnumerable<string> FindFileMatches(string name)
         {
             var candidates = Module.GetFullTree("HEAD");
 
             var predicate = _fildFilePredicateProvider.Get(name, Module.WorkingDir);
 
-            return candidates.Where(predicate).ToList();
+            return candidates.Where(predicate);
         }
 
         private void Commit(Dictionary<string, string> arguments)


### PR DESCRIPTION
Changes proposed in this pull request:
- SearchControl  consumes only the first 20 elements.
There is no need to apply search predicate to the all elements.
 
What did I do to test the code and ensure quality:
- Manual tests.

Has been tested on (remove any that don't apply):
- GIT 2.15
- Windows 10
