### PR TITLE
Browse Diff lost: Handle must be created prior to insertion

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -284,6 +284,9 @@ namespace GitUI.CommandsDialogs
 
         private void LayoutRevisionInfo()
         {
+            // Handle must be created prior to insertion
+            IntPtr h = CommitInfoTabControl.Handle;
+
             if (_showRevisionInfoNextToRevisionGrid)
             {
                 RevisionInfo.Parent = RevisionsSplitContainer.Panel2;

--- a/GitUI/CommandsDialogs/RevisionFileTree.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTree.cs
@@ -55,6 +55,9 @@ See the changes in the commit form.");
             Translate();
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _findFilePredicateProvider = new FindFilePredicateProvider();
+            _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
+                                                                         new GitRevisionInfoProvider(() => Module),
+                                                                         new FileAssociatedIconProvider());
         }
 
         public void ExpandToFile(string filePath)
@@ -217,10 +220,6 @@ See the changes in the commit form.");
 
         protected override void OnRuntimeLoad()
         {
-            _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
-                                                                         new GitRevisionInfoProvider(() => Module),
-                                                                         new FileAssociatedIconProvider());
-
             tvGitTree.ImageList = new ImageList(components)
             {
                 ColorDepth = ColorDepth.Depth32Bit,


### PR DESCRIPTION
Closes #4955

Changes proposed in this pull request:
Diff tab was lost if Commit info was shown in RevisionTree
The DiffTab is lost when inserted to the left.
This is related to the Dashboard changes that seem to restructure loading, the handle to the tabcontrol must be created to inserting:
https://social.msdn.microsoft.com/Forums/windows/en-US/5d10fd0c-1aa6-4092-922e-1fd7af979663/tabpagesinsert-bug?forum=winforms
 
Screenshots before and after (if PR changes UI):
- No tab lost

What did I do to test the code and ensure quality:
- Manual

Has been tested on (remove any that don't apply):
- Windows 10
