### PR TITLE
fix Visual Studio form designer

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2931,7 +2931,7 @@ namespace GitUI.CommandsDialogs
         private void submoduleSummaryMenuItem_Click(object sender, EventArgs e)
         {
             string summary = Module.GetSubmoduleSummary(_currentItem.Name);
-            using (var frm = new FormEdit(summary))
+            using (var frm = new FormEdit(UICommands, summary))
             {
                 frm.ShowDialog(this);
             }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -297,7 +297,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (var frm = new FormEdit(Module.ShowSha1(currenItem.Hash)))
+            using (var frm = new FormEdit(UICommands, Module.ShowSha1(currenItem.Hash)))
             {
                 frm.IsReadOnly = true;
                 frm.ShowDialog(this);

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -858,7 +858,7 @@ namespace GitUI.CommandsDialogs
                 summary += Module.GetSubmoduleSummary(name);
             }
 
-            using (var frm = new FormEdit(summary))
+            using (var frm = new FormEdit(UICommands, summary))
             {
                 frm.ShowDialog(this);
             }

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -128,18 +128,7 @@ namespace GitUI
                     }
                     else
                     {
-                        if (parent.Parent == null)
-                        {
-                            var form = parent as Form;
-                            if (form != null)
-                            {
-                                parent = form.Owner;
-                            }
-                        }
-                        else
-                        {
-                            parent = parent.Parent;
-                        }
+                        parent = parent.Parent;
                     }
                 }
 

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -8,7 +8,7 @@ namespace GitUI
 {
     /// <summary>Base class for a <see cref="UserControl"/> requiring
     /// <see cref="GitModule"/> and <see cref="GitUICommands"/>.</summary>
-    public abstract class GitModuleControl : GitExtensionsControl
+    public class GitModuleControl : GitExtensionsControl
     {
         private readonly object _lock = new object();
 

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -1,9 +1,9 @@
 ﻿namespace GitUI.HelperDialogs
 {
-    public partial class FormEdit : GitExtensionsForm
+    public partial class FormEdit : GitModuleForm
     {
-        public FormEdit(string text)
-            : base(true)
+        public FormEdit(GitUICommands commands, string text)
+            : base(true, commands)
         {
             InitializeComponent();
             Translate();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4937

Changes proposed in this pull request:
- make `GitModuleControl` non-abstract again
- fix infinite loop when opening form designer by reverting the commit which caused it (a2e1251477d8faa04b5ec1c27a2ca606a3ea8013)
- modify FormEdit to accept GitUICommands in its constructor (it requires the git module because it applies autocrlf setting to the copied text fragment)
 
Screenshots before and after (if PR changes UI):
- before 
![image](https://user-images.githubusercontent.com/1851369/39965689-42de9a6a-569e-11e8-94b0-5b7ec6c216e5.png)
- after 
![image](https://user-images.githubusercontent.com/1851369/39965692-491e4038-569e-11e8-921d-c7d19620149f.png)

What did I do to test the code and ensure quality:
- open form designer in VS
- open Repository->Git maintenance->Recover lost objects..., right click a row in the table, click View, select and copy a part of the text

Has been tested on (remove any that don't apply):
- Git 2.16.1
- Windows 8.1
- Visual Studio 15.7
