### PR TITLE
FileTree submodule doubleclick: Latest commit selected instead of cur…

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -303,6 +303,10 @@ See the changes in the commit form.");
                     WorkingDirectory = _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator())
                 }
             };
+            if (item.Guid.IsNotNullOrWhitespace())
+            {
+                process.StartInfo.Arguments += " -commit=" + item.Guid;
+            }
 
             process.Start();
         }


### PR DESCRIPTION
…rent

Closes #4958

Changes proposed in this pull request:
- Select current commit instead of HEAD when opening submodules in FileTree
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/40203130-96570eaa-5a24-11e8-9023-bb28985075ac.png)

- 
![image](https://user-images.githubusercontent.com/6248932/40203174-b8bba65e-5a24-11e8-9cf0-fdf5c1c085ff.png)


What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- Windows 10
