### PR TITLE
Left panel tweaks

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -82,7 +82,7 @@ namespace GitUI.BranchTreePanel
 
         private void FilterInRevisionGrid(BaseBranchNode branch)
         {
-            FilterBranchHelper.SetBranchFilter(branch.FullPath, refresh: true);
+            _filterBranchHelper?.SetBranchFilter(branch.FullPath, refresh: true);
         }
 
         private void PopupManageRemotesForm(string remoteName)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -8,6 +8,49 @@ namespace GitUI.BranchTreePanel
     {
         private TreeNode _lastRightClickedNode;
 
+        private void ContextMenuAddExpandCollapseTree(ContextMenuStrip contextMenu)
+        {
+            // Add the following to the every participating context menu:
+            //
+            //    ---------
+            //    Collapse All
+            //    Expand All
+
+            if (!contextMenu.Items.Contains(tsmiSpacer1))
+            {
+                contextMenu.Items.Add(tsmiSpacer1);
+            }
+
+            if (!contextMenu.Items.Contains(mnubtnCollapseAll))
+            {
+                contextMenu.Items.Add(mnubtnCollapseAll);
+            }
+
+            if (!contextMenu.Items.Contains(mnubtnExpandAll))
+            {
+                contextMenu.Items.Add(mnubtnExpandAll);
+            }
+        }
+
+        private void ContextMenuBranchSpecific(ContextMenuStrip contextMenu)
+        {
+            if (contextMenu != menuBranch)
+            {
+                return;
+            }
+
+            var node = (contextMenu.SourceControl as TreeView)?.SelectedNode;
+            if (node == null)
+            {
+                return;
+            }
+
+            var isNotActiveBranch = !((node.Tag as LocalBranchNode)?.IsActive ?? false);
+            mnuBtnCheckoutLocal.Visible = isNotActiveBranch;
+            tsmiSpacer2.Visible = isNotActiveBranch;
+            mnubtnBranchDelete.Visible = isNotActiveBranch;
+        }
+
         private void OnNodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
         {
             _lastRightClickedNode = e.Button == MouseButtons.Right ? e.Node : null;
@@ -99,26 +142,8 @@ namespace GitUI.BranchTreePanel
                 return;
             }
 
-            // Add the following to the every participating context menu:
-            //
-            //    ---------
-            //    Collapse All
-            //    Expand All
-
-            if (!contextMenu.Items.Contains(tsmiSpacer1))
-            {
-                contextMenu.Items.Add(tsmiSpacer1);
-            }
-
-            if (!contextMenu.Items.Contains(mnubtnCollapseAll))
-            {
-                contextMenu.Items.Add(mnubtnCollapseAll);
-            }
-
-            if (!contextMenu.Items.Contains(mnubtnExpandAll))
-            {
-                contextMenu.Items.Add(mnubtnExpandAll);
-            }
+            ContextMenuAddExpandCollapseTree(contextMenu);
+            ContextMenuBranchSpecific(contextMenu);
         }
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace GitUI.BranchTreePanel
@@ -88,6 +89,36 @@ namespace GitUI.BranchTreePanel
         private void PopupManageRemotesForm(string remoteName)
         {
             UICommands.StartRemotesDialog(this, remoteName);
+        }
+
+        private void contextMenu_Opening(object sender, CancelEventArgs e)
+        {
+            var contextMenu = sender as ContextMenuStrip;
+            if (contextMenu == null)
+            {
+                return;
+            }
+
+            // Add the following to the every participating context menu:
+            //
+            //    ---------
+            //    Collapse All
+            //    Expand All
+
+            if (!contextMenu.Items.Contains(tsmiSpacer1))
+            {
+                contextMenu.Items.Add(tsmiSpacer1);
+            }
+
+            if (!contextMenu.Items.Contains(mnubtnCollapseAll))
+            {
+                contextMenu.Items.Add(mnubtnCollapseAll);
+            }
+
+            if (!contextMenu.Items.Contains(mnubtnExpandAll))
+            {
+                contextMenu.Items.Add(mnubtnExpandAll);
+            }
         }
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -96,6 +96,7 @@ namespace GitUI.BranchTreePanel
             this.treeMain.FullRowSelect = true;
             this.treeMain.Location = new System.Drawing.Point(3, 41);
             this.treeMain.Name = "treeMain";
+            this.treeMain.PathSeparator = "/";
             this.treeMain.ShowNodeToolTips = true;
             this.treeMain.Size = new System.Drawing.Size(294, 350);
             this.treeMain.TabIndex = 3;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -320,7 +320,7 @@ namespace GitUI.BranchTreePanel
             // 
             // mnubtnDeleteRemoteBranch
             // 
-            this.mnubtnDeleteRemoteBranch.Image = global::GitUI.Properties.Resources.Delete;
+            this.mnubtnDeleteRemoteBranch.Image = global::GitUI.Properties.Resources.IconBranchDelete;
             this.mnubtnDeleteRemoteBranch.Name = "mnubtnDeleteRemoteBranch";
             this.mnubtnDeleteRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnDeleteRemoteBranch.Text = "&Delete";
@@ -361,7 +361,7 @@ namespace GitUI.BranchTreePanel
             // 
             // mnubtnDeleteTag
             // 
