### PR TITLE
Fix 4830 inconsistent branch ordering

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -87,7 +87,6 @@ namespace GitCommands
     public sealed class GitModule : IGitModule
     {
         private const char LineSeparator = '\n';
-        public static readonly char ActiveBranchIndicator = '*';
 
         private static readonly Regex AnsiCodePattern = new Regex(@"\u001B[\u0040-\u005F].*?[\u0040-\u007E]", RegexOptions.Compiled);
         private static readonly Regex CpEncodingPattern = new Regex("cp\\d+", RegexOptions.Compiled);
@@ -2968,18 +2967,6 @@ namespace GitCommands
             gitRefs.AddRange(headByRemote.Values);
 
             return gitRefs;
-        }
-
-        /// <summary>Gets the branch names, with the active branch, if applicable, listed first.
-        /// The active branch will be indicated by a "*", so ensure to Trim before processing.</summary>
-        public IEnumerable<string> GetBranchNames()
-        {
-            return RunGitCmd("branch", SystemEncoding)
-                .Split(LineSeparator)
-                .Where(branch => !string.IsNullOrWhiteSpace(branch)) // first is ""
-                .OrderByDescending(branch => branch.Contains(ActiveBranchIndicator)) // * for current branch
-                .ThenBy(r => r)
-                .Select(line => line.Trim());
         }
 
         /// <summary>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2822,11 +2822,17 @@ namespace GitCommands
             }
         }
 
-        public IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true)
+        public IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true, GitRefsOrder order = GitRefsOrder.ByLastAccessDate)
         {
             var refList = GetRefList();
 
-            return ParseRefs(refList);
+            var refs = ParseRefs(refList);
+            if (order == GitRefsOrder.Alphabetically)
+            {
+                refs = refs.OrderBy(b => b.Name).ToList();
+            }
+
+            return refs;
 
             string GetRefList()
             {

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -124,7 +124,6 @@
     <Compile Include="UserRepositoryHistory\RepositoryDescriptionProvider.cs" />
     <Compile Include="UserRepositoryHistory\RepositoryStorage.cs" />
     <Compile Include="UserRepositoryHistory\RepositoryXmlSerialiser.cs" />
-    <Compile Include="Settings\BranchOrdering.cs" />
     <Compile Include="Git\GitGpgController.cs" />
     <Compile Include="SshPathLocator.cs" />
     <Compile Include="Git\IndexLockManager.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -10,8 +10,10 @@ using System.Text;
 using System.Windows.Forms;
 using GitCommands.Logging;
 using GitCommands.Settings;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using Microsoft.Win32;
+using StringSetting = GitCommands.Settings.StringSetting;
 
 namespace GitCommands
 {
@@ -1464,9 +1466,9 @@ namespace GitCommands
             set => SetBool("UseConsoleEmulatorForCommands", value);
         }
 
-        public static BranchOrdering BranchOrderingCriteria
+        public static GitRefsOrder BranchOrderingCriteria
         {
-            get => GetEnum("BranchOrderingCriteria", BranchOrdering.ByLastAccessDate);
+            get => GetEnum("BranchOrderingCriteria", GitRefsOrder.ByLastAccessDate);
             set => SetEnum("BranchOrderingCriteria", value);
         }
 

--- a/GitCommands/Settings/BranchOrdering.cs
+++ b/GitCommands/Settings/BranchOrdering.cs
@@ -1,8 +1,0 @@
-namespace GitCommands
-{
-    public enum BranchOrdering
-    {
-        ByLastAccessDate = 0,
-        Alphabetically = 1,
-    }
-}

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -106,10 +106,10 @@ namespace GitUI.BranchTreePanel
 
         private sealed class LocalBranchNode : BaseBranchNode
         {
-            public LocalBranchNode(Tree tree, string fullPath)
-                : base(tree, fullPath.TrimStart(GitModule.ActiveBranchIndicator))
+            public LocalBranchNode(Tree tree, string fullPath, bool isCurrent)
+                : base(tree, fullPath)
             {
-                IsActive = fullPath.StartsWith(GitModule.ActiveBranchIndicator.ToString());
+                IsActive = isCurrent;
             }
 
             public bool IsActive { get; }
@@ -231,7 +231,14 @@ namespace GitUI.BranchTreePanel
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
-                FillBranchTree(Module.GetBranchNames(), token);
+
+                var branchNames = Module.GetRefs(false).Select(b => b.Name);
+                if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
+                {
+                    branchNames = branchNames.OrderBy(b => b);
+                }
+
+                FillBranchTree(branchNames, token);
             }
 
             private void FillBranchTree(IEnumerable<string> branches, CancellationToken token)
@@ -265,12 +272,14 @@ namespace GitUI.BranchTreePanel
                 // 0 master
 
                 #endregion ex
+
+                var currentBranch = Module.GetSelectedBranch();
                 var nodes = new Dictionary<string, BaseBranchNode>();
                 var branchFullPaths = new List<string>();
                 foreach (var branch in branches)
                 {
                     token.ThrowIfCancellationRequested();
-                    var localBranchNode = new LocalBranchNode(this, branch);
+                    var localBranchNode = new LocalBranchNode(this, branch, branch == currentBranch);
                     var parent = localBranchNode.CreateRootNode(nodes,
                         (tree, parentPath) => new BranchPathNode(tree, parentPath));
                     if (parent != null)
@@ -295,7 +304,7 @@ namespace GitUI.BranchTreePanel
                 }
             }
         }
