### PR TITLE
Enable git-status porcelain v2 format

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -684,7 +684,7 @@ namespace GitCommands
             var args = new ArgumentBuilder
             {
                 { noLocks && VersionInUse.SupportNoOptionalLocks, "--no-optional-locks" },
-                "status --porcelain -z",
+                $"status --porcelain={(VersionInUse.SupportStatusPorcelainV2 ? 2 : 1)} -z",
                 untrackedFiles,
                 ignoreSubmodules,
                 { !excludeIgnoredFiles, "--ignored" }
@@ -822,7 +822,130 @@ namespace GitCommands
         /// <seealso href="https://git-scm.com/docs/git-status"/>
         public static IReadOnlyList<GitItemStatus> GetStatusChangedFilesFromString(IGitModule module, string statusString)
         {
-            return GetAllChangedFilesFromString_v1(module, statusString, false, StagedStatus.Index);
+            if (VersionInUse.SupportStatusPorcelainV2)
+            {
+                return GetAllChangedFilesFromString_v2(module, statusString);
+            }
+            else
+            {
+                return GetAllChangedFilesFromString_v1(module, statusString, false, StagedStatus.Index);
+            }
+        }
+
+        /// <summary>
+        /// Parse the output from git-status --porcelain=2
+        /// </summary>
+        /// <param name="module">The Git module</param>
+        /// <param name="statusString">output from the git command</param>
+        /// <returns>list with the parsed GitItemStatus</returns>
+        private static IReadOnlyList<GitItemStatus> GetAllChangedFilesFromString_v2(IGitModule module, string statusString)
+        {
+            var diffFiles = new List<GitItemStatus>();
+
+            if (string.IsNullOrEmpty(statusString))
+            {
+                return diffFiles;
+            }
+
+            // Split all files on '\0'
+            var files = statusString.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+            for (int n = 0; n < files.Length; n++)
+            {
+                string line = files[n];
+                char entryType = line[0];
+
+                if (entryType == '?' || entryType == '!')
+                {
+                    Debug.Assert(line.Length > 2 && line[1] == ' ', "Cannot parse for untracked:" + line);
+                    string fileName = line.Substring(2);
+                    UpdateItemStatus(entryType, false, "N...", fileName, null, null);
+                }
+                else if (entryType == '1' || entryType == '2' || entryType == 'u')
+                {
+                    // Parse from git-status documentation, assuming SHA-1 is used
+                    // Ignore octal and treeGuid
+                    // 1 XY subm <mH> <mI> <mW> <hH> <hI> <path>
+                    // renamed:
+                    // 2 XY subm <mH> <mI> <mW> <hH> <hI> <X><score> <path><sep><origPath>
+                    // unstaged (merge conflicts)
+                    // u XY subm <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
+
+                    char x = line[2];
+                    char y = line[3];
+                    string fileName;
+                    string oldFileName = null;
+                    string renamePercent = null;
+                    string subm = line.Substring(5, 4);
+
+                    if (entryType == '1')
+                    {
+                        Debug.Assert(line.Length > 113 && line[1] == ' ', "Cannot parse line:" + line);
+                        fileName = line.Substring(113);
+                    }
+                    else if (entryType == '2')
+                    {
+                        Debug.Assert(line.Length > 2 && n + 1 < files.Length, "Cannot parse renamed:" + line);
+
+                        // Find renamed files...
+                        string[] renames = line.Substring(114).Split(new char[] { ' ' }, 2);
+                        renamePercent = renames[0];
+                        fileName = renames[1];
+                        oldFileName = files[++n];
+                    }
+                    else if (entryType == 'u')
+                    {
+                        Debug.Assert(line.Length > 161, "Cannot parse unmerged:" + line);
+                        fileName = line.Substring(161);
+                    }
+                    else
+                    {
+                        // suppress warning for variable not assigned
+                        fileName = null;
+                    }
+
+                    UpdateItemStatus(x, true, subm, fileName, oldFileName, renamePercent);
+                    UpdateItemStatus(y, false, subm, fileName, oldFileName, renamePercent);
+                }
+            }
+
+            return diffFiles;
+
+            void UpdateItemStatus(char x, bool isIndex, string subm, string fileName, string oldFileName, string renamePercent)
+            {
+                if (x == '.')
+                {
+                    return;
+                }
+
+                var staged = isIndex ? StagedStatus.Index : StagedStatus.WorkTree;
+                GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(staged, fileName, x);
+                if (oldFileName != null)
+                {
+                    gitItemStatus.OldName = oldFileName;
+                }
+
+                if (renamePercent != null)
+                {
+                    gitItemStatus.RenameCopyPercentage = renamePercent;
+                }
+
+                if (subm[0] == 'S')
+                {
+                    gitItemStatus.IsSubmodule = true;
+
+                    if (!isIndex)
+                    {
+                        // Slight modification on how the following flags are used
+                        // Changed commit
+                        gitItemStatus.IsChanged = subm[1] == 'C';
+
+                        // Is dirty
+                        gitItemStatus.IsTracked = subm[2] != 'M' && subm[3] != 'U';
+                    }
+                }
+
+                diffFiles.Add(gitItemStatus);
+            }
         }
 
         /// <summary>
@@ -1040,6 +1163,8 @@ namespace GitCommands
                 IsChanged = x == 'M',
                 IsDeleted = x == 'D',
                 IsSkipWorktree = x == 'S',
+                IsRenamed = x == 'R',
+                IsCopied = x == 'C',
                 IsTracked = (x != '?' && x != '!' && x != ' ') || !isNew,
                 IsIgnored = x == '!',
                 IsConflict = x == 'U',

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -15,6 +15,7 @@ namespace GitCommands
         private static readonly GitVersion v2_5_1 = new GitVersion("2.5.1");
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
+        private static readonly GitVersion v2_11_0 = new GitVersion("2.11.0");
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
         private static readonly GitVersion v2_16_3 = new GitVersion("2.16.3");
 
@@ -61,6 +62,8 @@ namespace GitCommands
         public bool SupportWorktreeList => this >= v2_7_0;
 
         public bool SupportMergeUnrelatedHistory => this >= v2_9_0;
+
+        public bool SupportStatusPorcelainV2 => this >= v2_11_0;
 
         public bool SupportNoOptionalLocks => this >= v2_15_2;
 

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using GitCommands;
 using GitCommands.Git;
 using NUnit.Framework;
@@ -211,8 +211,9 @@ namespace GitCommandsTests.Git
         {
             GitModule module = new GitModule(null);
             {
-                // git status --porcelain --untracked-files=no -z
-                string statusString = "M  adfs.h\0M  dir.c\0";
+                // git status --porcelain=2 --untracked-files=no -z
+                // porcelain v1: string statusString = "M  adfs.h\0M  dir.c\0";
+                string statusString = "#Header\03 unknown info\01 .M S..U 160000 160000 160000 cbca134e29be13b35f21ca4553ba04f796324b1c cbca134e29be13b35f21ca4553ba04f796324b1c adfs.h\01 .M SCM. 160000 160000 160000 6bd3b036fc5718a51a0d27cde134c7019798c3ce 6bd3b036fc5718a51a0d27cde134c7019798c3ce dir.c\0\r\nwarning: LF will be replaced by CRLF in adfs.h.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in dir.c.\nThe file will have its original line endings in your working directory.";
                 var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "adfs.h");
@@ -220,8 +221,9 @@ namespace GitCommandsTests.Git
             }
 
             {
-                // git status --porcelain --untracked-files -z
-                string statusString = "M  adfs.h\0?? untracked_file\0";
+                // git status --porcelain=2 --untracked-files -z
+                // porcelain v1: string statusString = "M  adfs.h\0?? untracked_file\0";
+                string statusString = "1 .M S..U 160000 160000 160000 cbca134e29be13b35f21ca4553ba04f796324b1c cbca134e29be13b35f21ca4553ba04f796324b1c adfs.h\0? untracked_file\0";
                 var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "adfs.h");
@@ -229,8 +231,9 @@ namespace GitCommandsTests.Git
             }
 
             {
-                // git status --porcelain --ignored-files -z
-                string statusString = "M  adfs.h\0!! ignored_file\0";
+                // git status --porcelain=2 --ignored-files -z
+                // porcelain v1: string statusString = ".M  adfs.h\0!! ignored_file\0";
+                string statusString = "1 .M S..U 160000 160000 160000 cbca134e29be13b35f21ca4553ba04f796324b1c cbca134e29be13b35f21ca4553ba04f796324b1c adfs.h\0! ignored_file\0";
                 var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "adfs.h");