-            this.mnubtnDeleteTag.Image = global::GitUI.Properties.Resources.Delete;
+            this.mnubtnDeleteTag.Image = global::GitUI.Properties.Resources.IconBranchDelete;
             this.mnubtnDeleteTag.Name = "mnubtnDeleteTag";
             this.mnubtnDeleteTag.Size = new System.Drawing.Size(157, 22);
             this.mnubtnDeleteTag.Text = "&Delete";

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -35,11 +35,13 @@ namespace GitUI.BranchTreePanel
             this.components = new System.ComponentModel.Container();
             this.treeMain = new GitUI.UserControls.NativeTreeView();
             this.menuMain = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.mnubtnReload = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiSpacer1 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnCollapseAll = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnExpandAll = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnubtnReload = new System.Windows.Forms.ToolStripMenuItem();
             this.menuBranch = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnuBtnCheckoutLocal = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiSpacer2 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnBranchDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFilterLocalBranchInRevisionGrid = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFilterRemoteBranchInRevisionGrid = new System.Windows.Forms.ToolStripMenuItem();
@@ -54,10 +56,10 @@ namespace GitUI.BranchTreePanel
             this.mnubtnFetchCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFetchOneBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.mnubtnReset = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnubtnRebase = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnMergeBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnRebase = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnCreateBranchBasedOnRemoteBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnReset = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnDeleteRemoteBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFetchAllBranchesFromARemote = new System.Windows.Forms.ToolStripMenuItem();
@@ -68,6 +70,7 @@ namespace GitUI.BranchTreePanel
             this.menuBranchPath = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnDeleteAllBranches = new System.Windows.Forms.ToolStripMenuItem();
             this.menuRemoteRepoNode = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.tsmiSpacer3 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnManageRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.repoTreePanel = new System.Windows.Forms.TableLayoutPanel();
             this.branchSearchPanel = new System.Windows.Forms.TableLayoutPanel();
@@ -76,6 +79,7 @@ namespace GitUI.BranchTreePanel
             this.btnSettings = new System.Windows.Forms.Button();
             this.menuSettings = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiSpacer4 = new System.Windows.Forms.ToolStripSeparator();
             this.menuMain.SuspendLayout();
             this.menuBranch.SuspendLayout();
             this.menuRemotes.SuspendLayout();
@@ -105,11 +109,25 @@ namespace GitUI.BranchTreePanel
             // menuMain
             // 
             this.menuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnubtnReload,
+            this.tsmiSpacer1,
             this.mnubtnCollapseAll,
-            this.mnubtnExpandAll,
-            this.mnubtnReload});
+            this.mnubtnExpandAll});
             this.menuMain.Name = "menuMain";
-            this.menuMain.Size = new System.Drawing.Size(137, 70);
+            this.menuMain.Size = new System.Drawing.Size(137, 76);
+            // 
+            // mnubtnReload
+            // 
+            this.mnubtnReload.Image = global::GitUI.Properties.Resources.arrow_refresh;
+            this.mnubtnReload.Name = "mnubtnReload";
+            this.mnubtnReload.Size = new System.Drawing.Size(136, 22);
+            this.mnubtnReload.Text = "Reload";
+            this.mnubtnReload.ToolTipText = "Reload the tree";
+            // 
+            // tsmiSpacer1
+            // 
+            this.tsmiSpacer1.Name = "tsmiSpacer1";
+            this.tsmiSpacer1.Size = new System.Drawing.Size(133, 6);
             // 
             // mnubtnCollapseAll
             // 
@@ -127,22 +145,15 @@ namespace GitUI.BranchTreePanel
             this.mnubtnExpandAll.Text = "Expand All";
             this.mnubtnExpandAll.ToolTipText = "Expand all nodes";
             // 
-            // mnubtnReload
-            // 
-            this.mnubtnReload.Image = global::GitUI.Properties.Resources.arrow_refresh;
-            this.mnubtnReload.Name = "mnubtnReload";
-            this.mnubtnReload.Size = new System.Drawing.Size(136, 22);
-            this.mnubtnReload.Text = "Reload";
-            this.mnubtnReload.ToolTipText = "Reload the tree";
-            // 
             // menuBranch
             // 
             this.menuBranch.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuBtnCheckoutLocal,
+            this.tsmiSpacer2,
             this.mnubtnBranchDelete,
             this.mnubtnFilterLocalBranchInRevisionGrid});
             this.menuBranch.Name = "contextmenuBranch";
-            this.menuBranch.Size = new System.Drawing.Size(192, 92);
+            this.menuBranch.Size = new System.Drawing.Size(192, 98);
             // 
             // mnuBtnCheckoutLocal
             // 
@@ -151,6 +162,11 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnCheckoutLocal.Size = new System.Drawing.Size(191, 22);
             this.mnuBtnCheckoutLocal.Text = "Checkout";
             this.mnuBtnCheckoutLocal.ToolTipText = "Checkout this branch";
+            // 
+            // tsmiSpacer2
+            // 
+            this.tsmiSpacer2.Name = "tsmiSpacer2";
+            this.tsmiSpacer2.Size = new System.Drawing.Size(188, 6);
             // 
             // mnubtnBranchDelete
             // 
@@ -171,14 +187,14 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnFilterRemoteBranchInRevisionGrid.Image = global::GitUI.Properties.Resources.IconFilter;
             this.mnubtnFilterRemoteBranchInRevisionGrid.Name = "mnubtnFilterRemoteBranchInRevisionGrid";
-            this.mnubtnFilterRemoteBranchInRevisionGrid.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFilterRemoteBranchInRevisionGrid.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFilterRemoteBranchInRevisionGrid.Text = "Show this branch only";
             // 
             // mnubtnBranchCheckout
             // 
             this.mnubtnBranchCheckout.Image = global::GitUI.Properties.Resources.IconBranchCheckout;
             this.mnubtnBranchCheckout.Name = "mnubtnBranchCheckout";
