### PR TITLE
Fix "Current unstaged changes" and "Commit index"

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -857,7 +857,7 @@ namespace GitCommands
         public static string GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None, bool noLocks = false)
         {
             StringBuilder stringBuilder = new StringBuilder( 
-                noLocks && VersionInUse.SupportNoOptionalLocks ? "--no-optional-locks" : ""
+                (noLocks && VersionInUse.SupportNoOptionalLocks ? "--no-optional-locks " : "")
                 + "status --porcelain -z");
 
             switch (untrackedFiles)


### PR DESCRIPTION
Fixes #5127 

The previous commit of this file introduced the bug that the status command was omitted from the command string if the --no-optional-locks option was added. This resulted in wrong counts of "Current unstaged changes" and "Commit index" (always 1).