### PR TITLE
5234 part 7

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1218,19 +1218,6 @@ namespace GitCommands
             return args.ToString();
         }
 
-        [CanBeNull]
-        public static string GetFileExtension(string fileName)
-        {
-            var index = fileName.LastIndexOf('.');
-
-            if (index != -1)
-            {
-                return fileName.Substring(index + 1);
-            }
-
-            return null;
-        }
-
         // returns " --find-renames=..." according to app settings
         public static string FindRenamesOpt()
         {

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -281,5 +281,18 @@ namespace GitCommands
             exactPath = null;
             return false;
         }
+
+        [CanBeNull]
+        public static string GetFileExtension(string fileName)
+        {
+            var index = fileName.LastIndexOf('.');
+
+            if (index != -1)
+            {
+                return fileName.Substring(index + 1);
+            }
+
+            return null;
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -412,7 +412,7 @@ namespace GitUI.CommandsDialogs
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),
                     FileName = Path.GetFileName(fullName),
-                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                    DefaultExt = PathUtil.GetFileExtension(fullName),
                     AddExtension = true
                 })
                 {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1069,9 +1069,9 @@ namespace GitUI.CommandsDialogs
                     AddExtension = true
                 })
                 {
-                    fileDialog.DefaultExt = GitCommandHelpers.GetFileExtension(fileDialog.FileName);
-                    fileDialog.Filter = string.Format(_currentFormatFilter.Text, GitCommandHelpers.GetFileExtension(fileDialog.FileName)) + "|*." +
-                                        GitCommandHelpers.GetFileExtension(fileDialog.FileName) + "|" + _allFilesFilter.Text + "|*.*";
+                    var ext = PathUtil.GetFileExtension(fileDialog.FileName);
+                    fileDialog.DefaultExt = ext;
+                    fileDialog.Filter = string.Format(_currentFormatFilter.Text, ext) + "|*." + ext + "|" + _allFilesFilter.Text + "|*.*";
 
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)
                     {

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -699,7 +699,7 @@ namespace GitUI.CommandsDialogs
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),
                     FileName = Path.GetFileName(fullName),
-                    DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                    DefaultExt = PathUtil.GetFileExtension(fullName),
                     AddExtension = true
                 })
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -671,11 +671,11 @@ See the changes in the commit form.");
                     {
                         InitialDirectory = Path.GetDirectoryName(fullName),
                         FileName = Path.GetFileName(fullName),
-                        DefaultExt = GitCommandHelpers.GetFileExtension(fullName),
+                        DefaultExt = PathUtil.GetFileExtension(fullName),
                         AddExtension = true
                     })
                 {
-                    var extension = GitCommandHelpers.GetFileExtension(fileDialog.FileName);
+                    var extension = PathUtil.GetFileExtension(fileDialog.FileName);
 
                     fileDialog.Filter = $@"{_saveFileFilterCurrentFormat.Text}(*.{extension})|*.{extension}| {_saveFileFilterAllFiles.Text} (*.*)|*.*";
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -239,5 +239,19 @@ namespace GitCommandsTests.Helpers
                 }
             }
         }
+
+        [Test]
+        public void GetFileExtension()
+        {
+            Assert.AreEqual("txt", PathUtil.GetFileExtension("foo.txt"));
+            Assert.AreEqual("txt", PathUtil.GetFileExtension("foo.txt.txt"));
+            Assert.AreEqual("txt", PathUtil.GetFileExtension(".txt"));
+            Assert.AreEqual("", PathUtil.GetFileExtension("foo."));
+            Assert.AreEqual("", PathUtil.GetFileExtension("."));
+            Assert.AreEqual("", PathUtil.GetFileExtension(".."));
+            Assert.AreEqual("", PathUtil.GetFileExtension("..."));
+            Assert.Null(PathUtil.GetFileExtension("foo"));
+            Assert.Null(PathUtil.GetFileExtension(""));
+        }
     }
 }


### PR DESCRIPTION
Part seven from #5234

Changes proposed in this pull request:
- Move `GitCommandHelpers.GetFileExtension` to `PathUtil` and add tests

What did I do to test the code and ensure quality:
- Manual tests
- Unit tests

Has been tested on:
- GIT 2.18
- Windows 10
