### PR TITLE
git-diff parsing of unmerged and staged

### DIFF
--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -32,26 +32,21 @@ namespace GitCommands
         public bool IsSkipWorktree { get; set; }
         public bool IsSubmodule { get; set; }
         public string RenameCopyPercentage { get; set; }
-        private StagedStatus StagedUnsafe { get; set; } = StagedStatus.Unknown;
+
+        // Staged is three state and has no default status
+        private StagedStatus _staged { get; set; } = StagedStatus.Unknown;
         public StagedStatus Staged
         {
             get
             {
-                // Staged is not available in all scenarios, this is temporary (?) to catch usage
-                if (StagedUnsafe == StagedStatus.Unknown)
-                {
-#if DEBUG
-                    Debug.Assert(false, "StagedStatus is not set - this throws in Release builds. Continue should generally be OK.");
-#else
-                    throw new ArgumentException("StagedStatus is not set", StagedUnsafe.ToString());
-#endif
-                }
+                // Catch usage of unset accesses
+                Debug.Assert(_staged != StagedStatus.Unknown, "Staged is used without being set. Continue should generally be OK.");
 
-                return StagedUnsafe;
+                return _staged;
             }
             set
             {
-                StagedUnsafe = value;
+                _staged = value;
             }
         }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2399,7 +2399,7 @@ namespace GitCommands
             noCache = noCache || firstRevision.IsArtificial() || secondRevision.IsArtificial();
             string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             string result = noCache ? RunGitCmd(cmd) : RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
-            var resultCollection = GitCommandHelpers.GetAllChangedFilesFromString(this, result, true).ToList();
+            var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result).ToList();
             if (firstRevision == GitRevision.UnstagedGuid || secondRevision == GitRevision.UnstagedGuid)
             {
                 // For unstaged the untracked must be added too
@@ -2474,7 +2474,7 @@ namespace GitCommands
             UntrackedFilesMode untrackedFiles = UntrackedFilesMode.Default)
         {
             var status = RunGitCmd(GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles, untrackedFiles));
-            var result = GitCommandHelpers.GetAllChangedFilesFromString(this, status).ToList();
+            var result = GitCommandHelpers.GetStatusChangedFilesFromString(this, status).ToList();
 
             if (!excludeAssumeUnchangedFiles || !excludeSkipWorktreeFiles)
             {
@@ -2560,11 +2560,11 @@ namespace GitCommands
                 // This command is a little more expensive because it will return both staged and unstaged files
                 string command = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.No);
                 status = RunGitCmd(command, SystemEncoding);
-                IReadOnlyList<GitItemStatus> stagedFiles = GitCommandHelpers.GetAllChangedFilesFromString(this, status, false);
+                IReadOnlyList<GitItemStatus> stagedFiles = GitCommandHelpers.GetStatusChangedFilesFromString(this, status);
                 return stagedFiles.Where(f => f.IsStaged).ToList();
             }
 
-            return GitCommandHelpers.GetAllChangedFilesFromString(this, status, true);
+            return GitCommandHelpers.GetDiffChangedFilesFromString(this, status);
         }
 
         public IReadOnlyList<GitItemStatus> GetStagedFilesWithSubmodulesStatus()
@@ -2588,7 +2588,7 @@ namespace GitCommands
         {
             string command = GitCommandHelpers.GetAllChangedFilesCmd(true, untrackedFilesMode, ignoreSubmodulesMode);
             string status = RunGitCmd(command);
-            return GitCommandHelpers.GetAllChangedFilesFromString(this, status);
+            return GitCommandHelpers.GetStatusChangedFilesFromString(this, status);
         }
 
         /// <summary>Indicates whether there are any changes to the repository,

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2399,7 +2399,7 @@ namespace GitCommands
             noCache = noCache || firstRevision.IsArtificial() || secondRevision.IsArtificial();
             string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             string result = noCache ? RunGitCmd(cmd) : RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
