### PR TITLE
Cleanup: WorkTree/Index should be used rather than Unstaged/Staged

### DIFF
--- a/GitCommands/Git/Extensions/GitRevisionExtensions.cs
+++ b/GitCommands/Git/Extensions/GitRevisionExtensions.cs
@@ -4,7 +4,7 @@
     {
         public static bool IsArtificial(this string sha1)
         {
-            return sha1 == GitRevision.UnstagedGuid ||
+            return sha1 == GitRevision.WorkTreeGuid ||
                    sha1 == GitRevision.IndexGuid ||
                    sha1 == GitRevision.CombinedDiffGuid;
         }

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -892,7 +892,7 @@ namespace GitCommands
                     // 1 XY subm <mH> <mI> <mW> <hH> <hI> <path>
                     // renamed:
                     // 2 XY subm <mH> <mI> <mW> <hH> <hI> <X><score> <path><sep><origPath>
-                    // unstaged (merge conflicts)
+                    // worktree (merge conflicts)
                     // u XY subm <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
 
                     char x = line[2];

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -816,7 +816,7 @@ namespace GitCommands
         public static IReadOnlyList<GitItemStatus> GetDiffChangedFilesFromString(IGitModule module, string statusString, [CanBeNull] string firstRevision, [CanBeNull] string secondRevision, [CanBeNull] string parentToSecond)
         {
             StagedStatus staged;
-            if (firstRevision == GitRevision.IndexGuid && secondRevision == GitRevision.UnstagedGuid)
+            if (firstRevision == GitRevision.IndexGuid && secondRevision == GitRevision.WorkTreeGuid)
             {
                 staged = StagedStatus.WorkTree;
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2484,8 +2484,8 @@ namespace GitCommands
             var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result, firstRevision, secondRevision, parentToSecond).ToList();
             if (firstRevision == GitRevision.WorkTreeGuid || secondRevision == GitRevision.WorkTreeGuid)
             {
-                // For unstaged the untracked must be added too
-                var files = GetUnstagedFilesWithSubmodulesStatus().Where(item => item.IsNew);
+                // For worktree the untracked must be added too
+                var files = GetWorkTreeFilesWithSubmodulesStatus().Where(item => item.IsNew);
                 if (firstRevision == GitRevision.WorkTreeGuid)
                 {
                     // The file is seen as "deleted" in 'to' revision
@@ -2632,13 +2632,13 @@ namespace GitCommands
             }
         }
 
-        public IReadOnlyList<GitItemStatus> GetStagedFiles()
+        public IReadOnlyList<GitItemStatus> GetIndexFiles()
         {
             string status = RunGitCmd(DiffCommandWithStandardArgs + "-M -C -z --cached --name-status", SystemEncoding);
 
             if (status.Length < 50 && status.Contains("fatal: No HEAD commit to compare"))
             {
-                // This command is a little more expensive because it will return both staged and unstaged files
+                // This command is a little more expensive because it will return both index and worktree files
                 string command = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.No);
                 status = RunGitCmd(command, SystemEncoding);
                 IReadOnlyList<GitItemStatus> stagedFiles = GitCommandHelpers.GetStatusChangedFilesFromString(this, status);
@@ -2648,19 +2648,19 @@ namespace GitCommands
             return GitCommandHelpers.GetDiffChangedFilesFromString(this, status, "HEAD", GitRevision.IndexGuid, "HEAD");
         }
 
-        public IReadOnlyList<GitItemStatus> GetStagedFilesWithSubmodulesStatus()
+        public IReadOnlyList<GitItemStatus> GetIndexFilesWithSubmodulesStatus()
         {
-            var status = GetStagedFiles();
+            var status = GetIndexFiles();
             GetCurrentSubmoduleStatus(status);
             return status;
         }
 
-        public IReadOnlyList<GitItemStatus> GetUnstagedFiles()
+        public IReadOnlyList<GitItemStatus> GetWorkTreeFiles()
         {
             return GetAllChangedFiles().Where(x => x.Staged == StagedStatus.WorkTree).ToArray();
         }
 
-        public IReadOnlyList<GitItemStatus> GetUnstagedFilesWithSubmodulesStatus()
+        public IReadOnlyList<GitItemStatus> GetWorkTreeFilesWithSubmodulesStatus()
         {
             return GetAllChangedFilesWithSubmodulesStatus().Where(x => x.Staged == StagedStatus.WorkTree).ToArray();
         }
@@ -3428,7 +3428,7 @@ namespace GitCommands
             if (objectId == ObjectId.WorkTreeId)
             {
                 // working directory changes
-                Debug.Assert(false, "Tried to get blob for unstaged file");
+                Debug.Assert(false, "Tried to get blob for worktree file");
                 return null;
             }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2482,11 +2482,11 @@ namespace GitCommands
             string cmd = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
             string result = noCache ? RunGitCmd(cmd) : RunCacheableGitCmd(cmd, SystemEncoding);
             var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, result, firstRevision, secondRevision, parentToSecond).ToList();
-            if (firstRevision == GitRevision.UnstagedGuid || secondRevision == GitRevision.UnstagedGuid)
+            if (firstRevision == GitRevision.WorkTreeGuid || secondRevision == GitRevision.WorkTreeGuid)
             {
                 // For unstaged the untracked must be added too
                 var files = GetUnstagedFilesWithSubmodulesStatus().Where(item => item.IsNew);
-                if (firstRevision == GitRevision.UnstagedGuid)
+                if (firstRevision == GitRevision.WorkTreeGuid)
                 {
                     // The file is seen as "deleted" in 'to' revision
                     foreach (var item in files)
@@ -3425,7 +3425,7 @@ namespace GitCommands
         [CanBeNull]
         public ObjectId GetFileBlobHash(string fileName, ObjectId objectId)
         {
-            if (objectId == ObjectId.UnstagedId)
+            if (objectId == ObjectId.WorkTreeId)
             {
                 // working directory changes
                 Debug.Assert(false, "Tried to get blob for unstaged file");
@@ -3494,7 +3494,7 @@ namespace GitCommands
                 });
         }
 
-        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.UnstagedGuid, string extraDiffArguments = null, bool isTracked = true)
+        public string OpenWithDifftool(string filename, string oldFileName = "", string firstRevision = GitRevision.IndexGuid, string secondRevision = GitRevision.WorkTreeGuid, string extraDiffArguments = null, bool isTracked = true)
         {
             var args = new ArgumentBuilder
             {

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -13,7 +13,7 @@ namespace GitCommands
     public sealed class GitRevision : IGitItem, INotifyPropertyChanged
     {
         /// <summary>40 characters of 1's</summary>
-        public const string UnstagedGuid = "1111111111111111111111111111111111111111";
+        public const string WorkTreeGuid = "1111111111111111111111111111111111111111";
 
         /// <summary>40 characters of 2's</summary>
         public const string IndexGuid = "2222222222222222222222222222222222222222";

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -85,7 +85,7 @@ namespace GitCommands.Git
                 extra.Add("-R");
             }
 
-            // Special case: Remove options comparing unstaged-staged
+            // Special case: Remove options comparing worktree-index
             if ((firstRevision.IsNullOrEmpty() && secondRevision == StagedOpt) ||
                 (firstRevision == StagedOpt && secondRevision.IsNullOrEmpty()))
             {
@@ -107,7 +107,7 @@ namespace GitCommands.Git
             else
             {
                 // Untracked files can only be compared to /dev/null
-                // The UI should normally only allow this for unstaged to staged, but it can be included in multi selections
+                // The UI should normally only allow this for worktree to index, but it can be included in multi selections
                 if (!isTracked)
                 {
                     extra.Add("--no-index");

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -138,20 +138,20 @@ namespace GitCommands.Git
         {
             switch (rev)
             {
-                case GitRevision.UnstagedGuid:
+                case GitRevision.WorkTreeGuid:
                 case "":
                 case null:
                     return "";
                 case "^":
-                case GitRevision.UnstagedGuid + "^":
+                case GitRevision.WorkTreeGuid + "^":
                 case GitRevision.IndexGuid:
                     return StagedOpt;
                 case "^^":
-                case GitRevision.UnstagedGuid + "^^":
+                case GitRevision.WorkTreeGuid + "^^":
                 case GitRevision.IndexGuid + "^":
                     return "\"HEAD\"";
                 case "^^^":
-                case GitRevision.UnstagedGuid + "^^^":
+                case GitRevision.WorkTreeGuid + "^^^":
                 case GitRevision.IndexGuid + "^^":
                     return "HEAD^";
                 default:

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -343,7 +343,7 @@ namespace GitCommands
             set => SetBool("showcommitandpush", value);
         }
 
-        public static bool ShowResetUnstagedChanges
+        public static bool ShowResetWorkTreeChanges
         {
             get => GetBool("showresetunstagedchanges", true);
             set => SetBool("showresetunstagedchanges", value);

--- a/GitUI/CommandsDialogs/FileStatusListContextMenuController.cs
+++ b/GitUI/CommandsDialogs/FileStatusListContextMenuController.cs
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs
                 && (!selectionInfo.FirstIsParent || !selectionInfo.AllAreNew)
 
                 // First (A) is not local
-                && (selectionInfo.SelectedItemParentRevs == null || !selectionInfo.SelectedItemParentRevs.Contains(ObjectId.UnstagedId));
+                && (selectionInfo.SelectedItemParentRevs == null || !selectionInfo.SelectedItemParentRevs.Contains(ObjectId.WorkTreeId));
         }
 
         public bool ShouldShowMenuSelectedToLocal(ContextMenuDiffToolInfo selectionInfo)
@@ -74,7 +74,7 @@ namespace GitUI.CommandsDialogs
                 && !selectionInfo.AllAreDeleted
 
                 // Selected (B) is not local
-                && selectionInfo.SelectedRevision.Guid != GitRevision.UnstagedGuid;
+                && selectionInfo.SelectedRevision.Guid != GitRevision.WorkTreeGuid;
         }
 
         public bool ShouldShowMenuFirstParentToLocal(ContextMenuDiffToolInfo selectionInfo)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -261,7 +261,7 @@ namespace GitUI.CommandsDialogs
 
             SetVisibilityOfSelectionFilter(AppSettings.CommitDialogSelectionFilter);
             Reset.Visible = AppSettings.ShowResetAllChanges;
-            ResetUnStaged.Visible = AppSettings.ShowResetUnstagedChanges;
+            ResetUnStaged.Visible = AppSettings.ShowResetWorkTreeChanges;
             CommitAndPush.Visible = AppSettings.ShowCommitAndPush;
             splitRight.Panel2MinSize = Math.Max(splitRight.Panel2MinSize, flowCommitButtons.PreferredSize.Height);
             splitRight.SplitterDistance = Math.Min(splitRight.SplitterDistance, splitRight.Height - splitRight.Panel2MinSize);
@@ -875,7 +875,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                patch = PatchManager.GetResetUnstagedLinesAsPatch(Module, SelectedDiff.GetText(),
+                patch = PatchManager.GetResetWorkTreeLinesAsPatch(Module, SelectedDiff.GetText(),
                     SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(), SelectedDiff.Encoding);
             }
 
@@ -967,7 +967,7 @@ namespace GitUI.CommandsDialogs
                 Staged.SetDiffs(
                     new GitRevision(ObjectId.IndexId),
                     new GitRevision(headId),
-                    Module.GetStagedFilesWithSubmodulesStatus());
+                    Module.GetIndexFilesWithSubmodulesStatus());
             }
         }
 
@@ -2492,7 +2492,7 @@ namespace GitUI.CommandsDialogs
 
         private void HandleResetButton(bool onlyUnstaged)
         {
-            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyUnstaged: onlyUnstaged));
+            BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.ToList(), onlyWorkTree: onlyUnstaged));
             Initialize();
         }
 