-            this.mnubtnBranchCheckout.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnBranchCheckout.Size = new System.Drawing.Size(193, 22);
             this.mnubtnBranchCheckout.Text = "&Checkout";
             this.mnubtnBranchCheckout.ToolTipText = "Checkout this branch";
             // 
@@ -219,13 +235,13 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteRemoteBranch,
             this.mnubtnFilterRemoteBranchInRevisionGrid});
             this.menuRemote.Name = "contextmenuRemote";
-            this.menuRemote.Size = new System.Drawing.Size(192, 280);
+            this.menuRemote.Size = new System.Drawing.Size(194, 280);
             // 
             // mnubtnRemoteBranchFetchAndCheckout
             // 
             this.mnubtnRemoteBranchFetchAndCheckout.Image = global::GitUI.Properties.Resources.IconBranchCheckout;
             this.mnubtnRemoteBranchFetchAndCheckout.Name = "mnubtnRemoteBranchFetchAndCheckout";
-            this.mnubtnRemoteBranchFetchAndCheckout.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnRemoteBranchFetchAndCheckout.Size = new System.Drawing.Size(193, 22);
             this.mnubtnRemoteBranchFetchAndCheckout.Text = "&Fetch && Checkout";
             this.mnubtnRemoteBranchFetchAndCheckout.ToolTipText = "Checkout this branch";
             // 
@@ -233,14 +249,14 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnPullFromRemoteBranch.Image = global::GitUI.Properties.Resources.IconPull;
             this.mnubtnPullFromRemoteBranch.Name = "mnubtnPullFromRemoteBranch";
-            this.mnubtnPullFromRemoteBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnPullFromRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnPullFromRemoteBranch.Text = "Fetch && Merge (&Pull)";
             // 
             // mnubtnFetchRebase
             // 
             this.mnubtnFetchRebase.Image = global::GitUI.Properties.Resources.IconRebase;
             this.mnubtnFetchRebase.Name = "mnubtnFetchRebase";
-            this.mnubtnFetchRebase.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFetchRebase.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFetchRebase.Text = "Fetch && Re&base";
             this.mnubtnFetchRebase.ToolTipText = "Fetch & Rebase current branch to this branch";
             // 
@@ -248,7 +264,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnFetchCreateBranch.Image = global::GitUI.Properties.MsVsImages.Branch_16x;
             this.mnubtnFetchCreateBranch.Name = "mnubtnFetchCreateBranch";
-            this.mnubtnFetchCreateBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFetchCreateBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFetchCreateBranch.Text = "Fetc&h && Create Branch";
             this.mnubtnFetchCreateBranch.ToolTipText = "Fetch then create a local branch from the remote branch";
             // 
@@ -256,20 +272,20 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnFetchOneBranch.Image = global::GitUI.Properties.Resources.IconStage;
             this.mnubtnFetchOneBranch.Name = "mnubtnFetchOneBranch";
-            this.mnubtnFetchOneBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnFetchOneBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnFetchOneBranch.Text = "Fe&tch";
             this.mnubtnFetchOneBranch.ToolTipText = "Fetch the new remote branch";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(188, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(190, 6);
             // 
             // mnubtnMergeBranch
             // 
             this.mnubtnMergeBranch.Image = global::GitUI.Properties.Resources.IconMerge;
             this.mnubtnMergeBranch.Name = "mnubtnMergeBranch";
-            this.mnubtnMergeBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnMergeBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnMergeBranch.Text = "&Merge";
             this.mnubtnMergeBranch.ToolTipText = "Merge remote branch into current branch";
             // 
@@ -277,7 +293,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnRebase.Image = global::GitUI.Properties.Resources.IconRebase;
             this.mnubtnRebase.Name = "mnubtnRebase";
-            this.mnubtnRebase.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnRebase.Size = new System.Drawing.Size(193, 22);
             this.mnubtnRebase.Text = "&Rebase";
             this.mnubtnRebase.ToolTipText = "Rebase current branch to this branch";
             // 
@@ -285,7 +301,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnCreateBranchBasedOnRemoteBranch.Image = global::GitUI.Properties.MsVsImages.Branch_16x;
             this.mnubtnCreateBranchBasedOnRemoteBranch.Name = "mnubtnCreateBranchBasedOnRemoteBranch";
-            this.mnubtnCreateBranchBasedOnRemoteBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnCreateBranchBasedOnRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnCreateBranchBasedOnRemoteBranch.Text = "Create &Branch...";
             this.mnubtnCreateBranchBasedOnRemoteBranch.ToolTipText = "Create a local branch from the remote branch";
             // 
@@ -293,20 +309,20 @@ namespace GitUI.BranchTreePanel
             // 
             this.mnubtnReset.Image = global::GitUI.Properties.Resources.IconResetCurrentBranchToHere;
             this.mnubtnReset.Name = "mnubtnReset";
-            this.mnubtnReset.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnReset.Size = new System.Drawing.Size(193, 22);
             this.mnubtnReset.Text = "Re&set";
             this.mnubtnReset.ToolTipText = "Reset current branch to here";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(188, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(190, 6);
             // 
             // mnubtnDeleteRemoteBranch
             // 
             this.mnubtnDeleteRemoteBranch.Image = global::GitUI.Properties.Resources.Delete;
             this.mnubtnDeleteRemoteBranch.Name = "mnubtnDeleteRemoteBranch";
-            this.mnubtnDeleteRemoteBranch.Size = new System.Drawing.Size(191, 22);
+            this.mnubtnDeleteRemoteBranch.Size = new System.Drawing.Size(193, 22);
             this.mnubtnDeleteRemoteBranch.Text = "&Delete";
             this.mnubtnDeleteRemoteBranch.ToolTipText = "Delete the branch from the remote";
             // 
@@ -322,9 +338,10 @@ namespace GitUI.BranchTreePanel
             this.menuTag.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnubtnCreateBranchForTag,
             this.mnuBtnCheckoutTag,
+            this.tsmiSpacer4,
             this.mnubtnDeleteTag});
             this.menuTag.Name = "contextmenuTag";
