### PR TITLE
FormChooseCommit: fix crash when click on parent commit link

### DIFF
--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -75,9 +75,9 @@ namespace GitUI.HelperDialogs
         private void linkLabelParent_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             var linkLabel = (LinkLabel)sender;
-            var parentId = (ObjectId)linkLabel.Tag;
+            var parentId = (string)linkLabel.Tag;
 
-            revisionGrid.SetSelectedRevision(parentId.ToString());
+            revisionGrid.SetSelectedRevision(parentId);
         }
 
         private void revisionGrid_SelectionChanged(object sender, EventArgs e)


### PR DESCRIPTION
`Tag` was badly casted as `ObjectId` but contains the sha1 as string...
