### PR TITLE
Fix broken TranslationString [3.0 branch]

### DIFF
--- a/ResourceManager/TranslationString.cs
+++ b/ResourceManager/TranslationString.cs
@@ -13,6 +13,7 @@ namespace ResourceManager
         }
 
         /// <summary>Gets the translated text.</summary>
+        /// <remarks>Setter is required because this property is set via reflection by the translation engine.</remarks>
         public string Text { get; private set; }
 
         /// <summary>Returns <see cref="Text"/> value.</summary>

--- a/ResourceManager/TranslationString.cs
+++ b/ResourceManager/TranslationString.cs
@@ -13,7 +13,7 @@ namespace ResourceManager
         }
 
         /// <summary>Gets the translated text.</summary>
-        public string Text { get; }
+        public string Text { get; private set; }
 
         /// <summary>Returns <see cref="Text"/> value.</summary>
         public override string ToString()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4922 

Changes proposed in this pull request:
- restore TranslationString.Text property setter which was lost in a code cleanup (see commit ed2ae7bdcfa09029a4ce75166f65371c201a3f2c)
- add a comment that may help future code reviews not to remove it again
 
Screenshots before and after (if PR changes UI):
- before 
![image](https://user-images.githubusercontent.com/1851369/39670343-cd62052e-5102-11e8-8f2d-8c1ea93e11d3.png)

- after 
![image](https://user-images.githubusercontent.com/1851369/39670340-c834b664-5102-11e8-982c-7b4ccd69f06e.png)


What did I do to test the code and ensure quality:
- manual verification

Has been tested on (remove any that don't apply):
- GIT 2.16.1
- Windows 8.1
