### PR TITLE
Added "Select All" feature to Delete Unused Branches plugin

### DIFF
--- a/Plugins/DeleteUnusedBranches/CheckBoxHeaderCellEventArgs.cs
+++ b/Plugins/DeleteUnusedBranches/CheckBoxHeaderCellEventArgs.cs
@@ -4,6 +4,11 @@ namespace DeleteUnusedBranches
 {
     public class CheckBoxHeaderCellEventArgs : EventArgs
     {
-        public bool Checked { get; set; }
+        public CheckBoxHeaderCellEventArgs(bool checkedValue)
+        {
+            Checked = checkedValue;
+        }
+
+        public bool Checked { get; }
     }
 }

--- a/Plugins/DeleteUnusedBranches/CheckBoxHeaderCellEventArgs.cs
+++ b/Plugins/DeleteUnusedBranches/CheckBoxHeaderCellEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DeleteUnusedBranches
+{
+    public class CheckBoxHeaderCellEventArgs : EventArgs
+    {
+        public bool Checked { get; set; }
+    }
+}

--- a/Plugins/DeleteUnusedBranches/DataGridViewCheckBoxHeaderCell.cs
+++ b/Plugins/DeleteUnusedBranches/DataGridViewCheckBoxHeaderCell.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+using System.Windows.Forms.VisualStyles;
+
+namespace DeleteUnusedBranches
+{
+    public delegate void CheckBoxClickedHandler(bool state);
+
+    public class DataGridViewCheckBoxHeaderCellEventArgs : EventArgs
+    {
+        public DataGridViewCheckBoxHeaderCellEventArgs(bool value)
+        {
+            Checked = value;
+        }
+
+        public bool Checked { get; }
+    }
+
+    internal class DataGridViewCheckBoxHeaderCell : DataGridViewColumnHeaderCell
+    {
+        private Point _checkBoxLocation;
+        private Size _checkBoxSize;
+        private bool _checked = false;
+        private Point _cellLocation = new Point();
+        private CheckBoxState _cbState = CheckBoxState.UncheckedNormal;
+        public event CheckBoxClickedHandler OnCheckBoxClicked;
+
+        public DataGridViewCheckBoxHeaderCell()
+        {
+        }
+
+        protected override void Paint(Graphics graphics,
+            Rectangle clipBounds,
+            Rectangle cellBounds,
+            int rowIndex,
+            DataGridViewElementStates dataGridViewElementState,
+            object value,
+            object formattedValue,
+            string errorText,
+            DataGridViewCellStyle cellStyle,
+            DataGridViewAdvancedBorderStyle advancedBorderStyle,
+            DataGridViewPaintParts paintParts)
+        {
+            base.Paint(graphics, clipBounds, cellBounds, rowIndex,
+                dataGridViewElementState, value,
+                formattedValue, errorText, cellStyle,
+                advancedBorderStyle, paintParts);
+            Point p = new Point();
+            Size s = CheckBoxRenderer.GetGlyphSize(graphics, CheckBoxState.UncheckedNormal);
+            p.X = cellBounds.Location.X + (cellBounds.Width / 2) - (s.Width / 2);
+            p.Y = cellBounds.Location.Y + (cellBounds.Height / 2) - (s.Height / 2);
+            _cellLocation = cellBounds.Location;
+            _checkBoxLocation = p;
+            _checkBoxSize = s;
+            if (_checked)
+            {
+                _cbState = CheckBoxState.CheckedNormal;
+            }
+            else
+            {
+                _cbState = CheckBoxState.UncheckedNormal;
+            }
+
+            CheckBoxRenderer.DrawCheckBox(graphics, _checkBoxLocation, _cbState);
+        }
+
+        protected override void OnMouseClick(DataGridViewCellMouseEventArgs e)
+        {
+            Point p = new Point(e.X + _cellLocation.X, e.Y + _cellLocation.Y);
+            if (p.X >= _checkBoxLocation.X && p.X <= _checkBoxLocation.X + _checkBoxSize.Width
+            && p.Y >= _checkBoxLocation.Y && p.Y <= _checkBoxLocation.Y + _checkBoxSize.Height)
+            {
+                _checked = !_checked;
+                if (OnCheckBoxClicked != null)
+                {
+                    OnCheckBoxClicked(_checked);
+                    DataGridView.InvalidateCell(this);
+                }
+            }
+
+            base.OnMouseClick(e);
+        }
+
+        public void SetValue(bool value)
+        {
+            _checked = value;
+            DataGridView.InvalidateCell(this);
+        }
+    }
+}