-            this.menuTag.Size = new System.Drawing.Size(158, 70);
+            this.menuTag.Size = new System.Drawing.Size(158, 98);
             // 
             // mnubtnCreateBranchForTag
             // 
@@ -370,9 +387,15 @@ namespace GitUI.BranchTreePanel
             // 
             this.menuRemoteRepoNode.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnubtnFetchAllBranchesFromARemote,
+            this.tsmiSpacer3,
             this.mnubtnManageRemotes});
             this.menuRemoteRepoNode.Name = "contextmenuRemote";
-            this.menuRemoteRepoNode.Size = new System.Drawing.Size(164, 48);
+            this.menuRemoteRepoNode.Size = new System.Drawing.Size(164, 54);
+            // 
+            // tsmiSpacer3
+            // 
+            this.tsmiSpacer3.Name = "tsmiSpacer3";
+            this.tsmiSpacer3.Size = new System.Drawing.Size(160, 6);
             // 
             // mnubtnManageRemotes
             // 
@@ -470,6 +493,11 @@ namespace GitUI.BranchTreePanel
             this.showTagsToolStripMenuItem.Text = "Show &tags";
             this.showTagsToolStripMenuItem.Click += new System.EventHandler(this.ShowTagsToolStripMenuItem_Click);
             // 
+            // tsmiSpacer4
+            // 
+            this.tsmiSpacer4.Name = "tsmiSpacer4";
+            this.tsmiSpacer4.Size = new System.Drawing.Size(154, 6);
+            // 
             // RepoObjectsTree
             // 
             this.Controls.Add(this.repoTreePanel);
@@ -537,5 +565,9 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnuBtnCheckoutTag;
         private ToolStripMenuItem mnubtnFetchRebase;
         private ToolStripMenuItem mnubtnFetchCreateBranch;
+        private ToolStripSeparator tsmiSpacer1;
+        private ToolStripSeparator tsmiSpacer2;
+        private ToolStripSeparator tsmiSpacer3;
+        private ToolStripSeparator tsmiSpacer4;
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -212,7 +212,7 @@ namespace GitUI.BranchTreePanel
             // 
             // mnuBtnManageRemotesFromRootNode
             // 
-            this.mnuBtnManageRemotesFromRootNode.Image = global::GitUI.Properties.MsVsImages.Repository_16x;
+            this.mnuBtnManageRemotesFromRootNode.Image = global::GitUI.Properties.Resources.IconRemotes;
             this.mnuBtnManageRemotesFromRootNode.Name = "mnuBtnManageRemotesFromRootNode";
             this.mnuBtnManageRemotesFromRootNode.Size = new System.Drawing.Size(163, 22);
             this.mnuBtnManageRemotesFromRootNode.Text = "&Manage remotes";
@@ -399,7 +399,7 @@ namespace GitUI.BranchTreePanel
             // 
             // mnubtnManageRemotes
             // 
-            this.mnubtnManageRemotes.Image = global::GitUI.Properties.MsVsImages.Repository_16x;
+            this.mnubtnManageRemotes.Image = global::GitUI.Properties.Resources.IconRemotes;
             this.mnubtnManageRemotes.Name = "mnubtnManageRemotes";
             this.mnubtnManageRemotes.Size = new System.Drawing.Size(163, 22);
             this.mnubtnManageRemotes.Text = "&Manage remotes";

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -66,6 +66,7 @@ namespace GitUI.BranchTreePanel
             this.menuTag = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnCreateBranchForTag = new System.Windows.Forms.ToolStripMenuItem();
             this.mnuBtnCheckoutTag = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiSpacer4 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnDeleteTag = new System.Windows.Forms.ToolStripMenuItem();
             this.menuBranchPath = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnDeleteAllBranches = new System.Windows.Forms.ToolStripMenuItem();
@@ -79,7 +80,6 @@ namespace GitUI.BranchTreePanel
             this.btnSettings = new System.Windows.Forms.Button();
             this.menuSettings = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiSpacer4 = new System.Windows.Forms.ToolStripSeparator();
             this.menuMain.SuspendLayout();
             this.menuBranch.SuspendLayout();
             this.menuRemotes.SuspendLayout();
@@ -115,6 +115,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnExpandAll});
             this.menuMain.Name = "menuMain";
             this.menuMain.Size = new System.Drawing.Size(137, 76);
+            this.menuMain.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // mnubtnReload
             // 
@@ -154,6 +155,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnFilterLocalBranchInRevisionGrid});
             this.menuBranch.Name = "contextmenuBranch";
             this.menuBranch.Size = new System.Drawing.Size(192, 98);
+            this.menuBranch.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // mnuBtnCheckoutLocal
             // 
@@ -209,6 +211,7 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnManageRemotesFromRootNode});
             this.menuRemotes.Name = "contextmenuRemotes";
             this.menuRemotes.Size = new System.Drawing.Size(164, 26);
+            this.menuRemotes.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // mnuBtnManageRemotesFromRootNode
             // 
