### PR TITLE
RevisionGrid: Multiselection of revert commit

### DIFF
--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -2531,16 +2531,6 @@ namespace GitUI
             MenuCommands.TriggerMenuChanged(); // apply checkboxes changes also to FormBrowse main menu
         }
 
-        private void RevertCommitToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            if (LatestSelectedRevision == null)
-            {
-                return;
-            }
-
-            UICommands.StartRevertCommitDialog(this, LatestSelectedRevision);
-        }
-
         internal void FilterToolStripMenuItemClick(object sender, EventArgs e)
         {
             _revisionFilter.ShowDialog(this);
@@ -2902,6 +2892,15 @@ namespace GitUI
         {
             AppSettings.ShowSuperprojectRemoteBranches = !AppSettings.ShowSuperprojectRemoteBranches;
             ForceRefreshRevisions();
+        }
+
+        private void RevertCommitToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            var revisions = GetSelectedRevisions(SortDirection.Ascending);
+            foreach (var rev in revisions)
+            {
+                UICommands.StartRevertCommitDialog(this, rev);
+            }
         }
 
         private void CherryPickCommitToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #4360

Changes proposed in this pull request:
Revert commit in revision grid only reverted the last selected commit.
The behavior is changed to be analog with cherry-pck commit, revert all selected starting with the newest (selection order is ignored, larger refactoring should be done with interactive rebasing).
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Select two (or more) commits 
- Revert the commits 
- Verify that reversion is done with the newest first

Has been tested on (remove any that don't apply):
- Windows10
