### PR TITLE
Bug in push multiple refs

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2806,8 +2806,29 @@ namespace GitCommands
 
         public IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true)
         {
-            var refList = GetRefList(tags, branches);
+            var refList = GetRefList();
+
             return ParseRefs(refList);
+
+            string GetRefList()
+            {
+                if (tags && branches)
+                {
+                    return RunGitCmd("show-ref --dereference", SystemEncoding);
+                }
+
+                if (tags)
+                {
+                    return RunGitCmd("show-ref --tags", SystemEncoding);
+                }
+
+                if (branches)
+                {
+                    return RunGitCmd(@"for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", SystemEncoding);
+                }
+
+                return "";
+            }
         }
 
         /// <param name="option">Ordery by date is slower.</param>
@@ -2878,26 +2899,6 @@ namespace GitCommands
                 .Select(b => string.Concat(refsPrefix, b))
                 .Where(b => !string.IsNullOrEmpty(GitRefName.GetRemoteName(b, remotes)))
                 .ToList();
-        }
-
-        private string GetRefList(bool tags, bool branches)
-        {
-            if (tags && branches)
-            {
-                return RunGitCmd("show-ref --dereference", SystemEncoding);
-            }
-
-            if (tags)
-            {
-                return RunGitCmd("show-ref --tags", SystemEncoding);
-            }
-
-            if (branches)
-            {
-                return RunGitCmd(@"for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", SystemEncoding);
-            }
-
-            return "";
         }
 
         [NotNull, ItemNotNull]

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2763,7 +2763,7 @@ namespace GitCommands
 
             remote = remote.ToPosixPath();
 
-            result.CmdResult = GetTreeFromRemoteRefs(remote, tags, branches);
+            result.CmdResult = RunLsRemote();
 
             var tree = result.CmdResult.StdOutput;
 
@@ -2782,26 +2782,26 @@ namespace GitCommands
             }
 
             return result;
-        }
 
-        private CmdResult GetTreeFromRemoteRefs(string remote, bool tags, bool branches)
-        {
-            if (tags && branches)
+            CmdResult RunLsRemote()
             {
-                return RunGitCmdResult("ls-remote --heads --tags \"" + remote + "\"");
-            }
+                if (tags && branches)
+                {
+                    return RunGitCmdResult($"ls-remote --heads --tags \"{remote}\"");
+                }
 
-            if (tags)
-            {
-                return RunGitCmdResult("ls-remote --tags \"" + remote + "\"");
-            }
+                if (tags)
+                {
+                    return RunGitCmdResult($"ls-remote --tags \"{remote}\"");
+                }
 
-            if (branches)
-            {
-                return RunGitCmdResult("ls-remote --heads \"" + remote + "\"");
-            }
+                if (branches)
+                {
+                    return RunGitCmdResult($"ls-remote --heads \"{remote}\"");
+                }
 
-            return new CmdResult();
+                return new CmdResult();
+            }
         }
 
         public IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2913,8 +2913,10 @@ namespace GitCommands
             // 69a7c7a40230346778e7eebed809773a6bc45268 refs/heads/master
             // 69a7c7a40230346778e7eebed809773a6bc45268 refs/remotes/origin/master
             // 366dfba1abf6cb98d2934455713f3d190df2ba34 refs/tags/2.51
+            //
+            // Lines may also use \t as a column delimiter, such as output of "ls-remote --heads origin".
 
-            var regex = new Regex(@"^(?<objectid>[0-9a-f]{40}) (?<refname>.+)$", RegexOptions.Multiline);
+            var regex = new Regex(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline);
 
             var matches = regex.Matches(tree);
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2784,7 +2784,7 @@ namespace GitCommands
             return result;
         }
 
-        private CmdResult GetTreeFromRemoteRefsEx(string remote, bool tags, bool branches)
+        private CmdResult GetTreeFromRemoteRefs(string remote, bool tags, bool branches)
         {
             if (tags && branches)
             {
@@ -2802,11 +2802,6 @@ namespace GitCommands
             }
 
             return new CmdResult();
-        }
-
-        private CmdResult GetTreeFromRemoteRefs(string remote, bool tags, bool branches)
-        {
-            return GetTreeFromRemoteRefsEx(remote, tags, branches);
         }
 
         public IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true)

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -959,73 +959,75 @@ namespace GitUI.CommandsDialogs
                     remoteHeads = Module.GetRemoteBranches().Where(r => r.Remote == remote).ToList();
                 }
 
