### PR TITLE
Fix 4949 settings rendering tweaks

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSettings.Designer.cs
@@ -107,16 +107,16 @@ namespace GitUI.CommandsDialogs
             //
             // tableLayoutPanel3
             //
-            this.tableLayoutPanel3.ColumnCount = 3;
+            this.tableLayoutPanel3.ColumnCount = 2;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 200F));
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel3.Controls.Add(this.settingsTreeView, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.panelCurrentSettingsPage, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel4, 1, 2);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.Padding = new Padding(8);
             this.tableLayoutPanel3.RowCount = 4;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.Designer.cs
@@ -32,7 +32,6 @@
             System.Windows.Forms.Label lblSpacer2;
             this.textBoxFind = new System.Windows.Forms.TextBox();
             this.treeView1 = new GitUI.UserControls.NativeTreeView();
-            this.labelNumFound = new System.Windows.Forms.Label();
             lblSpacer1 = new System.Windows.Forms.Label();
             lblSpacer2 = new System.Windows.Forms.Label();
             this.SuspendLayout();
@@ -77,20 +76,11 @@
             this.treeView1.TabIndex = 3;
             this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterSelect);
             // 
-            // labelNumFound
-            // 
-            this.labelNumFound.AutoSize = true;
-            this.labelNumFound.Location = new System.Drawing.Point(174, 9);
-            this.labelNumFound.Name = "labelNumFound";
-            this.labelNumFound.Size = new System.Drawing.Size(0, 25);
-            this.labelNumFound.TabIndex = 3;
-            // 
             // SettingsTreeViewUserControl
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.Controls.Add(this.treeView1);
             this.Controls.Add(lblSpacer2);
-            this.Controls.Add(this.labelNumFound);
             this.Controls.Add(this.textBoxFind);
             this.Controls.Add(lblSpacer1);
             this.MinimumSize = new System.Drawing.Size(100, 220);
@@ -105,6 +95,5 @@
 
         private System.Windows.Forms.TextBox textBoxFind;
         private UserControls.NativeTreeView treeView1;
-        private System.Windows.Forms.Label labelNumFound;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.Designer.cs
@@ -28,19 +28,38 @@
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.Label lblSpacer1;
+            System.Windows.Forms.Label lblSpacer2;
             this.textBoxFind = new System.Windows.Forms.TextBox();
-            this.treeView1 = new UserControls.NativeTreeView();
+            this.treeView1 = new GitUI.UserControls.NativeTreeView();
             this.labelNumFound = new System.Windows.Forms.Label();
+            lblSpacer1 = new System.Windows.Forms.Label();
+            lblSpacer2 = new System.Windows.Forms.Label();
             this.SuspendLayout();
+            // 
+            // lblSpacer1
+            // 
+            lblSpacer1.Dock = System.Windows.Forms.DockStyle.Top;
+            lblSpacer1.Location = new System.Drawing.Point(0, 0);
+            lblSpacer1.Name = "lblSpacer1";
+            lblSpacer1.Size = new System.Drawing.Size(200, 8);
+            lblSpacer1.TabIndex = 0;
+            // 
+            // lblSpacer2
+            // 
+            lblSpacer2.Dock = System.Windows.Forms.DockStyle.Top;
+            lblSpacer2.Location = new System.Drawing.Point(0, 39);
+            lblSpacer2.Name = "lblSpacer2";
+            lblSpacer2.Size = new System.Drawing.Size(200, 8);
+            lblSpacer2.TabIndex = 2;
             // 
             // textBoxFind
             // 
-            this.textBoxFind.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxFind.Location = new System.Drawing.Point(3, 6);
+            this.textBoxFind.Dock = System.Windows.Forms.DockStyle.Top;
+            this.textBoxFind.Location = new System.Drawing.Point(0, 0);
             this.textBoxFind.Name = "textBoxFind";
