### PR TITLE
Fix file viewer context menu

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -144,6 +144,7 @@ namespace GitUI.Editor
             // 
             // increaseNumberOfLinesToolStripMenuItem
             // 
+            this.increaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesIncrease;
             this.increaseNumberOfLinesToolStripMenuItem.Name = "increaseNumberOfLinesToolStripMenuItem";
             this.increaseNumberOfLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
             this.increaseNumberOfLinesToolStripMenuItem.Text = "Increase number of lines visible";
@@ -151,6 +152,7 @@ namespace GitUI.Editor
             // 
             // descreaseNumberOfLinesToolStripMenuItem
             // 
+            this.decreaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
             this.decreaseNumberOfLinesToolStripMenuItem.Name = "decreaseNumberOfLinesToolStripMenuItem";
             this.decreaseNumberOfLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
             this.decreaseNumberOfLinesToolStripMenuItem.Text = "Decrease number of lines visible";
@@ -158,6 +160,7 @@ namespace GitUI.Editor
             // 
             // showEntireFileToolStripMenuItem
             // 
+            this.showEntireFileToolStripMenuItem.Image = global::GitUI.Properties.Images.ShowEntireFile;
             this.showEntireFileToolStripMenuItem.Name = "showEntireFileToolStripMenuItem";
             this.showEntireFileToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
             this.showEntireFileToolStripMenuItem.Text = "Show entire file";
@@ -177,6 +180,7 @@ namespace GitUI.Editor
             // 
             // showNonprintableCharactersToolStripMenuItem
             // 
+            this.showNonprintableCharactersToolStripMenuItem.Image = global::GitUI.Properties.Images.ShowWhitespace;
             this.showNonprintableCharactersToolStripMenuItem.Name = "showNonprintableCharactersToolStripMenuItem";
             this.showNonprintableCharactersToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
             this.showNonprintableCharactersToolStripMenuItem.Text = "Show nonprinting characters";

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -154,7 +154,7 @@ namespace GitUI.Editor
 
             HotkeysEnabled = true;
 
-            if (IsDesignModeActive && ContextMenuStrip == null)
+            if (!IsDesignModeActive && ContextMenuStrip == null)
             {
                 ContextMenuStrip = contextMenu;
             }


### PR DESCRIPTION
Fixes #5208.

Changes proposed in this pull request:
- Fix inverted logic bug introduced in 4d1ff07e3b8c419b33df0253659fb2af0519f411
- Add some existing icons to the context menu

![image](https://user-images.githubusercontent.com/350947/43209499-a59d759e-9024-11e8-97a6-549ea70d5059.png)

New icons for:
- Increase / decrease number of lines
- Show non-printing characters
- Show entire file
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
