### PR TITLE
fix: Crash on opening repository in Recent list

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -210,13 +210,14 @@ namespace GitUI.CommandsDialogs
                         _toolStripGitStatus.Visible = false;
                         _toolStripGitStatus.Text = String.Empty;
                     }
-                    else if(status == GitStatusMonitorState.Running)
+                    else if (status == GitStatusMonitorState.Running)
                     {
                         _toolStripGitStatus.Visible = true;
                     }
                 };
 
-                _gitStatusMonitor.GitWorkingDirectoryStatusChanged += (s, e) => {
+                _gitStatusMonitor.GitWorkingDirectoryStatusChanged += (s, e) =>
+                {
                     var status = e.ItemStatuses.ToList();
                     _toolStripGitStatus.Image = commitIconProvider.GetCommitIcon(status);
 
@@ -780,6 +781,13 @@ namespace GitUI.CommandsDialogs
             }
             catch (System.Runtime.InteropServices.COMException ex)
             {
+                // reported in https://github.com/gitextensions/gitextensions/issues/2269
+                Trace.WriteLine(ex.Message, "UpdateJumplist");
+            }
+            catch (IOException ex)
+            {
+                // reported in https://github.com/gitextensions/gitextensions/issues/4549
+                // looks like a regression in Windows 10.0.16299 (1709)
                 Trace.WriteLine(ex.Message, "UpdateJumplist");
             }
 #endif
@@ -2023,7 +2031,7 @@ namespace GitUI.CommandsDialogs
             this.runMergetoolToolStripMenuItem.Enabled =
             this.cherryPickToolStripMenuItem.Enabled =
             this.checkoutToolStripMenuItem.Enabled =
-            this.toolStripMenuItemReflog.Enabled = 
+            this.toolStripMenuItemReflog.Enabled =
             this.bisectToolStripMenuItem.Enabled =
               enabled && !Module.IsBareRepository();
 


### PR DESCRIPTION
Fix for a alleged regression in Windows 10.0.16299 (1709):

```
"The process cannot access the file 'C:\Users\[me]\AppData\Roaming\GitExtensions\GitExtensions\Recent\[my repository].gitext' because it is  being used by another process."
```

Fixes #4549 