### PR TITLE
The process id can not be read before the process is started.

### DIFF
--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -127,8 +127,8 @@ namespace GitUI.UserControls
 
                 var operation = CommandLog.LogProcessStart(command, arguments);
                 process.Exited += (s, e) => operation.LogProcessEnd();
-                operation.SetProcessId(process.Id);
                 process.Start();
+                operation.SetProcessId(process.Id);
                 _process = process;
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes

"C:\Program Files\Git\bin\git.exe" fetch --progress "origin"

System.InvalidOperationException: Z tym obiektem nie jest skojarzony żaden proces.
   w System.Diagnostics.Process.EnsureState(State state)
   w System.Diagnostics.Process.EnsureState(State state)
   w System.Diagnostics.Process.get_Id()
   w GitUI.UserControls.EditboxBasedConsoleOutputControl.StartProcess(String command, String arguments, String workdir, Dictionary`2 envVariables) w D:\projekty\GitExt\GitUI\UserControls\EditboxBasedConsoleOutputControl.cs:wiersz 140
   w GitUI.FormProcess.ProcessStart(FormStatus form) w D:\projekty\GitExt\GitUI\FormProcess.cs:wiersz 148

command = C:\Program Files\Git\bin\git.exe
arguments = fetch --progress "origin"

