### PR TITLE
Fix invalid `version` attribute casting

### DIFF
--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TeamFoundation.Build.Client" Version="11.0.60610.1" />
     <PackageReference Include="Microsoft.TeamFoundation.Client-final" Version="12.0.21005.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" version="15.112.1" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.112.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\TfsInterop.Common\Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes invalid `Version` attribute casting. Otherwise, Rider is unable to parse that value and complains about missing types 😖 

Don't create an issue as change is very tiny.