### PR TITLE
fix: Init wrong folder

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -121,7 +121,19 @@ namespace GitUI.CommandsDialogs
             //if there is no destination directory, then use the parent of the current working directory
             //this would clone the new repo at the same level as the current one by default
             if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && Module.WorkingDir.IsNotNullOrWhitespace())
-                _NO_TRANSLATE_To.Text = Path.GetDirectoryName(Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar));
+            {
+                if (Module.IsValidGitWorkingDir())
+                {
+                    if (Path.GetPathRoot(Module.WorkingDir) != Module.WorkingDir)
+                    {
+                        _NO_TRANSLATE_To.Text = Path.GetDirectoryName(Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar));
+                    }
+                }
+                else
+                {
+                    _NO_TRANSLATE_To.Text = Module.WorkingDir;
+                }
+            }
 
             FromTextUpdate(null, null);
 


### PR DESCRIPTION
When launched from Windows explorer, the clone destination was set to the parent of the current folder. If the folder was at the root of the drive, the destination would be blank.

The fix sets the parent of the current directory unless the current directory is the root, or the current directory is not a git repository.

Fixes #4855

(cherry picked from commit ae2f871026a80023d451e62b8a8c5b73bcbcec9a)
