### PR TITLE
Check for recommended Git version

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -15,8 +15,10 @@ namespace GitCommands
         private static readonly GitVersion v2_5_1 = new GitVersion("2.5.1");
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
+        private static readonly GitVersion v2_16_3 = new GitVersion("2.16.3");
 
-        public static readonly GitVersion LastSupportedVersion = v1_7_0;
+        public static readonly GitVersion LastSupportedVersion = v2_9_0;
+        public static readonly GitVersion LastRecommendedVersion = v2_16_3;
 
         private const string Prefix = "git version";
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -19,6 +19,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _wrongGitVersion =
             new TranslationString("Git found but version {0} is not supported. Upgrade to version {1} or later");
 
+        private readonly TranslationString _notRecommendedGitVersion =
+            new TranslationString("Git found but version {0} is older than recommended. Upgrade to version {1} or later");
+
         private readonly TranslationString _gitVersionFound =
             new TranslationString("Git {0} is found on your computer.");
 
@@ -512,7 +515,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (GitCommandHelpers.VersionInUse < GitVersion.LastSupportedVersion)
             {
-                RenderSettingUnset(GitFound, GitFound_Fix, string.Format(_wrongGitVersion.Text, GitCommandHelpers.VersionInUse, GitVersion.LastSupportedVersion));
+                RenderSettingUnset(GitFound, GitFound_Fix, string.Format(_wrongGitVersion.Text, GitCommandHelpers.VersionInUse, GitVersion.LastRecommendedVersion));
+                return false;
+            }
+
+            if (GitCommandHelpers.VersionInUse < GitVersion.LastRecommendedVersion)
+            {
+                RenderSettingNotRecommended(GitFound, GitFound_Fix, string.Format(_notRecommendedGitVersion.Text, GitCommandHelpers.VersionInUse, GitVersion.LastRecommendedVersion));
                 return false;
             }
 
@@ -693,6 +702,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             settingButton.BackColor = Color.LavenderBlush;
             settingButton.ForeColor = Color.Crimson;
+            settingButton.Text = text;
+            settingFixButton.Visible = true;
+        }
+
+        private static void RenderSettingNotRecommended(Button settingButton, Button settingFixButton, string text)
+        {
+            settingButton.BackColor = Color.Coral;
+            settingButton.ForeColor = Color.Black;
             settingButton.Text = text;
             settingFixButton.Visible = true;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -179,7 +179,7 @@
             this.downloadGitForWindows.Size = new System.Drawing.Size(291, 13);
             this.downloadGitForWindows.TabIndex = 7;
             this.downloadGitForWindows.TabStop = true;
-            this.downloadGitForWindows.Text = "Download msysgit";
+            this.downloadGitForWindows.Text = "Download Git";
             this.downloadGitForWindows.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.downloadGitForWindows.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.downloadGitForWindows_LinkClicked);
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -86,7 +86,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void downloadGitForWindows_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://git-scm.com/downloads");
+            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Git");
         }
 
         private void ChangeHomeButton_Click(object sender, EventArgs e)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7364,7 +7364,7 @@ Check if file is accessible.</source>
         <target />
       </trans-unit>
       <trans-unit id="downloadGitForWindows.Text">
-        <source>Download msysgit</source>
+        <source>Download Git</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBox7.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of #4515

Changes proposed in this pull request:
- Raise (officially) supported version from 1.7.0 to 2.9.0. (There is no big reason to set 2.9, could be newer version). Support for older versions have not been removed, it is just that older versions are listed as red in settings.
- Set recommended Git version to 2.16.3 (latest is 2.17.0, could use that instead). Open to other colors...
- Change download link to GE wiki instead of "msysgit" (Git for Windows).
 
Screenshots before and after (if PR changes UI):
- (patched code to set the future version 2.18.3 as minimal version)

![image](https://user-images.githubusercontent.com/6248932/39782909-ca8e0ae2-5313-11e8-9f61-bdb4c0ca44a5.png)

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- GIT 2.17.0
- Windows 10
