### PR TITLE
Validate bounds width/height before paint

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -113,7 +113,9 @@ namespace GitUI.UserControls.RevisionGrid
 
             void OnRowPrePaint(object sender, DataGridViewRowPrePaintEventArgs e)
             {
-                if (e.PaintParts.HasFlag(DataGridViewPaintParts.Background))
+                if (e.PaintParts.HasFlag(DataGridViewPaintParts.Background) &&
+                    e.RowBounds.Width > 0 &&
+                    e.RowBounds.Height > 0)
                 {
                     // Draw row background
                     var backBrush = GetBackground(e.State, e.RowIndex);


### PR DESCRIPTION
Relates to #5236. Can't validate that it fixes the issue, as I cannot reproduce it.

Changes proposed in this pull request:
- Ensure the bounds width & height are both greater than zero before painting
 
What did I do to test the code and ensure quality:
- Can't test this as cannot repro original bug. It seems like this would fix the problem, and the change is benign.

Has been tested on:
- GIT 2.18
- Windows 10
