### PR TITLE
fix missing UI command source in FormEdit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2931,7 +2931,7 @@ namespace GitUI.CommandsDialogs
         private void submoduleSummaryMenuItem_Click(object sender, EventArgs e)
         {
             string summary = Module.GetSubmoduleSummary(_currentItem.Name);
-            using (var frm = new FormEdit(summary))
+            using (var frm = new FormEdit(UICommands, summary))
             {
                 frm.ShowDialog(this);
             }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -297,7 +297,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using (var frm = new FormEdit(Module.ShowSha1(currenItem.Hash)))
+            using (var frm = new FormEdit(UICommands, Module.ShowSha1(currenItem.Hash)))
             {
                 frm.IsReadOnly = true;
                 frm.ShowDialog(this);

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -858,7 +858,7 @@ namespace GitUI.CommandsDialogs
                 summary += Module.GetSubmoduleSummary(name);
             }
 
-            using (var frm = new FormEdit(summary))
+            using (var frm = new FormEdit(UICommands, summary))
             {
                 frm.ShowDialog(this);
             }

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -1,9 +1,9 @@
 ﻿namespace GitUI.HelperDialogs
 {
-    public partial class FormEdit : GitExtensionsForm
+    public partial class FormEdit : GitModuleForm
     {
-        public FormEdit(string text)
-            : base(true)
+        public FormEdit(GitUICommands commands, string text)
+            : base(true, commands)
         {
             InitializeComponent();
             Translate();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4937 - part 2 of 3

Changes proposed in this pull request:
- modify `FormEdit` to accept `GitUICommands` in its constructor (it requires the git module because it applies autocrlf setting to the copied text fragment)
- note: commit a2e1251477d8faa04b5ec1c27a2ca606a3ea8013 added a workaround for this bug in `SearchForUICommandsSource`, this PR is an independent fix for the form which makes it possible to work correctly without the workaround so that the workaround can be safely removed
 
Screenshots before and after (if PR changes UI):
- before 
![image](https://user-images.githubusercontent.com/1851369/39968503-026a99cc-56ce-11e8-9136-edf8e05321ee.png)
- after: no exception window

What did I do to test the code and ensure quality:
- open Repository->Git maintenance->Recover lost objects..., right click a row in the table, click View, select and copy a part of the text

Has been tested on (remove any that don't apply):
- Git 2.16.1
- Windows 8.1