### PR TITLE
fix: Windows size not restored

### DIFF
--- a/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
@@ -197,6 +197,7 @@
             //
             this.AcceptButton = this.Preview;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.Cancel;
             this.ClientSize = new System.Drawing.Size(434, 442);
             this.Controls.Add(this.labelPathHint);

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _reallyCleanupQuestionCaption = new TranslationString("Cleanup");
 
         public FormCleanupRepository(GitUICommands commands)
-            : base(commands)
+            : base(true, commands)
         {
             InitializeComponent();
             Translate();

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -239,6 +239,14 @@ namespace GitUI
             float scale = (float)DpiUtil.DpiX / position.DeviceDpi;
 
             StartPosition = FormStartPosition.Manual;
+            if (FormBorderStyle == FormBorderStyle.Sizable ||
+                FormBorderStyle == FormBorderStyle.SizableToolWindow)
+            {
+                Size formSize = position.Rect.Size;
+                formSize.Width = (int)(formSize.Width * scale);
+                formSize.Height = (int)(formSize.Height * scale);
+                Size = formSize;
+            }
 
             if (Owner == null || !_windowCentred)
             {


### PR DESCRIPTION
Reverting the change (#4891, cbb66f4a739642f47bc26d63a378fcee72126ce4) that caused the regression.
The underlying original issue seems to be due to the form not using DPI auto scale mode.

Fixes #5021

What did I do to test the code and ensure quality:
- manually run to ensure forms retain their sizes and positions across re-launches

Has been tested on (remove any that don't apply):
- Windows 10 with 200% scaling