-            var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result).ToList();
+            var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result, secondRevision).ToList();
             if (firstRevision == GitRevision.UnstagedGuid || secondRevision == GitRevision.UnstagedGuid)
             {
                 // For unstaged the untracked must be added too
@@ -2564,7 +2564,7 @@ namespace GitCommands
                 return stagedFiles.Where(f => f.IsStaged).ToList();
             }
 
-            return GitCommandHelpers.GetDiffChangedFilesFromString(this, status);
+            return GitCommandHelpers.GetDiffChangedFilesFromString(this, status, GitRevision.IndexGuid);
         }
 
         public IReadOnlyList<GitItemStatus> GetStagedFilesWithSubmodulesStatus()

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2387,19 +2387,19 @@ namespace GitCommands
             return noCache ? RunGitCmd(cmd) : RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
         }
 
-        public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(string firstRevision, string secondRevision)
+        public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(string firstRevision, string secondRevision, string parentToSecond)
         {
-            var status = GetDiffFiles(firstRevision, secondRevision);
+            var status = GetDiffFiles(firstRevision, secondRevision, parentToSecond);
             GetSubmoduleStatus(status, firstRevision, secondRevision);
             return status;
         }
 
-        public IReadOnlyList<GitItemStatus> GetDiffFiles(string firstRevision, string secondRevision, bool noCache = false)
+        public IReadOnlyList<GitItemStatus> GetDiffFiles(string firstRevision, string secondRevision, string parentToSecond, bool noCache = false)
         {
             noCache = noCache || firstRevision.IsArtificial() || secondRevision.IsArtificial();
             string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             string result = noCache ? RunGitCmd(cmd) : RunCacheableCmd(AppSettings.GitCommand, cmd, SystemEncoding);
-            var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result, secondRevision).ToList();
+            var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result, firstRevision, secondRevision, parentToSecond).ToList();
             if (firstRevision == GitRevision.UnstagedGuid || secondRevision == GitRevision.UnstagedGuid)
             {
                 // For unstaged the untracked must be added too
@@ -2425,7 +2425,7 @@ namespace GitCommands
 
         public IReadOnlyList<GitItemStatus> GetStashDiffFiles(string stashName)
         {
-            var resultCollection = GetDiffFiles(stashName + "^", stashName, true).ToList();
+            var resultCollection = GetDiffFiles(stashName + "^", stashName, stashName + "^", true).ToList();
 
             // shows untracked files
             string untrackedTreeHash = RunGitCmd("log " + stashName + "^3 --pretty=format:\"%T\" --max-count=1");
@@ -2451,9 +2451,9 @@ namespace GitCommands
                     IsNew = true,
                     IsChanged = false,
                     IsDeleted = false,
-                    IsStaged = false,
                     Name = file.Name,
-                    TreeGuid = file.Guid
+                    TreeGuid = file.Guid,
+                    Staged = StagedStatus.None
                 }).ToList();
 
             // Doesn't work with removed submodules
@@ -2513,7 +2513,7 @@ namespace GitCommands
                     {
                         await TaskScheduler.Default.SwitchTo(alwaysYield: true);
 
-                        var submoduleStatus = GitCommandHelpers.GetCurrentSubmoduleChanges(this, localItem.Name, localItem.OldName, localItem.IsStaged);
+                        var submoduleStatus = GitCommandHelpers.GetCurrentSubmoduleChanges(this, localItem.Name, localItem.OldName, localItem.Staged == StagedStatus.Index);
                         if (submoduleStatus != null && submoduleStatus.Commit != submoduleStatus.OldCommit)
                         {
                             var submodule = submoduleStatus.GetSubmodule(this);
@@ -2561,10 +2561,10 @@ namespace GitCommands
                 string command = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.No);
                 status = RunGitCmd(command, SystemEncoding);
                 IReadOnlyList<GitItemStatus> stagedFiles = GitCommandHelpers.GetStatusChangedFilesFromString(this, status);
-                return stagedFiles.Where(f => f.IsStaged).ToList();
+                return stagedFiles.Where(f => f.Staged == StagedStatus.Index).ToList();
             }
 
