### PR TITLE
Add git describe info to commit header - #84

### DIFF
--- a/GitCommands/Git/GitDescribeProvider.cs
+++ b/GitCommands/Git/GitDescribeProvider.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using GitUIPluginInterfaces;
+using JetBrains.Annotations;
+
+namespace GitCommands.Git
+{
+    public interface IGitDescribeProvider
+    {
+        /// <summary>
+        /// Runs <c>git describe</c> to find the most recent tag that is reachable from a commit.
+        /// If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number
+        /// of additional commits on top of the tagged object and the abbreviated object name of the most recent commit.
+        /// </summary>
+        /// <param name="revision">A revision to describe.</param>
+        /// <returns>Describe information.</returns>
+        (string precedingTag, string commitCount) Get(string revision);
+    }
+
+    public sealed class GitDescribeProvider : IGitDescribeProvider
+    {
+        private readonly Func<IGitModule> _getModule;
+
+        public GitDescribeProvider(Func<IGitModule> getModule)
+        {
+            _getModule = getModule;
+        }
+
+        /// <summary>
+        /// Runs <c>git describe</c> to find the most recent tag that is reachable from a commit.
+        /// If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number
+        /// of additional commits on top of the tagged object and the abbreviated object name of the most recent commit.
+        /// </summary>
+        /// <param name="revision">A revision to describe.</param>
+        /// <returns>Describe information.</returns>
+        public (string precedingTag, string commitCount) Get(string revision)
+        {
+            string description = GetModule().GetDescribe(revision);
+            if (string.IsNullOrEmpty(description))
+            {
+                return (string.Empty, string.Empty);
+            }
+
+            int commitHashPos = description.LastIndexOf("-g", description.Length - 1, StringComparison.OrdinalIgnoreCase);
+            if (commitHashPos == -1)
+            {
+                return (description, string.Empty);
+            }
+
+            string commitHash = description.Substring(commitHashPos + 2);
+            if (commitHash.Length == 0 || !revision.StartsWith(commitHash, StringComparison.OrdinalIgnoreCase))
+            {
+                return (description, string.Empty);
+            }
+
+            description = description.Substring(0, commitHashPos);
+            int commitCountPos = description.LastIndexOf("-", description.Length - 1, StringComparison.Ordinal);
+            if (commitCountPos == -1)
+            {
+                return (description, string.Empty);
+            }
+
+            string commitCount = description.Substring(commitCountPos + 1);
+            description = description.Substring(0, commitCountPos);
+            return (description, commitCount);
+        }
+
+        [NotNull]
+        private IGitModule GetModule()
+        {
+            var module = _getModule();
+
+            if (module == null)
+            {
+                throw new ArgumentException($"Require a valid instance of {nameof(IGitModule)}");
+            }
+
+            return module;
+        }
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3888,6 +3888,18 @@ namespace GitCommands
             return RunGitCmdResult("rm --cached " + filename).ExitedSuccessfully;
         }
 
+        public string GetDescribe(string commit)
+        {
+            string info = RunGitCmd("describe --tags --first-parent " + commit).TrimEnd();
+
+            if (IsGitErrorMessage(info))
+            {
+                return null;
+            }
+
+            return info;
+        }
+
         /// <summary>
         /// Determines whether a git command's output indicates an error occurred.
         /// </summary>

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -103,6 +103,7 @@
     <Compile Include="FullPathResolver.cs" />
     <Compile Include="GitRevisionInfoProvider.cs" />
     <Compile Include="Git\AuthorEmailEqualityComparer.cs" />
+    <Compile Include="Git\GitDescribeProvider.cs" />
     <Compile Include="Git\DetachedHeadParser.cs" />
     <Compile Include="Git\EnvironmentConfiguration.cs" />
     <Compile Include="Git\FileDeleteException.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -410,6 +410,12 @@ namespace GitCommands
             set => SetBool("commitinfoshowcontainedintags", value);
         }
 
+        public static bool CommitInfoShowTagThisCommitDerivesFrom
+        {
+            get => GetBool("commitinfoshowtagthiscommitderivesfrom", true);
+            set => SetBool("commitinfoshowtagthiscommitderivesfrom", value);
+        }
+
         public static string GravatarCachePath => Path.Combine(ApplicationDataPath.Value, "Images\\");
 
         public static string Translation

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -40,6 +40,7 @@
             this.showContainedInBranchesRemoteIfNoLocalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showContainedInTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showMessagesOfAnnotatedTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showTagThisCommitDerivesFromMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.addNoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._RevisionHeader = new System.Windows.Forms.RichTextBox();
@@ -107,6 +108,7 @@
             this.showContainedInBranchesRemoteIfNoLocalToolStripMenuItem,
             this.showContainedInTagsToolStripMenuItem,
             this.showMessagesOfAnnotatedTagsToolStripMenuItem,
+            this.showTagThisCommitDerivesFromMenuItem,
             this.toolStripSeparator2,
             this.addNoteToolStripMenuItem});
             this.commitInfoContextMenuStrip.Name = "commitInfoContextMenuStrip";
@@ -158,6 +160,13 @@
             this.showMessagesOfAnnotatedTagsToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
             this.showMessagesOfAnnotatedTagsToolStripMenuItem.Text = "Show messages of annotated tags";
             this.showMessagesOfAnnotatedTagsToolStripMenuItem.Click += new System.EventHandler(this.showMessagesOfAnnotatedTagsToolStripMenuItem_Click);
