### PR TITLE
Fix Regression: Ctrl+C on the revision grid no longer copy the hash of the commit

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.Designer.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.Designer.cs
@@ -65,7 +65,7 @@
             this.Name = "copyToClipboardToolStripMenuItem";
             this.Size = new System.Drawing.Size(264, 24);
             this.Text = "Copy to clipboard";
-            this.DropDownOpened += new System.EventHandler(this.copyToClipboardToolStripMenuItem_DropDownOpened);
+            this.DropDownOpening += new System.EventHandler(this.copyToClipboardToolStripMenuItem_DropDownOpening);
         }
 
         #endregion

--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
@@ -47,13 +47,13 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         private void AddDetailItems()
         {
-            InsertItemsAfterItem(separatorAfterRefNames, ViewModel.DetailItems.Select(i => new CopyToClipboardToolStripMenuItem(i.Text, i.Value)).ToArray());
+            InsertItemsAfterItem(separatorAfterRefNames, ViewModel.DetailItems.Select(i => new CopyToClipboardToolStripMenuItem(i.Text, () => i.Value)).ToArray());
             separatorAfterRefNames.Visible = ViewModel.SeparatorVisible;
         }
 
         private void AddRefNameItems(ToolStripItem captionItem, IReadOnlyList<string> gitNameList)
         {
-            InsertItemsAfterItem(captionItem, gitNameList.Select(name => new CopyToClipboardToolStripMenuItem(name, name)).ToArray());
+            InsertItemsAfterItem(captionItem, gitNameList.Select(name => new CopyToClipboardToolStripMenuItem(name, () => name)).ToArray());
             captionItem.Visible = gitNameList.Any();
         }
 

