### PR TITLE
Some other improvements/fixs in formverify (Recover lost objects form)

### DIFF
--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -28,7 +28,7 @@
             this.SaveObjects = new System.Windows.Forms.Button();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
-            this.ShowOnlyCommits = new System.Windows.Forms.CheckBox();
+            this.ShowCommits = new System.Windows.Forms.CheckBox();
             this.NoReflogs = new System.Windows.Forms.CheckBox();
             this.FullCheck = new System.Windows.Forms.CheckBox();
             this.Unreachable = new System.Windows.Forms.CheckBox();
@@ -46,6 +46,7 @@
             this.columnAuthor = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnHash = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnParent = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.ShowOtherObjects = new System.Windows.Forms.CheckBox();
             panel1 = new System.Windows.Forms.Panel();
             panel2 = new System.Windows.Forms.Panel();
             flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -129,7 +130,8 @@
             // 
             panel2.AutoSize = true;
             panel2.Controls.Add(flowLayoutPanel1);
-            panel2.Controls.Add(this.ShowOnlyCommits);
+            panel2.Controls.Add(this.ShowOtherObjects);
+            panel2.Controls.Add(this.ShowCommits);
             panel2.Controls.Add(this.NoReflogs);
             panel2.Controls.Add(this.FullCheck);
             panel2.Controls.Add(this.Unreachable);
@@ -172,16 +174,16 @@
             // 
             // ShowOnlyCommits
             // 
-            this.ShowOnlyCommits.AutoSize = true;
-            this.ShowOnlyCommits.Checked = true;
-            this.ShowOnlyCommits.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.ShowOnlyCommits.Location = new System.Drawing.Point(430, 9);
-            this.ShowOnlyCommits.Name = "ShowOnlyCommits";
-            this.ShowOnlyCommits.Size = new System.Drawing.Size(116, 17);
-            this.ShowOnlyCommits.TabIndex = 0;
-            this.ShowOnlyCommits.Text = "Show only commits";
-            this.ShowOnlyCommits.UseVisualStyleBackColor = true;
-            this.ShowOnlyCommits.CheckedChanged += new System.EventHandler(this.ShowOnlyCommitsCheckedChanged);
+            this.ShowCommits.AutoSize = true;
+            this.ShowCommits.Checked = true;
+            this.ShowCommits.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ShowCommits.Location = new System.Drawing.Point(430, 9);
+            this.ShowCommits.Name = "ShowCommits";
+            this.ShowCommits.Size = new System.Drawing.Size(93, 17);
+            this.ShowCommits.TabIndex = 0;
+            this.ShowCommits.Text = "Show commits";
+            this.ShowCommits.UseVisualStyleBackColor = true;
+            this.ShowCommits.CheckedChanged += new System.EventHandler(this.ShowCommitsCheckedChanged);
             // 
             // NoReflogs
             // 
@@ -358,6 +360,17 @@
             this.columnParent.Name = "columnParent";
             this.columnParent.ReadOnly = true;
             // 
+            // ShowOtherObjects
+            // 
+            this.ShowOtherObjects.AutoSize = true;
+            this.ShowOtherObjects.Location = new System.Drawing.Point(569, 9);
+            this.ShowOtherObjects.Name = "ShowOtherObjects";
+            this.ShowOtherObjects.Size = new System.Drawing.Size(119, 17);
+            this.ShowOtherObjects.TabIndex = 0;
+            this.ShowOtherObjects.Text = "Show other objects";
+            this.ShowOtherObjects.UseVisualStyleBackColor = true;
+            this.ShowOtherObjects.CheckedChanged += new System.EventHandler(this.ShowOtherObjects_CheckedChanged);
+            // 
             // FormVerify
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -396,7 +409,7 @@
         private System.Windows.Forms.Button Remove;
         private System.Windows.Forms.Button SaveObjects;
         private System.Windows.Forms.DataGridView Warnings;
-        private System.Windows.Forms.CheckBox ShowOnlyCommits;
+        private System.Windows.Forms.CheckBox ShowCommits;
         private System.Windows.Forms.CheckBox NoReflogs;
         private System.Windows.Forms.CheckBox FullCheck;
         private System.Windows.Forms.CheckBox Unreachable;
