### PR TITLE
Better accessibility for reset dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
@@ -76,7 +76,7 @@
             this.cbDeleteNewFilesAndDirectories.Name = "cbDeleteNewFilesAndDirectories";
             this.cbDeleteNewFilesAndDirectories.Size = new System.Drawing.Size(251, 20);
             this.cbDeleteNewFilesAndDirectories.TabIndex = 3;
-            this.cbDeleteNewFilesAndDirectories.Text = "Also delete new files and/or directories";
+            this.cbDeleteNewFilesAndDirectories.Text = "Also delete &new files and/or directories";
             this.cbDeleteNewFilesAndDirectories.UseVisualStyleBackColor = true;
             // 
             // label2


### PR DESCRIPTION
Changes proposed in this pull request:
- Add Alt+N as a hotkey for the checkbox 'Also delete new files and/or directories' in the reset dialog
 
Screenshots before and after (if PR changes UI):
- Nothing

What did I do to test the code and ensure quality:
- Nothing
