### PR TITLE
Simplify RepoObjectTree header

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -55,10 +55,10 @@ namespace GitUI.BranchTreePanel
             this.mnubtnFetchCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFetchOneBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.mnubtnReset = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnubtnRebase = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnMergeBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnRebase = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnCreateBranchBasedOnRemoteBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnReset = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnDeleteRemoteBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFetchAllBranchesFromARemote = new System.Windows.Forms.ToolStripMenuItem();
@@ -73,8 +73,6 @@ namespace GitUI.BranchTreePanel
             this.mnubtnManageRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.repoTreePanel = new System.Windows.Forms.TableLayoutPanel();
             this.branchSearchPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.lblSearchBranch = new System.Windows.Forms.Label();
-            this.btnSearch = new System.Windows.Forms.Button();
             this.btnSettings = new System.Windows.Forms.Button();
             this.menuSettings = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -96,10 +94,11 @@ namespace GitUI.BranchTreePanel
             this.treeMain.ContextMenuStrip = this.menuMain;
             this.treeMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.treeMain.FullRowSelect = true;
-            this.treeMain.Location = new System.Drawing.Point(3, 41);
+            this.treeMain.Location = new System.Drawing.Point(0, 26);
+            this.treeMain.Margin = new System.Windows.Forms.Padding(0, 3, 0, 0);
             this.treeMain.Name = "treeMain";
             this.treeMain.ShowNodeToolTips = true;
-            this.treeMain.Size = new System.Drawing.Size(294, 350);
+            this.treeMain.Size = new System.Drawing.Size(300, 350);
             this.treeMain.TabIndex = 3;
             this.treeMain.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnNodeSelected);
             // 
@@ -181,14 +180,14 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnFilterRemoteBranchInRevisionGrid.Image = global::GitUI.Properties.Resources.IconFilter;
             this.mnubtnFilterRemoteBranchInRevisionGrid.Name = "mnubtnFilterRemoteBranchInRevisionGrid";
-            this.mnubtnFilterRemoteBranchInRevisionGrid.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFilterRemoteBranchInRevisionGrid.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFilterRemoteBranchInRevisionGrid.Text = "Show this branch only";
             // 
             // mnubtnBranchCheckout
             // 
             this.mnubtnBranchCheckout.Image = global::GitUI.Properties.Resources.IconBranchCheckout;
             this.mnubtnBranchCheckout.Name = "mnubtnBranchCheckout";
-            this.mnubtnBranchCheckout.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnBranchCheckout.Size = new System.Drawing.Size(193, 22);
             this.mnubtnBranchCheckout.Text = "&Checkout";
             this.mnubtnBranchCheckout.ToolTipText = "Checkout this branch";
             // 
@@ -229,13 +228,13 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteRemoteBranch,
             this.mnubtnFilterRemoteBranchInRevisionGrid});
             this.menuRemote.Name = "contextmenuRemote";
-            this.menuRemote.Size = new System.Drawing.Size(192, 280);
+            this.menuRemote.Size = new System.Drawing.Size(194, 280);
             // 
             // mnubtnRemoteBranchFetchAndCheckout
             // 
             this.mnubtnRemoteBranchFetchAndCheckout.Image = global::GitUI.Properties.Resources.IconBranchCheckout;
             this.mnubtnRemoteBranchFetchAndCheckout.Name = "mnubtnRemoteBranchFetchAndCheckout";
-            this.mnubtnRemoteBranchFetchAndCheckout.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnRemoteBranchFetchAndCheckout.Size = new System.Drawing.Size(193, 22);
             this.mnubtnRemoteBranchFetchAndCheckout.Text = "&Fetch && Checkout";
             this.mnubtnRemoteBranchFetchAndCheckout.ToolTipText = "Checkout this branch";
             // 
@@ -243,14 +242,14 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnPullFromRemoteBranch.Image = global::GitUI.Properties.Resources.IconPull;
             this.mnubtnPullFromRemoteBranch.Name = "mnubtnPullFromRemoteBranch";
-            this.mnubtnPullFromRemoteBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnPullFromRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnPullFromRemoteBranch.Text = "Fetch && Merge (&Pull)";
             // 
             // mnubtnFetchRebase
             // 
             this.mnubtnFetchRebase.Image = global::GitUI.Properties.Resources.IconRebase;
             this.mnubtnFetchRebase.Name = "mnubtnFetchRebase";
-            this.mnubtnFetchRebase.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFetchRebase.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFetchRebase.Text = "Fetch && Re&base";
             this.mnubtnFetchRebase.ToolTipText = "Fetch & Rebase current branch to this branch";
             // 
@@ -258,7 +257,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnFetchCreateBranch.Image = global::GitUI.Properties.MsVsImages.Branch_16x;
             this.mnubtnFetchCreateBranch.Name = "mnubtnFetchCreateBranch";
-            this.mnubtnFetchCreateBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFetchCreateBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFetchCreateBranch.Text = "Fetc&h && Create Branch";
             this.mnubtnFetchCreateBranch.ToolTipText = "Fetch then create a local branch from the remote branch";
             // 
@@ -266,20 +265,20 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnFetchOneBranch.Image = global::GitUI.Properties.Resources.IconStage;
             this.mnubtnFetchOneBranch.Name = "mnubtnFetchOneBranch";