@@ -236,6 +239,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnFilterRemoteBranchInRevisionGrid});
             this.menuRemote.Name = "contextmenuRemote";
             this.menuRemote.Size = new System.Drawing.Size(194, 280);
+            this.menuRemote.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // mnubtnRemoteBranchFetchAndCheckout
             // 
@@ -341,7 +345,8 @@ namespace GitUI.BranchTreePanel
             this.tsmiSpacer4,
             this.mnubtnDeleteTag});
             this.menuTag.Name = "contextmenuTag";
-            this.menuTag.Size = new System.Drawing.Size(158, 98);
+            this.menuTag.Size = new System.Drawing.Size(158, 76);
+            this.menuTag.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // mnubtnCreateBranchForTag
             // 
@@ -359,6 +364,11 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnCheckoutTag.Text = "&Checkout";
             this.mnuBtnCheckoutTag.ToolTipText = "Checkout this branch";
             // 
+            // tsmiSpacer4
+            // 
+            this.tsmiSpacer4.Name = "tsmiSpacer4";
+            this.tsmiSpacer4.Size = new System.Drawing.Size(154, 6);
+            // 
             // mnubtnDeleteTag
             // 
             this.mnubtnDeleteTag.Image = global::GitUI.Properties.Resources.IconBranchDelete;
@@ -373,6 +383,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteAllBranches});
             this.menuBranchPath.Name = "contextmenuBranch";
             this.menuBranchPath.Size = new System.Drawing.Size(157, 48);
+            this.menuBranchPath.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // mnubtnDeleteAllBranches
             // 
@@ -390,7 +401,8 @@ namespace GitUI.BranchTreePanel
             this.tsmiSpacer3,
             this.mnubtnManageRemotes});
             this.menuRemoteRepoNode.Name = "contextmenuRemote";
-            this.menuRemoteRepoNode.Size = new System.Drawing.Size(164, 54);
+            this.menuRemoteRepoNode.Size = new System.Drawing.Size(164, 76);
+            this.menuRemoteRepoNode.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
             // tsmiSpacer3
             // 
@@ -492,11 +504,6 @@ namespace GitUI.BranchTreePanel
             this.showTagsToolStripMenuItem.Size = new System.Drawing.Size(128, 22);
             this.showTagsToolStripMenuItem.Text = "Show &tags";
             this.showTagsToolStripMenuItem.Click += new System.EventHandler(this.ShowTagsToolStripMenuItem_Click);
-            // 
-            // tsmiSpacer4
-            // 
-            this.tsmiSpacer4.Name = "tsmiSpacer4";
-            this.tsmiSpacer4.Size = new System.Drawing.Size(154, 6);
             // 
             // RepoObjectsTree
             // 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -254,7 +254,6 @@ namespace GitUI.BranchTreePanel
 
                 var currentBranch = Module.GetSelectedBranch();
                 var nodes = new Dictionary<string, BaseBranchNode>();
-                var branchFullPaths = new List<string>();
                 foreach (var branch in branches)
                 {
                     token.ThrowIfCancellationRequested();
@@ -265,8 +264,6 @@ namespace GitUI.BranchTreePanel
                     {
                         Nodes.AddNode(parent);
                     }
-
-                    branchFullPaths.Add(localBranchNode.FullPath);
                 }
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -171,6 +171,7 @@ namespace GitUI.BranchTreePanel
                 {
                     _treeViewNode = value;
                     _treeViewNode.Tag = this;
+                    _treeViewNode.Name = DisplayText();
                     _treeViewNode.Text = DisplayText();
                     _treeViewNode.ContextMenuStrip = GetContextMenuStrip();
                     ApplyStyle();

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -25,6 +25,7 @@ namespace GitUI.BranchTreePanel
         private TagTree _tagTree;
         private RemoteBranchTree _remoteTree;
         private List<TreeNode> _searchResult;
+        private FilterBranchHelper _filterBranchHelper;
         private bool _searchCriteriaChanged;
 
         public RepoObjectsTree()
@@ -49,7 +50,10 @@ namespace GitUI.BranchTreePanel
             mnubtnFilterLocalBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
         }
 
