### PR TITLE
Reset file to index failed due to ObjectId handling

### DIFF
--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using GitCommands.Git;
 using GitUIPluginInterfaces;
@@ -205,10 +206,24 @@ namespace GitCommands
         /// <summary>
         /// Adds <paramref name="objectId"/> as a SHA-1 argument.
         /// </summary>
+        /// <remarks>
+        /// If <paramref name="objectId"/> is <c>null</c> then no change is made to the arguments.
+        /// </remarks>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-        /// <param name="objectId">The SHA-1 object ID to add to the builder.</param>
-        public static void Add(this ArgumentBuilder builder, ObjectId objectId)
+        /// <param name="objectId">The SHA-1 object ID to add to the builder, or <c>null</c>.</param>
+        /// <exception cref="ArgumentException"><paramref name="objectId"/> represents an artificial commit.</exception>
+        public static void Add(this ArgumentBuilder builder, [CanBeNull] ObjectId objectId)
         {
+            if (objectId == null)
+            {
+                return;
+            }
+
+            if (objectId.IsArtificial)
+            {
+                throw new ArgumentException("Unexpected artificial commit in Git command: " + objectId);
+            }
+
             builder.Add(objectId.ToString());
         }
     }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1638,16 +1638,10 @@ namespace GitCommands
                 return "";
             }
 
-            if (revision == ObjectId.UnstagedId)
-            {
-                Debug.Assert(false, "Unexpectedly reset to unstaged - should be blocked in GUI");
-
-                // Not an error to user, just nothing happens
-                return "";
-            }
-
             if (revision == ObjectId.IndexId)
             {
+                // Reset to index has no revision
+                // All other artificial commits are errors
                 revision = null;
             }
 

--- a/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GitCommands;
 using GitCommands.Git;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitCommandsTests
@@ -224,6 +225,33 @@ namespace GitCommandsTests
                     Assert.DoesNotThrow(() => method.Invoke(null, new object[] { args, member }));
                 }
             }
+        }
+
+        [Test]
+        public void Handle_artificial_objectid()
+        {
+            Assert.Throws<ArgumentException>(() => new ArgumentBuilder
+            {
+                ObjectId.UnstagedId
+            });
+            Assert.Throws<ArgumentException>(() => new ArgumentBuilder
+            {
+                ObjectId.IndexId
+            });
+            Assert.Throws<ArgumentException>(() => new ArgumentBuilder
+            {
+                ObjectId.CombinedDiffId
+            });
+        }
+
+        [TestCase(null)]
+        public void Handle_null_objectid(ObjectId id)
+        {
+            var args = new ArgumentBuilder
+            {
+                id
+            };
+            Assert.AreEqual(args.ToString(), "");
         }
     }
 }


### PR DESCRIPTION
Regression from ObjectId handling in #5087

Fixes #5193

Note: The only other command with special handling for ObjectId.InndexId is GetFileBlobHash(), OK special handling there.

Changes proposed in this pull request:
- Exception when resetting to Index
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- manual test resetting worktree file

Has been tested on (remove any that don't apply):
- Windows 10
