### PR TITLE
Workaround consecutive null bytes from git log

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -224,6 +224,15 @@ namespace GitCommands
             // at the beginning of the chunk. The latter part of the chunk will require
             // decoding as a string.
 
+            if (chunk.Count == 0)
+            {
+                // "git log -z --name-only" returns multiple consecutive null bytes when logging
+                // the history of a single file. Haven't worked out why, but it's safe to skip
+                // such chunks.
+                revision = default;
+                return false;
+            }
+
             #region Object ID, Tree ID, Parent IDs
 
             // The first 40 bytes are the revision ID and the tree ID back to back


### PR DESCRIPTION
`git log -z --name-only` returns multiple consecutive null bytes. This may be a bug in git, or may not, but it causes parsing to fail.

This change works around the issue.

Changes proposed in this pull request:
- Skip zero length chunks in git log output
 
What did I do to test the code and ensure quality:
- Manual testing
- Asked question on git mailing list to see whether this is a bug or signal of something else

Has been tested on:
- GIT 2.18.0.windows.1
- Windows 10
