### PR TITLE
Bugfix for #5065 and #5083: hotkeys 'B' and 'H' in RevisionDiff.

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -99,6 +99,11 @@ namespace GitUI.CommandsDialogs
 
         protected override bool ExecuteCommand(int cmd)
         {
+            if (DiffFiles.FilterFocused && IsTextEditKey(GetShortcutKeys(cmd)))
+            {
+                return false;
+            }
+
             switch ((Command)cmd)
             {
                 case Command.DeleteSelectedFiles: return DeleteSelectedFiles();
@@ -456,7 +461,7 @@ namespace GitUI.CommandsDialogs
         {
             GitItemStatus item = DiffFiles.SelectedItem;
 
-            if (item.IsTracked)
+            if (item != null && item.IsTracked)
             {
                 UICommands.StartFileHistoryDialog(this, item.Name, DiffFiles.Revision, true, true);
             }
@@ -538,7 +543,7 @@ namespace GitUI.CommandsDialogs
         {
             GitItemStatus item = DiffFiles.SelectedItem;
 
-            if (item.IsTracked)
+            if (item != null && item.IsTracked)
             {
                 UICommands.StartFileHistoryDialog(this, item.Name, DiffFiles.Revision);
             }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -159,6 +159,8 @@ namespace GitUI
             }
         }
 
+        public bool FilterFocused => FilterComboBox.Focused;
+
         public override bool Focused => FileStatusListView.Focused;
 
         public new void Focus()

--- a/ResourceManager/GitExtensionsUserControl.cs
+++ b/ResourceManager/GitExtensionsUserControl.cs
@@ -127,6 +127,37 @@ namespace ResourceManager
             return false;
         }
 
+        /// <summary>
+        /// Returns whether the given [combination of] key[s] represents a keypress which is used for text input by default.
+        /// <remarks>Can be used to ignore hotkeys which would prevent from typing text into an input control if it's focused.</remarks>
+        /// </summary>
+        /// <param name="multiLine">Should be set to true for multi-line input controls to match keys for vertical movement, too.</param>
+        public static bool IsTextEditKey(Keys keys, bool multiLine = false)
+        {
+            keys &= ~Keys.Shift; // ignore the SHIFT key as modifier
+            switch (keys)
+            {
+                case Keys key when (key >= Keys.A && key <= Keys.Z) || (key >= Keys.D0 && key <= Keys.D9) || (key >= Keys.Oem1 && key <= Keys.Oem102):
+                case Keys.Space:
+                case Keys.Back:
+                case Keys.Delete:
+                case Keys.Insert:
+                case Keys.Left:
+                case Keys.Right:
+                case Keys.Home:
+                case Keys.End:
+                    return true;
+
+                case Keys.Up:
+                case Keys.Down:
+                case Keys.PageUp:
+                case Keys.PageDown:
+                    return multiLine;
+            }
+
+            return false;
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #5065, fixes #5083.

Changes proposed in this pull request:
- ignore the hotkey if the DiffFiles.FilterComboBox is focused and the hotkey is a normal character
- ignore the hotkey if no item is selected in DiffFiles
 
Screenshots before and after (if PR changes UI):
N/A

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Windows 7