### PR TITLE
String handling review

### DIFF
--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -25,11 +25,13 @@ namespace GitCommands.Config
         {
             _configKeys = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-            if (name.Contains("\""))
+            var slashIndex = name.IndexOf('\"');
+
+            if (slashIndex != -1)
             {
                 // [section "subsection"] case sensitive
-                SectionName = name.Substring(0, name.IndexOf('\"')).Trim();
-                SubSection = name.Substring(name.IndexOf('\"') + 1, name.LastIndexOf('\"') - name.IndexOf('\"') - 1);
+                SectionName = name.Substring(0, slashIndex).Trim();
+                SubSection = name.Substring(slashIndex + 1, name.LastIndexOf('\"') - slashIndex - 1);
                 SubSectionCaseSensitive = true;
             }
             else if (!name.Contains("."))

--- a/GitCommands/DateTimeExtensions.cs
+++ b/GitCommands/DateTimeExtensions.cs
@@ -1,0 +1,22 @@
+// ReSharper disable once CheckNamespace
+
+namespace System
+{
+    public static class DateTimeExtensions
+    {
+        public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime)
+        {
+            if (dateTime.ToUniversalTime() <= DateTimeOffset.MinValue.UtcDateTime)
+            {
+                return DateTimeOffset.MinValue;
+            }
+
+            if (dateTime.ToUniversalTime() >= DateTimeOffset.MaxValue.UtcDateTime)
+            {
+                return DateTimeOffset.MaxValue;
+            }
+
+            return new DateTimeOffset(dateTime);
+        }
+    }
+}

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1111,7 +1111,7 @@ namespace GitCommands
                     continue;
                 }
 
-                string fileName = line.Substring(line.IndexOf(' ') + 1);
+                string fileName = line.SubstringAfter(' ');
                 GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(StagedStatus.Unknown, fileName, statusCharacter);
                 gitItemStatus.IsAssumeUnchanged = true;
                 result.Add(gitItemStatus);
