### PR TITLE
Add current working dir as fallback for GitModule

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -105,7 +105,7 @@ namespace GitCommands
         public static readonly string NoNewLineAtTheEnd = "\\ No newline at end of file";
         private const string DiffCommandWithStandardArgs = " -c diff.submodule=short diff --no-color ";
 
-        public GitModule(string workingdir)
+        public GitModule([CanBeNull] string workingdir)
         {
             _superprojectInit = false;
             WorkingDir = (workingdir ?? "").EnsureTrailingPathSeparator();

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -479,17 +479,17 @@ namespace GitCommands
             }
         }
 
-        [NotNull]
-        public static string FindGitWorkingDir([CanBeNull] string startDir)
+        /// <summary>
+        /// Searches from <paramref name="startDir"/> and up through the directory
+        /// hierarchy for a valid git working directory. If found, the path is returned,
+        /// otherwise <c>null</c>.
+        /// </summary>
+        [CanBeNull]
+        public static string TryFindGitWorkingDir([CanBeNull] string startDir)
         {
-            if (string.IsNullOrEmpty(startDir))
-            {
-                return "";
-            }
+            var dir = startDir?.Trim();
 
-            var dir = startDir.Trim();
-
-            do
+            while (!string.IsNullOrWhiteSpace(dir))
             {
                 if (IsValidGitWorkingDir(dir))
                 {
@@ -498,9 +498,8 @@ namespace GitCommands
 
                 dir = PathUtil.GetDirectoryName(dir);
             }
-            while (!string.IsNullOrEmpty(dir));
 
-            return startDir;
+            return null;
         }
 
         [NotNull]

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -131,7 +131,8 @@ namespace GitExtensions
 
         private static string GetWorkingDir(string[] args)
         {
-            string workingDir = string.Empty;
+            var workingDir = "";
+
             if (args.Length >= 3)
             {
                 // there is bug in .net
@@ -164,6 +165,19 @@ namespace GitExtensions
                 if (GitModule.IsValidGitWorkingDir(AppSettings.RecentWorkingDir))
                 {
                     workingDir = AppSettings.RecentWorkingDir;
+                }
+            }
+
+            if (workingDir == "")
+            {
+                // If no working dir is yet found, try to find one relative to the current working directory.
+                // This allows the `fileeditor` command to discover repository configuration which is
+                // required for core.commentChar support.
+                var cwd = Environment.CurrentDirectory;
+                var gitDir = GitModule.FindGitWorkingDir(cwd);
+                if (GitModule.IsValidGitWorkingDir(gitDir))
+                {
+                    workingDir = gitDir;
                 }
             }
 

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -7,6 +7,7 @@ using GitCommands.Utils;
 using GitUI;
 using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
+using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
 
 namespace GitExtensions
@@ -129,6 +130,7 @@ namespace GitExtensions
             AppSettings.SaveSettings();
         }
 
+        [CanBeNull]
         private static string GetWorkingDir(string[] args)
         {
             var workingDir = "";

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -38,7 +38,7 @@ namespace GitUI
             _fildFilePredicateProvider = new FindFilePredicateProvider();
         }
 
-        public GitUICommands(string workingDir)
+        public GitUICommands([CanBeNull] string workingDir)
             : this(new GitModule(workingDir))
         {
         }


### PR DESCRIPTION
(This PR created as [requested in #4809](https://github.com/gitextensions/gitextensions/pull/4809#discussion_r180905799))

When running commands from the command line, and if no working directory argument is passed, use the `Environment.CurrentDirectory` to find a valid git working directory, if possible.

This is important for #4809 where we need values from the config file. Without this change, the editor does cannot read config and therefore does not know git's `core.commentChar` value.

@RussKie pointed out that this change seems to be related to #4740 and asked for it to be pulled out to its own PR. Let's work out what is required here and document it in the code to prevent future flip-flops.

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.16
- Windows 10