@@ -411,5 +424,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn columnAuthor;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnHash;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnParent;
+        private System.Windows.Forms.CheckBox ShowOtherObjects;
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -298,7 +298,7 @@
             this.Warnings.TabIndex = 4;
             this.Warnings.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDoubleClick);
             this.Warnings.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDown);
-            this.Warnings.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.Warnings_KeyPress);
+            this.Warnings.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Warnings_KeyDown);
             // 
             // copyParentHashToolStripMenuItem
             // 

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -28,7 +28,8 @@
             this.SaveObjects = new System.Windows.Forms.Button();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
-            this.ShowCommits = new System.Windows.Forms.CheckBox();
+            this.ShowOtherObjects = new System.Windows.Forms.CheckBox();
+            this.ShowCommitsAndTags = new System.Windows.Forms.CheckBox();
             this.NoReflogs = new System.Windows.Forms.CheckBox();
             this.FullCheck = new System.Windows.Forms.CheckBox();
             this.Unreachable = new System.Windows.Forms.CheckBox();
@@ -46,7 +47,6 @@
             this.columnAuthor = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnHash = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnParent = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ShowOtherObjects = new System.Windows.Forms.CheckBox();
             panel1 = new System.Windows.Forms.Panel();
             panel2 = new System.Windows.Forms.Panel();
             flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -131,7 +131,7 @@
             panel2.AutoSize = true;
             panel2.Controls.Add(flowLayoutPanel1);
             panel2.Controls.Add(this.ShowOtherObjects);
-            panel2.Controls.Add(this.ShowCommits);
+            panel2.Controls.Add(this.ShowCommitsAndTags);
             panel2.Controls.Add(this.NoReflogs);
             panel2.Controls.Add(this.FullCheck);
             panel2.Controls.Add(this.Unreachable);
@@ -172,18 +172,29 @@
             this.label1.TabIndex = 16;
             this.label1.Text = "Double-click on a row for quick view";
             // 
-            // ShowOnlyCommits
+            // ShowOtherObjects
             // 
-            this.ShowCommits.AutoSize = true;
-            this.ShowCommits.Checked = true;
-            this.ShowCommits.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.ShowCommits.Location = new System.Drawing.Point(430, 9);
-            this.ShowCommits.Name = "ShowCommits";
-            this.ShowCommits.Size = new System.Drawing.Size(93, 17);
-            this.ShowCommits.TabIndex = 0;
-            this.ShowCommits.Text = "Show commits";
-            this.ShowCommits.UseVisualStyleBackColor = true;
-            this.ShowCommits.CheckedChanged += new System.EventHandler(this.ShowCommitsCheckedChanged);
+            this.ShowOtherObjects.AutoSize = true;
+            this.ShowOtherObjects.Location = new System.Drawing.Point(588, 9);
+            this.ShowOtherObjects.Name = "ShowOtherObjects";
+            this.ShowOtherObjects.Size = new System.Drawing.Size(119, 17);
+            this.ShowOtherObjects.TabIndex = 0;
+            this.ShowOtherObjects.Text = "Show other objects";
+            this.ShowOtherObjects.UseVisualStyleBackColor = true;
+            this.ShowOtherObjects.CheckedChanged += new System.EventHandler(this.ShowOtherObjects_CheckedChanged);
+            // 
+            // ShowCommitsAndTags
+            // 
+            this.ShowCommitsAndTags.AutoSize = true;
+            this.ShowCommitsAndTags.Checked = true;
+            this.ShowCommitsAndTags.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ShowCommitsAndTags.Location = new System.Drawing.Point(430, 9);
+            this.ShowCommitsAndTags.Name = "ShowCommitsAndTags";
+            this.ShowCommitsAndTags.Size = new System.Drawing.Size(138, 17);
+            this.ShowCommitsAndTags.TabIndex = 0;
+            this.ShowCommitsAndTags.Text = "Show commits and tags";
+            this.ShowCommitsAndTags.UseVisualStyleBackColor = true;
+            this.ShowCommitsAndTags.CheckedChanged += new System.EventHandler(this.ShowCommitsCheckedChanged);
             // 
             // NoReflogs
             // 
