### PR TITLE
fix: Dahsboard is shown when app is closed

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2230,7 +2230,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnClosed(EventArgs e)
         {
-            SetWorkingDir("");
+            UnregisterPlugins();
 
             base.OnClosed(e);
         }


### PR DESCRIPTION
Whenever the app is closed, an empty repository is opened which causes the dashboard to be shown before the app is finally closed.
This creates an unwelcome flickering.

The original code was introduced in 466deca55dc22c7f70f6510894721cc76738bf3d citing that plugins must be given a chance to unload before the app closes.
Replace the existing flow that opens an empty repository with a call to unregister plugins, that essentially should cause them to unload.

@PombeirP do you have any recollection of the original issue?