### PR TITLE
Fix case when GitCommonDirectory equals "."

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -388,7 +388,7 @@ namespace GitCommands
                 {
                     var commDir = RunGitCmdResult("rev-parse --git-common-dir");
                     _gitCommonDirectory = PathUtil.ToNativePath(commDir.StdOutput.Trim());
-                    if (!commDir.ExitedSuccessfully || _gitCommonDirectory == ".git" || !Directory.Exists(_gitCommonDirectory))
+                    if (!commDir.ExitedSuccessfully || _gitCommonDirectory == ".git" || _gitCommonDirectory == "." || !Directory.Exists(_gitCommonDirectory))
                     {
                         _gitCommonDirectory = GetGitDirectory();
                     }


### PR DESCRIPTION
(This PR created as [requested in #4809](https://github.com/gitextensions/gitextensions/pull/4809#discussion_r180909537))

When running the "fileeditor" command during an interactive rebase, this property was returning `"."` which prohibits loading local configuration, yet `Environment.CurrentDirectory` is the work dir, hence `./config` isn't found.

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.16
- Windows 10