@@ -360,17 +371,6 @@
             this.columnParent.Name = "columnParent";
             this.columnParent.ReadOnly = true;
             // 
-            // ShowOtherObjects
-            // 
-            this.ShowOtherObjects.AutoSize = true;
-            this.ShowOtherObjects.Location = new System.Drawing.Point(569, 9);
-            this.ShowOtherObjects.Name = "ShowOtherObjects";
-            this.ShowOtherObjects.Size = new System.Drawing.Size(119, 17);
-            this.ShowOtherObjects.TabIndex = 0;
-            this.ShowOtherObjects.Text = "Show other objects";
-            this.ShowOtherObjects.UseVisualStyleBackColor = true;
-            this.ShowOtherObjects.CheckedChanged += new System.EventHandler(this.ShowOtherObjects_CheckedChanged);
-            // 
             // FormVerify
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -409,7 +409,7 @@
         private System.Windows.Forms.Button Remove;
         private System.Windows.Forms.Button SaveObjects;
         private System.Windows.Forms.DataGridView Warnings;
-        private System.Windows.Forms.CheckBox ShowCommits;
+        private System.Windows.Forms.CheckBox ShowCommitsAndTags;
         private System.Windows.Forms.CheckBox NoReflogs;
         private System.Windows.Forms.CheckBox FullCheck;
         private System.Windows.Forms.CheckBox Unreachable;

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -47,6 +47,7 @@
             this.columnAuthor = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnHash = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnParent = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             panel1 = new System.Windows.Forms.Panel();
             panel2 = new System.Windows.Forms.Panel();
             flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -241,7 +242,8 @@
             this.mnuLostObjectsCreateTag,
             this.mnuLostObjectsCreateBranch,
             this.copyHashToolStripMenuItem,
-            this.copyParentHashToolStripMenuItem});
+            this.copyParentHashToolStripMenuItem,
+            this.saveAsToolStripMenuItem});
             this.mnuLostObjects.Name = "mnuLostObjects";
             this.mnuLostObjects.Size = new System.Drawing.Size(190, 114);
             this.mnuLostObjects.Opening += new System.ComponentModel.CancelEventHandler(this.mnuLostObjects_Opening);
@@ -371,6 +373,14 @@
             this.columnParent.Name = "columnParent";
             this.columnParent.ReadOnly = true;
             // 
+            // saveAsToolStripMenuItem
+            // 
+            this.saveAsToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconSaveAs;
+            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.saveAsToolStripMenuItem.Text = "Save as...";
+            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
+            // 
             // FormVerify
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -425,5 +435,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn columnHash;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnParent;
         private System.Windows.Forms.CheckBox ShowOtherObjects;
+        private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -38,12 +38,14 @@
             this.mnuLostObjectsCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.copyHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Warnings = new System.Windows.Forms.DataGridView();
+            this.copyParentHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.columnIsLostObjectSelected = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.columnDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnSubject = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnAuthor = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnHash = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnParent = new System.Windows.Forms.DataGridViewTextBoxColumn();
             panel1 = new System.Windows.Forms.Panel();
             panel2 = new System.Windows.Forms.Panel();
             flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
@@ -134,7 +136,7 @@
             panel2.Dock = System.Windows.Forms.DockStyle.Top;
             panel2.Location = new System.Drawing.Point(0, 0);
             panel2.Name = "panel2";
-            panel2.Size = new System.Drawing.Size(859, 138);
+            panel2.Size = new System.Drawing.Size(859, 134);
             panel2.TabIndex = 4;
             // 
             // flowLayoutPanel1
@@ -146,7 +148,7 @@
             flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
             flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(5);
-            flowLayoutPanel1.Size = new System.Drawing.Size(351, 138);
+            flowLayoutPanel1.Size = new System.Drawing.Size(322, 134);
             flowLayoutPanel1.TabIndex = 13;
             // 
             // label2
