### PR TITLE
Raise Git minimum, recommended version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,5 @@ What did I do to test the code and ensure quality:
 - 
 
 Has been tested on (remove any that don't apply):
-- GIT 2.10 and above
+- GIT 2.11 and above
 - Windows 7 and above

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -17,10 +17,10 @@ namespace GitCommands
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
         private static readonly GitVersion v2_11_0 = new GitVersion("2.11.0");
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
-        private static readonly GitVersion v2_16_3 = new GitVersion("2.16.3");
+        private static readonly GitVersion v2_18_0 = new GitVersion("2.18.0");
 
-        public static readonly GitVersion LastSupportedVersion = v2_9_0;
-        public static readonly GitVersion LastRecommendedVersion = v2_16_3;
+        public static readonly GitVersion LastSupportedVersion = v2_11_0;
+        public static readonly GitVersion LastRecommendedVersion = v2_18_0;
 
         private const string Prefix = "git version";
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5106

Changes proposed in this pull request:
- Raise minimum Git version 2.11 (no hard limit enforced, just warning when starting up)
- Raise recommended version 2.18.0 
 
Note: There are some soft limits, for instance will older than 2.11 provide less information for #5104 .

Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Using 2.18 for a month

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