-            this.mnubtnFetchOneBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFetchOneBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFetchOneBranch.Text = "Fe&tch";
             this.mnubtnFetchOneBranch.ToolTipText = "Fetch the new remote branch";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(188, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(190, 6);
             // 
             // mnubtnMergeBranch
             // 
             this.mnubtnMergeBranch.Image = global::GitUI.Properties.Resources.IconMerge;
             this.mnubtnMergeBranch.Name = "mnubtnMergeBranch";
-            this.mnubtnMergeBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnMergeBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnMergeBranch.Text = "&Merge";
             this.mnubtnMergeBranch.ToolTipText = "Merge remote branch into current branch";
             // 
@@ -287,7 +286,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnRebase.Image = global::GitUI.Properties.Resources.IconRebase;
             this.mnubtnRebase.Name = "mnubtnRebase";
-            this.mnubtnRebase.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnRebase.Size = new System.Drawing.Size(193, 22);
             this.mnubtnRebase.Text = "&Rebase";
             this.mnubtnRebase.ToolTipText = "Rebase current branch to this branch";
             // 
@@ -295,7 +294,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnCreateBranchBasedOnRemoteBranch.Image = global::GitUI.Properties.MsVsImages.Branch_16x;
             this.mnubtnCreateBranchBasedOnRemoteBranch.Name = "mnubtnCreateBranchBasedOnRemoteBranch";
-            this.mnubtnCreateBranchBasedOnRemoteBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnCreateBranchBasedOnRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnCreateBranchBasedOnRemoteBranch.Text = "Create &Branch...";
             this.mnubtnCreateBranchBasedOnRemoteBranch.ToolTipText = "Create a local branch from the remote branch";
             // 
@@ -303,20 +302,20 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnReset.Image = global::GitUI.Properties.Resources.IconResetCurrentBranchToHere;
             this.mnubtnReset.Name = "mnubtnReset";
-            this.mnubtnReset.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnReset.Size = new System.Drawing.Size(193, 22);
             this.mnubtnReset.Text = "Re&set";
             this.mnubtnReset.ToolTipText = "Reset current branch to here";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(188, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(190, 6);
             // 
             // mnubtnDeleteRemoteBranch
             // 
             this.mnubtnDeleteRemoteBranch.Image = global::GitUI.Properties.Resources.Delete;
             this.mnubtnDeleteRemoteBranch.Name = "mnubtnDeleteRemoteBranch";
-            this.mnubtnDeleteRemoteBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnDeleteRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnDeleteRemoteBranch.Text = "&Delete";
             this.mnubtnDeleteRemoteBranch.ToolTipText = "Delete the branch from the remote";
             // 
@@ -420,44 +419,19 @@ namespace GitUI.BranchTreePanel
             this.branchSearchPanel.AutoSize = true;
             this.branchSearchPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.branchSearchPanel.BackColor = System.Drawing.SystemColors.Control;
-            this.branchSearchPanel.ColumnCount = 4;
-            this.branchSearchPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.branchSearchPanel.ColumnCount = 3;
             this.branchSearchPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.branchSearchPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.branchSearchPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.branchSearchPanel.Controls.Add(this.lblSearchBranch, 0, 0);
-            this.branchSearchPanel.Controls.Add(this.btnSearch, 2, 0);
-            this.branchSearchPanel.Controls.Add(this.btnSettings, 3, 0);
+            this.branchSearchPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.branchSearchPanel.Controls.Add(this.btnSettings, 2, 0);
             this.branchSearchPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.branchSearchPanel.Location = new System.Drawing.Point(3, 3);
+            this.branchSearchPanel.Location = new System.Drawing.Point(1, 1);
+            this.branchSearchPanel.Margin = new System.Windows.Forms.Padding(1, 1, 0, 0);
             this.branchSearchPanel.Name = "branchSearchPanel";
             this.branchSearchPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.branchSearchPanel.Size = new System.Drawing.Size(294, 32);
+            this.branchSearchPanel.Size = new System.Drawing.Size(299, 22);
             this.branchSearchPanel.TabIndex = 4;
-            // 
-            // lblSearchBranch
-            // 
-            this.lblSearchBranch.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.lblSearchBranch.AutoSize = true;
-            this.lblSearchBranch.Location = new System.Drawing.Point(3, 9);
-            this.lblSearchBranch.Name = "lblSearchBranch";
-            this.lblSearchBranch.Size = new System.Drawing.Size(44, 13);
-            this.lblSearchBranch.TabIndex = 0;
-            this.lblSearchBranch.Text = "Search:";
-            // 
-            // btnSearch
-            // 
-            this.btnSearch.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.btnSearch.AutoSize = true;
-            this.btnSearch.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.btnSearch.Image = global::GitUI.Properties.Resources.IconFind;
-            this.btnSearch.Location = new System.Drawing.Point(233, 3);
-            this.btnSearch.Name = "btnSearch";
-            this.btnSearch.Padding = new System.Windows.Forms.Padding(2);
-            this.btnSearch.Size = new System.Drawing.Size(26, 26);
-            this.btnSearch.TabIndex = 2;
-            this.btnSearch.UseVisualStyleBackColor = true;
-            this.btnSearch.Click += new System.EventHandler(this.OnBtnSearchClicked);
             // 
             // btnSettings
             // 
@@ -465,11 +439,14 @@ namespace GitUI.BranchTreePanel
             this.btnSettings.AutoSize = true;
             this.btnSettings.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.btnSettings.ContextMenuStrip = this.menuSettings;
+            this.btnSettings.FlatAppearance.BorderSize = 0;
+            this.btnSettings.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnSettings.ForeColor = System.Drawing.SystemColors.Control;
             this.btnSettings.Image = global::GitUI.Properties.Resources.Settings;
-            this.btnSettings.Location = new System.Drawing.Point(265, 3);
+            this.btnSettings.Location = new System.Drawing.Point(277, 0);
+            this.btnSettings.Margin = new System.Windows.Forms.Padding(0);
             this.btnSettings.Name = "btnSettings";
-            this.btnSettings.Padding = new System.Windows.Forms.Padding(2);
-            this.btnSettings.Size = new System.Drawing.Size(26, 26);
+            this.btnSettings.Size = new System.Drawing.Size(22, 22);
             this.btnSettings.TabIndex = 3;
             this.btnSettings.UseVisualStyleBackColor = true;
             this.btnSettings.Click += new System.EventHandler(this.OnBtnSettingsClicked);
@@ -542,8 +519,6 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnubtnDeleteTag;
         private TableLayoutPanel repoTreePanel;
         private TableLayoutPanel branchSearchPanel;
-        private Label lblSearchBranch;
-        private Button btnSearch;
         private Button btnSettings;
         private ContextMenuStrip menuSettings;
         private ToolStripMenuItem showTagsToolStripMenuItem;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -19,8 +19,9 @@ namespace GitUI.BranchTreePanel
         public FilterBranchHelper FilterBranchHelper { private get; set; }
 
         private readonly List<Tree> _rootNodes = new List<Tree>();
+
         private SearchControl<string> _txtBranchCriterion;
-        private readonly ImageList _imageList = new ImageList();
+
         public RepoObjectsTree()
         {
             _currentToken = _reloadCancellation.Next();
@@ -45,12 +46,17 @@ namespace GitUI.BranchTreePanel
 
         private void InitImageList()
         {
-            _imageList.Images.Add(nameof(MsVsImages.Branch_16x), MsVsImages.Branch_16x);
-            _imageList.Images.Add(nameof(MsVsImages.Repository_16x), MsVsImages.Repository_16x);
-            _imageList.Images.Add(nameof(MsVsImages.BranchRemote_16x), MsVsImages.BranchRemote_16x);
-            _imageList.Images.Add(nameof(MsVsImages.Folder_grey_16x), MsVsImages.Folder_grey_16x);
-            _imageList.Images.Add(nameof(MsVsImages.Tag_16x), MsVsImages.Tag_16x);
-            treeMain.ImageList = _imageList;
+            treeMain.ImageList = new ImageList
+            {
+                Images =
+                {
+                    { nameof(MsVsImages.Branch_16x), MsVsImages.Branch_16x },
+                    { nameof(MsVsImages.Repository_16x), MsVsImages.Repository_16x },
+                    { nameof(MsVsImages.BranchRemote_16x), MsVsImages.BranchRemote_16x },
+                    { nameof(MsVsImages.Folder_grey_16x), MsVsImages.Folder_grey_16x },
+                    { nameof(MsVsImages.Tag_16x), MsVsImages.Tag_16x }
+                }
+            };
             treeMain.ImageKey = nameof(MsVsImages.Branch_16x);
             treeMain.SelectedImageKey = treeMain.ImageKey;
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -29,8 +29,6 @@ namespace GitUI.BranchTreePanel
             InitImageList();
             InitializeSearchBox();
             treeMain.PreviewKeyDown += OnPreviewKeyDown;
-
-            btnSearch.PreviewKeyDown += OnPreviewKeyDown;
             PreviewKeyDown += OnPreviewKeyDown;
             Translate();
 
@@ -63,20 +61,24 @@ namespace GitUI.BranchTreePanel
 
         private void InitializeSearchBox()
         {
-            _txtBranchCriterion = new SearchControl<string>(SearchForBranch, i => { });
+            _txtBranchCriterion = new SearchControl<string>(SearchForBranch, i => { })
+            {
+                Anchor = AnchorStyles.Left | AnchorStyles.Right,
+                Name = "txtBranchCritierion",
+                TabIndex = 1,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(0),
+                Height = 16
+            };
             _txtBranchCriterion.OnTextEntered += () =>
             {
                 OnBranchCriterionChanged(null, null);
                 OnBtnSearchClicked(null, null);
             };
-            _txtBranchCriterion.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-            _txtBranchCriterion.Name = "txtBranchCritierion";
-            _txtBranchCriterion.TabIndex = 1;
             _txtBranchCriterion.TextChanged += OnBranchCriterionChanged;
-            _txtBranchCriterion.KeyDown += TxtBranchCriterion_KeyDown;
-            branchSearchPanel.Controls.Add(_txtBranchCriterion, 1, 0);
-
             _txtBranchCriterion.PreviewKeyDown += OnPreviewKeyDown;
+            _txtBranchCriterion.KeyDown += TxtBranchCriterion_KeyDown;
+            branchSearchPanel.Controls.Add(_txtBranchCriterion, 0, 0);
         }
 
         private IEnumerable<string> SearchForBranch(string arg)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -26,7 +26,7 @@ namespace GitUI.BranchTreePanel
             _currentToken = _reloadCancellation.Next();
             InitializeComponent();
             InitImageList();
-            InitiliazeSearchBox();
+            InitializeSearchBox();
             treeMain.PreviewKeyDown += OnPreviewKeyDown;
 
             btnSearch.PreviewKeyDown += OnPreviewKeyDown;
@@ -55,7 +55,7 @@ namespace GitUI.BranchTreePanel
             treeMain.SelectedImageKey = treeMain.ImageKey;
         }
 
-        private void InitiliazeSearchBox()
+        private void InitializeSearchBox()
         {
             _txtBranchCriterion = new SearchControl<string>(SearchForBranch, i => { });
             _txtBranchCriterion.OnTextEntered += () =>

--- a/GitUI/BranchTreePanel/RepoObjectsTree.resx
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="menuMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 88</value>
+    <value>17, 56</value>
   </metadata>
   <metadata name="menuBranch.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>11, 54</value>
+    <value>161, 17</value>
   </metadata>
   <metadata name="menuTags.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>592, 49</value>
+    <value>281, 17</value>
   </metadata>
   <metadata name="menuRemotes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>951, 49</value>
+    <value>516, 17</value>
   </metadata>
   <metadata name="menuRemote.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1081, 49</value>
+    <value>646, 17</value>
   </metadata>
   <metadata name="menuTag.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1206, 49</value>
+    <value>771, 17</value>
   </metadata>
   <metadata name="menuBranchPath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>3, 25</value>
+    <value>17, 17</value>
   </metadata>
   <metadata name="menuRemoteRepoNode.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>929, 88</value>
+    <value>127, 56</value>
   </metadata>
   <metadata name="menuSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>700, 49</value>
+    <value>389, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>213</value>

--- a/GitUI/CommandsDialogs/SearchControl.Designer.cs
+++ b/GitUI/CommandsDialogs/SearchControl.Designer.cs
@@ -38,10 +38,9 @@
             // 
             // listBoxSearchResult
             // 
-            this.listBoxSearchResult.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left))));
             this.listBoxSearchResult.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.listBoxSearchResult.FormattingEnabled = true;