-                ProcessHeads(remote, remoteHeads);
-            }
-        }
-
-        private static string TakeCommandOutput(string processOutput)
-        {
-            // the command output consists of lines in the format:
-            // fa77791d780a01a06d1f7d4ccad4ef93ed0ae2fd\trefs/heads/branchName
-            int firstTabIdx = processOutput.IndexOf('\t');
-            if (firstTabIdx < 40)
-            {
-                return string.Empty;
+                ProcessHeads(remoteHeads);
             }
 
-            var cmdOutput = processOutput.Substring(firstTabIdx - 40);
-            return cmdOutput;
-        }
+            return;
 
-        private void ProcessHeads(string remote, IReadOnlyList<IGitRef> remoteHeads)
-        {
-            var localHeads = GetLocalBranches().ToList();
-            var remoteBranches = remoteHeads.ToHashSet(h => h.LocalName);
-
-            // Add all the local branches.
-            foreach (var head in localHeads)
+            string TakeCommandOutput(string processOutput)
             {
-                DataRow row = _branchTable.NewRow();
-                row[ForceColumnName] = false;
-                row[DeleteColumnName] = false;
-                row[LocalColumnName] = head.Name;
-
-                string remoteName;
-                if (head.Remote == remote)
+                // the command output consists of lines in the format:
+                // fa77791d780a01a06d1f7d4ccad4ef93ed0ae2fd\trefs/heads/branchName
+                int firstTabIdx = processOutput.IndexOf('\t');
+                if (firstTabIdx < 40)
                 {
-                    remoteName = head.MergeWith ?? head.Name;
-                }
-                else
-                {
-                    remoteName = head.Name;
+                    return string.Empty;
                 }
 
-                row[RemoteColumnName] = remoteName;
-                bool knownAtRemote = remoteBranches.Contains(remoteName);
-                row[NewColumnName] = knownAtRemote ? _no.Text : _yes.Text;
-                row[PushColumnName] = knownAtRemote;
-
-                _branchTable.Rows.Add(row);
+                var cmdOutput = processOutput.Substring(firstTabIdx - 40);
+                return cmdOutput;
             }
 
-            // Offer to delete all the left over remote branches.
-            foreach (var remoteHead in remoteHeads)
+            void ProcessHeads(IReadOnlyList<IGitRef> remoteHeads)
             {
-                var head = remoteHead;
-                if (localHeads.All(h => h.Name != head.LocalName))
+                var localHeads = GetLocalBranches().ToList();
+                var remoteBranches = remoteHeads.ToHashSet(h => h.LocalName);
+
+                // Add all the local branches.
+                foreach (var head in localHeads)
                 {
                     DataRow row = _branchTable.NewRow();
-                    row[LocalColumnName] = null;
-                    row[RemoteColumnName] = remoteHead.LocalName;
-                    row[NewColumnName] = _no.Text;
-                    row[PushColumnName] = false;
                     row[ForceColumnName] = false;
                     row[DeleteColumnName] = false;
+                    row[LocalColumnName] = head.Name;
+
+                    string remoteName;
+                    if (head.Remote == remote)
+                    {
+                        remoteName = head.MergeWith ?? head.Name;
+                    }
+                    else
+                    {
+                        remoteName = head.Name;
+                    }
+
+                    row[RemoteColumnName] = remoteName;
+                    bool knownAtRemote = remoteBranches.Contains(remoteName);
+                    row[NewColumnName] = knownAtRemote ? _no.Text : _yes.Text;
+                    row[PushColumnName] = knownAtRemote;
+
                     _branchTable.Rows.Add(row);
                 }
-            }
 
-            BranchGrid.Enabled = true;
+                // Offer to delete all the left over remote branches.
+                foreach (var remoteHead in remoteHeads)
+                {
+                    var head = remoteHead;
+                    if (localHeads.All(h => h.Name != head.LocalName))
+                    {
+                        DataRow row = _branchTable.NewRow();
+                        row[LocalColumnName] = null;
+                        row[RemoteColumnName] = remoteHead.LocalName;
+                        row[NewColumnName] = _no.Text;
+                        row[PushColumnName] = false;
+                        row[ForceColumnName] = false;
+                        row[DeleteColumnName] = false;
+                        _branchTable.Rows.Add(row);
+                    }
+                }
+
+                BranchGrid.Enabled = true;
+            }
         }
 
         private static void BranchTable_ColumnChanged(object sender, DataColumnChangeEventArgs e)

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -926,8 +926,7 @@ namespace GitUI.CommandsDialogs
 
         private void LoadMultiBranchViewData(string remote)
         {
-            Cursor = Cursors.AppStarting;
-            try
+            using (WaitCursorScope.Enter(Cursors.AppStarting))
             {
                 IReadOnlyList<IGitRef> remoteHeads;
                 if (Module.EffectiveSettings.Detailed.GetRemoteBranchesDirectlyFromRemote.ValueOrDefault)
@@ -961,10 +960,6 @@ namespace GitUI.CommandsDialogs
                 }
 
                 ProcessHeads(remote, remoteHeads);
-            }
-            finally
-            {
-                Cursor = Cursors.Default;
             }
         }
 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -947,9 +947,9 @@ namespace GitUI.CommandsDialogs
                             return;
                         }
 
