### PR TITLE
fix Git config diff.noprefix true option breaks most of GitExtensions functionality

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -99,7 +99,7 @@ namespace GitCommands
         private readonly IRevisionDiffProvider _revisionDiffProvider = new RevisionDiffProvider();
 
         public static readonly string NoNewLineAtTheEnd = "\\ No newline at end of file";
-        private const string DiffCommandWithStandardArgs = " -c diff.submodule=short diff --no-color ";
+        private const string DiffCommandWithStandardArgs = " -c diff.submodule=short -c diff.noprefix=false diff --no-color ";
 
         public GitModule(string workingdir)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4392 

Changes proposed in this pull request:
- added `-c diff.noprefix=false` to the standard git diff args (this was the simplest solution, supported from git v1.7.2)
- there was a [comment](https://github.com/gitextensions/gitextensions/issues/4392#issuecomment-362044980) below the original issue, but I think that this simple solution is enough, and is not a big risk for the future yet
 
Screenshots before and after (if PR changes UI):
- before 
![image](https://user-images.githubusercontent.com/1851369/39717655-3b11b40c-5234-11e8-97f7-84fbcd6f0833.png)
- after 
![image](https://user-images.githubusercontent.com/1851369/39717688-51c4778e-5234-11e8-8487-3e03293ac10b.png)
- 
![image](https://user-images.githubusercontent.com/1851369/39717951-13610588-5235-11e8-985a-437998714b91.png)


What did I do to test the code and ensure quality:
- manual verification 

Has been tested on (remove any that don't apply):
- GIT 2.16.1
- Windows 8.1
