### PR TITLE
F3 opens the external diff viewer unless searching text.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2124,7 +2124,8 @@ namespace GitUI.CommandsDialogs
             RotateApplicationIcon = 14,
             CloseRepository = 15,
             Stash = 16,
-            StashPop = 17
+            StashPop = 17,
+            OpenWithDifftool = 19
         }
 
         private void AddNotes()
@@ -2153,6 +2154,18 @@ namespace GitUI.CommandsDialogs
             UICommands.RepoChangedNotifier.Notify();
         }
 
+        private void OpenWithDifftool()
+        {
+            if (revisionDiff.Visible)
+            {
+                revisionDiff.ExecuteCommand(RevisionDiff.Command.OpenWithDifftool);
+            }
+            else if (fileTree.Visible)
+            {
+                fileTree.ExecuteCommand(RevisionFileTree.Command.OpenWithDifftool);
+            }
+        }
+
         protected override bool ExecuteCommand(int cmd)
         {
             switch ((Commands)cmd)
@@ -2176,6 +2189,7 @@ namespace GitUI.CommandsDialogs
                 case Commands.CloseRepository: CloseToolStripMenuItemClick(null, null); break;
                 case Commands.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;
                 case Commands.StashPop: UICommands.StashPop(this); break;
+                case Commands.OpenWithDifftool: OpenWithDifftool(); break;
                 default: return base.ExecuteCommand(cmd);
             }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -346,7 +346,8 @@ namespace GitUI.CommandsDialogs
             UnStageSelectedFile = 8,
             ShowHistory = 9,
             ToggleSelectionFilter = 10,
-            StageAll = 11
+            StageAll = 11,
+            OpenWithDifftool = 12
         }
 
         private bool AddToGitIgnore()
@@ -512,6 +513,7 @@ namespace GitUI.CommandsDialogs
                 case Commands.ShowHistory: return StartFileHistoryDialog();
                 case Commands.ToggleSelectionFilter: return ToggleSelectionFilter();
                 case Commands.StageAll: return StageAllFiles();
+                case Commands.OpenWithDifftool: SelectedDiff.OpenWithDifftool?.Invoke(); return true;
                 default: return base.ExecuteCommand(cmd);
             }
         }
