### PR TITLE
DVCS Graph tweaks

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -95,7 +95,7 @@ namespace GitCommands
         /// was provided the string <see cref="CommitDataManager.LogFormat"/>.</param>
         /// <returns>CommitData object populated with parsed info from git string.</returns>
         [NotNull]
-        public CommitData CreateFromFormattedData([NotNull] string data)
+        internal CommitData CreateFromFormattedData([NotNull] string data)
         {
             if (data == null)
             {

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -24,7 +24,6 @@ namespace GitCommands
         public static readonly Regex Sha1HashRegex = new Regex("^" + Sha1HashPattern + "$", RegexOptions.Compiled);
         public static readonly Regex Sha1HashShortRegex = new Regex(string.Format(@"\b{0}\b", Sha1HashShortPattern), RegexOptions.Compiled);
 
-        public string[] ParentGuids;
         private BuildInfo _buildStatus;
 
         public GitRevision(string guid)
@@ -36,6 +35,10 @@ namespace GitCommands
         }
 
         public List<IGitRef> Refs { get; } = new List<IGitRef>();
+
+        // TODO seems inconsistent that this can be null, yet Refs is never null
+        [CanBeNull, ItemNotNull]
+        public IReadOnlyList<string> ParentGuids { get; set; }
 
         public string TreeGuid { get; set; }
 
@@ -109,7 +112,7 @@ namespace GitCommands
         /// </summary>
         public bool IsArtificial => Guid.IsArtificial();
 
-        public bool HasParent => ParentGuids != null && ParentGuids.Length > 0;
+        public bool HasParent => ParentGuids != null && ParentGuids.Count > 0;
 
         public string FirstParentGuid => HasParent ? ParentGuids[0] : null;
 

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -62,6 +63,17 @@ namespace GitUI
                 string message = string.Format(CultureInfo.CurrentCulture, "{0} must be called on the UI thread.", callerMemberName);
                 throw new COMException(message, RPC_E_WRONG_THREAD);
             }
+        }
+
+        [Conditional("DEBUG")]
+        public static void AssertOnUIThread()
+        {
+            if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
+            {
+                return;
+            }
+
+            Debug.Assert(JoinableTaskContext.IsOnMainThread, "Must be on the UI thread.");
         }
 
         public static void ThrowIfOnUIThread([CallerMemberName] string callerMemberName = "")

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -156,5 +156,12 @@ namespace System.Linq
                 action(t);
             }
         }
+
+        public static void Swap<T>(this IList<T> list, int index1, int index2)
+        {
+            var temp = list[index1];
+            list[index1] = list[index2];
+            list[index2] = temp;
+        }
     }
 }

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -73,6 +73,12 @@ namespace System.Linq
             return result;
         }
 
+        public static IEnumerable<TValue> SelectMany<TValue>(
+            this IEnumerable<IEnumerable<TValue>> source)
+        {
+            return source.SelectMany(i => i);
+        }
+
         public static string Join(this IEnumerable<string> source, string separator)
         {
             return string.Join(separator, source);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -470,7 +470,7 @@ namespace GitUI.CommandsDialogs
                 bool refresh = plugin.Execute(eventArgs);
                 if (refresh)
                 {
-                    RefreshToolStripMenuItemClick(null, null);
+                    RefreshRevisions();
                 }
             }
         }
@@ -1406,7 +1406,7 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshButtonClick(object sender, EventArgs e)
         {
-            RefreshToolStripMenuItemClick(sender, e);
+            RefreshRevisions();
         }
 
         private void CommitcountPerUserToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -133,14 +133,14 @@ namespace GitUI.CommandsDialogs
                 if (revisions.Count == 1)
                 {
                     var parents = revisions[0].ParentGuids;
-                    rev1 = parents.Length > 0 ? parents[0] : "";
+                    rev1 = parents?.Count > 0 ? parents[0] : "";
                     rev2 = revisions[0].Guid;
                     result = Module.FormatPatch(rev1, rev2, savePatchesToDir);
                 }
                 else if (revisions.Count == 2)
                 {
                     var parents = revisions[0].ParentGuids;
-                    rev1 = parents.Length > 0 ? parents[0] : "";
+                    rev1 = parents?.Count > 0 ? parents[0] : "";
                     rev2 = revisions[1].Guid;
                     result = Module.FormatPatch(rev1, rev2, savePatchesToDir);
                 }
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
                     {
                         n++;
                         var parents = revision.ParentGuids;
-                        rev1 = parents.Length > 0 ? parents[0] : "";
+                        rev1 = parents?.Count > 0 ? parents[0] : "";
                         rev2 = revision.Guid;
                         result += Module.FormatPatch(rev1, rev2, savePatchesToDir, n);
                     }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -189,8 +189,8 @@ namespace GitUI.CommitInfo
             }
 
             data.ChildrenGuids = _children;
-            var header = _commitDataHeaderRenderer.Render(data, CommandClick != null);
-            var body = _commitDataBodyRenderer.Render(data, CommandClick != null);
+            var header = _commitDataHeaderRenderer.Render(data, showRevisionsAsLinks: CommandClick != null);
+            var body = _commitDataBodyRenderer.Render(data, showRevisionsAsLinks: CommandClick != null);
 
             _RevisionHeader.SetXHTMLText(header);
             _RevisionHeader.Height = GetRevisionHeaderHeight();

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -60,10 +60,6 @@ namespace GitUI
         private readonly TranslationString _baseForCompareNotSelectedError = new TranslationString("Base commit for compare is not selected.");
         private readonly TranslationString _strError = new TranslationString("Error");
 
-        private const int NodeDimension = 10;
-        private const int LaneWidth = 13;
-        private const int LaneLineWidth = 2;
-        private const int LaneSidePadding = 4;
         private const int MaxSuperprojectRefs = 4;
         private Brush _selectedItemBrush;
         private SolidBrush _authoredRevisionsBrush;
@@ -3458,7 +3454,7 @@ namespace GitUI
                 _selectedItemBrush = _filledItemBrush;
 
                 Revisions.ShowAuthor(!IsCardLayout());
-                Revisions.SetDimensions(NodeDimension, LaneWidth, LaneLineWidth, _rowHeigth, LaneSidePadding);
+                Revisions.SetRowHeight(_rowHeigth);
             }
             else
             {
@@ -3486,7 +3482,7 @@ namespace GitUI
                 }
 
                 Revisions.ShowAuthor(!IsCardLayout());
-                Revisions.SetDimensions(NodeDimension, LaneWidth, LaneLineWidth, _rowHeigth, LaneSidePadding);
+                Revisions.SetRowHeight(_rowHeigth);
             }
 
             // Hide graph column when there it is disabled OR when a filter is active

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3005,7 +3005,7 @@ namespace GitUI
             {
                 dataType = DvcsGraph.DataType.Active;
             }
-            else if (rev.Refs.Any())
+            else if (rev.Refs.Count != 0)
             {
                 dataType = DvcsGraph.DataType.Special;
             }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3000,21 +3000,21 @@ namespace GitUI
                 CheckUncommitedChanged(_filtredCurrentCheckout);
             }
 
-            DvcsGraph.DataType dataType;
+            DvcsGraph.DataTypes dataTypes;
             if (rev.Guid == _filtredCurrentCheckout)
             {
-                dataType = DvcsGraph.DataType.Active;
+                dataTypes = DvcsGraph.DataTypes.Active;
             }
             else if (rev.Refs.Count != 0)
             {
-                dataType = DvcsGraph.DataType.Special;
+                dataTypes = DvcsGraph.DataTypes.Special;
             }
             else
             {
-                dataType = DvcsGraph.DataType.Normal;
+                dataTypes = DvcsGraph.DataTypes.Normal;
             }
 
-            Revisions.Add(rev, dataType);
+            Revisions.Add(rev, dataTypes);
         }
 
         public void UpdateArtificialCommitCount(IReadOnlyList<GitItemStatus> status)
@@ -3063,7 +3063,7 @@ namespace GitUI
                 Subject = Strings.GetCurrentUnstagedChanges(),
                 ParentGuids = new[] { GitRevision.IndexGuid }
             };
