### PR TITLE
Change VisualStudio.CommandBars ref to compile in VS2017 Community

### DIFF
--- a/GitExtensionsVSIX/GitExtensionsVSIX.csproj
+++ b/GitExtensionsVSIX/GitExtensionsVSIX.csproj
@@ -20,7 +20,6 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-
     <!-- Disable the automatic inclusion of Microsoft.VisualStudio.Threading since Visual Studio has a specific version. -->
     <EnableVisualStudioThreading>false</EnableVisualStudioThreading>
   </PropertyGroup>
@@ -162,7 +161,7 @@
       <VersionMajor>8</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
+      <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>


### PR DESCRIPTION
Fixes #4458

Changes proposed in this pull request:
- Removed and re-added the reference to VisualStudio.CommandBars and found that this fixed the build error that was seen previously by @RussKie in #4458 and still seen by me. More specifically in my references I chose the item "Microsoft Visual Studio Command Bars 8.0". There was no other version appearing in my list.
 
What did I do to test the code and ensure quality:
- Has NOT been tested.

Currently I do not have a full build of Setup but this fixed the build error with CommandBars. 
I've created this pull request for maintainers and others to decide if this is a valid change to make.
