### PR TITLE
fix for #5187: can't open settings

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -34,14 +34,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     continue;
                 }
                 string fullName;
-                string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
+                string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles") ?? "";
+
 
                 if (CheckFileExists(programFilesPath, location, fileName, out fullName))
                 {
                     return fullName;
                 }
 
-                programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+                programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)") ?? "";
 
                 if ((IntPtr.Size == 8 ||
                     !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432"))) &&


### PR DESCRIPTION
Fix for #5187 
programFilesPath === null can't be used with Path.Combine.
I've added additional condition here.

mono -V
Mono JIT compiler version 5.12.0.226 (tarball Thu May  3 09:42:09 UTC 2018)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
        TLS:           __thread
        SIGSEGV:       altstack
        Notifications: epoll
        Architecture:  amd64
        Disabled:      none
        Misc:          softdebug 
        Interpreter:   yes
        LLVM:          supported, not enabled.
        GC:            sgen (concurrent by default)
