### PR TITLE
fix: Clean working directory constant grow

### DIFF
--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -231,7 +231,6 @@ namespace GitUI
             _windowCentred = StartPosition == FormStartPosition.CenterParent;
 
             var position = LookupWindowPosition(name);
-
             if (position == null)
             {
                 return;
@@ -240,14 +239,6 @@ namespace GitUI
             float scale = (float)DpiUtil.DpiX / position.DeviceDpi;
 
             StartPosition = FormStartPosition.Manual;
-            if (FormBorderStyle == FormBorderStyle.Sizable ||
-                FormBorderStyle == FormBorderStyle.SizableToolWindow)
-            {
-                Size formSize = position.Rect.Size;
-                formSize.Width = (int)(formSize.Width * scale);
-                formSize.Height = (int)(formSize.Height * scale);
-                Size = formSize;
-            }
 
             if (Owner == null || !_windowCentred)
             {
@@ -279,7 +270,7 @@ namespace GitUI
         {
             SortedDictionary<float, Rectangle> distance = new SortedDictionary<float, Rectangle>();
             foreach (var rect in from screen in Screen.AllScreens
-                                  select screen.WorkingArea)
+                                 select screen.WorkingArea)
             {
                 if (rect.Contains(location) && !distance.ContainsKey(0.0f))
                 {


### PR DESCRIPTION
Forms get resized by .NET runtime automatically.
Because most of forms track own size, manual resize doubled up and caused the form grow overtime.

Fixes #3828
 

What did I do to test the code and ensure quality:
- opened FormCleanupRepository multiple time to ensure its dimensions remained constant
- opened numerous other forms to ensure no unexpected resizes (NB: not exhaustive check)

Has been tested on (remove any that don't apply):
- Windows 10
- 34" with 200% scaling
