### PR TITLE
Add two patterns to C# AutoCompleteRegexes

### DIFF
--- a/GitExtensions/AutoCompleteRegexes.txt
+++ b/GitExtensions/AutoCompleteRegexes.txt
@@ -5,7 +5,7 @@
 .build = \sname\s*=\s*\"(\w+)\"
 .cbl, .cpy = ^.{6} ([A-Z][A-Z0-9-]*)(?: SECTION)?\.
 .c, .cc, .cpp, .cxx = \s(?:[\w]+)::([\w]+)|[ \t:.>]([\w]+)\s?\([\w\s,.)]*\);|^#\s*define\s+(\w+)
-.asp, .aspx, .cs = (?:(?:(?:public|protected|private|internal)\s+(?:[\w.]+(?:\s*<[<>\w\s.,]+>)?\s+)*([\w.]+)(?:\s*<[<>\w\s.,]+>)?)|(?:namespace\s+([\w.]+)))
+.asp, .aspx, .cs = (?:(?:(?:public|protected|private|internal)\s+(?:[\w.]+(?:\s*<[<>\w\s.,]+>)?\s+)*([\w.]+)(?:\s*<[<>\w\s.,]+>)?)|(?:namespace\s+([\w.]+))|(?:new\s+([\w]+))|(?:using\s+([\w.]+)))
 .h, .hpp, .hxx = ^\s*(?:class|struct)\s+([\w]+)|^\s+(?:\w+\s+)*([\w]+)\s*\(|^#define\s+(\w+)
 .html = \"#(\w+)\"
 .java = (?:public|protected|private|internal)\s+(?:[\w.]+\s+)*([\w.]+)|class\s+([\w]+)(?:(?:\s+)?(?:extends|implements)(?:\s+)?([\w]+)?)


### PR DESCRIPTION
This adds auto-complete/dictionary entries for the commit message text box based on `new` and `using` patterns.

As an example, in a recent commit message:

> Use ArgumentBuilder and move SmartFormat reference

Before this change, both ArgumentBuilder and SmartFormat were flagged as spelling mistakes. These symbols were present in code resembling `new ArgumentBuilder` and `using SmartFormat;`.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