-            return GitCommandHelpers.GetDiffChangedFilesFromString(this, status, GitRevision.IndexGuid);
+            return GitCommandHelpers.GetDiffChangedFilesFromString(this, status, "HEAD", GitRevision.IndexGuid, "HEAD");
         }
 
         public IReadOnlyList<GitItemStatus> GetStagedFilesWithSubmodulesStatus()
@@ -2576,12 +2576,12 @@ namespace GitCommands
 
         public IReadOnlyList<GitItemStatus> GetUnstagedFiles()
         {
-            return GetAllChangedFiles().Where(x => !x.IsStaged).ToArray();
+            return GetAllChangedFiles().Where(x => x.Staged == StagedStatus.WorkTree).ToArray();
         }
 
         public IReadOnlyList<GitItemStatus> GetUnstagedFilesWithSubmodulesStatus()
         {
-            return GetAllChangedFilesWithSubmodulesStatus().Where(x => !x.IsStaged).ToArray();
+            return GetAllChangedFilesWithSubmodulesStatus().Where(x => x.Staged == StagedStatus.WorkTree).ToArray();
         }
 
         public IReadOnlyList<GitItemStatus> GitStatus(UntrackedFilesMode untrackedFilesMode, IgnoreSubmodulesMode ignoreSubmodulesMode = IgnoreSubmodulesMode.None)
@@ -3846,9 +3846,9 @@ namespace GitCommands
                     IsConflict = true,
                     IsTracked = true,
                     IsDeleted = false,
-                    IsStaged = false,
                     IsNew = false,
                     Name = file,
+                    Staged = StagedStatus.None
                 }).ToList();
         }
 

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -116,7 +116,7 @@ namespace GitUI.AutoCompletion
 
         private static string GetChangedFileText(GitModule module, GitItemStatus file)
         {
-            var changes = module.GetCurrentChanges(file.Name, file.OldName, file.IsStaged, "-U1000000", module.FilesEncoding);
+            var changes = module.GetCurrentChanges(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000", module.FilesEncoding);
 
             if (changes != null)
             {

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -304,7 +304,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 return;
             }
 
-            var allChangedFiles = GitCommandHelpers.GetAllChangedFilesFromString(Module, updatedStatus);
+            var allChangedFiles = GitCommandHelpers.GetStatusChangedFilesFromString(Module, updatedStatus);
             OnGitWorkingDirectoryStatusChanged(new GitWorkingDirectoryStatusEventArgs(allChangedFiles.Where(item => !item.IsIgnored)));
             if (_ignoredFilesPending)
             {

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs
             else if (checkboxRevisionFilter.Checked)
             {
                 // 1. get all changed (and not deleted files) from selected to current revision
-                var files = UICommands.Module.GetDiffFiles(DiffSelectedRevision.Guid, SelectedRevision.Guid).Where(f => !f.IsDeleted);
+                var files = UICommands.Module.GetDiffFiles(DiffSelectedRevision.Guid, SelectedRevision.Guid, SelectedRevision.ParentGuids.FirstOrDefault()).Where(f => !f.IsDeleted);
 
                 // 2. wrap file names with ""
                 // 3. join together with space as separator

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1757,6 +1757,7 @@ namespace GitUI.CommandsDialogs
             var module = e.GitModule;
             HideVariableMainMenuItems();
             UnregisterPlugins();
+            RevisionGrid.InvalidateCount();
 
             UICommands = new GitUICommands(module);
             if (Module.IsValidGitWorkingDir())

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -804,7 +804,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var fileStatus in allChangedFiles)
             {
-                if (fileStatus.IsStaged)
+                if (fileStatus.Staged == StagedStatus.Index)
                 {
                     stagedFiles.Add(fileStatus);
                 }
@@ -1478,7 +1478,7 @@ namespace GitUI.CommandsDialogs
                                 Name = item.OldName,
                                 IsDeleted = true,
                                 IsTracked = true,
-                                IsStaged = false
+                                Staged = StagedStatus.WorkTree
                             };
                             unstagedFiles.Add(clone);
 
@@ -1488,7 +1488,7 @@ namespace GitUI.CommandsDialogs
                             item.OldName = string.Empty;
                         }
 
-                        item.IsStaged = false;
+                        item.Staged = StagedStatus.WorkTree;
                         unstagedFiles.Add(item);
                     }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -808,7 +808,7 @@ namespace GitUI.CommandsDialogs
                 {
                     stagedFiles.Add(fileStatus);
                 }
-                else
+                else if (fileStatus.Staged == StagedStatus.WorkTree)
                 {
                     unstagedFiles.Add(fileStatus);
                 }

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -300,7 +300,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     IsNew = false,
                     IsDeleted = false,
                     IsTracked = true,
-                    Name = match.Groups[2].Value.Trim()
+                    Name = match.Groups[2].Value.Trim(),
+                    Staged = StagedStatus.None
                 };
 
                 giss.Add(gis);