--- a/Plugins/DeleteUnusedBranches/DataGridViewCheckBoxHeaderCell.cs
+++ b/Plugins/DeleteUnusedBranches/DataGridViewCheckBoxHeaderCell.cs
@@ -9,17 +9,19 @@ namespace DeleteUnusedBranches
     {
         private Point _checkBoxLocation;
         private Size _checkBoxSize;
-        private Point _cellLocation = new Point();
-        private CheckBoxState _cbState = CheckBoxState.UncheckedNormal;
-        private bool _checked = false;
+        private Point _cellLocation;
+        private bool _checked;
 
         public bool Checked
         {
             get { return _checked; }
             set
             {
-                _checked = value;
-                DataGridView.InvalidateCell(this);
+                if (_checked != value)
+                {
+                    _checked = value;
+                    DataGridView.InvalidateCell(this);
+                }
             }
         }
 
@@ -51,17 +53,18 @@ namespace DeleteUnusedBranches
             _cellLocation = cellBounds.Location;
             _checkBoxLocation = p;
             _checkBoxSize = s;
+            CheckBoxState checkboxState;
 
             if (_checked)
             {
-                _cbState = CheckBoxState.CheckedNormal;
+                checkboxState = CheckBoxState.CheckedNormal;
             }
             else
             {
-                _cbState = CheckBoxState.UncheckedNormal;
+                checkboxState = CheckBoxState.UncheckedNormal;
             }
 
-            CheckBoxRenderer.DrawCheckBox(graphics, _checkBoxLocation, _cbState);
+            CheckBoxRenderer.DrawCheckBox(graphics, _checkBoxLocation, checkboxState);
         }
 
         protected override void OnMouseClick(DataGridViewCellMouseEventArgs e)
@@ -75,11 +78,7 @@ namespace DeleteUnusedBranches
                 Checked = !Checked;
                 if (CheckBoxClicked != null)
                 {
-                    CheckBoxHeaderCellEventArgs args = new CheckBoxHeaderCellEventArgs
-                    {
-                        Checked = Checked
-                    };
-                    OnCheckBoxClicked(args);
+                    OnCheckBoxClicked(new CheckBoxHeaderCellEventArgs(Checked));
                     DataGridView.InvalidateCell(this);
                 }
             }

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
@@ -49,6 +49,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Branch.cs" />
+    <Compile Include="DataGridViewCheckBoxHeaderCell.cs" />
     <Compile Include="DeleteUnusedBranchesFormSettings.cs" />
     <Compile Include="DeleteUnusedBranchesPlugin.cs" />
     <Compile Include="DeleteUnusedBranchesForm.cs">

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
@@ -49,6 +49,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Branch.cs" />
+    <Compile Include="CheckBoxHeaderCellEventArgs.cs" />
     <Compile Include="DataGridViewCheckBoxHeaderCell.cs" />
     <Compile Include="DeleteUnusedBranchesFormSettings.cs" />
     <Compile Include="DeleteUnusedBranchesPlugin.cs" />

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
@@ -40,6 +40,7 @@
             this.deleteDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.nameDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dateDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.checkBoxHeaderCell = new DataGridViewCheckBoxHeaderCell();
             this.Author = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Message = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.branchBindingSource = new System.Windows.Forms.BindingSource(this.components);
@@ -136,8 +137,8 @@
             // 
             this.deleteDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.deleteDataGridViewCheckBoxColumn.FillWeight = 20F;
-            this.deleteDataGridViewCheckBoxColumn.HeaderText = "Delete";
             this.deleteDataGridViewCheckBoxColumn.Name = "deleteDataGridViewCheckBoxColumn";
+            this.deleteDataGridViewCheckBoxColumn.HeaderCell = checkBoxHeaderCell;
             // 
             // nameDataGridViewTextBoxColumn
             // 
@@ -469,6 +470,7 @@
         private System.Windows.Forms.Panel pnlBranchesArea;
         private System.Windows.Forms.ToolStripStatusLabel lblStatus;
         private System.Windows.Forms.DataGridViewCheckBoxColumn deleteDataGridViewCheckBoxColumn;
+        private DeleteUnusedBranches.DataGridViewCheckBoxHeaderCell checkBoxHeaderCell;
         private System.Windows.Forms.DataGridViewTextBoxColumn nameDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn dateDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn Author;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
@@ -59,6 +59,7 @@
             this.mergedIntoBranch = new System.Windows.Forms.TextBox();
             this.olderThanDays = new System.Windows.Forms.NumericUpDown();
             this.RefreshBtn = new System.Windows.Forms.Button();
