### PR TITLE
Improve FormVerify (Recover lost objects form)

### DIFF
--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -226,6 +226,7 @@
             this.mnuLostObjectsCreateBranch});
             this.mnuLostObjects.Name = "mnuLostObjects";
             this.mnuLostObjects.Size = new System.Drawing.Size(190, 70);
+            this.mnuLostObjects.Opening += new System.ComponentModel.CancelEventHandler(this.mnuLostObjects_Opening);
             // 
             // mnuLostObjectView
             // 

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -232,6 +232,7 @@
             // 
             // mnuLostObjectView
             // 
+            this.mnuLostObjectView.Image = global::GitUI.Properties.Resources.IconViewFile;
             this.mnuLostObjectView.Name = "mnuLostObjectView";
             this.mnuLostObjectView.Size = new System.Drawing.Size(189, 22);
             this.mnuLostObjectView.Text = "View";
@@ -239,6 +240,7 @@
             // 
             // mnuLostObjectsCreateTag
             // 
+            this.mnuLostObjectsCreateTag.Image = global::GitUI.Properties.Resources.IconTagCreate;
             this.mnuLostObjectsCreateTag.Name = "mnuLostObjectsCreateTag";
             this.mnuLostObjectsCreateTag.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
             this.mnuLostObjectsCreateTag.Size = new System.Drawing.Size(189, 22);
@@ -247,6 +249,7 @@
             // 
             // mnuLostObjectsCreateBranch
             // 
+            this.mnuLostObjectsCreateBranch.Image = global::GitUI.Properties.Resources.IconBranchCreate;
             this.mnuLostObjectsCreateBranch.Name = "mnuLostObjectsCreateBranch";
             this.mnuLostObjectsCreateBranch.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
             this.mnuLostObjectsCreateBranch.Size = new System.Drawing.Size(189, 22);
@@ -255,6 +258,7 @@
             // 
             // copyHashToolStripMenuItem
             // 
+            this.copyHashToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
             this.copyHashToolStripMenuItem.Name = "copyHashToolStripMenuItem";
             this.copyHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
             this.copyHashToolStripMenuItem.Text = "Copy object hash";

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -278,6 +278,7 @@
             this.Warnings.TabIndex = 4;
             this.Warnings.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDoubleClick);
             this.Warnings.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDown);
+            this.Warnings.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.Warnings_KeyPress);
             // 
             // columnIsLostObjectSelected
             // 

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -36,6 +36,7 @@
             this.mnuLostObjectView = new System.Windows.Forms.ToolStripMenuItem();
             this.mnuLostObjectsCreateTag = new System.Windows.Forms.ToolStripMenuItem();
             this.mnuLostObjectsCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Warnings = new System.Windows.Forms.DataGridView();
             this.columnIsLostObjectSelected = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.columnDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -223,7 +224,8 @@
             this.mnuLostObjects.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuLostObjectView,
             this.mnuLostObjectsCreateTag,
-            this.mnuLostObjectsCreateBranch});
+            this.mnuLostObjectsCreateBranch,
+            this.copyHashToolStripMenuItem});
             this.mnuLostObjects.Name = "mnuLostObjects";
             this.mnuLostObjects.Size = new System.Drawing.Size(190, 70);
             this.mnuLostObjects.Opening += new System.ComponentModel.CancelEventHandler(this.mnuLostObjects_Opening);
@@ -250,6 +252,13 @@
             this.mnuLostObjectsCreateBranch.Size = new System.Drawing.Size(189, 22);
             this.mnuLostObjectsCreateBranch.Text = "Create branch";
             this.mnuLostObjectsCreateBranch.Click += new System.EventHandler(this.mnuLostObjectsCreateBranch_Click);
+            // 
+            // copyHashToolStripMenuItem
+            // 
+            this.copyHashToolStripMenuItem.Name = "copyHashToolStripMenuItem";
+            this.copyHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.copyHashToolStripMenuItem.Text = "Copy object hash";
+            this.copyHashToolStripMenuItem.Click += new System.EventHandler(this.copyHashToolStripMenuItem_Click);
             // 
             // Warnings
             // 
@@ -374,5 +383,6 @@
         private System.Windows.Forms.CheckBox Unreachable;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ToolStripMenuItem copyHashToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Text.RegularExpressions;
 using GitCommands;
 
@@ -91,6 +92,12 @@ namespace GitUI.CommandsDialogs
                         result.Subject = module.ReEncodeCommitMessage(logPatternMatch.Groups[3].Value, encodingName);
                         result.Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups[4].Value);
                     }
