### PR TITLE
Hide useless buttons for empty bare repo

### DIFF
--- a/GitUI/UserControls/RevisionGrid/EmptyRepoControl.cs
+++ b/GitUI/UserControls/RevisionGrid/EmptyRepoControl.cs
@@ -7,15 +7,29 @@ namespace GitUI.UserControls.RevisionGrid
     {
         private readonly TranslationString _repoHasNoCommits = new TranslationString("This repository does not yet contain any commits.");
 
+        /// <summary>For VS designer.</summary>
         public EmptyRepoControl()
+            : this(false)
+        {
+        }
+
+        public EmptyRepoControl(bool isBareRepository)
         {
             InitializeComponent();
             InitializeComplete();
 
             lblEmptyRepository.Text = _repoHasNoCommits.Text;
 
-            btnEditGitIgnore.Click += (_, e) => UICommands.StartEditGitIgnoreDialog(this, localExcludes: false);
-            btnOpenCommitForm.Click += (_, e) => UICommands.StartCommitDialog(this);
+            if (isBareRepository)
+            {
+                btnEditGitIgnore.Visible = false;
+                btnOpenCommitForm.Visible = false;
+            }
+            else
+            {
+                btnEditGitIgnore.Click += (_, e) => UICommands.StartEditGitIgnoreDialog(this, localExcludes: false);
+                btnOpenCommitForm.Click += (_, e) => UICommands.StartCommitDialog(this);
+            }
 
             Dock = DockStyle.Fill;
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -931,7 +931,7 @@ namespace GitUI
                     this.InvokeAsync(
                             () =>
                             {
-                                SetPage(new EmptyRepoControl());
+                                SetPage(new EmptyRepoControl(Module.IsBareRepository()));
                                 _isRefreshingRevisions = false;
                             })
                         .FileAndForget();


### PR DESCRIPTION
Prior to this change, the UI would show "Edit .gitignore" and "Commit" buttons when detecting an empty repo, even if bare. These buttons have no utility for bare repos, and are now hidden under such conditions.

Clicking the buttons on such repos had no effect. The edit button showed a warning dialog. The commit button did nothing at all.
 
## Screenshots

### Before

![image](https://user-images.githubusercontent.com/350947/43290328-b4184d36-9125-11e8-8219-a7dd4d88219b.png)

### After

![image](https://user-images.githubusercontent.com/350947/43291475-7b9419a0-9129-11e8-94ed-afe82e24a8d4.png)

What did I do to test the code and ensure quality:
- Manual testing with a variety of test repos

Has been tested on:
- GIT 2.18
- Windows 10