+            this.SelectAllBtn = new System.Windows.Forms.Button();
             this.includeUnmergedBranches = new System.Windows.Forms.CheckBox();
             this.useRegexCaseInsensitive = new System.Windows.Forms.CheckBox();
             this.regexDoesNotMatch = new System.Windows.Forms.CheckBox();
@@ -210,6 +211,7 @@
             this.tableLayoutPanel2.Controls.Add(this.buttonSettings, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.Cancel, 3, 0);
             this.tableLayoutPanel2.Controls.Add(this.Delete, 2, 0);
+            this.tableLayoutPanel2.Controls.Add(this.SelectAllBtn, 1, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 365);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
@@ -383,6 +385,17 @@
             this.RefreshBtn.UseVisualStyleBackColor = true;
             this.RefreshBtn.Click += new System.EventHandler(this.Refresh_Click);
             // 
+            // SelectAllBtn
+            // 
+            this.SelectAllBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.SelectAllBtn.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.SelectAllBtn.Name = "SelectAllBtn";
+            this.SelectAllBtn.Size = new System.Drawing.Size(75, 25);
+            this.SelectAllBtn.TabIndex = 3;
+            this.SelectAllBtn.Text = "Select All";
+            this.SelectAllBtn.UseVisualStyleBackColor = true;
+            this.SelectAllBtn.Click += new System.EventHandler(this.SelectAll_Click);
+            // 
             // includeUnmergedBranches
             // 
             this.includeUnmergedBranches.AutoSize = true;
@@ -460,6 +473,7 @@
         private System.Windows.Forms.TextBox regexFilter;
         private System.Windows.Forms.CheckBox useRegexFilter;
         private System.Windows.Forms.Button RefreshBtn;
+        private System.Windows.Forms.Button SelectAllBtn;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox mergedIntoBranch;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
@@ -59,7 +59,6 @@
             this.mergedIntoBranch = new System.Windows.Forms.TextBox();
             this.olderThanDays = new System.Windows.Forms.NumericUpDown();
             this.RefreshBtn = new System.Windows.Forms.Button();
-            this.SelectAllBtn = new System.Windows.Forms.Button();
             this.includeUnmergedBranches = new System.Windows.Forms.CheckBox();
             this.useRegexCaseInsensitive = new System.Windows.Forms.CheckBox();
             this.regexDoesNotMatch = new System.Windows.Forms.CheckBox();
@@ -211,7 +210,6 @@
             this.tableLayoutPanel2.Controls.Add(this.buttonSettings, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.Cancel, 3, 0);
             this.tableLayoutPanel2.Controls.Add(this.Delete, 2, 0);
-            this.tableLayoutPanel2.Controls.Add(this.SelectAllBtn, 1, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 365);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
@@ -385,17 +383,6 @@
             this.RefreshBtn.UseVisualStyleBackColor = true;
             this.RefreshBtn.Click += new System.EventHandler(this.Refresh_Click);
             // 
-            // SelectAllBtn
-            // 
-            this.SelectAllBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
-            this.SelectAllBtn.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.SelectAllBtn.Name = "SelectAllBtn";
-            this.SelectAllBtn.Size = new System.Drawing.Size(75, 25);
-            this.SelectAllBtn.TabIndex = 3;
-            this.SelectAllBtn.Text = "Select All";
-            this.SelectAllBtn.UseVisualStyleBackColor = true;
-            this.SelectAllBtn.Click += new System.EventHandler(this.SelectAll_Click);
-            // 
             // includeUnmergedBranches
             // 
             this.includeUnmergedBranches.AutoSize = true;
@@ -473,7 +460,6 @@
         private System.Windows.Forms.TextBox regexFilter;
         private System.Windows.Forms.CheckBox useRegexFilter;
         private System.Windows.Forms.Button RefreshBtn;
-        private System.Windows.Forms.Button SelectAllBtn;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox mergedIntoBranch;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -77,6 +77,9 @@ namespace DeleteUnusedBranches
             regexDoesNotMatch.Checked = _settings.RegexInvertedFlag;
             includeUnmergedBranches.Checked = _settings.IncludeUnmergedBranchesFlag;
 
+            checkBoxHeaderCell.OnCheckBoxClicked += new CheckBoxClickedHandler(CheckBoxHeader_OnCheckBoxClicked);
+            deleteDataGridViewCheckBoxColumn.HeaderText = string.Empty;
+
             BranchesGrid.DataSource = _branches;
         }
 
@@ -212,15 +215,29 @@ namespace DeleteUnusedBranches
             ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
         }
 