@@ -679,37 +682,37 @@ namespace GitCommandsTests.Git
         public void GetAllChangedFilesCmd()
         {
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules --ignored",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules --ignored",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: false, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files=no --ignore-submodules",
+                "status --porcelain=2 -z --untracked-files=no --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.No, IgnoreSubmodulesMode.Default));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files=normal --ignore-submodules",
+                "status --porcelain=2 -z --untracked-files=normal --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Normal, IgnoreSubmodulesMode.Default));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files=all --ignore-submodules",
+                "status --porcelain=2 -z --untracked-files=all --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.All, IgnoreSubmodulesMode.Default));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules=none",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules=none",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.None));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules=none",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules=none",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules=untracked",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules=untracked",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Untracked));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules=dirty",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules=dirty",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Dirty));
             Assert.AreEqual(
-                "status --porcelain -z --untracked-files --ignore-submodules=all",
+                "status --porcelain=2 -z --untracked-files --ignore-submodules=all",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.All));
             Assert.AreEqual(
-                "--no-optional-locks status --porcelain -z --untracked-files --ignore-submodules",
+                "--no-optional-locks status --porcelain=2 -z --untracked-files --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default, noLocks: true));
         }
 


### PR DESCRIPTION
GE uses a common routine to parse git-status porcelain v1 and git-diff output.
The routine is hard to maintain.

git-status added porcelain v2 format in Git 2.11. This PR enables this format to simplify the parsing of git-status, as well as providing more information. Git outputs more data but parsing of v2 is more efficient. This information will make it possible to find if submodules are changed (commit updated) or dirty without an explicit query of the submodule (used in #5104).

Note: Git older than 2.11 can still be used but will not provide the changed/dirty information. GetAllChangedFilesFromString_v1() can be simplified when older than 2.11 is dropped (hard limit).

Changes proposed in this pull request:
- The porcelain v2 format used
- Rename GetAllChangedFilesFromString() to reflect the use in git-status and git-diff
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual tests (together with #5104), also with porcelain v1
- Added porcelain v2 parse tests

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