--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
+using ResourceManager;
 
 namespace GitUI.UserControls.RevisionGridClasses
 {
@@ -58,8 +59,20 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         private void AddDetailItems()
         {
-            InsertItemsAfterItem(separatorAfterRefNames, ViewModel.DetailItems.Select(i => new CopyToClipboardToolStripMenuItem(i.Text, () => i.Value)).ToArray());
+            InsertItemsAfterItem(separatorAfterRefNames, CommitHashFollowedByAllOtherDetailItems());
             separatorAfterRefNames.Visible = ViewModel.SeparatorVisible;
+        }
+
+        private CopyToClipboardToolStripMenuItem[] CommitHashFollowedByAllOtherDetailItems()
+        {
+            var commitHashCaption = new CopyContextMenuViewModel.DetailItem(Strings.GetCommitHashText(), ViewModel?.CommitHash, 15).Text;
+            var copyCommitHashItem = new CopyToClipboardToolStripMenuItem(commitHashCaption, () => ViewModel?.CommitHash, Keys.Control | Keys.C);
+
+            var items =
+                new[] { copyCommitHashItem }
+                    .Concat(ViewModel.DetailItems.Select(i => new CopyToClipboardToolStripMenuItem(i.Text, () => i.Value)));
+
+            return items.ToArray();
         }
 
         private void AddRefNameItems(ToolStripItem captionItem, IReadOnlyList<string> gitNameList)

--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
@@ -22,7 +22,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         /// </remarks>
         private void AddDefaultCopyCommitHashMenuItemWithCtrlCShortcut()
         {
-            DropDownItems.Add(new CopyToClipboardToolStripMenuItem("(tmp)", () => ViewModel?.CommitHash, Keys.Control | Keys.C));
+            DropDownItems.Add(CreateCopyCommitHashMenuItem("(tmp)"));
         }
 
         [Browsable(false)]
@@ -66,13 +66,18 @@ namespace GitUI.UserControls.RevisionGridClasses
         private CopyToClipboardToolStripMenuItem[] CommitHashFollowedByAllOtherDetailItems()
         {
             var commitHashCaption = new CopyContextMenuViewModel.DetailItem(Strings.GetCommitHashText(), ViewModel?.CommitHash, 15).Text;
-            var copyCommitHashItem = new CopyToClipboardToolStripMenuItem(commitHashCaption, () => ViewModel?.CommitHash, Keys.Control | Keys.C);
+            var copyCommitHashItem = CreateCopyCommitHashMenuItem(commitHashCaption);
 
             var items =
                 new[] { copyCommitHashItem }
                     .Concat(ViewModel.DetailItems.Select(i => new CopyToClipboardToolStripMenuItem(i.Text, () => i.Value)));
 
             return items.ToArray();
+        }
+
+        private CopyToClipboardToolStripMenuItem CreateCopyCommitHashMenuItem(string caption)
+        {
+            return new CopyToClipboardToolStripMenuItem(caption, () => ViewModel?.CommitHash, Keys.Control | Keys.C);
         }
 
         private void AddRefNameItems(ToolStripItem captionItem, IReadOnlyList<string> gitNameList)

--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
@@ -31,7 +31,7 @@ namespace GitUI.UserControls.RevisionGridClasses
         [Browsable(false)]
         private CopyContextMenuViewModel ViewModel => GetViewModel?.Invoke();
 
-        private void copyToClipboardToolStripMenuItem_DropDownOpened(object sender, EventArgs e)
+        private void copyToClipboardToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
             var r = ViewModel;
             if (r == null)

--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuItem.cs
@@ -11,6 +11,17 @@ namespace GitUI.UserControls.RevisionGridClasses
         public CopyContextMenuItem()
         {
             InitializeComponent();
+            AddDefaultCopyCommitHashMenuItemWithCtrlCShortcut();
+        }
+
+        /// <remarks>
+        /// This menu item is needed to override the default Ctrl+C handler of the grid control.
+        /// Because menu items' caption is a string value, this menu item must be updated
+        /// or replaced when the menu is opened to display updated commit hash in its label.
+        /// </remarks>
+        private void AddDefaultCopyCommitHashMenuItemWithCtrlCShortcut()
+        {
+            DropDownItems.Add(new CopyToClipboardToolStripMenuItem("(tmp)", () => ViewModel?.CommitHash, Keys.Control | Keys.C));
         }
 
         [Browsable(false)]

--- a/GitUI/UserControls/RevisionGridClasses/CopyContextMenuViewModel.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyContextMenuViewModel.cs
@@ -24,21 +24,23 @@ namespace GitUI.UserControls.RevisionGridClasses
         public IReadOnlyList<string> BranchNames { get; }
         public IReadOnlyList<string> TagNames { get; }
         public bool SeparatorVisible => BranchNames.Any() || TagNames.Any();
+        public string CommitHash { get; }
         public IReadOnlyList<DetailItem> DetailItems { get; }
 
         public CopyContextMenuViewModel(GitRevision gitRevision)
         {
             if (gitRevision == null)
             {
+                CommitHash = null;
                 DetailItems = new DetailItem[0];
                 BranchNames = new string[0];
                 TagNames = new string[0];
                 return;
             }
 
+            CommitHash = gitRevision.Guid;
             DetailItems = new[]
             {
-                new DetailItem(Strings.GetCommitHashText(), gitRevision.Guid, 15),
                 new DetailItem(Strings.GetMessageText(), gitRevision.Subject, 30),
                 new DetailItem(Strings.GetAuthorText(), gitRevision.Author),
                 new DetailItem(Strings.GetDateText(), gitRevision.CommitDate.ToString()),

--- a/GitUI/UserControls/RevisionGridClasses/CopyToClipboardToolStripMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyToClipboardToolStripMenuItem.cs
@@ -11,11 +11,12 @@ namespace GitUI.UserControls.RevisionGridClasses
     {
         private readonly Func<string> _value;
 
-        public CopyToClipboardToolStripMenuItem(string text, Func<string> value)
+        public CopyToClipboardToolStripMenuItem(string text, Func<string> value, Keys shortcut = default)
             : base(text)
         {
             _value = value;
             Click += CopyToClipboard;
+            ShortcutKeys = shortcut;
         }
 
         private void CopyToClipboard(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGridClasses/CopyToClipboardToolStripMenuItem.cs
+++ b/GitUI/UserControls/RevisionGridClasses/CopyToClipboardToolStripMenuItem.cs
@@ -6,11 +6,12 @@ namespace GitUI.UserControls.RevisionGridClasses
     /// <summary>
     /// Specialized menu item that has a title and a value which will be copied to the clipboard on click.
     /// </summary>
+    /// <remarks>Clipboard value is provided by a function, this allows the click event handler to react to some external changes without additional update events.</remarks>
     public class CopyToClipboardToolStripMenuItem : ToolStripMenuItem
     {
-        private readonly string _value;
+        private readonly Func<string> _value;
 
-        public CopyToClipboardToolStripMenuItem(string text, string value)
+        public CopyToClipboardToolStripMenuItem(string text, Func<string> value)
             : base(text)
         {
             _value = value;
@@ -19,7 +20,7 @@ namespace GitUI.UserControls.RevisionGridClasses
 
         private void CopyToClipboard(object sender, EventArgs e)
         {
-            Clipboard.SetText(_value);
+            Clipboard.SetText(_value());
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5049 (original PR #4925)

Changes proposed in this pull request:
- restore Ctrl+C shortcut on the copy commit hash submenu item
- in the original implementation this was achieved in the form designer, but because the predesigned menu was replaced with a dynamic one, some extra steps have to be done:
    - separate commit hash from other commit details in the view model
    - handle commit hash in a special way (add menu item with keyboard shortcut and special value function)
    - add a new menu item which handles Ctrl+C shortcut and is always created, this is required for the keyboard shortcut to work before the Copy to clipboard submenu is opened at least once
- despite the required extra logic, I have chosen this way of fixing the regression because this resembles the original implementation as much as possible
 
Screenshots before and after (if PR changes UI):
- before regression (v2.51.02) 
![image](https://user-images.githubusercontent.com/1851369/41190877-c0c56690-6be6-11e8-8b95-77b809d43820.png)
- before (after original PR)
![image](https://user-images.githubusercontent.com/1851369/41190795-4b0ec7ee-6be5-11e8-829d-80ad1bfa3d1e.png)
- after fix
![image](https://user-images.githubusercontent.com/1851369/41190817-a978f96c-6be5-11e8-8a6c-ff5cce90e5dc.png)

What did I do to test the code and ensure quality:
- manual verification
    - select a random revision and ctrl+c before opening the Copy to clipboard context menu
    - copy commit hash via the Copy to clipboard context menu
    - select a random revision and ctrl+c after opening the Copy to clipboard context menu

Has been tested on (remove any that don't apply):
- GIT 2.17.1
- Windows 8.1
