### PR TITLE
Add Atom to editors list

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -19,7 +19,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 "notepad",
                 GetNotepadPP(),
                 GetSublimeText3(),
-                GetVsCode()
+                GetVsCode(),
+                GetAtom()
             };
         }
 
@@ -33,6 +34,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private static string GetVsCode()
         {
             return GetEditorCommandLine("Visual Studio Code", "code.exe", " --wait", "Microsoft VS Code");
+        }
+
+        [NotNull]
+        private static string GetAtom()
+        {
+            return GetEditorCommandLine("Atom", "atom.exe", " --wait", "atom");
         }
 
         [NotNull]

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -39,49 +39,38 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     continue;
                 }
 
+                string fullName = string.Empty;
                 string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
 
-                if (CheckFileExists(programFilesPath, location, fileName, out string fullName))
+                if (CheckFileExists(programFilesPath))
                 {
                     return fullName;
                 }
 
-                if (IntPtr.Size == 8
-                    || (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432"))))
-                {
-                    programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+                programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
 
-                    if (CheckFileExists(programFilesPath, location, fileName, out fullName))
-                    {
-                        return fullName;
-                    }
+                if ((IntPtr.Size == 8 ||
+                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432"))) &&
+                    CheckFileExists(programFilesPath))
+                {
+                    return fullName;
                 }
 
                 string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-                if (CheckFileExists(localAppDataPath, location, fileName, out fullName))
+                if (CheckFileExists(localAppDataPath))
                 {
                     return fullName;
                 }
-            }
 
-            return string.Empty;
-        }
-
-        private static bool CheckFileExists(string path, string location, string fileName, out string fullName)
-        {
-            if (!string.IsNullOrEmpty(path))
-            {
-                path = Path.Combine(path, location);
-                if (Directory.Exists(path))
+                bool CheckFileExists(string path)
                 {
-                    fullName = Path.Combine(path, fileName);
+                    fullName = Path.Combine(path, location, fileName);
                     return File.Exists(fullName);
                 }
             }
 
-            fullName = string.Empty;
-            return false;
+            return string.Empty;
         }
 
         private static string UnquoteString(string str)

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -39,11 +39,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     continue;
                 }
 
+                string fullName = string.Empty;
                 string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
 
-                if (CheckFileExists(programFilesPath, location, ref fileName))
+                if (CheckFileExists(programFilesPath, location, fileName, out fullName))
                 {
-                    return fileName;
+                    return fullName;
                 }
 
                 if (IntPtr.Size == 8
@@ -51,35 +52,36 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 {
                     programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
 
-                    if (CheckFileExists(programFilesPath, location, ref fileName))
+                    if (CheckFileExists(programFilesPath, location, fileName, out fullName))
                     {
-                        return fileName;
+                        return fullName;
                     }
                 }
 
                 string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-                if (CheckFileExists(localAppDataPath, location, ref fileName))
+                if (CheckFileExists(localAppDataPath, location, fileName, out fullName))
                 {
-                    return fileName;
+                    return fullName;
                 }
             }
 
             return string.Empty;
         }
 
-        private static bool CheckFileExists(string path, string location, ref string fileName)
+        private static bool CheckFileExists(string path, string location, string fileName, out string fullName)
         {
             if (!string.IsNullOrEmpty(path))
             {
                 path = Path.Combine(path, location);
                 if (Directory.Exists(path))
                 {
-                    fileName = Path.Combine(path, fileName);
-                    return File.Exists(fileName);
+                    fullName = Path.Combine(path, fileName);
+                    return File.Exists(fullName);
                 }
             }
 
+            fullName = string.Empty;
             return false;
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -39,10 +39,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     continue;
                 }
 
-                string fullName = string.Empty;
                 string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
 
-                if (CheckFileExists(programFilesPath, location, fileName, out fullName))
+                if (CheckFileExists(programFilesPath, location, fileName, out string fullName))
                 {
                     return fullName;
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -41,19 +41,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
                 string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
 
-                string path;
-
-                if (!string.IsNullOrEmpty(programFilesPath))
+                if (CheckFileExists(programFilesPath, location, ref fileName))
                 {
-                    path = Path.Combine(programFilesPath, location);
-                    if (Directory.Exists(path))
-                    {
-                        string fullName = Path.Combine(path, fileName);
-                        if (File.Exists(fullName))
-                        {
-                            return fullName;
-                        }
-                    }
+                    return fileName;
                 }
 
                 if (IntPtr.Size == 8
@@ -61,37 +51,36 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 {
                     programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
 
-                    if (!string.IsNullOrEmpty(programFilesPath))
+                    if (CheckFileExists(programFilesPath, location, ref fileName))
                     {
-                        path = Path.Combine(programFilesPath, location);
-                        if (Directory.Exists(path))
-                        {
-                            string fullName = Path.Combine(path, fileName);
-                            if (File.Exists(fullName))
-                            {
-                                return fullName;
-                            }
-                        }
+                        return fileName;
                     }
                 }
 
                 string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
-                if (!string.IsNullOrEmpty(localAppDataPath))
+                if (CheckFileExists(localAppDataPath, location, ref fileName))
                 {
-                    path = Path.Combine(localAppDataPath, location);
-                    if (Directory.Exists(path))
-                    {
-                        string fullName = Path.Combine(path, fileName);
-                        if (File.Exists(fullName))
-                        {
-                            return fullName;
-                        }
-                    }
+                    return fileName;
                 }
             }
 
             return string.Empty;
+        }
+
+        private static bool CheckFileExists(string path, string location, ref string fileName)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                path = Path.Combine(path, location);
+                if (Directory.Exists(path))
+                {
+                    fileName = Path.Combine(path, fileName);
+                    return File.Exists(fileName);
+                }
+            }
+
+            return false;
         }
 
         private static string UnquoteString(string str)

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -74,6 +74,21 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                         }
                     }
                 }
+
+                string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+                if (!string.IsNullOrEmpty(localAppDataPath))
+                {
+                    path = Path.Combine(localAppDataPath, location);
+                    if (Directory.Exists(path))
+                    {
+                        string fullName = Path.Combine(path, fileName);
+                        if (File.Exists(fullName))
+                        {
+                            return fullName;
+                        }
+                    }
+                }
             }
 
             return string.Empty;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2507

Changes proposed in this pull request:
- Added Atom editor to editors list in Git Config.
 
What did I do to test the code and ensure quality:
- Set Atom editor as the global editor and opened the "Reword commit" dialog, to see it opens Atom.

Has been tested on (remove any that don't apply):
- GIT 2.10 and above
- Windows 10
