### PR TITLE
fix Visual Studio form designer - revert previous workaround in SearchForUICommandsSource

### DIFF
--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -128,18 +128,7 @@ namespace GitUI
                     }
                     else
                     {
-                        if (parent.Parent == null)
-                        {
-                            var form = parent as Form;
-                            if (form != null)
-                            {
-                                parent = form.Owner;
-                            }
-                        }
-                        else
-                        {
-                            parent = parent.Parent;
-                        }
+                        parent = parent.Parent;
                     }
                 }
 


### PR DESCRIPTION
This reverts commit a2e1251477d8faa04b5ec1c27a2ca606a3ea8013.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4937 - part 3 of 3

Changes proposed in this pull request:
- commit a2e1251477d8faa04b5ec1c27a2ca606a3ea8013 added a workaround in `SearchForUICommandsSource` for a bug where an exception happened in the "Recover lost objects" dialog when copying text from a file in the viewer
    - the reverted change change caused Visual Studio to become unresponsive when opening the form designer
    - after PR #4940 this workaround is no longer necessary
 
Screenshots before and after (if PR changes UI):
- before 
![image](https://user-images.githubusercontent.com/1851369/39968735-39d95aca-56d2-11e8-9d2b-34da54c7ed82.png)
- after 
![image](https://user-images.githubusercontent.com/1851369/39968763-b06e8390-56d2-11e8-8fc6-8c525006651f.png)

What did I do to test the code and ensure quality:
- form designer: find `RevisionGpgInfo.cs`, then open it in form designer in VS
- exception on copying text: open Repository->Git maintenance->Recover lost objects..., right click a row in the table, click View, select and copy a part of the text

Has been tested on (remove any that don't apply):
- Windows 8.1
- Visual Studio 15.7
