### PR TITLE
fix AddAsMostRecentAsync_should_add_new_path_as_top_entry tests

### DIFF
--- a/UnitTests/GitCommandsTests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
+++ b/UnitTests/GitCommandsTests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
@@ -21,10 +21,15 @@ namespace GitCommandsTests.UserRepositoryHistory
         private IRepositoryStorage _repositoryStorage;
         private IRepositoryHistoryMigrator _repositoryHistoryMigrator;
         private LocalRepositoryManager _manager;
+        private int _userSetting;
 
         [SetUp]
         public void Setup()
         {
+            // backup the user setting, will restore it at the end of the test run
+            _userSetting = AppSettings.RecentRepositoriesHistorySize;
+            AppSettings.RecentRepositoriesHistorySize = 30;
+
             _repositoryStorage = Substitute.For<IRepositoryStorage>();
             _repositoryHistoryMigrator = Substitute.For<IRepositoryHistoryMigrator>();
             _manager = new LocalRepositoryManager(_repositoryStorage, _repositoryHistoryMigrator);
@@ -33,7 +38,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         [TearDown]
         public void TearDown()
         {
-            AppSettings.RecentRepositoriesHistorySize = 30;
+            AppSettings.RecentRepositoriesHistorySize = _userSetting;
         }
 
         [Test]


### PR DESCRIPTION
`AddAsMostRecentAsync_should_add_new_path_as_top_entry` could have failed if user has configured `AppSettings.RecentRepositoriesHistorySize` to be less than 5.