### PR TITLE
fix: FormClone is messed up in HiDPI

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -386,9 +386,7 @@ namespace GitUI.CommandsDialogs
             this.ClientSize = new System.Drawing.Size(616, 336);
             this.Controls.Add(this.tableLayoutPanel2);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(933, 375);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(430, 375);
             this.Name = "FormClone";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Clone";

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils.GitUI;
 using GitUIPluginInterfaces;
 using ResourceManager;
 
@@ -61,6 +62,11 @@ namespace GitUI.CommandsDialogs
         protected override void OnRuntimeLoad(EventArgs e)
         {
             base.OnRuntimeLoad(e);
+
+            // scale up for hi DPI
+            MaximumSize = DpiUtil.Scale(new Size(950, 375));
+            MinimumSize = DpiUtil.Scale(new Size(450, 375));
+
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 var repositoryHistory = await RepositoryHistoryManager.Remotes.LoadHistoryAsync();


### PR DESCRIPTION
Fixes to #4776 
 
Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/350947/38332272-81684336-384d-11e8-8b38-acac88369b5b.png)

- after 
Win10 scale 100%
![image](https://user-images.githubusercontent.com/4403806/39359551-cc9cd2c8-4a5d-11e8-995a-5187bdfd6eb7.png)
Win10 scale 150%
![image](https://user-images.githubusercontent.com/4403806/39359519-abfced50-4a5d-11e8-8f45-5968053a7e50.png)

What did I do to test the code and ensure quality:
- manual runs in 100% and 150% scaling
