### PR TITLE
Jenkins: Ignore build events for certain branches

### DIFF
--- a/Plugins/BuildServerIntegration/JenkinsIntegration/Settings/JenkinsSettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/Settings/JenkinsSettingsUserControl.Designer.cs
@@ -30,9 +30,11 @@ namespace JenkinsIntegration.Settings
         {
             this.lblJenkinsServerUrl = new System.Windows.Forms.Label();
             this.lblProjectName = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.JenkinsServerUrl = new System.Windows.Forms.TextBox();
             this.JenkinsProjectName = new System.Windows.Forms.TextBox();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.lblIgnoreBuildBranch = new System.Windows.Forms.Label();
+            this.IgnoreBuildBranch = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -56,6 +58,16 @@ namespace JenkinsIntegration.Settings
             this.lblProjectName.TabIndex = 2;
             this.lblProjectName.Text = "Project name";
             // 
+            // lblIgnoreBuildBranch
+            // 
+            this.lblIgnoreBuildBranch.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblIgnoreBuildBranch.AutoSize = true;
+            this.lblIgnoreBuildBranch.Location = new System.Drawing.Point(3, 54);
+            this.lblIgnoreBuildBranch.Name = "lblIgnoreBuildBranch";
+            this.lblIgnoreBuildBranch.Size = new System.Drawing.Size(98, 13);
+            this.lblIgnoreBuildBranch.TabIndex = 4;
+            this.lblIgnoreBuildBranch.Text = "Ignore build for branch";
+            // 
             // JenkinsServerUrl
             // 
             this.JenkinsServerUrl.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -72,6 +84,14 @@ namespace JenkinsIntegration.Settings
             this.JenkinsProjectName.Size = new System.Drawing.Size(504, 21);
             this.JenkinsProjectName.TabIndex = 3;
             // 
+            // IgnoreBuildBranch
+            // 
+            this.IgnoreBuildBranch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.IgnoreBuildBranch.Location = new System.Drawing.Point(107, 3);
+            this.IgnoreBuildBranch.Name = "IgnoreBuildBranch";
+            this.IgnoreBuildBranch.Size = new System.Drawing.Size(504, 21);
+            this.IgnoreBuildBranch.TabIndex = 5;
+            // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.AutoSize = true;
@@ -80,15 +100,18 @@ namespace JenkinsIntegration.Settings
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.lblJenkinsServerUrl, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.JenkinsProjectName, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.lblProjectName, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblIgnoreBuildBranch, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.JenkinsServerUrl, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.JenkinsProjectName, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.IgnoreBuildBranch, 1, 2);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(614, 54);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(614, 87);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
             // JenkinsSettingsUserControl
@@ -99,7 +122,7 @@ namespace JenkinsIntegration.Settings
             this.Controls.Add(this.tableLayoutPanel1);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "JenkinsSettingsUserControl";
-            this.Size = new System.Drawing.Size(617, 57);
+            this.Size = new System.Drawing.Size(617, 90);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
@@ -111,8 +134,10 @@ namespace JenkinsIntegration.Settings
 
         private System.Windows.Forms.TextBox JenkinsServerUrl;
         private System.Windows.Forms.TextBox JenkinsProjectName;
+        private System.Windows.Forms.TextBox IgnoreBuildBranch;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label lblJenkinsServerUrl;
         private System.Windows.Forms.Label lblProjectName;
+        private System.Windows.Forms.Label lblIgnoreBuildBranch;
     }
 }

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/Settings/JenkinsSettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/Settings/JenkinsSettingsUserControl.cs
@@ -33,6 +33,7 @@ namespace JenkinsIntegration.Settings
             {
                 JenkinsServerUrl.Text = buildServerConfig.GetString("BuildServerUrl", string.Empty);
                 JenkinsProjectName.Text = buildServerConfig.GetString("ProjectName", _defaultProjectName);
+                IgnoreBuildBranch.Text = buildServerConfig.GetString("IgnoreBuildBranch", string.Empty);
             }
         }
 
@@ -40,6 +41,7 @@ namespace JenkinsIntegration.Settings
         {
             buildServerConfig.SetString("BuildServerUrl", JenkinsServerUrl.Text);
             buildServerConfig.SetString("ProjectName", JenkinsProjectName.Text);
+            buildServerConfig.SetString("IgnoreBuildBranch", IgnoreBuildBranch.Text);
         }
     }
 }


### PR DESCRIPTION
Fixes #5054

Changes proposed in this pull request:
- Configureable ignore build events for certain branch names
 
Screenshots before and after (if PR changes UI):
n/a

What did I do to test the code and ensure quality:
- Manually - Jenkins setup with multiple build events for one branch required to see the benefits, but logging-log4net on builds.apache.org can be used to suppress certain branches.

Has been tested on (remove any that don't apply):
- Windows 7 and 10
