### PR TITLE
Fixed EqualsAtIndex.

### DIFF
--- a/GitCommands/StringPool.cs
+++ b/GitCommands/StringPool.cs
@@ -38,7 +38,7 @@ namespace GitCommands
 
             if (bucket is string s)
             {
-                if (EqualsAtIndex(source, index, s))
+                if (EqualsAtIndex(source, index, length, s))
                 {
                     return s;
                 }
@@ -55,7 +55,7 @@ namespace GitCommands
                 for (var i = 0; i < list.Count; i++)
                 {
                     var item = list[i];
-                    if (item.Length == length && EqualsAtIndex(source, index, item))
+                    if (EqualsAtIndex(source, index, length, item))
                     {
                         return item;
                     }
@@ -137,11 +137,16 @@ namespace GitCommands
         #region Zero-allocation equality and hashing from substrings
 
         [Pure]
-        internal static unsafe bool EqualsAtIndex(string source, int index, string comparand)
+        internal static unsafe bool EqualsAtIndex(string source, int index, int length, string comparand)
         {
             var len = comparand.Length;
 
-            if (index + comparand.Length > source.Length)
+            if (len != length)
+            {
+                return false;
+            }
+
+            if (index + length > source.Length)
             {
                 throw new InvalidOperationException("Index and length extend beyond end of source string.");
             }

--- a/UnitTests/GitCommandsTests/StringPoolTests.cs
+++ b/UnitTests/GitCommandsTests/StringPoolTests.cs
@@ -74,34 +74,40 @@ namespace GitCommandsTests
                 {
                     const string format = "index={0} length={1}";
 
-                    Assert.True(StringPool.EqualsAtIndex(s, index, s.Substring(index, length)), format, index, length);
+                    Assert.True(StringPool.EqualsAtIndex(s, index, length, s.Substring(index, length)), format, index, length);
 
                     if (length < s.Length)
                     {
-                        Assert.False(StringPool.EqualsAtIndex(s, index, s.Substring(index, length) + 'Z'), format, index, length);
+                        Assert.False(StringPool.EqualsAtIndex(s, index, length, s.Substring(index, length) + 'Z'), format, index, length);
                     }
 
                     if (index > 0 && length > 0)
                     {
-                        Assert.False(StringPool.EqualsAtIndex(s, index - 1, s.Substring(index, length)), format, index, length);
-                        Assert.False(StringPool.EqualsAtIndex(s, index, s.Substring(index - 1, length)), format, index, length);
+                        Assert.False(StringPool.EqualsAtIndex(s, index - 1, length, s.Substring(index, length)), format, index, length);
+                        Assert.False(StringPool.EqualsAtIndex(s, index, length, s.Substring(index - 1, length)), format, index, length);
                     }
 
                     if (index + length < s.Length)
                     {
                         if (length == 0)
                         {
-                            Assert.True(StringPool.EqualsAtIndex(s, index + 1, s.Substring(index, length)), format, index, length);
-                            Assert.True(StringPool.EqualsAtIndex(s, index, s.Substring(index + 1, length)), format, index, length);
+                            Assert.True(StringPool.EqualsAtIndex(s, index + 1, length, s.Substring(index, length)), format, index, length);
+                            Assert.True(StringPool.EqualsAtIndex(s, index, length, s.Substring(index + 1, length)), format, index, length);
                         }
                         else
                         {
-                            Assert.False(StringPool.EqualsAtIndex(s, index + 1, s.Substring(index, length)), format, index, length);
-                            Assert.False(StringPool.EqualsAtIndex(s, index, s.Substring(index + 1, length)), format, index, length);
+                            Assert.False(StringPool.EqualsAtIndex(s, index + 1, length, s.Substring(index, length)), format, index, length);
+                            Assert.False(StringPool.EqualsAtIndex(s, index, length, s.Substring(index + 1, length)), format, index, length);
                         }
                     }
                 }
             }
+        }
+
+        [Test]
+        public void EqualsAtIndex_Substring()
+        {
+            Assert.False(StringPool.EqualsAtIndex("janusz@gitext.pl", 0, 16, "janusz"));
         }
 
         [Test]


### PR DESCRIPTION
The current implementation uses the candidate's length to compare with the source.
If the candidate is a substring of the source at the given index then EqualsAtIndex returns a false positive.
