### PR TITLE
fix "bugs" link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ you'll want to browse our [wiki](https://github.com/gitextensions/gitextensions/
 
 Good places to start contributing include:
 
-- Open [bugs](https://github.com/gitextensions/gitextensions/labels/bugs)
+- Open [bugs](https://github.com/gitextensions/gitextensions/labels/bug)
 - Open issues marked [good first issue](https://github.com/gitextensions/gitextensions/labels/good%20first%20issue)
 - Open issues marked [help wanted](https://github.com/gitextensions/gitextensions/labels/help%20wanted)
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Changes proposed in this pull request:
- fix "bugs" link in CONTRIBUTING.md to point to the correct label
 
Screenshots before and after (if PR changes UI):
- before: 
![image](https://user-images.githubusercontent.com/1851369/39095250-c23e6496-463d-11e8-9388-4f9de78db681.png)

- after: 
![image](https://user-images.githubusercontent.com/1851369/39095256-d85408a8-463d-11e8-8177-c12bde820a65.png)

What did I do to test the code and ensure quality:
- manual verification

Has been tested on (remove any that don't apply):
- n/a