@@ -2887,7 +2887,7 @@ namespace GitUI.CommandsDialogs
                 // Also delete new files, if requested.
                 if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    var submoduleUnstagedFiles = module.GetUnstagedFiles();
+                    var submoduleUnstagedFiles = module.GetWorkTreeFiles();
                     foreach (var file in submoduleUnstagedFiles.Where(file => file.IsNew))
                     {
                         try

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -998,7 +998,7 @@ namespace GitUI.CommandsDialogs
             }
 
             var headId = Module.RevParse("HEAD");
-            Unstaged.SetDiffs(new GitRevision(ObjectId.UnstagedId), new GitRevision(ObjectId.IndexId), unstagedFiles);
+            Unstaged.SetDiffs(new GitRevision(ObjectId.WorkTreeId), new GitRevision(ObjectId.IndexId), unstagedFiles);
             Staged.SetDiffs(new GitRevision(ObjectId.IndexId), new GitRevision(headId), stagedFiles);
 
             var doChangesExist = Unstaged.AllItems.Any() || Staged.AllItems.Any();
@@ -1671,7 +1671,7 @@ namespace GitUI.CommandsDialogs
                     }
 
                     var headId = Module.RevParse("HEAD");
-                    Unstaged.SetDiffs(new GitRevision(ObjectId.UnstagedId), new GitRevision(ObjectId.IndexId), unstagedFiles);
+                    Unstaged.SetDiffs(new GitRevision(ObjectId.WorkTreeId), new GitRevision(ObjectId.IndexId), unstagedFiles);
                     Staged.SetDiffs(new GitRevision(ObjectId.IndexId), new GitRevision(headId), stagedFiles);
                     _skipUpdate = false;
                     Staged.SelectStoredNextIndex();
