### PR TITLE
Avoid obtaining locks for git-status in the background

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -677,10 +677,11 @@ namespace GitCommands
             return args.ToString();
         }
 
-        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None)
+        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None, bool noLocks = false)
         {
             var args = new ArgumentBuilder
             {
+                { noLocks && VersionInUse.SupportNoOptionalLocks, "--no-optional-locks" },
                 "status --porcelain -z",
                 untrackedFiles,
                 ignoreSubmodules,

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -15,6 +15,7 @@ namespace GitCommands
         private static readonly GitVersion v2_5_1 = new GitVersion("2.5.1");
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
+        private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
         private static readonly GitVersion v2_16_3 = new GitVersion("2.16.3");
 
         public static readonly GitVersion LastSupportedVersion = v2_9_0;
@@ -60,6 +61,8 @@ namespace GitCommands
         public bool SupportWorktreeList => this >= v2_7_0;
 
         public bool SupportMergeUnrelatedHistory => this >= v2_9_0;
+
+        public bool SupportNoOptionalLocks => this >= v2_15_2;
 
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -283,7 +283,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             _ignoredFilesPending = _ignoredFilesAreStale;
 
             // git-status with ignored files when needed only
-            string command = GitCommandHelpers.GetAllChangedFilesCmd(!_ignoredFilesPending, UntrackedFilesMode.Default);
+            string command = GitCommandHelpers.GetAllChangedFilesCmd(!_ignoredFilesPending, UntrackedFilesMode.Default, noLocks: true);
             return Module.RunGitCmd(command);
         }
 

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -630,6 +630,9 @@ namespace GitCommandsTests.Git
             Assert.AreEqual(
                 "status --porcelain -z --untracked-files --ignore-submodules=all",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.All));
+            Assert.AreEqual(
+                "--no-optional-locks status --porcelain -z --untracked-files --ignore-submodules",
+                GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default, noLocks: true));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #5066
To be submitted for 2.51 too.

Changes proposed in this pull request:
- Use --no-optional-locks for git-status related to the commit count to avoid blocking interactive commands
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- GIT 2.17.1
- Windows 10
