### PR TITLE
Fix create new repository does not use current folder

### DIFF
--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -84,5 +84,19 @@ namespace GitUI.CommandsDialogs
                 Directory.Text = userSelectedPath;
             }
         }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FormInit _form;
+
+            public TestAccessor(FormInit form)
+            {
+                _form = form;
+            }
+
+            public ComboBox DirectoryCombo => _form.Directory;
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -39,8 +39,10 @@ namespace GitUI.CommandsDialogs
                 await this.SwitchToMainThreadAsync();
                 Directory.DataSource = repositoryHistory;
                 Directory.DisplayMember = nameof(Repository.Path);
-                Directory.Text = string.IsNullOrEmpty(dir) ? AppSettings.DefaultCloneDestinationPath : dir;
             });
+
+            Directory.SelectedIndex = -1;
+            Directory.Text = string.IsNullOrEmpty(dir) ? AppSettings.DefaultCloneDestinationPath : dir;
         }
 
         private void InitClick(object sender, EventArgs e)

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -48,15 +48,15 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         {
             var generatedCommitMessage = Guid.NewGuid().ToString();
 
-            RunFormCommitTest(formCommit =>
+            RunFormTest(form =>
             {
-                Assert.IsEmpty(formCommit.GetTestAccessor().Message.Text);
-                formCommit.GetTestAccessor().Message.Text = generatedCommitMessage;
+                Assert.IsEmpty(form.GetTestAccessor().Message.Text);
+                form.GetTestAccessor().Message.Text = generatedCommitMessage;
             });
 
-            RunFormCommitTest(formCommit =>
+            RunFormTest(form =>
             {
-                Assert.AreEqual(generatedCommitMessage, formCommit.GetTestAccessor().Message.Text);
+                Assert.AreEqual(generatedCommitMessage, form.GetTestAccessor().Message.Text);
             });
         }
 
@@ -66,18 +66,18 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         {
             var generatedCommitMessage = Guid.NewGuid().ToString();
 
-            RunFormCommitTest(
-                formCommit =>
+            RunFormTest(
+                form =>
                 {
                     string prefix = commitKind.ToString().ToLowerInvariant();
-                    Assert.AreEqual($"{prefix}! A commit message", formCommit.GetTestAccessor().Message.Text);
-                    formCommit.GetTestAccessor().Message.Text = generatedCommitMessage;
+                    Assert.AreEqual($"{prefix}! A commit message", form.GetTestAccessor().Message.Text);
+                    form.GetTestAccessor().Message.Text = generatedCommitMessage;
                 },
                 commitKind);
 
-            RunFormCommitTest(formCommit =>
+            RunFormTest(form =>
             {
-                Assert.IsEmpty(formCommit.GetTestAccessor().Message.Text);
+                Assert.IsEmpty(form.GetTestAccessor().Message.Text);
             });
         }
 
@@ -86,9 +86,9 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         {
             var generatedCommitMessage = Guid.NewGuid().ToString();
 
-            RunFormCommitTest(formCommit =>
+            RunFormTest(form =>
             {
-                var commitMessageToolStripMenuItem = formCommit.GetTestAccessor().CommitMessageToolStripMenuItem;
+                var commitMessageToolStripMenuItem = form.GetTestAccessor().CommitMessageToolStripMenuItem;
 
                 // Verify the message appears correctly
                 commitMessageToolStripMenuItem.ShowDropDown();
@@ -96,42 +96,42 @@ namespace GitUITests.CommandsDialogs.CommitDialog
 
                 // Verify the message is selected correctly
                 commitMessageToolStripMenuItem.DropDownItems[0].PerformClick();
-                Assert.AreEqual("A commit message", formCommit.GetTestAccessor().Message.Text);
+                Assert.AreEqual("A commit message", form.GetTestAccessor().Message.Text);
             });
         }
 
-        private void RunFormCommitTest(Action<FormCommit> testDriver, CommitKind commitKind = CommitKind.Normal)
+        private void RunFormTest(Action<FormCommit> testDriver, CommitKind commitKind = CommitKind.Normal)
         {
-            RunFormCommitTest(
-                formCommit =>
+            RunFormTest(
+                form =>
                 {
-                    testDriver(formCommit);
+                    testDriver(form);
                     return Task.CompletedTask;
                 },
                 commitKind);
         }
 
-        private void RunFormCommitTest(Func<FormCommit, Task> testDriverAsync, CommitKind commitKind = CommitKind.Normal)
+        private void RunFormTest(Func<FormCommit, Task> testDriverAsync, CommitKind commitKind = CommitKind.Normal)
         {
             UITest.RunForm(
                 () =>
                 {
                     switch (commitKind)
                     {
-                    case CommitKind.Normal:
-                        Assert.True(_commands.StartCommitDialog(owner: null));
-                        break;
+                        case CommitKind.Normal:
+                            Assert.True(_commands.StartCommitDialog(owner: null));
+                            break;
 
-                    case CommitKind.Squash:
-                        Assert.True(_commands.StartSquashCommitDialog(owner: null, _referenceRepository.Module.GetRevision("HEAD")));
-                        break;
+                        case CommitKind.Squash:
+                            Assert.True(_commands.StartSquashCommitDialog(owner: null, _referenceRepository.Module.GetRevision("HEAD")));
+                            break;
 
-                    case CommitKind.Fixup:
-                        Assert.True(_commands.StartFixupCommitDialog(owner: null, _referenceRepository.Module.GetRevision("HEAD")));
-                        break;
+                        case CommitKind.Fixup:
+                            Assert.True(_commands.StartFixupCommitDialog(owner: null, _referenceRepository.Module.GetRevision("HEAD")));
+                            break;
 
-                    default:
-                        throw new ArgumentException($"Unsupported commit kind: {commitKind}", nameof(commitKind));
+                        default:
+                            throw new ArgumentException($"Unsupported commit kind: {commitKind}", nameof(commitKind));
                     }
                 },
                 testDriverAsync);

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormInitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormInitTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs.CommitDialog
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormInitTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _commands;
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository == null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _commands = null;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [Test]
+        public void Should_show_supplied_path()
+        {
+            var currentDir = "bla";
+            RunFormTest(
+                form =>
+                {
+                    Assert.AreEqual(currentDir, form.GetTestAccessor().DirectoryCombo.Text);
+                },
+                currentDir);
+        }
+
+        // Strictly speaking this is a test for GitUICommands.StartInitializeDialog
+        [Test]
+        public void Should_show_current_GitModuleWorkingDir_if_supplied_path_null()
+        {
+            RunFormTest(
+                form =>
+                {
+                    Assert.AreEqual(_referenceRepository.Module.WorkingDir, form.GetTestAccessor().DirectoryCombo.Text);
+                },
+                null);
+        }
+
+        private void RunFormTest(Action<FormInit> testDriver, string path)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                },
+                path);
+        }
+
+        private void RunFormTest(Func<FormInit, Task> testDriverAsync, string path)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    Assert.True(_commands.StartInitializeDialog(owner: null, path));
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CancellationTokenSequenceTests.cs" />
+    <Compile Include="CommandsDialogs\CommitDialog\FormInitTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormCommitTests.cs" />
     <Compile Include="CommandsDialogs\ReferenceRepository.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffContextMenuControllerTests.cs" />

--- a/UnitTests/GitUITests/app.config
+++ b/UnitTests/GitUITests/app.config
@@ -3,6 +3,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
       </dependentAssembly>


### PR DESCRIPTION
Fixes #5107

Changes proposed in this pull request:
- reset `ComboBox.SelectedIndex` before assigning a free form text to `ComboBox.Text` to display the current folder
- add UI tests to ensure the correct behavior

What did I do to test the code and ensure quality:
- manual
- automated tests
