### PR TITLE
Handle start with dashboard explicitly

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -118,7 +118,7 @@ namespace GitExtensions
 
             if (args.Length <= 1)
             {
-                commands.StartBrowseDialog();
+                commands.StartBrowseDialog(startWithDashboard: !AppSettings.StartWithRecentWorkingDir);
             }
             else
             {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1066,9 +1066,9 @@ namespace GitUI
             return StartSettingsDialog(owner, CommandsDialogs.SettingsDialog.Pages.GitConfigSettingsPage.GetPageReference());
         }
 
-        public bool StartBrowseDialog(IWin32Window owner = null, string filter = "", string selectedCommit = null)
+        public bool StartBrowseDialog(IWin32Window owner = null, string filter = "", string selectedCommit = null, bool startWithDashboard = false)
         {
-            var form = new FormBrowse(this, filter, selectedCommit);
+            var form = new FormBrowse(this, filter, selectedCommit, startWithDashboard);
 
             if (Application.MessageLoop)
             {


### PR DESCRIPTION
This is an update of #4870 See that PR for original motivation and why this is opened as a separate PR.
Fixes #4860 

The first commit tried to always resolve the current working directory when starting GE.
That broke the Dashboard handling, that was set to start if there were no directory supplied and GE was configured to not use last used repo. The dashboard must be explicitly handled for the change to work.

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- Windows 10