-            Revisions.Add(unstagedRev, DvcsGraph.DataType.Normal);
+            Revisions.Add(unstagedRev, DvcsGraph.DataTypes.Normal);
 
             // Add index as virtual commit
             var stagedRev = new GitRevision(GitRevision.IndexGuid)
@@ -3077,7 +3077,7 @@ namespace GitUI
                 Subject = Strings.GetCurrentIndex(),
                 ParentGuids = new[] { filtredCurrentCheckout }
             };
-            Revisions.Add(stagedRev, DvcsGraph.DataType.Normal);
+            Revisions.Add(stagedRev, DvcsGraph.DataTypes.Normal);
 
             if (_artificialStatus != null)
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -63,6 +63,7 @@ namespace GitUI
         private const int NodeDimension = 10;
         private const int LaneWidth = 13;
         private const int LaneLineWidth = 2;
+        private const int LaneSidePadding = 4;
         private const int MaxSuperprojectRefs = 4;
         private Brush _selectedItemBrush;
         private SolidBrush _authoredRevisionsBrush;
@@ -3457,7 +3458,7 @@ namespace GitUI
                 _selectedItemBrush = _filledItemBrush;
 
                 Revisions.ShowAuthor(!IsCardLayout());
-                Revisions.SetDimensions(NodeDimension, LaneWidth, LaneLineWidth, _rowHeigth);
+                Revisions.SetDimensions(NodeDimension, LaneWidth, LaneLineWidth, _rowHeigth, LaneSidePadding);
             }
             else
             {
@@ -3485,7 +3486,7 @@ namespace GitUI
                 }
 
                 Revisions.ShowAuthor(!IsCardLayout());
-                Revisions.SetDimensions(NodeDimension, LaneWidth, LaneLineWidth, _rowHeigth);
+                Revisions.SetDimensions(NodeDimension, LaneWidth, LaneLineWidth, _rowHeigth, LaneSidePadding);
             }
 
             // Hide graph column when there it is disabled OR when a filter is active

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3014,7 +3014,7 @@ namespace GitUI
                 dataType = DvcsGraph.DataType.Normal;
             }
 
-            Revisions.Add(rev.Guid, rev.ParentGuids, dataType, rev);
+            Revisions.Add(rev, dataType);
         }
 
         public void UpdateArtificialCommitCount(IReadOnlyList<GitItemStatus> status)
@@ -3063,7 +3063,7 @@ namespace GitUI
                 Subject = Strings.GetCurrentUnstagedChanges(),
                 ParentGuids = new[] { GitRevision.IndexGuid }
             };
-            Revisions.Add(unstagedRev.Guid, unstagedRev.ParentGuids, DvcsGraph.DataType.Normal, unstagedRev);
+            Revisions.Add(unstagedRev, DvcsGraph.DataType.Normal);
 
             // Add index as virtual commit
             var stagedRev = new GitRevision(GitRevision.IndexGuid)
@@ -3077,7 +3077,7 @@ namespace GitUI
                 Subject = Strings.GetCurrentIndex(),
                 ParentGuids = new[] { filtredCurrentCheckout }
             };
-            Revisions.Add(stagedRev.Guid, stagedRev.ParentGuids, DvcsGraph.DataType.Normal, stagedRev);
+            Revisions.Add(stagedRev, DvcsGraph.DataType.Normal);
 
             if (_artificialStatus != null)
             {

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1359,15 +1359,16 @@ namespace GitUI
         private void _revisionGraphCommand_Error(object sender, AsyncErrorEventArgs e)
         {
             // This has to happen on the UI thread
-            this.InvokeAsync(() =>
-                                  {
-                                      Error.Visible = true;
-                                      ////Error.BringToFront();
-                                      NoGit.Visible = false;
-                                      NoCommits.Visible = false;
-                                      Revisions.Visible = false;
-                                      Loading.Visible = false;
-                                  })
+            this.InvokeAsync(
+                    () =>
+                    {
+                        Error.Visible = true;
+                        ////Error.BringToFront();
+                        NoGit.Visible = false;
+                        NoCommits.Visible = false;
+                        Revisions.Visible = false;
+                        Loading.Visible = false;
+                    })
                 .FileAndForget();
 
             DisposeRevisionGraphCommand();
@@ -1424,15 +1425,16 @@ namespace GitUI
                 !FilterIsApplied(true))
             {
                 // This has to happen on the UI thread
-                this.InvokeAsync(() =>
-                                      {
-                                          NoGit.Visible = false;
-                                          NoCommits.Visible = true;
-                                          ////NoCommits.BringToFront();
-                                          Revisions.Visible = false;
-                                          Loading.Visible = false;
-                                          _isRefreshingRevisions = false;
-                                      })
+                this.InvokeAsync(
+                        () =>
+                        {
+                            NoGit.Visible = false;
+                            NoCommits.Visible = true;
+                            ////NoCommits.BringToFront();
+                            Revisions.Visible = false;
+                            Loading.Visible = false;
+                            _isRefreshingRevisions = false;
+                        })
                     .FileAndForget();
             }
             else
@@ -1567,6 +1569,7 @@ namespace GitUI
             }
 
             _initialLoad = false;
+
             SelectionTimer.Enabled = false;
             SelectionTimer.Stop();
             SelectionTimer.Enabled = true;
@@ -2992,21 +2995,23 @@ namespace GitUI
                 }
             }
 
-            string filtredCurrentCheckout = _filtredCurrentCheckout;
-
-            if (filtredCurrentCheckout == rev.Guid && ShowUncommitedChanges() && !Module.IsBareRepository())
+            if (_filtredCurrentCheckout == rev.Guid && ShowUncommitedChanges() && !Module.IsBareRepository())
             {
-                CheckUncommitedChanged(filtredCurrentCheckout);
+                CheckUncommitedChanged(_filtredCurrentCheckout);
             }
 
-            var dataType = DvcsGraph.DataType.Normal;
-            if (rev.Guid == filtredCurrentCheckout)
+            DvcsGraph.DataType dataType;
+            if (rev.Guid == _filtredCurrentCheckout)
             {
                 dataType = DvcsGraph.DataType.Active;
             }
             else if (rev.Refs.Any())
             {
                 dataType = DvcsGraph.DataType.Special;
+            }
+            else
+            {
+                dataType = DvcsGraph.DataType.Normal;
             }
 
             Revisions.Add(rev.Guid, rev.ParentGuids, dataType, rev);
@@ -3023,6 +3028,7 @@ namespace GitUI
         {
             int staged = status.Count(item => item.IsStaged);
             int unstaged = status.Count - staged;
+
             if (unstagedRev != null)
             {
                 unstagedRev.SubjectCount = "(" + unstaged + ") ";
@@ -3033,14 +3039,9 @@ namespace GitUI
                 stagedRev.SubjectCount = "(" + staged + ") ";
             }
 
-            if (unstagedRev == null || stagedRev == null)
-            {
-                _artificialStatus = status;
-            }
-            else
-            {
-                _artificialStatus = null;
-            }
+            _artificialStatus = unstagedRev == null || stagedRev == null
+                ? status
+                : null;
 
             Revisions.Invalidate();
         }

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -208,9 +208,7 @@ namespace GitUI.RevisionGridClasses
                             Debugger.Break();
                         }
 
-                        Node temp = AddedNodes[i];
-                        AddedNodes[i] = AddedNodes[i - 1];
-                        AddedNodes[i - 1] = temp;
+                        AddedNodes.Swap(i - 1, i);
                         i--;
                         isChanged = true;
                     }

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -10,13 +10,13 @@ namespace GitUI.RevisionGridClasses
     {
         private sealed class Graph
         {
-            public readonly List<Node> AddedNodes = new List<Node>();
+            public event Action Updated;
 
             private readonly List<Junction> _junctions = new List<Junction>();
             private readonly Lanes _lanes;
-
             private int _processedNodes;
 
+            public List<Node> AddedNodes { get; } = new List<Node>();
             public Dictionary<string, Node> Nodes { get; } = new Dictionary<string, Node>();
             public int Count { get; private set; }
 
@@ -69,8 +69,6 @@ namespace GitUI.RevisionGridClasses
                     }
                 }
             }
