### PR TITLE
Fixed Bitbucket plugin error on non-Bitbucket repo

### DIFF
--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.Composition;
+using System.Windows.Forms;
 using Bitbucket.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -13,6 +14,8 @@ namespace Bitbucket
         public readonly StringSetting BitbucketBaseUrl = new StringSetting("Specify the base URL to Bitbucket", "https://example.bitbucket.com");
         public readonly BoolSetting BitbucketDisableSsl = new BoolSetting("Disable SSL verification", false);
 
+        private readonly TranslationString _yourRepositoryIsNotInBitbucket = new TranslationString("Your repository is not hosted in BitBucket Server.");
+
         public BitbucketPlugin()
         {
             SetNameAndDescription("Bitbucket Server");
@@ -23,7 +26,18 @@ namespace Bitbucket
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using (var frm = new BitbucketPullRequestForm(this, Settings, args))
+            Settings settings = Bitbucket.Settings.Parse(args.GitModule, Settings, this);
+            if (settings == null)
+            {
+                MessageBox.Show(args.OwnerForm,
+                                _yourRepositoryIsNotInBitbucket.Text,
+                                string.Empty,
+                                MessageBoxButtons.OK,
+                                MessageBoxIcon.Exclamation);
+                return false;
+            }
+
+            using (var frm = new BitbucketPullRequestForm(settings))
             {
                 frm.ShowDialog(args.OwnerForm);
             }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -15,7 +15,6 @@ namespace Bitbucket
 {
     public partial class BitbucketPullRequestForm : GitExtensionsFormBase
     {
-        private readonly TranslationString _yourRepositoryIsNotInBitbucket = new TranslationString("Your repository is not hosted in Bitbucket.");
         private readonly TranslationString _committed = new TranslationString("{0} committed\n{1}");
         private readonly TranslationString _success = new TranslationString("Success");
         private readonly TranslationString _error = new TranslationString("Error");
@@ -24,7 +23,7 @@ namespace Bitbucket
         [CanBeNull] private readonly Settings _settings;
         private readonly BindingList<BitbucketUser> _reviewers = new BindingList<BitbucketUser>();
 
-        public BitbucketPullRequestForm(BitbucketPlugin plugin, ISettingsSource settings, GitUIEventArgs gitUiCommands)
+        public BitbucketPullRequestForm(Settings settings)
         {
             InitializeComponent();
 
@@ -32,13 +31,7 @@ namespace Bitbucket
             ddlRepositorySource.DisplayMember = nameof(Repository.DisplayName);
             ddlRepositoryTarget.DisplayMember = nameof(Repository.DisplayName);
 
-            _settings = Settings.Parse(gitUiCommands.GitModule, settings, plugin);
-            if (_settings == null)
-            {
-                MessageBox.Show(_yourRepositoryIsNotInBitbucket.Text);
-                Close();
-                return;
-            }
+            _settings = settings;
 
             Load += delegate
             {

--- a/Plugins/Bitbucket/Settings.cs
+++ b/Plugins/Bitbucket/Settings.cs
@@ -7,7 +7,7 @@ using JetBrains.Annotations;
 
 namespace Bitbucket
 {
-    internal class Settings
+    public class Settings
     {
         private const string BitbucketHttpRegex =
             @"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-\/]+?)):?(\d+)?\/scm\/(?<project>~?([\w\-]+?))\/(?<repo>([\w\-]+)).git";


### PR DESCRIPTION
Fixes #5147 

Changes proposed in this pull request:
- Fixed Bitbucket plugin server error on non-Bitbucket repo.
The error was trying to use BitbucketPullRequestForm after it was disposed.

What did I do to test the code and ensure quality:
- Run the scenario and made sure the bug does not reproduce.
