### PR TITLE
Selecting branch in tree shows wait cursor

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -356,9 +356,13 @@ namespace GitUI.CommandsDialogs
         }
 
         #region IBrowseRepo
+
         public void GoToRef(string refName, bool showNoRevisionMsg)
         {
-            RevisionGrid.GoToRef(refName, showNoRevisionMsg);
+            using (WaitCursorScope.Enter())
+            {
+                RevisionGrid.GoToRef(refName, showNoRevisionMsg);
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes #4985. This gives the user some feedback in case the operation takes a long time.

Changes proposed in this pull request:
- Show a wait cursor during `RevisionGrid.GoToRef` on `FormBrowse` 
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- Windows 10