@@ -154,17 +156,17 @@
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(8, 5);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(335, 105);
+            this.label2.Size = new System.Drawing.Size(306, 91);
             this.label2.TabIndex = 15;
             this.label2.Text = resources.GetString("label2.Text");
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(8, 115);
+            this.label1.Location = new System.Drawing.Point(8, 101);
             this.label1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(200, 15);
+            this.label1.Size = new System.Drawing.Size(177, 13);
             this.label1.TabIndex = 16;
             this.label1.Text = "Double-click on a row for quick view";
             // 
@@ -175,7 +177,7 @@
             this.ShowOnlyCommits.CheckState = System.Windows.Forms.CheckState.Checked;
             this.ShowOnlyCommits.Location = new System.Drawing.Point(430, 9);
             this.ShowOnlyCommits.Name = "ShowOnlyCommits";
-            this.ShowOnlyCommits.Size = new System.Drawing.Size(131, 19);
+            this.ShowOnlyCommits.Size = new System.Drawing.Size(116, 17);
             this.ShowOnlyCommits.TabIndex = 0;
             this.ShowOnlyCommits.Text = "Show only commits";
             this.ShowOnlyCommits.UseVisualStyleBackColor = true;
@@ -188,7 +190,7 @@
             this.NoReflogs.CheckState = System.Windows.Forms.CheckState.Checked;
             this.NoReflogs.Location = new System.Drawing.Point(430, 35);
             this.NoReflogs.Name = "NoReflogs";
-            this.NoReflogs.Size = new System.Drawing.Size(375, 34);
+            this.NoReflogs.Size = new System.Drawing.Size(345, 30);
             this.NoReflogs.TabIndex = 1;
             this.NoReflogs.Text = "Do not consider commits that are referenced only by an entry in a \r\nreflog to be " +
     "reachable.";
@@ -200,7 +202,7 @@
             this.FullCheck.AutoSize = true;
             this.FullCheck.Location = new System.Drawing.Point(430, 101);
             this.FullCheck.Name = "FullCheck";
-            this.FullCheck.Size = new System.Drawing.Size(397, 34);
+            this.FullCheck.Size = new System.Drawing.Size(376, 30);
             this.FullCheck.TabIndex = 3;
             this.FullCheck.Text = "Check not just objects in GIT_OBJECT_DIRECTORY ($GIT_DIR/objects), \r\nbut also the" +
     " ones found in alternate object pools.\r\n";
@@ -212,7 +214,7 @@
             this.Unreachable.AutoSize = true;
             this.Unreachable.Location = new System.Drawing.Point(430, 68);
             this.Unreachable.Name = "Unreachable";
-            this.Unreachable.Size = new System.Drawing.Size(429, 34);
+            this.Unreachable.Size = new System.Drawing.Size(403, 30);
             this.Unreachable.TabIndex = 2;
             this.Unreachable.Text = "Print out objects that exist but that aren\'t readable from any of the reference \r" +
     "\nnodes.\r\n";
@@ -225,9 +227,10 @@
             this.mnuLostObjectView,
             this.mnuLostObjectsCreateTag,
             this.mnuLostObjectsCreateBranch,
-            this.copyHashToolStripMenuItem});
+            this.copyHashToolStripMenuItem,
+            this.copyParentHashToolStripMenuItem});
             this.mnuLostObjects.Name = "mnuLostObjects";
-            this.mnuLostObjects.Size = new System.Drawing.Size(190, 70);
+            this.mnuLostObjects.Size = new System.Drawing.Size(190, 114);
             this.mnuLostObjects.Opening += new System.ComponentModel.CancelEventHandler(this.mnuLostObjects_Opening);
             // 
             // mnuLostObjectView
@@ -278,21 +281,30 @@
             this.columnType,
             this.columnSubject,
             this.columnAuthor,
-            this.columnHash});
+            this.columnHash,
+            this.columnParent});
             this.Warnings.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Warnings.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