-        public FilterBranchHelper FilterBranchHelper { private get; set; }
+        public void SetBranchFilterer(FilterBranchHelper filterBranchHelper)
+        {
+            _filterBranchHelper = filterBranchHelper;
+        }
 
         public async Task ReloadAsync()
         {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -17,10 +17,15 @@ namespace GitUI.BranchTreePanel
         private readonly TranslationString _showBranchOnly =
             new TranslationString("Filter the revision grid to show this branch only\nTo show all branches, right click the revision grid, select 'view' and then the 'show all branches'");
 
-        public FilterBranchHelper FilterBranchHelper { private get; set; }
-
         private readonly List<Tree> _rootNodes = new List<Tree>();
         private SearchControl<string> _txtBranchCriterion;
+        private readonly CancellationTokenSequence _reloadCancellation = new CancellationTokenSequence();
+        private CancellationToken _currentToken;
+        private TreeNode _tagTreeRootNode;
+        private TagTree _tagTree;
+        private RemoteBranchTree _remoteTree;
+        private List<TreeNode> _searchResult;
+        private bool _searchCriteriaChanged;
 
         public RepoObjectsTree()
         {
@@ -42,6 +47,136 @@ namespace GitUI.BranchTreePanel
             treeMain.NodeMouseDoubleClick += OnNodeDoubleClick;
             mnubtnFilterRemoteBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
             mnubtnFilterLocalBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
+        }
+
+        public FilterBranchHelper FilterBranchHelper { private get; set; }
+
+        public async Task ReloadAsync()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var token = CancelBackgroundTasks();
+            Enabled = false;
+            try
+            {
+                var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            finally
+            {
+                await this.SwitchToMainThreadAsync(token);
+                Enabled = true;
+            }
+        }
+
+        protected override void OnUICommandsSourceChanged(IGitUICommandsSource newSource)
+        {
+            base.OnUICommandsSourceChanged(newSource);
+
+            CancelBackgroundTasks();
+
+            var localBranchesRootNode = new TreeNode(Strings.BranchesText.Text)
+            {
+                ImageKey = nameof(MsVsImages.Repository_16x),
+            };
+            localBranchesRootNode.SelectedImageKey = localBranchesRootNode.ImageKey;
+            AddTree(new BranchTree(localBranchesRootNode, newSource));
+
+            var remoteBranchesRootNode = new TreeNode(Strings.RemotesText.Text)
+            {
+                ImageKey = nameof(MsVsImages.Repository_16x),
+            };
+            remoteBranchesRootNode.SelectedImageKey = remoteBranchesRootNode.ImageKey;
+            _remoteTree = new RemoteBranchTree(remoteBranchesRootNode, newSource)
+            {
+                TreeViewNode =
+                {
+                    ContextMenuStrip = menuRemotes
+                }
+            };
+            AddTree(_remoteTree);
+
+            if (showTagsToolStripMenuItem.Checked)
+            {
+                AddTags();
+            }
+        }
+
+        private static void AddTreeNodeToSearchResult(ICollection<TreeNode> ret, TreeNode node)
+        {
+            node.BackColor = Color.LightYellow;
+            ret.Add(node);
+        }
+
+        private void AddTags()
+        {
+            _tagTreeRootNode = new TreeNode(Strings.TagsText.Text) { ImageKey = nameof(MsVsImages.Tag_16x) };
+            _tagTreeRootNode.SelectedImageKey = _tagTreeRootNode.ImageKey;
+            _tagTree = new TagTree(_tagTreeRootNode, UICommandsSource);
+            AddTree(_tagTree);
+            _searchResult = null;
+        }
+
+        private void AddTree(Tree tree)
+        {
+            tree.TreeViewNode.SelectedImageKey = tree.TreeViewNode.ImageKey;
+            tree.TreeViewNode.Tag = tree;
+            treeMain.Nodes.Add(tree.TreeViewNode);
+            _rootNodes.Add(tree);
+        }
+
+        private CancellationToken CancelBackgroundTasks()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            _currentToken = _reloadCancellation.Next();
+
+            return _currentToken;
+        }
+
+        private IEnumerable<string> CollectFilterCandidates()
+        {
+            var list = new List<string>();
+
+            foreach (TreeNode rootNode in treeMain.Nodes)
+            {
+                CollectFromNodes(rootNode.Nodes);
+            }
+
+            return list;
+
+            void CollectFromNodes(TreeNodeCollection nodes)
+            {
+                foreach (TreeNode node in nodes)
+                {
+                    if (node.Tag is BaseBranchNode branch)
+                    {
+                        if (branch.Nodes.Count == 0)
+                        {
+                            list.Add(branch.FullPath);
+                        }
+                    }
+                    else
+                    {
+                        list.Add(node.Text);
+                    }
+
+                    CollectFromNodes(node.Nodes);
+                }
+            }
+        }
+
+        private TreeNode GetNextSearchResult()
+        {
+            if (_searchResult == null || !_searchResult.Any())
+            {
+                return null;
+            }
+
+            var node = _searchResult.First();
+            _searchResult.RemoveAt(0);
+            _searchResult.Add(node);
+            return node;
         }
 
         private void InitImageList()
@@ -86,36 +221,30 @@ namespace GitUI.BranchTreePanel
                 .Where(r => r.IndexOf(arg, StringComparison.OrdinalIgnoreCase) != -1);
         }
 
-        private IEnumerable<string> CollectFilterCandidates()
+        private static List<TreeNode> SearchTree(string text, TreeNodeCollection nodes)
         {
-            var list = new List<string>();
-
-            foreach (TreeNode rootNode in treeMain.Nodes)
+            var ret = new List<TreeNode>();
+            foreach (TreeNode node in nodes)
             {
-                CollectFromNodes(rootNode.Nodes);
-            }
-
-            return list;
-
-            void CollectFromNodes(TreeNodeCollection nodes)
-            {
-                foreach (TreeNode node in nodes)
+                if (node.Tag is BaseBranchNode branch)
                 {
-                    if (node.Tag is BaseBranchNode branch)
+                    if (branch.FullPath.IndexOf(text, StringComparison.InvariantCultureIgnoreCase) != -1)
                     {
-                        if (branch.Nodes.Count == 0)
-                        {
-                            list.Add(branch.FullPath);
-                        }
+                        AddTreeNodeToSearchResult(ret, node);
                     }
-                    else
-                    {
-                        list.Add(node.Text);
-                    }
-
-                    CollectFromNodes(node.Nodes);
                 }
+                else
+                {
+                    if (node.Text.IndexOf(text, StringComparison.InvariantCultureIgnoreCase) != -1)
+                    {
+                        AddTreeNodeToSearchResult(ret, node);
+                    }
+                }
+
+                ret.AddRange(SearchTree(text, node.Nodes));
             }
+
+            return ret;
         }
 
         private void OnPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
