### PR TITLE
Debug config uses release mode ICSharp.TextEditor

### DIFF
--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -692,10 +692,10 @@ Global
 		{2B9B62FA-3E0C-45C5-9287-68B69413C5DF}.ReleaseTC|Any CPU.Build.0 = Release|Any CPU
 		{2B9B62FA-3E0C-45C5-9287-68B69413C5DF}.ReleaseTC|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{2B9B62FA-3E0C-45C5-9287-68B69413C5DF}.ReleaseTC|Mixed Platforms.Build.0 = Release|Any CPU
-		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Debug|Mixed Platforms.Build.0 = Release|Any CPU
 		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2D18BE89-D210-49EB-A9DD-2246FBB3DF6D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
(Follows research into #2272 and #2253)

Changes proposed in this pull request:

The debug configuration of that project includes a DATACONSISTENCYTEST symbol that causes very slow assertion logic to run.

We used to take this dependency via NuGet, using release builds.

This change means we use the release build even during debugging, as we would have before making the project a source submodule.

Note that this results in a prompt after the first debug run in the IDE, so long as you select "continue and don't ask again".

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
