### PR TITLE
Add "Stop tracking file" feature to the Commit Form

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -4000,7 +4000,7 @@ namespace GitCommands
 
         public bool StopTrackingFile(string filename)
         {
-            return RunGitCmdResult("rm --cached " + filename).ExitedSuccessfully;
+            return RunGitCmdResult($"rm --cached \"{filename}\"").ExitedSuccessfully;
         }
 
         [CanBeNull]

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -154,6 +154,7 @@ namespace GitUI.CommandsDialogs
             this.commitCursorColumnLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.commitCursorColumn = new System.Windows.Forms.ToolStripStatusLabel();
             this.commitEndPadding = new System.Windows.Forms.ToolStripStatusLabel();
+            this.stopTrackingThisFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.UnstagedFileContext.SuspendLayout();
             this.StagedFileContext.SuspendLayout();
             this.UnstagedSubmoduleContext.SuspendLayout();
@@ -203,6 +204,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5,
             this.addFileToGitIgnoreToolStripMenuItem,
             this.addFileToGitInfoExcludeLocallyToolStripMenuItem,
+            this.stopTrackingThisFileToolStripMenuItem,
             this.skipWorktreeToolStripMenuItem,
             this.doNotSkipWorktreeToolStripMenuItem,
             this.assumeUnchangedToolStripMenuItem,
@@ -1458,6 +1460,14 @@ namespace GitUI.CommandsDialogs
             this.commitEndPadding.AutoSize = false;
             this.commitEndPadding.Name = "commitEndPadding";
             this.commitEndPadding.Size = new System.Drawing.Size(1, 17);
+            //
+            // stopTrackingThisFileToolStripMenuItem
+            //
+            this.stopTrackingThisFileToolStripMenuItem.Image = global::GitUI.Properties.Images.StopTrackingFile;
+            this.stopTrackingThisFileToolStripMenuItem.Name = "stopTrackingThisFileToolStripMenuItem";
+            this.stopTrackingThisFileToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
+            this.stopTrackingThisFileToolStripMenuItem.Text = "Stop tracking this file";
+            this.stopTrackingThisFileToolStripMenuItem.Click += new System.EventHandler(this.stopTrackingThisFileToolStripMenuItem_Click);
             // 
             // FormCommit
             //
@@ -1649,5 +1659,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator14;
         private ToolStripTextBox toolStripGpgKeyTextBox;
         private ToolStripComboBox gpgSignCommitToolStripComboBox;
+        private ToolStripMenuItem stopTrackingThisFileToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -35,6 +35,7 @@ namespace GitUI.CommandsDialogs
     {
         #region Translation
 
+        private readonly TranslationString _error = new TranslationString("Error");
         private readonly TranslationString _amendCommit =
             new TranslationString("You are about to rewrite history." + Environment.NewLine +
                                   "Only use amend if the commit is not published yet!" + Environment.NewLine +
@@ -95,7 +96,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _stageDetails = new TranslationString("Stage Details");
         private readonly TranslationString _stageFiles = new TranslationString("Stage {0} files");
         private readonly TranslationString _selectOnlyOneFile = new TranslationString("You must have only one file selected.");
-        private readonly TranslationString _selectOnlyOneFileCaption = new TranslationString("Error");
 
         private readonly TranslationString _stageSelectedLines = new TranslationString("Stage selected line(s)");
         private readonly TranslationString _unstageSelectedLines = new TranslationString("Unstage selected line(s)");
@@ -134,6 +134,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _assumeUnchangedToolTip = new TranslationString("Tell git to not check the status of this file for performance benefits."
             + Environment.NewLine + "Use this feature when a file is big and never change."
             + Environment.NewLine + "Git will never check if the file has changed that will improve status check performance.");
+        private readonly TranslationString _stopTrackingFail = new TranslationString("Fail to stop tracking the file '{0}'.");
         #endregion
 
         private event Action OnStageAreaLoaded;
@@ -2565,7 +2566,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(this, _selectOnlyOneFile.Text, _selectOnlyOneFileCaption.Text);
+                MessageBox.Show(this, _selectOnlyOneFile.Text, _error.Text);
             }
         }
 
@@ -3159,6 +3160,25 @@ namespace GitUI.CommandsDialogs
             public EditNetSpell Message => _formCommit.Message;
 
             public ToolStripDropDownButton CommitMessageToolStripMenuItem => _formCommit.commitMessageToolStripMenuItem;
+        }
+
+        private void stopTrackingThisFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (Unstaged.SelectedItem == null || !Unstaged.SelectedItem.IsTracked)
+            {
+                return;
+            }
+
+            var filename = Unstaged.SelectedItem.Name;
+
+            if (Module.StopTrackingFile(filename))
+            {
+                RescanChanges();
+            }
+            else
+            {
+                MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
     }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1598,6 +1598,7 @@ namespace GitUI.CommandsDialogs
                     var files = new List<GitItemStatus>();
                     var allFiles = new List<GitItemStatus>();
 
+                    var shouldRescanChanges = false;
                     foreach (var item in Staged.SelectedItems)
                     {
                         toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
@@ -1609,6 +1610,11 @@ namespace GitUI.CommandsDialogs
                             if (item.IsRenamed)
                             {
                                 Module.UnstageFileToRemove(item.OldName);
+                            }
+
+                            if (item.IsDeleted)
+                            {
+                                shouldRescanChanges = true;
                             }
                         }
                         else
@@ -1684,6 +1690,11 @@ namespace GitUI.CommandsDialogs
                         _currentFilesList = Unstaged;
                         RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
                         Unstaged.Focus();
+                    }
+
+                    if (shouldRescanChanges)
+                    {
+                        RescanChanges();
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Followup of the "Stop tracking" feature in the file tree (#4093) added to the Commit Form...

Changes proposed in this pull request:
- Add "Stop tracking file" feature to the Commit Form
- Fix "Stop tracking" command that fail when there is a space in the path (existing bug in master :( )
- Fix state of file displayed in "unstaged changes" list after unstaging a delete change (after using the "stop tracking" feature)

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
