### PR TITLE
fix: Dashboard categories can't collapse

### DIFF
--- a/GitUI/UserControls/ExListView.cs
+++ b/GitUI/UserControls/ExListView.cs
@@ -355,7 +355,7 @@ namespace GitUI.UserControls
                 group.Mask = NativeMethods.ListViewGroupMask.State;
 
                 var handleRef = new HandleRef(this, Handle);
-                group.IGroupId = groupId < 0 ? groupId : groupIndex;
+                group.IGroupId = groupId > 0 ? groupId : groupIndex;
                 NativeMethods.SendMessage(handleRef, NativeMethods.LVM_SETGROUPINFO, (IntPtr)group.IGroupId, ref group);
             }
         }


### PR DESCRIPTION
Relates to #5084

 
Screenshots before and after (if PR changes UI):
before:
![image](https://user-images.githubusercontent.com/4403806/41646653-bedfa078-74b7-11e8-8563-8a4d46ebce14.png)

after:
![image](https://user-images.githubusercontent.com/4403806/41647663-4a6b0aa4-74ba-11e8-977b-cdcc5f845127.png)


What did I do to test the code and ensure quality:
- manually

Has been tested on (remove any that don't apply):
- Windows 10
