### PR TITLE
Tweak DpiUtil

### DIFF
--- a/GitExtUtils/GitUI/ControlDpiExtensions.cs
+++ b/GitExtUtils/GitUI/ControlDpiExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using JetBrains.Annotations;
 
 namespace GitUI

--- a/GitExtUtils/GitUI/DpiUtil.cs
+++ b/GitExtUtils/GitUI/DpiUtil.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Microsoft.Win32.SafeHandles;
 
-namespace GitUI
+namespace GitExtUtils.GitUI
 {
     /// <summary>
     /// Utility class related to DPI settings, primarily used for scaling dimensions on high-DPI displays.
@@ -16,8 +16,8 @@ namespace GitUI
         public static int DpiX { get; }
         public static int DpiY { get; }
 
-        public static double ScaleX { get; }
-        public static double ScaleY { get; }
+        public static float ScaleX { get; }
+        public static float ScaleY { get; }
 
         static DpiUtil()
         {
@@ -31,16 +31,16 @@ namespace GitUI
                     DpiX = GetDeviceCaps(hdc, LOGPIXELSX);
                     DpiY = GetDeviceCaps(hdc, LOGPIXELSY);
 
-                    ScaleX = DpiX / 96.0;
-                    ScaleY = DpiY / 96.0;
+                    ScaleX = DpiX / 96.0f;
+                    ScaleY = DpiY / 96.0f;
                 }
                 catch
                 {
                     DpiX = 96;
                     DpiY = 96;
 
-                    ScaleX = 1.0;
-                    ScaleY = 1.0;
+                    ScaleX = 1.0f;
+                    ScaleY = 1.0f;
                 }
             }
         }

--- a/GitUI/BuildServerIntegration/BuildInfoDrawingLogic.cs
+++ b/GitUI/BuildServerIntegration/BuildInfoDrawingLogic.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitUI.Properties;
 using GitUI.UserControls;
 using GitUIPluginInterfaces.BuildServerIntegration;

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remote;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUI.RevisionGridClasses;
 using GitUI.UserControls;

--- a/GitUI/CommandsDialogs/AboutBox.cs
+++ b/GitUI/CommandsDialogs/AboutBox.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.AboutBoxDialog;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Properties;

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/DashboardEditor.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using GitCommands.Repository;
+using GitExtUtils.GitUI;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -14,6 +14,7 @@ using GitCommands.Git;
 using GitCommands.Gpg;
 using GitCommands.Repository;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
 using GitUI.CommandsDialogs.WorktreeDialog;

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -10,6 +10,7 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remote;
 using GitCommands.Repository;
+using GitExtUtils.GitUI;
 using GitUI.Script;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Tag;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using ResourceManager;
 

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Patches;
+using GitExtUtils.GitUI;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using ResourceManager;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitUI.Editor;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GitCommands.ExternalLinks;
+using GitExtUtils.GitUI;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 using GitUI.Script;
 using ResourceManager;
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using GitUI.Properties;
 
 namespace GitUI.CommandsDialogs.WorktreeDialog

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using GitUI.Properties;
 using Microsoft.WindowsAPICodePack.Taskbar;
 using ResourceManager;

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Patches;
+using GitExtUtils.GitUI;
 using GitUI.Editor;
 using JetBrains.Annotations;
 using ResourceManager;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
+using GitExtUtils.GitUI;
 using GitUI.Properties;
 using GitUI.UserControls;
 using ResourceManager;

--- a/GitUI/UserControls/GravatarControl.cs
+++ b/GitUI/UserControls/GravatarControl.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitUI.Properties;
 using Gravatar;
 using ResourceManager;

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands.Patches;
+using GitExtUtils.GitUI;
 using ResourceManager;
 
 namespace GitUI

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
+using GitExtUtils.GitUI;
 using GitUI.BuildServerIntegration;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 
 namespace GitUI.RevisionGridClasses
 {

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using DeleteUnusedBranches.Properties;
+using GitExtUtils.GitUI;
 using GitUI;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using GitUI;
 using GitUIPluginInterfaces;
 using ResourceManager;

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitFlow.Properties;
 using GitUI;
 using GitUIPluginInterfaces;


### PR DESCRIPTION
* Adjust the namespace
* Change ScaleX and ScaleY to float from double - UI control measurements are generally expressed as int or float, and it requires an explicit cast to float whenever ScaleX or ScaleY are used.
