### PR TITLE
fix display of script icons

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -79,7 +80,7 @@ Current Branch:
             if (EnvUtils.RunningOnWindows())
             {
                 System.Resources.ResourceManager rm =
-                    new System.Resources.ResourceManager("GitUI.Properties.Resources",
+                    new System.Resources.ResourceManager("GitUI.Properties.Images",
                                 System.Reflection.Assembly.GetExecutingAssembly());
 
                 // dummy request; for some strange reason the ResourceSets are not loaded untill after the first object request... bug?
@@ -89,6 +90,7 @@ Current Branch:
 
                 contextMenuStrip_SplitButton.Items.Clear();
 
+                var iconItems = new List<ToolStripItem>();
                 foreach (System.Collections.DictionaryEntry icon in resourceSet)
                 {
                     // add entry to toolstrip
@@ -98,10 +100,11 @@ Current Branch:
                     }
                     else if (icon.Value is Bitmap bitmap)
                     {
-                        contextMenuStrip_SplitButton.Items.Add(icon.Key.ToString(), bitmap, SplitButtonMenuItem_Click);
+                        iconItems.Add(new ToolStripMenuItem(icon.Key.ToString(), bitmap, SplitButtonMenuItem_Click));
                     }
-                    ////var aa = icon.Value.GetType();
                 }
+
+                contextMenuStrip_SplitButton.Items.AddRange(iconItems.OrderBy(i => i.Text).ToArray());
 
                 resourceSet.Close();
                 rm.ReleaseAllResources();

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -60,7 +60,7 @@ namespace GitUI.Script
         {
             // Get all resources
             System.Resources.ResourceManager rm
-                = new System.Resources.ResourceManager("GitUI.Properties.Resources",
+                = new System.Resources.ResourceManager("GitUI.Properties.Images",
                     System.Reflection.Assembly.GetExecutingAssembly());
 
             // return icon


### PR DESCRIPTION
fix for #5219 

regression introduced by refactoring done in #5087
where icons are now in another resource file

Fix:
- icon menu was no more filled with the icons
- icons in the toolbar was no more displayed
- (additional improvement) the icons are now alphabetically sorted
