### PR TITLE
Distinguish between "Stash changes" and "Manage stashes"

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -328,7 +328,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSplitStash.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripSplitStash.Name = "toolStripSplitStash";
             this.toolStripSplitStash.Size = new System.Drawing.Size(32, 22);
-            this.toolStripSplitStash.ToolTipText = "Stash changes";
+            this.toolStripSplitStash.ToolTipText = "Manage stashes";
             this.toolStripSplitStash.ButtonClick += new System.EventHandler(this.ToolStripSplitStashButtonClick);
             this.toolStripSplitStash.DropDownOpened += new System.EventHandler(this.toolStripSplitStash_DropDownOpened);
             // 
@@ -1188,7 +1188,7 @@ namespace GitUI.CommandsDialogs
             this.stashToolStripMenuItem.Image = global::GitUI.Properties.Resources.stash;
             this.stashToolStripMenuItem.Name = "stashToolStripMenuItem";
             this.stashToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.stashToolStripMenuItem.Text = "Stash changes...";
+            this.stashToolStripMenuItem.Text = "Manage stashes...";
             this.stashToolStripMenuItem.Click += new System.EventHandler(this.StashToolStripMenuItemClick);
             // 
             // resetToolStripMenuItem

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2343,7 +2343,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         <target />
       </trans-unit>
       <trans-unit id="stashToolStripMenuItem.Text">
-        <source>Stash changes...</source>
+        <source>Manage stashes...</source>
         <target />
       </trans-unit>
       <trans-unit id="synchronizeAllSubmodulesToolStripMenuItem.Text">
@@ -2403,7 +2403,7 @@ Do you want to abort and remove it from the recent repositories list?</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripSplitStash.ToolTipText">
-        <source>Stash changes</source>
+        <source>Manage stashes</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripStatusLabel1.Text">

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -3016,8 +3016,8 @@ Wollen Sie abbrechen und es von der Liste der zuletzt verwendeten Repositorys st
         
       </trans-unit>
       <trans-unit id="stashToolStripMenuItem.Text">
-        <source>Stash changes...</source>
-        <target>Änderungen stashen...</target>
+        <source>Manage stashes...</source>
+        <target>Stashes verwalten...</target>
         
       </trans-unit>
       <trans-unit id="synchronizeAllSubmodulesToolStripMenuItem.Text">
@@ -3086,8 +3086,8 @@ Wollen Sie abbrechen und es von der Liste der zuletzt verwendeten Repositorys st
         
       </trans-unit>
       <trans-unit id="toolStripSplitStash.ToolTipText">
-        <source>Stash changes</source>
-        <target>Änderungen stashen</target>
+        <source>Manage stashes</source>
+        <target>Stashes verwalten</target>
         
       </trans-unit>
       <trans-unit id="toolStripStatusLabel1.Text">


### PR DESCRIPTION
Changes proposed in this pull request:
- The tool strip button `Stash` does *not* stash changes at once, it just opens the stash dialog.
- That's why the tooltip should be "Manage stashes" instead of "Stash changes".
- The same applies to the main menu `Commands` | `Stash changes...`.
- Adapted the German translation, too.
 
Screenshots before and after (if PR changes UI):
- before:
![grafik](https://user-images.githubusercontent.com/36601201/42135807-9daadbce-7d50-11e8-9bcb-09f3f8108202.png)   ![grafik](https://user-images.githubusercontent.com/36601201/42135827-01b2c00a-7d51-11e8-8eed-649e7fb3d914.png)
- after:
![grafik](https://user-images.githubusercontent.com/36601201/42135840-36d00086-7d51-11e8-913a-a919f1444f96.png)   ![grafik](https://user-images.githubusercontent.com/36601201/42182257-e7f76b5a-7e3d-11e8-8b6a-611481ab7415.png)

What did I do to test the code and ensure quality:
- manual testing
- switched between English and German

Has been tested on (remove any that don't apply):
- GIT: 2.17.1.windows.2-x64
- Windows 7