### PR TITLE
Increase the initial capacity of StringPool in order to avoid frequet rehashing.

### DIFF
--- a/GitCommands/StringPool.cs
+++ b/GitCommands/StringPool.cs
@@ -15,8 +15,8 @@ namespace GitCommands
     /// </summary>
     public sealed class StringPool
     {
-        private object[] _buckets = new object[4];
-        private int _capacity = 3;
+        private object[] _buckets = new object[2048];
+        private int _capacity = 1536;
 
         /// <summary>
         /// Gets the number of items unique strings in the pool.


### PR DESCRIPTION
Changes proposed in this pull request:

- Increase the initial capacity of StringPool. An average repository of 10000+ commits needs about 1000 buckets. I propose to start with 2000 buckets to lower the number of collisions and leave some free buckets for larger repos. Avoiding unnecessary rehash operations decreases parsing time of ~100ms on my laptop.
 