### PR TITLE
Fix bug loading empty repo

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1280,15 +1280,30 @@ namespace GitCommands
             return RunGitCmd(GitCommandHelpers.DeleteTagCmd(tagName));
         }
 
-        [NotNull]
+        /// <summary>
+        /// Gets the commit ID of the currently checked out commit.
+        /// If the repo is bare or has no commits, <c>null</c> is returned.
+        /// </summary>
+        [CanBeNull]
         public ObjectId GetCurrentCheckout()
         {
             var output = RunGitCmd("rev-parse HEAD").TrimEnd();
 
-            if (output == "HEAD" && IsBareRepository())
+            if (output.StartsWith("HEAD"))
             {
-                // Caller should consider bare repositories before calling this method
-                throw new InvalidOperationException("Bare repositories do not have a current checkout.");
+                // A bare repo returns:
+                //
+                // HEAD
+                //
+                // A repository with no commits returns:
+                //
+                // HEAD
+                //
+                // fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
+                // Use '--' to separate paths from revisions, like this:
+                // 'git <command> [<revision>...] -- [<file>...]'
+
+                return null;
             }
 
             return ObjectId.Parse(output);

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
@@ -369,7 +370,9 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            var originalHash = Module.GetCurrentCheckout();
+            var originalId = Module.GetCurrentCheckout();
+
+            Debug.Assert(originalId != null, "originalId != null");
 
             ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
 
@@ -404,9 +407,9 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                var currentHash = Module.GetCurrentCheckout();
+                var currentId = Module.GetCurrentCheckout();
 
-                if (originalHash != currentHash)
+                if (originalId != currentId)
                 {
                     UICommands.UpdateSubmodules(this);
                 }
@@ -498,7 +501,11 @@ namespace GitUI.CommandsDialogs
                     {
                         await TaskScheduler.Default;
 
-                        var text = Module.GetCommitCountString(Module.GetCurrentCheckout().ToString(), branch);
+                        var currentCheckout = Module.GetCurrentCheckout();
+
+                        Debug.Assert(currentCheckout != null, "currentCheckout != null");
+
+                        var text = Module.GetCommitCountString(currentCheckout.ToString(), branch);
 
                         await this.SwitchToMainThreadAsync();
 

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -45,6 +45,9 @@ namespace GitUI.CommandsDialogs
                 }
 
                 var checkedOutObjectId = Module.GetCurrentCheckout();
+
+                Debug.Assert(checkedOutObjectId != null, "checkedOutObjectId != null");
+
                 ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
 
                 string command = GitCommandHelpers.CheckoutCmd(selectedObjectId.ToString(), Force.Checked ? LocalChangesAction.Reset : 0);

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -34,7 +34,10 @@ namespace GitUI.CommandsDialogs
             if (IsUICommandsInitialized)
             {
                 objectId = objectId ?? Module.GetCurrentCheckout();
-                commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
+                if (objectId != null)
+                {
+                    commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
+                }
             }
         }
 
@@ -108,20 +111,20 @@ namespace GitUI.CommandsDialogs
                     ? GitCommandHelpers.CreateOrphanCmd(branchName, objectId)
                     : GitCommandHelpers.BranchCmd(branchName, objectId.ToString(), chkbxCheckoutAfterCreate.Checked);
 
-                bool wasSuccessFul = FormProcess.ShowDialog(this, cmd);
-                if (Orphan.Checked && wasSuccessFul && ClearOrphan.Checked)
+                bool wasSuccessful = FormProcess.ShowDialog(this, cmd);
+                if (Orphan.Checked && wasSuccessful && ClearOrphan.Checked)
                 {
                     // orphan AND orphan creation success AND clear
                     cmd = GitCommandHelpers.RemoveCmd();
                     FormProcess.ShowDialog(this, cmd);
                 }
 
-                if (wasSuccessFul && chkbxCheckoutAfterCreate.Checked && objectId != originalHash)
+                if (wasSuccessful && chkbxCheckoutAfterCreate.Checked && objectId != originalHash)
                 {
                     UICommands.UpdateSubmodules(this);
                 }
 
