### PR TITLE
Change some default settings values

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -876,7 +876,7 @@ namespace GitCommands
 
         public static bool ShowIndicatorForMultilineMessage
         {
-            get => GetBool("showindicatorformultilinemessage", false);
+            get => GetBool("showindicatorformultilinemessage", true);
             set => SetBool("showindicatorformultilinemessage", value);
         }
 
@@ -900,7 +900,7 @@ namespace GitCommands
 
         public static bool ShowIds
         {
-            get => GetBool("showids", false);
+            get => GetBool("showids", true);
             set => SetBool("showids", value);
         }
 
@@ -1066,7 +1066,7 @@ namespace GitCommands
 
         public static bool MarkIllFormedLinesInCommitMsg
         {
-            get => GetBool("markillformedlinesincommitmsg", false);
+            get => GetBool("markillformedlinesincommitmsg", true);
             set => SetBool("markillformedlinesincommitmsg", value);
         }
 


### PR DESCRIPTION
A beginning following the discussion in #5030

Changes proposed in this pull request:
- In revision grid, "Show SHA-1" and "Show indicator for multiline message" are enabled by default
- In commit form, "Mark ill formed lines" is enabled by default

What did I do to test the code and ensure quality:
- I removed the folder `%APPDATA%\GitExtensions` to restart with the default settings
- Launch the application
- Verify that the 3 settings are enabled by default

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