@@ -1128,7 +1128,7 @@ namespace GitCommands
             {
                 char statusCharacter = line[0];
 
-                string fileName = line.Substring(line.IndexOf(' ') + 1);
+                string fileName = line.SubstringAfter(' ');
                 GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(StagedStatus.Unknown, fileName, statusCharacter);
                 if (gitItemStatus.IsSkipWorktree)
                 {
@@ -1221,9 +1221,11 @@ namespace GitCommands
         [CanBeNull]
         public static string GetFileExtension(string fileName)
         {
-            if (fileName.Contains(".") && fileName.LastIndexOf(".") < fileName.Length)
+            var index = fileName.LastIndexOf('.');
+
+            if (index != -1)
             {
-                return fileName.Substring(fileName.LastIndexOf('.') + 1);
+                return fileName.Substring(index + 1);
             }
 
             return null;

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1218,19 +1218,6 @@ namespace GitCommands
             return args.ToString();
         }
 
-        [CanBeNull]
-        public static string GetFileExtension(string fileName)
-        {
-            var index = fileName.LastIndexOf('.');
-
-            if (index != -1)
-            {
-                return fileName.Substring(index + 1);
-            }
-
-            return null;
-        }
-
         // returns " --find-renames=..." according to app settings
         public static string FindRenamesOpt()
         {

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -761,7 +761,7 @@ namespace GitCommands
                     // We are looking for lines resembling:
                     //
                     // -Subproject commit bfef4454fc51e345051ee5bf66686dc28deed627
-                    // +Subproject commit 8b20498b954609770205c2cc794b868b4ac3ee69
+                    // +Subproject commit 8b20498b954609770205c2cc794b868b4ac3ee69-dirty
 
                     if (!line.Contains("Subproject"))
                     {

--- a/GitCommands/Git/GitDirectoryResolver.cs
+++ b/GitCommands/Git/GitDirectoryResolver.cs
@@ -78,10 +78,11 @@ namespace GitCommands.Git
             var gitPath = Path.Combine(repositoryPath, ".git");
             if (_fileSystem.File.Exists(gitPath))
             {
-                var line = _fileSystem.File.ReadLines(gitPath).FirstOrDefault(l => l.StartsWith("gitdir:"));
+                const string gitdir = "gitdir:";
+                var line = _fileSystem.File.ReadLines(gitPath).FirstOrDefault(l => l.StartsWith(gitdir));
                 if (line != null)
                 {
-                    string path = line.Substring(7).Trim().ToNativePath();
+                    string path = line.Substring(gitdir.Length).Trim().ToNativePath();
                     if (Path.IsPathRooted(path))
                     {
                         return path.EnsureTrailingPathSeparator();

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1337,28 +1337,28 @@ namespace GitCommands
             }
         }
 
-        public (char code, string currentCommitId) GetSuperprojectCurrentCheckout()
+        public (char code, ObjectId currentCommitId) GetSuperprojectCurrentCheckout()
         {
             if (SuperprojectModule == null)
             {
-                return (' ', "");
+                return (' ', null);
             }
 
             var lines = SuperprojectModule.RunGitCmd("submodule status --cached " + _submodulePath).Split('\n');
 
             if (lines.Length == 0)
             {
-                return (' ', "");
+                return (' ', null);
             }
 
             string submodule = lines[0];
+
             if (submodule.Length < 43)
             {
-                return (' ', "");
+                return (' ', null);
             }
 
-            var currentCommitGuid = submodule.Substring(1, 40).Trim();
-            return (submodule[0], currentCommitGuid);
+            return (submodule[0], ObjectId.Parse(submodule, 1));
         }
 
         public bool ExistsMergeCommit(string startRev, string endRev)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -54,13 +54,13 @@ namespace GitCommands
 
     public readonly struct ConflictedFileData
     {
-        public ConflictedFileData(string hash, string filename)
+        public ConflictedFileData(ObjectId objectId, string filename)
         {
-            Hash = hash;
+            ObjectId = objectId;
             Filename = filename;
         }
 
-        public string Hash { get; }
+        public ObjectId ObjectId { get; }
         public string Filename { get; }
     }
 
@@ -961,7 +961,7 @@ namespace GitCommands
                         item = new ConflictedFileData[3];
                     }
 
-                    item[stage - 1] = new ConflictedFileData(hash, itemName);
+                    item[stage - 1] = new ConflictedFileData(ObjectId.Parse(hash), itemName);
                     prevItemName = itemName;
                 }
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1538,9 +1538,11 @@ namespace GitCommands
                 var lines = File.ReadLines(WorkingDir + ".git");
                 foreach (string line in lines)
                 {
-                    if (line.StartsWith("gitdir:"))
+                    const string gitdir = "gitdir:";
+
+                    if (line.StartsWith(gitdir))
                     {
-                        string gitPath = line.Substring(7).Trim();
+                        string gitPath = line.Substring(gitdir.Length).Trim();
                         int pos = gitPath.IndexOf("/.git/modules/");
                         if (pos != -1)
                         {
@@ -2863,7 +2865,7 @@ namespace GitCommands
                 return "";
             }
 
-            return remote + "/" + (merge.StartsWith("refs/heads/") ? merge.Substring(11) : merge);
+            return $"{remote}/{merge.RemovePrefix(GitRefName.RefsHeadsPrefix)}";
         }
 
         public IEnumerable<IGitRef> GetRemoteBranches()

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -91,27 +91,22 @@ namespace GitCommands
             {
                 if (IsRemote)
                 {
-                    return CompleteName.Substring(CompleteName.LastIndexOf("remotes/") + 8);
+                    return CompleteName.SubstringAfterLast("remotes/");
                 }
 
                 if (IsTag)
                 {
                     // we need the one containing ^{}, because it contains the reference
-                    var temp =
-                        CompleteName.Contains(GitRefName.TagDereferenceSuffix)
-                            ? CompleteName.Substring(0, CompleteName.Length - GitRefName.TagDereferenceSuffix.Length)
-                            : CompleteName;
-
-                    return temp.Substring(CompleteName.LastIndexOf("tags/") + 5);
+                    return CompleteName.RemoveSuffix(GitRefName.TagDereferenceSuffix).SubstringAfterLast("tags/");
                 }
 
                 if (IsHead)
                 {
-                    return CompleteName.Substring(CompleteName.LastIndexOf("heads/") + 6);
+                    return CompleteName.SubstringAfterLast("heads/");
                 }
 
                 // if we don't know ref type then we don't know if '/' is a valid ref character
-                return CompleteName.SkipStr("refs/");
+                return CompleteName.SubstringAfter("refs/");
             }
         }
 
@@ -180,11 +175,7 @@ namespace GitCommands
         /// <inheritdoc />
         public string GetMergeWith(ISettingsValueGetter configFile)
         {
-            var merge = configFile.GetValue(_mergeSettingName);
-
-            return merge.StartsWith(GitRefName.RefsHeadsPrefix)
-                ? merge.Substring(GitRefName.RefsHeadsPrefix.Length)
-                : merge;
+            return configFile.GetValue(_mergeSettingName).RemovePrefix(GitRefName.RefsHeadsPrefix);
         }
 
         public static GitRef NoHead(GitModule module)

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -72,6 +72,7 @@
     <Compile Include="CommitTemplateItem.cs" />
     <Compile Include="CommitTemplateManager.cs" />
     <Compile Include="Config\SettingKeyString.cs" />
+    <Compile Include="DateTimeExtensions.cs" />
     <Compile Include="DateTimeUtils.cs" />
     <Compile Include="DeconstructionExtensions.cs" />
     <Compile Include="EnvironmentAbstraction.cs" />

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -137,7 +137,7 @@ namespace GitCommands.Patches
                 body = body.Replace("\r", "");
             }
 
-            if (header == null || body == null)
+            if (body == null)
             {
                 return null;
             }
@@ -312,9 +312,8 @@ namespace GitCommands.Patches
                 diff = diff.Combine("\n", line.Text);
             }
 
-            for (int i = 0; i < RemovedLines.Count; i++)
+            foreach (var removedLine in RemovedLines)
             {
-                PatchLine removedLine = RemovedLines[i];
                 selectedLastLine = removedLine.Selected;
                 if (removedLine.Selected)
                 {
@@ -397,6 +396,7 @@ namespace GitCommands.Patches
         }
 
         // patch base is changed file
+        [CanBeNull]
         public string ToResetWorkTreeLinesPatch(ref int addedCount, ref int removedCount, ref bool wereSelectedLines)
         {
             string diff = null;

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -69,7 +70,7 @@ namespace GitCommands.Patches
         [NotNull]
         private static string CorrectHeaderForNewFile([NotNull] string header)
         {
-            string[] headerLines = header.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            string[] headerLines = header.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
             string pppLine = null;
             foreach (string line in headerLines)
             {
@@ -85,11 +86,11 @@ namespace GitCommands.Patches
             {
                 if (line.StartsWith("---"))
                 {
-                    sb.Append(pppLine + "\n");
+                    sb.Append(pppLine).Append('\n');
                 }
                 else if (!line.StartsWith("new file mode"))
                 {
-                    sb.Append(line + "\n");
+                    sb.Append(line).Append('\n');
                 }
             }
 
@@ -99,52 +100,46 @@ namespace GitCommands.Patches
         [CanBeNull]
         public static byte[] GetSelectedLinesAsNewPatch([NotNull] GitModule module, [NotNull] string newFileName, [NotNull] string text, int selectionPosition, int selectionLength, [NotNull] Encoding fileContentEncoding, bool reset, byte[] filePreamble)
         {
-            var sb = new StringBuilder();
-            const string fileMode = "100000"; // given fake mode to satisfy patch format, git will override this
-            sb.Append(string.Format("diff --git a/{0} b/{0}", newFileName));
-            sb.Append("\n");
-            if (!reset)
-            {
-                sb.Append("new file mode " + fileMode);
-                sb.Append("\n");
-            }
-
-            sb.Append("index 0000000..0000000");
-            sb.Append("\n");
-            if (reset)
-            {
-                sb.Append("--- a/" + newFileName);
-            }
-            else
-            {
-                sb.Append("--- /dev/null");
-            }
-
-            sb.Append("\n");
-            sb.Append("+++ b/" + newFileName);
-            sb.Append("\n");
-
-            string header = sb.ToString();
-
             var selectedChunks = FromNewFile(module, text, selectionPosition, selectionLength, reset, filePreamble, fileContentEncoding);
 
             string body = ToIndexPatch(selectedChunks, isIndex: false, isWholeFile: true);
-
-            // git apply has problem with dealing with autocrlf
-            // I noticed that patch applies when '\r' chars are removed from patch if autocrlf is set to true
-            if (reset && body != null && module.EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
-            {
-                body = body.Replace("\r", "");
-            }
 
             if (body == null)
             {
                 return null;
             }
+
+            // git apply has problem with dealing with autocrlf
+            // I noticed that patch applies when '\r' chars are removed from patch if autocrlf is set to true
+            if (reset && module.EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
+            {
+                body = body.Replace("\r", "");
+            }
+
+            const string fileMode = "100000"; // given fake mode to satisfy patch format, git will override this
+            var header = new StringBuilder();
+
+            header.Append("diff --git a/").Append(newFileName).Append(" b/").Append(newFileName).Append('\n');
+
+            if (!reset)
+            {
+                header.Append("new file mode ").Append(fileMode).Append('\n');
+            }
+
+            header.Append("index 0000000..0000000\n");
+
+            if (reset)
+            {
+                header.Append("--- a/").Append(newFileName).Append('\n');
+            }
             else
             {
-                return GetPatchBytes(header, body, fileContentEncoding);
+                header.Append("--- /dev/null").Append('\n');
             }
+
+            header.Append("+++ b/").Append(newFileName).Append('\n');
+
+            return GetPatchBytes(header.ToString(), body, fileContentEncoding);
         }
 
         [NotNull]
@@ -210,10 +205,7 @@ namespace GitCommands.Patches
         [NotNull]
         private static IReadOnlyList<Chunk> FromNewFile([NotNull] GitModule module, [NotNull] string text, int selectionPosition, int selectionLength, bool reset, [NotNull] byte[] filePreamble, [NotNull] Encoding fileContentEncoding)
         {
-            return new List<Chunk>
-            {
-                Chunk.FromNewFile(module, text, selectionPosition, selectionLength, reset, filePreamble, fileContentEncoding)
-            };
+            return new[] { Chunk.FromNewFile(module, text, selectionPosition, selectionLength, reset, filePreamble, fileContentEncoding) };
         }
 
         [CanBeNull]
@@ -264,6 +256,7 @@ namespace GitCommands.Patches
         }
     }
 
+    [DebuggerDisplay("{" + nameof(Text) + "}")]
     internal sealed class PatchLine
     {
         public string Text { get; private set; }
@@ -303,7 +296,8 @@ namespace GitCommands.Patches
             string prePart = null;
             string postPart = null;
             bool inPostPart = false;
-            bool selectedLastLine = false;
+            bool selectedLastRemovedLine = false;
+            bool selectedLastAddedLine = false;
             addedCount += PreContext.Count + PostContext.Count;
             removedCount += PreContext.Count + PostContext.Count;
 
@@ -314,7 +308,7 @@ namespace GitCommands.Patches
 
             foreach (var removedLine in RemovedLines)
             {
-                selectedLastLine = removedLine.Selected;
+                selectedLastAddedLine = removedLine.Selected;
                 if (removedLine.Selected)
                 {
                     wereSelectedLines = true;
@@ -338,12 +332,9 @@ namespace GitCommands.Patches
                 }
             }
 
-            bool selectedLastRemovedLine = selectedLastLine;
-
-            for (int i = 0; i < AddedLines.Count; i++)
+            foreach (var addedLine in AddedLines)
             {
-                PatchLine addedLine = AddedLines[i];
-                selectedLastLine = addedLine.Selected;
+                selectedLastRemovedLine = addedLine.Selected;
                 if (addedLine.Selected)
                 {
                     wereSelectedLines = true;
@@ -369,7 +360,7 @@ namespace GitCommands.Patches
 
             diff = diff.Combine("\n", prePart);
             diff = diff.Combine("\n", removePart);
-            if (PostContext.Count == 0 && (!isIndex || selectedLastRemovedLine))
+            if (PostContext.Count == 0 && (selectedLastRemovedLine || !isIndex))
             {
                 diff = diff.Combine("\n", WasNoNewLineAtTheEnd);
             }
@@ -382,7 +373,7 @@ namespace GitCommands.Patches
             }
 
             // stage no new line at the end only if last +- line is selected
-            if (PostContext.Count == 0 && (selectedLastLine || isIndex || isWholeFile))
+            if (PostContext.Count == 0 && (selectedLastAddedLine || isIndex || isWholeFile))
             {
                 diff = diff.Combine("\n", IsNoNewLineAtTheEnd);
             }

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -281,5 +281,18 @@ namespace GitCommands
             exactPath = null;
             return false;
         }
+
+        [CanBeNull]
+        public static string GetFileExtension(string fileName)
+        {
+            var index = fileName.LastIndexOf('.');
+
+            if (index != -1)
+            {
+                return fileName.Substring(index + 1);
+            }
+
+            return null;
+        }
     }
 }

--- a/GitCommands/Statistics/CommitCounter.cs
+++ b/GitCommands/Statistics/CommitCounter.cs
@@ -24,6 +24,11 @@ namespace GitCommands.Statistics
                     .Split('\n');
 
             return ParseCommitsPerContributor(unformattedCommitsPerContributor);
+
+            string GetDateParameter(DateTime sinceDate, string paramName)
+            {
+                return $" --{paramName}=\"{sinceDate:yyyy-MM-dd hh:mm:ss}\"";
+            }
         }
 
         private static (Dictionary<string, int> commitsPerContributor, int totalCommits)
@@ -65,11 +70,6 @@ namespace GitCommands.Statistics
             }
 
             return (commitsPerContributor, totalCommits);
-        }
-
-        private static string GetDateParameter(DateTime sinceDate, string paramName)
-        {
-            return string.Format(" --{1}=\"{0}\"", sinceDate.ToString("yyyy-MM-dd hh:mm:ss"), paramName);
         }
     }
 }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -7,24 +7,6 @@ using JetBrains.Annotations;
 
 namespace System
 {
-    public static class DateTimeExtensions
-    {
-        public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime)
-        {
-            if (dateTime.ToUniversalTime() <= DateTimeOffset.MinValue.UtcDateTime)
-            {
-                return DateTimeOffset.MinValue;
-            }
-
-            if (dateTime.ToUniversalTime() >= DateTimeOffset.MaxValue.UtcDateTime)
-            {
-                return DateTimeOffset.MaxValue;
-            }
-
-            return new DateTimeOffset(dateTime);
-        }
-    }
-
     public static class StringExtensions
     {
         private static readonly char[] _newLine = { '\n' };

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
+// ReSharper disable once CheckNamespace
+
 namespace System
 {
     public static class DateTimeExtensions
@@ -25,69 +27,131 @@ namespace System
 
     public static class StringExtensions
     {
-        /// <summary>'\n'</summary>
-        private static readonly char[] NewLineSeparator = { '\n' };
+        private static readonly char[] _newLine = { '\n' };
+        private static readonly char[] _space = { ' ' };
 
+        // NOTE ordinal string comparison is the default as most string comparison in GE is against static ASCII output from git.exe
+
+        /// <summary>
+        /// Returns <paramref name="str"/> without <paramref name="prefix"/>.
+        /// If <paramref name="prefix"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
         [Pure]
-        [CanBeNull]
-        public static string SkipStr([CanBeNull] this string str, [NotNull] string toSkip)
+        [NotNull]
+        public static string RemovePrefix([NotNull] this string str, [NotNull] string prefix, StringComparison comparison = StringComparison.Ordinal)
         {
-            if (str == null)
-            {
-                return null;
-            }
-
-            var idx = str.IndexOf(toSkip);
-            if (idx != -1)
-            {
-                return str.Substring(idx + toSkip.Length);
-            }
-            else
-            {
-                return null;
-            }
+            return str.StartsWith(prefix, comparison)
+                ? str.Substring(prefix.Length)
+                : str;
         }
 
+        /// <summary>
+        /// Returns <paramref name="str"/> without <paramref name="suffix"/>.
+        /// If <paramref name="suffix"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
         [Pure]
-        [ContractAnnotation("str:null=>null")]
-        [ContractAnnotation("str:notnull=>notnull")]
-        public static string SubstringUntil([CanBeNull] this string str, [NotNull] string untilStr)
+        [NotNull]
+        public static string RemoveSuffix([NotNull] this string str, [NotNull] string suffix, StringComparison comparison = StringComparison.Ordinal)
         {
-            if (str == null)
-            {
-                return null;
-            }
-
-            var idx = str.IndexOf(untilStr);
-            if (idx != -1)
-            {
-                return str.Substring(0, idx);
-            }
-            else
-            {
-                return str;
-            }
+            return str.EndsWith(suffix, comparison)
+                ? str.Substring(0, str.Length - suffix.Length)
+                : str;
         }
 
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the first
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
         [Pure]
-        [ContractAnnotation("str:null=>null")]
-        [ContractAnnotation("str:notnull=>notnull")]
-        public static string SubstringUntil(this string str, char untilChar)
+        [NotNull]
+        public static string SubstringUntil([NotNull] this string str, char c)
         {
-            if (str == null)
-            {
-                return null;
-            }
+            var index = str.IndexOf(c);
 
-            var idx = str.IndexOf(untilChar);
-            if (idx != -1)
-            {
-                return str.Substring(0, idx);
-            }
-            else
-            {
-                return str;
-            }
+            return index != -1
+                ? str.Substring(0, index)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the last
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringUntilLast([NotNull] this string str, char c)
+        {
+            var index = str.LastIndexOf(c);
+
+            return index != -1
+                ? str.Substring(0, index)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> after (and excluding) the first
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfter([NotNull] this string str, char c)
+        {
+            var index = str.IndexOf(c);
+
+            return index != -1
+                ? str.Substring(index + 1)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the first
+        /// instance of string <paramref name="s"/>.
+        /// If <paramref name="s"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfter([NotNull] this string str, string s, StringComparison comparison = StringComparison.Ordinal)
+        {
+            var index = str.IndexOf(s, comparison);
+
+            return index != -1
+                ? str.Substring(index + s.Length)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> after (and excluding) the last
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfterLast([NotNull] this string str, char c)
+        {
+            var index = str.LastIndexOf(c);
+
+            return index != -1
+                ? str.Substring(index + 1)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the last
+        /// instance of string <paramref name="s"/>.
+        /// If <paramref name="s"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfterLast([NotNull] this string str, string s, StringComparison comparison = StringComparison.Ordinal)
+        {
+            var index = str.LastIndexOf(s, comparison);
+
+            return index != -1
+                ? str.Substring(index + s.Length)
+                : str;
         }
 
         [Pure]
@@ -241,9 +305,7 @@ namespace System
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
         [Pure]
         [NotNull]
-        public static string[] SplitLines([NotNull] this string value) => value.Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
-
-        private static readonly char[] _space = new[] { ' ' };
+        public static string[] SplitLines([NotNull] this string value) => value.Split(_newLine, StringSplitOptions.RemoveEmptyEntries);
 
         /// <summary>Split a string, delimited by the space character, excluding empty entries.</summary>
         [Pure]
@@ -284,8 +346,7 @@ namespace System
         /// true if the <paramref name="other"/> parameter occurs within <paramref name="str"/>,
         /// or if <paramref name="other"/> is the empty string (""); otherwise, false.
         /// </returns>
-        public static bool Contains([NotNull]this string str, [NotNull] string other,
-            StringComparison stringComparison)
+        public static bool Contains([NotNull] this string str, [NotNull] string other, StringComparison stringComparison)
         {
             return str.IndexOf(other, stringComparison) != -1;
         }

--- a/GitExtensions.sln.DotSettings
+++ b/GitExtensions.sln.DotSettings
@@ -79,6 +79,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gitmodule/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gitreview/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gitrevisions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=git_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmail/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gnore_002Du/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=guitool/@EntryIndexedValue">True</s:Boolean>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1463,7 +1463,7 @@ namespace GitUI.CommandsDialogs
                 }
                 else if (revisions[1].ObjectId == currentCheckout)
                 {
-                    from = revisions[0].Guid.Substring(0, 8);
+                    from = revisions[0].ObjectId.ToShortString(8);
                     to = currentBranch;
                 }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1807,6 +1807,11 @@ namespace GitUI.CommandsDialogs
                     bool wereErrors = false;
                     if (AppSettings.ShowErrorsWhenStagingFiles)
                     {
+                        using (var form = new FormStatus(ProcessStart, _stageDetails.Text))
+                        {
+                            form.ShowDialogOnError(this);
+                        }
+
                         void ProcessStart(FormStatus form)
                         {
                             form.AppendMessageCrossThread(
@@ -1815,11 +1820,6 @@ namespace GitUI.CommandsDialogs
                             var output = Module.StageFiles(files, out wereErrors);
                             form.AppendMessageCrossThread(output);
                             form.Done(string.IsNullOrEmpty(output));
-                        }
-
-                        using (var process = new FormStatus(ProcessStart, null) { Text = _stageDetails.Text })
-                        {
-                            process.ShowDialogOnError(this);
                         }
                     }
                     else

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1959,7 +1959,7 @@ namespace GitUI.CommandsDialogs
                                 {
                                     File.Delete(path);
                                 }
-                                else
+                                else if (Directory.Exists(path))
                                 {
                                     Directory.Delete(path, recursive: true);
                                 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1797,15 +1797,11 @@ namespace GitUI.CommandsDialogs
 
                     var files = new List<GitItemStatus>();
 
-                    foreach (var gitItemStatus in items)
+                    foreach (var item in items)
                     {
                         toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + 1);
-                        if (gitItemStatus.Name.EndsWith("/"))
-                        {
-                            gitItemStatus.Name = gitItemStatus.Name.TrimEnd('/');
-                        }
-
-                        files.Add(gitItemStatus);
+                        item.Name = item.Name.TrimEnd('/');
+                        files.Add(item);
                     }
 
                     bool wereErrors = false;
@@ -1965,7 +1961,7 @@ namespace GitUI.CommandsDialogs
                                 }
                                 else
                                 {
-                                    Directory.Delete(path, true);
+                                    Directory.Delete(path, recursive: true);
                                 }
                             }
                             catch (IOException)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -412,7 +412,7 @@ namespace GitUI.CommandsDialogs
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),
                     FileName = Path.GetFileName(fullName),
-                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                    DefaultExt = PathUtil.GetFileExtension(fullName),
                     AddExtension = true
                 })
                 {

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -39,17 +39,17 @@ namespace GitUI.CommandsDialogs
 
         private void StageSubmodule()
         {
+            using (var form = new FormStatus(ProcessStart, string.Format(_stageFilename.Text, _filename)))
+            {
+                form.ShowDialogOnError(this);
+            }
+
             void ProcessStart(FormStatus form)
             {
                 form.AddMessageLine(string.Format(_stageFilename.Text, _filename));
                 string output = Module.RunGitCmd($"add -- \"{_filename}\"");
                 form.AddMessageLine(output);
                 form.Done(string.IsNullOrEmpty(output));
-            }
-
-            using (var process = new FormStatus(ProcessStart, null) { Text = string.Format(_stageFilename.Text, _filename) })
-            {
-                process.ShowDialogOnError(this);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -8,9 +8,10 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormMergeSubmodule : GitModuleForm
     {
-        private readonly string _filename;
         private readonly TranslationString _stageFilename = new TranslationString("Stage {0}");
         private readonly TranslationString _deleted = new TranslationString("deleted");
+
+        private readonly string _filename;
 
         public FormMergeSubmodule(GitUICommands commands, string filename)
             : base(commands)
@@ -24,9 +25,10 @@ namespace GitUI.CommandsDialogs
         private void FormMergeSubmodule_Load(object sender, EventArgs e)
         {
             var item = Module.GetConflict(_filename);
-            tbBase.Text = item.Base.Hash ?? _deleted.Text;
-            tbLocal.Text = item.Local.Hash ?? _deleted.Text;
-            tbRemote.Text = item.Remote.Hash ?? _deleted.Text;
+
+            tbBase.Text = item.Base.ObjectId?.ToString() ?? _deleted.Text;
+            tbLocal.Text = item.Local.ObjectId?.ToString() ?? _deleted.Text;
+            tbRemote.Text = item.Remote.ObjectId?.ToString() ?? _deleted.Text;
             tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
         }
 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -954,7 +954,7 @@ namespace GitUI.CommandsDialogs
                 }
                 else
                 {
-                    // use remote branches from the git's local database if there were problems with receiving branches from the remote server
+                    // use remote branches from git's local database if there were problems with receiving branches from the remote server
                     remoteHeads = Module.GetRemoteBranches().Where(r => r.Remote == remote).ToList();
                 }
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision != null)
                 {
-                    txtFrom.Text = chooseForm.SelectedRevision.Guid.Substring(0, 8);
+                    txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString(8);
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -646,12 +646,12 @@ namespace GitUI.CommandsDialogs
 
         private string GetShortHash(ConflictedFileData item)
         {
-            if (item.Hash == null)
+            if (item.ObjectId == null)
             {
                 return "@" + _deleted.Text;
             }
 
-            return '@' + item.Hash.Substring(0, 8);
+            return '@' + item.ObjectId.ToShortString(8);
         }
 
         private void ConflictedFiles_SelectionChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1169,17 +1169,17 @@ namespace GitUI.CommandsDialogs
 
         private void StageFile(string filename)
         {
+            using (var form = new FormStatus(ProcessStart, string.Format(_stageFilename.Text, filename)))
+            {
+                form.ShowDialogOnError(this);
+            }
+
             void ProcessStart(FormStatus form)
             {
                 form.AddMessageLine(string.Format(_stageFilename.Text, filename));
                 string output = Module.RunGitCmd("add -- \"" + filename + "\"");
                 form.AddMessageLine(output);
                 form.Done(string.IsNullOrEmpty(output));
-            }
-
-            using (var process = new FormStatus(ProcessStart, null) { Text = string.Format(_stageFilename.Text, filename) })
-            {
-                process.ShowDialogOnError(this);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1069,9 +1069,9 @@ namespace GitUI.CommandsDialogs
                     AddExtension = true
                 })
                 {
-                    fileDialog.DefaultExt = GitCommandHelpers.GetFileExtension(fileDialog.FileName);
-                    fileDialog.Filter = string.Format(_currentFormatFilter.Text, GitCommandHelpers.GetFileExtension(fileDialog.FileName)) + "|*." +
-                                        GitCommandHelpers.GetFileExtension(fileDialog.FileName) + "|" + _allFilesFilter.Text + "|*.*";
+                    var ext = PathUtil.GetFileExtension(fileDialog.FileName);
+                    fileDialog.DefaultExt = ext;
+                    fileDialog.Filter = string.Format(_currentFormatFilter.Text, ext) + "|*." + ext + "|" + _allFilesFilter.Text + "|*.*";
 
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)
                     {

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -135,8 +135,7 @@ namespace GitUI.CommandsDialogs
                 }
                 else if (objectType == LostObjectType.Blob)
                 {
-                    var hash = objectId.ToString();
-                    var blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash.Substring(0, 2), hash.Substring(2, ObjectId.Sha1CharCount - 2));
+                    var blobPath = objectId.ToObjectFilePath(module.WorkingDirGitDir);
                     result.Date = new FileInfo(blobPath).CreationTime;
                 }
 

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -166,7 +166,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             if (_prevTitle == _titleTB.Text && !_yourBranchesCB.Text.IsNullOrWhiteSpace() && MyRemote != null)
             {
                 var lastMsg = Module.GetPreviousCommitMessages(1, MyRemote.Name.Combine("/", _yourBranchesCB.Text)).FirstOrDefault();
-                _titleTB.Text = lastMsg.SubstringUntil("\n");
+                _titleTB.Text = lastMsg?.SubstringUntil('\n');
                 _prevTitle = _titleTB.Text;
             }
         }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -699,7 +699,7 @@ namespace GitUI.CommandsDialogs
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),
                     FileName = Path.GetFileName(fullName),
-                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                    DefaultExt = PathUtil.GetFileExtension(fullName),
                     AddExtension = true
                 })
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -320,16 +320,7 @@ See the changes in the commit form.");
                 gitItem.ObjectType == GitObjectType.Blob &&
                 !string.IsNullOrWhiteSpace(gitItem.FileName))
             {
-                var fileName = gitItem.FileName;
-                if (fileName.Contains("\\") && fileName.LastIndexOf("\\", StringComparison.Ordinal) < fileName.Length)
-                {
-                    fileName = fileName.Substring(fileName.LastIndexOf('\\') + 1);
-                }
-
-                if (fileName.Contains("/") && fileName.LastIndexOf("/", StringComparison.Ordinal) < fileName.Length)
-                {
-                    fileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
-                }
+                var fileName = gitItem.FileName.SubstringAfterLast('/').SubstringAfterLast('\\');
 
                 fileName = (Path.GetTempPath() + fileName).ToNativePath();
                 Module.SaveBlobAs(fileName, gitItem.Guid);

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -671,11 +671,11 @@ See the changes in the commit form.");
                     {
                         InitialDirectory = Path.GetDirectoryName(fullName),
                         FileName = Path.GetFileName(fullName),
-                        DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                        DefaultExt = PathUtil.GetFileExtension(fullName),
                         AddExtension = true
                     })
                 {
-                    var extension = GitCommandHelpers.GetFileExtension(fileDialog.FileName);
+                    var extension = PathUtil.GetFileExtension(fileDialog.FileName);
 
                     fileDialog.Filter = $@"{_saveFileFilterCurrentFormat.Text}(*.{extension})|*.{extension}| {_saveFileFilterAllFiles.Text} (*.*)|*.*";
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1194,17 +1194,14 @@ namespace GitUI.Editor
                 int pos = noSelection ? 0 : _internalFileViewer.GetSelectionPosition();
                 string fileText = _internalFileViewer.GetText();
 
-                if (pos > 0)
+                if (pos > 0 && fileText[pos - 1] != '\n')
                 {
-                    if (fileText[pos - 1] != '\n')
-                    {
-                        code = " " + code;
-                    }
+                    code = " " + code;
                 }
 
-                IEnumerable<string> lines = code.Split('\n');
-                lines = lines.Where(s => s.Length == 0 || s[0] != startChar || (s.Length > 2 && s[1] == s[0] && s[2] == s[0]));
-                int hpos = fileText.IndexOf("\n@@");
+                var lines = code.Split('\n')
+                    .Where(s => s.Length == 0 || s[0] != startChar || (s.Length > 2 && s[1] == s[0] && s[2] == s[0]));
+                var hpos = fileText.IndexOf("\n@@");
 
                 // if header is selected then don't remove diff extra chars
                 if (hpos <= pos)

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -37,7 +37,7 @@ namespace GitUI
             Remote = "";
             ProcessInput = input;
             WorkingDirectory = workingDirectory;
-            Text = Text + " (" + WorkingDirectory + ")";
+            Text += $" ({PathUtil.GetDisplayPath(WorkingDirectory)})";
 
             ConsoleOutput.ProcessExited += delegate { OnExit(ConsoleOutput.ExitCode); };
             ConsoleOutput.DataReceived += DataReceivedCore;

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -91,16 +91,12 @@ namespace GitUI
             int index = text.LastIndexOf('%');
             if (index > 4 && int.TryParse(text.Substring(index - 3, 3), out var progressValue) && progressValue >= 0)
             {
-                if (ProgressBar.Style != ProgressBarStyle.Blocks)
-                {
-                    ProgressBar.Style = ProgressBarStyle.Blocks;
-                }
-
+                ProgressBar.Style = ProgressBarStyle.Blocks;
                 ProgressBar.Value = Math.Min(100, progressValue);
                 TaskbarProgress.SetProgress(TaskbarProgressBarState.Normal, progressValue, 100);
             }
 
-            // Show last progress message in the title, unless it's showin in the control body already
+            // Show last progress message in the title, unless it's showing in the control body already
             if (!ConsoleOutput.IsDisplayingFullProcessOutput)
             {
                 Text = text;

--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -48,11 +48,11 @@ namespace GitUI
             InitializeComplete();
         }
 
-        public FormStatus(Action<FormStatus> process, Action<FormStatus> abort)
+        public FormStatus(Action<FormStatus> process, string text)
             : this(new EditboxBasedConsoleOutputControl(), true)
         {
             ProcessCallback = process;
-            AbortCallback = abort;
+            Text = text;
         }
 
         protected readonly ConsoleOutputControl ConsoleOutput;

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -98,7 +98,7 @@ namespace GitUI.Hotkey
             var culture = CultureInfo.CurrentCulture; // TODO: replace this with the GitExtensions language setting
 
             // for modifier keys this yields for example "Ctrl+None" thus we have to strip the rest after the +
-            return new KeysConverter().ConvertToString(null, culture, key).SubstringUntil("+");
+            return new KeysConverter().ConvertToString(null, culture, key)?.SubstringUntil('+');
         }
     }
 }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -81,24 +81,13 @@ namespace GitUI.Script
 
         private static string GetRemotePath(string url)
         {
-            Uri uri;
-            string path = "";
-            if (Uri.TryCreate(url, UriKind.Absolute, out uri))
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+                Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
             {
-                path = uri.LocalPath;
-            }
-            else if (Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
-            {
-                path = uri.LocalPath;
+                return uri.LocalPath.SubstringAfterLast('.');
             }
 
-            int pos = path.LastIndexOf(".");
-            if (pos >= 0)
-            {
-                path = path.Substring(0, pos);
-            }
-
-            return path;
+            return "";
         }
 
         private static bool RunScript(IWin32Window owner, GitModule module, ScriptInfo scriptInfo, RevisionGridControl revisionGrid)

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -55,25 +55,26 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             if (_grid.TryGetSuperProjectInfo(out var spi))
             {
-                if (spi.Conflict_Base == revision.Guid)
+                if (spi.ConflictBase == revision.ObjectId)
                 {
                     DrawSuperProjectRef("Base");
                 }
 
-                if (spi.Conflict_Local == revision.Guid)
+                if (spi.ConflictLocal == revision.ObjectId)
                 {
                     DrawSuperProjectRef("Local");
                 }
 
-                if (spi.Conflict_Remote == revision.Guid)
+                if (spi.ConflictRemote == revision.ObjectId)
                 {
                     DrawSuperProjectRef("Remote");
                 }
 
-                if (spi.Refs?.ContainsKey(revision.Guid) == true)
+                if (spi.Refs != null &&
+                    revision.ObjectId != null &&
+                    spi.Refs.TryGetValue(revision.ObjectId, out var refs))
                 {
-                    superprojectRefs.AddRange(
-                        spi.Refs[revision.Guid].Where(RevisionGridControl.ShowRemoteRef));
+                    superprojectRefs.AddRange(refs.Where(RevisionGridControl.ShowRemoteRef));
                 }
 
                 void DrawSuperProjectRef(string label)

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -71,7 +71,7 @@ namespace GitUI.UserControls.RevisionGrid
                 }
 
                 // Add other items
-                AddItem($"{Strings.CommitHash}     ({revision.Guid.ShortenTo(15)})", r => r.Guid, Images.CommitId, Keys.Control | Keys.C);
+                AddItem($"{Strings.CommitHash}     ({revision.ObjectId.ToShortString()}...)", r => r.Guid, Images.CommitId, Keys.Control | Keys.C);
                 AddItem($"{Strings.Message}     ({revision.Subject.ShortenTo(30)})", r => r.Body ?? r.Subject, Images.Message);
                 AddItem($"{Strings.Author}     ({revision.Author})", r => r.Author, Images.Author);
 

--- a/GitUI/UserControls/RevisionGrid/FormQuickGitRefSelector.cs
+++ b/GitUI/UserControls/RevisionGrid/FormQuickGitRefSelector.cs
@@ -86,7 +86,7 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 // what is this magic number "MaxVisibleItemsWithoutScroll + 0.5"?
                 // we are limiting number of visible items in the listbox before enabling vscroll, this is to reduce the risk of not fitting on user's screen.
-                // when listbox.IntergralHeight=true, the listbox automatically calculates its size and only show full items (i.e. you can't render it
+                // when listbox.IntegralHeight=true, the listbox automatically calculates its size and only show full items (i.e. you can't render it
                 // at 20px high if the ItemHeight=13px, it can only be 13, 26, 39 etc (NB: slightly more if you account for the furniture)).
                 // listbox.PreferredHeight returns the height of the listbox showing all items.
                 // for some strange reason, MaxVisibleItemsWithoutScroll*listbox.ItemHeight renders the listbox showing MaxVisibleItemsWithoutScroll-1 items.

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -980,9 +980,9 @@ namespace GitUI
             {
                 // return local and remote hashes
                 var array = gitModule.SuperprojectModule.GetConflict(gitModule.SubmodulePath);
-                spi.Conflict_Base = array.Base.Hash;
-                spi.Conflict_Local = array.Local.Hash;
-                spi.Conflict_Remote = array.Remote.Hash;
+                spi.ConflictBase = array.Base.ObjectId;
+                spi.ConflictLocal = array.Local.ObjectId;
+                spi.ConflictRemote = array.Remote.ObjectId;
             }
             else
             {
@@ -993,7 +993,10 @@ namespace GitUI
 
             if (refs != null)
             {
-                spi.Refs = refs.Where(a => a.Value != null).GroupBy(a => a.Value.Guid).ToDictionary(gr => gr.Key, gr => gr.Select(a => a.Key).ToList());
+                spi.Refs = refs
+                    .Where(a => a.Value != null)
+                    .GroupBy(a => a.Value.ObjectId)
+                    .ToDictionary(gr => gr.Key, gr => gr.Select(a => a.Key).AsReadOnlyList());
             }
 
             return spi;

--- a/GitUI/UserControls/RevisionGrid/SuperProjectInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/SuperProjectInfo.cs
@@ -1,14 +1,16 @@
 using System.Collections.Generic;
 using GitUIPluginInterfaces;
+using JetBrains.Annotations;
 
 namespace GitUI
 {
     internal sealed class SuperProjectInfo
     {
-        public string CurrentBranch;
-        public string Conflict_Base;
-        public string Conflict_Remote;
-        public string Conflict_Local;
-        public Dictionary<string, List<IGitRef>> Refs;
+        // TODO nothing reads this property
+        [CanBeNull] public ObjectId CurrentBranch { get; set; }
+        [CanBeNull] public ObjectId ConflictBase { get; set; }
+        [CanBeNull] public ObjectId ConflictRemote { get; set; }
+        [CanBeNull] public ObjectId ConflictLocal { get; set; }
+        [CanBeNull] public IReadOnlyDictionary<ObjectId, IReadOnlyList<IGitRef>> Refs { get; set; }
     }
 }

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
@@ -158,7 +158,7 @@ namespace TfsIntegration
 
         private static BuildInfo CreateBuildInfo(IBuild buildDetail)
         {
-            var objectId = ObjectId.Parse(buildDetail.Revision.Substring(buildDetail.Revision.LastIndexOf(":") + 1));
+            var objectId = ObjectId.Parse(buildDetail.Revision.SubstringAfter(':'));
 
             return new BuildInfo
             {

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -112,28 +112,12 @@ namespace Gerrit
                 {
                     if (hadNewChanges)
                     {
-                        change = line;
-                        const string remotePrefix = "remote:";
-
-                        if (change.StartsWith(remotePrefix))
-                        {
-                            change = change.Substring(remotePrefix.Length);
-                        }
-
-                        int escapePos = change.LastIndexOf((char)27);
-                        if (escapePos != -1)
-                        {
-                            change = change.Substring(0, escapePos);
-                        }
-
-                        change = change.Trim();
-
-                        int spacePos = change.IndexOf(' ');
-                        if (spacePos != -1)
-                        {
-                            change = change.Substring(0, spacePos);
-                        }
-
+                        const char esc = (char)27;
+                        change = line
+                            .RemovePrefix("remote:")
+                            .SubstringUntilLast(esc)
+                            .Trim()
+                            .SubstringUntil(' ');
                         break;
                     }
                     else if (line.Contains("New Changes"))

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -94,10 +94,10 @@ namespace GitFlow
         {
             foreach (Branch branch in Enum.GetValues(typeof(Branch)))
             {
-                var startRef = branch.ToString("G") + "/";
+                var startRef = branch + "/";
                 if (currentRef.StartsWith(startRef))
                 {
-                    branchType = branch.ToString("G");
+                    branchType = branch.ToString();
                     branchName = currentRef.Substring(startRef.Length);
                     return true;
                 }

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -25,7 +25,6 @@ namespace GitFlow
         private readonly AsyncLoader _task = new AsyncLoader();
 
         public bool IsRefreshNeeded { get; set; }
-        private const string RefHeads = "refs/heads/";
 
         private string CurrentBranch { get; set; }
 
@@ -344,7 +343,8 @@ namespace GitFlow
         {
             var head = _gitUiCommands.GitModule.RunGitCmd("symbolic-ref HEAD").Trim('*', ' ', '\n', '\r');
             lblHead.Text = head;
-            var currentRef = head.StartsWith(RefHeads) ? head.Substring(RefHeads.Length) : head;
+
+            var currentRef = head.RemovePrefix(GitRefName.RefsHeadsPrefix);
 
             if (TryExtractBranchFromHead(currentRef, out var branchTypes, out var branchName))
             {

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -482,6 +482,18 @@ namespace GitUIPluginInterfaces
             char ParseHexDigit(uint j) => j < 10 ? (char)('0' + j) : (char)(j + 0x57);
         }
 
+        /// <summary>
+        /// Gets the path to the git object file within the <c>.git</c> folder specified by <paramref name="gitDir"/>.
+        /// </summary>
+        /// <remarks>
+        /// The return value resembles <c>path\to\.git\objects\01\23456789012345678901234567890123456789</c>.
+        /// </remarks>
+        public string ToObjectFilePath(string gitDir)
+        {
+            var str = ToString();
+            return Path.Combine(gitDir, "objects", str.Substring(0, 2), str.Substring(2));
+        }
+
         #region Equality and hashing
 
         /// <inheritdoc />

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -350,8 +350,8 @@ namespace GitImpact
                         // Create a new random brush for the author if none exists yet
                         if (!_brushes.ContainsKey(author))
                         {
-                            int partLength = author.Length / 3;
-                            _brushes.Add(author, new SolidBrush(Color.FromArgb(GenerateIntFromString(author.Substring(0, partLength)) % 255, GenerateIntFromString(author.Substring(partLength, partLength)) % 255, GenerateIntFromString(author.Substring(partLength)) % 255)));
+                            var color = Color.FromArgb((int)(author.GetHashCode() | 0xFF000000));
+                            _brushes.Add(author, new SolidBrush(color));
                         }
 
                         // Increase y for next block
@@ -469,11 +469,6 @@ namespace GitImpact
                     }
                 }
             }
-        }
-
-        private static int GenerateIntFromString(string text)
-        {
-            return text.Sum(c => (int)c);
         }
 
         /// <summary>

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -91,15 +91,23 @@ namespace ResourceManager
                 return linkUri;
             }
 
-            string uriCandidate = linkText;
-            while (uriCandidate != null)
+            var uriCandidate = linkText;
+
+            while (true)
             {
                 if (Uri.TryCreate(uriCandidate, UriKind.Absolute, out var uri))
                 {
                     return uri.AbsoluteUri;
                 }
 
-                uriCandidate = uriCandidate.SkipStr("#");
+                var idx = uriCandidate.IndexOf('#');
+
+                if (idx == -1)
+                {
+                    break;
+                }
+
+                uriCandidate = uriCandidate.Substring(idx + 1);
             }
 
             return linkText;

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -6,6 +6,8 @@ using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using NUnit.Framework;
 
+// ReSharper disable StringLiteralTypo
+
 namespace GitCommandsTests.Git
 {
     // TODO SUT is in GitUIPluginInterfaces but no test assembly exists for that assembly
@@ -275,6 +277,13 @@ namespace GitCommandsTests.Git
             Assert.False(ObjectId.Random().Equals("gibberish"));
             Assert.False(ObjectId.Parse("0123456789012345678901234567890123456789").Equals(" 0123456789012345678901234567890123456789 "));
             Assert.False(ObjectId.Parse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Equals("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+        }
+
+        [TestCase("0123456789abcdef0123456789abcdef01234567", "", "objects\\01\\23456789abcdef0123456789abcdef01234567")]
+        [TestCase("0123456789abcdef0123456789abcdef01234567", ".git", ".git\\objects\\01\\23456789abcdef0123456789abcdef01234567")]
+        public void ToObjectFilePath_works_as_expected(string hash, string gitDir, string expected)
+        {
+            Assert.AreEqual(expected, ObjectId.Parse(hash).ToObjectFilePath(gitDir));
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -239,5 +239,19 @@ namespace GitCommandsTests.Helpers
                 }
             }
         }
+
+        [Test]
+        public void GetFileExtension()
+        {
+            Assert.AreEqual("txt", PathUtil.GetFileExtension("foo.txt"));
+            Assert.AreEqual("txt", PathUtil.GetFileExtension("foo.txt.txt"));
+            Assert.AreEqual("txt", PathUtil.GetFileExtension(".txt"));
+            Assert.AreEqual("", PathUtil.GetFileExtension("foo."));
+            Assert.AreEqual("", PathUtil.GetFileExtension("."));
+            Assert.AreEqual("", PathUtil.GetFileExtension(".."));
+            Assert.AreEqual("", PathUtil.GetFileExtension("..."));
+            Assert.Null(PathUtil.GetFileExtension("foo"));
+            Assert.Null(PathUtil.GetFileExtension(""));
+        }
     }
 }

--- a/UnitTests/GitCommandsTests/StringExtensionTests.cs
+++ b/UnitTests/GitCommandsTests/StringExtensionTests.cs
@@ -27,5 +27,111 @@ namespace GitCommandsTests
         {
             Assert.AreEqual(expected, str.Contains(other, StringComparison.InvariantCultureIgnoreCase));
         }
+
+        [TestCase("ABCDEFG", "ABC", "DEFG")]
+        [TestCase("ABCDEFG", "AB", "CDEFG")]
+        [TestCase("ABCDEFG", "A", "BCDEFG")]
+        [TestCase("ABCDEFG", "", "ABCDEFG")]
+        [TestCase("ABCDEFG", "XYZ", "ABCDEFG")]
+        [TestCase("AB", "ABCD", "AB")]
+        public void RemovePrefix_works_as_expected(string str, string prefix, string expected)
+        {
+            Assert.AreEqual(expected, str.RemovePrefix(prefix));
+        }
+
+        [TestCase("ABCDEFG", "EFG", "ABCD")]
+        [TestCase("ABCDEFG", "FG", "ABCDE")]
+        [TestCase("ABCDEFG", "G", "ABCDEF")]
+        [TestCase("ABCDEFG", "", "ABCDEFG")]
+        [TestCase("ABCDEFG", "XYZ", "ABCDEFG")]
+        [TestCase("CD", "ABCD", "CD")]
+        [TestCase("", "ABCD", "")]
+        [TestCase("ABCD", "", "ABCD")]
+        public void RemoveSuffix_works_as_expected(string str, string prefix, string expected)
+        {
+            Assert.AreEqual(expected, str.RemoveSuffix(prefix));
+        }
+
+        [TestCase("ABCDEFG", 'A', "")]
+        [TestCase("ABCDEFG", 'B', "A")]
+        [TestCase("ABCDEFG", 'C', "AB")]
+        [TestCase("ABCDEFG", 'D', "ABC")]
+        [TestCase("ABCDEFG", 'E', "ABCD")]
+        [TestCase("ABCDEFG", 'Z', "ABCDEFG")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        public void SubstringUntil_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringUntil(c));
+        }
+
+        [TestCase("ABCABC", 'A', "ABC")]
+        [TestCase("ABCABC", 'B', "ABCA")]
+        [TestCase("ABCABC", 'C', "ABCAB")]
+        [TestCase("ABCABC", 'Z', "ABCABC")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        [TestCase("AAAA", 'A', "AAA")]
+        public void SubstringUntilLast_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringUntilLast(c));
+        }
+
+        [TestCase("ABCDEFG", 'A', "BCDEFG")]
+        [TestCase("ABCDEFG", 'B', "CDEFG")]
+        [TestCase("ABCDEFG", 'C', "DEFG")]
+        [TestCase("ABCDEFG", 'Z', "ABCDEFG")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        [TestCase("ABBA", 'A', "BBA")]
+        public void SubstringAfter_char_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfter(c));
+        }
+
+        [TestCase("ABCDEFG", "A", "BCDEFG")]
+        [TestCase("ABCDEFG", "AB", "CDEFG")]
+        [TestCase("ABCDEFG", "B", "CDEFG")]
+        [TestCase("ABCDEFG", "C", "DEFG")]
+        [TestCase("ABCDEFG", "Z", "ABCDEFG")]
+        [TestCase("", "Z", "")]
+        [TestCase("A", "A", "")]
+        [TestCase("ABBA", "A", "BBA")]
+        public void SubstringAfter_string_works_as_expected(string str, string s, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfter(s));
+        }
+
+        [TestCase("ABCABC", 'A', "BC")]
+        [TestCase("ABCABC", 'B', "C")]
+        [TestCase("ABCABC", 'C', "")]
+        [TestCase("ABCDEFG", 'A', "BCDEFG")]
+        [TestCase("ABCDEFG", 'B', "CDEFG")]
+        [TestCase("ABCDEFG", 'C', "DEFG")]
+        [TestCase("ABCDEFG", 'Z', "ABCDEFG")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        [TestCase("ABBA", 'A', "")]
+        public void SubstringAfterLast_char_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfterLast(c));
+        }
+
+        [TestCase("ABCABC", "A", "BC")]
+        [TestCase("ABCABC", "B", "C")]
+        [TestCase("ABCABC", "C", "")]
+        [TestCase("ABCDEFG", "A", "BCDEFG")]
+        [TestCase("ABCDEFG", "AB", "CDEFG")]
+        [TestCase("ABCDEFG", "B", "CDEFG")]
+        [TestCase("ABCDEFG", "BCD", "EFG")]
+        [TestCase("ABCDEFG", "C", "DEFG")]
+        [TestCase("ABCDEFG", "Z", "ABCDEFG")]
+        [TestCase("", "Z", "")]
+        [TestCase("A", "A", "")]
+        [TestCase("ABBA", "A", "")]
+        public void SubstringAfterLast_string_works_as_expected(string str, string s, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfterLast(s));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4271 

We do a lot of string manipulation. Finding indexes and obtaining substrings can lead to verbose and confusing code, and bugs.

This change introduces a few extension methods for working with strings that leads to clearer code in several places.

- `RemovePrefix`
- `RemoveSuffix`
- `Until`
- `UntilLast`
- `After`
- `AfterLast`

It replaces some older versions of these (`SkipStr`, `SubstringUntil`) with versions that don't special case `null`.

What did I do to test the code and ensure quality:
- Add unit tests 
- Manual tests

Has been tested on:
- GIT 2.18
- Windows 10
