### PR TITLE
Prevent NRE in FormCommit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs
         private bool _loadUnstagedOutputFirstTime = true;
         private bool _initialized;
         private bool _selectedDiffReloaded = true;
-        private IReadOnlyList<GitItemStatus> _currentSelection;
+        [CanBeNull] private IReadOnlyList<GitItemStatus> _currentSelection;
         private int _alreadyLoadedTemplatesCount = -1;
 
         /// <summary>
@@ -979,7 +979,7 @@ namespace GitUI.CommandsDialogs
         private void LoadUnstagedOutput(IReadOnlyList<GitItemStatus> allChangedFiles)
         {
             var lastSelection = _currentFilesList != null
-                ? _currentSelection
+                ? _currentSelection ?? Array.Empty<GitItemStatus>()
                 : Array.Empty<GitItemStatus>();
 
             var unstagedFiles = new List<GitItemStatus>();


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes an internal NRE when attempting to restore previously selected files

Repro:
- run in debugger with 'break on all exceptions'
- have a clean workspace
- load commit form
- create unstaged change
- refresh form
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
