### PR TITLE
fix for #5187: can't open settings (master branch)

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -40,14 +40,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 }
 
                 string fullName = string.Empty;
-                string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles");
+                string programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles") ?? "";
 
                 if (CheckFileExists(programFilesPath))
                 {
                     return fullName;
                 }
 
-                programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+                programFilesPath = Environment.GetEnvironmentVariable("ProgramFiles(x86)") ?? "";
 
                 if ((IntPtr.Size == 8 ||
                     !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432"))) &&


### PR DESCRIPTION
master branch PR
Conflict:	GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs

Fix for #5187
programFilesPath === null can't be used with Path.Combine.