@@ -123,82 +252,6 @@ namespace GitUI.BranchTreePanel
             if (e.KeyCode == Keys.F3 || e.KeyCode == Keys.Enter)
             {
                 OnBtnSearchClicked(null, null);
-            }
-        }
-
-        protected override void OnUICommandsSourceChanged(IGitUICommandsSource newSource)
-        {
-            base.OnUICommandsSourceChanged(newSource);
-
-            CancelBackgroundTasks();
-
-            var localBranchesRootNode = new TreeNode(Strings.BranchesText.Text)
-            {
-                ImageKey = nameof(MsVsImages.Repository_16x),
-            };
-            localBranchesRootNode.SelectedImageKey = localBranchesRootNode.ImageKey;
-            AddTree(new BranchTree(localBranchesRootNode, newSource));
-
-            var remoteBranchesRootNode = new TreeNode(Strings.RemotesText.Text)
-            {
-                ImageKey = nameof(MsVsImages.Repository_16x),
-            };
-            remoteBranchesRootNode.SelectedImageKey = remoteBranchesRootNode.ImageKey;
-            _remoteTree = new RemoteBranchTree(remoteBranchesRootNode, newSource)
-            {
-                TreeViewNode =
-                {
-                    ContextMenuStrip = menuRemotes
-                }
-            };
-            AddTree(_remoteTree);
-
-            if (showTagsToolStripMenuItem.Checked)
-            {
-                AddTags();
-            }
-        }
-
-        private void AddTree(Tree tree)
-        {
-            tree.TreeViewNode.SelectedImageKey = tree.TreeViewNode.ImageKey;
-            tree.TreeViewNode.Tag = tree;
-            treeMain.Nodes.Add(tree.TreeViewNode);
-            _rootNodes.Add(tree);
-        }
-
-        private readonly CancellationTokenSequence _reloadCancellation = new CancellationTokenSequence();
-        private CancellationToken _currentToken;
-        private TreeNode _tagTreeRootNode;
-        private TagTree _tagTree;
-        private RemoteBranchTree _remoteTree;
-        private List<TreeNode> _searchResult;
-        private bool _searchCriteriaChanged;
-
-        private CancellationToken CancelBackgroundTasks()
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            _currentToken = _reloadCancellation.Next();
-
-            return _currentToken;
-        }
-
-        public async Task ReloadAsync()
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            var token = CancelBackgroundTasks();
-            Enabled = false;
-            try
-            {
-                var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-            }
-            finally
-            {
-                await this.SwitchToMainThreadAsync(token);
-                Enabled = true;
             }
         }
 
@@ -220,15 +273,6 @@ namespace GitUI.BranchTreePanel
                 _rootNodes.Remove(_tagTree);
                 treeMain.Nodes.Remove(_tagTreeRootNode);
             }
-        }
-
-        private void AddTags()
-        {
-            _tagTreeRootNode = new TreeNode(Strings.TagsText.Text) { ImageKey = nameof(MsVsImages.Tag_16x) };
-            _tagTreeRootNode.SelectedImageKey = _tagTreeRootNode.ImageKey;
-            _tagTree = new TagTree(_tagTreeRootNode, UICommandsSource);
-            AddTree(_tagTree);
-            _searchResult = null;
         }
 
         private void OnBtnSearchClicked(object sender, EventArgs e)
@@ -266,51 +310,6 @@ namespace GitUI.BranchTreePanel
 
             node.EnsureVisible();
             treeMain.SelectedNode = node;
-        }
-
-        private static List<TreeNode> SearchTree(string text, TreeNodeCollection nodes)
-        {
-            var ret = new List<TreeNode>();
-            foreach (TreeNode node in nodes)
-            {
-                if (node.Tag is BaseBranchNode branch)
-                {
-                    if (branch.FullPath.IndexOf(text, StringComparison.InvariantCultureIgnoreCase) != -1)
-                    {
-                        AddTreeNodeToSearchResult(ret, node);
-                    }
-                }
-                else
-                {
-                    if (node.Text.IndexOf(text, StringComparison.InvariantCultureIgnoreCase) != -1)
-                    {
-                        AddTreeNodeToSearchResult(ret, node);
-                    }
-                }
-
-                ret.AddRange(SearchTree(text, node.Nodes));
-            }
-
-            return ret;
-        }
-
-        private static void AddTreeNodeToSearchResult(ICollection<TreeNode> ret, TreeNode node)
-        {
-            node.BackColor = Color.LightYellow;
-            ret.Add(node);
-        }
-
-        private TreeNode GetNextSearchResult()
-        {
-            if (_searchResult == null || !_searchResult.Any())
-            {
-                return null;
-            }
-
-            var node = _searchResult.First();
-            _searchResult.RemoveAt(0);
-            _searchResult.Add(node);
-            return node;
         }
 
         private void OnBranchCriterionChanged(object sender, EventArgs e)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -61,6 +61,8 @@ namespace GitUI.BranchTreePanel
 
             var token = CancelBackgroundTasks();
             Enabled = false;