-
-            public event Action Updated;
 
             public void Add(GitRevision revision, DataTypes types)
             {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -374,21 +374,26 @@ namespace GitUI.RevisionGridClasses
 
             public struct LaneInfo
             {
-                private List<Junction> _junctions;
-
-                public LaneInfo(int connectLane, Junction junction)
-                {
-                    ConnectLane = connectLane;
-                    _junctions = new List<Junction>(1) { junction };
-                }
+                private readonly List<Junction> _junctions;
 
                 public int ConnectLane { get; set; }
+
+                public LaneInfo(int connectLane, Junction junction)
+                    : this(connectLane, new List<Junction> { junction })
+                {
+                }
+
+                private LaneInfo(int connectLane, List<Junction> junctions)
+                {
+                    ConnectLane = connectLane;
+                    _junctions = junctions;
+                }
 
                 public IEnumerable<Junction> Junctions => _junctions;
 
                 public LaneInfo Clone()
                 {
-                    return new LaneInfo { ConnectLane = ConnectLane, _junctions = new List<Junction>(_junctions) };
+                    return new LaneInfo(ConnectLane, new List<Junction>(_junctions));
                 }
 
                 public void UnionWith(LaneInfo other)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -76,7 +76,7 @@ namespace GitUI.RevisionGridClasses
 
             public event Action Updated;
 
-            public void Add(GitRevision revision, DataType type)
+            public void Add(GitRevision revision, DataTypes types)
             {
                 var parentIds = revision.ParentGuids;
 
@@ -89,7 +89,7 @@ namespace GitUI.RevisionGridClasses
 
                 Count++;
                 node.Data = revision;
-                node.DataType = type;
+                node.DataTypes = types;
                 node.Index = AddedNodes.Count;
                 AddedNodes.Add(node);
 
@@ -113,7 +113,7 @@ namespace GitUI.RevisionGridClasses
                         // and is about to start a new branch. This will also mean that the last
                         // revisions are non-relative. Make sure a new junction is added and this
                         // is the start of a new branch (and color!)
-                        && (type & DataType.Active) != DataType.Active)
+                        && (types & DataTypes.Active) != DataTypes.Active)
                     {
                         // The node isn't a junction point. Just the parent to the node's
                         // (only) ancestor junction.
@@ -147,7 +147,7 @@ namespace GitUI.RevisionGridClasses
                     }
                 }
 
