### PR TITLE
Syntax highlighting for JSM

### DIFF
--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -11,7 +11,7 @@ namespace GitStatistics
     {
         private const string _defaultCodeFiles =
             "*.c;*.cpp;*.cc;*.cxx;*.h;*.hpp;*.hxx;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" +
-            "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.ts;*.mk;*.java";
+            "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.jsm;*.ts;*.mk;*.java";
 
         private readonly StringSetting _codeFiles = new StringSetting("Code files", _defaultCodeFiles);
         private readonly StringSetting _ignoreDirectories = new StringSetting("Directories to ignore (EndsWith)", @"\Debug;\Release;\obj;\bin;\lib");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2155

Changes proposed in this pull request:
- Add syntax highlighting for `.jsm` files
- ~~~Make the loading of `AutoCompleteRegexes.txt` use async IO (this occurs during the first load of `FormCommit`)~~~

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