+            //
+            // showTagThisCommitDerivesFromMenuItem
+            //
+            this.showTagThisCommitDerivesFromMenuItem.Name = "showTagThisCommitDerivesFromMenuItem";
+            this.showTagThisCommitDerivesFromMenuItem.Size = new System.Drawing.Size(453, 22);
+            this.showTagThisCommitDerivesFromMenuItem.Text = "Show the most recent tag this commit derives from";
+            this.showTagThisCommitDerivesFromMenuItem.Click += new System.EventHandler(this.showTagThisCommitDerivesFromMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
@@ -218,5 +227,6 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem addNoteToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showMessagesOfAnnotatedTagsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showTagThisCommitDerivesFromMenuItem;
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -138,5 +138,7 @@ namespace GitUIPluginInterfaces
         string ReEncodeStringFromLossless(string s);
 
         string ReEncodeCommitMessage(string s, string toEncodingName);
+
+        string GetDescribe(string commit);
     }
 }

--- a/UnitTests/GitCommandsTests/Git/GitDescribeProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitDescribeProviderTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using FluentAssertions;
+using GitCommands.Git;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public class GitDescribeProviderTests
+    {
+        private IGitModule _module;
+        private GitDescribeProvider _provider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _module = Substitute.For<IGitModule>();
+            _provider = new GitDescribeProvider(() => _module);
+        }
+
+        [Test]
+        public void GitDescribeProvider_returns_nulls_for_invalid_revision()
+        {
+            // xxxxxx is not a valid revision.
+            // RunGitCmd returns "fatal: Not a valid object name xxxxxx"
+            _module.GetDescribe("xxxxxx").Returns(x => null);
+            var (precedingTag, commitCount) = _provider.Get("xxxxxx");
+
+            precedingTag.Should().BeNullOrEmpty();
+            commitCount.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GitDescribeProvider_returns_nulls_if_no_preceding_tag()
+        {
+            // 33f0bc7f021210eb4bf49f770b5fc5952dfd41c2 predates tag 0.90 by 1 commit.
+            // RunGitCmd returns "fatal: No tags can describe '33f0bc7f021210eb4bf49f770b5fc5952dfd41c2'.\r\nTry --always, or create some tags."
+            _module.GetDescribe("33f0bc7f021210eb4bf49f770b5fc5952dfd41c2").Returns(x => null);
+            var (precedingTag, commitCount) = _provider.Get("33f0bc7f021210eb4bf49f770b5fc5952dfd41c2");
+
+            precedingTag.Should().BeNullOrEmpty();
+            commitCount.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GitDescribeProvider_returns_null_commitCount_at_tag()
+        {
+            // 943d230ba465d86c3ad2cd00f7e8c508d144d9a5 is the commit at tag 0.90.
+            _module.GetDescribe("943d230ba465d86c3ad2cd00f7e8c508d144d9a5").Returns("0.90");
+            var (precedingTag, commitCount) = _provider.Get("943d230ba465d86c3ad2cd00f7e8c508d144d9a5");
+
+            precedingTag.Should().Be("0.90");
+            commitCount.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GitDescribeProvider_returns_precedingTag_and_commitCount()
+        {
+            // 16dc9d22d986f9ca03f6ec24007d65e6c062840e comes after tag 0.90 by 2 commits.
+            _module.GetDescribe("16dc9d22d986f9ca03f6ec24007d65e6c062840e").Returns("0.90-2-g16dc9d22d");
+            var (precedingTag, commitCount) = _provider.Get("16dc9d22d986f9ca03f6ec24007d65e6c062840e");
+
+            precedingTag.Should().Be("0.90");
+            commitCount.Should().Be("2");
+        }
+
+        [Test]
+        public void GitDescribeProvider_should_throw_if_module_is_not_provided()
+        {
+            _module = null;
+
+            ((Action)(() => _provider.Get("xx"))).Should().Throw<ArgumentException>();
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
     <Compile Include="ArgumentBuilderTests.cs" />
+    <Compile Include="Git\GitDescribeProviderTests.cs" />
     <Compile Include="Git\GitRefNameTests.cs" />
     <Compile Include="RepoNameExtractorTest.cs" />
     <Compile Include="GitModuleTest.cs" />


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Implements feature request #84

Changes proposed in this pull request:
- Show the output of "git describe --tags --first-parent" in the commit pane as per issue #84. 
git describe returns the first tag found in the history of the specified commit and also displays the number of commits since that tag and a shortened sha1 of the specified commit.
I have re-formatted the output text from the raw git output.
I chose to use the --tags option to show both annotated and lightweight tags.
I chose to use the --first-parent option because to me it seemed more useful to show the last tag on the first parent line rather than other merge parents.
 
Screenshots before and after (if PR changes UI):
Note the last line of the commit info now shows "Derives from tag: v2.51 + 211 commits".
![image](https://user-images.githubusercontent.com/1947040/38764122-fe6ed7e4-3ffc-11e8-9e47-533324c495b2.png)

What did I do to test the code and ensure quality:
- Tested manually on commits that derive from a tag (showed tag + commit count)
- Tested manually on commits that are at a tag (showed only the tag)
- Tested manually on commits that do not derive from a tag (showed the alternate text "Derives from no tag")
- Tested the same on both a lightweight and an annotated tag.

Has been tested on (remove any that don't apply):
- GIT 2.16.2.windows.1
- Windows 10

Review, suggestions, alterations, code-style comments are all welcome.

git describe documentation: https://git-scm.com/docs/git-describe

[Edit] After re-reading #84 I see this does not implement the request as requested. The original request is to get exactly the output of "git describe" as the user wished to use that output in bug reports. My re-wording of the git output means this PR does not actually satisfy the original request. Thoughts?