### PR TITLE
fix: IOE "Cannot rename a non-existing remote"

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -81,7 +81,9 @@ namespace GitUI.BranchTreePanel
                 var treeNode = FindRemoteRepoTreeNodeByName(orgName);
                 if (treeNode == null)
                 {
-                    throw new InvalidOperationException("Cannot rename a non-existing remote");
+                    // This may happen if attempting to save an inactive remote
+                    // which has been reactivated but not fetched/pulled
+                    return;
                 }
 
                 treeNode.Text = newName;
@@ -169,7 +171,8 @@ namespace GitUI.BranchTreePanel
                 var branch = FullPath.Substring(remote.Length + 1);
                 return new RemoteBranchInfo
                 {
-                    Remote = remote, BranchName = branch
+                    Remote = remote,
+                    BranchName = branch
                 };
             }
 

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -356,15 +356,6 @@ Inactive remote is completely invisible to git.");
                 }
                 else
                 {
-                    if (_selectedRemote?.Name == null)
-                    {
-                        FireRemoteAddedEvent(new RemoteChangedEventArgs(remote));
-                    }
-                    else
-                    {
-                        FireRemoteRenamedEvent(new RemoteRenamedEventArgs(_selectedRemote.Name, remote));
-                    }
-
                     var remotes = Repositories.RemoteRepositoryHistory.Repositories;
                     RemoteUpdate(remotes, _selectedRemote?.Url, remoteUrl);
                     if (checkBoxSepPushUrl.Checked)
@@ -373,6 +364,15 @@ Inactive remote is completely invisible to git.");
                     }
 
                     Repositories.SaveSettings();
+
+                    if (_selectedRemote?.Name == null)
+                    {
+                        FireRemoteAddedEvent(new RemoteChangedEventArgs(remote));
+                    }
+                    else if (!string.Equals(_selectedRemote.Name, remote))
+                    {
+                        FireRemoteRenamedEvent(new RemoteRenamedEventArgs(_selectedRemote.Name, remote));
+                    }
                 }
 
                 // if the user has just created a fresh new remote


### PR DESCRIPTION
LeftPanel throws InvalidOperationException "Cannot rename a non-existing remote"
if attempting to edit a inactive remote in Remotes Management dialog.

* The remotes added/renamed events are now raised after remotes are saved
* The event is now only raised if a remote has been renamed (case sensitively).
* LeftPanel no longer throws, if it can't locate the requested remote

Fixes #4829

What did I do to test the code and ensure quality:
- lots of manual testing

Has been tested on (remove any that don't apply):
- GIT 2.10 and above
- Windows 8.1