-            this.Warnings.Location = new System.Drawing.Point(0, 138);
+            this.Warnings.Location = new System.Drawing.Point(0, 134);
             this.Warnings.MultiSelect = false;
             this.Warnings.Name = "Warnings";
             this.Warnings.RowHeadersVisible = false;
             this.Warnings.RowTemplate.ContextMenuStrip = this.mnuLostObjects;
             this.Warnings.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.Warnings.ShowEditingIcon = false;
-            this.Warnings.Size = new System.Drawing.Size(859, 376);
+            this.Warnings.Size = new System.Drawing.Size(859, 380);
             this.Warnings.TabIndex = 4;
             this.Warnings.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDoubleClick);
             this.Warnings.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDown);
             this.Warnings.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.Warnings_KeyPress);
+            // 
+            // copyParentHashToolStripMenuItem
+            // 
+            this.copyParentHashToolStripMenuItem.Image = global::GitUI.Properties.Resources.IconCopyToClipboard;
+            this.copyParentHashToolStripMenuItem.Name = "copyParentHashToolStripMenuItem";
+            this.copyParentHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.copyParentHashToolStripMenuItem.Text = "Copy parent hash";
+            this.copyParentHashToolStripMenuItem.Click += new System.EventHandler(this.copyParentHashToolStripMenuItem_Click);
             // 
             // columnIsLostObjectSelected
             // 
@@ -300,6 +312,7 @@
             this.columnIsLostObjectSelected.HeaderText = "";
             this.columnIsLostObjectSelected.MinimumWidth = 20;
             this.columnIsLostObjectSelected.Name = "columnIsLostObjectSelected";
+            this.columnIsLostObjectSelected.Width = 20;
             // 
             // columnDate
             // 
@@ -307,6 +320,7 @@
             this.columnDate.HeaderText = "Date";
             this.columnDate.Name = "columnDate";
             this.columnDate.ReadOnly = true;
+            this.columnDate.Width = 55;
             // 
             // columnType
             // 
@@ -314,6 +328,7 @@
             this.columnType.HeaderText = "Type";
             this.columnType.Name = "columnType";
             this.columnType.ReadOnly = true;
+            this.columnType.Width = 56;
             // 
             // columnSubject
             // 
@@ -336,6 +351,12 @@
             this.columnHash.HeaderText = "Hash";
             this.columnHash.Name = "columnHash";
             this.columnHash.ReadOnly = true;
+            // 
+            // columnParent
+            // 
+            this.columnParent.HeaderText = "Parent(s) hashs";
+            this.columnParent.Name = "columnParent";
+            this.columnParent.ReadOnly = true;
             // 
             // FormVerify
             // 
@@ -375,12 +396,6 @@
         private System.Windows.Forms.Button Remove;
         private System.Windows.Forms.Button SaveObjects;
         private System.Windows.Forms.DataGridView Warnings;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn columnIsLostObjectSelected;
-        private System.Windows.Forms.DataGridViewTextBoxColumn columnDate;
-        private System.Windows.Forms.DataGridViewTextBoxColumn columnType;
-        private System.Windows.Forms.DataGridViewTextBoxColumn columnSubject;
-        private System.Windows.Forms.DataGridViewTextBoxColumn columnAuthor;
-        private System.Windows.Forms.DataGridViewTextBoxColumn columnHash;
         private System.Windows.Forms.CheckBox ShowOnlyCommits;
         private System.Windows.Forms.CheckBox NoReflogs;
         private System.Windows.Forms.CheckBox FullCheck;
@@ -388,5 +403,13 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ToolStripMenuItem copyHashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyParentHashToolStripMenuItem;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn columnIsLostObjectSelected;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnDate;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnType;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnSubject;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnAuthor;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnHash;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnParent;
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -24,8 +24,8 @@ namespace GitUI.CommandsDialogs
             /// %s  - subject.
             /// %ct - committer date, UNIX timestamp (easy to parse format).
             /// </summary>
