### PR TITLE
Fix 5275

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -248,38 +248,34 @@ namespace GitCommands
         [ContractAnnotation("path:null=>false,exactPath:null")]
         public static bool TryGetExactPath(string path, out string exactPath)
         {
-            // From https://stackoverflow.com/a/29578292/24874
-
-            // DirectoryInfo accepts either a file path or a directory path, and most of its properties work for either.
-            // However, its Exists property only works for a directory path.
-            var directory = new DirectoryInfo(path);
-
-            if (File.Exists(path) || directory.Exists)
+            if (!File.Exists(path) && !Directory.Exists(path))
             {
-                var parts = new List<string>();
-
-                var parentDirectory = directory.Parent;
-                while (parentDirectory != null)
-                {
-                    var entry = parentDirectory.EnumerateFileSystemInfos(directory.Name).First();
-                    parts.Add(entry.Name);
-
-                    directory = parentDirectory;
-                    parentDirectory = directory.Parent;
-                }
-
-                // Handle the root part (i.e., drive letter or UNC \\server\share).
-                var root = directory.FullName;
-
-                parts.Add(root.Contains(':') ? root.ToUpper() : root.ToLower());
-                parts.Reverse();
-
-                exactPath = Path.Combine(parts.ToArray());
-                return true;
+                exactPath = null;
+                return false;
             }
 
-            exactPath = null;
-            return false;
+            var directory = new DirectoryInfo(path);
+
+            var parts = new List<string>();
+
+            var parentDirectory = directory.Parent;
+            while (parentDirectory != null)
+            {
+                var entry = parentDirectory.EnumerateFileSystemInfos(directory.Name).First();
+                parts.Add(entry.Name);
+
+                directory = parentDirectory;
+                parentDirectory = directory.Parent;
+            }
+
+            // Handle the root part (i.e., drive letter or UNC \\server\share).
+            var root = directory.FullName;
+
+            parts.Add(root.Contains(':') ? root.ToUpper() : root.ToLower());
+            parts.Reverse();
+
+            exactPath = Path.Combine(parts.ToArray());
+            return true;
         }
 
         [CanBeNull]

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -37,7 +37,12 @@ namespace GitUI
             Remote = "";
             ProcessInput = input;
             WorkingDirectory = workingDirectory;
-            Text += $" ({PathUtil.GetDisplayPath(WorkingDirectory)})";
+
+            var displayPath = PathUtil.GetDisplayPath(WorkingDirectory);
+            if (!string.IsNullOrWhiteSpace(displayPath))
+            {
+                Text += $" ({displayPath})";
+            }
 
             ConsoleOutput.ProcessExited += delegate { OnExit(ConsoleOutput.ExitCode); };
             ConsoleOutput.DataReceived += DataReceivedCore;

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -207,6 +207,8 @@ namespace GitCommandsTests.Helpers
                 @"Does not exist",
                 @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32",
                 @"..",
+                "",
+                " "
             };
 
             var expectedExactPaths = new Dictionary<string, string>()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5275

Changes proposed in this pull request:
- Ensure `PathUtil.tryGetExactPathName` doesn't throw on empty or whitespace inputs
- Don't show empty parenthesis in `FormProcess` title text
 
Screenshots:

![image](https://user-images.githubusercontent.com/350947/43680156-b90a6038-982b-11e8-9881-b64eff7b8994.png)

What did I do to test the code and ensure quality:
- Unit test
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