@@ -978,7 +980,7 @@ namespace GitUI.CommandsDialogs
             }
             else if (item.IsTracked)
             {
-                SelectedDiff.ViewCurrentChanges(item, staged);
+                SelectedDiff.ViewCurrentChanges(item, staged, () => (staged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick());
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -98,7 +98,7 @@ namespace GitUI.CommandsDialogs
         {
             if (DiffFiles.SelectedItem == null)
             {
-                DiffText.ViewPatch("");
+                DiffText.ViewPatch(null);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs
         {
             if (DiffFiles.SelectedItem == null)
             {
-                diffViewer.ViewPatch("");
+                diffViewer.ViewPatch(null);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -170,15 +170,16 @@ namespace GitUI.CommandsDialogs
                                 Patch patch = Module.GetSingleDiff(gitStash.Name + "^", gitStash.Name, stashedItem.Name, stashedItem.OldName, extraDiffArguments, encoding, true, stashedItem.IsTracked);
                                 if (patch == null)
                                 {
-                                    return string.Empty;
+                                    return (text: string.Empty, openWithDifftool: null /* not applicable */);
                                 }
 
                                 if (stashedItem.IsSubmodule)
                                 {
-                                    return LocalizationHelpers.ProcessSubmodulePatch(Module, stashedItem.Name, patch);
+                                    return (text: LocalizationHelpers.ProcessSubmodulePatch(Module, stashedItem.Name, patch),
+                                            openWithDifftool: null /* not implemented */);
                                 }
 
-                                return patch.Text;
+                                return (text: patch.Text, openWithDifftool: null /* not implemented */);
                             });
                     }
                 }

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -178,7 +178,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private void ResetAllAndShowLoadingPullRequests()
         {
             _discussionWB.DocumentText = "";
-            _diffViewer.ViewPatch("");
+            _diffViewer.ViewPatch(null);
             _fileStatusList.SetDiffs();
 
             _pullRequestsList.Items.Clear();
@@ -232,7 +232,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
 
             _discussionWB.DocumentText = DiscussionHtmlCreator.CreateFor(_currentPullRequestInfo);
-            _diffViewer.ViewPatch("");
+            _diffViewer.ViewPatch(null);
             _fileStatusList.SetDiffs();
 
             LoadDiffPatch();
@@ -401,7 +401,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
 
             var data = _diffCache[gis.Name];
-            _diffViewer.ViewPatch(data);
+            _diffViewer.ViewPatch(text: data, openWithDifftool: null /* not implemented */);
         }
 
         private void _closePullRequestBtn_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.Designer.cs
@@ -170,7 +170,6 @@ namespace GitUI.CommandsDialogs
             // firstToSelectedToolStripMenuItem
             // 
             this.firstToSelectedToolStripMenuItem.Name = "firstToSelectedToolStripMenuItem";
-            this.firstToSelectedToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.firstToSelectedToolStripMenuItem.Size = new System.Drawing.Size(254, 22);
             this.firstToSelectedToolStripMenuItem.Text = "First -> Selected";
             this.firstToSelectedToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);

--- a/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.Designer.cs
@@ -32,6 +32,7 @@
             this.FileTreeSplitContainer = new System.Windows.Forms.SplitContainer();
             this.tvGitTree = new UserControls.NativeTreeView();
             this.FileTreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetToThisRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparatorFileSystemActions = new System.Windows.Forms.ToolStripSeparator();
@@ -101,6 +102,7 @@
             // FileTreeContextMenu
             // 
             this.FileTreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.openWithDifftoolToolStripMenuItem,
             this.saveAsToolStripMenuItem,
             this.resetToThisRevisionToolStripMenuItem,
             this.toolStripSeparatorFileSystemActions,
@@ -128,6 +130,14 @@
             this.FileTreeContextMenu.Name = "FileTreeContextMenu";
             this.FileTreeContextMenu.Size = new System.Drawing.Size(326, 474);
             this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
+            // 
+            // openWithDifftoolToolStripMenuItem
+            // 
+            this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconDiffTool;
+            this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
+            this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
+            this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
+            this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
@@ -340,6 +350,7 @@
         private UserControls.NativeTreeView tvGitTree;
         private Editor.FileViewer FileText;
         private System.Windows.Forms.ContextMenuStrip FileTreeContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resetToThisRevisionToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorFileSystemActions;
@@ -354,9 +365,9 @@
         private System.Windows.Forms.ToolStripMenuItem findToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorEditFileActions;
         private System.Windows.Forms.ToolStripMenuItem editCheckedOutFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openFileWithToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorFileTreeActions;
         private System.Windows.Forms.ToolStripMenuItem expandAllToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem collapseAllToolStripMenuItem;

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -10,6 +10,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
+using GitUI.Hotkey;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -53,6 +54,7 @@ See the changes in the commit form.");
         {
             InitializeComponent();
             Translate();
+            HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _findFilePredicateProvider = new FindFilePredicateProvider();
             _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
@@ -213,10 +215,50 @@ See the changes in the commit form.");
             }
         }
 
+        #region Hotkey commands
+
+        public static readonly string HotkeySettingsName = "RevisionFileTree";
+
+        public enum Command
+        {
+            ShowHistory = 0,
+            Blame = 1,
+            OpenWithDifftool = 2
+        }
+
+        public bool ExecuteCommand(Command cmd)
+        {
+            return ExecuteCommand((int)cmd);
+        }
+
+        protected override bool ExecuteCommand(int cmd)
+        {
+            switch ((Command)cmd)
+            {
+                case Command.ShowHistory: fileHistoryToolStripMenuItem.PerformClick(); break;
+                case Command.Blame: blameToolStripMenuItem1.PerformClick(); break;
+                case Command.OpenWithDifftool: openWithDifftoolToolStripMenuItem.PerformClick(); break;
+                default: return base.ExecuteCommand(cmd);
+            }
+
+            return true;
+        }
+
         public void ReloadHotkeys()
         {
+            Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
+            fileHistoryToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ShowHistory);
+            blameToolStripMenuItem1.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Blame);
+            openWithDifftoolToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftool);
             FileText.ReloadHotkeys();
         }
+
+        private string GetShortcutKeyDisplayString(Command cmd)
+        {
+            return GetShortcutKeys((int)cmd).ToShortcutKeyDisplayString();
+        }
+
+        #endregion
 
         protected override void OnRuntimeLoad()
         {
@@ -231,6 +273,8 @@ See the changes in the commit form.");
                     Properties.Resources.IconFolderSubmodule // Submodule
                 }
             };
+
+            ReloadHotkeys();
 
             GotFocus += (s, e1) => tvGitTree.Focus();
 
@@ -533,6 +577,8 @@ See the changes in the commit form.");
             editCheckedOutFileToolStripMenuItem.Enabled = isExistingFileOrDirectory;
             openWithToolStripMenuItem.Visible = isFile;
             openWithToolStripMenuItem.Enabled = isExistingFileOrDirectory;
