### PR TITLE
Fix the TranslationApp

### DIFF
--- a/GitExtUtils/Properties/AssemblyInfo.cs
+++ b/GitExtUtils/Properties/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 
 [assembly: InternalsVisibleTo("GitExtensions")]
 [assembly: InternalsVisibleTo("CommonTestUtils")]
+[assembly: InternalsVisibleTo("TranslationApp")]

--- a/GitUI/Translation/UpdateLocalEnglishTranslations.ps1
+++ b/GitUI/Translation/UpdateLocalEnglishTranslations.ps1
@@ -1,10 +1,15 @@
-Write-Host "Copying latest english translation before update..."
-robocopy .\ ..\..\GitExtensions\bin\Release\Translation English*.xlf
+Write-Host "Copying the latest English translation before the update..."
+$translationsFolder = Resolve-Path .\
+$releaseTranslationsFolder = Resolve-Path ..\..\GitExtensions\bin\Release\Translation
+Write-Debug " > $translationsFolder`r`n > $releaseTranslationsFolder"
+xcopy "$translationsFolder\English*.xlf" "$releaseTranslationsFolder" /Y
 
-pushd ..\..\GitExtensions\bin\Release
-Write-Host "Updating english translation..."
-Start-Process -FilePath "TranslationApp.exe" -ArgumentList "update" -Wait
+$src = Resolve-Path ..\..\GitExtensions\bin\Release
+pushd "$src"
+Write-Host "Updating the English translation..."
+Start-Process -FilePath "$src\TranslationApp.exe" -ArgumentList "update" -Wait
 popd
 
-Write-Host "Copying updated english translation for commit..."
-robocopy ..\..\GitExtensions\bin\Release\Translation .\ English*.xlf
+Write-Host "Copying the updated English translation to commit..."
+Write-Debug " > $releaseTranslationsFolder`r`n > $translationsFolder"
+xcopy "$releaseTranslationsFolder\English*.xlf" "$translationsFolder"  /Y

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitUI;
-using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;

--- a/ResourceManager/Xliff/TranslationUtil.cs
+++ b/ResourceManager/Xliff/TranslationUtil.cs
@@ -271,6 +271,7 @@ namespace ResourceManager.Xliff
             "SMDiag",
             "System",
             "vshost",
+            "Atlassian",
         };
 
         /// <summary>true if the specified <see cref="Assembly"/> may be translatable.</summary>

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands.Utils;
 using GitUI;
+using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 
 namespace TranslationApp
@@ -30,10 +31,17 @@ namespace TranslationApp
                 NBug.Settings.MaxQueuedReports = 10;
                 NBug.Settings.StopReportingAfter = 90;
                 NBug.Settings.SleepBeforeSend = 30;
-                NBug.Settings.StoragePath = "WindowsTemp";
+                NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
 
                 AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
                 Application.ThreadException += NBug.Handler.ThreadException;
+            }
+
+            // This form created for obtain UI synchronization context only
+            using (new Form())
+            {
+                // Store the shared JoinableTaskContext
+                ThreadHelper.JoinableTaskContext = new JoinableTaskContext();
             }
 
             // required for translation

--- a/TranslationApp/TranslationApp.csproj
+++ b/TranslationApp/TranslationApp.csproj
@@ -15,6 +15,7 @@
     <ApplicationIcon>..\Logo\git-extensions-logo.ico</ApplicationIcon>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -85,6 +86,10 @@
     <ProjectReference Include="..\GitCommands\GitCommands.csproj">
       <Project>{BD6AA2A2-997D-4AFF-ACC7-B64F6E51D181}</Project>
       <Name>GitCommands</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
     </ProjectReference>
     <ProjectReference Include="..\GitUI\GitUI.csproj">
       <Project>{CF5B22E7-230F-4E50-BE88-C4F7023CED2C}</Project>

--- a/TranslationApp/app.config
+++ b/TranslationApp/app.config
@@ -6,22 +6,4 @@
   <appSettings>
     <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
   </appSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="plugins" />
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-  <connectionStrings></connectionStrings>
 </configuration>


### PR DESCRIPTION
The app could not be run due to missing binding redirects and JTC.

While fixing I observed an interesting problem - some of the translations get rendered with the runtime context, e.g.

https://github.com/gitextensions/gitextensions/blob/3689f62beac05299d71a87f36b5b9a1848613802/GitUI/CommandsDialogs/FormClone.cs#L18
https://github.com/gitextensions/gitextensions/blob/3689f62beac05299d71a87f36b5b9a1848613802/GitUI/CommandsDialogs/FormClone.cs#L376
gets recorded as:

```diff
@@ -2808,6 +2834,11 @@ revision:</source>
         <source>&amp;Browse</source>
         <target />
       </trans-unit>
+      <trans-unit id="Info.Text">
+        <source>The repository will be cloned to a new directory located here:
+D:\Development\gitextensions\gitextensions\ (None)\[&amp;Subdirectory to create:]</source>
+        <target />
+      </trans-unit>
       <trans-unit id="LoadSSHKey.Text">
         <source>&amp;Load SSH key</source>
         <target />
 ```

The reason for this is that the `Info` label gets its text assigned in `ToTextUpdate()` event handler, triggered through the chain of events in `RuntimeLoaded()` call, which itself is called from the `.ctor`. Subsequently the translation records the state of controls after a given type (i.e. a form) is instantiated, that is, after `.ctor` and `RuntimeLoaded()` calls are complete.

So far I couldn't come up with an easy fix to this. Thoughts and ideas are welcome.