### PR TITLE
Apply font setting when using git commit template

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -250,8 +250,6 @@ namespace GitUI.CommandsDialogs
             Message.WatermarkText = _useFormCommitMessage
                 ? _enterCommitMessageHint.Text
                 : _commitMessageDisabled.Text;
-
-            AssignCommitMessageFromTemplate();
         }
 
         private void AssignCommitMessageFromTemplate()
@@ -1962,6 +1960,10 @@ namespace GitUI.CommandsDialogs
             if (_useFormCommitMessage && !string.IsNullOrEmpty(message))
             {
                 Message.Text = message;
+            }
+            else
+            {
+                AssignCommitMessageFromTemplate();
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5044 

## Changes proposed in this pull request:
- Apply font setting for commit message in commit dialog when using git commit template
 
## Screenshots before and after (if PR changes UI):
I intentionally set the commit font to a big size at 20
- Before<br><img src="https://user-images.githubusercontent.com/11786151/41055617-5f252fe0-69f4-11e8-8c34-47a73af55394.png" width=500>
- After<br><img src="https://user-images.githubusercontent.com/11786151/41055712-90eedf08-69f4-11e8-83a8-011758746580.png" width=500>

## What did I do to test the code and ensure quality:
- Deploy the beta version on my computer and keep using it. It seems good to me.

Has been tested on (remove any that don't apply):
- GIT 2.17.1 and above
- Windows 10 and above
