### PR TITLE
fix: CommitPickerSmallControl is messed up in HiDPI

### DIFF
--- a/GitUI/UserControls/CommitPickerSmallControl.Designer.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.Designer.cs
@@ -28,55 +28,82 @@
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+            this.lbCommits = new System.Windows.Forms.Label();
             this.textBoxCommitHash = new System.Windows.Forms.TextBox();
             this.buttonPickCommit = new System.Windows.Forms.Button();
-            this.lbCommits = new System.Windows.Forms.Label();
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            tableLayoutPanel1.AutoSize = true;
+            tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.ColumnCount = 3;
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.Controls.Add(this.lbCommits, 2, 0);
+            tableLayoutPanel1.Controls.Add(this.textBoxCommitHash, 0, 0);
+            tableLayoutPanel1.Controls.Add(this.buttonPickCommit, 1, 0);
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 1;
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.Size = new System.Drawing.Size(156, 26);
+            tableLayoutPanel1.TabIndex = 0;
+            // 
+            // lbCommits
+            // 
+            this.lbCommits.AutoEllipsis = true;
+            this.lbCommits.AutoSize = true;
+            this.lbCommits.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lbCommits.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lbCommits.Location = new System.Drawing.Point(138, 0);
+            this.lbCommits.Name = "lbCommits";
+            this.lbCommits.Size = new System.Drawing.Size(15, 26);
+            this.lbCommits.TabIndex = 2;
+            this.lbCommits.Text = "=";
+            this.lbCommits.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // textBoxCommitHash
             // 
-            this.textBoxCommitHash.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxCommitHash.Location = new System.Drawing.Point(0, 0);
+            this.textBoxCommitHash.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBoxCommitHash.Location = new System.Drawing.Point(0, 2);
+            this.textBoxCommitHash.Margin = new System.Windows.Forms.Padding(0, 2, 0, 0);
+            this.textBoxCommitHash.MaxLength = 100;
             this.textBoxCommitHash.Name = "textBoxCommitHash";
-            this.textBoxCommitHash.Size = new System.Drawing.Size(97, 23);
-            this.textBoxCommitHash.TabIndex = 31;
+            this.textBoxCommitHash.Size = new System.Drawing.Size(104, 21);
+            this.textBoxCommitHash.TabIndex = 0;
             this.textBoxCommitHash.Leave += new System.EventHandler(this.textBoxCommitHash_TextLeave);
             // 
             // buttonPickCommit
             // 
             this.buttonPickCommit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonPickCommit.Image = global::GitUI.Properties.Resources.IconSelectRevision;
-            this.buttonPickCommit.Location = new System.Drawing.Point(101, 0);
+            this.buttonPickCommit.Location = new System.Drawing.Point(107, 0);
+            this.buttonPickCommit.Margin = new System.Windows.Forms.Padding(3, 0, 3, 0);
             this.buttonPickCommit.Name = "buttonPickCommit";
             this.buttonPickCommit.Size = new System.Drawing.Size(25, 24);
-            this.buttonPickCommit.TabIndex = 32;
+            this.buttonPickCommit.TabIndex = 1;
             this.buttonPickCommit.UseVisualStyleBackColor = true;
             this.buttonPickCommit.Click += new System.EventHandler(this.buttonPickCommit_Click);
-            // 
-            // lbCommits
-            // 
-            this.lbCommits.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.lbCommits.AutoEllipsis = true;
-            this.lbCommits.AutoSize = true;
-            this.lbCommits.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lbCommits.Location = new System.Drawing.Point(132, 3);
-            this.lbCommits.Name = "lbCommits";
-            this.lbCommits.Size = new System.Drawing.Size(15, 15);
-            this.lbCommits.TabIndex = 33;
-            this.lbCommits.Text = "=";
             // 
             // CommitPickerSmallControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.Controls.Add(this.lbCommits);
-            this.Controls.Add(this.textBoxCommitHash);
-            this.Controls.Add(this.buttonPickCommit);
+            this.Controls.Add(tableLayoutPanel1);
             this.MinimumSize = new System.Drawing.Size(100, 26);
             this.Name = "CommitPickerSmallControl";
-            this.Size = new System.Drawing.Size(207, 26);
+            this.Size = new System.Drawing.Size(156, 26);
+            tableLayoutPanel1.ResumeLayout(false);
+            tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/GitUI/UserControls/CommitPickerSmallControl.resx
+++ b/GitUI/UserControls/CommitPickerSmallControl.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="tableLayoutPanel1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
 </root>


### PR DESCRIPTION
The controls messes layout any form that host it, e.g. `FormCreateBranch` or `FormCreateTag`.
Fixes to #4862

Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/4403806/39360633-5e15ea9c-4a62-11e8-8b9c-4246df799d7f.png)
![image](https://user-images.githubusercontent.com/350947/39059310-0e476934-44b6-11e8-9354-6716b2f71954.png)

- after 
Win10 scale 100%
![image](https://user-images.githubusercontent.com/4403806/39361419-b9df1dc8-4a65-11e8-8786-af75062cb361.png)
![image](https://user-images.githubusercontent.com/4403806/39361429-c4709884-4a65-11e8-8bac-de89653d218e.png)
Win10 scale 200%
![image](https://user-images.githubusercontent.com/4403806/39361336-564716da-4a65-11e8-8eb6-abce020d6078.png)
![image](https://user-images.githubusercontent.com/4403806/39361347-5da16e80-4a65-11e8-8c73-733de43d1237.png)


What did I do to test the code and ensure quality:
- manual runs in 100% and 200% scaling