@@ -1871,7 +1871,7 @@ namespace GitUI.CommandsDialogs
                             item.GetSubmoduleStatusAsync().CompletedResult().Status = SubmoduleStatus.Unknown;
                         }
 
-                        Unstaged.SetDiffs(new GitRevision(ObjectId.UnstagedId), new GitRevision(ObjectId.IndexId), unstagedFiles);
+                        Unstaged.SetDiffs(new GitRevision(ObjectId.WorkTreeId), new GitRevision(ObjectId.IndexId), unstagedFiles);
                         Unstaged.ClearSelected();
                         _skipUpdate = false;
                         Unstaged.SelectStoredNextIndex();
@@ -2462,7 +2462,7 @@ namespace GitUI.CommandsDialogs
 
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Unstaged.SelectedItems, GitRevision.IndexGuid, GitRevision.UnstagedGuid);
+            OpenFilesWithDiffTool(Unstaged.SelectedItems, GitRevision.IndexGuid, GitRevision.WorkTreeGuid);
         }
 
         private void ResetPartOfFileToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -485,7 +485,7 @@ namespace GitUI.CommandsDialogs
             var selectedRevisions = FileChanges.GetSelectedRevisions();
 
             diffToolRemoteLocalStripMenuItem.Enabled =
-                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.UnstagedGuid &&
+                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.WorkTreeGuid &&
                 File.Exists(_fullPathResolver.Resolve(FileName));
             openWithDifftoolToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -200,7 +200,7 @@ namespace GitUI.CommandsDialogs
         {
             var parents = DiffFiles.SelectedItemParents
                 .Where(i => showUnstagedAndCombined ||
-                    !(i.Guid.IsNullOrWhiteSpace() || i.Guid == GitRevision.UnstagedGuid || i.Guid == GitRevision.CombinedDiffGuid))
+                    !(i.Guid.IsNullOrWhiteSpace() || i.Guid == GitRevision.WorkTreeGuid || i.Guid == GitRevision.CombinedDiffGuid))
                 .Distinct()
                 .Count();
 
@@ -662,7 +662,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (DiffFiles.Revision.Guid == GitRevision.UnstagedGuid)
+            if (DiffFiles.Revision.Guid == GitRevision.WorkTreeGuid)
             {
                 resetFileToSelectedToolStripMenuItem.Visible = false;
             }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -196,10 +196,10 @@ namespace GitUI.CommandsDialogs
         /// Provide a description for the first selected or parent to the "primary" selected last
         /// </summary>
         /// <returns>A description of the selected parent</returns>
