### PR TITLE
Don't prepend blank message in FormCommit's message history

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2032,7 +2032,7 @@ namespace GitUI.CommandsDialogs
                 .Select(message => message.TrimEnd('\n'))
                 .ToList();
 
-            if (!prevMsgs.Contains(msg))
+            if (!string.IsNullOrWhiteSpace(msg) && !prevMsgs.Contains(msg))
             {
                 // If the list is already full
                 if (prevMsgs.Count == maxCount)


### PR DESCRIPTION
Fixes #4856

In practice this bug would occur for the first commit when `AppSettings.LastCommitMessage` is `""`.

Changes proposed in this pull request:
- Add precondition
 
What did I do to test the code and ensure quality:
- Ran @sharwell's unit tests from #4717

Has been tested on:
- GIT 2.16.02
- Windows 10
