### PR TITLE
Nullexception when no submodule status

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3477,7 +3477,13 @@ namespace GitCommands
                 return SubmoduleStatus.Unknown;
             }
 
-            string baseCommit = GetMergeBase(commit, oldCommit).ToString();
+            ObjectId baseOid = GetMergeBase(commit, oldCommit);
+            if (baseOid == null)
+            {
+                return SubmoduleStatus.Unknown;
+            }
+
+            string baseCommit = baseOid.ToString();
             if (baseCommit == oldCommit)
             {
                 return SubmoduleStatus.FastForward;

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -56,8 +56,8 @@ namespace GitUI.CommandsDialogs
 
             _baseRevision = new GitRevision(baseCommitSha);
             _headRevision = new GitRevision(headCommitSha);
-            _mergeBase = new GitRevision(Module.GetMergeBase(_baseRevision.Guid, _headRevision.Guid).ToString());
-            ckCompareToMergeBase.Text += $" ({GitRevision.ToShortSha(_mergeBase.Guid)})";
+            _mergeBase = new GitRevision(Module.GetMergeBase(_baseRevision.Guid, _headRevision.Guid)?.ToString());
+            ckCompareToMergeBase.Text += $" ({GitRevision.ToShortSha(_mergeBase?.Guid)})";
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _findFilePredicateProvider = new FindFilePredicateProvider();
             _revisionTester = new GitRevisionTester(_fullPathResolver);
@@ -295,7 +295,7 @@ namespace GitUI.CommandsDialogs
                 if (form.ShowDialog(this) == DialogResult.OK)
                 {
                     displayStr = form.BranchName;
-                    revision = new GitRevision(Module.RevParse(form.BranchName).ToString());
+                    revision = new GitRevision(Module.RevParse(form.BranchName)?.ToString());
                     PopulateDiffFiles();
                 }
             }


### PR DESCRIPTION
Regression from #4988
A few similar adjustments that will cause argument exception instead.

What did I do to test the code and ensure quality:
- Manual test with incorrectly removed submodule (giving strange messages also on command prompt)
- Other changes by code review.

Has been tested on (remove any that don't apply):
- Windows 10