-            private const string LogCommandArgumentsFormat = "log -n1 --pretty=format:\"%aN, %e, %s, %ct\" {0}";
-            private const string LogPattern = @"^([^,]+), (.*), (.+), (\d+)$";
+            private const string LogCommandArgumentsFormat = "log -n1 --pretty=format:\"%aN, %e, %s, %ct, %P\" {0}";
+            private const string LogPattern = @"^([^,]+), (.*), (.+), (\d+), (.+)?$";
             private const string RawDataPattern = "^((dangling|missing|unreachable) (commit|blob|tree|tag)|warning in tree) (" + GitRevision.Sha1HashPattern + ")(.)*$";
 
             private static readonly Regex RawDataRegex = new Regex(RawDataPattern, RegexOptions.Compiled);
@@ -37,6 +37,11 @@ namespace GitUI.CommandsDialogs
             /// Sha1 hash of lost object.
             /// </summary>
             public string Hash { get; }
+
+            /// <summary>
+            /// Sha1 hash of parent commit of commit lost object.
+            /// </summary>
+            public string Parent { get; private set; }
 
             /// <summary>
             /// Diagnostics and object type.
@@ -91,6 +96,10 @@ namespace GitUI.CommandsDialogs
                         string encodingName = logPatternMatch.Groups[2].Value;
                         result.Subject = module.ReEncodeCommitMessage(logPatternMatch.Groups[3].Value, encodingName);
                         result.Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups[4].Value);
+                        if (logPatternMatch.Groups.Count >= 5)
+                        {
+                            result.Parent = logPatternMatch.Groups[5].Value;
+                        }
                     }
                 }
 

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -57,6 +57,11 @@ namespace GitUI.CommandsDialogs
             public string Subject { get; private set; }
             public DateTime? Date { get; private set; }
 
+            /// <summary>
+            /// Tag name (for a tag object)
+            /// </summary>
+            public string TagName { get; set; }
+
             private LostObject(LostObjectType objectType, string rawType, string hash)
             {
                 ObjectType = objectType;
@@ -116,7 +121,8 @@ namespace GitUI.CommandsDialogs
                     {
                         result.Parent = tagPatternMatch.Groups[1].Value;
                         result.Author = module.ReEncodeStringFromLossless(tagPatternMatch.Groups[3].Value);
-                        result.Subject = tagPatternMatch.Groups[2].Value + ":" + tagPatternMatch.Groups[5].Value;
+                        result.TagName = tagPatternMatch.Groups[2].Value;
+                        result.Subject = result.TagName + ":" + tagPatternMatch.Groups[5].Value;
                         result.Date = DateTimeUtils.ParseUnixTime(tagPatternMatch.Groups[4].Value);
                     }
                 }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -174,8 +174,23 @@ namespace GitUI.CommandsDialogs
             UpdateLostObjects();
         }
 
-        private void ShowOnlyCommitsCheckedChanged(object sender, EventArgs e)
+        private void ShowCommitsCheckedChanged(object sender, EventArgs e)
         {
+            if (!ShowCommits.Checked && !ShowOtherObjects.Checked)
+            {
+                ShowOtherObjects.Checked = true;
+            }
+
+            UpdateFilteredLostObjects();
+        }
+
+        private void ShowOtherObjects_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!ShowCommits.Checked && !ShowOtherObjects.Checked)
+            {
+                ShowCommits.Checked = true;
+            }
+
             UpdateFilteredLostObjects();
         }
 
@@ -244,12 +259,8 @@ namespace GitUI.CommandsDialogs
         // TODO: add textbox for simple fulltext search/filtering (useful for large repos)
         private bool IsMatchToFilter(LostObject lostObject)
         {
-            if (ShowOnlyCommits.Checked)
-            {
-                return lostObject.ObjectType == LostObjectType.Commit;
-            }
-
-            return true;
+            return (ShowCommits.Checked && lostObject.ObjectType == LostObjectType.Commit)
+                || (ShowOtherObjects.Checked && lostObject.ObjectType != LostObjectType.Commit);
         }
 
         private string GetOptions()

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -378,11 +378,12 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void Warnings_KeyPress(object sender, KeyPressEventArgs e)
+        private void Warnings_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyChar == 13)
+            if (e.KeyValue == 13)
             {
                 e.Handled = true;
+                e.SuppressKeyPress = true;
                 ViewCurrentItem();
             }
         }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -295,6 +295,7 @@ namespace GitUI.CommandsDialogs
 
             using (var frm = new FormEdit(Module.ShowSha1(currenItem.Hash)))
             {
+                frm.IsReadOnly = true;
                 frm.ShowDialog(this);
             }
         }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -47,6 +47,8 @@ namespace GitUI.CommandsDialogs
             columnAuthor.Width = DpiUtil.Scale(150);
             columnHash.Width = DpiUtil.Scale(280);
             columnHash.MinimumWidth = DpiUtil.Scale(75);
