### PR TITLE
Fix 4174 open local repository layout messed up

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.Designer.cs
@@ -48,7 +48,7 @@
             // 
             // _NO_TRANSLATE_Directory
             // 
-            this._NO_TRANSLATE_Directory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this._NO_TRANSLATE_Directory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this._NO_TRANSLATE_Directory.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this._NO_TRANSLATE_Directory.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystemDirectories;
@@ -106,6 +106,7 @@
             this.AcceptButton = this.Load;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.ClientSize = new System.Drawing.Size(595, 81);
             this.Controls.Add(this.folderGoUpbutton);
             this.Controls.Add(this.folderBrowserButton1);
@@ -113,11 +114,9 @@
             this.Controls.Add(this._NO_TRANSLATE_Directory);
             this.Controls.Add(this.label1);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(1000, 120);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(450, 120);
             this.Name = "FormOpenDirectory";
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Open local repository";
             this.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Repository;
 using ResourceManager;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
 {
@@ -30,6 +31,16 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             _NO_TRANSLATE_Directory.Focus();
             _NO_TRANSLATE_Directory.Select();
+        }
+
+        protected override void OnRuntimeLoad(EventArgs e)
+        {
+            base.OnRuntimeLoad(e);
+
+            // scale up for hi DPI
+            float scale = GetScaleFactor();
+            MaximumSize = new Size((int)(800 * scale), (int)(116 * scale));
+            MinimumSize = new Size((int)(450 * scale), (int)(116 * scale));
         }
 
         private IList<string> GetDirectories(GitModule currentModule)
@@ -65,7 +76,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     directories.Add(PathUtil.EnsureTrailingPathSeparator(homeDir));
                 }
             }
-            
+
             return directories.Distinct().ToList();
         }
 

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
@@ -118,7 +117,7 @@ namespace GitUI
         public static Icon GetApplicationIcon(string iconStyle, string iconColor)
         {
             var colorIndex = (int)GetColorIndexByName(iconColor);
-            if (colorIndex == (int) ColorIndex.Unknown)
+            if (colorIndex == (int)ColorIndex.Unknown)
                 colorIndex = 0;
 
             Icon appIcon;
@@ -257,7 +256,7 @@ namespace GitUI
                 Location = new Point(Owner.Left + Owner.Width / 2 - Width / 2,
                     Math.Max(0, Owner.Top + Owner.Height / 2 - Height / 2));
             }
-            if(WindowState != position.State)
+            if (WindowState != position.State)
                 WindowState = position.State;
         }
 
@@ -298,6 +297,14 @@ namespace GitUI
             }
 #endif
             return deviceDpi;
+        }
+
+        public float GetScaleFactor()
+        {
+            var currentDpi = GetCurrentDeviceDpi();
+            var standardDpi = 96; // Default DPI at 100% zoom
+            var scaleFactor = (float)currentDpi / standardDpi;
+            return scaleFactor;
         }
 
         private static WindowPositionList _windowPositionList;


### PR DESCRIPTION
Fixes to #4174
(cherry picked from commit 8568a389786428510a1f27e88ff42bf3cd8b3308)

 
Screenshots before and after (if PR changes UI):
- before
![2017-11-25_1216](https://user-images.githubusercontent.com/346209/33227661-7533c704-d1da-11e7-9699-f141054c8872.png)

- after 
Win10 scale 100%
![image](https://user-images.githubusercontent.com/4403806/39359019-97e5f2a0-4a5b-11e8-9245-0259dd4e77e5.png)
Win10 scale 150%
![image](https://user-images.githubusercontent.com/4403806/39358953-4e2ef756-4a5b-11e8-81bf-8f3aa2ca4034.png)

What did I do to test the code and ensure quality:
- manual runs in 100% and 200% scaling
