### PR TITLE
Artificial commit count was cleared when manually refreshing the index

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2946,6 +2946,11 @@ namespace GitUI
 
         private void UpdateArtificialCommitCount(IReadOnlyList<GitItemStatus> status, GitRevision unstagedRev, GitRevision stagedRev)
         {
+            if (status == null)
+            {
+                return;
+            }
+
             int staged = status.Count(item => item.IsStaged);
             int unstaged = status.Count - staged;
 
@@ -2959,9 +2964,8 @@ namespace GitUI
                 stagedRev.SubjectCount = "(" + staged + ") ";
             }
 
-            _artificialStatus = unstagedRev == null || stagedRev == null
-                ? status
-                : null;
+            // cache the status, if commits do not exist or for a refresh
+            _artificialStatus = status;
 
             Revisions.Invalidate();
         }
@@ -2999,10 +3003,7 @@ namespace GitUI
             };
             Revisions.Add(stagedRev, DvcsGraph.DataTypes.Normal);
 
-            if (_artificialStatus != null)
-            {
-                UpdateArtificialCommitCount(_artificialStatus, unstagedRev, stagedRev);
-            }
+            UpdateArtificialCommitCount(_artificialStatus, unstagedRev, stagedRev);
         }
 
         internal void DrawNonrelativesGray_ToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
fixes #4483
The count was cleared when refreshing the index (recreating all commits) but the commit count was not forced to be updated.
This change caches the count (similar to the commit button).

What did I do to test the code and ensure quality:
- Enable artificial commits
- Refresh the index
- Verify that count (may be 0) is still visible

Has been tested on (remove any that don't apply):
- Windows 10 and above