-            this.textBoxFind.Size = new System.Drawing.Size(165, 20);
-            this.textBoxFind.TabIndex = 0;
+            this.textBoxFind.Size = new System.Drawing.Size(200, 31);
+            this.textBoxFind.TabIndex = 1;
             this.textBoxFind.TextChanged += new System.EventHandler(this.textBoxFind_TextChanged);
             this.textBoxFind.Enter += new System.EventHandler(this.textBoxFind_Enter);
             this.textBoxFind.KeyUp += new System.Windows.Forms.KeyEventHandler(this.textBoxFind_KeyUp);
@@ -48,16 +67,14 @@
             // 
             // treeView1
             // 
-            this.treeView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.treeView1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.treeView1.FullRowSelect = true;
             this.treeView1.HideSelection = false;
             this.treeView1.HotTracking = true;
-            this.treeView1.Location = new System.Drawing.Point(3, 32);
+            this.treeView1.Location = new System.Drawing.Point(0, 31);
             this.treeView1.Name = "treeView1";
-            this.treeView1.Size = new System.Drawing.Size(194, 185);
-            this.treeView1.TabIndex = 2;
+            this.treeView1.Size = new System.Drawing.Size(200, 189);
+            this.treeView1.TabIndex = 3;
             this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterSelect);
             // 
             // labelNumFound
@@ -65,15 +82,17 @@
             this.labelNumFound.AutoSize = true;
             this.labelNumFound.Location = new System.Drawing.Point(174, 9);
             this.labelNumFound.Name = "labelNumFound";
-            this.labelNumFound.Size = new System.Drawing.Size(0, 13);
+            this.labelNumFound.Size = new System.Drawing.Size(0, 25);
             this.labelNumFound.TabIndex = 3;
             // 
             // SettingsTreeViewUserControl
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            this.Controls.Add(this.labelNumFound);
             this.Controls.Add(this.treeView1);
+            this.Controls.Add(lblSpacer2);
+            this.Controls.Add(this.labelNumFound);
             this.Controls.Add(this.textBoxFind);
+            this.Controls.Add(lblSpacer1);
             this.MinimumSize = new System.Drawing.Size(100, 220);
             this.Name = "SettingsTreeViewUserControl";
             this.Size = new System.Drawing.Size(200, 220);

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.Designer.cs
@@ -54,10 +54,8 @@
             this.treeView1.FullRowSelect = true;
             this.treeView1.HideSelection = false;
             this.treeView1.HotTracking = true;
-            this.treeView1.ItemHeight = 25;
             this.treeView1.Location = new System.Drawing.Point(3, 32);
             this.treeView1.Name = "treeView1";
-            this.treeView1.ShowLines = false;
             this.treeView1.Size = new System.Drawing.Size(194, 185);
             this.treeView1.TabIndex = 2;
             this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterSelect);

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
@@ -27,6 +28,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             _origTextBoxFont = textBoxFind.Font;
             SetFindPrompt(true);
+
+            treeView1.ImageList = new ImageList();
+            treeView1.ImageList.ImageSize = DpiUtil.Scale(new Size(16, 16)); // Scale ImageSize and images scale automatically
+            this.AdjustForDpiScaling();
         }
 
         /// <param name="asRoot">only one page can be set as the root page (for the GitExt and Plugin root node)</param>

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -101,73 +101,68 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             if (textBoxFind.Text.IsNullOrEmpty() || textBoxFind.Text == FindPrompt)
             {
                 ResetAllNodeHighlighting();
+                return;
             }
