### PR TITLE
Provide capability to generate git -c calls in git commands: master

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -113,8 +113,6 @@ namespace GitCommands
             new KeyValuePair<string, string>("log.ShowSignature", "false") // Prevent git config log.ShowSignature true from including gpg lines in log output for our log calls
          };
 
-
-
         public GitModule([CanBeNull] string workingDir)
         {
             _superprojectInit = false;

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -544,7 +544,7 @@ namespace GitCommands
         {
             KeyValuePair<string, string>[] configs = DefaultConfigValues.Concat(configValues) // DO NOT sort.  The overrides are controlled by the order of the elements.
                   .Where(kv => !string.IsNullOrWhiteSpace(kv.Key))
-                  .GroupBy(kv => kv.Key)
+                  .GroupBy(kv => kv.Key.ToLower())
                   .Select(gkv => gkv.Last()).ToArray(); // Allow overrides of defaults with passed in config values.
 
             string config = configs.Any() ? " -c " + string.Join(" -c ", configs.Select(kv => $"{kv.Key}={(string.IsNullOrWhiteSpace(kv.Value) ? string.Empty : kv.Value)}")) + " " : string.Empty;

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -545,10 +545,11 @@ namespace GitCommands
         private static string GetConfigArguments(IEnumerable<KeyValuePair<string, string>> configValues)
         {
             KeyValuePair<string, string>[] configs = DefaultConfigValues.Concat(configValues) // DO NOT sort.  The overrides are controlled by the order of the elements.
+                  .Where(kv => !string.IsNullOrWhiteSpace(kv.Key))
                   .GroupBy(kv => kv.Key)
                   .Select(gkv => gkv.Last()).ToArray(); // Allow overrides of defaults with passed in config values.
 
-            string config = configs.Any() ? " -c " + string.Join(" -c ", configs.Select(kv => $"{kv.Key}={kv.Value}")) + " " : string.Empty;
+            string config = configs.Any() ? " -c " + string.Join(" -c ", configs.Select(kv => $"{kv.Key}={(string.IsNullOrWhiteSpace(kv.Value) ? string.Empty : kv.Value)}")) + " " : string.Empty;
 
             return config;
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5179

Changes proposed in this pull request:
- Add --no-show-signature option to log calls
 
Screenshots before and after (if PR changes UI):


What did I do to test the code and ensure quality:
- Signed a commit and made sure it showed in revision grid.  
- Verified log calls were not broken


Has been tested on (remove any that don't apply):
- GIT 2.18 and above
