### PR TITLE
5234 part 3

### DIFF
--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -25,11 +25,13 @@ namespace GitCommands.Config
         {
             _configKeys = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-            if (name.Contains("\""))
+            var slashIndex = name.IndexOf('\"');
+
+            if (slashIndex != -1)
             {
                 // [section "subsection"] case sensitive
-                SectionName = name.Substring(0, name.IndexOf('\"')).Trim();
-                SubSection = name.Substring(name.IndexOf('\"') + 1, name.LastIndexOf('\"') - name.IndexOf('\"') - 1);
+                SectionName = name.Substring(0, slashIndex).Trim();
+                SubSection = name.Substring(slashIndex + 1, name.LastIndexOf('\"') - slashIndex - 1);
                 SubSectionCaseSensitive = true;
             }
             else if (!name.Contains("."))

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1111,7 +1111,7 @@ namespace GitCommands
                     continue;
                 }
 
-                string fileName = line.Substring(line.IndexOf(' ') + 1);
+                string fileName = line.SubstringAfter(' ');
                 GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(StagedStatus.Unknown, fileName, statusCharacter);
                 gitItemStatus.IsAssumeUnchanged = true;
                 result.Add(gitItemStatus);
@@ -1128,7 +1128,7 @@ namespace GitCommands
             {
                 char statusCharacter = line[0];
 
-                string fileName = line.Substring(line.IndexOf(' ') + 1);
+                string fileName = line.SubstringAfter(' ');
                 GitItemStatus gitItemStatus = GitItemStatusFromStatusCharacter(StagedStatus.Unknown, fileName, statusCharacter);
                 if (gitItemStatus.IsSkipWorktree)
                 {
@@ -1221,9 +1221,11 @@ namespace GitCommands
         [CanBeNull]
         public static string GetFileExtension(string fileName)
         {
-            if (fileName.Contains(".") && fileName.LastIndexOf(".") < fileName.Length)
+            var index = fileName.LastIndexOf('.');
+
+            if (index != -1)
             {
-                return fileName.Substring(fileName.LastIndexOf('.') + 1);
+                return fileName.Substring(index + 1);
             }
 
             return null;

--- a/GitCommands/Git/GitDirectoryResolver.cs
+++ b/GitCommands/Git/GitDirectoryResolver.cs
@@ -78,10 +78,11 @@ namespace GitCommands.Git
             var gitPath = Path.Combine(repositoryPath, ".git");
             if (_fileSystem.File.Exists(gitPath))
             {
-                var line = _fileSystem.File.ReadLines(gitPath).FirstOrDefault(l => l.StartsWith("gitdir:"));
+                const string gitdir = "gitdir:";
+                var line = _fileSystem.File.ReadLines(gitPath).FirstOrDefault(l => l.StartsWith(gitdir));
                 if (line != null)
                 {
-                    string path = line.Substring(7).Trim().ToNativePath();
+                    string path = line.Substring(gitdir.Length).Trim().ToNativePath();
                     if (Path.IsPathRooted(path))
                     {
                         return path.EnsureTrailingPathSeparator();

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1538,9 +1538,11 @@ namespace GitCommands
                 var lines = File.ReadLines(WorkingDir + ".git");
                 foreach (string line in lines)
                 {
-                    if (line.StartsWith("gitdir:"))
+                    const string gitdir = "gitdir:";
+
+                    if (line.StartsWith(gitdir))
                     {
-                        string gitPath = line.Substring(7).Trim();
+                        string gitPath = line.Substring(gitdir.Length).Trim();
                         int pos = gitPath.IndexOf("/.git/modules/");
                         if (pos != -1)
                         {
@@ -2862,7 +2864,7 @@ namespace GitCommands
                 return "";
             }
 
-            return remote + "/" + (merge.StartsWith("refs/heads/") ? merge.Substring(11) : merge);
+            return $"{remote}/{merge.RemovePrefix(GitRefName.RefsHeadsPrefix)}";
         }
 
         public IEnumerable<IGitRef> GetRemoteBranches()

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -91,27 +91,22 @@ namespace GitCommands
             {
                 if (IsRemote)
                 {
-                    return CompleteName.Substring(CompleteName.LastIndexOf("remotes/") + 8);
+                    return CompleteName.SubstringAfterLast("remotes/");
                 }
 
                 if (IsTag)
                 {
                     // we need the one containing ^{}, because it contains the reference
-                    var temp =
-                        CompleteName.Contains(GitRefName.TagDereferenceSuffix)
-                            ? CompleteName.Substring(0, CompleteName.Length - GitRefName.TagDereferenceSuffix.Length)
-                            : CompleteName;
-
-                    return temp.Substring(CompleteName.LastIndexOf("tags/") + 5);
+                    return CompleteName.RemoveSuffix(GitRefName.TagDereferenceSuffix).SubstringAfterLast("tags/");
                 }
 
                 if (IsHead)
                 {
-                    return CompleteName.Substring(CompleteName.LastIndexOf("heads/") + 6);
+                    return CompleteName.SubstringAfterLast("heads/");
                 }
 
                 // if we don't know ref type then we don't know if '/' is a valid ref character
-                return CompleteName.SkipStr("refs/");
+                return CompleteName.SubstringAfter("refs/");
             }
         }
 
@@ -180,11 +175,7 @@ namespace GitCommands
         /// <inheritdoc />
         public string GetMergeWith(ISettingsValueGetter configFile)
         {
-            var merge = configFile.GetValue(_mergeSettingName);
-
-            return merge.StartsWith(GitRefName.RefsHeadsPrefix)
-                ? merge.Substring(GitRefName.RefsHeadsPrefix.Length)
-                : merge;
+            return configFile.GetValue(_mergeSettingName).RemovePrefix(GitRefName.RefsHeadsPrefix);
         }
 
         public static GitRef NoHead(GitModule module)

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
+// ReSharper disable once CheckNamespace
+
 namespace System
 {
     public static class DateTimeExtensions
@@ -25,69 +27,131 @@ namespace System
 
     public static class StringExtensions
     {
-        /// <summary>'\n'</summary>
-        private static readonly char[] NewLineSeparator = { '\n' };
+        private static readonly char[] _newLine = { '\n' };
+        private static readonly char[] _space = { ' ' };
 
+        // NOTE ordinal string comparison is the default as most string comparison in GE is against static ASCII output from git.exe
+
+        /// <summary>
+        /// Returns <paramref name="str"/> without <paramref name="prefix"/>.
+        /// If <paramref name="prefix"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
         [Pure]
-        [CanBeNull]
-        public static string SkipStr([CanBeNull] this string str, [NotNull] string toSkip)
+        [NotNull]
+        public static string RemovePrefix([NotNull] this string str, [NotNull] string prefix, StringComparison comparison = StringComparison.Ordinal)
         {
-            if (str == null)
-            {
-                return null;
-            }
-
-            var idx = str.IndexOf(toSkip);
-            if (idx != -1)
-            {
-                return str.Substring(idx + toSkip.Length);
-            }
-            else
-            {
-                return null;
-            }
+            return str.StartsWith(prefix, comparison)
+                ? str.Substring(prefix.Length)
+                : str;
         }
 
+        /// <summary>
+        /// Returns <paramref name="str"/> without <paramref name="suffix"/>.
+        /// If <paramref name="suffix"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
         [Pure]
-        [ContractAnnotation("str:null=>null")]
-        [ContractAnnotation("str:notnull=>notnull")]
-        public static string SubstringUntil([CanBeNull] this string str, [NotNull] string untilStr)
+        [NotNull]
+        public static string RemoveSuffix([NotNull] this string str, [NotNull] string suffix, StringComparison comparison = StringComparison.Ordinal)
         {
-            if (str == null)
-            {
-                return null;
-            }
-
-            var idx = str.IndexOf(untilStr);
-            if (idx != -1)
-            {
-                return str.Substring(0, idx);
-            }
-            else
-            {
-                return str;
-            }
+            return str.EndsWith(suffix, comparison)
+                ? str.Substring(0, str.Length - suffix.Length)
+                : str;
         }
 
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the first
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
         [Pure]
-        [ContractAnnotation("str:null=>null")]
-        [ContractAnnotation("str:notnull=>notnull")]
-        public static string SubstringUntil(this string str, char untilChar)
+        [NotNull]
+        public static string SubstringUntil([NotNull] this string str, char c)
         {
-            if (str == null)
-            {
-                return null;
-            }
+            var index = str.IndexOf(c);
 
-            var idx = str.IndexOf(untilChar);
-            if (idx != -1)
-            {
-                return str.Substring(0, idx);
-            }
-            else
-            {
-                return str;
-            }
+            return index != -1
+                ? str.Substring(0, index)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the last
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringUntilLast([NotNull] this string str, char c)
+        {
+            var index = str.LastIndexOf(c);
+
+            return index != -1
+                ? str.Substring(0, index)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> after (and excluding) the first
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfter([NotNull] this string str, char c)
+        {
+            var index = str.IndexOf(c);
+
+            return index != -1
+                ? str.Substring(index + 1)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the first
+        /// instance of string <paramref name="s"/>.
+        /// If <paramref name="s"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfter([NotNull] this string str, string s, StringComparison comparison = StringComparison.Ordinal)
+        {
+            var index = str.IndexOf(s, comparison);
+
+            return index != -1
+                ? str.Substring(index + s.Length)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> after (and excluding) the last
+        /// instance of character <paramref name="c"/>.
+        /// If <paramref name="c"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfterLast([NotNull] this string str, char c)
+        {
+            var index = str.LastIndexOf(c);
+
+            return index != -1
+                ? str.Substring(index + 1)
+                : str;
+        }
+
+        /// <summary>
+        /// Returns the substring of <paramref name="str"/> up until (and excluding) the last
+        /// instance of string <paramref name="s"/>.
+        /// If <paramref name="s"/> is not found, <paramref name="str"/> is returned unchanged.
+        /// </summary>
+        [Pure]
+        [NotNull]
+        public static string SubstringAfterLast([NotNull] this string str, string s, StringComparison comparison = StringComparison.Ordinal)
+        {
+            var index = str.LastIndexOf(s, comparison);
+
+            return index != -1
+                ? str.Substring(index + s.Length)
+                : str;
         }
 
         [Pure]
@@ -241,9 +305,7 @@ namespace System
         /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
         [Pure]
         [NotNull]
-        public static string[] SplitLines([NotNull] this string value) => value.Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
-
-        private static readonly char[] _space = new[] { ' ' };
+        public static string[] SplitLines([NotNull] this string value) => value.Split(_newLine, StringSplitOptions.RemoveEmptyEntries);
 
         /// <summary>Split a string, delimited by the space character, excluding empty entries.</summary>
         [Pure]
@@ -284,8 +346,7 @@ namespace System
         /// true if the <paramref name="other"/> parameter occurs within <paramref name="str"/>,
         /// or if <paramref name="other"/> is the empty string (""); otherwise, false.
         /// </returns>
-        public static bool Contains([NotNull]this string str, [NotNull] string other,
-            StringComparison stringComparison)
+        public static bool Contains([NotNull] this string str, [NotNull] string other, StringComparison stringComparison)
         {
             return str.IndexOf(other, stringComparison) != -1;
         }

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -166,7 +166,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             if (_prevTitle == _titleTB.Text && !_yourBranchesCB.Text.IsNullOrWhiteSpace() && MyRemote != null)
             {
                 var lastMsg = Module.GetPreviousCommitMessages(1, MyRemote.Name.Combine("/", _yourBranchesCB.Text)).FirstOrDefault();
-                _titleTB.Text = lastMsg.SubstringUntil("\n");
+                _titleTB.Text = lastMsg?.SubstringUntil('\n');
                 _prevTitle = _titleTB.Text;
             }
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -320,16 +320,7 @@ See the changes in the commit form.");
                 gitItem.ObjectType == GitObjectType.Blob &&
                 !string.IsNullOrWhiteSpace(gitItem.FileName))
             {
-                var fileName = gitItem.FileName;
-                if (fileName.Contains("\\") && fileName.LastIndexOf("\\", StringComparison.Ordinal) < fileName.Length)
-                {
-                    fileName = fileName.Substring(fileName.LastIndexOf('\\') + 1);
-                }
-
-                if (fileName.Contains("/") && fileName.LastIndexOf("/", StringComparison.Ordinal) < fileName.Length)
-                {
-                    fileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
-                }
+                var fileName = gitItem.FileName.SubstringAfterLast('/').SubstringAfterLast('\\');
 
                 fileName = (Path.GetTempPath() + fileName).ToNativePath();
                 Module.SaveBlobAs(fileName, gitItem.Guid);

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -98,7 +98,7 @@ namespace GitUI.Hotkey
             var culture = CultureInfo.CurrentCulture; // TODO: replace this with the GitExtensions language setting
 
             // for modifier keys this yields for example "Ctrl+None" thus we have to strip the rest after the +
-            return new KeysConverter().ConvertToString(null, culture, key).SubstringUntil("+");
+            return new KeysConverter().ConvertToString(null, culture, key)?.SubstringUntil('+');
         }
     }
 }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -81,24 +81,13 @@ namespace GitUI.Script
 
         private static string GetRemotePath(string url)
         {
-            Uri uri;
-            string path = "";
-            if (Uri.TryCreate(url, UriKind.Absolute, out uri))
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+                Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
             {
-                path = uri.LocalPath;
-            }
-            else if (Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
-            {
-                path = uri.LocalPath;
+                return uri.LocalPath.SubstringAfterLast('.');
             }
 
-            int pos = path.LastIndexOf(".");
-            if (pos >= 0)
-            {
-                path = path.Substring(0, pos);
-            }
-
-            return path;
+            return "";
         }
 
         private static bool RunScript(IWin32Window owner, GitModule module, ScriptInfo scriptInfo, RevisionGridControl revisionGrid)

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
@@ -158,7 +158,7 @@ namespace TfsIntegration
 
         private static BuildInfo CreateBuildInfo(IBuild buildDetail)
         {
-            var objectId = ObjectId.Parse(buildDetail.Revision.Substring(buildDetail.Revision.LastIndexOf(":") + 1));
+            var objectId = ObjectId.Parse(buildDetail.Revision.SubstringAfter(':'));
 
             return new BuildInfo
             {

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -112,28 +112,12 @@ namespace Gerrit
                 {
                     if (hadNewChanges)
                     {
-                        change = line;
-                        const string remotePrefix = "remote:";
-
-                        if (change.StartsWith(remotePrefix))
-                        {
-                            change = change.Substring(remotePrefix.Length);
-                        }
-
-                        int escapePos = change.LastIndexOf((char)27);
-                        if (escapePos != -1)
-                        {
-                            change = change.Substring(0, escapePos);
-                        }
-
-                        change = change.Trim();
-
-                        int spacePos = change.IndexOf(' ');
-                        if (spacePos != -1)
-                        {
-                            change = change.Substring(0, spacePos);
-                        }
-
+                        const char esc = (char)27;
+                        change = line
+                            .RemovePrefix("remote:")
+                            .SubstringUntilLast(esc)
+                            .Trim()
+                            .SubstringUntil(' ');
                         break;
                     }
                     else if (line.Contains("New Changes"))

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -25,7 +25,6 @@ namespace GitFlow
         private readonly AsyncLoader _task = new AsyncLoader();
 
         public bool IsRefreshNeeded { get; set; }
-        private const string RefHeads = "refs/heads/";
 
         private string CurrentBranch { get; set; }
 
@@ -344,7 +343,8 @@ namespace GitFlow
         {
             var head = _gitUiCommands.GitModule.RunGitCmd("symbolic-ref HEAD").Trim('*', ' ', '\n', '\r');
             lblHead.Text = head;
-            var currentRef = head.StartsWith(RefHeads) ? head.Substring(RefHeads.Length) : head;
+
+            var currentRef = head.RemovePrefix(GitRefName.RefsHeadsPrefix);
 
             if (TryExtractBranchFromHead(currentRef, out var branchTypes, out var branchName))
             {

--- a/UnitTests/GitCommandsTests/StringExtensionTests.cs
+++ b/UnitTests/GitCommandsTests/StringExtensionTests.cs
@@ -27,5 +27,111 @@ namespace GitCommandsTests
         {
             Assert.AreEqual(expected, str.Contains(other, StringComparison.InvariantCultureIgnoreCase));
         }
+
+        [TestCase("ABCDEFG", "ABC", "DEFG")]
+        [TestCase("ABCDEFG", "AB", "CDEFG")]
+        [TestCase("ABCDEFG", "A", "BCDEFG")]
+        [TestCase("ABCDEFG", "", "ABCDEFG")]
+        [TestCase("ABCDEFG", "XYZ", "ABCDEFG")]
+        [TestCase("AB", "ABCD", "AB")]
+        public void RemovePrefix_works_as_expected(string str, string prefix, string expected)
+        {
+            Assert.AreEqual(expected, str.RemovePrefix(prefix));
+        }
+
+        [TestCase("ABCDEFG", "EFG", "ABCD")]
+        [TestCase("ABCDEFG", "FG", "ABCDE")]
+        [TestCase("ABCDEFG", "G", "ABCDEF")]
+        [TestCase("ABCDEFG", "", "ABCDEFG")]
+        [TestCase("ABCDEFG", "XYZ", "ABCDEFG")]
+        [TestCase("CD", "ABCD", "CD")]
+        [TestCase("", "ABCD", "")]
+        [TestCase("ABCD", "", "ABCD")]
+        public void RemoveSuffix_works_as_expected(string str, string prefix, string expected)
+        {
+            Assert.AreEqual(expected, str.RemoveSuffix(prefix));
+        }
+
+        [TestCase("ABCDEFG", 'A', "")]
+        [TestCase("ABCDEFG", 'B', "A")]
+        [TestCase("ABCDEFG", 'C', "AB")]
+        [TestCase("ABCDEFG", 'D', "ABC")]
+        [TestCase("ABCDEFG", 'E', "ABCD")]
+        [TestCase("ABCDEFG", 'Z', "ABCDEFG")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        public void SubstringUntil_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringUntil(c));
+        }
+
+        [TestCase("ABCABC", 'A', "ABC")]
+        [TestCase("ABCABC", 'B', "ABCA")]
+        [TestCase("ABCABC", 'C', "ABCAB")]
+        [TestCase("ABCABC", 'Z', "ABCABC")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        [TestCase("AAAA", 'A', "AAA")]
+        public void SubstringUntilLast_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringUntilLast(c));
+        }
+
+        [TestCase("ABCDEFG", 'A', "BCDEFG")]
+        [TestCase("ABCDEFG", 'B', "CDEFG")]
+        [TestCase("ABCDEFG", 'C', "DEFG")]
+        [TestCase("ABCDEFG", 'Z', "ABCDEFG")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        [TestCase("ABBA", 'A', "BBA")]
+        public void SubstringAfter_char_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfter(c));
+        }
+
+        [TestCase("ABCDEFG", "A", "BCDEFG")]
+        [TestCase("ABCDEFG", "AB", "CDEFG")]
+        [TestCase("ABCDEFG", "B", "CDEFG")]
+        [TestCase("ABCDEFG", "C", "DEFG")]
+        [TestCase("ABCDEFG", "Z", "ABCDEFG")]
+        [TestCase("", "Z", "")]
+        [TestCase("A", "A", "")]
+        [TestCase("ABBA", "A", "BBA")]
+        public void SubstringAfter_string_works_as_expected(string str, string s, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfter(s));
+        }
+
+        [TestCase("ABCABC", 'A', "BC")]
+        [TestCase("ABCABC", 'B', "C")]
+        [TestCase("ABCABC", 'C', "")]
+        [TestCase("ABCDEFG", 'A', "BCDEFG")]
+        [TestCase("ABCDEFG", 'B', "CDEFG")]
+        [TestCase("ABCDEFG", 'C', "DEFG")]
+        [TestCase("ABCDEFG", 'Z', "ABCDEFG")]
+        [TestCase("", 'Z', "")]
+        [TestCase("A", 'A', "")]
+        [TestCase("ABBA", 'A', "")]
+        public void SubstringAfterLast_char_works_as_expected(string str, char c, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfterLast(c));
+        }
+
+        [TestCase("ABCABC", "A", "BC")]
+        [TestCase("ABCABC", "B", "C")]
+        [TestCase("ABCABC", "C", "")]
+        [TestCase("ABCDEFG", "A", "BCDEFG")]
+        [TestCase("ABCDEFG", "AB", "CDEFG")]
+        [TestCase("ABCDEFG", "B", "CDEFG")]
+        [TestCase("ABCDEFG", "BCD", "EFG")]
+        [TestCase("ABCDEFG", "C", "DEFG")]
+        [TestCase("ABCDEFG", "Z", "ABCDEFG")]
+        [TestCase("", "Z", "")]
+        [TestCase("A", "A", "")]
+        [TestCase("ABBA", "A", "")]
+        public void SubstringAfterLast_string_works_as_expected(string str, string s, string expected)
+        {
+            Assert.AreEqual(expected, str.SubstringAfterLast(s));
+        }
     }
 }


### PR DESCRIPTION
Part three from #5234

We do a lot of string manipulation. Finding indexes and obtaining
substrings can lead to verbose and confusing code, and bugs.

This change introduces a few extension methods for working with
strings that leads to clearer code in several places.

- RemovePrefix
- RemoveSuffix
- SubstringUntil
- SubstringUntilLast
- SubstringAfter
- SubstringAfterLast

It replaces some older versions of these (SkipStr, SubstringUntil) with
versions that don't special case null values.

Changes proposed in this pull request:
- Substring review and extension methods

What did I do to test the code and ensure quality:
- Manual tests
- Unit tests

Has been tested on:
- GIT 2.18
- Windows 10
