### PR TITLE
Don't pass artificial ObjectId to GitModule.GetTree

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -163,7 +163,7 @@ See the changes in the commit form.");
                 tvGitTree.Nodes.Clear();
 
                 // restore selected file and scroll position when new selection is done
-                if (_revision != null && tvGitTree.ImageList != null)
+                if (_revision != null && !_revision.IsArtificial && tvGitTree.ImageList != null)
                 {
                     _revisionFileTreeController.LoadChildren(_revision, tvGitTree.Nodes, tvGitTree.ImageList.Images);
                     ////GitTree.Sort();


### PR DESCRIPTION
Fixes #5272

Changes proposed in this pull request:
- Bypass operation for artificial commit IDs, avoiding exception later on

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