+            openWithDifftoolToolStripMenuItem.Visible = isFile;
+            openWithDifftoolToolStripMenuItem.Enabled = FileText.OpenWithDifftool != null;
             openFileToolStripMenuItem.Visible = isFile;
             openFileWithToolStripMenuItem.Visible = isFile;
 
@@ -595,6 +641,11 @@ See the changes in the commit form.");
                 var fileName = _fullPathResolver.Resolve(gitItem.FileName);
                 OsShellUtil.OpenAs(fileName.ToNativePath());
             }
+        }
+
+        private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FileText.OpenWithDifftool?.Invoke();
         }
 
         private void resetToThisRevisionToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using JetBrains.Annotations;
 
@@ -29,9 +30,10 @@ namespace GitUI.Editor
 
         void EnableScrollBars(bool enable);
         void Find();
+        Task FindNextAsync(bool searchForwardOrOpenWithDifftool);
 
         string GetText();
-        void SetText([NotNull] string text, bool isDiff = false);
+        void SetText([NotNull] string text, [CanBeNull] Action openWithDifftool, bool isDiff = false);
         void SetHighlighting(string syntax);
         void SetHighlightingForFile(string filename);
         void HighlightLine(int line, Color color);
@@ -41,6 +43,7 @@ namespace GitUI.Editor
         int GetSelectionPosition();
         int GetSelectionLength();
         void AddPatchHighlighting();
+        Action OpenWithDifftool { get;  }
         int ScrollPos { get; set; }
 
         bool ShowLineNumbers { get; set; }
@@ -65,6 +68,7 @@ namespace GitUI.Editor
         /// Code-behind goto line function is always availabe, so we can goto next diff section.
         /// </summary>
         bool IsGotoLineUIApplicable();
+
         Font Font { get; set; }
 
         void SetFileLoader(GetNextFileFnc fileLoader);

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -85,7 +85,7 @@ namespace GitUI
                 firstRevision = selectedRevision.FirstParentGuid;
             }
 
-            return ViewChangesAsync(diffViewer, firstRevision, secondRevision, file, defaultText);
+            return ViewChangesAsync(diffViewer, firstRevision, secondRevision, file, defaultText, openWithDifftool: null /* use default */);
         }
 
         public static Task ViewChangesAsync(
@@ -93,7 +93,8 @@ namespace GitUI
             [CanBeNull] string firstRevision,
             string secondRevision,
             [NotNull] GitItemStatus file,
-            [NotNull] string defaultText)
+            [NotNull] string defaultText,
+            [CanBeNull] Action openWithDifftool)
         {
             if (firstRevision == null)
             {
@@ -117,7 +118,13 @@ namespace GitUI
                 return diffViewer.ViewPatchAsync(() =>
                 {
                     string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
-                    return selectedPatch ?? defaultText;
+                    if (selectedPatch == null)
+                    {
+                        return (text: defaultText, openWithDifftool: null /* not applicable */);
+                    }
+
+                    return (text: selectedPatch,
+                            openWithDifftool: openWithDifftool ?? (() => { diffViewer.Module.OpenWithDifftool(file.Name, null, firstRevision, secondRevision, "", file.IsTracked); }));
                 });
             }
         }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -246,9 +246,12 @@ namespace GitUI.Hotkey
 
             HotkeyCommand[] scriptsHotkeys = LoadScriptHotkeys();
 
+            const Keys OpenWithDifftoolHotkey = Keys.F3;
+            const Keys ShowHistoryHotkey = Keys.H;
+            const Keys BlameHotkey = Keys.B;
+
             return new[]
               {
-                // FormCommit
                 new HotkeySettings(
                     FormCommit.HotkeySettingsName,
                     Hk(FormCommit.Commands.AddToGitIgnore, Keys.None),
@@ -260,9 +263,10 @@ namespace GitUI.Hotkey
                     Hk(FormCommit.Commands.ResetSelectedFiles, Keys.R),
                     Hk(FormCommit.Commands.StageSelectedFile, Keys.S),
                     Hk(FormCommit.Commands.UnStageSelectedFile, Keys.U),
-                    Hk(FormCommit.Commands.ShowHistory, Keys.H),
+                    Hk(FormCommit.Commands.ShowHistory, ShowHistoryHotkey),
                     Hk(FormCommit.Commands.ToggleSelectionFilter, Keys.Control | Keys.F),
-                    Hk(FormCommit.Commands.StageAll, Keys.Control | Keys.S)),
+                    Hk(FormCommit.Commands.StageAll, Keys.Control | Keys.S),
+                    Hk(FormCommit.Commands.OpenWithDifftool, OpenWithDifftoolHotkey)),
                 new HotkeySettings(
                     FormBrowse.HotkeySettingsName,
                     Hk(FormBrowse.Commands.GitBash, Keys.Control | Keys.G),
@@ -283,7 +287,8 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Commands.Stash, Keys.Control | Keys.Alt | Keys.Up),
                     Hk(FormBrowse.Commands.StashPop, Keys.Control | Keys.Alt | Keys.Down),
                     Hk(FormBrowse.Commands.CloseRepository, Keys.Control | Keys.W),
