### PR TITLE
fix: `FormBrowse` layout incorrect

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -382,7 +382,12 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnLoad(EventArgs e)
         {
+            SetSplitterPositions();
+            HideVariableMainMenuItems();
+            RefreshSplitViewLayout();
+            LayoutRevisionInfo();
             InternalInitialize(false);
+
             if (_startWithDashboard)
             {
                 return;
@@ -395,14 +400,9 @@ namespace GitUI.CommandsDialogs
                     new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
 
-            SetSplitterPositions();
-            HideVariableMainMenuItems();
-            RefreshSplitViewLayout();
-
             RevisionGrid.Load();
             _filterBranchHelper.InitToolStripBranchFilter();
 
-            LayoutRevisionInfo();
             RevisionGrid.Focus();
             RevisionGrid.IndexWatcher.Reset();
 


### PR DESCRIPTION
Fix the initialisation sequence to correctly set/restore spliters, layouts and menus.

Fixes #5247
Fixes #5262

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

What did I do to test the code and ensure quality:
- manual runs
