### PR TITLE
Add 'Remove Missing Projects' feature to dashboard

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -56,6 +56,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             this.tsmiCategoryAdd = new System.Windows.Forms.ToolStripMenuItem();
             this.contextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsmiRemoveFromList = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiRemoveMissingReposFromList = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiOpenFolder = new System.Windows.Forms.ToolStripMenuItem();
             this.listView1 = new ExListView();
             this.clmhdrPath = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -167,7 +168,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             this.toolStripMenuItem1,
             this.tsmiCategories,
             this.toolStripMenuItem2,
-            this.tsmiOpenFolder});
+            this.tsmiOpenFolder,
+            this.tsmiRemoveMissingReposFromList});
             this.contextMenuStrip.Name = "contextMenuStrip";
             this.contextMenuStrip.Size = new System.Drawing.Size(225, 126);
             this.contextMenuStrip.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
@@ -179,6 +181,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             this.tsmiRemoveFromList.Size = new System.Drawing.Size(224, 22);
             this.tsmiRemoveFromList.Text = "Remove project from the list";
             this.tsmiRemoveFromList.Click += new System.EventHandler(this.tsmiRemoveFromList_Click);
+            // 
+            // tsmiRemoveMissingReposFromList
+            // 
+            this.tsmiRemoveMissingReposFromList.Name = "tsmiRemoveMissingReposFromList";
+            this.tsmiRemoveMissingReposFromList.Size = new System.Drawing.Size(224, 22);
+            this.tsmiRemoveMissingReposFromList.Text = "Remove Missing Projects from the list";
+            this.tsmiRemoveMissingReposFromList.Click += new System.EventHandler(this.tsmiRemoveMissingReposFromList_Click);
             // 
             // tsmiOpenFolder
             // 
@@ -310,6 +319,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private System.Windows.Forms.ToolStripMenuItem tsmiCategoryAdd;
         private System.Windows.Forms.ToolStripMenuItem tsmiCategories;
         private System.Windows.Forms.ToolStripMenuItem tsmiCategoryNone;
+        private System.Windows.Forms.ToolStripMenuItem tsmiRemoveMissingReposFromList;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -164,11 +164,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             // contextMenuStrip
             // 
             this.contextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsmiRemoveFromList,
+            this.tsmiOpenFolder,
             this.toolStripMenuItem1,
             this.tsmiCategories,
             this.toolStripMenuItem2,
-            this.tsmiOpenFolder,
+            this.tsmiRemoveFromList,
             this.tsmiRemoveMissingReposFromList});
             this.contextMenuStrip.Name = "contextMenuStrip";
             this.contextMenuStrip.Size = new System.Drawing.Size(225, 126);
@@ -186,7 +186,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             // 
             this.tsmiRemoveMissingReposFromList.Name = "tsmiRemoveMissingReposFromList";
             this.tsmiRemoveMissingReposFromList.Size = new System.Drawing.Size(224, 22);
-            this.tsmiRemoveMissingReposFromList.Text = "Remove Missing Projects from the list";
+            this.tsmiRemoveMissingReposFromList.Text = "Remove missing projects from the list";
             this.tsmiRemoveMissingReposFromList.Click += new System.EventHandler(this.tsmiRemoveMissingReposFromList_Click);
             // 
             // tsmiOpenFolder

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -37,6 +37,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private ListViewItem _prevHoveredItem;
         private readonly ListViewGroup _lvgRecentRepositories;
         private readonly IUserRepositoriesListController _controller = new UserRepositoriesListController(RepositoryHistoryManager.Locals);
+        private bool _hasInvalidRepos;
 
         public event EventHandler<GitModuleEventArgs> GitModuleChanged;
 
@@ -224,6 +225,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 listView1.TileSize = GetTileSize(recentRepositories, favouriteRepositories);
                 Debug.WriteLine($"Tile size: {listView1.TileSize}");
 
+                _hasInvalidRepos = false;
                 BindRepositories(recentRepositories);
                 BindRepositories(favouriteRepositories);
             }
@@ -242,12 +244,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                 foreach (var repository in repos)
                 {
+                    var isInvalidRepo = !_controller.IsValidGitWorkingDir(repository.Repo.Path);
+                    _hasInvalidRepos |= isInvalidRepo;
+
                     var item = new ListViewItem(repository.Caption)
                     {
                         ForeColor = ForeColor,
                         Font = AppSettings.Font,
                         Group = GetTileGroup(repository.Repo),
-                        ImageIndex = _controller.IsValidGitWorkingDir(repository.Repo.Path) ? 0 : 1,
+                        ImageIndex = isInvalidRepo ? 1 : 0,
                         UseItemStyleForSubItems = false,
                         Tag = repository.Repo,
                         ToolTipText = repository.Repo.Path
@@ -421,6 +426,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                     tsmiCategories.Visible =
                         toolStripMenuItem2.Visible =
                             tsmiOpenFolder.Visible = selected != null;
+
+            tsmiRemoveMissingReposFromList.Visible = _hasInvalidRepos;
 
             if (selected == null)
             {

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -657,10 +657,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         {
             RepositoryContextAction(sender as ToolStripMenuItem, repository =>
             {
-                foreach (Repository repo in _missingRepositories)
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.RemoveRecentAsync(repo.Path));
-                }
+                    foreach (Repository repo in _missingRepositories)
+                    {
+                        await RepositoryHistoryManager.Locals.RemoveRecentAsync(repo.Path);
+                    }
+                });
 
                 ShowRecentRepositories();
             });


### PR DESCRIPTION
Resolves #5143 

Changes proposed in this pull request:
- Added 'Remove Missing Projects from the list' feature to dashboard, removes all missing repositories.

Screenshots before and after (if PR changes UI):
Before:
![before](https://user-images.githubusercontent.com/14019835/43037095-d67ad73a-8d11-11e8-9047-cfc5bb5b028d.png)

After:
![after](https://user-images.githubusercontent.com/14019835/43037097-d83ce662-8d11-11e8-95ed-217fb3c3e933.png)