+
+            var currentBranch = Module.GetSelectedBranch();
             try
             {
                 var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
@@ -70,6 +72,14 @@ namespace GitUI.BranchTreePanel
             {
                 await this.SwitchToMainThreadAsync(token);
                 Enabled = true;
+
+                var selectedNode = treeMain.AllNodes().FirstOrDefault(n =>
+                    _rootNodes.Any(rn => $"{rn.TreeViewNode.FullPath}{treeMain.PathSeparator}{currentBranch}" == n.FullPath));
+                if (selectedNode != null)
+                {
+                    treeMain.SelectedNode = selectedNode;
+                    treeMain.SelectedNode.EnsureVisible();
+                }
             }
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.resx
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.resx
@@ -118,33 +118,33 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="menuMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 88</value>
+    <value>17, 56</value>
   </metadata>
   <metadata name="menuBranch.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>11, 54</value>
+    <value>161, 17</value>
   </metadata>
   <metadata name="menuTags.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>592, 49</value>
+    <value>281, 17</value>
   </metadata>
   <metadata name="menuRemotes.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>951, 49</value>
+    <value>516, 17</value>
   </metadata>
   <metadata name="menuRemote.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1081, 49</value>
+    <value>646, 17</value>
   </metadata>
   <metadata name="menuTag.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1206, 49</value>
+    <value>771, 17</value>
   </metadata>
   <metadata name="menuBranchPath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>3, 25</value>
+    <value>17, 17</value>
   </metadata>
   <metadata name="menuRemoteRepoNode.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>929, 88</value>
+    <value>127, 56</value>
   </metadata>
   <metadata name="menuSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>700, 49</value>
+    <value>389, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>213</value>
+    <value>123</value>
   </metadata>
 </root>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -670,17 +670,12 @@ namespace GitUI.CommandsDialogs
 
         private void ReloadRepoObjectsTree()
         {
-            if (IsRepoObjectsTreeVisible())
+            if (MainSplitContainer.Panel1Collapsed)
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(() => repoObjectsTree.ReloadAsync()).FileAndForget();
+                return;
             }
 
-            return;
-
-            bool IsRepoObjectsTreeVisible()
-            {
-                return !MainSplitContainer.Panel1Collapsed;
-            }
+            ThreadHelper.JoinableTaskFactory.RunAsync(() => repoObjectsTree.ReloadAsync()).FileAndForget();
         }
 
         private void OnActivate()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -172,7 +172,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.OnToggleBranchTreePanelRequested = () => toggleBranchTreePanel_Click(null, null);
             _filterRevisionsHelper = new FilterRevisionsHelper(toolStripRevisionFilterTextBox, toolStripRevisionFilterDropDownButton, RevisionGrid, toolStripRevisionFilterLabel, ShowFirstParent, form: this);
             _filterBranchHelper = new FilterBranchHelper(toolStripBranchFilterComboBox, toolStripBranchFilterDropDownButton, RevisionGrid);
-            repoObjectsTree.FilterBranchHelper = _filterBranchHelper;
+            repoObjectsTree.SetBranchFilterer(_filterBranchHelper);
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
             revisionDiff.Bind(RevisionGrid, fileTree);
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -72,6 +72,25 @@
     </Compile>
     <Compile Include="AutoCompletion\CommitAutoCompleteProvider.cs" />
     <Compile Include="AutoCompletion\IAutoCompleteProvider.cs" />
+    <Compile Include="BranchTreePanel\RepoObjectsTree.ContextActions.cs">
+      <SubType>UserControl</SubType>
+      <DependentUpon>RepoObjectsTree.cs</DependentUpon>
+    </Compile>
+    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Branches.cs">
+      <SubType>UserControl</SubType>
+      <DependentUpon>RepoObjectsTree.Nodes.cs</DependentUpon>
+    </Compile>
+    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Remotes.cs">
+      <SubType>UserControl</SubType>
+      <DependentUpon>RepoObjectsTree.Nodes.cs</DependentUpon>
+    </Compile>
+    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Tags.cs">
+      <SubType>UserControl</SubType>
+      <DependentUpon>RepoObjectsTree.Nodes.cs</DependentUpon>
+    </Compile>
     <Compile Include="BuildServerIntegration\BuildInfoDrawingLogic.cs" />
     <Compile Include="BuildServerIntegration\BuildServerWatcher.cs" />
     <Compile Include="CommandsDialogs\AboutBox.cs">
@@ -668,9 +687,6 @@
     <Compile Include="Properties\Resources.Custom.cs">
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="BranchTreePanel\RepoObjectsTree.ContextActions.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
     <Compile Include="Script\ScriptInfo.cs" />
     <Compile Include="Script\ScriptManager.cs" />
     <Compile Include="CommandsDialogs\SettingsDialog\CheckSettingsLogic.cs" />
@@ -1084,23 +1100,11 @@
     <Compile Include="UserControls\FolderBrowserButton.Designer.cs">
       <DependentUpon>FolderBrowserButton.cs</DependentUpon>
     </Compile>
-    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Branches.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
     <Compile Include="BranchTreePanel\RepoObjectsTree.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="BranchTreePanel\RepoObjectsTree.Designer.cs">
       <DependentUpon>RepoObjectsTree.cs</DependentUpon>
-    </Compile>
-    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Remotes.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Tags.cs">
-      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="UserControls\WarningToolStripItem.cs">
       <SubType>Component</SubType>


### PR DESCRIPTION
Fixes a number of issues reported in #4814

There are a few tweaks, probably the easiest to go over each commit.
The most notable changes proposed in this pull request:
- Automatically select and expand to the current branch
- Do no allow checkout the current branch
- Do not allow delete the current branch
- Add context menu spacers to various menus
- Add expand/collapse all to almost all nodes
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/4403806/40919279-66808ed2-684c-11e8-86e9-9f47e9423364.png)
![image](https://user-images.githubusercontent.com/4403806/40919126-ee52b9bc-684b-11e8-8ceb-70b2a1e5f2f5.png)
![image](https://user-images.githubusercontent.com/4403806/41022132-ef982e2c-69ab-11e8-98bf-d47b5d225602.png)

What did I do to test the code and ensure quality:
- a lot of manual checks

/cc: @EbenZhang 