-    #endregion private classes
+        #endregion private classes
 
         [Pure]
         public static GitRef CreateBranchRef(GitModule module, string name)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -232,12 +232,7 @@ namespace GitUI.BranchTreePanel
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
-                var branchNames = Module.GetRefs(false).Select(b => b.Name);
-                if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
-                {
-                    branchNames = branchNames.OrderBy(b => b);
-                }
-
+                var branchNames = Module.GetRefs(false, order: AppSettings.BranchOrderingCriteria).Select(b => b.Name);
                 FillBranchTree(branchNames, token);
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1916,11 +1916,7 @@ namespace GitUI.CommandsDialogs
 
         private IEnumerable<string> GetBranchNames()
         {
-            IEnumerable<string> branchNames = Module.GetRefs(false).Select(b => b.Name);
-            if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
-            {
-                branchNames = branchNames.OrderBy(b => b);
-            }
+            IEnumerable<string> branchNames = Module.GetRefs(false, order: AppSettings.BranchOrderingCriteria).Select(b => b.Name);
 
             // Make sure there are never more than a 100 branches added to the menu
             // GitExtensions will hang when the drop down is too large...

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ToolbarSettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands;
+using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
@@ -18,7 +19,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void PageToSettings()
         {
-            AppSettings.BranchOrderingCriteria = (BranchOrdering)cbBranchOrderingCriteria.SelectedIndex;
+            AppSettings.BranchOrderingCriteria = (GitRefsOrder)cbBranchOrderingCriteria.SelectedIndex;
         }
 
         public static SettingsPageReference GetPageReference()

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -202,7 +202,7 @@ namespace Bitbucket
         private async Task RefreshDDLBranchAsync(ComboBox branchComboBox, object selectedValue)
         {
             List<string> branchNames = (await GetBitbucketBranchesAsync((Repository)selectedValue)).ToList();
-            if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
+            if (AppSettings.BranchOrderingCriteria == GitRefsOrder.Alphabetically)
             {
                 branchNames.Sort();
             }

--- a/Plugins/GitUIPluginInterfaces/GitRefsOrder.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRefsOrder.cs
@@ -1,0 +1,8 @@
+namespace GitUIPluginInterfaces
+{
+    public enum GitRefsOrder
+    {
+        ByLastAccessDate = 0,
+        Alphabetically,
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="GitRefsOrder.cs" />
     <Compile Include="BuildServerIntegration\BuildDurationFormatter.cs" />
     <Compile Include="BuildServerIntegration\BuildInfo.cs" />
     <Compile Include="BuildServerIntegration\BuildServerAdapterMetadataAttribute.cs" />

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -12,7 +12,7 @@ namespace GitUIPluginInterfaces
         IConfigFileSettings LocalConfigFile { get; }
 
         string AddRemote(string remoteName, string path);
-        IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true);
+        IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true, GitRefsOrder order = GitRefsOrder.ByLastAccessDate);
         IEnumerable<string> GetSettings(string setting);
         IEnumerable<IGitItem> GetTree(string id, bool full);
 


### PR DESCRIPTION
The user can specify whether branches are sorted in A-Z or by date order. The left panel now uses the same ordering techniques.

At the same time git ref sorting has been centralised:
* Incorporate git ref sorting into `IGitModule.GetRefs` method so it is universally and uniformly available across the app.
* Rename `BranchOrdering` to `GitRefsOrder` to align with the purpose.

Fixes #4830
Relates to #4814
 
Screenshots before and after (if PR changes UI):
before:
- ![image](https://user-images.githubusercontent.com/4403806/38706935-7aee475c-3ef2-11e8-9990-26b177f0bb7a.png)
after:
- ![image](https://user-images.githubusercontent.com/4403806/40918290-37fbee60-6849-11e8-939f-e41295bf167c.png)
- ![image](https://user-images.githubusercontent.com/4403806/40918345-60be40a0-6849-11e8-91ab-19147290c6ba.png)


What did I do to test the code and ensure quality:
- manual tests
