### PR TITLE
Fix gitext.sh if ran from different directory

### DIFF
--- a/Bin/gitext.sh
+++ b/Bin/gitext.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-mono GitExtensions.exe "$@" &
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+mono "$DIR/GitExtensions.exe" "$@" &
+


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4975 

Changes proposed in this pull request:
- Add shell start script's directory to start GitExtensions with absolute path

What did I do to test the code and ensure quality:
- Uses well-known bash snippet from https://stackoverflow.com/q/59895/

Has been tested on (remove any that don't apply):
- GIT 2.10 and above
- Ubuntu 16.04 LTS
