### PR TITLE
[WIP]Revision Grid: Display an abbreviated hash

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -83,6 +83,7 @@ namespace GitCommands
         #region IGitItem Members
 
         public string Guid { get; set; }
+        public string AbbrevGuid { get; set; }
         public string Name { get; set; }
 
         #endregion

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -98,6 +98,7 @@ namespace GitCommands
                 /* Author date     */ "%at%n" +
                 /* Commit date     */ "%ct%n" +
                 /* Encoding        */ "%e%n" +
+                /* Abbrev Object ID*/ "%h%n" +
 
                 // Items below here must be decoded as strings to support non-ASCII
 
@@ -336,13 +337,14 @@ namespace GitCommands
 
             #endregion
 
-            #region Encoded string valies (names, emails, subject, body)
+            #region Encoded string values (names, emails, subject, body)
 
             // Finally, decode the names, email, subject and body strings using the required text encoding
             var s = encoding.GetString(array, offset, lastOffset - offset);
 
             var reader = new StringLineReader(s);
 
+            var abbrevObjectId = reader.ReadLine(stringPool);
             var author = reader.ReadLine(stringPool);
             var authorEmail = reader.ReadLine(stringPool);
             var committer = reader.ReadLine(stringPool);
@@ -371,6 +373,7 @@ namespace GitCommands
             {
                 // TODO are we really sure we can't make Revision.Guid an ObjectId?
                 Guid = objectIdStr,
+                AbbrevGuid = abbrevObjectId,
 
                 // TODO take IReadOnlyList<ObjectId> instead
                 ParentGuids = parentIds.ToArray(p => p.ToString()),

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -51,12 +51,6 @@ namespace GitUI
                     _authoredRevisionsBrush.Dispose();
                     _authoredRevisionsBrush = null;
                 }
-
-                if (_fontOfSHAColumn != null)
-                {
-                    _fontOfSHAColumn.Dispose();
-                    _fontOfSHAColumn = null;
-                }
             }
 
             if (disposing && (components != null))

--- a/GitUI/UserControls/RevisionGrid.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid.Designer.cs
@@ -259,8 +259,7 @@ namespace GitUI
             this.IdDataGridViewColumn.ReadOnly = true;
             this.IdDataGridViewColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             this.IdDataGridViewColumn.Visible = false;
-            this.IdDataGridViewColumn.FillWeight = 20f;
-            this.IdDataGridViewColumn.Resizable = DataGridViewTriState.False;
+            this.IdDataGridViewColumn.FillWeight = 7f;
             // 
             // mainContextMenu
             // 

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1979,7 +1979,7 @@ namespace GitUI
                     if (!revision.IsArtificial)
                     {
                         // do not show artificial GUID
-                        var text = revision.Guid;
+                        var text = revision.AbbrevGuid;
                         DrawColumnText(e, text, _fontOfSHAColumn, foreColor);
                     }
                 }

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -334,8 +334,7 @@ namespace GitUI
                 _normalFont = value;
                 MessageDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 DateDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
-                _fontOfSHAColumn = new Font("Consolas", _normalFont.SizeInPoints);
-                IdDataGridViewColumn.DefaultCellStyle.Font = _fontOfSHAColumn;
+                IdDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 IsMessageMultilineDataGridViewColumn.DefaultCellStyle.Font = _normalFont;
                 IsMessageMultilineDataGridViewColumn.Width = TextRenderer.MeasureText(MultilineMessageIndicator, NormalFont).Width;
 
@@ -1980,7 +1979,7 @@ namespace GitUI
                     {
                         // do not show artificial GUID
                         var text = revision.AbbrevGuid;
-                        DrawColumnText(e, text, _fontOfSHAColumn, foreColor);
+                        DrawColumnText(e, text, rowFont, foreColor);
                     }
                 }
                 else if (columnIndex == BuildServerWatcher.BuildStatusImageColumnIndex)
@@ -3183,7 +3182,6 @@ namespace GitUI
         }
 
         private bool _settingsLoaded;
-        private Font _fontOfSHAColumn;
 
         private void RunScript(object sender, EventArgs e)
         {


### PR DESCRIPTION
Fixes #5032

Changes proposed in this pull request:
- Display an abbreviated hash in the revision grid
- Change the font of the displayed hash (asked by @RussKie https://github.com/gitextensions/gitextensions/issues/5032#issuecomment-394700509 but I'm not sure to like it...)
- Make Hash column resizable again (revert of 74871a9bfe6c9437456da2dac9dab29ae6ca0bc5 #4990)
 /cc @mstv Why did you fix the column size?

- 👎 Broke the behavior of the copy with ctrl+c  that now copy all the line and not just the hash. **I need to fix that** but I had a look and I have no idea how my changes changed this behavior. If someone has an idea....

 
Screenshots before and after (if PR changes UI):
Before (the hash column is **not** resizable):
![image](https://user-images.githubusercontent.com/460196/41052338-c5931986-69b8-11e8-898e-baa153128e6f.png)

After (the abbreviated hash column is resizable):
![image](https://user-images.githubusercontent.com/460196/41051533-b4285550-69b6-11e8-9ed7-2cf4c9e60a48.png)

What did I do to test the code and ensure quality:
- Used my eyes ;)

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10 (High dpi)
