### PR TITLE
 Update version for GE in master to v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.cs text diff=csharp
 *.sln text eol=crlf
 *.sh text eol=lf
+*.py text eol=lf

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -21,9 +21,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.51.00")]
-[assembly: AssemblyFileVersion("2.51.00")]
-[assembly: AssemblyInformationalVersion("2.51")]
+[assembly: AssemblyVersion("2.99.90")]
+[assembly: AssemblyFileVersion("2.99.90")]
+[assembly: AssemblyInformationalVersion("3.00.a1")]
 
 // Disable CLS compliance. See https://github.com/gitextensions/gitextensions/issues/4710
 [assembly: CLSCompliant(isCompliant: false)]

--- a/GitExtSshAskPass/SshAskPass.rc2
+++ b/GitExtSshAskPass/SshAskPass.rc2
@@ -13,8 +13,8 @@
 // Version
 //
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,51,00,0
- PRODUCTVERSION 2,51,00,0
+ FILEVERSION 2,99,90,0
+ PRODUCTVERSION 2,99,90,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -30,12 +30,12 @@ BEGIN
         BLOCK "040904B0"
         BEGIN
             VALUE "FileDescription", "Git Extensions"
-            VALUE "FileVersion", "2.51.00"
+            VALUE "FileVersion", "2.99.90"
             VALUE "InternalName", "Git Extensions"
             VALUE "LegalCopyright", "Copyright 2013-2018"
             VALUE "OriginalFilename", "GitExtSshAskPass.exe"
             VALUE "ProductName", "Git Extensions"
-            VALUE "ProductVersion", "2.51"
+            VALUE "ProductVersion", "3.00.a1"
         END
     END
     BLOCK "VarFileInfo"

--- a/GitExtensionsShellEx/GitExtensionsShellEx.rc
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.rc
@@ -50,8 +50,8 @@ IDI_ICONCREATEREPOSITORY ICON                   "Resources\\IconRepoCreate.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,51,00,0
- PRODUCTVERSION 2,51,00,0
+ FILEVERSION 2,99,90,0
+ PRODUCTVERSION 2,99,90,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -67,12 +67,12 @@ BEGIN
         BLOCK "040904B0"
         BEGIN
             VALUE "FileDescription", "Git Extensions"
-            VALUE "FileVersion", "2.51.00"
+            VALUE "FileVersion", "2.99.90"
             VALUE "InternalName", "Git Extensions"
             VALUE "LegalCopyright", "Copyright 2008-2018"
             VALUE "OriginalFilename", "GitExtensionsShellEx.dll"
             VALUE "ProductName", "Git Extensions"
-            VALUE "ProductVersion", "2.51"
+            VALUE "ProductVersion", "3.00.a1"
         END
     END
     BLOCK "VarFileInfo"

--- a/GitExtensionsVSIX/source.extension.vsixmanifest
+++ b/GitExtensionsVSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Publisher="GitExt Team" Version="2.51.00" Language="en-US" Id="GitExtensions..550013F4-337C-4750-8967-DDEEEC2EB497" />
+        <Identity Publisher="GitExt Team" Version="2.99.90" Language="en-US" Id="GitExtensions..550013F4-337C-4750-8967-DDEEEC2EB497" />
         <DisplayName>GitExtensions</DisplayName>
         <Description xml:space="preserve" >Git Extensions is a graphical user interface for Git that allows you to control Git without using the command-line</Description>
         <MoreInfo>http://gitextensions.github.io/</MoreInfo>

--- a/Setup/MakeInstallers.cmd
+++ b/Setup/MakeInstallers.cmd
@@ -4,8 +4,8 @@ rem
 rem Update this version number with every release
 rem
 setlocal
-set version=2.51
-set numericVersion=2.51.00
+set version=3.00.a1
+set numericVersion=2.99.90
 if not "%APPVEYOR_BUILD_VERSION%"=="" (
     set version=%APPVEYOR_BUILD_VERSION%
     set numericVersion=%APPVEYOR_BUILD_VERSION%

--- a/Setup/set_version_to.py
+++ b/Setup/set_version_to.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Update version in GitExtension source files
+"""
+
 import argparse, sys
 import re
 


### PR DESCRIPTION
As next version is called "v3" or 3.0, the version in master should reflect that. AppVeyor version is already updated.
Also, increasing the version from 2.51 will avoid the popup "Do you want to update to the latest 2.51?"

Numeric version set to 2.99.90, display to 3.00.a1 similar to before.
Personally, I would have preferred to have a more Continuous Delivery naming and set 3.00.00 and just increase for every release. Then we decide that 3.00.22 is rc1, 3.00.34 is first release etc.