-        private string DescribeSelectedParentRevision(bool showUnstagedAndCombined)
+        private string DescribeSelectedParentRevision(bool showWorkTreeAndCombined)
         {
             var parents = DiffFiles.SelectedItemParents
-                .Where(i => showUnstagedAndCombined ||
+                .Where(i => showWorkTreeAndCombined ||
                     !(i.Guid.IsNullOrWhiteSpace() || i.Guid == GitRevision.WorkTreeGuid || i.Guid == GitRevision.CombinedDiffGuid))
                 .Distinct()
                 .Count();
@@ -263,8 +263,8 @@ namespace GitUI.CommandsDialogs
             // No changes to files in bare repos
             bool isBareRepository = Module.IsBareRepository();
             bool isAnyTracked = DiffFiles.SelectedItems.Any(item => item.IsTracked);
-            bool isAnyStaged = DiffFiles.SelectedItems.Any(item => item.Staged == StagedStatus.Index);
-            bool isAnyUnstaged = DiffFiles.SelectedItems.Any(item => item.Staged == StagedStatus.WorkTree);
+            bool isAnyIndex = DiffFiles.SelectedItems.Any(item => item.Staged == StagedStatus.Index);
+            bool isAnyWorkTree = DiffFiles.SelectedItems.Any(item => item.Staged == StagedStatus.WorkTree);
             bool isAnySubmodule = DiffFiles.SelectedItems.Any(item => item.IsSubmodule);
             bool singleFileExists = isExactlyOneItemSelected && File.Exists(_fullPathResolver.Resolve(DiffFiles.SelectedItem.Name));
 
@@ -273,8 +273,8 @@ namespace GitUI.CommandsDialogs
                 isAnyCombinedDiff: isAnyCombinedDiff,
                 isSingleGitItemSelected: isExactlyOneItemSelected,
                 isAnyItemSelected: isAnyItemSelected,
-                isAnyItemStaged: isAnyStaged,
-                isAnyItemUnstaged: isAnyUnstaged,
+                isAnyItemIndex: isAnyIndex,
+                isAnyItemWorkTree: isAnyWorkTree,
                 isBareRepository: isBareRepository,
                 singleFileExists: singleFileExists,
                 isAnyTracked: isAnyTracked,
@@ -818,8 +818,8 @@ namespace GitUI.CommandsDialogs
                 // Also delete new files, if requested.
                 if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    var unstagedFiles = module.GetUnstagedFiles();
-                    foreach (var file in unstagedFiles.Where(file => file.IsNew))
+                    var workTreeFiles = module.GetWorkTreeFiles();
+                    foreach (var file in workTreeFiles.Where(file => file.IsNew))
                     {
                         try
                         {

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -28,8 +28,8 @@ namespace GitUI.CommandsDialogs
             bool isAnyCombinedDiff = false,
             bool isSingleGitItemSelected = true,
             bool isAnyItemSelected = true,
-            bool isAnyItemStaged = false,
-            bool isAnyItemUnstaged = false,
+            bool isAnyItemIndex = false,
+            bool isAnyItemWorkTree = false,
             bool isBareRepository = false,
             bool singleFileExists = true,
             bool isAnyTracked = true,
@@ -40,8 +40,8 @@ namespace GitUI.CommandsDialogs
             IsAnyCombinedDiff = isAnyCombinedDiff;
             IsSingleGitItemSelected = isSingleGitItemSelected;
             IsAnyItemSelected = isAnyItemSelected;
-            IsAnyItemStaged = isAnyItemStaged;
-            IsAnyItemUnstaged = isAnyItemUnstaged;
+            IsAnyItemIndex = isAnyItemIndex;
+            IsAnyItemWorkTree = isAnyItemWorkTree;
             IsBareRepository = isBareRepository;
             SingleFileExists = singleFileExists;
             IsAnyTracked = isAnyTracked;
@@ -53,8 +53,8 @@ namespace GitUI.CommandsDialogs
         public bool IsAnyCombinedDiff { get; }
         public bool IsSingleGitItemSelected { get; }
         public bool IsAnyItemSelected { get; }
-        public bool IsAnyItemStaged { get; }
-        public bool IsAnyItemUnstaged { get; }
+        public bool IsAnyItemIndex { get; }
+        public bool IsAnyItemWorkTree { get; }
         public bool IsBareRepository { get; }
         public bool SingleFileExists { get; }
         public bool IsAnyTracked { get; }
@@ -99,12 +99,12 @@ namespace GitUI.CommandsDialogs
         // Stage/unstage must limit the selected items, IsStaged is not reflecting Staged status
         public bool ShouldShowMenuStage(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsAnyItemUnstaged;
+            return selectionInfo.IsAnyItemWorkTree;
         }
 
         public bool ShouldShowMenuUnstage(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsAnyItemStaged;
+            return selectionInfo.IsAnyItemIndex;
         }
 
         public bool ShouldShowSubmoduleMenus(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowSubmoduleMenus(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsAnySubmodule && selectionInfo.SelectedRevision.Guid == GitRevision.UnstagedGuid;
+            return selectionInfo.IsAnySubmodule && selectionInfo.SelectedRevision.Guid == GitRevision.WorkTreeGuid;
         }
 
         public bool ShouldShowMenuEditFile(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.grpAdditionalButtons = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.chkShowCommitAndPush = new System.Windows.Forms.CheckBox();
-            this.chkShowResetUnstagedChanges = new System.Windows.Forms.CheckBox();
+            this.chkShowResetWorkTreeChanges = new System.Windows.Forms.CheckBox();
             this.chkShowResetAllChanges = new System.Windows.Forms.CheckBox();
             this.chkAddNewlineToCommitMessageWhenMissing = new System.Windows.Forms.CheckBox();
             this.groupBoxBehaviour.SuspendLayout();
@@ -182,7 +182,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.flowLayoutPanel1.Controls.Add(this.chkShowCommitAndPush);
-            this.flowLayoutPanel1.Controls.Add(this.chkShowResetUnstagedChanges);
+            this.flowLayoutPanel1.Controls.Add(this.chkShowResetWorkTreeChanges);
             this.flowLayoutPanel1.Controls.Add(this.chkShowResetAllChanges);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
@@ -203,13 +203,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             // 
             // chkShowResetUnstagedChanges
             // 
-            this.chkShowResetUnstagedChanges.AutoSize = true;
-            this.chkShowResetUnstagedChanges.Location = new System.Drawing.Point(3, 26);
-            this.chkShowResetUnstagedChanges.Name = "chkShowResetUnstagedChanges";
-            this.chkShowResetUnstagedChanges.Size = new System.Drawing.Size(148, 17);
-            this.chkShowResetUnstagedChanges.TabIndex = 1;
-            this.chkShowResetUnstagedChanges.Text = "Reset Unstaged Changes";
-            this.chkShowResetUnstagedChanges.UseVisualStyleBackColor = true;
+            this.chkShowResetWorkTreeChanges.AutoSize = true;
+            this.chkShowResetWorkTreeChanges.Location = new System.Drawing.Point(3, 26);
+            this.chkShowResetWorkTreeChanges.Name = "chkShowResetUnstagedChanges";
+            this.chkShowResetWorkTreeChanges.Size = new System.Drawing.Size(148, 17);
+            this.chkShowResetWorkTreeChanges.TabIndex = 1;
+            this.chkShowResetWorkTreeChanges.Text = "Reset Unstaged Changes";
+            this.chkShowResetWorkTreeChanges.UseVisualStyleBackColor = true;
             // 
             // chkShowResetAllChanges
             // 
@@ -264,7 +264,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private System.Windows.Forms.GroupBox grpAdditionalButtons;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.CheckBox chkShowCommitAndPush;
-        private System.Windows.Forms.CheckBox chkShowResetUnstagedChanges;
+        private System.Windows.Forms.CheckBox chkShowResetWorkTreeChanges;
         private System.Windows.Forms.CheckBox chkShowResetAllChanges;
         private System.Windows.Forms.CheckBox chkAddNewlineToCommitMessageWhenMissing;
         private System.Windows.Forms.CheckBox chkAutocomplete;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
@@ -18,7 +18,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkWriteCommitMessageInCommitWindow.Checked = AppSettings.UseFormCommitMessage;
             _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = AppSettings.CommitDialogNumberOfPreviousMessages;
             chkShowCommitAndPush.Checked = AppSettings.ShowCommitAndPush;
-            chkShowResetUnstagedChanges.Checked = AppSettings.ShowResetUnstagedChanges;
+            chkShowResetWorkTreeChanges.Checked = AppSettings.ShowResetWorkTreeChanges;
             chkShowResetAllChanges.Checked = AppSettings.ShowResetAllChanges;
             chkAutocomplete.Checked = AppSettings.ProvideAutocompletion;
             cbRememberAmendCommitState.Checked = AppSettings.RememberAmendCommitState;
@@ -31,7 +31,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.UseFormCommitMessage = chkWriteCommitMessageInCommitWindow.Checked;
             AppSettings.CommitDialogNumberOfPreviousMessages = (int)_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value;
             AppSettings.ShowCommitAndPush = chkShowCommitAndPush.Checked;
-            AppSettings.ShowResetUnstagedChanges = chkShowResetUnstagedChanges.Checked;
+            AppSettings.ShowResetWorkTreeChanges = chkShowResetWorkTreeChanges.Checked;
             AppSettings.ShowResetAllChanges = chkShowResetAllChanges.Checked;
             AppSettings.ProvideAutocompletion = chkAutocomplete.Checked;
             AppSettings.RememberAmendCommitState = cbRememberAmendCommitState.Checked;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -624,7 +624,7 @@ namespace GitUI.Editor
         {
             if (objectId == ObjectId.WorkTreeId)
             {
-                // No blob exists for unstaged, present contents from file system
+                // No blob exists for worktree, present contents from file system
                 return ViewFileAsync(fileName);
             }
             else
@@ -1248,7 +1248,7 @@ namespace GitUI.Editor
 
             if (reverse)
             {
-                patch = PatchManager.GetResetUnstagedLinesAsPatch(
+                patch = PatchManager.GetResetWorkTreeLinesAsPatch(
                     Module, GetText(),
                     selectionStart, selectionLength, Encoding);
             }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -622,7 +622,7 @@ namespace GitUI.Editor
 
         public Task ViewGitItemRevisionAsync(string fileName, ObjectId objectId)
         {
-            if (objectId == ObjectId.UnstagedId)
+            if (objectId == ObjectId.WorkTreeId)
             {
                 // No blob exists for unstaged, present contents from file system
                 return ViewFileAsync(fileName);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -614,14 +614,14 @@ namespace GitUI
 
         public bool StartResetChangesDialog(IWin32Window owner = null)
         {
-            var unstagedFiles = Module.GetUnstagedFiles();
-            return StartResetChangesDialog(owner, unstagedFiles, false);
+            var workTreeFiles = Module.GetWorkTreeFiles();
+            return StartResetChangesDialog(owner, workTreeFiles, false);
         }
 
-        public bool StartResetChangesDialog(IWin32Window owner, IReadOnlyCollection<GitItemStatus> unstagedFiles, bool onlyUnstaged)
+        public bool StartResetChangesDialog(IWin32Window owner, IReadOnlyCollection<GitItemStatus> workTreeFiles, bool onlyWorkTree)
         {
             // Show a form asking the user if they want to reset the changes.
-            FormResetChanges.ActionEnum resetAction = FormResetChanges.ShowResetDialog(owner, unstagedFiles.Any(item => !item.IsNew), unstagedFiles.Any(item => item.IsNew));
+            FormResetChanges.ActionEnum resetAction = FormResetChanges.ShowResetDialog(owner, workTreeFiles.Any(item => !item.IsNew), workTreeFiles.Any(item => item.IsNew));
 
             if (resetAction == FormResetChanges.ActionEnum.Cancel)
             {
@@ -630,7 +630,7 @@ namespace GitUI
 
             bool Action()
             {
-                if (onlyUnstaged)
+                if (onlyWorkTree)
                 {
                     Module.RunGitCmd("checkout -- .");
                 }

--- a/GitUI/UserControls/RepoStateVisualiser.cs
+++ b/GitUI/UserControls/RepoStateVisualiser.cs
@@ -29,20 +29,20 @@ namespace GitUI.UserControls
 
         public (Image, Brush) Invoke(IReadOnlyList<GitItemStatus> allChangedFiles)
         {
-            var stagedCount = 0;
-            var unstagedSubmodulesCount = 0;
+            var indexCount = 0;
+            var workTreeSubmodulesCount = 0;
             var notTrackedCount = 0;
 
             foreach (var status in allChangedFiles)
             {
                 if (status.Staged == StagedStatus.Index)
                 {
-                    stagedCount++;
+                    indexCount++;
                 }
 
                 if (status.Staged == StagedStatus.WorkTree && status.IsSubmodule)
                 {
-                    unstagedSubmodulesCount++;
+                    workTreeSubmodulesCount++;
                 }
 
                 if (!status.IsTracked)
@@ -51,26 +51,26 @@ namespace GitUI.UserControls
                 }
             }
 
-            var unstagedCount = allChangedFiles.Count - stagedCount;
+            var workTreeCount = allChangedFiles.Count - indexCount;
 
-            if (stagedCount == 0 && unstagedCount == 0)
+            if (indexCount == 0 && workTreeCount == 0)
             {
                 return (IconClean, BrushClean);
             }
 
-            if (stagedCount == 0)
+            if (indexCount == 0)
             {
-                if (notTrackedCount == unstagedCount)
+                if (notTrackedCount == workTreeCount)
                 {
                     return (IconUntrackedOnly, BrushUntrackedOnly);
                 }
 
-                return unstagedCount != unstagedSubmodulesCount
+                return workTreeCount != workTreeSubmodulesCount
                     ? (IconDirty, BrushDirty)
                     : (IconDirtySubmodules, BrushDirtySubmodules);
             }
 
-            return unstagedCount == 0
+            return workTreeCount == 0
                 ? (IconStaged, BrushStaged)
                 : (IconMixed, BrushMixed);
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -877,7 +877,7 @@ namespace GitUI
                     var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
 
                     // Add working directory as virtual commit
-                    var unstagedRev = new GitRevision(ObjectId.UnstagedId)
+                    var unstagedRev = new GitRevision(ObjectId.WorkTreeId)
                     {
                         Author = userName,
                         AuthorDate = DateTime.MaxValue,
@@ -1787,7 +1787,7 @@ namespace GitUI
         [CanBeNull]
         public ChangeCount GetChangeCount(ObjectId objectId)
         {
-            return objectId == ObjectId.UnstagedId
+            return objectId == ObjectId.WorkTreeId
                 ? _unstagedChangeCount
                 : objectId == ObjectId.IndexId
                     ? _indexChangeCount
@@ -1807,13 +1807,13 @@ namespace GitUI
                 return;
             }
 
-            unstagedRev = unstagedRev ?? GetRevision(ObjectId.UnstagedId);
+            unstagedRev = unstagedRev ?? GetRevision(ObjectId.WorkTreeId);
             stagedRev = stagedRev ?? GetRevision(ObjectId.IndexId);
 
             if (unstagedRev != null)
             {
                 var items = status.Where(item => item.Staged == StagedStatus.WorkTree);
-                UpdateChangeCount(ObjectId.UnstagedId, items.ToList());
+                UpdateChangeCount(ObjectId.WorkTreeId, items.ToList());
             }
 
             if (stagedRev != null)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -871,13 +871,13 @@ namespace GitUI
                 void CheckUncommittedChanged(ObjectId filteredCurrentCheckout)
                 {
                     _indexChangeCount = new ChangeCount();
-                    _unstagedChangeCount = new ChangeCount();
+                    _workTreeChangeCount = new ChangeCount();
 
                     var userName = Module.GetEffectiveSetting(SettingKeyString.UserName);
                     var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
 
                     // Add working directory as virtual commit
-                    var unstagedRev = new GitRevision(ObjectId.WorkTreeId)
+                    var workTreeRev = new GitRevision(ObjectId.WorkTreeId)
                     {
                         Author = userName,
                         AuthorDate = DateTime.MaxValue,
@@ -888,10 +888,10 @@ namespace GitUI
                         Subject = Strings.Workspace,
                         ParentIds = new[] { ObjectId.IndexId }
                     };
-                    _gridView.Add(unstagedRev);
+                    _gridView.Add(workTreeRev);
 
                     // Add index as virtual commit
-                    var stagedRev = new GitRevision(ObjectId.IndexId)
+                    var indexRev = new GitRevision(ObjectId.IndexId)
                     {
                         Author = userName,
                         AuthorDate = DateTime.MaxValue,
@@ -902,9 +902,9 @@ namespace GitUI
                         Subject = Strings.Index,
                         ParentIds = new[] { filteredCurrentCheckout }
                     };
-                    _gridView.Add(stagedRev);
+                    _gridView.Add(indexRev);
 
-                    UpdateArtificialCommitCount(_artificialStatus, unstagedRev, stagedRev);
+                    UpdateArtificialCommitCount(_artificialStatus, workTreeRev, indexRev);
                 }
             }
 
@@ -1788,35 +1788,35 @@ namespace GitUI
         public ChangeCount GetChangeCount(ObjectId objectId)
         {
             return objectId == ObjectId.WorkTreeId
-                ? _unstagedChangeCount
+                ? _workTreeChangeCount
                 : objectId == ObjectId.IndexId
                     ? _indexChangeCount
                     : null;
         }
 
-        private ChangeCount _unstagedChangeCount = new ChangeCount();
+        private ChangeCount _workTreeChangeCount = new ChangeCount();
         private ChangeCount _indexChangeCount = new ChangeCount();
 
         public void UpdateArtificialCommitCount(
             [CanBeNull] IReadOnlyList<GitItemStatus> status,
-            [CanBeNull] GitRevision unstagedRev = null,
-            [CanBeNull] GitRevision stagedRev = null)
+            [CanBeNull] GitRevision workTreeRev = null,
+            [CanBeNull] GitRevision indexRev = null)
         {
             if (status == null)
             {
                 return;
             }
 
-            unstagedRev = unstagedRev ?? GetRevision(ObjectId.WorkTreeId);
-            stagedRev = stagedRev ?? GetRevision(ObjectId.IndexId);
+            workTreeRev = workTreeRev ?? GetRevision(ObjectId.WorkTreeId);
+            indexRev = indexRev ?? GetRevision(ObjectId.IndexId);
 
-            if (unstagedRev != null)
+            if (workTreeRev != null)
             {
                 var items = status.Where(item => item.Staged == StagedStatus.WorkTree);
                 UpdateChangeCount(ObjectId.WorkTreeId, items.ToList());
             }
 
-            if (stagedRev != null)
+            if (indexRev != null)
             {
                 var items = status.Where(item => item.Staged == StagedStatus.Index);
                 UpdateChangeCount(ObjectId.IndexId, items.ToList());

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -18,10 +18,10 @@ namespace GitUIPluginInterfaces
         private static readonly Random _random = new Random();
 
         /// <summary>
-        /// Gets the artificial ObjectId used to represent unstaged changes.
+        /// Gets the artificial ObjectId used to represent working directory tree (unstaged) changes.
         /// </summary>
         [NotNull]
-        public static ObjectId UnstagedId { get; } = new ObjectId(0x11111111, 0x11111111, 0x11111111, 0x11111111, 0x11111111);
+        public static ObjectId WorkTreeId { get; } = new ObjectId(0x11111111, 0x11111111, 0x11111111, 0x11111111, 0x11111111);
 
         /// <summary>
         /// Gets the artificial ObjectId used to represent changes staged to the index.
@@ -50,7 +50,7 @@ namespace GitUIPluginInterfaces
                 unchecked((uint)_random.Next()));
         }
 
-        public bool IsArtificial => this == UnstagedId || this == IndexId || this == CombinedDiffId;
+        public bool IsArtificial => this == WorkTreeId || this == IndexId || this == CombinedDiffId;
 
         private const int Sha1ByteCount = 20;
         public const int Sha1CharCount = 40;

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -63,7 +63,7 @@ namespace ResourceManager
         {
             if (linkText == null)
             {
-                if (objectId == ObjectId.UnstagedId)
+                if (objectId == ObjectId.WorkTreeId)
                 {
                     linkText = Strings.Workspace;
                 }

--- a/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
@@ -232,7 +232,7 @@ namespace GitCommandsTests
         {
             Assert.Throws<ArgumentException>(() => new ArgumentBuilder
             {
-                ObjectId.UnstagedId
+                ObjectId.WorkTreeId
             });
             Assert.Throws<ArgumentException>(() => new ArgumentBuilder
             {

--- a/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Extensions/GitRevisionExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace GitCommandsTests.Git.Extensions
         [TestCase("", false)]
         [TestCase(" ", false)]
         [TestCase("0000", false)]
-        [TestCase(GitRevision.UnstagedGuid, true)]
+        [TestCase(GitRevision.WorkTreeGuid, true)]
         [TestCase(GitRevision.IndexGuid, true)]
         [TestCase(GitRevision.CombinedDiffGuid, true)]
         public void IsArtificial_tests(string sha1, bool expected)

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -155,7 +155,7 @@ namespace GitCommandsTests.Git
                 // git diff -M -C -z --cached --name-status
                 // Ignore unmerged (in conflict) if revision is work tree
                 string statusString = "M  testfile.txt\0U  testfile.txt\0";
-                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid, GitRevision.UnstagedGuid, GitRevision.IndexGuid);
+                var status = GitCommandHelpers.GetDiffChangedFilesFromString(module, statusString, GitRevision.IndexGuid, GitRevision.WorkTreeGuid, GitRevision.IndexGuid);
                 Assert.IsTrue(status.Count == 1);
                 Assert.IsTrue(status[0].Name == "testfile.txt");
                 Assert.IsTrue(status[0].Staged == StagedStatus.WorkTree);

--- a/UnitTests/GitCommandsTests/Git/GitRevisionTesterTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitRevisionTesterTests.cs
@@ -39,7 +39,7 @@ namespace GitCommandsTests.Git
         {
             var firstSelected = new[] { new GitRevision(ObjectId.IndexId), new GitRevision(ObjectId.Random()) };
 
-            var selectedRevision = new GitRevision(ObjectId.UnstagedId)
+            var selectedRevision = new GitRevision(ObjectId.WorkTreeId)
             {
                 ParentIds = new[] { ObjectId.IndexId }
             };

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -101,7 +101,7 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void UnstagedId_has_expected_value()
+        public void WorkTreeId_has_expected_value()
         {
             Assert.AreEqual(
                 "1111111111111111111111111111111111111111",
@@ -125,7 +125,7 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void UnstagedId_is_artificial()
+        public void WorkTreeId_is_artificial()
         {
             Assert.IsTrue(ObjectId.WorkTreeId.IsArtificial);
         }

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -105,7 +105,7 @@ namespace GitCommandsTests.Git
         {
             Assert.AreEqual(
                 "1111111111111111111111111111111111111111",
-                ObjectId.UnstagedId.ToString());
+                ObjectId.WorkTreeId.ToString());
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void UnstagedId_is_artificial()
         {
-            Assert.IsTrue(ObjectId.UnstagedId.IsArtificial);
+            Assert.IsTrue(ObjectId.WorkTreeId.IsArtificial);
         }
 
         [Test]
@@ -154,12 +154,12 @@ namespace GitCommandsTests.Git
                 ObjectId.Parse("abcdefabcdefabcdefabcdefabcdefabcdefabcd"));
 
             Assert.AreEqual(
-                ObjectId.UnstagedId,
-                ObjectId.UnstagedId);
+                ObjectId.WorkTreeId,
+                ObjectId.WorkTreeId);
 
             Assert.AreEqual(
-                ObjectId.UnstagedId,
-                ObjectId.Parse(GitRevision.UnstagedGuid));
+                ObjectId.WorkTreeId,
+                ObjectId.Parse(GitRevision.WorkTreeGuid));
 
             Assert.AreEqual(
                 ObjectId.IndexId,
@@ -186,7 +186,7 @@ namespace GitCommandsTests.Git
                 ObjectId.Parse("0102030405060708091011121314151617181920"));
 
             Assert.AreNotEqual(
-                ObjectId.UnstagedId,
+                ObjectId.WorkTreeId,
                 ObjectId.IndexId);
         }
 
@@ -202,8 +202,8 @@ namespace GitCommandsTests.Git
                 ObjectId.Parse("abcdefabcdefabcdefabcdefabcdefabcdefabcd").GetHashCode());
 
             Assert.AreEqual(
-                ObjectId.UnstagedId.GetHashCode(),
-                ObjectId.UnstagedId.GetHashCode());
+                ObjectId.WorkTreeId.GetHashCode(),
+                ObjectId.WorkTreeId.GetHashCode());
 
             Assert.AreEqual(
                 ObjectId.IndexId.GetHashCode(),
@@ -218,7 +218,7 @@ namespace GitCommandsTests.Git
                 ObjectId.Parse("0102030405060708091011121314151617181920").GetHashCode());
 
             Assert.AreNotEqual(
-                ObjectId.UnstagedId.GetHashCode(),
+                ObjectId.WorkTreeId.GetHashCode(),
                 ObjectId.IndexId.GetHashCode());
         }
 

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -22,18 +22,18 @@ namespace GitCommandsTests.Git
 
 #if !DEBUG
         // Test cases that should assert in debug; should not occur but undefined behavior that should be blocked in GUI
-        // Cannot compare unstaged to unstaged or staged to staged but give predictive output in release builds
+        // Cannot compare worktree to worktree or index to index but give predictive output in release builds
 
         // Two empty parameters will compare working dir to index
         [TestCase(null)]
         [TestCase("")]
-        [TestCase(GitRevision.UnstagedGuid)]
-        public void RevisionDiffProvider_should_return_empty_if_To_is_UnstagedGuid(string firstRevision)
+        [TestCase(GitRevision.WorkTreeGuid)]
+        public void RevisionDiffProvider_should_return_empty_if_To_is_WorkTreeGuid(string firstRevision)
         {
-            _revisionDiffProvider.Get(firstRevision, GitRevision.UnstagedGuid).Should().BeEmpty();
+            _revisionDiffProvider.Get(firstRevision, GitRevision.WorkTreeGuid).Should().BeEmpty();
         }
 
-        // Two staged revisions gives duplicated options, no reason to clean
+        // Two index revisions gives duplicated options, no reason to clean
         [TestCase("^")]
         [TestCase(GitRevision.IndexGuid)]
         public void RevisionDiffProvider_should_return_cached_if_both_IndexGuid(string firstRevision)
@@ -53,14 +53,14 @@ namespace GitCommandsTests.Git
         [TestCase(GitRevision.IndexGuid, GitRevision.WorkTreeGuid)]
         [TestCase("^", "")]
         [TestCase(GitRevision.IndexGuid, null)]
-        public void RevisionDiffProvider_staged_to_unstaged(string firstRevision, string secondRevision)
+        public void RevisionDiffProvider_index_to_worktree(string firstRevision, string secondRevision)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision).Should().BeEmpty();
         }
 
         [TestCase(GitRevision.WorkTreeGuid, GitRevision.IndexGuid)]
         [TestCase("", "^")]
-        public void RevisionDiffProvider_unstaged_to_staged(string firstRevision, string secondRevision)
+        public void RevisionDiffProvider_worktree_to_index(string firstRevision, string secondRevision)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("-R");
         }
@@ -68,20 +68,20 @@ namespace GitCommandsTests.Git
         [TestCase(GitRevision.WorkTreeGuid + "^^")]
         [TestCase(GitRevision.IndexGuid + "^")]
         [TestCase("HEAD")]
-        public void RevisionDiffProvider_head_to_unstaged(string firstRevision)
+        public void RevisionDiffProvider_head_to_worktree(string firstRevision)
         {
             _revisionDiffProvider.Get(firstRevision, GitRevision.WorkTreeGuid).Should().Be("\"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid + "^", "^")]
         [TestCase("HEAD", GitRevision.IndexGuid)]
-        public void RevisionDiffProvider_head_to_staged(string firstRevision, string secondRevision)
+        public void RevisionDiffProvider_head_to_index(string firstRevision, string secondRevision)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("--cached \"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid, "HEAD")]
-        public void RevisionDiffProvider_staged_to_head(string firstRevision, string secondRevision)
+        public void RevisionDiffProvider_index_to_head(string firstRevision, string secondRevision)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("-R --cached \"HEAD\"");
         }

--- a/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommandsTests/Git/RevisionDiffProviderTest.cs
@@ -50,7 +50,7 @@ namespace GitCommandsTests.Git
             Assert.Throws<ArgumentOutOfRangeException>(() => _revisionDiffProvider.Get(firstRevision, secondRevision));
         }
 
-        [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid)]
+        [TestCase(GitRevision.IndexGuid, GitRevision.WorkTreeGuid)]
         [TestCase("^", "")]
         [TestCase(GitRevision.IndexGuid, null)]
         public void RevisionDiffProvider_staged_to_unstaged(string firstRevision, string secondRevision)
@@ -58,19 +58,19 @@ namespace GitCommandsTests.Git
             _revisionDiffProvider.Get(firstRevision, secondRevision).Should().BeEmpty();
         }
 
-        [TestCase(GitRevision.UnstagedGuid, GitRevision.IndexGuid)]
+        [TestCase(GitRevision.WorkTreeGuid, GitRevision.IndexGuid)]
         [TestCase("", "^")]
         public void RevisionDiffProvider_unstaged_to_staged(string firstRevision, string secondRevision)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision).Should().Be("-R");
         }
 
-        [TestCase(GitRevision.UnstagedGuid + "^^")]
+        [TestCase(GitRevision.WorkTreeGuid + "^^")]
         [TestCase(GitRevision.IndexGuid + "^")]
         [TestCase("HEAD")]
         public void RevisionDiffProvider_head_to_unstaged(string firstRevision)
         {
-            _revisionDiffProvider.Get(firstRevision, GitRevision.UnstagedGuid).Should().Be("\"HEAD\"");
+            _revisionDiffProvider.Get(firstRevision, GitRevision.WorkTreeGuid).Should().Be("\"HEAD\"");
         }
 
         [TestCase(GitRevision.IndexGuid + "^", "^")]
@@ -99,7 +99,7 @@ namespace GitCommandsTests.Git
         }
 
         // Standard usage when filename is included
-        [TestCase("123456789", GitRevision.UnstagedGuid, "a.txt", null, true)]
+        [TestCase("123456789", GitRevision.WorkTreeGuid, "a.txt", null, true)]
         public void RevisionDiffProvider_fileName_tracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("\"123456789\" -- \"a.txt\"");
@@ -120,14 +120,14 @@ namespace GitCommandsTests.Git
         }
 
         // normal test case when untracked is set
-        [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, "a.txt", null, false)]
+        [TestCase(GitRevision.IndexGuid, GitRevision.WorkTreeGuid, "a.txt", null, false)]
         public void RevisionDiffProvider_fileName_untracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().Be("--no-index -- \"/dev/null\" \"a.txt\"");
         }
 
         // If fileName is null, ignore oldFileName and tracked
-        [TestCase(GitRevision.IndexGuid, GitRevision.UnstagedGuid, null, "b.txt", false)]
+        [TestCase(GitRevision.IndexGuid, GitRevision.WorkTreeGuid, null, "b.txt", false)]
         public void RevisionDiffProvider_fileName_null_Untracked(string firstRevision, string secondRevision, string fileName, string oldFileName, bool isTracked)
         {
             _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked).Should().BeEmpty();

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionDiffContextMenuControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionDiffContextMenuControllerTests.cs
@@ -43,7 +43,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_ShowContextDiffToolForUnstaged()
         {
-            var rev = new GitRevision(ObjectId.UnstagedId);
+            var rev = new GitRevision(ObjectId.WorkTreeId);
             var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev);
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeTrue();
@@ -56,7 +56,7 @@ namespace GitUITests.CommandsDialogs
         public void BrowseDiff_ShowContextDiffToolForUnstagedParent()
         {
             var rev = new GitRevision(ObjectId.Random());
-            var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev, selectedItemParentRevs: new[] { ObjectId.UnstagedId });
+            var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev, selectedItemParentRevs: new[] { ObjectId.WorkTreeId });
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeFalse();
             _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo).Should().BeTrue();

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionDiffContextMenuControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionDiffContextMenuControllerTests.cs
@@ -41,7 +41,7 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void BrowseDiff_ShowContextDiffToolForUnstaged()
+        public void BrowseDiff_ShowContextDiffToolForWorkTree()
         {
             var rev = new GitRevision(ObjectId.WorkTreeId);
             var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev);