-                DialogResult = wasSuccessFul ? DialogResult.OK : DialogResult.None;
+                DialogResult = wasSuccessful ? DialogResult.OK : DialogResult.None;
             }
             catch (Exception ex)
             {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -37,7 +37,10 @@ namespace GitUI.CommandsDialogs
             if (IsUICommandsInitialized)
             {
                 objectId = objectId ?? Module.GetCurrentCheckout();
-                commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
+                if (objectId != null)
+                {
+                    commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
+                }
             }
 
             if (commands != null)

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -27,12 +27,12 @@ namespace GitUI.CommandsDialogs
             tbBase.Text = item.Base.Hash ?? _deleted.Text;
             tbLocal.Text = item.Local.Hash ?? _deleted.Text;
             tbRemote.Text = item.Remote.Hash ?? _deleted.Text;
-            tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout().ToString();
+            tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
         }
 
         private void btRefresh_Click(object sender, EventArgs e)
         {
-            tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout().ToString();
+            tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
         }
 
         private void StageSubmodule()

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -67,10 +67,10 @@ namespace GitUI.HelperDialogs
             {
                 if (MessageBox.Show(this, _resetHardWarning.Text, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
                 {
-                    var originalHash = Module.GetCurrentCheckout();
+                    var currentCheckout = Module.GetCurrentCheckout();
                     if (FormProcess.ShowDialog(this, GitCommandHelpers.ResetHardCmd(Revision.Guid)))
                     {
-                        if (originalHash != Revision.ObjectId)
+                        if (currentCheckout != Revision.ObjectId)
                         {
                             UICommands.UpdateSubmodules(this);
                         }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -498,9 +498,9 @@ namespace GitUI.Script
         }
 
         [CanBeNull]
-        private static GitRevision GetCurrentRevision(GitModule module, RevisionGridControl revisionGrid, List<IGitRef> currentTags, List<IGitRef> currentLocalBranches,
-                                                      List<IGitRef> currentRemoteBranches, List<IGitRef> currentBranches,
-                                                      GitRevision currentRevision)
+        private static GitRevision GetCurrentRevision(
+            GitModule module, [CanBeNull] RevisionGridControl revisionGrid, List<IGitRef> currentTags, List<IGitRef> currentLocalBranches,
+            List<IGitRef> currentRemoteBranches, List<IGitRef> currentBranches, [CanBeNull] GitRevision currentRevision)
         {
             if (currentRevision == null)
             {
@@ -508,8 +508,8 @@ namespace GitUI.Script
 
                 if (revisionGrid == null)
                 {
-                    var currentRevisionGuid = module.GetCurrentCheckout().ToString();
-                    refs = module.GetRefs(true, true).Where(gitRef => gitRef.Guid == currentRevisionGuid).ToList();
+                    var currentRevisionGuid = module.GetCurrentCheckout();
+                    refs = module.GetRefs(true, true).Where(gitRef => gitRef.ObjectId == currentRevisionGuid).ToList();
                 }
                 else
                 {

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -121,7 +121,13 @@ namespace GitUI.UserControls
             else
             {
                 var branchName = SelectedBranchName;
-                var currentCheckout = CommitToCompare ?? Module.GetCurrentCheckout();
+                var currentCheckout = CommitToCompare ?? Module?.GetCurrentCheckout();
+
+                if (currentCheckout == null)
+                {
+                    lbChanges.Text = "";
+                    return;
+                }
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(
                     async () =>

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitUI.HelperDialogs;
@@ -52,7 +53,11 @@ namespace GitUI.UserControls
                     {
                         await TaskScheduler.Default.SwitchTo(alwaysYield: true);
 
-                        var text = Module.GetCommitCountString(Module.GetCurrentCheckout().ToString(), SelectedObjectId.ToString());
+                        var currentCheckout = Module.GetCurrentCheckout();
+
+                        Debug.Assert(currentCheckout != null, "currentCheckout != null");
+
+                        var text = Module.GetCommitCountString(currentCheckout.ToString(), SelectedObjectId.ToString());
 
                         await this.SwitchToMainThreadAsync();
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -668,7 +668,7 @@ namespace GitUI
 
                 DisposeRevisionReader();
 
-                var newCurrentCheckout = Module.IsBareRepository() ? null : Module.GetCurrentCheckout();
+                var newCurrentCheckout = Module.GetCurrentCheckout();
                 GitModule capturedModule = Module;
                 JoinableTask<SuperProjectInfo> newSuperProjectInfo =
                     ThreadHelper.JoinableTaskFactory.RunAsync(async () =>


### PR DESCRIPTION
Follows on from #5210. There are at least two scenarios where the checked out commit ID cannot be obtained:

- It is a bare repo with no work dir
- The repository has no commits

This change makes `GitModule.GetCurrentCheckout` return `null` in either of these cases, and updates callers to handle null values where necessary.

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
