### PR TITLE
fix: Crash when you click on the Commit tab

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -8,17 +8,17 @@ namespace GitCommands
     {
         public CommitData(string guid,
             string treeGuid, ReadOnlyCollection<string> parentGuids,
-            string author, DateTimeOffset authorDate,
-            string committer, DateTimeOffset commitDate,
+            string author, DateTime authorDate,
+            string committer, DateTime commitDate,
             string body)
         {
             Guid = guid;
             TreeGuid = treeGuid;
             ParentGuids = parentGuids;
             Author = author;
-            AuthorDate = authorDate;
+            AuthorDate = authorDate.ToDateTimeOffset();
             Committer = committer;
-            CommitDate = commitDate;
+            CommitDate = commitDate.ToDateTimeOffset();
 
             Body = body;
         }
@@ -33,7 +33,7 @@ namespace GitCommands
         public DateTimeOffset CommitDate { get; }
 
         // TODO: this needs review, it shouldn't be mutable
-        public string Body { get;  set; }
+        public string Body { get; set; }
 
     }
 }

--- a/GitCommands/System.cs
+++ b/GitCommands/System.cs
@@ -5,6 +5,24 @@ using JetBrains.Annotations;
 
 namespace System
 {
+    public static class DateTimeExtensions
+    {
+        public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime)
+        {
+            if (dateTime.ToUniversalTime() <= DateTimeOffset.MinValue.UtcDateTime)
+            {
+                return DateTimeOffset.MinValue;
+            }
+
+            if (dateTime.ToUniversalTime() >= DateTimeOffset.MaxValue.UtcDateTime)
+            {
+                return DateTimeOffset.MaxValue;
+            }
+
+            return new DateTimeOffset(dateTime);
+        }
+    }
+
     public static class StringExtensions
     {
         /// <summary>'\n'</summary>


### PR DESCRIPTION
Some users to the west of GM experience AOORE when navigating to the artificial commits.

Artificial commits are constructed using `DateTime.MaxValue`, and for users with timezones to the west of GM the MaxValue falls outside `DateTimeOffset.MaxValue`.

The `DateTimeOffset` constructor first converts any `DateTime` that is not of Kind 'UTC' to the equivalent UTC time. It will then check whether the UTC-equivalent DateTime falls outside of the bounds of `DateTimeOffset.MinValue` and `DateTimeOffset.MaxValue`, and if it does, will throw an
`ArgumentOutOfRangeException`.

Fixes #4956