-                bool isRelative = (type & DataType.Active) == DataType.Active;
+                bool isRelative = (types & DataTypes.Active) == DataTypes.Active;
                 if (!isRelative && node.Descendants.Any(d => d.IsRelative))
                 {
                     isRelative = true;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -48,12 +48,8 @@ namespace GitUI.RevisionGridClasses
 
             public bool IsRevisionRelative(string guid)
             {
-                if (Nodes.TryGetValue(guid, out var startNode))
-                {
-                    return startNode.Ancestors.Any(a => a.IsRelative);
-                }
-
-                return false;
+                return Nodes.TryGetValue(guid, out var startNode)
+                    && startNode.Ancestors.Any(a => a.IsRelative);
             }
 
             private void HighlightBranchRecursive(string id)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -225,7 +225,7 @@ namespace GitUI.RevisionGridClasses
 
             public void Prune()
             {
-                Node[] nodesToRemove = Nodes.Values.Where(n => n.Data == null).ToArray();
+                var nodesToRemove = Nodes.Values.Where(n => n.Data == null).ToList();
 
                 // Remove all nodes that don't have a value associated with them.
                 foreach (Node n in nodesToRemove)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -10,12 +10,6 @@ namespace GitUI.RevisionGridClasses
     {
         private sealed class Graph
         {
-            #region Delegates
-
-            public delegate void GraphUpdatedHandler(object sender);
-
-            #endregion
-
             public readonly List<Node> AddedNodes = new List<Node>();
 
             private readonly List<Junction> _junctions = new List<Junction>();
@@ -81,7 +75,7 @@ namespace GitUI.RevisionGridClasses
                 }
             }
 
-            public event GraphUpdatedHandler Updated;
+            public event Action Updated;
 
             public void Add(string id, string[] parentIds, DataType type, GitRevision data)
             {
@@ -183,7 +177,7 @@ namespace GitUI.RevisionGridClasses
                     _lanes.CacheTo(lastLane);
 
                     // We need to signal the DvcsGraph object that it needs to redraw everything.
-                    Updated?.Invoke(this);
+                    Updated?.Invoke();
                 }
                 else
                 {
@@ -225,7 +219,7 @@ namespace GitUI.RevisionGridClasses
                         // Signal that these rows have changed
                         if (isChanged)
                         {
-                            Updated?.Invoke(this);
+                            Updated?.Invoke();
                         }
 
                         _processedNodes++;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -193,33 +193,36 @@ namespace GitUI.RevisionGridClasses
             {
                 for (int i = _processedNodes; i < AddedNodes.Count; i++)
                 {
-                    if (AddedNodes[i] == node)
+                    if (AddedNodes[i] != node)
                     {
-                        bool isChanged = false;
-                        while (i > _processedNodes)
-                        {
-                            // This only happens if we weren't in topo order
-                            if (Debugger.IsAttached)
-                            {
-                                Debugger.Break();
-                            }
-
-                            Node temp = AddedNodes[i];
-                            AddedNodes[i] = AddedNodes[i - 1];
-                            AddedNodes[i - 1] = temp;
-                            i--;
-                            isChanged = true;
-                        }
-
-                        // Signal that these rows have changed
-                        if (isChanged)
-                        {
-                            Updated?.Invoke();
-                        }
-
-                        _processedNodes++;
-                        break;
+                        continue;
                     }
+
+                    bool isChanged = false;
+
+                    while (i > _processedNodes)
+                    {
+                        // This only happens if we weren't in topo order
+                        if (Debugger.IsAttached)
+                        {
+                            Debugger.Break();
+                        }
+
+                        Node temp = AddedNodes[i];
+                        AddedNodes[i] = AddedNodes[i - 1];
+                        AddedNodes[i - 1] = temp;
+                        i--;
+                        isChanged = true;
+                    }
+
+                    // Signal that these rows have changed
+                    if (isChanged)
+                    {
+                        Updated?.Invoke();
+                    }
+
+                    _processedNodes++;
+                    break;
                 }
             }
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -77,17 +77,19 @@ namespace GitUI.RevisionGridClasses
 
             public event Action Updated;
 
-            public void Add(string id, IReadOnlyList<string> parentIds, DataType type, GitRevision data)
+            public void Add(GitRevision revision, DataType type)
             {
+                var parentIds = revision.ParentGuids;
+
                 // If we haven't seen this node yet, create a new junction.
-                if (!GetNode(id, out var node) && (parentIds == null || parentIds.Count == 0))
+                if (!GetNode(revision.Guid, out var node) && (parentIds == null || parentIds.Count == 0))
                 {
                     var newJunction = new Junction(node, node);
                     _junctions.Add(newJunction);
                 }
 
                 _nodeCount++;
-                node.Data = data;
+                node.Data = revision;
                 node.DataType = type;
                 node.Index = AddedNodes.Count;
                 AddedNodes.Add(node);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -13,18 +13,17 @@ namespace GitUI.RevisionGridClasses
             public readonly List<Node> AddedNodes = new List<Node>();
 
             private readonly List<Junction> _junctions = new List<Junction>();
-            public readonly Dictionary<string, Node> Nodes = new Dictionary<string, Node>();
             private readonly Lanes _lanes;
 
-            private int _nodeCount;
             private int _processedNodes;
+
+            public Dictionary<string, Node> Nodes { get; } = new Dictionary<string, Node>();
+            public int Count { get; private set; }
 
             public Graph()
             {
                 _lanes = new Lanes(this);
             }
-
-            public int Count => _nodeCount;
 
             public ILaneRow this[int col] => _lanes[col];
 
@@ -88,7 +87,7 @@ namespace GitUI.RevisionGridClasses
                     _junctions.Add(newJunction);
                 }
 
-                _nodeCount++;
+                Count++;
                 node.Data = revision;
                 node.DataType = type;
                 node.Index = AddedNodes.Count;
@@ -193,7 +192,7 @@ namespace GitUI.RevisionGridClasses
                 _junctions.Clear();
                 Nodes.Clear();
                 _lanes.Clear();
-                _nodeCount = 0;
+                Count = 0;
             }
 
             public void ProcessNode(Node node)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -29,7 +29,7 @@ namespace GitUI.RevisionGridClasses
 
             public int CachedCount => _lanes.CachedCount;
 
-            public void ClearHighlightBranch()
+            private void ClearHighlightBranch()
             {
                 foreach (Node node in Nodes.Values)
                 {
@@ -56,7 +56,7 @@ namespace GitUI.RevisionGridClasses
                 return false;
             }
 
-            public void HighlightBranchRecursive(string id)
+            private void HighlightBranchRecursive(string id)
             {
                 if (Nodes.TryGetValue(id, out var startNode))
                 {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -106,7 +106,7 @@ namespace GitUI.RevisionGridClasses
                         // and is about to start a new branch. This will also mean that the last
                         // revisions are non-relative. Make sure a new junction is added and this
                         // is the start of a new branch (and color!)
-                        && (types & DataTypes.Active) != DataTypes.Active)
+                        && !types.HasFlag(DataTypes.Active))
                     {
                         // The node isn't a junction point. Just the parent to the node's
                         // (only) ancestor junction.
@@ -135,7 +135,7 @@ namespace GitUI.RevisionGridClasses
                     }
                 }
 
-                bool isRelative = (types & DataTypes.Active) == DataTypes.Active;
+                bool isRelative = types.HasFlag(DataTypes.Active);
                 if (!isRelative && node.Descendants.Any(d => d.IsRelative))
                 {
                     isRelative = true;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -77,10 +77,10 @@ namespace GitUI.RevisionGridClasses
 
             public event Action Updated;
 
-            public void Add(string id, string[] parentIds, DataType type, GitRevision data)
+            public void Add(string id, IReadOnlyList<string> parentIds, DataType type, GitRevision data)
             {
                 // If we haven't seen this node yet, create a new junction.
-                if (!GetNode(id, out var node) && (parentIds == null || parentIds.Length == 0))
+                if (!GetNode(id, out var node) && (parentIds == null || parentIds.Count == 0))
                 {
                     var newJunction = new Junction(node, node);
                     _junctions.Add(newJunction);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -21,9 +21,7 @@ namespace GitUI.RevisionGridClasses
             private readonly List<Junction> _junctions = new List<Junction>();
             public readonly Dictionary<string, Node> Nodes = new Dictionary<string, Node>();
             private readonly Lanes _lanes;
-            private int _filterNodeCount;
 
-            private bool _isFilter;
             private int _nodeCount;
             private int _processedNodes;
 
@@ -32,65 +30,11 @@ namespace GitUI.RevisionGridClasses
                 _lanes = new Lanes(this);
             }
 
-            public bool IsFilter
-            {
-                get { return _isFilter; }
-                set
-                {
-                    _isFilter = value;
-                    _lanes.Clear();
-                    foreach (Node n in Nodes.Values)
-                    {
-                        n.InLane = int.MaxValue;
-                    }
-
-                    foreach (Junction j in _junctions)
-                    {
-                        j.CurrentState = Junction.State.Unprocessed;
-                    }
-
-                    // We need to signal the DvcsGraph object that it needs to
-                    // redraw everything.
-                    Updated?.Invoke(this);
-                }
-            }
-
-            public int Count
-            {
-                get
-                {
-                    if (IsFilter)
-                    {
-                        return _filterNodeCount;
-                    }
-
-                    return _nodeCount;
-                }
-            }
+            public int Count => _nodeCount;
 
             public ILaneRow this[int col] => _lanes[col];
 
             public int CachedCount => _lanes.CachedCount;
-
-            public void Filter(string id)
-            {
-                Node node = Nodes[id];
-
-                if (!node.IsFiltered)
-                {
-                    _filterNodeCount++;
-                    node.IsFiltered = true;
-                }
-
-                // Clear the filtered lane data.
-                // TODO: We could be smart and only clear items after Node[id]. The check
-                // below isn't valid, since it could be either the filtered or unfiltered
-                // lane...
-                ////if (node.InLane != int.MaxValue)
-                ////{
-                ////   filteredLanes.Clear();
-                ////}
-            }
 
             public void ClearHighlightBranch()
             {
@@ -254,16 +198,10 @@ namespace GitUI.RevisionGridClasses
                 Nodes.Clear();
                 _lanes.Clear();
                 _nodeCount = 0;
-                _filterNodeCount = 0;
             }
 
             public void ProcessNode(Node node)
             {
-                if (_isFilter)
-                {
-                    return;
-                }
-
                 for (int i = _processedNodes; i < AddedNodes.Count; i++)
                 {
                     if (AddedNodes[i] == node)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -242,7 +242,8 @@ namespace GitUI.RevisionGridClasses
 
             public IEnumerable<Node> GetRefs()
             {
-                var nodes = new List<Node>();
+                var nodes = new List<Node>(capacity: _junctions.Count);
+
                 foreach (Junction j in _junctions)
                 {
                     if (j.Youngest.Descendants.Count == 0 && !nodes.Contains(j.Youngest))

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Graph.cs
@@ -77,8 +77,7 @@ namespace GitUI.RevisionGridClasses
                 // If we haven't seen this node yet, create a new junction.
                 if (!GetNode(revision.Guid, out var node) && (parentIds == null || parentIds.Count == 0))
                 {
-                    var newJunction = new Junction(node, node);
-                    _junctions.Add(newJunction);
+                    _junctions.Add(new Junction(node, node));
                 }
 
                 Count++;
@@ -116,28 +115,23 @@ namespace GitUI.RevisionGridClasses
                     else if (node.Ancestors.Count == 1 && node.Ancestors[0].Youngest != node)
                     {
                         // The node is in the middle of a junction. We need to split it.
-                        Junction splitNode = node.Ancestors[0].Split(node);
-                        _junctions.Add(splitNode);
+                        _junctions.Add(node.Ancestors[0].SplitIntoJunctionWith(node));
 
                         // The node is a junction point. We are a new junction
-                        var junction = new Junction(node, parent);
-                        _junctions.Add(junction);
+                        _junctions.Add(new Junction(node, parent));
                     }
                     else if (parent.Descendants.Count == 1 && parent.Descendants[0].Oldest != parent)
                     {
                         // The parent is in the middle of a junction. We need to split it.
-                        Junction splitNode = parent.Descendants[0].Split(parent);
-                        _junctions.Add(splitNode);
+                        _junctions.Add(parent.Descendants[0].SplitIntoJunctionWith(parent));
 
                         // The node is a junction point. We are a new junction
-                        var junction = new Junction(node, parent);
-                        _junctions.Add(junction);
+                        _junctions.Add(new Junction(node, parent));
                     }
                     else
                     {
                         // The node is a junction point. We are a new junction
-                        var junction = new Junction(node, parent);
-                        _junctions.Add(junction);
+                        _junctions.Add(new Junction(node, parent));
                     }
                 }
 
@@ -394,8 +388,7 @@ namespace GitUI.RevisionGridClasses
 
                 public LaneInfo Clone()
                 {
-                    var other = new LaneInfo { ConnectLane = ConnectLane, _junctions = new List<Junction>(_junctions) };
-                    return other;
+                    return new LaneInfo { ConnectLane = ConnectLane, _junctions = new List<Junction>(_junctions) };
                 }
 
                 public void UnionWith(LaneInfo other)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Junction.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.Junction.cs
@@ -89,7 +89,7 @@ namespace GitUI.RevisionGridClasses
                 Oldest.Ancestors.Remove(this);
             }
 
-            public Junction Split(Node node)
+            public Junction SplitIntoJunctionWith(Node node)
             {
                 // The 'top' (Child->node) of the junction is retained by this.
                 // The 'bottom' (node->Parent) of the junction is returned.

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1060,14 +1060,16 @@ namespace GitUI.RevisionGridClasses
                         Point c0, c1;
                         if (singleLane)
                         {
-                            c0 = c1 = Point.Empty;
+                            c0 = c1 = default;
                         }
                         else
                         {
-                            // Controls the curvature of cross-lane lines (0 = straight line, 1 = 90 degree turns)
-                            const float severity = 0.5f;
-                            c0 = new Point(x0, (int)((y0 * (1.0f - severity)) + (y1 * severity)));
-                            c1 = new Point(x1, (int)((y1 * (1.0f - severity)) + (y0 * severity)));
+                            // Left shifting int is fast equivalent of dividing by two,
+                            // thus computing the average of y0 and y1.
+                            var yMid = (y0 + y1) >> 1;
+
+                            c0 = new Point(x0, yMid);
+                            c1 = new Point(x1, yMid);
                         }
 
                         for (int i = drawBorder ? 0 : 2; i < 3; i++)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -62,7 +62,7 @@ namespace GitUI.RevisionGridClasses
         private Pen _blackBorderPen;
 
         private readonly AutoResetEvent _backgroundEvent = new AutoResetEvent(false);
-        private readonly Dictionary<Junction, int> _junctionColors = new Dictionary<Junction, int>();
+        private readonly Dictionary<Junction, int> _colorByJunction = new Dictionary<Junction, int>();
         private readonly Color _nonRelativeColor = Color.LightGray;
 
         private readonly Graph _graphData = new Graph();
@@ -315,7 +315,7 @@ namespace GitUI.RevisionGridClasses
             lock (_graphData)
             {
                 SetRowCount(0);
-                _junctionColors.Clear();
+                _colorByJunction.Clear();
                 _graphData.Clear();
                 _graphDataCount = 0;
                 RebuildGraph();
@@ -744,7 +744,7 @@ namespace GitUI.RevisionGridClasses
             }
 
             // See if this junciton's colour has already been calculated
-            if (_junctionColors.TryGetValue(junction, out var colorIndex))
+            if (_colorByJunction.TryGetValue(junction, out var colorIndex))
             {
                 return _possibleColors[colorIndex];
             }
@@ -754,7 +754,7 @@ namespace GitUI.RevisionGridClasses
             _adjacentColors.Clear();
             _adjacentColors.AddRange(
                 from peer in GetPeers().SelectMany()
-                where _junctionColors.TryGetValue(peer, out colorIndex)
+                where _colorByJunction.TryGetValue(peer, out colorIndex)
                 select colorIndex);
 
             if (_adjacentColors.Count == 0)
@@ -782,7 +782,7 @@ namespace GitUI.RevisionGridClasses
                 }
             }
 
-            _junctionColors[junction] = colorIndex;
+            _colorByJunction[junction] = colorIndex;
             return _possibleColors[colorIndex];
 
             // Get adjacent (peer) junctions

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -15,7 +15,7 @@ namespace GitUI.RevisionGridClasses
 {
     public sealed partial class DvcsGraph : DataGridView
     {
-        #region Delegates
+        #region EventArgs
 
         public class LoadingEventArgs : EventArgs
         {
@@ -161,26 +161,10 @@ namespace GitUI.RevisionGridClasses
             }
         }
 
-        /// <summary>
-        /// 0
-        /// </summary>
         internal DataGridViewColumn GraphColumn => Columns[0];
-
-        /// <summary>
-        /// 1
-        /// </summary>
         internal DataGridViewColumn MessageColumn => Columns[1];
-
-        /// <summary>
-        /// 2
-        /// </summary>
         internal DataGridViewColumn AuthorColumn => Columns[2];
-
-        /// <summary>
-        /// 3
-        /// </summary>
         internal DataGridViewColumn DateColumn => Columns[3];
-
         internal DataGridViewColumn IdColumn => Columns[4];
 
         public void ShowAuthor(bool show)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1009,8 +1009,8 @@ namespace GitUI.RevisionGridClasses
                     UpdateJunctionColors(laneInfo.Junctions);
 
                     // Create the brush for drawing the line
-                    Brush brushLineColor = null;
-                    Pen brushLineColorPen = null;
+                    Brush lineBrush = null;
+                    Pen linePen = null;
                     try
                     {
                         bool drawBorder = highLight && AppSettings.BranchBorders; // hide border for "non-relatives"
@@ -1019,16 +1019,16 @@ namespace GitUI.RevisionGridClasses
                         {
                             if (_junctionColors[0] != _nonRelativeColor)
                             {
-                                brushLineColor = new SolidBrush(_junctionColors[0]);
+                                lineBrush = new SolidBrush(_junctionColors[0]);
                             }
                             else if (_junctionColors.Count > 1 && _junctionColors[1] != _nonRelativeColor)
                             {
-                                brushLineColor = new SolidBrush(_junctionColors[1]);
+                                lineBrush = new SolidBrush(_junctionColors[1]);
                             }
                             else
                             {
                                 drawBorder = false;
-                                brushLineColor = new SolidBrush(_nonRelativeColor);
+                                lineBrush = new SolidBrush(_nonRelativeColor);
                             }
                         }
                         else
@@ -1037,20 +1037,20 @@ namespace GitUI.RevisionGridClasses
 
                             if (lastRealColor.IsEmpty)
                             {
-                                brushLineColor = new SolidBrush(_nonRelativeColor);
+                                lineBrush = new SolidBrush(_nonRelativeColor);
                                 drawBorder = false;
                             }
                             else
                             {
-                                brushLineColor = new HatchBrush(HatchStyle.DarkDownwardDiagonal, _junctionColors[0], lastRealColor);
+                                lineBrush = new HatchBrush(HatchStyle.DarkDownwardDiagonal, _junctionColors[0], lastRealColor);
                             }
                         }
 
                         // Precalculate line endpoints
-                        bool singleLane = laneInfo.ConnectLane == lane;
+                        bool sameLane = laneInfo.ConnectLane == lane;
                         int x0 = mid;
                         int y0 = top - 1;
-                        int x1 = singleLane ? x0 : mid + ((laneInfo.ConnectLane - lane) * _laneWidth);
+                        int x1 = sameLane ? x0 : mid + ((laneInfo.ConnectLane - lane) * _laneWidth);
                         int y1 = top + _rowHeight;
 
                         Point p0 = new Point(x0, y0);
@@ -1058,8 +1058,10 @@ namespace GitUI.RevisionGridClasses
 
                         // Precalculate curve control points when needed
                         Point c0, c1;
-                        if (singleLane)
+                        if (sameLane)
                         {
+                            // We are drawing between two points in the same
+                            // lane, so there will be no curve
                             c0 = c1 = default;
                         }
                         else
@@ -1074,39 +1076,39 @@ namespace GitUI.RevisionGridClasses
 
                         for (int i = drawBorder ? 0 : 2; i < 3; i++)
                         {
-                            Pen penLine;
+                            Pen pen;
                             switch (i)
                             {
                                 case 0:
-                                    penLine = _whiteBorderPen;
+                                    pen = _whiteBorderPen;
                                     break;
                                 case 1:
-                                    penLine = _blackBorderPen;
+                                    pen = _blackBorderPen;
                                     break;
                                 default:
-                                    if (brushLineColorPen == null)
+                                    if (linePen == null)
                                     {
-                                        brushLineColorPen = new Pen(brushLineColor, _laneLineWidth);
+                                        linePen = new Pen(lineBrush, _laneLineWidth);
                                     }
 
-                                    penLine = brushLineColorPen;
+                                    pen = linePen;
                                     break;
                             }
 
-                            if (singleLane)
+                            if (sameLane)
                             {
-                                wa.DrawLine(penLine, p0, p1);
+                                wa.DrawLine(pen, p0, p1);
                             }
                             else
                             {
-                                wa.DrawBezier(penLine, p0, c0, c1, p1);
+                                wa.DrawBezier(pen, p0, c0, c1, p1);
                             }
                         }
                     }
                     finally
                     {
-                        brushLineColorPen?.Dispose();
-                        brushLineColor?.Dispose();
+                        linePen?.Dispose();
+                        lineBrush?.Dispose();
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1289,6 +1289,8 @@ namespace GitUI.RevisionGridClasses
                 }
             }
 
+            nodeBrush.Dispose();
+
             return true;
         }
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -32,7 +32,7 @@ namespace GitUI.RevisionGridClasses
         #region DataType enum
 
         [Flags]
-        public enum DataType
+        public enum DataTypes
         {
             Normal = 0,
             Active = 1,
@@ -294,11 +294,11 @@ namespace GitUI.RevisionGridClasses
         [Browsable(false)]
         public bool RevisionGraphVisible => GraphColumn.Visible;
 
-        public void Add(GitRevision revision, DataType type)
+        public void Add(GitRevision revision, DataTypes types)
         {
             lock (_graphData)
             {
-                _graphData.Add(revision, type);
+                _graphData.Add(revision, types);
             }
 
             UpdateData();
@@ -1295,7 +1295,7 @@ namespace GitUI.RevisionGridClasses
             public readonly List<Junction> Descendants = new List<Junction>();
             public readonly string Id;
             public GitRevision Data;
-            public DataType DataType;
+            public DataTypes DataTypes;
             public int InLane = int.MaxValue;
             public int Index = int.MaxValue;
 
@@ -1304,25 +1304,25 @@ namespace GitUI.RevisionGridClasses
                 Id = id;
             }
 
-            public bool IsActive => (DataType & DataType.Active) == DataType.Active;
+            public bool IsActive => (DataTypes & DataTypes.Active) == DataTypes.Active;
 
             public bool IsFiltered
             {
-                get { return (DataType & DataType.Filtered) == DataType.Filtered; }
+                get { return (DataTypes & DataTypes.Filtered) == DataTypes.Filtered; }
                 set
                 {
                     if (value)
                     {
-                        DataType |= DataType.Filtered;
+                        DataTypes |= DataTypes.Filtered;
                     }
                     else
                     {
-                        DataType &= ~DataType.Filtered;
+                        DataTypes &= ~DataTypes.Filtered;
                     }
                 }
             }
 
-            public bool IsSpecial => (DataType & DataType.Special) == DataType.Special;
+            public bool IsSpecial => (DataTypes & DataTypes.Special) == DataTypes.Special;
 
             public override string ToString()
             {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1289,8 +1289,8 @@ namespace GitUI.RevisionGridClasses
                 Id = id;
             }
 
-            public bool IsActive => (DataTypes & DataTypes.Active) == DataTypes.Active;
-            public bool IsSpecial => (DataTypes & DataTypes.Special) == DataTypes.Special;
+            public bool IsActive => DataTypes.HasFlag(DataTypes.Active);
+            public bool IsSpecial => DataTypes.HasFlag(DataTypes.Special);
 
             public override string ToString()
             {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1276,8 +1276,8 @@ namespace GitUI.RevisionGridClasses
 
         private sealed class Node
         {
-            public readonly List<Junction> Ancestors = new List<Junction>();
-            public readonly List<Junction> Descendants = new List<Junction>();
+            public readonly List<Junction> Ancestors = new List<Junction>(capacity: 2);
+            public readonly List<Junction> Descendants = new List<Junction>(capacity: 2);
             public readonly string Id;
             public GitRevision Data;
             public DataTypes DataTypes;

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -294,11 +294,11 @@ namespace GitUI.RevisionGridClasses
         [Browsable(false)]
         public bool RevisionGraphVisible => GraphColumn.Visible;
 
-        public void Add(string id, IReadOnlyList<string> parentIds, DataType type, GitRevision data)
+        public void Add(GitRevision revision, DataType type)
         {
             lock (_graphData)
             {
-                _graphData.Add(id, parentIds, type, data);
+                _graphData.Add(revision, type);
             }
 
             UpdateData();

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -63,9 +63,10 @@ namespace GitUI.RevisionGridClasses
         private Pen _blackBorderPen;
 
         private readonly AutoResetEvent _backgroundEvent = new AutoResetEvent(false);
-        private readonly Graph _graphData;
         private readonly Dictionary<Junction, int> _junctionColors = new Dictionary<Junction, int>();
         private readonly Color _nonRelativeColor = Color.LightGray;
+
+        private readonly Graph _graphData = new Graph();
 
         private readonly Color[] _possibleColors =
             {
@@ -107,8 +108,6 @@ namespace GitUI.RevisionGridClasses
 
         public DvcsGraph()
         {
-            _graphData = new Graph();
-
             _backgroundThread = new Thread(BackgroundThreadEntry)
             {
                 IsBackground = true,

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1276,13 +1276,14 @@ namespace GitUI.RevisionGridClasses
 
         private sealed class Node
         {
-            public readonly List<Junction> Ancestors = new List<Junction>(capacity: 2);
-            public readonly List<Junction> Descendants = new List<Junction>(capacity: 2);
-            public readonly string Id;
-            public GitRevision Data;
-            public DataTypes DataTypes;
-            public int InLane = int.MaxValue;
-            public int Index = int.MaxValue;
+            public List<Junction> Ancestors { get; } = new List<Junction>(capacity: 2);
+            public List<Junction> Descendants { get; } = new List<Junction>(capacity: 2);
+            public string Id { get; }
+
+            public GitRevision Data { get; set; }
+            public DataTypes DataTypes { get; set; }
+            public int InLane { get; set; } = int.MaxValue;
+            public int Index { get; set; } = int.MaxValue;
 
             public Node(string id)
             {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -989,7 +989,7 @@ namespace GitUI.RevisionGridClasses
             else
             {
                 // Item already in the cache
-                return CreateRectangle(neededRow, width);
+                return CreateRectangle();
             }
 
             if (RevisionGraphVisible)
@@ -1000,7 +1000,16 @@ namespace GitUI.RevisionGridClasses
                 }
             }
 
-            return CreateRectangle(neededRow, width);
+            return CreateRectangle();
+
+            Rectangle CreateRectangle()
+            {
+                return new Rectangle(
+                    0,
+                    ((_cacheHeadRow + neededRow - _cacheHead) % _cacheCountMax) * RowTemplate.Height,
+                    width,
+                    _rowHeight);
+            }
         }
 
         private bool DrawVisibleGraph(int start, int end)
@@ -1057,15 +1066,6 @@ namespace GitUI.RevisionGridClasses
             }
 
             return true;
-        }
-
-        private Rectangle CreateRectangle(int neededRow, int width)
-        {
-            return new Rectangle(
-                0,
-                ((_cacheHeadRow + neededRow - _cacheHead) % _cacheCountMax) * RowTemplate.Height,
-                width,
-                _rowHeight);
         }
 
         // end drawGraph

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -53,10 +53,10 @@ namespace GitUI.RevisionGridClasses
 
         #endregion
 
-        private int _nodeDimension = DpiUtil.Scale(10);
-        private int _laneWidth = DpiUtil.Scale(13);
-        private int _laneSidePadding = DpiUtil.Scale(4);
-        private int _laneLineWidth = DpiUtil.Scale(2);
+        private readonly int _nodeDimension = DpiUtil.Scale(10);
+        private readonly int _laneWidth = DpiUtil.Scale(13);
+        private readonly int _laneSidePadding = DpiUtil.Scale(4);
+        private readonly int _laneLineWidth = DpiUtil.Scale(2);
         private const int MaxLanes = 40;
 
         private Pen _whiteBorderPen;
@@ -98,13 +98,9 @@ namespace GitUI.RevisionGridClasses
         private int _visibleBottom;
         private int _visibleTop;
 
-        public void SetDimensions(int nodeDimension, int laneWidth, int laneLineWidth, int rowHeight, int laneSidePadding)
+        public void SetRowHeight(int rowHeight)
         {
             RowTemplate.Height = rowHeight;
-            _nodeDimension = DpiUtil.Scale(nodeDimension);
-            _laneWidth = DpiUtil.Scale(laneWidth);
-            _laneSidePadding = DpiUtil.Scale(laneSidePadding);
-            _laneLineWidth = DpiUtil.Scale(laneLineWidth);
 
             dataGrid_Resize(null, null);
         }

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1246,30 +1246,30 @@ namespace GitUI.RevisionGridClasses
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if (e.KeyData == Keys.Home)
+            switch (e.KeyData)
             {
-                if (RowCount != 0)
-                {
-                    ClearSelection();
-                    Rows[0].Selected = true;
-                    CurrentCell = Rows[0].Cells[1];
-                }
+                case Keys.Home:
+                    if (RowCount != 0)
+                    {
+                        ClearSelection();
+                        Rows[0].Selected = true;
+                        CurrentCell = Rows[0].Cells[1];
+                    }
 
-                return;
+                    break;
+                case Keys.End:
+                    if (RowCount != 0)
+                    {
+                        ClearSelection();
+                        Rows[RowCount - 1].Selected = true;
+                        CurrentCell = Rows[RowCount - 1].Cells[1];
+                    }
+
+                    break;
+                default:
+                    base.OnKeyDown(e);
+                    break;
             }
-            else if (e.KeyData == Keys.End)
-            {
-                if (RowCount != 0)
-                {
-                    ClearSelection();
-                    Rows[RowCount - 1].Selected = true;
-                    CurrentCell = Rows[RowCount - 1].Cells[1];
-                }
-
-                return;
-            }
-
-            base.OnKeyDown(e);
         }
 
         #region Nested type: Node

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -929,6 +929,12 @@ namespace GitUI.RevisionGridClasses
                     _graphBitmap = null;
                 }
 
+                if (_graphWorkArea != null)
+                {
+                    _graphWorkArea.Dispose();
+                    _graphWorkArea = null;
+                }
+
                 if (width > 0 && height > 0)
                 {
                     _graphBitmap = new Bitmap(Math.Max(width, _laneWidth * 3), height, PixelFormat.Format32bppPArgb);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -670,7 +670,7 @@ namespace GitUI.RevisionGridClasses
             {
                 if (_revisionGraphDrawStyle == RevisionGraphDrawStyleEnum.HighlightSelected)
                 {
-                    return _revisionGraphDrawStyle;
+                    return RevisionGraphDrawStyleEnum.HighlightSelected;
                 }
 
                 if (AppSettings.RevisionGraphDrawNonRelativesGray)

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -294,7 +294,7 @@ namespace GitUI.RevisionGridClasses
         [Browsable(false)]
         public bool RevisionGraphVisible => GraphColumn.Visible;
 
-        public void Add(string id, string[] parentIds, DataType type, GitRevision data)
+        public void Add(string id, IReadOnlyList<string> parentIds, DataType type, GitRevision data)
         {
             lock (_graphData)
             {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -55,6 +55,7 @@ namespace GitUI.RevisionGridClasses
 
         private int _nodeDimension = DpiUtil.Scale(10);
         private int _laneWidth = DpiUtil.Scale(13);
+        private int _laneSidePadding = DpiUtil.Scale(4);
         private int _laneLineWidth = DpiUtil.Scale(2);
         private const int MaxLanes = 40;
 
@@ -97,11 +98,12 @@ namespace GitUI.RevisionGridClasses
         private int _visibleBottom;
         private int _visibleTop;
 
-        public void SetDimensions(int nodeDimension, int laneWidth, int laneLineWidth, int rowHeight)
+        public void SetDimensions(int nodeDimension, int laneWidth, int laneLineWidth, int rowHeight, int laneSidePadding)
         {
             RowTemplate.Height = rowHeight;
             _nodeDimension = DpiUtil.Scale(nodeDimension);
             _laneWidth = DpiUtil.Scale(laneWidth);
+            _laneSidePadding = DpiUtil.Scale(laneSidePadding);
             _laneLineWidth = DpiUtil.Scale(laneLineWidth);
 
             dataGrid_Resize(null, null);
@@ -769,7 +771,7 @@ namespace GitUI.RevisionGridClasses
 
                 if (GraphColumn.Width != _laneWidth * laneCount && _laneWidth * laneCount > GraphColumn.MinimumWidth)
                 {
-                    GraphColumn.Width = _laneWidth * laneCount;
+                    GraphColumn.Width = (_laneWidth * laneCount) + (_laneSidePadding * 2);
                 }
             }
         }
@@ -1023,7 +1025,7 @@ namespace GitUI.RevisionGridClasses
 
                 // Get the x,y value of the current item's upper left in the cache
                 int curCacheRow = (_cacheHeadRow + rowIndex - _cacheHead) % _cacheCountMax;
-                const int x = 0;
+                int x = _laneSidePadding;
                 int y = curCacheRow * _rowHeight;
 
                 var laneRect = new Rectangle(0, y, Width, _rowHeight);

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -1210,82 +1210,82 @@ namespace GitUI.RevisionGridClasses
 
             // Reset the clip region
             wa.Clip = oldClip;
+
+            // Draw node
+            var nodeRect = new Rectangle(
+                wa.RenderingOrigin.X + ((_laneWidth - _nodeDimension) / 2) + (row.NodeLane * _laneWidth),
+                wa.RenderingOrigin.Y + ((_rowHeight - _nodeDimension) / 2),
+                _nodeDimension,
+                _nodeDimension);
+
+            Brush nodeBrush;
+
+            List<Color> nodeColors = GetJunctionColors(row.Node.Ancestors);
+
+            bool highlight = (_revisionGraphDrawStyleCache == RevisionGraphDrawStyleEnum.DrawNonRelativesGray && row.Node.Ancestors.Any(j => j.IsRelative)) ||
+                             (_revisionGraphDrawStyleCache == RevisionGraphDrawStyleEnum.HighlightSelected && row.Node.Ancestors.Any(j => j.HighLight)) ||
+                             (_revisionGraphDrawStyleCache == RevisionGraphDrawStyleEnum.Normal);
+
+            bool drawNodeBorder = AppSettings.BranchBorders && highlight;
+
+            if (nodeColors.Count == 1)
             {
-                // Draw node
-                var nodeRect = new Rectangle(
-                    wa.RenderingOrigin.X + ((_laneWidth - _nodeDimension) / 2) + (row.NodeLane * _laneWidth),
-                    wa.RenderingOrigin.Y + ((_rowHeight - _nodeDimension) / 2),
-                    _nodeDimension,
-                    _nodeDimension);
-
-                Brush nodeBrush;
-
-                List<Color> nodeColors = GetJunctionColors(row.Node.Ancestors);
-
-                bool highlight = (_revisionGraphDrawStyleCache == RevisionGraphDrawStyleEnum.DrawNonRelativesGray && row.Node.Ancestors.Any(j => j.IsRelative)) ||
-                                 (_revisionGraphDrawStyleCache == RevisionGraphDrawStyleEnum.HighlightSelected && row.Node.Ancestors.Any(j => j.HighLight)) ||
-                                 (_revisionGraphDrawStyleCache == RevisionGraphDrawStyleEnum.Normal);
-
-                bool drawBorder = AppSettings.BranchBorders && highlight;
-
-                if (nodeColors.Count == 1)
+                nodeBrush = new SolidBrush(highlight ? nodeColors[0] : _nonRelativeColor);
+                if (nodeColors[0] == _nonRelativeColor)
                 {
-                    nodeBrush = new SolidBrush(highlight ? nodeColors[0] : _nonRelativeColor);
-                    if (nodeColors[0] == _nonRelativeColor)
-                    {
-                        drawBorder = false;
-                    }
+                    drawNodeBorder = false;
                 }
-                else
+            }
+            else
+            {
+                nodeBrush = new LinearGradientBrush(
+                    nodeRect, nodeColors[0], nodeColors[1],
+                    LinearGradientMode.Horizontal);
+                if (nodeColors.All(c => c == _nonRelativeColor))
                 {
-                    nodeBrush = new LinearGradientBrush(nodeRect, nodeColors[0], nodeColors[1],
-                                                        LinearGradientMode.Horizontal);
-                    if (nodeColors.All(c => c == _nonRelativeColor))
-                    {
-                        drawBorder = false;
-                    }
+                    drawNodeBorder = false;
                 }
+            }
 
-                if (_filterMode == FilterType.Highlight && row.Node.IsFiltered)
-                {
-                    Rectangle highlightRect = nodeRect;
-                    highlightRect.Inflate(2, 3);
-                    wa.FillRectangle(Brushes.Yellow, highlightRect);
-                    wa.DrawRectangle(Pens.Black, highlightRect);
-                }
+            if (_filterMode == FilterType.Highlight && row.Node.IsFiltered)
+            {
+                Rectangle highlightRect = nodeRect;
+                highlightRect.Inflate(2, 3);
+                wa.FillRectangle(Brushes.Yellow, highlightRect);
+                wa.DrawRectangle(Pens.Black, highlightRect);
+            }
 
-                if (row.Node.Data == null)
+            if (row.Node.Data == null)
+            {
+                wa.FillEllipse(Brushes.White, nodeRect);
+                using (var pen = new Pen(Color.Red, 2))
                 {
-                    wa.FillEllipse(Brushes.White, nodeRect);
-                    using (var pen = new Pen(Color.Red, 2))
-                    {
-                        wa.DrawEllipse(pen, nodeRect);
-                    }
+                    wa.DrawEllipse(pen, nodeRect);
                 }
-                else if (row.Node.IsActive)
+            }
+            else if (row.Node.IsActive)
+            {
+                wa.FillRectangle(nodeBrush, nodeRect);
+                nodeRect.Inflate(1, 1);
+                using (var pen = new Pen(Color.Black, 3))
                 {
-                    wa.FillRectangle(nodeBrush, nodeRect);
-                    nodeRect.Inflate(1, 1);
-                    using (var pen = new Pen(Color.Black, 3))
-                    {
-                        wa.DrawRectangle(pen, nodeRect);
-                    }
+                    wa.DrawRectangle(pen, nodeRect);
                 }
-                else if (row.Node.IsSpecial)
+            }
+            else if (row.Node.IsSpecial)
+            {
+                wa.FillRectangle(nodeBrush, nodeRect);
+                if (drawNodeBorder)
                 {
-                    wa.FillRectangle(nodeBrush, nodeRect);
-                    if (drawBorder)
-                    {
-                        wa.DrawRectangle(Pens.Black, nodeRect);
-                    }
+                    wa.DrawRectangle(Pens.Black, nodeRect);
                 }
-                else
+            }
+            else
+            {
+                wa.FillEllipse(nodeBrush, nodeRect);
+                if (drawNodeBorder)
                 {
-                    wa.FillEllipse(nodeBrush, nodeRect);
-                    if (drawBorder)
-                    {
-                        wa.DrawEllipse(Pens.Black, nodeRect);
-                    }
+                    wa.DrawEllipse(Pens.Black, nodeRect);
                 }
             }
 

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -36,18 +36,7 @@ namespace GitUI.RevisionGridClasses
         {
             Normal = 0,
             Active = 1,
-            Special = 2,
-            Filtered = 4,
-        }
-
-        #endregion
-
-        #region FilterType enum
-
-        public enum FilterType
-        {
-            None,
-            Highlight
+            Special = 2
         }
 
         #endregion
@@ -90,7 +79,6 @@ namespace GitUI.RevisionGridClasses
         private int _cacheCountMax; // Number of elements allowed in the cache. Is based on control height.
         private int _cacheHead = -1; // The 'slot' that is the head of the circular bitmap
         private int _cacheHeadRow; // The node row that is in the head slot
-        private FilterType _filterMode = FilterType.None;
         private Bitmap _graphBitmap;
         private int _graphDataCount;
         private Graphics _graphWorkArea;
@@ -320,8 +308,6 @@ namespace GitUI.RevisionGridClasses
                 _graphDataCount = 0;
                 RebuildGraph();
             }
-
-            _filterMode = FilterType.None;
         }
 
         public bool RowIsRelative(int rowIndex)
@@ -1152,14 +1138,6 @@ namespace GitUI.RevisionGridClasses
                 }
             }
 
-            if (_filterMode == FilterType.Highlight && row.Node.IsFiltered)
-            {
-                Rectangle highlightRect = nodeRect;
-                highlightRect.Inflate(2, 3);
-                wa.FillRectangle(Brushes.Yellow, highlightRect);
-                wa.DrawRectangle(Pens.Black, highlightRect);
-            }
-
             if (row.Node.Data == null)
             {
                 wa.FillEllipse(Brushes.White, nodeRect);
@@ -1312,23 +1290,6 @@ namespace GitUI.RevisionGridClasses
             }
 
             public bool IsActive => (DataTypes & DataTypes.Active) == DataTypes.Active;
-
-            public bool IsFiltered
-            {
-                get { return (DataTypes & DataTypes.Filtered) == DataTypes.Filtered; }
-                set
-                {
-                    if (value)
-                    {
-                        DataTypes |= DataTypes.Filtered;
-                    }
-                    else
-                    {
-                        DataTypes &= ~DataTypes.Filtered;
-                    }
-                }
-            }
-
             public bool IsSpecial => (DataTypes & DataTypes.Special) == DataTypes.Special;
 
             public override string ToString()

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -453,7 +453,7 @@ namespace GitUI.RevisionGridClasses
             }
         }
 
-        private void graphData_Updated(object graph)
+        private void graphData_Updated()
         {
             // We have to post this since the thread owns a lock on GraphData that we'll
             // need in order to re-draw the graph.

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -47,8 +47,7 @@ namespace GitUI.RevisionGridClasses
         public enum FilterType
         {
             None,
-            Highlight,
-            Hide,
+            Highlight
         }
 
         #endregion
@@ -111,7 +110,6 @@ namespace GitUI.RevisionGridClasses
             _backgroundThread = new Thread(BackgroundThreadEntry)
             {
                 IsBackground = true,
-                Priority = ThreadPriority.Normal,
                 Name = "DvcsGraph.backgroundThread"
             };
             _backgroundThread.Start();
@@ -189,63 +187,6 @@ namespace GitUI.RevisionGridClasses
         {
             AuthorColumn.Visible = show;
             DateColumn.Visible = show;
-        }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Justification = "It looks like such lock was made intentionally but it is better to rewrite this")]
-        [DefaultValue(FilterType.None)]
-        [Category("Behavior")]
-        public FilterType FilterMode
-        {
-            get { return _filterMode; }
-            set
-            {
-                // TODO: We only need to rebuild the graph if switching to or from hide
-                if (_filterMode == value)
-                {
-                    return;
-                }
-
-                this.InvokeSync(() =>
-                    {
-                        lock (_backgroundEvent)
-                        {
-                            // Make sure the background thread isn't running
-                            lock (_backgroundThread)
-                            {
-                                _backgroundScrollTo = 0;
-                                _graphDataCount = 0;
-                            }
-
-                            lock (_graphData)
-                            {
-                                _filterMode = value;
-                                _graphData.IsFilter = (_filterMode & FilterType.Hide) == FilterType.Hide;
-                                RebuildGraph();
-                            }
-                        }
-                    });
-            }
-        }
-
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [Browsable(false)]
-        public object[] SelectedData
-        {
-            get
-            {
-                if (SelectedRows.Count == 0)
-                {
-                    return null;
-                }
-
-                var data = new object[SelectedRows.Count];
-                for (int i = 0; i < SelectedRows.Count; i++)
-                {
-                    data[i] = _graphData[i].Node.Data;
-                }
-
-                return data;
-            }
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity")]
@@ -397,27 +338,6 @@ namespace GitUI.RevisionGridClasses
             }
 
             _filterMode = FilterType.None;
-        }
-
-        public void FilterClear()
-        {
-            lock (_graphData)
-            {
-                foreach (Node n in _graphData.Nodes.Values)
-                {
-                    n.IsFiltered = false;
-                }
-
-                _graphData.IsFilter = false;
-            }
-        }
-
-        public void Filter(string id)
-        {
-            lock (_graphData)
-            {
-                _graphData.Filter(id);
-            }
         }
 
         public bool RowIsRelative(int rowIndex)
