### PR TITLE
5234 part 4

### DIFF
--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -350,8 +350,8 @@ namespace GitImpact
                         // Create a new random brush for the author if none exists yet
                         if (!_brushes.ContainsKey(author))
                         {
-                            int partLength = author.Length / 3;
-                            _brushes.Add(author, new SolidBrush(Color.FromArgb(GenerateIntFromString(author.Substring(0, partLength)) % 255, GenerateIntFromString(author.Substring(partLength, partLength)) % 255, GenerateIntFromString(author.Substring(partLength)) % 255)));
+                            var color = Color.FromArgb((int)(author.GetHashCode() | 0xFF000000));
+                            _brushes.Add(author, new SolidBrush(color));
                         }
 
                         // Increase y for next block
@@ -469,11 +469,6 @@ namespace GitImpact
                     }
                 }
             }
-        }
-
-        private static int GenerateIntFromString(string text)
-        {
-            return text.Sum(c => (int)c);
         }
 
         /// <summary>


### PR DESCRIPTION
Part four from #5234

Code still generates a random colour based upon the author string, it just uses the hash code rather than string manipulation.

Changes proposed in this pull request:
- Simplify colour selection
 
What did I do to test the code and ensure quality:
- Manual tests

Has been tested on:
- GIT 2.18
- Windows 10