-                        var tree = CleanCommandOutput(formProcess.GetOutputString());
+                        var refList = CleanCommandOutput(formProcess.GetOutputString());
 
-                        remoteHeads = Module.GetTreeRefs(tree);
+                        remoteHeads = Module.ParseRefs(refList);
                     }
                 }
                 else

--- a/GitUI/WaitCursorScope.cs
+++ b/GitUI/WaitCursorScope.cs
@@ -26,11 +26,11 @@ namespace GitUI
         /// <summary>
         /// Starts a new scope, recording <see cref="Cursor.Current"/> and setting the mouse cursor to <see cref="Cursors.WaitCursor"/>.
         /// </summary>
-        public static WaitCursorScope Enter()
+        public static WaitCursorScope Enter(Cursor cursor = null)
         {
             var cursorAtStartOfScope = Cursor.Current;
 
-            Cursor.Current = Cursors.WaitCursor;
+            Cursor.Current = cursor ?? Cursors.WaitCursor;
 
             return new WaitCursorScope(cursorAtStartOfScope);
         }

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -200,8 +200,8 @@ namespace GitCommandsTests
             const string tree =
                 "69a7c7a40230346778e7eebed809773a6bc45268 refs/heads/master\n" +
                 "69a7c7a40230346778e7eebed809773a6bc45268 refs/remotes/origin/master\n" +
-                "5303e7114f1896c639dea0231fac522752cc44a2 refs/remotes/upstream/mono\n" +
-                "366dfba1abf6cb98d2934455713f3d190df2ba34 refs/tags/2.51\n";
+                "5303e7114f1896c639dea0231fac522752cc44a2\trefs/remotes/upstream/mono\n" +
+                "366dfba1abf6cb98d2934455713f3d190df2ba34\trefs/tags/2.51\n";
 
             var refs = _gitModule.GetTreeRefs(tree);
 

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -192,18 +192,18 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void GetTreeRefs()
+        public void ParseRefs()
         {
-            Assert.IsEmpty(_gitModule.GetTreeRefs(""));
-            Assert.IsEmpty(_gitModule.GetTreeRefs("Foo"));
+            Assert.IsEmpty(_gitModule.ParseRefs(""));
+            Assert.IsEmpty(_gitModule.ParseRefs("Foo"));
 
-            const string tree =
+            const string refList =
                 "69a7c7a40230346778e7eebed809773a6bc45268 refs/heads/master\n" +
                 "69a7c7a40230346778e7eebed809773a6bc45268 refs/remotes/origin/master\n" +
                 "5303e7114f1896c639dea0231fac522752cc44a2\trefs/remotes/upstream/mono\n" +
                 "366dfba1abf6cb98d2934455713f3d190df2ba34\trefs/tags/2.51\n";
 
-            var refs = _gitModule.GetTreeRefs(tree);
+            var refs = _gitModule.ParseRefs(refList);
 
             Assert.AreEqual(4, refs.Count);
 


### PR DESCRIPTION
To reproduce this bug, ensure you have this option checked:

![image](https://user-images.githubusercontent.com/350947/38837734-ffe06a46-41ca-11e8-8ce3-bc4eb52aab4a.png)

## Changes proposed in this pull request:

- Fixes a regression in the parsing of ref lists. `GitModule.GetTreeRefs` expects the column separator to be a space. `git ls-remote` uses tab separators. This change expands the parsing regex to accept space or tab. This works in 2.51.01, so it's a regression and I probably caused it during a conversion to regex.
- Add another use of `WaitCursorScope` with alternative cursor (`Cursors.AppStarting`)
- Nest some private functions with only one using method
- Lists of refs were referred to as trees, but a git tree is something different. Rename a few things.
- Refactor `LoadMultiBranchViewData`

I tried squashing the nested function commits and they all conflict with intermediary changes.
 
## Screenshots before and after (if PR changes UI):

### master

![image](https://user-images.githubusercontent.com/350947/38837015-51bafa82-41c8-11e8-97bc-fe5596c5cd66.png)

### PR branch

![image](https://user-images.githubusercontent.com/350947/38837253-2872dfea-41c9-11e8-9061-85797ce016ff.png)

### 2.51.01

![image](https://user-images.githubusercontent.com/350947/38837275-3edd5cf6-41c9-11e8-85ba-9e5df9caaaa0.png)


## What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.16.2
- Windows 10