+            columnParent.Width = DpiUtil.Scale(280);
+            columnParent.MinimumWidth = DpiUtil.Scale(75);
 
             _selectedItemsHeader.AttachTo(columnIsLostObjectSelected);
 
@@ -59,6 +61,7 @@ namespace GitUI.CommandsDialogs
             columnSubject.DataPropertyName = nameof(LostObject.Subject);
             columnAuthor.DataPropertyName = nameof(LostObject.Author);
             columnHash.DataPropertyName = nameof(LostObject.Hash);
+            columnParent.DataPropertyName = nameof(LostObject.Parent);
 
             if (commands != null)
             {
@@ -359,6 +362,7 @@ namespace GitUI.CommandsDialogs
                 var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
                 contextMenu.Items[1].Enabled = isCommit;
                 contextMenu.Items[2].Enabled = isCommit;
+                contextMenu.Items[4].Enabled = isCommit;
             }
         }
 
@@ -377,6 +381,15 @@ namespace GitUI.CommandsDialogs
             {
                 var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
                 Clipboard.SetText(lostObject.Hash);
+            }
+        }
+
+        private void copyParentHashToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (Warnings != null && Warnings.SelectedRows.Count != 0 && Warnings.SelectedRows[0].DataBoundItem != null)
+            {
+                var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+                Clipboard.SetText(lostObject.Parent);
             }
         }
     }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -376,10 +376,12 @@ namespace GitUI.CommandsDialogs
             {
                 var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
                 var isCommit = lostObject != null && lostObject.ObjectType == LostObjectType.Commit;
+                var isBlob = lostObject != null && lostObject.ObjectType == LostObjectType.Blob;
                 var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
                 contextMenu.Items[1].Enabled = isCommit;
                 contextMenu.Items[2].Enabled = isCommit;
                 contextMenu.Items[4].Enabled = isCommit;
+                contextMenu.Items[5].Enabled = isBlob;
             }
         }
 
@@ -408,6 +410,34 @@ namespace GitUI.CommandsDialogs
             {
                 var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
                 Clipboard.SetText(lostObject.Parent);
+            }
+        }
+
+        private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (Warnings == null || Warnings.SelectedRows.Count == 0 || Warnings.SelectedRows[0].DataBoundItem == null)
+            {
+                return;
+            }
+
+            var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+            if (lostObject.ObjectType == LostObjectType.Blob)
+            {
+                using (var fileDialog =
+                    new SaveFileDialog
+                    {
+                        InitialDirectory = Module.WorkingDir,
+                        FileName = "LOST_FOUND.txt",
+                        DefaultExt = "txt",
+                        AddExtension = true
+                    })
+                {
+                    fileDialog.Filter = "(*.*)|*.*";
+                    if (fileDialog.ShowDialog(this) == DialogResult.OK)
+                    {
+                        Module.SaveBlobAs(fileDialog.FileName, lostObject.Hash);
+                    }
+                }
             }
         }
     }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -323,7 +323,8 @@ namespace GitUI.CommandsDialogs
             foreach (var lostObject in selectedLostObjects)
             {
                 currentTag++;
-                var createTagArgs = new GitCreateTagArgs($"{RestoredObjectsTagPrefix}{currentTag}", lostObject.Hash);
+                var tagName = lostObject.ObjectType == LostObjectType.Tag ? lostObject.TagName : currentTag.ToString();
+                var createTagArgs = new GitCreateTagArgs($"{RestoredObjectsTagPrefix}{tagName}", lostObject.Hash);
                 _gitTagController.CreateTag(createTagArgs, this);
             }
 

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -252,6 +252,10 @@ namespace GitUI.CommandsDialogs
             SuspendLayout();
             _filteredLostObjects.Clear();
             _filteredLostObjects.AddRange(_lostObjects.Where(IsMatchToFilter));
