### PR TITLE
Fixing mergetool (setting) status message

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -54,6 +54,22 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public const string GitExtensionsShellEx32Name = "GitExtensionsShellEx32.dll";
         public const string GitExtensionsShellEx64Name = "GitExtensionsShellEx64.dll";
 
+        public string GetGlobalDiffTool()
+        {
+            return ConfigFileSettingsSet.GlobalSettings.GetValue("diff.guitool");
+        }
+
+        public void SetGlobalDiffTool(string value)
+        {
+            ConfigFileSettingsSet.GlobalSettings.SetValue("diff.guitool", value);
+        }
+
+        public bool IsDiffTool(string toolName)
+        {
+            return GetGlobalDiffTool().Equals(toolName,
+                StringComparison.CurrentCultureIgnoreCase);
+        }
+
         public string GetGlobalMergeTool()
         {
             return ConfigFileSettingsSet.GlobalSettings.GetValue("merge.tool");

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -97,7 +97,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             new TranslationString("There is a custom mergetool configured: {0}");
 
         private readonly TranslationString _mergeToolXConfigured =
-            new TranslationString("There is a custom mergetool configured.");
+            new TranslationString("There is a mergetool configured: {0}");
 
         private readonly TranslationString _linuxToolsSshFound =
             new TranslationString("Linux tools (sh) found on your computer.");
@@ -532,7 +532,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private bool CheckDiffToolConfiguration()
         {
             DiffTool.Visible = true;
-            if (string.IsNullOrEmpty(CheckSettingsLogic.GetDiffToolFromConfig(CheckSettingsLogic.CommonLogic.ConfigFileSettingsSet.GlobalSettings)))
+            if (string.IsNullOrEmpty(CommonLogic.GetGlobalDiffTool()))
             {
                 RenderSettingUnset(DiffTool, DiffTool_Fix, _adviceDiffToolConfiguration.Text);
                 return false;
@@ -540,7 +540,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (EnvUtils.RunningOnWindows())
             {
-                if (CheckSettingsLogic.GetDiffToolFromConfig(CheckSettingsLogic.CommonLogic.ConfigFileSettingsSet.GlobalSettings).Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase))
+                if (CommonLogic.IsDiffTool("kdiff3"))
                 {
                     string p = GetGlobalSetting("difftool.kdiff3.path");
                     if (string.IsNullOrEmpty(p) || !File.Exists(p))
@@ -554,7 +554,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 }
             }
 
-            string difftool = CheckSettingsLogic.GetDiffToolFromConfig(CheckSettingsLogic.CommonLogic.ConfigFileSettingsSet.GlobalSettings);
+            string difftool = CommonLogic.GetGlobalDiffTool().ToLowerInvariant();
             RenderSettingSet(DiffTool, DiffTool_Fix, string.Format(_diffToolXConfigured.Text, difftool));
             return true;
         }
@@ -568,6 +568,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return false;
             }
 
+            string mergetool = CommonLogic.GetGlobalMergeTool().ToLowerInvariant();
             if (EnvUtils.RunningOnWindows())
             {
                 if (CommonLogic.IsMergeTool("kdiff3"))
@@ -583,7 +584,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     return true;
                 }
 
-                string mergetool = CommonLogic.GetGlobalMergeTool().ToLowerInvariant();
                 if (mergetool == "p4merge" || mergetool == "tmerge" || mergetool == "meld")
                 {
                     string p = GetGlobalSetting(string.Format("mergetool.{0}.cmd", mergetool));
@@ -598,7 +598,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 }
             }
 
-            RenderSettingSet(MergeTool, MergeTool_Fix, _mergeToolXConfigured.Text);
+            RenderSettingSet(MergeTool, MergeTool_Fix, string.Format(_mergeToolXConfigured.Text, mergetool));
             return true;
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -420,7 +420,7 @@ Please make sure there are linux tools installed (through Git for Windows or cyg
         <target />
       </trans-unit>
       <trans-unit id="_mergeToolXConfigured.Text">
-        <source>There is a custom mergetool configured.</source>
+        <source>There is a mergetool configured: {0}</source>
         <target />
       </trans-unit>
       <trans-unit id="_mergeToolXConfiguredNeedsCmd.Text">


### PR DESCRIPTION
Also extended CommonLogic with Diff utility functions similar to Merge.

Changes proposed in this pull request:
- The translation text _mergeToolXConfigured was wrong and hence the (auto) configured merge tool was never reported.
- Simplified the code for diff tool reporting by extending CommonLogic so diff and merge is treated similarly. 

NB! I only updated the English XLF file (so I could verify that the fix was correct) since I imagine that you have some batch tool to update all the XLF files.
 
Screenshots before and after (if PR changes UI):
- No UI changes.

What did I do to test the code and ensure quality:
- Compiled and verified that the merge tool was reported correctly.

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10 