--- a/GitUI/CommandsDialogs/RevisionDiff.cs
+++ b/GitUI/CommandsDialogs/RevisionDiff.cs
@@ -469,11 +469,8 @@ namespace GitUI.CommandsDialogs
 
         private void StageFileToolStripMenuItemClick(object sender, EventArgs e)
         {
-            // IsStaged is set by default, so that cannot be trusted, must be limited when selecting
-            var files = DiffFiles.SelectedItemsWithParent
-                .Where(it => it.ParentRevision.Guid == GitRevision.IndexGuid)
-                .Select(it => it.Item)
-                .ToList();
+            // files must be limited when selecting to index -> worktree
+            var files = DiffFiles.SelectedItems.ToList();
 
             Module.StageFiles(files, out _);
             RefreshArtificial();
@@ -481,8 +478,9 @@ namespace GitUI.CommandsDialogs
 
         private void UnstageFileToolStripMenuItemClick(object sender, EventArgs e)
         {
+            // files must be limited to HEAD -> index
             var files = new List<GitItemStatus>();
-            foreach (var item in DiffFiles.SelectedItems.Where(i => i.IsStaged))
+            foreach (var item in DiffFiles.SelectedItems)
             {
                 if (!item.IsNew)
                 {

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -28,6 +28,8 @@ namespace GitUI.CommandsDialogs
             bool isAnyCombinedDiff = false,
             bool isSingleGitItemSelected = true,
             bool isAnyItemSelected = true,
+            bool isAnyItemStaged = false,
+            bool isAnyItemUnstaged = false,
             bool isBareRepository = false,
             bool singleFileExists = true,
             bool isAnyTracked = true,
@@ -38,6 +40,8 @@ namespace GitUI.CommandsDialogs
             IsAnyCombinedDiff = isAnyCombinedDiff;
             IsSingleGitItemSelected = isSingleGitItemSelected;
             IsAnyItemSelected = isAnyItemSelected;
+            IsAnyItemStaged = isAnyItemStaged;
+            IsAnyItemUnstaged = isAnyItemUnstaged;
             IsBareRepository = isBareRepository;
             SingleFileExists = singleFileExists;
             IsAnyTracked = isAnyTracked;
@@ -49,6 +53,8 @@ namespace GitUI.CommandsDialogs
         public bool IsAnyCombinedDiff { get; }
         public bool IsSingleGitItemSelected { get; }
         public bool IsAnyItemSelected { get; }
+        public bool IsAnyItemStaged { get; }
+        public bool IsAnyItemUnstaged { get; }
         public bool IsBareRepository { get; }
         public bool SingleFileExists { get; }
         public bool IsAnyTracked { get; }
@@ -93,12 +99,12 @@ namespace GitUI.CommandsDialogs
         // Stage/unstage must limit the selected items, IsStaged is not reflecting Staged status
         public bool ShouldShowMenuStage(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.FirstIsParent && selectionInfo.SelectedRevision.Guid == GitRevision.UnstagedGuid;
+            return selectionInfo.IsAnyItemUnstaged;
         }
 
         public bool ShouldShowMenuUnstage(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.FirstIsParent && selectionInfo.SelectedRevision.Guid == GitRevision.IndexGuid;
+            return selectionInfo.IsAnyItemStaged;
         }
 
         public bool ShouldShowSubmoduleMenus(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -435,7 +435,7 @@ namespace GitUI.Editor
 
         public void ViewCurrentChanges(GitItemStatus item)
         {
-            ViewCurrentChanges(item.Name, item.OldName, item.IsStaged, item.IsSubmodule, item.GetSubmoduleStatusAsync, null /* not implemented */);
+            ViewCurrentChanges(item.Name, item.OldName, item.Staged == StagedStatus.Index, item.IsSubmodule, item.GetSubmoduleStatusAsync, null /* not implemented */);
         }
 
         public void ViewCurrentChanges(GitItemStatus item, bool isStaged, [CanBeNull] Action openWithDifftool)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1171,7 +1171,7 @@ namespace GitUI
 
                     foreach (var rev in parentRevs)
                     {
-                        dictionary.Add(rev, Module.GetDiffFilesWithSubmodulesStatus(rev.Guid, Revision.Guid));
+                        dictionary.Add(rev, Module.GetDiffFilesWithSubmodulesStatus(rev.Guid, Revision.Guid, Revision.ParentGuids.FirstOrDefault()));
                     }
 
                     // Show combined (merge conflicts) only when all first (A) are parents to selected (B)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -750,12 +750,12 @@ namespace GitUI
                 return 0;
             }
 
-            if (gitItemStatus.IsNew || !gitItemStatus.IsTracked)
+            if (gitItemStatus.IsNew || (!gitItemStatus.IsTracked && !gitItemStatus.IsSubmodule))
             {
                 return 1;
             }
 
-            if (gitItemStatus.IsChanged || gitItemStatus.IsConflict)
+            if (gitItemStatus.IsChanged || gitItemStatus.IsConflict || gitItemStatus.IsSubmodule)
             {
                 if (!gitItemStatus.IsSubmodule || gitItemStatus.GetSubmoduleStatusAsync() == null ||
                     !gitItemStatus.GetSubmoduleStatusAsync().IsCompleted)

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3029,6 +3029,11 @@ namespace GitUI
             Revisions.Add(rev, dataTypes);
         }
 
+        public void InvalidateCount()
+        {
+            _artificialStatus = null;
+        }
+
         public void UpdateArtificialCommitCount(IReadOnlyList<GitItemStatus> status)
         {
             GitRevision unstagedRev = GetRevision(GitRevision.UnstagedGuid);

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -3043,17 +3043,16 @@ namespace GitUI
                 return;
             }
 
-            int staged = status.Count(item => item.IsStaged);
-            int unstaged = status.Count - staged;
-
             if (unstagedRev != null)
             {
-                unstagedRev.SubjectCount = "(" + unstaged + ") ";
+                var count = status.Count(item => item.Staged == StagedStatus.WorkTree);
+                unstagedRev.SubjectCount = "(" + count + ") ";
             }
 
             if (stagedRev != null)
             {
-                stagedRev.SubjectCount = "(" + staged + ") ";
+                var count = status.Count(item => item.Staged == StagedStatus.Index);
+                stagedRev.SubjectCount = "(" + count + ") ";
             }
 
             // cache the status, if commits do not exist or for a refresh

--- a/GitUI/UserControls/ToolStripClasses/CommitIconProvider.cs
+++ b/GitUI/UserControls/ToolStripClasses/CommitIconProvider.cs
@@ -21,9 +21,9 @@ namespace GitUI.UserControls.ToolStripClasses
 
         public Image GetCommitIcon(IReadOnlyList<GitItemStatus> allChangedFiles)
         {
-            var stagedCount = allChangedFiles.Count(status => status.IsStaged);
+            var stagedCount = allChangedFiles.Count(status => status.Staged == StagedStatus.Index);
             var unstagedCount = allChangedFiles.Count - stagedCount;
-            var unstagedSubmodulesCount = allChangedFiles.Count(status => status.IsSubmodule && !status.IsStaged);
+            var unstagedSubmodulesCount = allChangedFiles.Count(status => status.IsSubmodule && status.Staged == StagedStatus.WorkTree);
             var notTrackedCount = allChangedFiles.Count(status => !status.IsTracked);
 
             return GetStatusIcon(stagedCount, unstagedCount, unstagedSubmodulesCount, notTrackedCount);

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -121,7 +121,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\r\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\r\nThe file will have its original line endings in your working directory.\r\nwarning: LF will be replaced by CRLF in FxCop.targets.\r\nThe file will have its original line endings in your working directory.\r\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -129,7 +129,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\0\r\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\r\nThe file will have its original line endings in your working directory.\r\nwarning: LF will be replaced by CRLF in FxCop.targets.\r\nThe file will have its original line endings in your working directory.\r\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -137,7 +137,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\0\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in FxCop.targets.\nThe file will have its original line endings in your working directory.\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -145,8 +145,26 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "M  testfile.txt\0\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in FxCop.targets.\nThe file will have its original line endings in your working directory.\n";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
                 Assert.IsTrue(status.Count == 1);
+                Assert.IsTrue(status[0].Name == "testfile.txt");
+            }
+
+            {
+                // git diff -M -C -z --cached --name-status
+                // Ignore unmerged (in conflict) if revision is work tree
+                string statusString = "M  testfile.txt\0U  testfile.txt\0";
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.UnstagedGuid);
+                Assert.IsTrue(status.Count == 1);
+                Assert.IsTrue(status[0].Name == "testfile.txt");
+            }
+
+            {
+                // git diff -M -C -z --cached --name-status
+                // Include unmerged (in conflict) if revision is index
+                string statusString = "M  testfile.txt\0U  testfile2.txt\0";
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
+                Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
         }

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -115,13 +115,13 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void TestGetAllChangedFilesFromString()
+        public void TestGetDiffChangedFilesFromString()
         {
             GitModule module = new GitModule(null);
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\r\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\r\nThe file will have its original line endings in your working directory.\r\nwarning: LF will be replaced by CRLF in FxCop.targets.\r\nThe file will have its original line endings in your working directory.\r\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetAllChangedFilesFromString(module, statusString, true);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -129,7 +129,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\0\r\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\r\nThe file will have its original line endings in your working directory.\r\nwarning: LF will be replaced by CRLF in FxCop.targets.\r\nThe file will have its original line endings in your working directory.\r\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetAllChangedFilesFromString(module, statusString, true);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -137,7 +137,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\0\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in FxCop.targets.\nThe file will have its original line endings in your working directory.\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetAllChangedFilesFromString(module, statusString, true);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -145,18 +145,32 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "M  testfile.txt\0\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in FxCop.targets.\nThe file will have its original line endings in your working directory.\n";
-                var status = GitCommandHelpers.GetAllChangedFilesFromString(module, statusString, true);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
+        }
 
+        [Test]
+        public void TestGetStatusChangedFilesFromString()
+        {
+            GitModule module = new GitModule(null);
             {
                 // git status --porcelain --untracked-files=no -z
-                string statusString = "M  adfs.h\0M  dir.c\0\r\nwarning: LF will be replaced by CRLF in adfs.h.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in dir.c.\nThe file will have its original line endings in your working directory.";
-                var status = GitCommandHelpers.GetAllChangedFilesFromString(module, statusString, false);
+                string statusString = "M  adfs.h\0M  dir.c\0";
+                var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "adfs.h");
                 Assert.IsTrue(status[1].Name == "dir.c");
+            }
+
+            {
+                // git status --porcelain --untracked-files -z
+                string statusString = "M  adfs.h\0M  dir.c\0";
+                var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
+                Assert.IsTrue(status.Count == 2);
+                Assert.IsTrue(status[0].Name == "adfs.h");
+                Assert.IsTrue(status[1].Name == "untracked_file");
             }
         }
 

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -121,7 +121,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\r\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\r\nThe file will have its original line endings in your working directory.\r\nwarning: LF will be replaced by CRLF in FxCop.targets.\r\nThe file will have its original line endings in your working directory.\r\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, "HEAD", GitRevision.IndexGuid, "HEAD");
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -129,7 +129,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\0\r\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\r\nThe file will have its original line endings in your working directory.\r\nwarning: LF will be replaced by CRLF in FxCop.targets.\r\nThe file will have its original line endings in your working directory.\r\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, "HEAD", GitRevision.IndexGuid, "HEAD");
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -137,7 +137,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "\0\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in FxCop.targets.\nThe file will have its original line endings in your working directory.\nM\0testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, "HEAD", GitRevision.IndexGuid, "HEAD");
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -145,7 +145,7 @@ namespace GitCommandsTests.Git
             {
                 // git diff -M -C -z --cached --name-status
                 string statusString = "M  testfile.txt\0\nwarning: LF will be replaced by CRLF in CustomDictionary.xml.\nThe file will have its original line endings in your working directory.\nwarning: LF will be replaced by CRLF in FxCop.targets.\nThe file will have its original line endings in your working directory.\n";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, "HEAD", GitRevision.IndexGuid, "HEAD");
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
             }
