### PR TITLE
Update GitExtensions.releases

### DIFF
--- a/GitExtensions.releases
+++ b/GitExtensions.releases
@@ -1,3 +1,13 @@
+[Version "2.51.04"]
+    DownloadPage = https://github.com/gitextensions/gitextensions/releases/download/v2.51.04/GitExtensions-2.51.04.msi
+    ReleaseType = hotfix
+    ;branch to which bugfixes found in this version should be merged (base for a pull request)
+    BugFixBranch = release/2.51
+[Version "2.51.03"]
+    DownloadPage = https://github.com/gitextensions/gitextensions/releases/download/v2.51.03/GitExtensions-2.51.03.msi
+    ReleaseType = hotfix
+    ;branch to which bugfixes found in this version should be merged (base for a pull request)
+    BugFixBranch = release/2.51
 [Version "2.51.02"]
     DownloadPage = https://github.com/gitextensions/gitextensions/releases/download/v2.51.02/GitExtensions-2.51.02.msi
     ReleaseType = hotfix


### PR DESCRIPTION
Not sure if 2.51.04 is a ReleaseCandidate or a HotFix.