### PR TITLE
Fixed "Toggle branch tree panel" menu item icon

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGridClasses/RevisionGridMenuCommands.cs
@@ -356,6 +356,7 @@ namespace GitUI.UserControls.RevisionGridClasses
                 {
                     Name = "ToggleBranchTreePanel",
                     Text = "Toggle left panel",
+                    Image = Properties.MsVsImages.Branch_16x,
                     ExecuteAction = () => _revisionGrid.OnToggleBranchTreePanelRequested()
                 }
             };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5052 

Changes proposed in this pull request:
- Fixed a bug where "Toggle Branch Tree Panel" menu item command had no icon.
 
Screenshots before and after (if PR changes UI):
- Before:
![image](https://user-images.githubusercontent.com/14019835/41510866-a436577a-7274-11e8-91c4-38a74eb6fa8a.png)

- After:
![image](https://user-images.githubusercontent.com/14019835/41510849-61012390-7274-11e8-92b8-8d8fde9a1ccb.png)

