### PR TITLE
Await tasks in order to propagate errors to the caller.

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -168,7 +168,6 @@ namespace GitUI.BranchTreePanel
         private RemoteBranchTree _remoteTree;
         private List<TreeNode> _searchResult;
         private bool _searchCriteriaChanged;
-        private Task[] _tasks;
 
         private CancellationToken CancelBackgroundTasks()
         {
@@ -187,16 +186,8 @@ namespace GitUI.BranchTreePanel
 
             var token = CancelBackgroundTasks();
 
-            // wait for prev tasks to not overload the computer
-            if (_tasks != null)
-            {
-                await Task.WhenAll(_tasks).ConfigureAwait(false);
-            }
-
-            await this.SwitchToMainThreadAsync(token);
-            _tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
-
-            await Task.WhenAll(_tasks).ConfigureAwait(false);
+            var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
         private void OnBtnSettingsClicked(object sender, EventArgs e)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -195,6 +195,8 @@ namespace GitUI.BranchTreePanel
 
             await this.SwitchToMainThreadAsync(token);
             _tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
+
+            await Task.WhenAll(_tasks).ConfigureAwait(false);
         }
 
         private void OnBtnSettingsClicked(object sender, EventArgs e)


### PR DESCRIPTION
Changes proposed in this pull request:
- Await for all the fired tasks to propagate errors and let the caller await for ROT reload completion.
 
@sharwell A candidate for analyzers?