-                    Hk(FormBrowse.Commands.RotateApplicationIcon, Keys.Control | Keys.Shift | Keys.I)),
+                    Hk(FormBrowse.Commands.RotateApplicationIcon, Keys.Control | Keys.Shift | Keys.I),
+                    Hk(FormBrowse.Commands.OpenWithDifftool, OpenWithDifftoolHotkey)),
                 new HotkeySettings(
                     RevisionGrid.HotkeySettingsName,
                     Hk(RevisionGrid.Commands.RevisionFilter, Keys.Control | Keys.F),
@@ -315,6 +320,8 @@ namespace GitUI.Hotkey
                 new HotkeySettings(
                     FileViewer.HotkeySettingsName,
                     Hk(FileViewer.Commands.Find, Keys.Control | Keys.F),
+                    Hk(FileViewer.Commands.FindNextOrOpenWithDifftool, OpenWithDifftoolHotkey),
+                    Hk(FileViewer.Commands.FindPrevious, Keys.Shift | OpenWithDifftoolHotkey),
                     Hk(FileViewer.Commands.GoToLine, Keys.Control | Keys.G),
                     Hk(FileViewer.Commands.IncreaseNumberOfVisibleLines, Keys.None),
                     Hk(FileViewer.Commands.DecreaseNumberOfVisibleLines, Keys.None),
@@ -331,7 +338,15 @@ namespace GitUI.Hotkey
                     Hk(FormResolveConflicts.Commands.Rescan, Keys.F5)),
                 new HotkeySettings(
                     RevisionDiff.HotkeySettingsName,
-                    Hk(RevisionDiff.Commands.DeleteSelectedFiles, Keys.Delete)),
+                    Hk(RevisionDiff.Command.DeleteSelectedFiles, Keys.Delete),
+                    Hk(RevisionDiff.Command.ShowHistory, ShowHistoryHotkey),
+                    Hk(RevisionDiff.Command.Blame, BlameHotkey),
+                    Hk(RevisionDiff.Command.OpenWithDifftool, OpenWithDifftoolHotkey)),
+                new HotkeySettings(
+                    RevisionFileTree.HotkeySettingsName,
+                    Hk(RevisionFileTree.Command.ShowHistory, ShowHistoryHotkey),
+                    Hk(RevisionFileTree.Command.Blame, BlameHotkey),
+                    Hk(RevisionFileTree.Command.OpenWithDifftool, OpenWithDifftoolHotkey)),
                 new HotkeySettings(
                     FormSettings.HotkeySettingsName,
                     scriptsHotkeys)

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -68,7 +68,8 @@ namespace GitUI.UserControls
             GitRevision revision = DiffFiles.Revision;
             if (DiffFiles.SelectedItem != null && revision != null)
             {
-                await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.Guid, revision.Guid, DiffFiles.SelectedItem, string.Empty);
+                await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.Guid, revision.Guid, DiffFiles.SelectedItem, string.Empty,
+                    openWithDifftool: null /* use default */);
             }
         }
     }


### PR DESCRIPTION
Fixes #4500: F3 should open the external diff viewer instead of showing "No string specified to look for!"

Changes proposed in this pull request:
- added getter for FileViewer's FindAndReplaceForm.LookFor
- added Action FileViewerInternal._openWithDifftool to be invoked on F3 when LookFor is not set
- adapted all sources of diffs to be displayed in FileViewer with/without such an action
- KeyPreview = true in forms to react on F3, too, when the diff is visible but not focused
 
Screenshots before and after (if PR changes UI):
- affects only keypress handling

What did I do to test the code and ensure quality:
- hit F3 with different focused controls in FormCommit, FormBrowse, File History with & without search text
- reviewed changes multiple times before committing

Has been tested on (remove any that don't apply):
- GIT: N/A
- Windows 7
