### PR TITLE
Persist migrated user's repository settings

### DIFF
--- a/GitCommands/UserRepositoryHistory/LocalRepositoryManager.cs
+++ b/GitCommands/UserRepositoryHistory/LocalRepositoryManager.cs
@@ -123,13 +123,13 @@ namespace GitCommands.UserRepositoryHistory
             var history = _repositoryStorage.Load(KeyFavouriteHistory) ?? Array.Empty<Repository>();
 
             // backwards compatibility - port the existing user's categorised repositories
-            var migrated = await _repositoryHistoryMigrator.MigrateAsync(history);
+            var (migrated, changed) = await _repositoryHistoryMigrator.MigrateAsync(history);
+            if (changed)
+            {
+                _repositoryStorage.Save(KeyFavouriteHistory, migrated);
+            }
 
-            // TODO: should we save now?
-            //      in an edge case scenario, the legacy setting has been migrated,
-            //      the app crashes before the updated history persisted...
-
-            return migrated;
+            return migrated ?? new List<Repository>();
         }
 
         /// <summary>

--- a/UnitTests/GitCommandsTests/UserRepositoryHistory/Legacy/RepositoryHistoryMigratorTests.cs
+++ b/UnitTests/GitCommandsTests/UserRepositoryHistory/Legacy/RepositoryHistoryMigratorTests.cs
@@ -44,12 +44,14 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
 
             _repositoryStorage.Load().Returns(x => new RepositoryCategoryXmlSerialiser().Deserialize(xml));
 
-            var currentHistory = await _historyMigrator.MigrateAsync(new List<Current.Repository>());
+            var (currentHistory, migrated) = await _historyMigrator.MigrateAsync(new List<Current.Repository>());
 
             currentHistory.Count.Should().Be(8);
             currentHistory.Count(r => r.Category == "Git Extensions").Should().Be(1);
             currentHistory.Count(r => r.Category == "3rd Party").Should().Be(2);
             currentHistory.Count(r => r.Category == "Tests").Should().Be(5);
+
+            migrated.Should().BeTrue();
         }
     }
 }

--- a/UnitTests/GitCommandsTests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
+++ b/UnitTests/GitCommandsTests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
@@ -209,7 +209,7 @@ namespace GitCommandsTests.UserRepositoryHistory
                 new Repository("path5"),
             };
             _repositoryStorage.Load(KeyFavouriteHistory).Returns(x => history);
-            _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => history);
+            _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => (history, false));
 
             var newHistory = await _manager.RemoveFavouriteAsync(repoToDelete);
 
@@ -236,7 +236,7 @@ namespace GitCommandsTests.UserRepositoryHistory
                 new Repository("path5"),
             };
             _repositoryStorage.Load(KeyFavouriteHistory).Returns(x => history);
-            _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => history);
+            _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => (history, false));
 
             var newHistory = await _manager.RemoveFavouriteAsync(repoToDelete);
 


### PR DESCRIPTION
In some scenarios, if the app crashes before the migrated legacy settings have been persisted, the categorised repositories would not be available to the user on following runs.
To address this, persist the migrated settings immediately after the migration.

Follow up on #4899
