### PR TITLE
fix Visual Studio form designer - GitModuleControl must not be abstract

### DIFF
--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -8,7 +8,7 @@ namespace GitUI
 {
     /// <summary>Base class for a <see cref="UserControl"/> requiring
     /// <see cref="GitModule"/> and <see cref="GitUICommands"/>.</summary>
-    public abstract class GitModuleControl : GitExtensionsControl
+    public class GitModuleControl : GitExtensionsControl
     {
         private readonly object _lock = new object();
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4937 - part 1 of 3

Changes proposed in this pull request:
- make `GitModuleControl` non-abstract again
 
Screenshots before and after (if PR changes UI):
- before 
![image](https://user-images.githubusercontent.com/1851369/39965689-42de9a6a-569e-11e8-94b0-5b7ec6c216e5.png)
- after 
![image](https://user-images.githubusercontent.com/1851369/39965692-491e4038-569e-11e8-921d-c7d19620149f.png)

What did I do to test the code and ensure quality:
- open form designer in VS

Has been tested on (remove any that don't apply):
- Windows 8.1
- Visual Studio 15.7
