### PR TITLE
Stats support TypeScript, and some perf work

### DIFF
--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -9,6 +9,10 @@ namespace System.Linq
     {
         [NotNull]
         [MustUseReturnValue]
+        public static HashSet<T> ToHashSet<T>([NotNull] this IEnumerable<T> source, IEqualityComparer<T> comparer = null) => new HashSet<T>(source, comparer ?? EqualityComparer<T>.Default);
+
+        [NotNull]
+        [MustUseReturnValue]
         public static HashSet<TKey> ToHashSet<TSource, TKey>(
             [NotNull] this IEnumerable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector)

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using GitStatistics.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -8,6 +9,14 @@ namespace GitStatistics
     [Export(typeof(IGitPlugin))]
     public class GitStatisticsPlugin : GitPluginBase, IGitPluginForRepository
     {
+        private const string _defaultCodeFiles =
+            "*.c;*.cpp;*.cc;*.cxx;*.h;*.hpp;*.hxx;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" +
+            "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.ts;*.mk;*.java";
+
+        private readonly StringSetting _codeFiles = new StringSetting("Code files", _defaultCodeFiles);
+        private readonly StringSetting _ignoreDirectories = new StringSetting("Directories to ignore (EndsWith)", @"\Debug;\Release;\obj;\bin;\lib");
+        private readonly BoolSetting _ignoreSubmodules = new BoolSetting("Ignore submodules", defaultValue: true);
+
         public GitStatisticsPlugin()
         {
             SetNameAndDescription("Statistics");
@@ -15,15 +24,7 @@ namespace GitStatistics
             Icon = Resources.IconGitStatistics;
         }
 
-        private readonly StringSetting _codeFiles = new StringSetting("Code files",
-                                "*.c;*.cpp;*.cc;*.cxx;*.h;*.hpp;*.hxx;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" +
-                                "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.mk;*.java");
-        private readonly StringSetting _ignoreDirectories = new StringSetting("Directories to ignore (EndsWith)", "\\Debug;\\Release;\\obj;\\bin;\\lib");
-        private readonly BoolSetting _ignoreSubmodules = new BoolSetting("Ignore submodules", true);
-
-        #region IGitPlugin Members
-
-        public override System.Collections.Generic.IEnumerable<ISetting> GetSettings()
+        public override IEnumerable<ISetting> GetSettings()
         {
             yield return _codeFiles;
             yield return _ignoreDirectories;
@@ -51,7 +52,5 @@ namespace GitStatistics
 
             return false;
         }
-
-        #endregion
     }
 }

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -5,67 +5,43 @@ using System.Linq;
 
 namespace GitStatistics
 {
-    public class LineCounter
+    public sealed class LineCounter
     {
-        public event EventHandler LinesOfCodeUpdated;
+        public event EventHandler Updated;
 
-        public int NumberCommentsLines { get; private set; }
-        public int NumberLines { get; private set; }
-        public int NumberLinesInDesignerFiles { get; private set; }
-        public int NumberTestCodeLines { get; private set; }
-        public int NumberBlankLines { get; private set; }
-        public int NumberCodeLines { get; private set; }
+        public int CommentLineCount { get; private set; }
+        public int TotalLineCount { get; private set; }
+        public int DesignerLineCount { get; private set; }
+        public int TestCodeLineCount { get; private set; }
+        public int BlankLineCount { get; private set; }
+        public int CodeLineCount { get; private set; }
 
         public Dictionary<string, int> LinesOfCodePerExtension { get; } = new Dictionary<string, int>();
 
-        private static IEnumerable<FileInfo> GetFiles(List<string> filesToCheck, string[] codeFilePatterns)
+        public void FindAndAnalyzeCodeFiles(string filePattern, string directoriesToIgnore, IEnumerable<string> filesToCheck)
         {
-            foreach (var file in filesToCheck)
-            {
-                if (codeFilePatterns.Contains(Path.GetExtension(file), StringComparer.InvariantCultureIgnoreCase))
-                {
-                    FileInfo fileInfo;
-                    try
-                    {
-                        fileInfo = new FileInfo(file);
-                    }
-                    catch
-                    {
-                        continue;
-                    }
-
-                    yield return fileInfo;
-                }
-            }
-        }
-
-        public void FindAndAnalyzeCodeFiles(string filePattern, string directoriesToIgnore, List<string> filesToCheck)
-        {
-            var filters = filePattern.Replace("*", "").Split(';');
+            var extensions = filePattern.Replace("*", "").Split(';').ToHashSet(StringComparer.InvariantCultureIgnoreCase);
             var directoryFilter = directoriesToIgnore.Split(';');
             var lastUpdate = DateTime.Now;
             var timer = TimeSpan.FromMilliseconds(500);
 
-            foreach (var file in GetFiles(filesToCheck, filters))
+            foreach (var file in GetFiles())
             {
                 if (DirectoryIsFiltered(file.Directory, directoryFilter))
                 {
                     continue;
                 }
 
-                var codeFile = new CodeFile(file.FullName);
-                codeFile.CountLines();
+                AddFile(file);
 
-                CalculateSums(codeFile);
-
-                if (LinesOfCodeUpdated != null && DateTime.Now - lastUpdate > timer)
+                if (Updated != null && DateTime.Now - lastUpdate > timer)
                 {
                     lastUpdate = DateTime.Now;
-                    LinesOfCodeUpdated(this, EventArgs.Empty);
+                    Updated(this, EventArgs.Empty);
                 }
             }
 
-            LinesOfCodeUpdated?.Invoke(this, EventArgs.Empty);
+            Updated?.Invoke(this, EventArgs.Empty);
 
             return;
 
@@ -74,34 +50,53 @@ namespace GitStatistics
                 return directoryFilters.Any(
                     filter => dir.FullName.EndsWith(filter, StringComparison.InvariantCultureIgnoreCase));
             }
-        }
 
-        private void CalculateSums(CodeFile codeFile)
-        {
-            NumberLines += codeFile.NumberLines;
-            NumberBlankLines += codeFile.NumberBlankLines;
-            NumberCommentsLines += codeFile.NumberCommentsLines;
-            NumberLinesInDesignerFiles += codeFile.NumberLinesInDesignerFiles;
-
-            var codeLines =
-                codeFile.NumberLines -
-                codeFile.NumberBlankLines -
-                codeFile.NumberCommentsLines -
-                codeFile.NumberLinesInDesignerFiles;
-
-            var extension = codeFile.File.Extension.ToLower();
-
-            if (!LinesOfCodePerExtension.ContainsKey(extension))
+            IEnumerable<FileInfo> GetFiles()
             {
-                LinesOfCodePerExtension.Add(extension, 0);
+                foreach (var file in filesToCheck)
+                {
+                    if (extensions.Contains(Path.GetExtension(file)))
+                    {
+                        FileInfo fileInfo;
+                        try
+                        {
+                            fileInfo = new FileInfo(file);
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+
+                        yield return fileInfo;
+                    }
+                }
             }
 
-            LinesOfCodePerExtension[extension] += codeLines;
-            NumberCodeLines += codeLines;
-
-            if (codeFile.IsTestFile || codeFile.File.Directory?.FullName.IndexOf("test", StringComparison.OrdinalIgnoreCase) >= 0)
+            void AddFile(FileInfo file)
             {
-                NumberTestCodeLines += codeLines;
+                if (!file.Exists)
+                {
+                    return;
+                }
+
+                var codeFile = CodeFile.Parse(file);
+
+                TotalLineCount += codeFile.TotalLineCount;
+                BlankLineCount += codeFile.BlankLineCount;
+                CommentLineCount += codeFile.CommentLineCount;
+                DesignerLineCount += codeFile.DesignerLineCount;
+
+                var extension = file.Extension.ToLower();
+
+                LinesOfCodePerExtension.TryGetValue(extension, out var linesForExtensions);
+                LinesOfCodePerExtension[extension] = linesForExtensions + codeFile.CodeLineCount;
+
+                CodeLineCount += codeFile.CodeLineCount;
+
+                if (codeFile.IsTestFile || file.Directory?.FullName.Contains("test", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    TestCodeLineCount += codeFile.CodeLineCount;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #5190

Changes proposed in this pull request:
- Include `*.ts` files in statistics
- Refactor statistics generation for performance
 
What did I do to test the code and ensure quality:
- Manual testing on repositories containing TypeScript files

Has been tested on:
- GIT 2.18
- Windows 10
