### PR TITLE
Remove 'Force Delete' functionality

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -32,12 +32,10 @@ namespace GitUI.BranchTreePanel
 
             RegisterClick<LocalBranchNode>(mnuBtnCheckoutLocal, branch => branch.Checkout());
             RegisterClick<LocalBranchNode>(mnubtnBranchDelete, branch => branch.Delete());
-            RegisterClick<LocalBranchNode>(mnubtnBranchDeleteForce, branch => branch.DeleteForce());
             RegisterClick<LocalBranchNode>(mnubtnFilterLocalBranchInRevisionGrid, FilterInRevisionGrid);
             Node.RegisterContextMenu(typeof(LocalBranchNode), menuBranch);
 
             RegisterClick<BranchPathNode>(mnubtnDeleteAllBranches, branchPath => branchPath.DeleteAll());
-            RegisterClick<BranchPathNode>(mnubtnDeleteAllBranchesForce, branchPath => branchPath.DeleteAllForce());
             Node.RegisterContextMenu(typeof(BranchPathNode), menuBranchPath);
 
             RegisterClick<RemoteBranchNode>(mnubtnDeleteRemoteBranch, remoteBranch => remoteBranch.Delete());

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -41,7 +41,6 @@ namespace GitUI.BranchTreePanel
             this.menuBranch = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnuBtnCheckoutLocal = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnBranchDelete = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnubtnBranchDeleteForce = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFilterLocalBranchInRevisionGrid = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnFilterRemoteBranchInRevisionGrid = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnBranchCheckout = new System.Windows.Forms.ToolStripMenuItem();
@@ -68,7 +67,6 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteTag = new System.Windows.Forms.ToolStripMenuItem();
             this.menuBranchPath = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnDeleteAllBranches = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnubtnDeleteAllBranchesForce = new System.Windows.Forms.ToolStripMenuItem();
             this.menuRemoteRepoNode = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnManageRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.repoTreePanel = new System.Windows.Forms.TableLayoutPanel();
@@ -141,7 +139,6 @@ namespace GitUI.BranchTreePanel
             this.menuBranch.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuBtnCheckoutLocal,
             this.mnubtnBranchDelete,
-            this.mnubtnBranchDeleteForce,
             this.mnubtnFilterLocalBranchInRevisionGrid});
             this.menuBranch.Name = "contextmenuBranch";
             this.menuBranch.Size = new System.Drawing.Size(192, 92);
@@ -161,14 +158,6 @@ namespace GitUI.BranchTreePanel
             this.mnubtnBranchDelete.Size = new System.Drawing.Size(191, 22);
             this.mnubtnBranchDelete.Text = "Delete";
             this.mnubtnBranchDelete.ToolTipText = "Delete the branch, which must be fully merged in its upstream branch or in HEAD";
-            // 
-            // mnubtnBranchDeleteForce
-            // 
-            this.mnubtnBranchDeleteForce.Image = global::GitUI.Properties.Resources.Delete;
-            this.mnubtnBranchDeleteForce.Name = "mnubtnBranchDeleteForce";
-            this.mnubtnBranchDeleteForce.Size = new System.Drawing.Size(191, 22);
-            this.mnubtnBranchDeleteForce.Text = "Force Delete";
-            this.mnubtnBranchDeleteForce.ToolTipText = "Delete the branch, regardless of its merged status";
             // 
             // mnubtnFilterLocalBranchInRevisionGrid
             // 
@@ -363,8 +352,7 @@ namespace GitUI.BranchTreePanel
             // menuBranchPath
             // 
             this.menuBranchPath.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnubtnDeleteAllBranches,
-            this.mnubtnDeleteAllBranchesForce});
+            this.mnubtnDeleteAllBranches});
             this.menuBranchPath.Name = "contextmenuBranch";
             this.menuBranchPath.Size = new System.Drawing.Size(157, 48);
             // 
@@ -376,14 +364,6 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteAllBranches.Text = "Delete All";
             this.mnubtnDeleteAllBranches.ToolTipText = "Delete all child branchs, which must all be fully merged in its upstream branch o" +
     "r in HEAD";
-            // 
-            // mnubtnDeleteAllBranchesForce
-            // 
-            this.mnubtnDeleteAllBranchesForce.Image = global::GitUI.Properties.Resources.Delete;
-            this.mnubtnDeleteAllBranchesForce.Name = "mnubtnDeleteAllBranchesForce";
-            this.mnubtnDeleteAllBranchesForce.Size = new System.Drawing.Size(156, 22);
-            this.mnubtnDeleteAllBranchesForce.Text = "Force Delete All";
-            this.mnubtnDeleteAllBranchesForce.ToolTipText = "Delete all child branches, regardless of their merged status";
             // 
             // menuRemoteRepoNode
             // 
@@ -517,7 +497,6 @@ namespace GitUI.BranchTreePanel
         private ContextMenuStrip menuBranch;
         private ToolStripMenuItem mnubtnBranchCheckout;
         private ToolStripMenuItem mnubtnBranchDelete;
-        private ToolStripMenuItem mnubtnBranchDeleteForce;
         private ToolStripMenuItem mnubtnFilterLocalBranchInRevisionGrid;
         private ToolStripMenuItem mnubtnFilterRemoteBranchInRevisionGrid;
         private ContextMenuStrip menuTags;
@@ -529,7 +508,6 @@ namespace GitUI.BranchTreePanel
         private ContextMenuStrip menuTag;
         private ContextMenuStrip menuBranchPath;
         private ToolStripMenuItem mnubtnDeleteAllBranches;
-        private ToolStripMenuItem mnubtnDeleteAllBranchesForce;
         private ContextMenuStrip menuMain;
         private ToolStripMenuItem mnubtnCollapseAll;
         private ToolStripMenuItem mnubtnExpandAll;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -164,13 +164,6 @@ namespace GitUI.BranchTreePanel
                     FullPath
                 });
             }
-
-            public void DeleteForce()
-            {
-                var branchHead = CreateBranchRef(UICommands.Module, FullPath);
-                var cmd = new GitDeleteBranchCmd(new[] { branchHead }, true);
-                UICommands.StartCommandLineProcessDialog(null, cmd);
-            }
         }
 
         private class BasePathNode : BaseBranchNode
@@ -202,15 +195,6 @@ namespace GitUI.BranchTreePanel
             {
                 var branches = Nodes.DepthEnumerator<LocalBranchNode>().Select(branch => branch.FullPath);
                 UICommands.StartDeleteBranchDialog(ParentWindow(), branches);
-            }
-
-            public void DeleteAllForce()
-            {
-                var branches = Nodes.DepthEnumerator<LocalBranchNode>();
-                var branchHeads =
-                    branches.Select(branch => CreateBranchRef(UICommands.Module, branch.FullPath));
-                var cmd = new GitDeleteBranchCmd(branchHeads.ToList(), true);
-                UICommands.StartCommandLineProcessDialog(null, cmd);
             }
         }
 


### PR DESCRIPTION
The functionality adds a nice touch, however it can be extremely harmful, if used carelessly. It also introduces an inconsistent UX, because other parts of application do no allow deletion of refs without prior confirmation.

The functionality can be re-instated with an introduction of a user controller setting (explicit opt in, placed on the Advanced tab), that would enable force deletion of refs universally all across the app.
This includes branch and tag deletion dialogs.

Relates to #4814

/cc: @EbenZhang 