+        private void CheckBoxHeader_OnCheckBoxClicked(bool state)
+        {
+            for (int i = 0; i < BranchesGrid.Rows.Count; i++)
+            {
+                DataGridViewRow row = BranchesGrid.Rows[i];
+                DataGridViewCheckBoxCell cell =
+                    (DataGridViewCheckBoxCell)row.Cells[nameof(deleteDataGridViewCheckBoxColumn)];
+                cell.Value = state;
+            }
+
+            BranchesGrid.EndEdit();
+        }
+
         private void BranchesGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
-            // track only “Deleted” column
-            if (e.ColumnIndex != 0)
+            // track only “Deleted” column, ignoring the checkbox header
+            if (e.ColumnIndex != 0 || e.RowIndex == -1)
             {
                 return;
             }
 
             BranchesGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
+            checkBoxHeaderCell.SetValue(_branches.All(b => b.Delete));
             lblStatus.Text = GetDefaultStatusText();
         }
 

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -212,6 +212,16 @@ namespace DeleteUnusedBranches
             ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
         }
 
+        private void SelectAll_Click(object sender, EventArgs e)
+        {
+            foreach (DataGridViewRow row in BranchesGrid.Rows)
+            {
+                DataGridViewCheckBoxCell cell =
+                    (DataGridViewCheckBoxCell)row.Cells[nameof(deleteDataGridViewCheckBoxColumn)];
+                cell.Value = true;
+            }
+        }
+
         private void BranchesGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
             // track only “Deleted” column

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -212,16 +212,6 @@ namespace DeleteUnusedBranches
             ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
         }
 
-        private void SelectAll_Click(object sender, EventArgs e)
-        {
-            foreach (DataGridViewRow row in BranchesGrid.Rows)
-            {
-                DataGridViewCheckBoxCell cell =
-                    (DataGridViewCheckBoxCell)row.Cells[nameof(deleteDataGridViewCheckBoxColumn)];
-                cell.Value = true;
-            }
-        }
-
         private void BranchesGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
             // track only “Deleted” column

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -292,6 +292,7 @@ namespace DeleteUnusedBranches
 
             _branches.Clear();
             _branches.AddRange(branches);
+            checkBoxHeaderCell.Checked = _branches.All(b => b.Delete);
             _branches.ResetBindings();
 
             IsRefreshing = false;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -77,7 +77,7 @@ namespace DeleteUnusedBranches
             regexDoesNotMatch.Checked = _settings.RegexInvertedFlag;
             includeUnmergedBranches.Checked = _settings.IncludeUnmergedBranchesFlag;
 
-            checkBoxHeaderCell.OnCheckBoxClicked += new CheckBoxClickedHandler(CheckBoxHeader_OnCheckBoxClicked);
+            checkBoxHeaderCell.CheckBoxClicked += CheckBoxHeader_OnCheckBoxClicked;
             deleteDataGridViewCheckBoxColumn.HeaderText = string.Empty;
 
             BranchesGrid.DataSource = _branches;
@@ -215,14 +215,16 @@ namespace DeleteUnusedBranches
             ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
         }
 
-        private void CheckBoxHeader_OnCheckBoxClicked(bool state)
+        private void CheckBoxHeader_OnCheckBoxClicked(object sender, CheckBoxHeaderCellEventArgs e)
         {
+            BranchesGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
+
             for (int i = 0; i < BranchesGrid.Rows.Count; i++)
             {
                 DataGridViewRow row = BranchesGrid.Rows[i];
                 DataGridViewCheckBoxCell cell =
                     (DataGridViewCheckBoxCell)row.Cells[nameof(deleteDataGridViewCheckBoxColumn)];
-                cell.Value = state;
+                cell.Value = e.Checked;
             }
 
             BranchesGrid.EndEdit();
@@ -237,7 +239,7 @@ namespace DeleteUnusedBranches
             }
 
             BranchesGrid.CommitEdit(DataGridViewDataErrorContexts.Commit);
-            checkBoxHeaderCell.SetValue(_branches.All(b => b.Delete));
+            checkBoxHeaderCell.Checked = _branches.All(b => b.Delete);
             lblStatus.Text = GetDefaultStatusText();
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3522

Changes proposed in this pull request:
- Added "Select All" feature to Delete Unused Branches plugin
 
Screenshots before and after (if PR changes UI):
- Before:
![image](https://user-images.githubusercontent.com/14019835/41669969-bc14830a-74bb-11e8-9a87-43aeb08bb25f.png)

- After:
![image](https://user-images.githubusercontent.com/14019835/41670119-1349fcb8-74bc-11e8-8704-56c9f9bd9dd5.png)


What did I do to test the code and ensure quality:
- Pressed the button and made sure it selects all branches.

Has been tested on (remove any that don't apply):
- GIT 2.10 and above
- Windows 10
