### PR TITLE
fix: Dashboard menu items are missing

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -210,8 +210,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             showCurrentBranchMenuItem.Click += showCurrentBranchMenuItem_Click;
             showCurrentBranchMenuItem.Checked = AppSettings.DashboardShowCurrentBranch;
 
-            var form = Application.OpenForms.Cast<Form>().FirstOrDefault(x => x.Name == nameof(FormBrowse));
-            if (form != null)
+            if (Parent.FindForm() is FormBrowse form)
             {
                 var menuStrip = form.FindDescendantOfType<MenuStrip>(p => p.Name == "menuStrip1");
                 var dashboardMenu = (ToolStripMenuItem)menuStrip.Items.Cast<ToolStripItem>().SingleOrDefault(p => p.Name == "dashboardToolStripMenuItem");

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -530,8 +530,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void RecentRepositoriesList_Load(object sender, EventArgs e)
         {
-            var form = Application.OpenForms.Cast<Form>().FirstOrDefault(x => x.Name == nameof(FormBrowse));
-            if (form == null)
+            if (!(Parent.FindForm() is FormBrowse form))
             {
                 return;
             }


### PR DESCRIPTION
The dashboard control got its `Parent` assigned before the form was actually opened,
this caused the main menu not available.

Fixes #5265

 
Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/4403806/43517781-3d49343e-95cd-11e8-95bd-541b54229254.png)


- after
![image](https://user-images.githubusercontent.com/4403806/43517720-052019f6-95cd-11e8-8c08-be49689a3da3.png)