-            else
+
+            string searchFor = textBoxFind.Text.ToLowerInvariant();
+            foreach (var node in treeView1.AllNodes())
             {
-                string searchFor = textBoxFind.Text.ToLowerInvariant();
+                var settingsPage = (ISettingsPage)node.Tag;
 
-                foreach (var node in treeView1.AllNodes())
+                // search for title
+                if (settingsPage.GetTitle().ToLowerInvariant().Contains(searchFor))
                 {
-                    var settingsPage = (ISettingsPage)node.Tag;
+                    _nodesFoundByTextBox.Add(node);
+                }
 
-                    // search for title
-                    if (settingsPage.GetTitle().ToLowerInvariant().Contains(searchFor))
+                // search for keywords (space combines as 'and')
+                var andKeywords = searchFor.Split(' ');
+                if (andKeywords.All(keyword => settingsPage.GetSearchKeywords().Any(k => k.Contains(keyword))))
+                {
+                    // only part of a keyword must match to have a match
+                    if (!_nodesFoundByTextBox.Contains(node))
                     {
                         _nodesFoundByTextBox.Add(node);
                     }
-
-                    // search for keywords (space combines as 'and')
-                    var andKeywords = searchFor.Split(' ');
-                    if (andKeywords.All(keyword => settingsPage.GetSearchKeywords().Any(k => k.Contains(keyword))))
-                    {
-                        // only part of a keyword must match to have a match
-                        if (!_nodesFoundByTextBox.Contains(node))
-                        {
-                            _nodesFoundByTextBox.Add(node);
-                        }
-                    }
                 }
+            }
 
-                ResetAllNodeHighlighting();
+            ResetAllNodeHighlighting();
 
-                foreach (var node in _nodesFoundByTextBox)
-                {
-                    HighlightNode(node, true);
-                }
+            foreach (var node in _nodesFoundByTextBox)
+            {
+                HighlightNode(node, true);
+            }
 
-                labelNumFound.Text = _nodesFoundByTextBox.Count.ToString();
-
-                if (_nodesFoundByTextBox.Any())
-                {
-                    // if visible: when searching, if the selected node is valid, it will still have grey background
-                    treeView1.HideSelection = true;
-                }
+            if (_nodesFoundByTextBox.Any())
+            {
+                // if visible: when searching, if the selected node is valid, it will still have grey background
+                treeView1.HideSelection = true;
             }
         }
 
         /// <summary>Highlights a <see cref="TreeNode"/> or returns it to the default colors.</summary>
         private static void HighlightNode(TreeNode treeNode, bool highlight)
         {
-            treeNode.ForeColor = highlight ? Color.White : Color.Black;
-            treeNode.BackColor = highlight ? Color.SeaGreen : new Color();
+            treeNode.ForeColor = highlight ? SystemColors.HighlightText : SystemColors.ControlText;
+            treeNode.BackColor = highlight ? SystemColors.Highlight : new Color();
         }
 
         private void ResetAllNodeHighlighting()
         {
             treeView1.BeginUpdate();
-            ResetAllNodeHighlighting(treeView1.Nodes);
+            ResetHighlighting(treeView1.Nodes);
             treeView1.HideSelection = false;
             treeView1.EndUpdate();
-        }
+            return;
 
-        private void ResetAllNodeHighlighting(TreeNodeCollection nodes)
-        {
-            labelNumFound.Text = "";
-
-            foreach (TreeNode node in nodes.Cast<TreeNode>())
+            void ResetHighlighting(TreeNodeCollection nodes)
             {
-                HighlightNode(node, false);
-                ResetAllNodeHighlighting(node.Nodes);
+                foreach (TreeNode node in nodes.Cast<TreeNode>())
+                {
+                    HighlightNode(node, false);
+                    ResetHighlighting(node.Nodes);
+                }
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="lblSpacer1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="lblSpacer2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
 </root>


### PR DESCRIPTION
* Render the treeview consistently with the other treeviews
* Align the search textbox with the treeview

Fixes #4949


 
Screenshots before and after (if PR changes UI):
before:
![image](https://user-images.githubusercontent.com/4403806/40056982-559c0a90-5890-11e8-9fdb-bdd05c9f328f.png)

after:
![image](https://user-images.githubusercontent.com/4403806/40058298-1c125a32-5894-11e8-8670-ec8d200254e3.png)


What did I do to test the code and ensure quality:
- manual tests at 250%
