### PR TITLE
Add dir-diff support and various diff options

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3522,6 +3522,12 @@ namespace GitCommands
                 });
         }
 
+        public string OpenWithDifftoolDirDiff(string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.WorkTreeGuid, string extraDiffArguments = null)
+        {
+            extraDiffArguments = ((extraDiffArguments ?? "") + " --dir-diff").Trim();
+            return OpenWithDifftool(null, null, firstRevision: firstRevision, secondRevision: secondRevision, extraDiffArguments: extraDiffArguments);
+        }
+
         public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.WorkTreeGuid, string extraDiffArguments = null, bool isTracked = true)
         {
             var args = new ArgumentBuilder

--- a/GitUI/CommandsDialogs/FormDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDiff.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs
 {
     partial class FormDiff
     {
@@ -36,6 +38,8 @@
             this.settingsLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.btnSwap = new System.Windows.Forms.Button();
             this.ckCompareToMergeBase = new System.Windows.Forms.CheckBox();
+            this.btnCompareDirectoriesWithDiffTool = new System.Windows.Forms.Button();
+            this.diffOptionsPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.baseCommitGroup = new System.Windows.Forms.GroupBox();
             this.baseCommitPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.lblBaseCommit = new System.Windows.Forms.Label();
@@ -136,7 +140,7 @@
             this.settingsLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.settingsLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.settingsLayoutPanel.Controls.Add(this.btnSwap, 1, 0);
-            this.settingsLayoutPanel.Controls.Add(this.ckCompareToMergeBase, 0, 1);
+            this.settingsLayoutPanel.Controls.Add(this.diffOptionsPanel, 0, 1);
             this.settingsLayoutPanel.Controls.Add(this.baseCommitGroup, 0, 0);
             this.settingsLayoutPanel.Controls.Add(this.headCommitGroup, 2, 0);
             this.settingsLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -166,14 +170,39 @@
             // 
             // ckCompareToMergeBase
             // 
+            this.ckCompareToMergeBase.Anchor = AnchorStyles.Left;
             this.ckCompareToMergeBase.AutoSize = true;
-            this.ckCompareToMergeBase.Location = new System.Drawing.Point(3, 51);
             this.ckCompareToMergeBase.Name = "ckCompareToMergeBase";
-            this.ckCompareToMergeBase.Size = new System.Drawing.Size(141, 17);
-            this.ckCompareToMergeBase.TabIndex = 8;
-            this.ckCompareToMergeBase.Text = "Compare to merge base";
+            this.ckCompareToMergeBase.TabIndex = 9;
+            this.ckCompareToMergeBase.Text = "Compare to merge &base";
+            this.ckCompareToMergeBase.UseMnemonic = true;
             this.ckCompareToMergeBase.UseVisualStyleBackColor = true;
             this.ckCompareToMergeBase.CheckedChanged += new System.EventHandler(this.ckCompareToMergeBase_CheckedChanged);
+            // 
+            // btnCompareDirectoriesWithDiffTool
+            // 
+            this.btnCompareDirectoriesWithDiffTool.Anchor = AnchorStyles.Left;
+            this.btnCompareDirectoriesWithDiffTool.AutoSize = true;
+            this.btnCompareDirectoriesWithDiffTool.Name = "btnCompareDirectoriesWithDiffTool";
+            this.btnCompareDirectoriesWithDiffTool.Margin = new System.Windows.Forms.Padding(0);
+            this.btnCompareDirectoriesWithDiffTool.Size = new System.Drawing.Size(141, 17);
+            this.btnCompareDirectoriesWithDiffTool.TabIndex = 10;
+            this.btnCompareDirectoriesWithDiffTool.Text = "Open diff using &directory diff tool";
+            this.btnCompareDirectoriesWithDiffTool.UseMnemonic = true;
+            this.btnCompareDirectoriesWithDiffTool.UseVisualStyleBackColor = true;
+            this.btnCompareDirectoriesWithDiffTool.Click += new System.EventHandler(this.btnCompareDirectoriesWithDiffTool_Clicked);
+            this.btnCompareDirectoriesWithDiffTool.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            // 
+            // diffOptionsPanel
+            // 
+            this.diffOptionsPanel.AutoSize = true;
+            this.diffOptionsPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.diffOptionsPanel.Controls.Add(this.ckCompareToMergeBase);
+            this.diffOptionsPanel.Controls.Add(this.btnCompareDirectoriesWithDiffTool);
+            this.diffOptionsPanel.Margin = new System.Windows.Forms.Padding(3);
+            this.diffOptionsPanel.Name = "diffOptionsPanel";
+            this.diffOptionsPanel.Size = new System.Drawing.Size(491, 23);
+            this.diffOptionsPanel.TabIndex = 14;
             // 
             // baseCommitGroup
             // 
@@ -237,7 +266,7 @@
             this.btnAnotherBaseCommit.Location = new System.Drawing.Point(237, 3);
             this.btnAnotherBaseCommit.Name = "btnAnotherBaseCommit";
             this.btnAnotherBaseCommit.Size = new System.Drawing.Size(22, 22);
-            this.btnAnotherBaseCommit.TabIndex = 9;
+            this.btnAnotherBaseCommit.TabIndex = 10;
             this.btnAnotherBaseCommit.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.btnAnotherBaseCommit.UseVisualStyleBackColor = true;
             this.btnAnotherBaseCommit.Click += new System.EventHandler(this.btnAnotherCommit_Click);
@@ -449,6 +478,8 @@
             this.splitContainer1.ResumeLayout(false);
             this.settingsLayoutPanel.ResumeLayout(false);
             this.settingsLayoutPanel.PerformLayout();
+            this.diffOptionsPanel.ResumeLayout(false);
+            this.diffOptionsPanel.PerformLayout();
             this.baseCommitGroup.ResumeLayout(false);
             this.baseCommitGroup.PerformLayout();
             this.baseCommitPanel.ResumeLayout(false);
@@ -493,8 +524,10 @@
         private System.Windows.Forms.FlowLayoutPanel headCommitPanel;
         private System.Windows.Forms.Button btnAnotherHeadBranch;
         private System.Windows.Forms.Button btnAnotherHeadCommit;
+        private System.Windows.Forms.Button btnCompareDirectoriesWithDiffTool;
         private System.Windows.Forms.CheckBox ckCompareToMergeBase;
         private System.Windows.Forms.GroupBox baseCommitGroup;
         private System.Windows.Forms.GroupBox headCommitGroup;
+        private System.Windows.Forms.FlowLayoutPanel diffOptionsPanel;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -82,7 +82,7 @@
             this.chkShowDiffForAllParents.Name = "chkShowDiffForAllParents";
             this.chkShowDiffForAllParents.Size = new System.Drawing.Size(280, 17);
             this.chkShowDiffForAllParents.TabIndex = 10;
-            this.chkShowDiffForAllParents.Text = "Show file differences for all parents in browse dialog.";
+            this.chkShowDiffForAllParents.Text = "Show file differences for all parents in browse dialog";
             this.chkShowDiffForAllParents.UseVisualStyleBackColor = true;
             // 
             // chkOpenSubmoduleDiffInSeparateWindow

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -297,7 +297,11 @@ namespace GitUI.Hotkey
                     Hk(RevisionGridControl.Commands.SelectAsBaseToCompare, Keys.Control | Keys.L),
                     Hk(RevisionGridControl.Commands.CompareToBase, Keys.Control | Keys.R),
                     Hk(RevisionGridControl.Commands.GoToCommit, Keys.Control | Keys.Shift | Keys.G),
-                    Hk(RevisionGridControl.Commands.CreateFixupCommit, Keys.Control | Keys.X)),
+                    Hk(RevisionGridControl.Commands.CreateFixupCommit, Keys.Control | Keys.X),
+                    Hk(RevisionGridControl.Commands.CompareToWorkingDirectory, Keys.Control | Keys.D),
+                    Hk(RevisionGridControl.Commands.CompareToCurrentBranch, Keys.None),
+                    Hk(RevisionGridControl.Commands.CompareToBranch, Keys.None),
+                    Hk(RevisionGridControl.Commands.CompareSelectedCommits, Keys.None)),
                 new HotkeySettings(
                     FileViewer.HotkeySettingsName,
                     Hk(FileViewer.Commands.Find, Keys.Control | Keys.F),

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -1,4 +1,5 @@
 using System.Windows.Forms;
+using GitUI.Hotkey;
 using GitUI.UserControls.RevisionGrid;
 
 namespace GitUI
@@ -42,6 +43,8 @@ namespace GitUI
             this.compareToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compareWithCurrentBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compareToBaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.compareToWorkingDirectoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.compareSelectedCommitsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.selectAsBaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.createTagToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -227,7 +230,6 @@ namespace GitUI
             // 
             this.createNewBranchToolStripMenuItem.Image = global::GitUI.Properties.Images.BranchCreate;
             this.createNewBranchToolStripMenuItem.Name = "createNewBranchToolStripMenuItem";
-            this.createNewBranchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
             this.createNewBranchToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
             this.createNewBranchToolStripMenuItem.Text = "Create new branch";
             this.createNewBranchToolStripMenuItem.Click += new System.EventHandler(this.CreateNewBranchToolStripMenuItemClick);
@@ -271,17 +273,29 @@ namespace GitUI
             this.selectAsBaseToolStripMenuItem.Name = "selectAsBaseToolStripMenuItem";
             this.selectAsBaseToolStripMenuItem.Size = new System.Drawing.Size(230, 22);
             this.selectAsBaseToolStripMenuItem.Text = "Select as BASE to compare";
-            this.selectAsBaseToolStripMenuItem.ShortcutKeys = Keys.Control | Keys.L;
             this.selectAsBaseToolStripMenuItem.Click += new System.EventHandler(this.selectAsBaseToolStripMenuItem_Click);
             // 
-            // selectAsBaseToolStripMenuItem
+            // compareToBaseToolStripMenuItem
             // 
             this.compareToBaseToolStripMenuItem.Name = "compareToBaseToolStripMenuItem";
             this.compareToBaseToolStripMenuItem.Size = new System.Drawing.Size(230, 22);
             this.compareToBaseToolStripMenuItem.Text = "Compare to BASE";
-            this.compareToBaseToolStripMenuItem.ShortcutKeys = Keys.Control | Keys.R;
             this.compareToBaseToolStripMenuItem.Enabled = false;
             this.compareToBaseToolStripMenuItem.Click += new System.EventHandler(this.compareToBaseToolStripMenuItem_Click);
+            // 
+            // compareToWorkingDirectoryMenuItem
+            // 
+            this.compareToWorkingDirectoryMenuItem.Name = "compareToWorkingDirectoryMenuItem";
+            this.compareToWorkingDirectoryMenuItem.Size = new System.Drawing.Size(230, 22);
+            this.compareToWorkingDirectoryMenuItem.Text = "Compare to working directory";
+            this.compareToWorkingDirectoryMenuItem.Click += new System.EventHandler(this.compareToWorkingDirectoryMenuItem_Click);
+            // 
+            // compareSelectedCommitsMenuItem
+            // 
+            this.compareSelectedCommitsMenuItem.Name = "compareSelectedCommitsMenuItem";
+            this.compareSelectedCommitsMenuItem.Size = new System.Drawing.Size(230, 22);
+            this.compareSelectedCommitsMenuItem.Text = "Compare selected commits";
+            this.compareSelectedCommitsMenuItem.Click += new System.EventHandler(this.compareSelectedCommitsMenuItem_Click);
             // 
             // compareToolStripMenuItem
             // 
@@ -294,6 +308,8 @@ namespace GitUI
                 compareWithCurrentBranchToolStripMenuItem,
                 selectAsBaseToolStripMenuItem,
                 compareToBaseToolStripMenuItem,
+                compareToWorkingDirectoryMenuItem,
+                compareSelectedCommitsMenuItem,
             });
             // 
             // toolStripSeparator5
