### PR TITLE
Add checkbox Push After Finish in GitFlow plugin panel

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.Designer.cs
+++ b/Plugins/GitFlow/GitFlowForm.Designer.cs
@@ -37,6 +37,7 @@
             this.btnFinish = new System.Windows.Forms.Button();
             this.gbManage = new System.Windows.Forms.GroupBox();
             this.pnlManageBranch = new System.Windows.Forms.Panel();
+            this.cbPushAfterFinish = new System.Windows.Forms.CheckBox();
             this.panel2 = new System.Windows.Forms.Panel();
             this.pnlPull = new System.Windows.Forms.Panel();
             this.cbRemote = new System.Windows.Forms.ComboBox();
@@ -90,7 +91,7 @@
             // 
             this.txtBranchName.Location = new System.Drawing.Point(163, 25);
             this.txtBranchName.Name = "txtBranchName";
-            this.txtBranchName.Size = new System.Drawing.Size(374, 20);
+            this.txtBranchName.Size = new System.Drawing.Size(374, 21);
             this.txtBranchName.TabIndex = 2;
             // 
             // btnCreateBranch
@@ -135,6 +136,7 @@
             // 
             // pnlManageBranch
             // 
+            this.pnlManageBranch.Controls.Add(this.cbPushAfterFinish);
             this.pnlManageBranch.Controls.Add(this.panel2);
             this.pnlManageBranch.Controls.Add(this.pnlPull);
             this.pnlManageBranch.Controls.Add(this.panel1);
@@ -147,6 +149,16 @@
             this.pnlManageBranch.Name = "pnlManageBranch";
             this.pnlManageBranch.Size = new System.Drawing.Size(610, 131);
             this.pnlManageBranch.TabIndex = 7;
+            // 
+            // cbPushAfterFinish
+            // 
+            this.cbPushAfterFinish.AutoSize = true;
+            this.cbPushAfterFinish.Location = new System.Drawing.Point(492, 97);
+            this.cbPushAfterFinish.Name = "cbPushAfterFinish";
+            this.cbPushAfterFinish.Size = new System.Drawing.Size(104, 17);
+            this.cbPushAfterFinish.TabIndex = 8;
+            this.cbPushAfterFinish.Text = "Push after finish";
+            this.cbPushAfterFinish.UseVisualStyleBackColor = true;
             // 
             // panel2
             // 
@@ -180,7 +192,7 @@
             this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(80, 9);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(104, 13);
+            this.label9.Size = new System.Drawing.Size(108, 13);
             this.label9.TabIndex = 1;
             this.label9.Text = "Remote to pull from :";
             // 
@@ -208,7 +220,7 @@
             this.lblPrefixManage.AutoSize = true;
             this.lblPrefixManage.Location = new System.Drawing.Point(104, 11);
             this.lblPrefixManage.Name = "lblPrefixManage";
-            this.lblPrefixManage.Size = new System.Drawing.Size(43, 13);
+            this.lblPrefixManage.Size = new System.Drawing.Size(47, 13);
             this.lblPrefixManage.TabIndex = 1;
             this.lblPrefixManage.Text = "[prefix]/";
             this.lblPrefixManage.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -218,7 +230,7 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(38, 11);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(43, 13);
+            this.label1.Size = new System.Drawing.Size(44, 13);
             this.label1.TabIndex = 1;
             this.label1.Text = "branch:";
             // 
@@ -267,7 +279,7 @@
             this.label10.AutoSize = true;
             this.label10.Location = new System.Drawing.Point(9, 28);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(84, 13);
+            this.label10.Size = new System.Drawing.Size(85, 13);
             this.label10.TabIndex = 1;
             this.label10.Text = "Expected name:";
             // 
@@ -276,7 +288,7 @@
             this.lblPrefixName.AutoSize = true;
             this.lblPrefixName.Location = new System.Drawing.Point(119, 28);
             this.lblPrefixName.Name = "lblPrefixName";
-            this.lblPrefixName.Size = new System.Drawing.Size(49, 13);
+            this.lblPrefixName.Size = new System.Drawing.Size(47, 13);
             this.lblPrefixName.TabIndex = 1;
             this.lblPrefixName.Text = "[prefix]/";
             this.lblPrefixName.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -319,7 +331,7 @@
             this.cbBasedOn.AutoSize = true;
             this.cbBasedOn.Location = new System.Drawing.Point(3, 11);
             this.cbBasedOn.Name = "cbBasedOn";
