### PR TITLE
Initialise BuildServerWatcher earlier

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -213,6 +213,8 @@ namespace GitUI
 
             Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
             fixupCommitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Commands.CreateFixupCommit).ToShortcutKeyDisplayString();
+
+            BuildServerWatcher = new BuildServerWatcher(this, Revisions);
         }
 
         private static void FillMenuFromMenuCommands(IEnumerable<MenuCommand> menuCommands, ToolStripMenuItem targetMenuItem)
@@ -808,8 +810,6 @@ namespace GitUI
             Revisions.Visible = false;
             Loading.Visible = true;
             Loading.BringToFront();
-
-            BuildServerWatcher = new BuildServerWatcher(this, Revisions);
         }
 
         public new void Load()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5029

### Changes

- Move the initialisation of `BuildServerWatcher` to the constructor of `RevisionGrid` so that a NRE is not possible. There appears to be no reason to defer this construction as it doesn't do anything that depends upon later activity.
 
### QA Process

- Manual testing

### Environment

- GitExtensions version: master (observed as far back as 
- GIT version: 2.17.1.windows.2
- OS version: Windows 10 1803 (OS build 17134.81)

