### PR TITLE
fix compile error in FormCommitTests.cs

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -119,7 +119,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                     switch (commitKind)
                     {
                     case CommitKind.Normal:
-                        Assert.True(_commands.StartCommitDialog());
+                        Assert.True(_commands.StartCommitDialog(owner: null));
                         break;
 
                     case CommitKind.Squash:


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4854 

Changes proposed in this pull request:
- fix compile error in FormCommitTests.cs because afc7fa0984068d617b3e95dcb3c0fa5e57392e40 removed the parameterless overload of StartCommitDialog
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/1851369/39445673-1f439312-4cbc-11e8-83f2-8b6c59d8d065.png)

What did I do to test the code and ensure quality:
- build

Has been tested on (remove any that don't apply):
- n/a