@@ -154,19 +154,56 @@ namespace GitCommandsTests.Git
                 // git diff -M -C -z --cached --name-status
                 // Ignore unmerged (in conflict) if revision is work tree
                 string statusString = "M  testfile.txt\0U  testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.UnstagedGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid, GitRevision.UnstagedGuid, GitRevision.IndexGuid);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
+                Assert.IsTrue(status[0].Staged == StagedStatus.WorkTree);
             }
 
             {
                 // git diff -M -C -z --cached --name-status
                 // Include unmerged (in conflict) if revision is index
                 string statusString = "M  testfile.txt\0U  testfile2.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, "HEAD", GitRevision.IndexGuid, "HEAD");
                 Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
+                Assert.IsTrue(status[0].Staged == StagedStatus.Index);
             }
+
+            {
+                // git diff -M -C -z --name-status 123 456
+                // Check that the staged status is None if not Index/WorkTree
+                string statusString = "M  testfile.txt\0U  testfile2.txt\0";
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid, "456", "678");
+                Assert.IsTrue(status.Count == 2);
+                Assert.IsTrue(status[0].Name == "testfile.txt");
+                Assert.IsTrue(status[0].Staged == StagedStatus.None);
+            }
+
+            {
+                // git diff -M -C -z --name-status 123 456
+                // Check that the staged status is None if not Index/WorkTree
+                string statusString = "M  testfile.txt\0U  testfile2.txt\0";
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, "123", "456", null);
+                Assert.IsTrue(status.Count == 2);
+                Assert.IsTrue(status[0].Name == "testfile.txt");
+                Assert.IsTrue(status[0].Staged == StagedStatus.None);
+            }
+
+#if !DEBUG && false
+            // This test is for documentation, but as the throw is in a called function, it will not test cleanly
+            {
+                // git diff -M -C -z --name-status 123 456
+                // Check that the staged status is None if not Index/WorkTree
+                // Assertion in Debug, throws in Release
+                string statusString = "M  testfile.txt\0U  testfile2.txt\0";
+
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, null, null, null);
+                Assert.IsTrue(status.Count == 2);
+                Assert.IsTrue(status[0].Name == "testfile.txt");
+                Assert.IsTrue(status[0].Staged == StagedStatus.Unknown);
+             }
+#endif
         }
 
         [Test]