-            this.listBoxSearchResult.Location = new System.Drawing.Point(0, 20);
+            this.listBoxSearchResult.Location = new System.Drawing.Point(0, 22);
             this.listBoxSearchResult.Margin = new System.Windows.Forms.Padding(0);
             this.listBoxSearchResult.Name = "listBoxSearchResult";
             this.listBoxSearchResult.Size = new System.Drawing.Size(64, 15);
@@ -50,11 +49,15 @@
             // 
             // txtSearchBox
             // 
-            this.txtSearchBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtSearchBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSearchBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.txtSearchBox.Location = new System.Drawing.Point(0, 0);
             this.txtSearchBox.Margin = new System.Windows.Forms.Padding(0);
+            this.txtSearchBox.MinimumSize = new System.Drawing.Size(0, 22);
             this.txtSearchBox.Name = "txtSearchBox";
-            this.txtSearchBox.Size = new System.Drawing.Size(64, 20);
+            this.txtSearchBox.Size = new System.Drawing.Size(64, 22);
             this.txtSearchBox.TabIndex = 1;
             this.txtSearchBox.TextChanged += new System.EventHandler(this.txtSearchBox_TextChange);
             this.txtSearchBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtSearchBox_KeyDown);


### PR DESCRIPTION
## Changes proposed in this pull request:
- Simplify the RepoObjectTree header area
- Reduce size and detail of icon, making it more closely match the main toolstrip
- Remove the search button. We don't have it on other search boxes, and with the completion it's easy to select a result with the mouse or press enter.
 
## Screenshots before and after:

### before

![image](https://user-images.githubusercontent.com/350947/38842835-1c8e82f4-41e4-11e8-8268-34c39b56faf9.png)

### after

![image](https://user-images.githubusercontent.com/350947/38842688-390bb61e-41e3-11e8-9871-61cf8b489710.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.16.2
- Windows 10
