### PR TITLE
Avoid obtaining locks for git-status in the background

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -854,9 +854,11 @@ namespace GitCommands
             return command;
         }
 
-        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = 0)
+        public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None, bool noLocks = false)
         {
-            StringBuilder stringBuilder = new StringBuilder("status --porcelain -z");
+            StringBuilder stringBuilder = new StringBuilder( 
+                noLocks && VersionInUse.SupportNoOptionalLocks ? "--no-optional-locks" : ""
+                + "status --porcelain -z");
 
             switch (untrackedFiles)
             {

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -15,6 +15,7 @@ namespace GitCommands
         private static readonly GitVersion v2_5_1 = new GitVersion("2.5.1");
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
+        private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
         private static readonly GitVersion v2_16_3 = new GitVersion("2.16.3");
 
         public static readonly GitVersion LastSupportedVersion = v2_9_0;
@@ -98,6 +99,8 @@ namespace GitCommands
         {
             get { return a == 0 && b == 0 && c == 0 && d == 0; }
         }
+
+        public bool SupportNoOptionalLocks => this >= v2_15_2;
 
         // Returns true if it's possible to pass given string as command line
         // argument to git for searching.

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -286,7 +286,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private string RunStatusCommand()
         {
-            string command = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.Default);
+            string command = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.Default, noLocks: true);
             return Module.RunGitCmd(command);
         }
 


### PR DESCRIPTION
Cherry-pick of 1b5d811c50 for 2.51
Same as #5067 , no tests
resolves #5066

Has been tested on (remove any that don't apply):
- GIT 2.17
