### PR TITLE
Try to create .git/hooks folder if missing

### DIFF
--- a/Plugins/Gerrit/GerritPlugin.cs
+++ b/Plugins/Gerrit/GerritPlugin.cs
@@ -20,11 +20,15 @@ namespace Gerrit
         private readonly TranslationString _installCommitMsgHook = new TranslationString("Install Hook");
         private readonly TranslationString _installCommitMsgHookShortText = new TranslationString("Install commit-msg hook");
         private readonly TranslationString _installCommitMsgHookMessage = new TranslationString("Gerrit requires a commit-msg hook to be installed. Do you want to install the commit-msg hook into your repository?");
-        private readonly TranslationString _installCommitMsgHookFailed = new TranslationString("Could not download the commit-msg file. Please install the commit-msg hook manually.");
+        private readonly TranslationString _installCommitMsgHookFolderCreationFailed = new TranslationString("Could not create the hooks folder. Please create the folder manually and try again.");
+        private readonly TranslationString _installCommitMsgHookDownloadFileFailed = new TranslationString("Could not download the commit-msg file. Please install the commit-msg hook manually.");
         #endregion
 
         private static readonly Dictionary<string, bool> _validatedHooks = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private static readonly object _syncRoot = new object();
+
+        private const string HooksFolderName = "hooks";
+        private const string CommitMessageHookFileName = "commit-msg";
 
         private bool _initialized;
         private ToolStripItem[] _gerritMenuItems;
@@ -97,7 +101,7 @@ namespace Gerrit
             if (gitModule == null)
                 throw new ArgumentNullException("gitDirectory");
 
-            string path = Path.Combine(gitModule.ResolveGitInternalPath("hooks"), "commit-msg");
+            string path = Path.Combine(gitModule.ResolveGitInternalPath(HooksFolderName), CommitMessageHookFileName);
 
             if (!File.Exists(path))
                 return false;
@@ -279,10 +283,28 @@ namespace Gerrit
             if (settings == null)
                 return;
 
-            string path = Path.Combine(
-                _gitUiCommands.GitModule.ResolveGitInternalPath("hooks"),
-                "commit-msg"
-            );
+            var hooksFolderPath = _gitUiCommands.GitModule.ResolveGitInternalPath(HooksFolderName);
+            if (!Directory.Exists(hooksFolderPath))
+            {
+                try
+                {
+                    Directory.CreateDirectory(hooksFolderPath);
+                }
+                catch
+                {
+                    MessageBox.Show(
+                        _mainForm,
+                        _installCommitMsgHookFolderCreationFailed.Text,
+                        _installCommitMsgHookShortText.Text,
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error
+                    );
+
+                    return;
+                }
+            }
+
+            var commitMessageHookPath = Path.Combine(hooksFolderPath, CommitMessageHookFileName);
 
             string content;
 
@@ -299,7 +321,7 @@ namespace Gerrit
             {
                 MessageBox.Show(
                     _mainForm,
-                    _installCommitMsgHookFailed.Text,
+                    _installCommitMsgHookDownloadFileFailed.Text,
                     _installCommitMsgHookShortText.Text,
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error
@@ -307,7 +329,7 @@ namespace Gerrit
             }
             else
             {
-                File.WriteAllText(path, content);
+                File.WriteAllText(commitMessageHookPath, content);
 
                 // Update the cache.
 


### PR DESCRIPTION
Fixes #3512

Changes proposed in this pull request:
- Try to create the .git/hooks folder if missing. Should any problems occur during folder creation, display a message and exit the installation flow.

What did I do to test the code and ensure quality:
- gave variables explicit names
- extracted constants
- simulated exception being thrown upon folder creation to visualize message and ensure flow exit

Has been tested on:
- GIT 2.51.02
- Windows 10
