### PR TITLE
Checkout Branch dialog - Branches combobox is now readonly

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
@@ -186,6 +186,7 @@ namespace GitUI.CommandsDialogs
             this.Branches.Location = new System.Drawing.Point(92, 24);
             this.Branches.Name = "Branches";
             this.Branches.Size = new System.Drawing.Size(433, 21);
+            this.Branches.DropDownStyle = ComboBoxStyle.DropDownList;
             this.Branches.TabIndex = 3;
             this.Branches.SelectedIndexChanged += new System.EventHandler(this.Branches_SelectedIndexChanged);
             // 


### PR DESCRIPTION
Related to #5151 

Changes proposed in this pull request:
- The branches combobox is now readonly, the user can choose **only** an existing branch to checkout. 

Screenshots before and after (if PR changes UI):

Before: 
![before1](https://user-images.githubusercontent.com/14019835/43036243-5304bfca-8d06-11e8-86eb-53d2df4077f0.png)

After:
![after](https://user-images.githubusercontent.com/14019835/43036245-568a02cc-8d06-11e8-82db-1ddbacdd76a8.png)
