### PR TITLE
Adding Winmerge as (auto) merge tool

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -340,8 +340,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             {
                 case "kdiff3":
                     return "";
-                case "winmerge":
-                    return "\"" + exeFile + "\" -e -u -dl \"Original\" -dr \"Modified\" \"$MERGED\" \"$REMOTE\"";
             }
 
             return AutoConfigMergeToolCmd(mergeToolText, exeFile);
@@ -376,6 +374,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "\"" + exeFile + "\" --wait \"$MERGED\" ";
                 case "vsdiffmerge":
                     return "\"" + exeFile + "\" /m \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"";
+                case "winmerge":
+                    return "\"" + exeFile + "\" -e -u  -wl -wr -fm -dl \"Mine: $LOCAL\" -dm \"Merged: $BASE\" -dr \"Theirs: $REMOTE\" \"$LOCAL\" \"$BASE\" \"$REMOTE\" -o \"$MERGED\"";
             }
 
             // other commands supported natively by git for windows

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -338,7 +338,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             SaveAndRescan_Click(null, null);
         }
 
-        private readonly string[] _autoConfigMergeTools = { "p4merge", "TortoiseMerge", "meld", "beyondcompare3", "beyondcompare4", "diffmerge", "semanticmerge", "vscode", "vsdiffmerge" };
+        private readonly string[] _autoConfigMergeTools = { "p4merge", "TortoiseMerge", "meld", "beyondcompare3", "beyondcompare4", "diffmerge", "semanticmerge", "vscode", "vsdiffmerge", "winmerge" };
         private void MergeToolFix_Click(object sender, EventArgs e)
         {
             if (string.IsNullOrEmpty(CommonLogic.GetGlobalMergeTool()))

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -215,10 +215,10 @@
             "tkdiff",
             "tmerge",
             "vimdiff",
-            "winmerge",
-            "xxdiff",
             "vscode",
-            "vsdiffmerge"});
+            "vsdiffmerge",
+            "winmerge",
+            "xxdiff"});
             this._NO_TRANSLATE_GlobalDiffTool.Location = new System.Drawing.Point(192, 265);
             this._NO_TRANSLATE_GlobalDiffTool.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this._NO_TRANSLATE_GlobalDiffTool.Name = "_NO_TRANSLATE_GlobalDiffTool";
@@ -351,7 +351,8 @@
             "semanticmerge",
             "TortoiseMerge",
             "vscode",
-            "vsdiffmerge"});
+            "vsdiffmerge",
+            "winmerge"});
             this._NO_TRANSLATE_GlobalMergeTool.Location = new System.Drawing.Point(192, 109);
             this._NO_TRANSLATE_GlobalMergeTool.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this._NO_TRANSLATE_GlobalMergeTool.Name = "_NO_TRANSLATE_GlobalMergeTool";


### PR DESCRIPTION
Winmerge since 2.15.2 supports 3-way merge and should be available as an (auto) configured merge tool. ([Changelog](https://bitbucket.org/winmerge/winmerge/src/7d1863b8c6867aef0407702f6d19cfbe608375f4/Docs/Users/ChangeLog.txt?fileviewer=file-view-default) for Winmerge.)

Fixes #3163.

Changes proposed in this pull request:
- Adding Winmerge as merge tool
- Fixing merge command for Winmerge
- Fixing sorting of diff tools.
 
Screenshots before and after (if PR changes UI):
- No UI changes.

What did I do to test the code and ensure quality:
- Compiled and tested that it worked. 

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
