### PR TITLE
GUID conflict for IndexGuid and CombinedDiffGuid

### DIFF
--- a/GitCommands/Git/Extensions/GitRevisionExtensions.cs
+++ b/GitCommands/Git/Extensions/GitRevisionExtensions.cs
@@ -5,7 +5,8 @@
         public static bool IsArtificial(this string sha1)
         {
             return sha1 == GitRevision.UnstagedGuid ||
-                   sha1 == GitRevision.IndexGuid;
+                   sha1 == GitRevision.IndexGuid ||
+                   sha1 == GitRevision.CombinedDiffGuid;
         }
     }
 }

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -19,6 +19,10 @@ namespace GitCommands
         /// <summary>40 characters of 2's</summary>
         public const string IndexGuid = "2222222222222222222222222222222222222222";
 
+        /// <summary>40 characters of 2's
+        /// Artificial commit for the combined diff</summary>
+        public const string CombinedDiffGuid = "3333333333333333333333333333333333333333";
+
         /// <summary>40 characters of a-f or any digit.</summary>
         public const string Sha1HashPattern = @"[a-f\d]{40}";
 

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -57,6 +57,14 @@ namespace GitCommands.Git
 
         private string GetInternal(string firstRevision, string secondRevision, string fileName = null, string oldFileName = null, bool isTracked = true)
         {
+            // Combined Diff artificial commit should not be included in diffs
+            if (firstRevision == GitRevision.CombinedDiffGuid || secondRevision == GitRevision.CombinedDiffGuid)
+            {
+                throw new ArgumentOutOfRangeException(nameof(firstRevision), firstRevision,
+                    "CombinedDiff artificial commit cannot be explicitly compared: " +
+                    firstRevision + ", " + secondRevision);
+            }
+
             string extra = string.Empty;
             firstRevision = ArtificialToDiffOptions(firstRevision);
             secondRevision = ArtificialToDiffOptions(secondRevision);

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -192,7 +192,7 @@ namespace GitUI.CommandsDialogs
         {
             var parents = DiffFiles.SelectedItemParents
                 .Where(i => showUnstagedAndCombined ||
-                    !(i.Guid.IsNullOrWhiteSpace() || i.Guid == GitRevision.UnstagedGuid || i.Guid == DiffFiles.CombinedDiffGuid))
+                    !(i.Guid.IsNullOrWhiteSpace() || i.Guid == GitRevision.UnstagedGuid || i.Guid == GitRevision.CombinedDiffGuid))
                 .Distinct()
                 .Count();
             if (parents == 0)
@@ -247,7 +247,7 @@ namespace GitUI.CommandsDialogs
             bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents, DiffFiles.Revision);
 
             // Combined diff is a display only diff, no manipulations
-            bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item.Guid == DiffFiles.CombinedDiffGuid);
+            bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item.Guid == GitRevision.CombinedDiffGuid);
             bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
             bool isAnyItemSelected = DiffFiles.SelectedItems.Any();
 
@@ -312,7 +312,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (DiffFiles.SelectedItemParent?.Guid == DiffFiles.CombinedDiffGuid)
+            if (DiffFiles.SelectedItemParent?.Guid == GitRevision.CombinedDiffGuid)
             {
                 var diffOfConflict = Module.GetCombinedDiffContent(DiffFiles.Revision, DiffFiles.SelectedItem.Name,
                     DiffText.GetExtraDiffArguments(), DiffText.Encoding);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -29,9 +29,6 @@ namespace GitUI
         private readonly TranslationString _diffWithParent = new TranslationString("Diff with:");
         public readonly TranslationString CombinedDiff = new TranslationString("Combined Diff");
 
-        // Artificial commit for the combined diff, similar to GitRevision.UnstagedGuid
-        public readonly string CombinedDiffGuid = "2222222222222222222222222222222222222222";
-
         private IDisposable _selectedIndexChangeSubscription;
         private static readonly TimeSpan SelectedIndexChangeThrottleDuration = TimeSpan.FromMilliseconds(50);
 
@@ -894,7 +891,7 @@ namespace GitUI
                 if (revision != null)
                 {
                     string groupName;
-                    if (revision.Guid == CombinedDiffGuid)
+                    if (revision.Guid == GitRevision.CombinedDiffGuid)
                     {
                         groupName = CombinedDiff.Text;
                     }
@@ -1185,7 +1182,7 @@ namespace GitUI
                         if (conflicts.Any())
                         {
                             // Create an artificial commit
-                            var rev = new GitRevision(CombinedDiffGuid);
+                            var rev = new GitRevision(GitRevision.CombinedDiffGuid);
                             dictionary.Add(rev, conflicts);
                         }
                     }

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -30,6 +30,12 @@ namespace GitUIPluginInterfaces
         public static ObjectId IndexId { get; } = new ObjectId(0x22222222, 0x22222222, 0x22222222, 0x22222222, 0x22222222);
 
         /// <summary>
+        /// Gets the artificial ObjectId used to represent combined diff for merge commits.
+        /// </summary>
+        [NotNull]
+        public static ObjectId CombinedDiffId { get; } = new ObjectId(0x33333333, 0x33333333, 0x33333333, 0x33333333, 0x33333333);
+
+        /// <summary>
         /// Produces an <see cref="ObjectId"/> populated with random bytes.
         /// </summary>
         [NotNull]
@@ -44,7 +50,7 @@ namespace GitUIPluginInterfaces
                 unchecked((uint)_random.Next()));
         }
 