@@ -184,11 +221,20 @@ namespace GitCommandsTests.Git
 
             {
                 // git status --porcelain --untracked-files -z
-                string statusString = "M  adfs.h\0M  dir.c\0";
+                string statusString = "M  adfs.h\0?? untracked_file\0";
                 var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
                 Assert.IsTrue(status.Count == 2);
                 Assert.IsTrue(status[0].Name == "adfs.h");
                 Assert.IsTrue(status[1].Name == "untracked_file");
+            }
+
+            {
+                // git status --porcelain --ignored-files -z
+                string statusString = "M  adfs.h\0!! ignored_file\0";
+                var status = GitCommandHelpers.GetStatusChangedFilesFromString(module, statusString);
+                Assert.IsTrue(status.Count == 2);
+                Assert.IsTrue(status[0].Name == "adfs.h");
+                Assert.IsTrue(status[1].Name == "ignored_file");
             }
         }
 

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -139,9 +139,8 @@ namespace GitUITests.CommandsDialogs
         public void BrowseDiff_StageMenus_Unstaged(bool t)
         {
             var rev = new GitRevision(GitRevision.UnstagedGuid);
-            var selectionInfo = new ContextMenuSelectionInfo(rev, firstIsParent: t);
-            _controller.ShouldShowMenuStage(selectionInfo).Should().Be(t);
-            _controller.ShouldShowMenuUnstage(selectionInfo).Should().BeFalse();
+            var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemStaged: t);
+            _controller.ShouldShowMenuUnstage(selectionInfo).Should().Be(t);
         }
 
         [TestCase(true)]
