### PR TITLE
GitModule uses ObjectId in a few more places

### DIFF
--- a/GitCommands/ArgumentBuilder.cs
+++ b/GitCommands/ArgumentBuilder.cs
@@ -37,6 +37,8 @@ namespace GitCommands
     {
         private readonly StringBuilder _command = new StringBuilder(capacity: 16);
 
+        public bool IsEmpty => _command.Length == 0;
+
         /// <summary>
         /// Adds <paramref name="s"/> to the argument list.
         /// </summary>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -727,16 +727,18 @@ namespace GitCommands
             return result;
         }
 
-        public void EditNotes(string revision)
+        public void EditNotes(ObjectId commitId)
         {
-            string editor = GetEffectiveSetting("core.editor").ToLower();
+            var arguments = new ArgumentBuilder { "notes", "edit", commitId };
+            var editor = GetEffectiveSetting("core.editor").ToLower();
+
             if (editor.Contains("gitextensions") || editor.Contains("notepad"))
             {
-                RunGitCmd("notes edit " + revision);
+                RunGitCmd(arguments);
             }
             else
             {
-                RunExternalCmdShowConsole(AppSettings.GitCommand, "notes edit " + revision);
+                RunExternalCmdShowConsole(AppSettings.GitCommand, arguments.ToString());
             }
         }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1165,12 +1165,7 @@ namespace GitCommands
             return GetParents(objectId).Count > 1;
         }
 
-        public GitRevision GetRevision(ObjectId objectId, bool shortFormat = false, bool loadRefs = false)
-        {
-            return GetRevision(objectId.ToString(), shortFormat, loadRefs);
-        }
-
-        public GitRevision GetRevision(string commit, bool shortFormat = false, bool loadRefs = false)
+        public GitRevision GetRevision([CanBeNull] ObjectId objectId = null, bool shortFormat = false, bool loadRefs = false)
         {
             const string formatString =
                 /* Hash           */ "%H%n" +
@@ -1186,9 +1181,17 @@ namespace GitCommands
 
             var format = formatString + (shortFormat ? "%s" : "%B%nNotes:%n%-N");
 
-            var revInfo = RunCacheableGitCmd($"log -n1 --format=format:{format} {commit}", LosslessEncoding);
+            var args = new ArgumentBuilder
+            {
+                "log",
+                "-n1",
+                $"--format=format:{format}",
+                objectId
+            };
 
-            // TODO improve parsing to reduce temporary string (see similar code in RevisionGraph)
+            var revInfo = RunCacheableGitCmd(args.ToString(), LosslessEncoding);
+
+            // TODO improve parsing to reduce temporary string (see similar code in RevisionReader)
             string[] lines = revInfo.Split('\n');
 
             var revision = new GitRevision(ObjectId.Parse(lines[0]))

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs
 
             FileName = fileName;
 
-            blameControl1.LoadBlame(revision ?? Module.GetRevision("Head"), null, fileName, null, null, Module.FilesEncoding, initialLine);
+            blameControl1.LoadBlame(revision ?? Module.GetRevision(), null, fileName, null, null, Module.FilesEncoding, initialLine);
         }
 
         public string FileName { get; set; }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2009,7 +2009,7 @@ namespace GitUI.CommandsDialogs
 
         private void AddNotes()
         {
-            Module.EditNotes(RevisionGrid.GetSelectedRevisions().Count > 0 ? RevisionGrid.GetSelectedRevisions()[0].Guid : string.Empty);
+            Module.EditNotes(RevisionGrid.GetSelectedRevisions().FirstOrDefault()?.ObjectId);
             FillCommitInfo();
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1060,8 +1060,6 @@ namespace GitUI.CommandsDialogs
 
                 _loadUnstagedOutputFirstTime = false;
             }
-
-            return;
         }
 
         private void RestoreSelectedFiles(IReadOnlyList<GitItemStatus> unstagedFiles, IReadOnlyList<GitItemStatus> stagedFiles, IReadOnlyList<GitItemStatus> lastSelection)

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -655,7 +655,7 @@ namespace GitUI.CommitInfo
 
         private void addNoteToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Module.EditNotes(_revision.Guid);
+            Module.EditNotes(_revision.ObjectId);
             ReloadCommitInfo();
         }
 

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -140,24 +140,6 @@ namespace GitUI.UserControls
             }
         }
 
