### PR TITLE
Include process ID in command log

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -89,6 +89,7 @@ namespace GitCommands
             var startInfo = CreateProcessStartInfo(fileName, arguments, workingDirectory, outputEncoding);
             var process = Process.Start(startInfo);
             process.EnableRaisingEvents = true;
+            operation.SetProcessId(process.Id);
 
             void ProcessExited(object sender, EventArgs args)
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -515,9 +515,10 @@ namespace GitCommands
             }
 
             var operation = CommandLog.LogProcessStart(fileName, arguments);
-            var startProcess = Process.Start(startInfo);
-            startProcess.Exited += (s, e) => operation.LogProcessEnd();
-            return startProcess;
+            var process = Process.Start(startInfo);
+            operation.SetProcessId(process.Id);
+            process.Exited += (s, e) => operation.LogProcessEnd();
+            return process;
         }
 
         [NotNull]

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -30,6 +30,12 @@ namespace GitCommands.Logging
             _entry.Duration = _stopwatch.Elapsed;
             _raiseCommandsChanged();
         }
+
+        public void SetProcessId(int processId)
+        {
+            _entry.ProcessId = processId;
+            _raiseCommandsChanged();
+        }
     }
 
     public sealed class CommandLogEntry
@@ -39,6 +45,7 @@ namespace GitCommands.Logging
         private DateTime StartedAt { get; }
         public bool IsOnMainThread { get; }
         public TimeSpan? Duration { get; internal set; }
+        public int? ProcessId { get; set; }
 
         internal CommandLogEntry(string fileName, string arguments, DateTime startedAt, bool isOnMainThread)
         {
@@ -61,7 +68,9 @@ namespace GitCommands.Logging
                 fileName = "git";
             }
 
-            return $"{StartedAt:HH:mm:ss.fff} {duration,7} {(IsOnMainThread ? "UI" : "  ")} {fileName} {Arguments}";
+            var pid = ProcessId == null ? "     " : $"{ProcessId,5}";
+
+            return $"{StartedAt:HH:mm:ss.fff} {duration,7} {pid} {(IsOnMainThread ? "UI" : "  ")} {fileName} {Arguments}";
         }
     }
 

--- a/GitUI/Script/PowerShellHelper.cs
+++ b/GitUI/Script/PowerShellHelper.cs
@@ -9,21 +9,21 @@ namespace GitUI.Script
         internal static void RunPowerShell(string command, string argument, string workingDir, bool runInBackground)
         {
             const string filename = "powershell.exe";
-            var psarguments = (runInBackground ? "" : "-NoExit") + " -ExecutionPolicy Unrestricted -Command \"" + command + " " + argument + "\"";
+            var arguments = (runInBackground ? "" : "-NoExit") + " -ExecutionPolicy Unrestricted -Command \"" + command + " " + argument + "\"";
             EnvironmentConfiguration.SetEnvironmentVariables();
 
             var startInfo = new ProcessStartInfo
             {
                 FileName = filename,
-                Arguments = psarguments,
+                Arguments = arguments,
                 WorkingDirectory = workingDir,
                 UseShellExecute = false
             };
 
-            var operation = CommandLog.LogProcessStart(filename, psarguments);
-            var startProcess = Process.Start(startInfo);
-
-            startProcess.Exited += (s, e) => operation.LogProcessEnd();
+            var operation = CommandLog.LogProcessStart(filename, arguments);
+            var process = Process.Start(startInfo);
+            operation.SetProcessId(process.Id);
+            process.Exited += (s, e) => operation.LogProcessEnd();
         }
     }
 }

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -127,7 +127,7 @@ namespace GitUI.UserControls
 
                 var operation = CommandLog.LogProcessStart(command, arguments);
                 process.Exited += (s, e) => operation.LogProcessEnd();
-
+                operation.SetProcessId(process.Id);
                 process.Start();
                 _process = process;
                 process.BeginOutputReadLine();


### PR DESCRIPTION
Motivated by issue reported in #4256. Relates to #4753.

Changes proposed in this pull request:
- Keep record of the PID of processes and display in command log
 
Screenshots:

![image](https://user-images.githubusercontent.com/350947/43232923-3ba627a2-906b-11e8-8513-6d4cc49b46e5.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