@@ -149,9 +148,8 @@ namespace GitUITests.CommandsDialogs
         public void BrowseDiff_StageMenus_Index(bool t)
         {
             var rev = new GitRevision(GitRevision.UnstagedGuid);
-            var selectionInfo = new ContextMenuSelectionInfo(rev, firstIsParent: t);
+            var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemUnstaged: t);
             _controller.ShouldShowMenuStage(selectionInfo).Should().Be(t);
-            _controller.ShouldShowMenuUnstage(selectionInfo).Should().BeFalse();
         }
 
         #endregion

--- a/UnitTests/GitUITests/UserControls/ToolStripClasses/CommitIconProviderTests.cs
+++ b/UnitTests/GitUITests/UserControls/ToolStripClasses/CommitIconProviderTests.cs
@@ -23,7 +23,7 @@ namespace GitUITests.UserControls.ToolStripClasses
         {
             return new GitItemStatus
             {
-                IsStaged = isStaged,
+                Staged = isStaged ? StagedStatus.Index : StagedStatus.WorkTree,
                 IsTracked = isTracked,
                 IsSubmodule = isSubmodule
             };
@@ -66,7 +66,7 @@ namespace GitUITests.UserControls.ToolStripClasses
         {
             var commitIcon = _commitIconProvider.GetCommitIcon(new[]
             {
-                CreateGitItemStatus(true),
+                CreateGitItemStatus(isStaged: true),
                 CreateGitItemStatus()
             });
 
@@ -78,8 +78,8 @@ namespace GitUITests.UserControls.ToolStripClasses
         {
             var commitIcon = _commitIconProvider.GetCommitIcon(new[]
             {
-                CreateGitItemStatus(true),
-                CreateGitItemStatus(true)
+                CreateGitItemStatus(isStaged: true),
+                CreateGitItemStatus(isStaged: true)
             });
 
             Assert.AreEqual(CommitIconProvider.IconStaged, commitIcon);


### PR DESCRIPTION
Part of #4281 
Required for wip #5104 and #5116 (will rebase on top of this)

Changes proposed in this pull request:
There is a common parsing method for git-status and git-diff. The output formats are mostly the same but not identical and do not carry the same information:
 - Unmerged (conflict) are duplicated for git-diff when comparing Index->WorkTree (see #5104)
 - Information about Staged status is not always available so GitItemStatus .IsStaged can be unknown. The PR will throw exception if unknown status is 

This PR documents the parsing (preparing for #5116 too) and clean up the use of staged.
Some limitations when Staged status was guessed was removed in RevisionDiff.

What did I do to test the code and ensure quality:
- Added tests
- Manual testing - mostly on top of drew's v3 branch

Has been tested on (remove any that don't apply):
- GIT 2.18