### PR TITLE
Don't swallow exceptions.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -279,21 +279,15 @@ namespace GitUI.CommandsDialogs
 
             RevisionGrid.SelectionChanged += (sender, e) =>
             {
-                try
-                {
-                    _selectedRevisionUpdatedTargets = UpdateTargets.None;
+                _selectedRevisionUpdatedTargets = UpdateTargets.None;
 
-                    FillFileTree();
-                    FillDiff();
-                    FillCommitInfo();
-                    ThreadHelper.JoinableTaskFactory.RunAsync(() => FillGpgInfoAsync());
-                    FillBuildReport();
-                }
-                catch (Exception ex)
-                {
-                    Trace.WriteLine(ex.Message);
-                }
+                FillFileTree();
+                FillDiff();
+                FillCommitInfo();
+                ThreadHelper.JoinableTaskFactory.RunAsync(() => FillGpgInfoAsync());
+                FillBuildReport();
             };
+
             _filterRevisionsHelper.SetFilter(filter);
 
             HotkeysEnabled = true;


### PR DESCRIPTION
It is better to show the exception to users than hiding it
and showing a partially loaded state.