### PR TITLE
git-log for artificial, remove unneeded signature

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -182,6 +182,13 @@ namespace GitCommands
         [ContractAnnotation("=>true,error:null,data:notnull")]
         private bool TryGetCommitLog([NotNull] string commitId, [NotNull] string format, out string error, out string data)
         {
+            if (GitCommands.Git.Extensions.GitRevisionExtensions.IsArtificial(commitId))
+            {
+                data = null;
+                error = "No log information for artificial commits";
+                return false;
+            }
+
             var arguments = $"log -1 --pretty=\"format:{format}\" {commitId}";
 
             // Do not cache this command, since notes can be added

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -143,7 +143,7 @@ namespace GitUI.CommandsDialogs
             _revisionDiffController = new RevisionDiffController(_gitRevisionTester);
 
             DiffFiles.FilterVisible = true;
-            DiffFiles.DescribeRevision = DescribeRevision;
+            DiffFiles.DescribeRevision = sha1 => DescribeRevision(sha1);
             DiffText.SetFileLoader(GetNextPatchFile);
             DiffText.Font = AppSettings.DiffFont;
             ReloadHotkeys();
@@ -153,12 +153,7 @@ namespace GitUI.CommandsDialogs
             base.OnRuntimeLoad();
         }
 
-        private string DescribeRevision(string sha1)
-        {
-            return DescribeRevision(sha1, 0);
-        }
-
-        private string DescribeRevision(string sha1, int maxLength)
+        private string DescribeRevision(string sha1, int maxLength = 0)
         {
             if (sha1.IsNullOrEmpty())
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of #4958
A few minor issues seen in relation to #4958 

Changes proposed in this pull request:
- git-log could be called for artificial commits if a artificial commit was selected when refreshing. Unnecessary and strange in the log.
- Remove unnecessary signature for DescribeRevision() in RevisionDiff. (The signature is used in a delegate and I missed this when updating the code - this was even a review comment).
 
Screenshots before and after (if PR changes UI):
n/a

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- Windows 10