@@ -53,7 +53,7 @@ namespace GitUITests.CommandsDialogs
         }
 
         [Test]
-        public void BrowseDiff_ShowContextDiffToolForUnstagedParent()
+        public void BrowseDiff_ShowContextDiffToolForWorkTreeParent()
         {
             var rev = new GitRevision(ObjectId.Random());
             var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev, selectedItemParentRevs: new[] { ObjectId.WorkTreeId });

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -139,7 +139,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_StageMenus_Unstaged(bool t)
         {
-            var rev = new GitRevision(ObjectId.UnstagedId);
+            var rev = new GitRevision(ObjectId.WorkTreeId);
             var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemStaged: t);
             _controller.ShouldShowMenuUnstage(selectionInfo).Should().Be(t);
         }
@@ -148,7 +148,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_StageMenus_Index(bool t)
         {
-            var rev = new GitRevision(ObjectId.UnstagedId);
+            var rev = new GitRevision(ObjectId.WorkTreeId);
             var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemUnstaged: t);
             _controller.ShouldShowMenuStage(selectionInfo).Should().Be(t);
         }

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -137,10 +137,10 @@ namespace GitUITests.CommandsDialogs
 
         [TestCase(true)]
         [TestCase(false)]
-        public void BrowseDiff_StageMenus_Unstaged(bool t)
+        public void BrowseDiff_StageMenus_WorkTree(bool t)
         {
             var rev = new GitRevision(ObjectId.WorkTreeId);
-            var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemStaged: t);
+            var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemIndex: t);
             _controller.ShouldShowMenuUnstage(selectionInfo).Should().Be(t);
         }
 