-        public bool IsArtificial => this == UnstagedId || this == IndexId;
+        public bool IsArtificial => this == UnstagedId || this == IndexId || this == CombinedDiffId;
 
         private const int Sha1ByteCount = 20;
         public const int Sha1CharCount = 40;

--- a/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
@@ -14,6 +14,7 @@ namespace GitCommandsTests.Git.Extensions
         [TestCase("0000", false)]
         [TestCase(GitRevision.UnstagedGuid, true)]
         [TestCase(GitRevision.IndexGuid, true)]
+        [TestCase(GitRevision.CombinedDiffGuid, true)]
         public void IsArtificial_tests(string sha1, bool expected)
         {
             sha1.IsArtificial().Should().Be(expected);

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -116,6 +116,14 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
+        public void CombinedDiffId_has_expected_value()
+        {
+            Assert.AreEqual(
+                "3333333333333333333333333333333333333333",
+                ObjectId.CombinedDiffId.ToString());
+        }
+
+        [Test]
         public void UnstagedId_is_artificial()
         {
             Assert.IsTrue(ObjectId.UnstagedId.IsArtificial);
@@ -125,6 +133,12 @@ namespace GitCommandsTests.Git
         public void IndexId_is_artificial()
         {
             Assert.IsTrue(ObjectId.IndexId.IsArtificial);
+        }
+
+        [Test]
+        public void CombinedDiffId_is_artificial()
+        {
+            Assert.IsTrue(ObjectId.CombinedDiffId.IsArtificial);
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using GitCommands;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using NUnit.Framework;
@@ -157,8 +158,24 @@ namespace GitCommandsTests.Git
                 ObjectId.UnstagedId);
 
             Assert.AreEqual(
+                ObjectId.UnstagedId,
+                ObjectId.Parse(GitRevision.UnstagedGuid));
+
+            Assert.AreEqual(
                 ObjectId.IndexId,
                 ObjectId.IndexId);
+
+            Assert.AreEqual(
+                ObjectId.IndexId,
+                ObjectId.Parse(GitRevision.IndexGuid));
+
+            Assert.AreEqual(
+                ObjectId.CombinedDiffId,
+                ObjectId.CombinedDiffId);
+
+            Assert.AreEqual(
+                ObjectId.CombinedDiffId,
+                ObjectId.Parse(GitRevision.CombinedDiffGuid));
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
@@ -40,6 +41,14 @@ namespace GitCommandsTests.Git
             _revisionDiffProvider.Get(firstRevision, GitRevision.IndexGuid).Should().Be("--cached --cached");
         }
 #endif
+
+        // Combined Diff artificial commit should not be included in diffs
+        [TestCase(GitRevision.CombinedDiffGuid, "")]
+        [TestCase("", GitRevision.CombinedDiffGuid)]
+        public void RevisionDiffProvider_should_throw_if_any_combined_diff(string firstRevision, string secondRevision)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _revisionDiffProvider.Get(firstRevision, secondRevision));
+        }
 
         [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid)]
         [TestCase("^", "")]


### PR DESCRIPTION
Handling of CombinedDiffGuid was kept in FileStatusList.
When GUIDs for other artificial GUIDs were changed, the CombinedDiffGuid was not changed

Fixes #5015

Changes proposed in this pull request:
- Move CombinedDiffGuid  to GitRevision

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- Windows 10
