### PR TITLE
Compute filter candidates on demand.

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -280,9 +280,6 @@ namespace GitUI.BranchTreePanel
 
                     branchFullPaths.Add(localBranchNode.FullPath);
                 }
-
-                token.ThrowIfCancellationRequested();
-                FireBranchAddedEvent(branchFullPaths);
             }
 
             protected override void FillTreeViewNode()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -61,9 +61,6 @@ namespace GitUI.BranchTreePanel
 
                     branchFullPaths.Add(remoteBranchNode.FullPath);
                 }
-
-                token.ThrowIfCancellationRequested();
-                FireBranchAddedEvent(branchFullPaths);
             }
 
             private static BaseBranchNode CreateRemoteBranchPathNode(Tree tree,

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -101,9 +101,6 @@ namespace GitUI.BranchTreePanel
 
                     branchFullPaths.Add(branchNode.FullPath);
                 }
-
-                token.ThrowIfCancellationRequested();
-                FireBranchAddedEvent(branchFullPaths);
             }
 
             protected override void FillTreeViewNode()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -108,7 +108,6 @@ namespace GitUI.BranchTreePanel
             public GitUICommands UICommands => _uiCommandsSource.UICommands;
             protected GitModule Module => UICommands.Module;
             public TreeNode TreeViewNode { get; }
-            public Action<List<string>> OnBranchesAdded;
 
             protected Tree(TreeNode treeNode, IGitUICommandsSource uiCommands)
             {
@@ -154,11 +153,6 @@ namespace GitUI.BranchTreePanel
             protected virtual void FillTreeViewNode()
             {
                 Nodes.FillTreeViewNode(TreeViewNode);
-            }
-
-            protected void FireBranchAddedEvent(List<string> branchFullPaths)
-            {
-                OnBranchesAdded?.Invoke(branchFullPaths);
             }
         }
 


### PR DESCRIPTION
 Fixes #4828.

Changes proposed in this pull request:
- Collect filter candidates on demand. All the data is already loaded into the memory, collecting it from the tree nodes is fast enough to not precompute them at ROT reloading.
 
What did I do to test the code and ensure quality:
- Manual tests.

Has been tested on (remove any that don't apply):
- GIT 2.15
- Windows 10
