### PR TITLE
Use ArgumentBuilder and move SmartFormat package reference

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -20,7 +20,6 @@ using GitUI;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
-using SmartFormat;
 
 namespace GitCommands
 {
@@ -1155,9 +1154,15 @@ namespace GitCommands
 
         public string Init(bool bare, bool shared)
         {
-            var result = RunGitCmd(Smart.Format("init{0: --bare|}{1: --shared=all|}", bare, shared));
+            var output = RunGitCmd(new ArgumentBuilder
+            {
+                "init",
+                { bare, "--bare" },
+                { shared, "--shared=all" }
+            });
+
             WorkingDirGitDir = GitDirectoryResolverInstance.Resolve(WorkingDir);
-            return result;
+            return output;
         }
 
         public bool IsMerge(ObjectId objectId)

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="SmartFormat.NET" Version="2.0.0.0" />
     <PackageReference Include="System.IO.Abstractions" Version="2.0.0.144" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/ResourceManager/ResourceManager.csproj
+++ b/ResourceManager/ResourceManager.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SmartFormat.NET" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>


### PR DESCRIPTION
SmartFormat is used by the ResourceManager project, and with this
change it's no longer needed in GitCommands. We can move the
PackageReference accordingly.

Manual testing.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->