### PR TITLE
Change artificial refs color to "Color other label" setting

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1905,7 +1905,7 @@ namespace GitUI
                         SizeF textSize = drawRefArgs.Graphics.MeasureString(text, rowFont);
 
                         offset += 1 + textSize.Width;
-                        offset = DrawRef(drawRefArgs, offset, revision.Subject, AppSettings.BranchColor, ArrowType.None, false, true);
+                        offset = DrawRef(drawRefArgs, offset, revision.Subject, AppSettings.OtherTagColor, ArrowType.None, false, true);
                     }
                 }
                 else if (columnIndex == authorColIndex)


### PR DESCRIPTION
Fixes #4963

Changes proposed in this pull request:
- Use the same color for artificial refs as the one used for stash ref

Screenshots before and after (if PR changes UI):
Before:
![image](https://user-images.githubusercontent.com/483659/40224678-860f1e78-5a8f-11e8-967b-363b97476983.png)

After:
![image](https://user-images.githubusercontent.com/483659/40224581-4be32d3e-5a8f-11e8-9d40-071b3351bed3.png)