@@ -1210,7 +1130,7 @@ namespace GitUI.RevisionGridClasses
                     finally
                     {
                         brushLineColorPen?.Dispose();
-                        ((IDisposable)brushLineColor)?.Dispose();
+                        brushLineColor?.Dispose();
                     }
                 }
             }


### PR DESCRIPTION
This PR contains small commits I've cherry-picked out of another PR related to revision loading performance. Probably easiest to review commit-by-commit as the overall diff is a tad confusing in places.

Changes proposed in this pull request:
- Several small screws tightened, such as:
  - Reduce allocations
  - Remove unused code
  - Use `IReadOnlyList<T>`
  - Reduce visibilities
- Add left/right padding to the graph UI (see screenshots below)

## Screenshots

The only visual change is the padding around the graph. Notice how the 'margin' on the left/right matches that at the top afterwards.

### Before

![image](https://user-images.githubusercontent.com/350947/40585344-dd514178-61a8-11e8-8a19-469d68d80fad.png)

### After

![image](https://user-images.githubusercontent.com/350947/40585346-eba66802-61a8-11e8-8c62-cb53584e5c9c.png)

What did I do to test the code and ensure quality:
- Lots of manual testing

I'd prefer this not to be squashed, as any problems will be easier to identify via bisect with small commits.

Has been tested on:
- GIT 2.16.02
- Windows 10
