### PR TITLE
Move large file warning from FormCommit to FileViewer

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -114,7 +114,6 @@ namespace GitUI.CommandsDialogs
             this.toolUnstageItem = new System.Windows.Forms.ToolStripButton();
             this.Ok = new System.Windows.Forms.Button();
             this.splitRight = new System.Windows.Forms.SplitContainer();
-            this.llShowPreview = new System.Windows.Forms.LinkLabel();
             this.SolveMergeconflicts = new System.Windows.Forms.Button();
             this.SelectedDiff = new GitUI.Editor.FileViewer();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
@@ -1024,7 +1023,6 @@ namespace GitUI.CommandsDialogs
             //
             // splitRight.Panel1
             //
-            this.splitRight.Panel1.Controls.Add(this.llShowPreview);
             this.splitRight.Panel1.Controls.Add(this.SolveMergeconflicts);
             this.splitRight.Panel1.Controls.Add(this.SelectedDiff);
             //
@@ -1035,18 +1033,6 @@ namespace GitUI.CommandsDialogs
             this.splitRight.SplitterDistance = 426;
             this.splitRight.TabIndex = 0;
             this.splitRight.TabStop = false;
-            //
-            // llShowPreview
-            //
-            this.llShowPreview.AutoSize = true;
-            this.llShowPreview.Location = new System.Drawing.Point(43, 23);
-            this.llShowPreview.Name = "llShowPreview";
-            this.llShowPreview.Size = new System.Drawing.Size(214, 13);
-            this.llShowPreview.TabIndex = 9;
-            this.llShowPreview.TabStop = true;
-            this.llShowPreview.Text = "This file is over 5 MB. Click to show preview";
-            this.llShowPreview.Visible = false;
-            this.llShowPreview.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llShowPreview_LinkClicked);
             //
             // SolveMergeconflicts
             //
@@ -1589,7 +1575,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripLabel toolStripLabel1;
         private ToolStripComboBox selectionFilter;
         private ToolStripMenuItem selectionFilterToolStripMenuItem;
-        private LinkLabel llShowPreview;
         private ContextMenuStrip UnstagedSubmoduleContext;
         private ToolStripMenuItem openSubmoduleMenuItem;
         private ToolStripMenuItem updateSubmoduleMenuItem;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1109,19 +1109,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            const long fiveMB = 5 * 1024 * 1024;
-
-            long length = GetItemLength(item.Name);
-            if (length < fiveMB)
-            {
-                SetSelectedDiff(item, staged);
-            }
-            else
-            {
-                SelectedDiff.Clear();
-                SelectedDiff.Refresh();
-                llShowPreview.Show();
-            }
+            SetSelectedDiff(item, staged);
 
             _stageSelectedLinesToolStripMenuItem.Text = staged ? _unstageSelectedLines.Text : _stageSelectedLines.Text;
             _stageSelectedLinesToolStripMenuItem.Image = staged ? toolUnstageItem.Image : toolStageItem.Image;
@@ -1129,29 +1117,6 @@ namespace GitUI.CommandsDialogs
                 GetShortcutKeys((int)(staged ? Commands.UnStageSelectedFile : Commands.StageSelectedFile)).ToShortcutKeyDisplayString();
 
             return;
-
-            long GetItemLength(string fileName)
-            {
-                long len = -1;
-                string path = fileName;
-                if (!File.Exists(fileName))
-                {
-                    path = _fullPathResolver.Resolve(fileName);
-                }
-
-                if (File.Exists(path))
-                {
-                    len = new FileInfo(path).Length;
-                }
-
-                return len;
-            }
-        }
-
-        private void llShowPreview_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            llShowPreview.Hide();
-            SetSelectedDiff(_currentItem, _currentItemStaged);
         }
 
         private void SetSelectedDiff(GitItemStatus item, bool staged)