-        public void SetCurrentBranch(string branch, bool remote)
-        {
-            // Set current branch after initialize, because initialize will reset it
-            if (!string.IsNullOrEmpty(branch))
-            {
-                Branches.Items.Add(branch);
-                Branches.SelectedItem = branch;
-            }
-
-            if (_containRevisions != null)
-            {
-                if (Branches.Items.Count == 0)
-                {
-                    Initialize(remote, _containRevisions);
-                }
-            }
-        }
-
         private void LocalBranch_CheckedChanged(object sender, EventArgs e)
         {
             Branches.Focus();

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -74,54 +74,54 @@ namespace GitUI.UserControls.RevisionGrid
 
         public string GetRevisionFilter()
         {
-            var filter = "";
+            var filter = new ArgumentBuilder();
+
             if (AuthorCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Author.Text))
             {
-                filter += string.Format(" --author=\"{0}\"", Author.Text);
+                filter.Add($"--author=\"{Author.Text}\"");
             }
 
             if (CommitterCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Committer.Text))
             {
-                filter += string.Format(" --committer=\"{0}\"", Committer.Text);
+                filter.Add($"--committer=\"{Committer.Text}\"");
             }
 
             if (MessageCheck.Checked && GitCommandHelpers.VersionInUse.IsRegExStringCmdPassable(Message.Text))
             {
-                filter += string.Format(" --grep=\"{0}\"", Message.Text);
+                filter.Add($"--grep=\"{Message.Text}\"");
             }
 
-            if (!string.IsNullOrEmpty(filter) && IgnoreCase.Checked)
+            if (!filter.IsEmpty && IgnoreCase.Checked)
             {
-                filter += " --regexp-ignore-case";
+                filter.Add("--regexp-ignore-case");
             }
 
             if (SinceCheck.Checked)
             {
-                filter += string.Format(" --since=\"{0}\"", Since.Value.ToString("yyyy-MM-dd hh:mm:ss"));
+                filter.Add($"--since=\"{Since.Value:yyyy-MM-dd hh:mm:ss}\"");
             }
 
             if (CheckUntil.Checked)
             {
-                filter += string.Format(" --until=\"{0}\"", Until.Value.ToString("yyyy-MM-dd hh:mm:ss"));
+                filter.Add($"--until=\"{Until.Value:yyyy-MM-dd hh:mm:ss}\"");
             }
 
             if (LimitCheck.Checked && _NO_TRANSLATE_Limit.Value > 0)
             {
-                filter += string.Format(" --max-count=\"{0}\"", (int)_NO_TRANSLATE_Limit.Value);
+                filter.Add($"--max-count=\"{(int)_NO_TRANSLATE_Limit.Value}\"");
             }
 
-            return filter;
+            return filter.ToString();
         }
 
         public string GetPathFilter()
         {
-            var filter = "";
             if (FileFilterCheck.Checked)
             {
-                filter += string.Format(" \"{0}\"", FileFilter.Text.ToPosixPath());
+                return FileFilter.Text.ToPosixPath().Quote();
             }
 
-            return filter;
+            return "";
         }
 
         public bool ShouldHideGraph()

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -121,11 +121,11 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                             break;
 
                         case CommitKind.Squash:
-                            Assert.True(_commands.StartSquashCommitDialog(owner: null, _referenceRepository.Module.GetRevision("HEAD")));
+                            Assert.True(_commands.StartSquashCommitDialog(owner: null, _referenceRepository.Module.GetRevision()));
                             break;
 
                         case CommitKind.Fixup:
-                            Assert.True(_commands.StartFixupCommitDialog(owner: null, _referenceRepository.Module.GetRevision("HEAD")));
+                            Assert.True(_commands.StartFixupCommitDialog(owner: null, _referenceRepository.Module.GetRevision()));
                             break;
 
                         default:


### PR DESCRIPTION
Changes proposed in this pull request:
- `GitModule.EditNotes` accepts `ObjectId`
- `GitModule.GetRevision` only accepts `ObjectId` (removing overload that accepts string in favour of allowing a `null` `ObjectId` to represent `HEAD`, as is done elsewhere)
- Use of local functions, `ArgumentBuilder`
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
