### PR TITLE
Fix 5098 margin adjustments

### DIFF
--- a/GitExtUtils/GitUI/ControlDpiExtensions.cs
+++ b/GitExtUtils/GitUI/ControlDpiExtensions.cs
@@ -34,37 +34,44 @@ namespace GitUI
                 switch (next)
                 {
                     case ButtonBase button:
-                    {
-                        if (button.Image != null)
                         {
-                            button.Image = DpiUtil.Scale(button.Image);
-                        }
+                            if (button.Image != null)
+                            {
+                                button.Image = DpiUtil.Scale(button.Image);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
 
                     case PictureBox pictureBox:
-                    {
-                        if (pictureBox.Image != null)
                         {
-                            pictureBox.Image = DpiUtil.Scale(pictureBox.Image);
+                            if (pictureBox.Image != null)
+                            {
+                                pictureBox.Image = DpiUtil.Scale(pictureBox.Image);
+                            }
+
+                            break;
                         }
 
-                        break;
-                    }
-
                     case TabControl tabControl:
-                    {
-                        tabControl.Padding = DpiUtil.Scale(tabControl.Padding);
-                        EnqueueChildren();
-                        break;
-                    }
+                        {
+                            tabControl.Padding = DpiUtil.Scale(tabControl.Padding);
+                            EnqueueChildren();
+                            break;
+                        }
 
                     default:
-                    {
-                        EnqueueChildren();
-                        break;
-                    }
+                        {
+                            if (next is TextBoxBase || next is UpDownBase)
+                            {
+                                // BUG: looks like a bug in WinForms - control's margin gets scaled beyond expectations
+                                // see https://github.com/gitextensions/gitextensions/issues/5098
+                                DpiUtil.ScaleDefaultMargins(next);
+                            }
+
+                            EnqueueChildren();
+                            break;
+                        }
                 }
 
                 void EnqueueChildren()

--- a/GitExtUtils/GitUI/DpiUtil.cs
+++ b/GitExtUtils/GitUI/DpiUtil.cs
@@ -52,6 +52,23 @@ namespace GitExtUtils.GitUI
         public static bool IsNonStandard => DpiX != 96 || DpiY != 96;
 
         /// <summary>
+        /// BUG: looks like a bug in WinForms - control's margin gets scaled beyond expectations
+        /// For example, if the design was done at 100% and Windows is set to scale to 200%, NUD's margins gets set at 96...
+        /// </summary>
+        /// <param name="control">The control that needs to have margins reset to default values and scaled appropriately.</param>
+        public static void ScaleDefaultMargins([NotNull] Control control)
+        {
+            if (control is Label)
+            {
+                control.Margin = Scale(new Padding(3, 0, 3, 0));
+            }
+            else
+            {
+                control.Margin = Scale(new Padding(3));
+            }
+        }
+
+        /// <summary>
         /// Returns a scaled copy of <paramref name="size"/> which takes equivalent
         /// screen space at the current DPI as the original would at 96 DPI.
         /// </summary>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -33,9 +33,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             base.OnRuntimeLoad();
 
             // align 1st columns across all tables
-            tlpnlGeneral.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblLanguage, lblSpellingDictionary);
-            tlpnlAuthor.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblLanguage, lblSpellingDictionary);
-            tlpnlLanguage.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblLanguage, lblSpellingDictionary);
+            tlpnlGeneral.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
+            tlpnlAuthor.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
+            tlpnlLanguage.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
 
             // align 2nd columns across all tables
             cbBranchOrderingCriteria.AdjustWidthToFitContent();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -173,6 +173,7 @@
             // 
             // lblShPath
             // 
+            this.lblShPath.AutoSize = true;
             this.lblShPath.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblShPath.Location = new System.Drawing.Point(3, 42);
             this.lblShPath.Name = "lblShPath";

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -44,6 +44,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             T result = new T();
 
+            result.AdjustForDpiScaling();
+
             result.Init(pageHost);
 
             return result;


### PR DESCRIPTION
It looks like a bug in WinForms - NumericUpDown and TextBox controls' margins seems to get scaled beyond expectations when Windows is set to scale.
For example, if the design was done at 100% and Windows is set to scale to 200%, NUD's margins get set to (96, 96, 96, 96) and TB's margins get set to (12, 12, 12, 12).

Fixes #5098
 
Screenshots before and after (if PR changes UI):
- refer to the original issue

What did I do to test the code and ensure quality:
- manual runs, opened various forms and dialogs to check for visual regressions