@@ -1172,7 +1137,6 @@ namespace GitUI.CommandsDialogs
 
         private void ClearDiffViewIfNoFilesLeft()
         {
-            llShowPreview.Hide();
             if ((Staged.IsEmpty && Unstaged.IsEmpty) || (!Unstaged.SelectedItems.Any() && !Staged.SelectedItems.Any()))
             {
                 SelectedDiff.Clear();

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -353,6 +353,7 @@ namespace GitUI.Editor
             // llShowPreview
             //
             this._NO_TRANSLATE_lblShowPreview.AutoSize = true;
+            this._NO_TRANSLATE_lblShowPreview.BackColor = System.Drawing.Color.White;
             this._NO_TRANSLATE_lblShowPreview.Location = new System.Drawing.Point(43, 23);
             this._NO_TRANSLATE_lblShowPreview.Name = "_NO_TRANSLATE_lblShowPreview";
             this._NO_TRANSLATE_lblShowPreview.Size = new System.Drawing.Size(214, 13);

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -50,6 +50,7 @@ namespace GitUI.Editor
             this.ignoreAllWhitespaces = new System.Windows.Forms.ToolStripButton();
             this.PictureBox = new System.Windows.Forms.PictureBox();
             this.revertSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._NO_TRANSLATE_lblShowPreview = new System.Windows.Forms.LinkLabel();
             this.contextMenu.SuspendLayout();
             this.fileviewerToolbar.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PictureBox)).BeginInit();
@@ -348,10 +349,23 @@ namespace GitUI.Editor
             this.revertSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
             this.revertSelectedLinesToolStripMenuItem.Text = "Revert selected lines";
             this.revertSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.revertSelectedLinesToolStripMenuItem_Click);
+            //
+            // llShowPreview
+            //
+            this._NO_TRANSLATE_lblShowPreview.AutoSize = true;
+            this._NO_TRANSLATE_lblShowPreview.Location = new System.Drawing.Point(43, 23);
+            this._NO_TRANSLATE_lblShowPreview.Name = "_NO_TRANSLATE_lblShowPreview";
+            this._NO_TRANSLATE_lblShowPreview.Size = new System.Drawing.Size(214, 13);
+            this._NO_TRANSLATE_lblShowPreview.TabIndex = 9;
+            this._NO_TRANSLATE_lblShowPreview.TabStop = true;
+            this._NO_TRANSLATE_lblShowPreview.Text = "This file is over 5 MB. Click to show preview";
+            this._NO_TRANSLATE_lblShowPreview.Visible = false;
+            this._NO_TRANSLATE_lblShowPreview.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llShowPreview_LinkClicked);
             // 
             // FileViewer
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this._NO_TRANSLATE_lblShowPreview);
             this.Controls.Add(this.PictureBox);
             this.Controls.Add(this.fileviewerToolbar);
             this.Margin = new System.Windows.Forms.Padding(0);
@@ -400,5 +414,6 @@ namespace GitUI.Editor
         private System.Windows.Forms.ToolStripMenuItem revertSelectedLinesToolStripMenuItem;
         private System.Windows.Forms.ToolStripButton ignoreAllWhitespaces;
         private System.Windows.Forms.ToolStripMenuItem ignoreAllWhitespaceChangesToolStripMenuItem;
+        private LinkLabel _NO_TRANSLATE_lblShowPreview;
     }
 }


### PR DESCRIPTION
Fixes #2272

## Changes
- Move UI for deferring display of large files to `FileViewer` from `FormBrowse` so that it appears in all places we show diffs.
- Display the actual file size in the link label text.
 
## Screenshots

### Before

![image](https://user-images.githubusercontent.com/350947/43471500-0d1b0de0-94e3-11e8-8e4d-ffc66b7fe7ac.png)

### After

![image](https://user-images.githubusercontent.com/350947/43471562-2a43824e-94e3-11e8-8790-ac9bc964db4e.png)

![image](https://user-images.githubusercontent.com/350947/43471586-3d3dc9fe-94e3-11e8-94cc-ea3a53c8410b.png)

(also applies to file tree)

## What did I do to test the code and ensure quality

- Manual testing

## Has been tested on:
- GIT 2.18
- Windows 10