+
+            columnAuthor.Visible = ShowCommitsAndTags.Checked;
+            columnSubject.Visible = ShowCommitsAndTags.Checked;
+            columnParent.Visible = ShowCommitsAndTags.Checked;
             ////Warnings.DataSource = filteredLostObjects;
             ResumeLayout();
         }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
 
         private void ShowCommitsCheckedChanged(object sender, EventArgs e)
         {
-            if (!ShowCommits.Checked && !ShowOtherObjects.Checked)
+            if (!ShowCommitsAndTags.Checked && !ShowOtherObjects.Checked)
             {
                 ShowOtherObjects.Checked = true;
             }
@@ -186,9 +186,9 @@ namespace GitUI.CommandsDialogs
 
         private void ShowOtherObjects_CheckedChanged(object sender, EventArgs e)
         {
-            if (!ShowCommits.Checked && !ShowOtherObjects.Checked)
+            if (!ShowCommitsAndTags.Checked && !ShowOtherObjects.Checked)
             {
-                ShowCommits.Checked = true;
+                ShowCommitsAndTags.Checked = true;
             }
 
             UpdateFilteredLostObjects();
@@ -259,8 +259,8 @@ namespace GitUI.CommandsDialogs
         // TODO: add textbox for simple fulltext search/filtering (useful for large repos)
         private bool IsMatchToFilter(LostObject lostObject)
         {
-            return (ShowCommits.Checked && lostObject.ObjectType == LostObjectType.Commit)
-                || (ShowOtherObjects.Checked && lostObject.ObjectType != LostObjectType.Commit);
+            return (ShowCommitsAndTags.Checked && (lostObject.ObjectType == LostObjectType.Commit || lostObject.ObjectType == LostObjectType.Tag))
+                || (ShowOtherObjects.Checked && (lostObject.ObjectType != LostObjectType.Commit && lostObject.ObjectType != LostObjectType.Tag));
         }
 
         private string GetOptions()

--- a/GitUI/CommandsDialogs/FormVerify.resx
+++ b/GitUI/CommandsDialogs/FormVerify.resx
@@ -156,6 +156,9 @@ Context menu for additional operations</value>
   <metadata name="columnHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="columnParent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>43</value>
   </metadata>

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -128,7 +128,18 @@ namespace GitUI
                     }
                     else
                     {
-                        parent = parent.Parent;
+                        if (parent.Parent == null)
+                        {
+                            var form = parent as Form;
+                            if (form != null)
+                            {
+                                parent = form.Owner;
+                            }
+                        }
+                        else
+                        {
+                            parent = parent.Parent;
+                        }
                     }
                 }
 

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -10,5 +10,11 @@
             Viewer.ViewTextAsync("", text);
             Viewer.IsReadOnly = false;
         }
+
+        public bool IsReadOnly
+        {
+            get { return Viewer.IsReadOnly; }
+            set { Viewer.IsReadOnly = value; }
+        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

* Display also hash(s) of parent commit(s)
* Add checkbox to display only other objects than commits
* Content in the View form should be displayed in readonly (to not be able to edit)
* Fix: prevent displaying bad object (the one of the next line :( ) when pressing 'Enter' key
* fix exception when trying to copy a text when viewing a dangling object
* Handle display of tags with its data
* Display tags in the same time than commits (make more sense)
* Hide columns that has no sense when displaying only blobs
* Restore annotated tags with a name similar to the original one
* Add a "Save as..." action in blob contextual menu

Screenshot of some improvments:

![image](https://user-images.githubusercontent.com/460196/39397962-991b75f8-4b07-11e8-89b4-658b21a87a3c.png)


Has been tested on (remove any that don't apply):
- GIT 2.10 and above
- Windows 7 and above
