### PR TITLE
Fix crash during file name extraction for combined diffs

### DIFF
--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -93,7 +93,7 @@ namespace GitCommands.Patches
             }
             else
             {
-                Match match = Regex.Match(header, "--cc [\\\"]?(.*)[\\\"]?");
+                Match match = Regex.Match(header, "(?:--cc|--combined) [\\\"]?(.*)[\\\"]?");
 
                 if (!match.Success)
                 {


### PR DESCRIPTION
Fixes a crash when viewing combined diff
Introduced in: 6c3185726cf29e95f5dfdfddee4a0f19c2534feb Merge pull request #4697 from drewnoakes/patches
cc @drewnoakes Please have a look as you are more familiar with this section of code

Changes proposed in this pull request:
- Fix regexp for file name extraction for combined diffs

The check at line 98 https://github.com/mdonatas/gitextensions/blob/28bdc3319c8f325dfe6e438a926e41873ad3802c/GitCommands/Patches/PatchProcessor.cs#L98 wasn't there before. The regex did fail but there was no exception and empty string got assigned as a result. Everything worked even though it didn't perform correctly.
If you look at the code which determines if it's a combined diff you see that it checks both cases `--cc` and `--combined` but inside of `CreatePatchFromString` it only checks one.

For repro:
- navigate to commit 97990e74c16edfb472b0bbca94bdfec52f6b00db
- in diff tab scroll to bottom
- select GitUI/GitUICommands.cs under Combined Diff group
- Exception