@@ -305,7 +321,6 @@ namespace GitUI
             // 
             this.createTagToolStripMenuItem.Image = global::GitUI.Properties.Images.TagCreate;
             this.createTagToolStripMenuItem.Name = "createTagToolStripMenuItem";
-            this.createTagToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
             this.createTagToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
             this.createTagToolStripMenuItem.Text = "Create new tag";
             this.createTagToolStripMenuItem.Click += new System.EventHandler(this.CreateTagToolStripMenuItemClick);
@@ -467,6 +482,7 @@ namespace GitUI
             ((System.ComponentModel.ISupportInitialize)(this._gridView)).EndInit();
             this.mainContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
+            this.SetShortcutKeys();
         }
 
         #endregion
@@ -501,6 +517,8 @@ namespace GitUI
         private System.Windows.Forms.ToolStripMenuItem compareToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem compareWithCurrentBranchToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem compareToBaseToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem compareToWorkingDirectoryMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem compareSelectedCommitsMenuItem;
         private System.Windows.Forms.ToolStripMenuItem selectAsBaseToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem getHelpOnHowToUseTheseFeaturesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openBuildReportToolStripMenuItem;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -44,6 +44,7 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 // null when TranslationApp is started
                 TriggerMenuChanged(); // trigger refresh
+                _revisionGrid.SetShortcutKeys();
             }
 
             return;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Looking for feedback on the below changes - I don't think they are ready to merge in, but looking for early advice (or taking over ownership, if there is an eager maintainer).

The dir-diff support is in relation to https://github.com/gitextensions/gitextensions/issues/1647
The diff modes are improvements I wanted while working on the dir-diff support.

Fixes #

Changes proposed in this pull request:
- Add support for diff-tool, in the settings page
- Add two new compare modes 
  - Compare to Working Directory
  - Compare Selected Commits (use CTRL + click to select two commits, compare them in the order selected)

 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/242763/40944525-fcd1d19a-6809-11e8-8b88-44be204e544e.png)
![image](https://user-images.githubusercontent.com/242763/40944547-0fdb5392-680a-11e8-8903-e14548eb637f.png)

What did I do to test the code and ensure quality:
- Local testing with my setup


Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
