### PR TITLE
Fix commit message adorners under high DPI

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2663,7 +2663,7 @@ namespace GitUI.CommandsDialogs
 
                 if (limit1 > 0 && line == 0)
                 {
-                    ColorTextAsNecessary(limit1, false);
+                    ColorTextAsNecessary(limit1, fullRefresh: false);
                 }
 
                 if (empty2 && line == 1)

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -384,13 +384,6 @@ namespace GitUI.SpellChecker
             TextBox.Select(start, length);
         }
 
-        private ToolStripMenuItem AddContextMenuItem(string text, EventHandler eventHandler)
-        {
-            var menuItem = new ToolStripMenuItem(text, null, eventHandler);
-            SpellCheckContextMenu.Items.Add(menuItem);
-            return menuItem;
-        }
-
         private void AddContextMenuSeparator()
         {
             SpellCheckContextMenu.Items.Add(new ToolStripSeparator());
@@ -425,16 +418,13 @@ namespace GitUI.SpellChecker
 
                     foreach (var suggestion in _spelling.Suggestions)
                     {
-                        var si = AddContextMenuItem(suggestion, SuggestionToolStripItemClick);
+                        var si = AddContextMenuItem(suggestion, SuggestionToolStripItemClick, true);
                         si.Font = new Font(si.Font, FontStyle.Bold);
                     }
 
-                    AddContextMenuItem(_addToDictionaryText.Text, AddToDictionaryClick)
-                        .Enabled = _spelling.CurrentWord.Length > 0;
-                    AddContextMenuItem(_ignoreWordText.Text, IgnoreWordClick)
-                        .Enabled = _spelling.CurrentWord.Length > 0;
-                    AddContextMenuItem(_removeWordText.Text, RemoveWordClick)
-                        .Enabled = _spelling.CurrentWord.Length > 0;
+                    AddContextMenuItem(_addToDictionaryText.Text, AddToDictionaryClick, _spelling.CurrentWord.Length > 0);
+                    AddContextMenuItem(_ignoreWordText.Text, IgnoreWordClick, _spelling.CurrentWord.Length > 0);
+                    AddContextMenuItem(_removeWordText.Text, RemoveWordClick, _spelling.CurrentWord.Length > 0);
 
                     if (_spelling.Suggestions.Count > 0)
                     {
@@ -447,15 +437,11 @@ namespace GitUI.SpellChecker
                 Trace.WriteLine(ex);
             }
 
-            AddContextMenuItem(_cutMenuItemText.Text, CutMenuItemClick)
-                .Enabled = TextBox.SelectedText.Length > 0;
-            AddContextMenuItem(_copyMenuItemText.Text, CopyMenuItemdClick)
-                .Enabled = TextBox.SelectedText.Length > 0;
-            AddContextMenuItem(_pasteMenuItemText.Text, PasteMenuItemClick)
-                .Enabled = Clipboard.ContainsText();
-            AddContextMenuItem(_deleteMenuItemText.Text, DeleteMenuItemClick)
-                .Enabled = TextBox.SelectedText.Length > 0;
-            AddContextMenuItem(_selectAllMenuItemText.Text, SelectAllMenuItemClick);
+            AddContextMenuItem(_cutMenuItemText.Text, CutMenuItemClick, TextBox.SelectedText.Length > 0);
+            AddContextMenuItem(_copyMenuItemText.Text, CopyMenuItemdClick, TextBox.SelectedText.Length > 0);
+            AddContextMenuItem(_pasteMenuItemText.Text, PasteMenuItemClick, Clipboard.ContainsText());
+            AddContextMenuItem(_deleteMenuItemText.Text, DeleteMenuItemClick, TextBox.SelectedText.Length > 0);
+            AddContextMenuItem(_selectAllMenuItemText.Text, SelectAllMenuItemClick, true);
 
             /*AddContextMenuSeparator();
 
@@ -521,6 +507,15 @@ namespace GitUI.SpellChecker
                 };
             mi.Click += MarkIllFormedLinesInCommitMsgClick;
             SpellCheckContextMenu.Items.Add(mi);
+
+            return;
+
+            ToolStripMenuItem AddContextMenuItem(string text, EventHandler eventHandler, bool enabled)
+            {
+                var menuItem = new ToolStripMenuItem(text, null, eventHandler);
+                SpellCheckContextMenu.Items.Add(menuItem);
+                return menuItem;
+            }
         }
 
         private void RemoveWordClick(object sender, EventArgs e)

--- a/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -9,7 +9,7 @@ using GitCommands.Utils;
 
 namespace GitUI.SpellChecker
 {
-    public class SpellCheckEditControl : NativeWindow, IDisposable
+    public sealed class SpellCheckEditControl : NativeWindow, IDisposable
     {
         public bool IsImeStartingComposition { get; private set; }
 
@@ -177,11 +177,11 @@ namespace GitUI.SpellChecker
         private void DrawMark(Point start, Point end)
         {
             var col = Color.FromArgb(120, 255, 255, 0);
-            var linHeight = LineHeight();
-            using (var pen = new Pen(col, linHeight))
+            var lineHeight = LineHeight();
+            using (var pen = new Pen(col, lineHeight))
             {
-                start.Offset(0, -linHeight / 2);
-                end.Offset(0, -linHeight / 2);
+                start.Offset(0, -lineHeight / 2);
+                end.Offset(0, -lineHeight / 2);
                 _bufferGraphics.DrawLine(pen, start, end);
             }
         }
@@ -193,7 +193,7 @@ namespace GitUI.SpellChecker
                 return 12;
             }
 
-            if (_lineHeight == 0 && !EnvUtils.RunningOnWindows())
+            if (_lineHeight == 0)
             {
                 if (_richTextBox.Lines.Any(line => line.Length != 0))
                 {
@@ -204,44 +204,19 @@ namespace GitUI.SpellChecker
             return _lineHeight == 0 ? 12 : _lineHeight;
         }
 
-        #region Nested type: DrawType
+        public void Dispose()
+        {
+            ReleaseHandle();
+
+            _bitmap?.Dispose();
+            _bufferGraphics?.Dispose();
+            _textBoxGraphics?.Dispose();
+        }
 
         private enum DrawType
         {
             Wave,
             Mark
-        }
-
-        #endregion
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposing)
-            {
-                return;
-            }
-
-            ReleaseHandle();
-            if (_bitmap != null)
-            {
-                _bitmap.Dispose();
-            }
-
-            if (_bufferGraphics != null)
-            {
-                _bufferGraphics.Dispose();
-            }
-
-            if (_textBoxGraphics != null)
-            {
-                _textBoxGraphics.Dispose();
-            }
         }
     }
 }

--- a/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 
 namespace GitUI.SpellChecker
 {
@@ -155,22 +156,26 @@ namespace GitUI.SpellChecker
 
         private void DrawWave(Point start, Point end)
         {
-            var pen = Pens.Red;
-            if ((end.X - start.X) > 4)
+            using (var pen = new Pen(Color.Red, DpiUtil.ScaleX))
             {
-                var pl = new List<Point>();
-                for (var i = start.X; i <= (end.X - 2); i += 4)
+                var waveWidth = DpiUtil.Scale(4);
+                var waveHalfWidth = waveWidth >> 1;
+                if ((end.X - start.X) > waveWidth)
                 {
-                    pl.Add(new Point(i, start.Y));
-                    pl.Add(new Point(i + 2, start.Y + 2));
-                }
+                    var pl = new List<Point>();
+                    for (var i = start.X; i <= (end.X - waveHalfWidth); i += waveWidth)
+                    {
+                        pl.Add(new Point(i, start.Y));
+                        pl.Add(new Point(i + waveHalfWidth, start.Y + waveHalfWidth));
+                    }
 
-                var p = pl.ToArray();
-                _bufferGraphics.DrawLines(pen, p);
-            }
-            else
-            {
-                _bufferGraphics.DrawLine(pen, start, end);
+                    var p = pl.ToArray();
+                    _bufferGraphics.DrawLines(pen, p);
+                }
+                else
+                {
+                    _bufferGraphics.DrawLine(pen, start, end);
+                }
             }
         }
 

--- a/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/GitUI/SpellChecker/TextBoxHelper.cs
@@ -13,47 +13,6 @@ namespace GitUI.SpellChecker
     {
         private const double AnInch = 14.4;
 
-        internal static int GetTextWidthAtCharIndex(TextBoxBase textBoxBase, int index, int length)
-        {
-            // TODO!
-            if (!(textBoxBase is RichTextBox richTextBox) || !EnvUtils.RunningOnWindows())
-            {
-                return textBoxBase.Font.Height;
-            }
-
-            NativeMethods.CHARRANGE charRange;
-            charRange.cpMin = index;
-            charRange.cpMax = index + length;
-
-            NativeMethods.RECT rect;
-            rect.Top = 0;
-            rect.Bottom = (int)AnInch;
-            rect.Left = 0;
-            rect.Right = (int)(richTextBox.ClientSize.Width * AnInch);
-
-            NativeMethods.RECT rectPage;
-            rectPage.Top = 0;
-            rectPage.Bottom = (int)AnInch;
-            rectPage.Left = 0;
-            rectPage.Right = (int)(richTextBox.ClientSize.Width * AnInch);
-
-            var canvas = Graphics.FromHwnd(richTextBox.Handle);
-            var canvasHdc = canvas.GetHdc();
-
-            var formatRange = GetFormatRange(charRange, canvasHdc, rect, rectPage);
-
-            NativeMethods.SendMessage(
-                richTextBox.Handle,
-                NativeMethods.EM_FORMATRANGE,
-                IntPtr.Zero,
-                ref formatRange);
-
-            canvas.ReleaseHdc(canvasHdc);
-            canvas.Dispose();
-
-            return (int)((formatRange.rc.Right - formatRange.rc.Left) / AnInch);
-        }
-
         internal static int GetBaselineOffsetAtCharIndex(TextBoxBase tb, int index)
         {
             if (!(tb is RichTextBox rtb) || !EnvUtils.RunningOnWindows())
@@ -62,33 +21,42 @@ namespace GitUI.SpellChecker
             }
 
             var lineNumber = rtb.GetLineFromCharIndex(index);
-            var lineIndex =
-                NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINEINDEX, new IntPtr(lineNumber), IntPtr.Zero)
-                    .ToInt32();
-            var lineLength =
-                NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINELENGTH, new IntPtr(lineNumber),
-                                             IntPtr.Zero).ToInt32();
+            var lineIndex = NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINEINDEX, new IntPtr(lineNumber), IntPtr.Zero).ToInt32();
+            var lineLength = NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINELENGTH, new IntPtr(lineNumber), IntPtr.Zero).ToInt32();
 
-            NativeMethods.CHARRANGE charRange;
-            charRange.cpMin = lineIndex;
-            charRange.cpMax = lineIndex + lineLength;
+            var charRange = new NativeMethods.CHARRANGE
+            {
+                cpMin = lineIndex,
+                cpMax = lineIndex + lineLength
+            };
 
-            NativeMethods.RECT rect;
-            rect.Top = 0;
-            rect.Bottom = (int)AnInch;
-            rect.Left = 0;
-            rect.Right = 10000000; ////(int)(rtb.Width * anInch + 20);
+            var rect = new NativeMethods.RECT
+            {
+                Top = 0,
+                Bottom = (int)AnInch,
+                Left = 0,
+                Right = 10000000 ////(int)(rtb.Width * anInch + 20);
+            };
 
-            NativeMethods.RECT rectPage;
-            rectPage.Top = 0;
-            rectPage.Bottom = (int)AnInch;
-            rectPage.Left = 0;
-            rectPage.Right = 10000000; ////(int)(rtb.Width * anInch + 20);
+            var rectPage = new NativeMethods.RECT
+            {
+                Top = 0,
+                Bottom = (int)AnInch,
+                Left = 0,
+                Right = 10000000 ////(int)(rtb.Width * anInch + 20);
+            };
 
             var canvas = Graphics.FromHwnd(rtb.Handle);
             var canvasHdc = canvas.GetHdc();
 
-            var formatRange = GetFormatRange(charRange, canvasHdc, rect, rectPage);
+            var formatRange = new NativeMethods.FORMATRANGE
+            {
+                chrg = charRange,
+                hdc = canvasHdc,
+                hdcTarget = canvasHdc,
+                rc = rect,
+                rcPage = rectPage
+            };
 
             NativeMethods.SendMessage(rtb.Handle, NativeMethods.EM_FORMATRANGE, IntPtr.Zero, ref formatRange);
 
@@ -96,118 +64,6 @@ namespace GitUI.SpellChecker
             canvas.Dispose();
 
             return (int)((formatRange.rc.Bottom - formatRange.rc.Top) / AnInch);
-        }
-
-        private static NativeMethods.FORMATRANGE GetFormatRange(NativeMethods.CHARRANGE charRange, IntPtr canvasHdc,
-                                                                NativeMethods.RECT rect, NativeMethods.RECT rectPage)
-        {
-            NativeMethods.FORMATRANGE formatRange;
-            formatRange.chrg = charRange;
-            formatRange.hdc = canvasHdc;
-            formatRange.hdcTarget = canvasHdc;
-            formatRange.rc = rect;
-            formatRange.rcPage = rectPage;
-            return formatRange;
-        }
-
-        /// <summary>
-        ///   Attempts to make the caret visible in a TextBox control.
-        ///   This will not always succeed since the TextBox control
-        ///   appears to destroy its caret fairly frequently.
-        /// </summary>
-        /// <param name = "textBox">The text box to show the caret in.</param>
-        internal static void ShowCaret(TextBox textBox)
-        {
-            if (!EnvUtils.RunningOnWindows())
-            {
-                return;
-            }
-
-            var ret = false;
-            var iter = 0;
-            while (!ret && iter < 10)
-            {
-                ret = NativeMethods.ShowCaretAPI(textBox.Handle);
-                iter++;
-            }
-        }
-
-        /// <summary>
-        ///   Returns the index of the character under the specified
-        ///   point in the control, or the nearest character if there
-        ///   is no character under the point.
-        /// </summary>
-        /// <param name = "textBox">The text box control to check.</param>
-        /// <param name = "point">The point to find the character for,
-        ///   specified relative to the client area of the text box.</param>
-        private static int CharFromPos(TextBoxBase textBox, Point point)
-        {
-            unchecked
-            {
-                // Convert the point into a DWord with horizontal position
-                // in the loword and vertical position in the hiword:
-                var xy = (point.X & 0xFFFF) + ((point.Y & 0xFFFF) << 16);
-
-                // Get the position from the text box.
-                var res =
-                    NativeMethods.SendMessageInt(
-                        textBox.Handle,
-                        NativeMethods.EM_CHARFROMPOS,
-                        IntPtr.Zero,
-                        new IntPtr(xy)).ToInt32();
-
-                // the Platform SDK appears to be incorrect on this matter.
-                // the hiword is the line number and the loword is the index
-                // of the character on this line
-                var lineNumber = (res & 0xFFFF) >> 16;
-                var charIndex = res & 0xFFFF;
-
-                // Find the index of the first character on the line within
-                // the control:
-                var lineStartIndex =
-                    NativeMethods.SendMessageInt(
-                        textBox.Handle,
-                        NativeMethods.EM_LINEINDEX,
-                        new IntPtr(lineNumber),
-                        IntPtr.Zero).ToInt32();
-
-                // Return the combined index:
-                return lineStartIndex + charIndex;
-            }
-        }
-
-        /// <summary>
-        ///   Returns the position of the specified character
-        /// </summary>
-        /// <param name = "textBoxBase">The text box to find the character in.</param>
-        /// <param name = "charIndex">The index of the character whose
-        ///   position needs to be found.</param>
-        /// <returns>The position of the character relative to the client
-        ///   area of the control.</returns>
-        private static Point PosFromChar(TextBoxBase textBoxBase, int charIndex)
-        {
-            var xy =
-                NativeMethods.SendMessageInt(
-                    textBoxBase.Handle,
-                    NativeMethods.EM_POSFROMCHAR,
-                    new IntPtr(charIndex),
-                    IntPtr.Zero).ToInt32();
-            return new Point(xy);
-        }
-
-        private static int GetFirstVisibleLine(TextBoxBase txt)
-        {
-            return
-                NativeMethods.SendMessageInt(
-                    txt.Handle,
-                    NativeMethods.EM_GETFIRSTVISIBLELINE,
-                    IntPtr.Zero,
-                    IntPtr.Zero).ToInt32();
-        }
-
-        private static int GetLineIndex(TextBoxBase txt, int line)
-        {
-            return NativeMethods.SendMessageInt(txt.Handle, 0xbb, new IntPtr(line), IntPtr.Zero).ToInt32();
         }
     }
 }

--- a/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/GitUI/SpellChecker/TextBoxHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Windows.Forms;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 
 namespace GitUI.SpellChecker
 {
@@ -11,7 +12,7 @@ namespace GitUI.SpellChecker
     /// </summary>
     internal static class TextBoxHelper
     {
-        private const double AnInch = 14.4;
+        private static readonly double AnInch = 14.4 / DpiUtil.ScaleX;
 
         internal static int GetBaselineOffsetAtCharIndex(TextBoxBase tb, int index)
         {


### PR DESCRIPTION
Fixes #5024

Changes proposed in this pull request:
- Scale the spelling mistake underline wave
- Scale the line-too-long highlight
- Some code formatting
 
Screenshots:

Before

![image](https://user-images.githubusercontent.com/350947/43228723-3d494348-905a-11e8-8684-cd9c60869c58.png)

After

![image](https://user-images.githubusercontent.com/350947/43228695-2b724f52-905a-11e8-99ea-1dd9572f0e79.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- Windows 10 at 200% scaling