-            this.cbBasedOn.Size = new System.Drawing.Size(73, 17);
+            this.cbBasedOn.Size = new System.Drawing.Size(74, 17);
             this.cbBasedOn.TabIndex = 0;
             this.cbBasedOn.Text = "based on:";
             this.cbBasedOn.UseVisualStyleBackColor = true;
@@ -339,7 +351,7 @@
             this.lnkGitFlow.AutoSize = true;
             this.lnkGitFlow.Location = new System.Drawing.Point(570, 17);
             this.lnkGitFlow.Name = "lnkGitFlow";
-            this.lnkGitFlow.Size = new System.Drawing.Size(73, 13);
+            this.lnkGitFlow.Size = new System.Drawing.Size(74, 13);
             this.lnkGitFlow.TabIndex = 9;
             this.lnkGitFlow.TabStop = true;
             this.lnkGitFlow.Text = "About GitFlow";
@@ -379,7 +391,7 @@
             this.lblCaptionHead.AutoSize = true;
             this.lblCaptionHead.Location = new System.Drawing.Point(176, 17);
             this.lblCaptionHead.Name = "lblCaptionHead";
-            this.lblCaptionHead.Size = new System.Drawing.Size(40, 13);
+            this.lblCaptionHead.Size = new System.Drawing.Size(38, 13);
             this.lblCaptionHead.TabIndex = 1;
             this.lblCaptionHead.Text = "HEAD:";
             // 
@@ -388,7 +400,7 @@
             this.lblHead.AutoSize = true;
             this.lblHead.Location = new System.Drawing.Point(217, 17);
             this.lblHead.Name = "lblHead";
-            this.lblHead.Size = new System.Drawing.Size(33, 13);
+            this.lblHead.Size = new System.Drawing.Size(37, 13);
             this.lblHead.TabIndex = 1;
             this.lblHead.Text = "ref/...";
             this.lblHead.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -432,7 +444,7 @@
             this.lblRunCommand.AutoSize = true;
             this.lblRunCommand.Location = new System.Drawing.Point(60, 14);
             this.lblRunCommand.Name = "lblRunCommand";
-            this.lblRunCommand.Size = new System.Drawing.Size(10, 13);
+            this.lblRunCommand.Size = new System.Drawing.Size(11, 13);
             this.lblRunCommand.TabIndex = 1;
             this.lblRunCommand.Text = "-";
             // 
@@ -512,5 +524,6 @@
         private System.Windows.Forms.GroupBox panel3;
         private System.Windows.Forms.Label lblRunCommand;
         private System.Windows.Forms.TextBox txtResult;
+        private System.Windows.Forms.CheckBox cbPushAfterFinish;
     }
 }

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -165,6 +165,7 @@ namespace GitFlow
             }
 
             btnFinish.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
+            cbPushAfterFinish.Enabled = isThereABranch && (branchType == Branch.hotfix.ToString("G") || branchType == Branch.release.ToString("G"));
             btnPublish.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
             btnPull.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
             pnlPull.Enabled = branchType != Branch.support.ToString("G");
@@ -245,7 +246,9 @@ namespace GitFlow
 
         private void btnFinish_Click(object sender, EventArgs e)
         {
-            RunCommand(string.Format("flow {0} finish {1}", cbManageType.SelectedValue, cbBranches.SelectedValue));
+            var command = string.Format("flow {0} finish {1} {2}", cbManageType.SelectedValue, cbPushAfterFinish.Checked ? " -p" : string.Empty, cbBranches.SelectedValue);
+
+            RunCommand(command);
         }
 
         private bool RunCommand(string commandText)


### PR DESCRIPTION
Changes proposed in this pull request:
- added checkbox for push Buxfixes and Releases after finished it.
- add parameter -P to git flow finish command
 
resolves #5157 

Screenshots before and after (if PR changes UI):
Git flow panel before changes
![gitflow_before](https://user-images.githubusercontent.com/6802895/42565751-9e246de8-8504-11e8-826a-169123db6179.JPG)

Git flow panel after changes
![gitflow_after](https://user-images.githubusercontent.com/6802895/42565760-a5498cf2-8504-11e8-883d-e4251ca538c1.JPG)

It can be useful?

Has been tested on (remove any that don't apply):
- GIT 2.51 and above
- Windows 8.5 and above