+                }
+
+                if (result.ObjectType == LostObjectType.Blob)
+                {
+                    var blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash.Substring(0, 2), hash.Substring(2, hash.Length - 2));
+                    result.Date = new FileInfo(blobPath).CreationTime;
                 }
 
                 return result;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -349,6 +349,15 @@ namespace GitUI.CommandsDialogs
             base.Dispose(disposing);
         }
 
+        private void mnuLostObjects_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+            var isCommit = lostObject != null && lostObject.ObjectType == LostObjectType.Commit;
+            var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
+            contextMenu.Items[1].Enabled = isCommit;
+            contextMenu.Items[2].Enabled = isCommit;
+        }
+
         private void Warnings_KeyPress(object sender, KeyPressEventArgs e)
         {
             if (e.KeyChar == 13)

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -45,7 +45,8 @@ namespace GitUI.CommandsDialogs
             columnDate.Width = DpiUtil.Scale(56);
             columnType.Width = DpiUtil.Scale(58);
             columnAuthor.Width = DpiUtil.Scale(150);
-            columnHash.Width = DpiUtil.Scale(80);
+            columnHash.Width = DpiUtil.Scale(280);
+            columnHash.MinimumWidth = DpiUtil.Scale(75);
 
             _selectedItemsHeader.AttachTo(columnIsLostObjectSelected);
 

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -347,5 +347,14 @@ namespace GitUI.CommandsDialogs
 
             base.Dispose(disposing);
         }
+
+        private void Warnings_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (e.KeyChar == 13)
+            {
+                e.Handled = true;
+                ViewCurrentItem();
+            }
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -352,11 +352,14 @@ namespace GitUI.CommandsDialogs
 
         private void mnuLostObjects_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
-            var isCommit = lostObject != null && lostObject.ObjectType == LostObjectType.Commit;
-            var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
-            contextMenu.Items[1].Enabled = isCommit;
-            contextMenu.Items[2].Enabled = isCommit;
+            if (Warnings != null && Warnings.SelectedRows.Count != 0 && Warnings.SelectedRows[0].DataBoundItem != null)
+            {
+                var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+                var isCommit = lostObject != null && lostObject.ObjectType == LostObjectType.Commit;
+                var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
+                contextMenu.Items[1].Enabled = isCommit;
+                contextMenu.Items[2].Enabled = isCommit;
+            }
         }
 
         private void Warnings_KeyPress(object sender, KeyPressEventArgs e)
@@ -370,8 +373,11 @@ namespace GitUI.CommandsDialogs
 
         private void copyHashToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
-            Clipboard.SetText(lostObject.Hash);
+            if (Warnings != null && Warnings.SelectedRows.Count != 0 && Warnings.SelectedRows[0].DataBoundItem != null)
+            {
+                var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+                Clipboard.SetText(lostObject.Hash);
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -367,5 +367,11 @@ namespace GitUI.CommandsDialogs
                 ViewCurrentItem();
             }
         }
+
+        private void copyHashToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+            Clipboard.SetText(lostObject.Hash);
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -222,7 +222,8 @@ namespace GitUI.CommandsDialogs
                         .Split('\r', '\n')
                         .Where(s => !string.IsNullOrEmpty(s))
                         .Select((s) => LostObject.TryParse(Module, s))
-                        .Where(parsedLostObject => parsedLostObject != null));
+                        .Where(parsedLostObject => parsedLostObject != null)
+                        .OrderByDescending(l => l.Date));
 
                 UpdateFilteredLostObjects();
             }


### PR DESCRIPTION
Changes proposed in this pull request:
- Display creation time of the blob objects and not only commit objects as it is done at the moment (taken from file creation time) to give a good clue to the user
- Open the viewer on press on 'Enter' (to let the user use its beloved keyboard for easy navigation)
- Better initial sizing of "Hash" column (because that's a lot easier to reduce the last column than enlarge it!)
- Disable creation tag and branch for not "Commit" objects in contextual menu (because that's not possible and we have an error message if we try to do it...)
- Display objects sorted by date (because a sort is better than none...)
- Add context menu item to be able to easily copy the hash

![image](https://user-images.githubusercontent.com/460196/39275364-4ef905f4-48e5-11e8-9507-e35485f5ab79.png)


What did I do to test the code and ensure quality:
- manual test

Has been tested on:
- GIT 2.16
- Windows 10
