### PR TITLE
Fix parsing of remote URLs that contain spaces

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2311,12 +2311,17 @@ namespace GitCommands
             return ReadGitOutputLines("remote").Where(r => !string.IsNullOrWhiteSpace(r)).ToList();
         }
 
-        private static readonly Regex _remoteVerboseLineRegex = new Regex(@"^(?<name>[^	]+)\t(?<url>[^ ]+) \((?<direction>fetch|push)\)$", RegexOptions.Compiled);
+        private static readonly Regex _remoteVerboseLineRegex = new Regex(@"^(?<name>[^	]+)\t(?<url>.+?) \((?<direction>fetch|push)\)$", RegexOptions.Compiled);
 
         public IReadOnlyList<Remote> GetRemotes()
         {
+            return ParseRemotesInternal(ReadGitOutputLines("remote -v"));
+        }
+
+        [NotNull]
+        internal static IReadOnlyList<Remote> ParseRemotesInternal([NotNull, InstantHandle] IEnumerable<string> lines)
+        {
             var remotes = new List<Remote>();
-            var lines = ReadGitOutputLines("remote -v");
 
             /*
              * $ git remote -v

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using GitCommands;
@@ -8,7 +9,7 @@ using NUnit.Framework;
 namespace GitCommandsTests
 {
     [TestFixture]
-    public class GitModuleTest
+    public sealed class GitModuleTest
     {
         private GitModule _gitModule;
 
@@ -243,6 +244,48 @@ namespace GitCommandsTests
             Assert.IsFalse(refs[3].IsRemote);
             Assert.IsTrue(refs[3].IsTag);
             Assert.AreSame(_gitModule, refs[3].Module);
+        }
+
+        [Test]
+        public void ParseRemotes()
+        {
+            var lines = new[]
+            {
+                "RussKie\tgit://github.com/RussKie/gitextensions.git (fetch)",
+                "RussKie\tgit://github.com/RussKie/gitextensions.git (push)",
+                "origin\tgit@github.com:drewnoakes/gitextensions.git (fetch)",
+                "origin\tgit@github.com:drewnoakes/gitextensions.git (push)",
+                "upstream\tgit@github.com:gitextensions/gitextensions.git (fetch)",
+                "upstream\tgit@github.com:gitextensions/gitextensions.git (push)",
+                "asymmetrical\thttps://github.com/gitextensions/fetch.git (fetch)",
+                "asymmetrical\thttps://github.com/gitextensions/push.git (push)",
+                "with-space\tc:\\Bare Repo (fetch)",
+                "with-space\tc:\\Bare Repo (push)"
+            };
+
+            var remotes = GitModule.ParseRemotesInternal(lines);
+
+            Assert.AreEqual(5, remotes.Count);
+
+            Assert.AreEqual("RussKie", remotes[0].Name);
+            Assert.AreEqual("git://github.com/RussKie/gitextensions.git", remotes[0].FetchUrl);
+            Assert.AreEqual("git://github.com/RussKie/gitextensions.git", remotes[0].PushUrl);
+
+            Assert.AreEqual("origin", remotes[1].Name);
+            Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[1].FetchUrl);
+            Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[1].PushUrl);
+
+            Assert.AreEqual("upstream", remotes[2].Name);
+            Assert.AreEqual("git@github.com:gitextensions/gitextensions.git", remotes[2].FetchUrl);
+            Assert.AreEqual("git@github.com:gitextensions/gitextensions.git", remotes[2].PushUrl);
+
+            Assert.AreEqual("asymmetrical", remotes[3].Name);
+            Assert.AreEqual("https://github.com/gitextensions/fetch.git", remotes[3].FetchUrl);
+            Assert.AreEqual("https://github.com/gitextensions/push.git", remotes[3].PushUrl);
+
+            Assert.AreEqual("with-space", remotes[4].Name);
+            Assert.AreEqual("c:\\Bare Repo", remotes[4].FetchUrl);
+            Assert.AreEqual("c:\\Bare Repo", remotes[4].PushUrl);
         }
     }
 }


### PR DESCRIPTION
Fixes #5232

Changes proposed in this pull request:
- Fix incorrect assumption in Regex that remote URL cannot contain a space
 
Screenshots before and after (if PR changes UI):

![image](https://user-images.githubusercontent.com/350947/43321113-c7f00f4c-91a2-11e8-9908-80425bbf996d.png)

What did I do to test the code and ensure quality:
- Manual testing (thanks to @pmme for clear repro steps)

Has been tested on:
- GIT 2.18
- Windows 10
