### PR TITLE
fix "Reset all changes" not working when "Refresh dialog on form focus" true [2.51 branch]

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2047,13 +2047,17 @@ namespace GitUI.CommandsDialogs
 
         private void ResetClick(object sender, EventArgs e)
         {
-            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyUnstaged: false));
-            Initialize();
+            HandleResetButton(onlyUnstaged: false);
         }
 
         private void ResetUnStagedClick(object sender, EventArgs e)
         {
-            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyUnstaged: true));
+            HandleResetButton(onlyUnstaged: true);
+        }
+
+        private void HandleResetButton(bool onlyUnstaged)
+        {
+            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyUnstaged: onlyUnstaged));
             Initialize();
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2047,14 +2047,28 @@ namespace GitUI.CommandsDialogs
 
         private void ResetClick(object sender, EventArgs e)
         {
-            UICommands.StartResetChangesDialog(this, Unstaged.AllItems, false);
+            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyUnstaged: false));
             Initialize();
         }
 
         private void ResetUnStagedClick(object sender, EventArgs e)
         {
-            UICommands.StartResetChangesDialog(this, Unstaged.AllItems, true);
+            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyUnstaged: true));
             Initialize();
+        }
+
+        private void BypassFormActivatedEventHandler(Action action)
+        {
+            try
+            {
+                Activated -= FormCommitActivated;
+
+                action();
+            }
+            finally
+            {
+                Activated += FormCommitActivated;
+            }
         }
 
         private void ShowUntrackedFilesToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -908,6 +908,11 @@ namespace GitUI.CommandsDialogs
 
         private void CheckForStagedAndCommit(bool amend, bool push)
         {
+            BypassFormActivatedEventHandler(() => DoCheckForStagedAndCommit(amend, push));
+        }
+
+        private void DoCheckForStagedAndCommit(bool amend, bool push)
+        {
             if (amend)
             {
                 // This is an amend commit.  Confirm the user understands the implications.  We don't want to prompt for an empty
@@ -933,20 +938,9 @@ namespace GitUI.CommandsDialogs
                         return;
                     }
 
-                    try
-                    {
-                        // unsubscribe the event handler so that after the message box is closed, the RescanChanges call is suppressed
-                        // (otherwise it would move all changed files from staged back to unstaged file list)
-                        this.Activated -= FormCommitActivated;
-
-                        // there are no staged files, but there are unstaged files. Most probably user forgot to stage them.
-                        if (MessageBox.Show(this, _noFilesStagedButSuggestToCommitAllUnstaged.Text, _noStagedChanges.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
-                            return;
-                    }
-                    finally
-                    {
-                        this.Activated += FormCommitActivated;
-                    }
+                    // there are no staged files, but there are unstaged files. Most probably user forgot to stage them.
+                    if (MessageBox.Show(this, _noFilesStagedButSuggestToCommitAllUnstaged.Text, _noStagedChanges.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+                        return;
 
                     StageAllAccordingToFilter();
                     // if staging failed (i.e. line endings conflict), user already got error message, don't try to commit empty changeset.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4907 (same as #4934, but for v2.51)

Changes proposed in this pull request:
- bypass the form activated event handler for Reset all changes/Reset unstaged changes buttons in the Commit dialog
    - Commit and Commit & push buttons do the same to avoid reloading
 
Screenshots before and after (if PR changes UI):
- (could not produce a reasonable screenshot)

What did I do to test the code and ensure quality:
- manual verification

Has been tested on (remove any that don't apply):
- GIT 2.16.1
- Windows 8.1