@@ -149,7 +149,7 @@ namespace GitUITests.CommandsDialogs
         public void BrowseDiff_StageMenus_Index(bool t)
         {
             var rev = new GitRevision(ObjectId.WorkTreeId);
-            var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemUnstaged: t);
+            var selectionInfo = new ContextMenuSelectionInfo(rev, isAnyItemWorkTree: t);
             _controller.ShouldShowMenuStage(selectionInfo).Should().Be(t);
         }
 

--- a/UnitTests/GitUITests/UserControls/RepoStateVisualiserTests.cs
+++ b/UnitTests/GitUITests/UserControls/RepoStateVisualiserTests.cs
@@ -38,7 +38,7 @@ namespace GitUITests.UserControls
         }
 
         [Test]
-        public void ReturnsIconDirtySubmodulesWhenThereAreOnlyUnstagedSubmodules()
+        public void ReturnsIconDirtySubmodulesWhenThereAreOnlyWorkTreeSubmodules()
         {
             var commitIcon = _repoStateVisualiser.Invoke(new[]
             {
@@ -50,7 +50,7 @@ namespace GitUITests.UserControls
         }
 
         [Test]
-        public void ReturnsIconDirtyWhenThereAreUnstagedChanges()
+        public void ReturnsIconDirtyWhenThereAreWorkTreeChanges()
         {
             var commitIcon = _repoStateVisualiser.Invoke(new[]
             {
@@ -62,7 +62,7 @@ namespace GitUITests.UserControls
         }
 
         [Test]
-        public void ReturnsIconMixedWhenThereAreStagedAndUnstagedFiles()
+        public void ReturnsIconMixedWhenThereAreIndexAndWorkTreeFiles()
         {
             var commitIcon = _repoStateVisualiser.Invoke(new[]
             {
@@ -74,7 +74,7 @@ namespace GitUITests.UserControls
         }
 
         [Test]
-        public void ReturnsIconStagedWhenThereAreOnlyStagedFiles()
+        public void ReturnsIconStagedWhenThereAreOnlyIndexFiles()
         {
             var commitIcon = _repoStateVisualiser.Invoke(new[]
             {

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -234,7 +234,7 @@ namespace ResourceManagerTests.CommitDataRenders
         }
 
         [TestCase(GitRevision.IndexGuid)]
-        [TestCase(GitRevision.UnstagedGuid)]
+        [TestCase(GitRevision.WorkTreeGuid)]
         public void Render_should_render_minimal_info_for_artificial_commits(string artificialGuid)
         {
             var author = "John Doe (Acme Inc) <John.Doe@test.com>";


### PR DESCRIPTION
Fixes #5230 

Changes proposed in this pull request:
- Internal renaming in the code:
 WorkTree/Index should be used rather than Unstaged/Staged
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- no changes

Has been tested on (remove any that don't apply):
