### PR TITLE
More robust guarantees for GitModuleForm and GitModuleControl properties

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -16,9 +16,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private readonly RevisionGridControl _revisionGrid;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormBisect()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -16,9 +16,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private readonly RevisionGridControl _revisionGrid;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormBisect()
-            : this((GitUICommands)null)
         {
+            InitializeComponent();
         }
 
         private FormBisect(GitUICommands commands)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -24,9 +24,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private readonly AsyncLoader _tagsLoader = new AsyncLoader();
         private readonly AsyncLoader _branchesLoader = new AsyncLoader();
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormGoToCommit()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -24,6 +24,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private readonly AsyncLoader _tagsLoader = new AsyncLoader();
         private readonly AsyncLoader _branchesLoader = new AsyncLoader();
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormGoToCommit()
+        {
+            InitializeComponent();
+        }
+
         public FormGoToCommit(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -270,17 +270,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             void commandsSource_activate(IGitUICommandsSource sender)
             {
                 var newCommands = sender.UICommands;
-                if (newCommands != null)
-                {
-                    newCommands.PreCheckoutBranch += GitUICommands_PreCheckout;
-                    newCommands.PreCheckoutRevision += GitUICommands_PreCheckout;
-                    newCommands.PostCheckoutBranch += GitUICommands_PostCheckout;
-                    newCommands.PostCheckoutRevision += GitUICommands_PostCheckout;
-                    newCommands.PostEditGitIgnore += GitUICommands_PostEditGitIgnore;
+                newCommands.PreCheckoutBranch += GitUICommands_PreCheckout;
+                newCommands.PreCheckoutRevision += GitUICommands_PreCheckout;
+                newCommands.PostCheckoutBranch += GitUICommands_PostCheckout;
+                newCommands.PostCheckoutRevision += GitUICommands_PostCheckout;
+                newCommands.PostEditGitIgnore += GitUICommands_PostEditGitIgnore;
 
-                    var module = newCommands.Module;
-                    StartWatchingChanges(module.WorkingDir, module.WorkingDirGitDir);
-                }
+                var module = newCommands.Module;
+                StartWatchingChanges(module.WorkingDir, module.WorkingDirGitDir);
             }
 
             void GitUICommands_PreCheckout(object sender, GitUIEventArgs e)

--- a/GitUI/CommandsDialogs/FormAddFiles.cs
+++ b/GitUI/CommandsDialogs/FormAddFiles.cs
@@ -4,9 +4,7 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormAddFiles : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormAddFiles()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormAddFiles.cs
+++ b/GitUI/CommandsDialogs/FormAddFiles.cs
@@ -5,11 +5,11 @@ namespace GitUI.CommandsDialogs
     public sealed partial class FormAddFiles : GitModuleForm
     {
         /// <summary>
-        /// For VS designer
+        /// For VS designer and translation test.
         /// </summary>
         private FormAddFiles()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormAddFiles(GitUICommands commands, string addFile = null)

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -19,9 +19,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly bool _localExclude;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormAddToGitIgnore()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -19,6 +19,14 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly bool _localExclude;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormAddToGitIgnore()
+        {
+            InitializeComponent();
+        }
+
         public FormAddToGitIgnore(GitUICommands commands, bool localExclude, params string[] filePatterns)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -29,9 +29,7 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormApplyPatch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormApplyPatch(GitUICommands commands)
-            : base(true, commands)
+            : base(commands)
         {
             InitializeComponent();
             InitializeComplete();

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -30,11 +30,11 @@ namespace GitUI.CommandsDialogs
         #endregion
 
         /// <summary>
-        /// For VS designer
+        /// For VS designer and translation test.
         /// </summary>
         private FormApplyPatch()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormApplyPatch(GitUICommands commands)
@@ -42,10 +42,7 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             InitializeComplete();
-            if (commands != null)
-            {
-                EnableButtons();
-            }
+            EnableButtons();
         }
 
         public void SetPatchFile(string name)

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -89,11 +89,11 @@ namespace GitUI.CommandsDialogs
         }
 
         /// <summary>
-        /// For VS designer
+        /// For VS designer and translation test.
         /// </summary>
         private FormArchive()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormArchive(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -88,9 +88,7 @@ namespace GitUI.CommandsDialogs
             Tar
         }
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormArchive()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -97,7 +97,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormArchive(GitUICommands commands)
-            : base(true, commands)
+            : base(commands)
         {
             InitializeComponent();
             InitializeComplete();

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -6,9 +6,12 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormBlame : GitModuleForm
     {
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormBlame()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         private FormBlame(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -6,9 +6,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormBlame : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormBlame()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -6,6 +6,8 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormBlame : GitModuleForm
     {
+        public string FileName { get; set; }
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormBlame()
         {
@@ -31,8 +33,6 @@ namespace GitUI.CommandsDialogs
 
             blameControl1.LoadBlame(revision ?? Module.GetRevision(), null, fileName, null, null, Module.FilesEncoding, initialLine);
         }
-
-        public string FileName { get; set; }
 
         private void FormBlameLoad(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -124,7 +124,7 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
         }
 
-        public FormBrowse([CanBeNull] GitUICommands commands, string filter, ObjectId selectCommit = null, bool startWithDashboard = false)
+        public FormBrowse([NotNull] GitUICommands commands, string filter, ObjectId selectCommit = null, bool startWithDashboard = false)
             : base(true, commands)
         {
             _startWithDashboard = startWithDashboard;
@@ -159,11 +159,8 @@ namespace GitUI.CommandsDialogs
                 CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
             }
 
-            if (commands != null)
-            {
-                RevisionGrid.UICommandsSource = this;
-                repoObjectsTree.UICommandsSource = this;
-            }
+            RevisionGrid.UICommandsSource = this;
+            repoObjectsTree.UICommandsSource = this;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -300,14 +297,12 @@ namespace GitUI.CommandsDialogs
                 oldCommands.BrowseRepo = null;
                 UICommands.BrowseRepo = this;
             };
-            if (commands != null)
-            {
-                RefreshPullIcon();
-                UICommands.PostRepositoryChanged += UICommands_PostRepositoryChanged;
-                UICommands.BrowseRepo = this;
-                _controller = new FormBrowseController(new GitGpgController(() => Module));
-                _commitDataManager = new CommitDataManager(() => Module);
-            }
+
+            RefreshPullIcon();
+            UICommands.PostRepositoryChanged += UICommands_PostRepositoryChanged;
+            UICommands.BrowseRepo = this;
+            _controller = new FormBrowseController(new GitGpgController(() => Module));
+            _commitDataManager = new CommitDataManager(() => Module);
 
             var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
             _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
@@ -595,7 +590,7 @@ namespace GitUI.CommandsDialogs
                 _repositoryHostsToolStripMenuItem.Text = PluginRegistry.GitHosters[0].Description;
             }
 
-            UpdatePluginMenu(Module?.IsValidGitWorkingDir() ?? false);
+            UpdatePluginMenu(Module.IsValidGitWorkingDir());
         }
 
         private void UnregisterPlugins()
@@ -727,7 +722,7 @@ namespace GitUI.CommandsDialogs
 
                 RefreshWorkingDirComboText();
                 var branchName = !string.IsNullOrEmpty(branchSelect.Text) ? branchSelect.Text : _noBranchTitle.Text;
-                Text = _appTitleGenerator.Generate(Module?.WorkingDir, validBrowseDir, branchName);
+                Text = _appTitleGenerator.Generate(Module.WorkingDir, validBrowseDir, branchName);
 
                 OnActivate();
 
@@ -2602,11 +2597,6 @@ namespace GitUI.CommandsDialogs
                 // Second task: Populate toolbar menu on UI thread.  Note further tasks are created by
                 // CreateSubmoduleMenuItem to update images with submodule status.
                 await this.SwitchToMainThreadAsync(cancelToken);
-
-                if (result == null)
-                {
-                    return;
-                }
 
                 RemoveSubmoduleButtons();
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -125,7 +125,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormBrowse([NotNull] GitUICommands commands, string filter, ObjectId selectCommit = null, bool startWithDashboard = false)
-            : base(true, commands)
+            : base(commands)
         {
             _startWithDashboard = startWithDashboard;
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -159,9 +159,6 @@ namespace GitUI.CommandsDialogs
                 CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
             }
 
-            RevisionGrid.UICommandsSource = this;
-            repoObjectsTree.UICommandsSource = this;
-
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -115,9 +115,7 @@ namespace GitUI.CommandsDialogs
 
         private UpdateTargets _selectedRevisionUpdatedTargets = UpdateTargets.None;
 
-        /// <summary>
-        /// For VS designer
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormBrowse()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -215,33 +215,30 @@ namespace GitUI.CommandsDialogs
 
         private void PopulateBranches()
         {
-            if (IsUICommandsInitialized)
+            Branches.Items.Clear();
+
+            IEnumerable<string> branchNames;
+
+            if (_containRevisions == null)
             {
-                Branches.Items.Clear();
+                var branches = LocalBranch.Checked ? GetLocalBranches() : GetRemoteBranches();
 
-                IEnumerable<string> branchNames;
+                branchNames = branches.Select(b => b.Name);
+            }
+            else
+            {
+                branchNames = GetContainsRevisionBranches();
+            }
 
-                if (_containRevisions == null)
-                {
-                    var branches = LocalBranch.Checked ? GetLocalBranches() : GetRemoteBranches();
+            Branches.Items.AddRange(branchNames.Where(name => name.IsNotNullOrWhitespace()).ToArray<object>());
 
-                    branchNames = branches.Select(b => b.Name);
-                }
-                else
-                {
-                    branchNames = GetContainsRevisionBranches();
-                }
-
-                Branches.Items.AddRange(branchNames.Where(name => name.IsNotNullOrWhitespace()).ToArray<object>());
-
-                if (_containRevisions != null && Branches.Items.Count == 1)
-                {
-                    Branches.SelectedIndex = 0;
-                }
-                else
-                {
-                    Branches.Text = null;
-                }
+            if (_containRevisions != null && Branches.Items.Count == 1)
+            {
+                Branches.SelectedIndex = 0;
+            }
+            else
+            {
+                Branches.Text = null;
             }
 
             IReadOnlyList<string> GetContainsRevisionBranches()

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -52,9 +52,12 @@ namespace GitUI.CommandsDialogs
         private IReadOnlyList<IGitRef> _localBranches;
         private IReadOnlyList<IGitRef> _remoteBranches;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormCheckoutBranch()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         internal FormCheckoutBranch(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -52,9 +52,7 @@ namespace GitUI.CommandsDialogs
         private IReadOnlyList<IGitRef> _localBranches;
         private IReadOnlyList<IGitRef> _remoteBranches;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCheckoutBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -21,7 +21,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormCheckoutRevision(GitUICommands commands)
-            : base(true, commands)
+            : base(commands)
         {
             InitializeComponent();
             InitializeComplete();

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -13,11 +13,11 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noRevisionSelectedMsgBoxCaption = new TranslationString("Checkout");
 
         /// <summary>
-        /// For VS designer
+        /// For VS designer and translation test.
         /// </summary>
         private FormCheckoutRevision()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormCheckoutRevision(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -12,9 +12,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noRevisionSelectedMsgBox = new TranslationString("Select 1 revision to checkout.");
         private readonly TranslationString _noRevisionSelectedMsgBoxCaption = new TranslationString("Checkout");
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCheckoutRevision()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.HelperDialogs;
+using JetBrains.Annotations;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -19,19 +20,22 @@ namespace GitUI.CommandsDialogs
 
         private bool _isMerge;
 
+        [CanBeNull]
         public GitRevision Revision { get; set; }
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormCherryPick()
-            : this(null, null)
         {
+            InitializeComponent();
         }
 
-        public FormCherryPick(GitUICommands commands, GitRevision revision)
+        public FormCherryPick(GitUICommands commands, [CanBeNull] GitRevision revision)
             : base(commands)
         {
             Revision = revision;
             InitializeComponent();
-
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -23,9 +23,7 @@ namespace GitUI.CommandsDialogs
         [CanBeNull]
         public GitRevision Revision { get; set; }
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCherryPick()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -14,6 +14,14 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Are you sure you want to cleanup the repository?");
         private readonly TranslationString _reallyCleanupQuestionCaption = new TranslationString("Cleanup");
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormCleanupRepository()
+        {
+            InitializeComponent();
+        }
+
         public FormCleanupRepository(GitUICommands commands)
             : base(true, commands)
         {

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -23,7 +23,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormCleanupRepository(GitUICommands commands)
-            : base(true, commands)
+            : base(commands)
         {
             InitializeComponent();
             InitializeComplete();

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -14,9 +14,7 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Are you sure you want to cleanup the repository?");
         private readonly TranslationString _reallyCleanupQuestionCaption = new TranslationString("Cleanup");
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCleanupRepository()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -32,9 +32,7 @@ namespace GitUI.CommandsDialogs
         private string _puttySshKey;
         private readonly IReadOnlyList<string> _defaultBranchItems;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormClone()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -32,10 +32,12 @@ namespace GitUI.CommandsDialogs
         private string _puttySshKey;
         private readonly IReadOnlyList<string> _defaultBranchItems;
 
-        // for translation only
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormClone()
-            : this(null, null, false, null)
         {
+            InitializeComponent();
         }
 
         public FormClone(GitUICommands commands, string url, bool openedFromProtocolHandler, EventHandler<GitModuleEventArgs> gitModuleChanged)

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -29,8 +29,8 @@ namespace GitUI.CommandsDialogs
         private readonly bool _openedFromProtocolHandler;
         private readonly string _url;
         private readonly EventHandler<GitModuleEventArgs> _gitModuleChanged;
-        private string _puttySshKey;
         private readonly IReadOnlyList<string> _defaultBranchItems;
+        private string _puttySshKey;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormClone()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormCommit([NotNull] GitUICommands commands, CommitKind commitKind = CommitKind.Normal, GitRevision editedCommit = null)
-            : base(enablePositionRestore: true, commands)
+            : base(commands)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -167,9 +167,7 @@ namespace GitUI.CommandsDialogs
         [CanBeNull] private IReadOnlyList<GitItemStatus> _currentSelection;
         private int _alreadyLoadedTemplatesCount = -1;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCommit()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -168,14 +168,14 @@ namespace GitUI.CommandsDialogs
         private int _alreadyLoadedTemplatesCount = -1;
 
         /// <summary>
-        /// For VS designer
+        /// For VS designer and translation test.
         /// </summary>
         private FormCommit()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        public FormCommit([CanBeNull] GitUICommands commands, CommitKind commitKind = CommitKind.Normal, GitRevision editedCommit = null)
+        public FormCommit([NotNull] GitUICommands commands, CommitKind commitKind = CommitKind.Normal, GitRevision editedCommit = null)
             : base(enablePositionRestore: true, commands)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -189,12 +189,8 @@ namespace GitUI.CommandsDialogs
 
             Message.TextChanged += Message_TextChanged;
             Message.TextAssigned += Message_TextAssigned;
-
-            if (Module != null)
-            {
-                Message.AddAutoCompleteProvider(new CommitAutoCompleteProvider(Module));
-                _commitTemplateManager = new CommitTemplateManager(Module);
-            }
+            Message.AddAutoCompleteProvider(new CommitAutoCompleteProvider(Module));
+            _commitTemplateManager = new CommitTemplateManager(Module);
 
             SolveMergeconflicts.Font = new Font(SolveMergeconflicts.Font, FontStyle.Bold);
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -195,12 +195,7 @@ namespace GitUI.CommandsDialogs
             SolveMergeconflicts.Font = new Font(SolveMergeconflicts.Font, FontStyle.Bold);
 
             SelectedDiff.ExtraDiffArgumentsChanged += SelectedDiffExtraDiffArgumentsChanged;
-
-            if (IsUICommandsInitialized)
-            {
-                StageInSuperproject.Visible = Module.SuperprojectModule != null;
-            }
-
+            StageInSuperproject.Visible = Module.SuperprojectModule != null;
             StageInSuperproject.Checked = AppSettings.StageInSuperprojectAfterCommit;
             closeDialogAfterEachCommitToolStripMenuItem.Checked = AppSettings.CloseCommitDialogAfterCommit;
             closeDialogAfterAllFilesCommittedToolStripMenuItem.Checked = AppSettings.CloseCommitDialogAfterLastCommit;
@@ -425,7 +420,7 @@ namespace GitUI.CommandsDialogs
             {
                 Message.Text = message;
             }
-            else if (IsUICommandsInitialized)
+            else
             {
                 AssignCommitMessageFromTemplate();
             }

--- a/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -7,12 +7,16 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormCompareToBranch : GitModuleForm
     {
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormCompareToBranch()
-            : this(null, null)
         {
+            InitializeComponent();
         }
 
-        public FormCompareToBranch([CanBeNull] GitUICommands commands, [CanBeNull] ObjectId selectedCommit) : base(commands)
+        public FormCompareToBranch([NotNull] GitUICommands commands, [CanBeNull] ObjectId selectedCommit)
+            : base(commands)
         {
             MinimizeBox = false;
             MaximizeBox = false;

--- a/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -7,9 +7,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormCompareToBranch : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCompareToBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -23,11 +23,6 @@ namespace GitUI.CommandsDialogs
             ShowInTaskbar = false;
             InitializeComponent();
             InitializeComplete();
-            if (!IsUICommandsInitialized)
-            {
-                // UICommands is not initialized in translation unit test.
-                return;
-            }
 
             branchSelector.Initialize(remote: true, containRevisions: null);
             branchSelector.CommitToCompare = selectedCommit;

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -17,6 +17,14 @@ namespace GitUI.CommandsDialogs
         private readonly IGitBranchNameNormaliser _branchNameNormaliser;
         private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormCreateBranch()
+        {
+            InitializeComponent();
+        }
+
         public FormCreateBranch(GitUICommands commands, ObjectId objectId)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -17,9 +17,7 @@ namespace GitUI.CommandsDialogs
         private readonly IGitBranchNameNormaliser _branchNameNormaliser;
         private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCreateBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -39,13 +39,10 @@ namespace GitUI.CommandsDialogs
             groupBox1.AutoSize = true;
 
             commitPickerSmallControl1.UICommandsSource = this;
-            if (IsUICommandsInitialized)
+            objectId = objectId ?? Module.GetCurrentCheckout();
+            if (objectId != null)
             {
-                objectId = objectId ?? Module.GetCurrentCheckout();
-                if (objectId != null)
-                {
-                    commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
-                }
+                commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -38,7 +38,6 @@ namespace GitUI.CommandsDialogs
 
             groupBox1.AutoSize = true;
 
-            commitPickerSmallControl1.UICommandsSource = this;
             objectId = objectId ?? Module.GetCurrentCheckout();
             if (objectId != null)
             {

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -14,8 +14,12 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noRevisionSelected = new TranslationString("Select 1 revision to create the branch on.");
         private readonly TranslationString _branchNameIsEmpty = new TranslationString("Enter branch name.");
         private readonly TranslationString _branchNameIsNotValid = new TranslationString("“{0}” is not valid branch name.");
-        private readonly IGitBranchNameNormaliser _branchNameNormaliser;
+        private readonly IGitBranchNameNormaliser _branchNameNormaliser = new GitBranchNameNormaliser();
         private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
+
+        public bool CheckoutAfterCreation { get; set; } = true;
+        public bool UserAbleToChangeRevision { get; set; } = true;
+        public bool CouldBeOrphan { get; set; } = true;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCreateBranch()
@@ -26,11 +30,6 @@ namespace GitUI.CommandsDialogs
         public FormCreateBranch(GitUICommands commands, ObjectId objectId)
             : base(commands)
         {
-            _branchNameNormaliser = new GitBranchNameNormaliser();
-            CheckoutAfterCreation = true;
-            UserAbleToChangeRevision = true;
-            CouldBeOrphan = true;
-
             InitializeComponent();
             InitializeComplete();
 
@@ -42,10 +41,6 @@ namespace GitUI.CommandsDialogs
                 commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
             }
         }
-
-        public bool CheckoutAfterCreation { get; set; }
-        public bool UserAbleToChangeRevision { get; set; }
-        public bool CouldBeOrphan { get; set; }
 
         private void BranchNameTextBox_Leave(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -42,8 +42,6 @@ namespace GitUI.CommandsDialogs
 
             tagMessage.MistakeFont = new Font(tagMessage.MistakeFont, FontStyle.Underline);
 
-            commitPickerSmallControl1.UICommandsSource = this;
-
             objectId = objectId ?? Module.GetCurrentCheckout();
             if (objectId != null)
             {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -43,13 +43,11 @@ namespace GitUI.CommandsDialogs
             tagMessage.MistakeFont = new Font(tagMessage.MistakeFont, FontStyle.Underline);
 
             commitPickerSmallControl1.UICommandsSource = this;
-            if (IsUICommandsInitialized)
+
+            objectId = objectId ?? Module.GetCurrentCheckout();
+            if (objectId != null)
             {
-                objectId = objectId ?? Module.GetCurrentCheckout();
-                if (objectId != null)
-                {
-                    commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
-                }
+                commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
             }
 
             _gitTagController = new GitTagController(commands);

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -23,9 +23,7 @@ namespace GitUI.CommandsDialogs
         private readonly IGitTagController _gitTagController;
         private string _currentRemote = "";
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCreateTag()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -23,7 +23,15 @@ namespace GitUI.CommandsDialogs
         private readonly IGitTagController _gitTagController;
         private string _currentRemote = "";
 
-        public FormCreateTag([CanBeNull] GitUICommands commands, [CanBeNull] ObjectId objectId)
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormCreateTag()
+        {
+            InitializeComponent();
+        }
+
+        public FormCreateTag([NotNull] GitUICommands commands, [CanBeNull] ObjectId objectId)
             : base(commands)
         {
             InitializeComponent();
@@ -44,10 +52,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            if (commands != null)
-            {
-                _gitTagController = new GitTagController(commands);
-            }
+            _gitTagController = new GitTagController(commands);
         }
 
         private void FormCreateTag_Load(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -23,6 +23,14 @@ namespace GitUI.CommandsDialogs
         private readonly HashSet<string> _mergedBranches = new HashSet<string>();
         private string _currentBranch;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormDeleteBranch()
+        {
+            InitializeComponent();
+        }
+
         public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -23,9 +23,7 @@ namespace GitUI.CommandsDialogs
         private readonly HashSet<string> _mergedBranches = new HashSet<string>();
         private string _currentBranch;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormDeleteBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -21,6 +21,14 @@ namespace GitUI.CommandsDialogs
         private readonly HashSet<string> _mergedBranches = new HashSet<string>();
         private readonly string _defaultRemoteBranch;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormDeleteRemoteBranch()
+        {
+            InitializeComponent();
+        }
+
         public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -21,9 +21,7 @@ namespace GitUI.CommandsDialogs
         private readonly HashSet<string> _mergedBranches = new HashSet<string>();
         private readonly string _defaultRemoteBranch;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormDeleteRemoteBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -8,9 +8,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormDeleteTag : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormDeleteTag()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -8,6 +8,14 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormDeleteTag : GitModuleForm
     {
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormDeleteTag()
+        {
+            InitializeComponent();
+        }
+
         public FormDeleteTag(GitUICommands commands, string tag)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -31,6 +31,14 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _anotherCommitTooltip = new TranslationString("Select another commit");
         private readonly TranslationString _btnSwapTooltip = new TranslationString("Swap BASE and Compare commits");
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormDiff()
+        {
+            InitializeComponent();
+        }
+
         public FormDiff(
             GitUICommands commands, bool firstParentIsValid,
             ObjectId baseId, ObjectId headId,

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -58,12 +58,6 @@ namespace GitUI.CommandsDialogs
             _toolTipControl.SetToolTip(btnAnotherHeadCommit, _anotherCommitTooltip.Text);
             _toolTipControl.SetToolTip(btnSwap, _btnSwapTooltip.Text);
 
-            if (!IsUICommandsInitialized)
-            {
-                // UICommands is not initialized in translation unit test.
-                return;
-            }
-
             _baseRevision = new GitRevision(baseId);
             _headRevision = new GitRevision(headId);
             _mergeBase = new GitRevision(Module.GetMergeBase(_baseRevision.ObjectId, _headRevision.ObjectId));

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -31,9 +31,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _anotherCommitTooltip = new TranslationString("Select another commit");
         private readonly TranslationString _btnSwapTooltip = new TranslationString("Swap BASE and Compare commits");
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormDiff()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -18,6 +18,14 @@ namespace GitUI.CommandsDialogs
 
         private bool _hasChanges;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormEditor()
+        {
+            InitializeComponent();
+        }
+
         public FormEditor([NotNull] GitUICommands commands, [CanBeNull] string fileName, bool showWarning)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -18,9 +18,7 @@ namespace GitUI.CommandsDialogs
 
         private bool _hasChanges;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormEditor()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -31,12 +31,15 @@ namespace GitUI.CommandsDialogs
 
         private string FileName { get; set; }
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormFileHistory()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        private FormFileHistory([CanBeNull] GitUICommands commands)
+        private FormFileHistory([NotNull] GitUICommands commands)
             : base(commands)
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -31,9 +31,7 @@ namespace GitUI.CommandsDialogs
 
         private string FileName { get; set; }
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormFileHistory()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -34,9 +34,12 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noGitMailConfigured =
             new TranslationString("There is no email address configured in the settings dialog.");
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormFormatPatch()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormFormatPatch(GitUICommands commands)
@@ -44,10 +47,8 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             InitializeComplete();
-            if (commands != null)
-            {
-                MailFrom.Text = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
-            }
+
+            MailFrom.Text = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
         }
 
         private void Browse_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -34,9 +34,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noGitMailConfigured =
             new TranslationString("There is no email address configured in the settings dialog.");
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormFormatPatch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -27,9 +27,7 @@ namespace GitUI.CommandsDialogs
         public string GitAttributesFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormGitAttributes()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -27,6 +27,14 @@ namespace GitUI.CommandsDialogs
         public string GitAttributesFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormGitAttributes()
+        {
+            InitializeComponent();
+        }
+
         public FormGitAttributes(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -63,6 +63,14 @@ namespace GitUI.CommandsDialogs
 
         private readonly IGitIgnoreDialogModel _dialogModel;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormGitIgnore()
+        {
+            InitializeComponent();
+        }
+
         public FormGitIgnore(GitUICommands commands, bool localExclude)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -63,9 +63,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly IGitIgnoreDialogModel _dialogModel;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormGitIgnore()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -4,9 +4,12 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormLog : GitModuleForm
     {
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormLog()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormLog(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -13,7 +13,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormLog(GitUICommands commands)
-            : base(enablePositionRestore: true, commands)
+            : base(commands)
         {
             InitializeComponent();
             InitializeComplete();

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -4,9 +4,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormLog : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormLog()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -27,6 +27,14 @@ namespace GitUI.CommandsDialogs
         public string MailMapFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormMailMap()
+        {
+            InitializeComponent();
+        }
+
         public FormMailMap(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -27,9 +27,7 @@ namespace GitUI.CommandsDialogs
         public string MailMapFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormMailMap()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -14,9 +14,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _formMergeBranchHoverShowImageLabelText = new TranslationString("Hover to see scenario when fast forward is possible.");
         private readonly string _defaultBranch;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormMergeBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -14,6 +14,14 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _formMergeBranchHoverShowImageLabelText = new TranslationString("Hover to see scenario when fast forward is possible.");
         private readonly string _defaultBranch;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormMergeBranch()
+        {
+            InitializeComponent();
+        }
+
         /// <summary>Initializes <see cref="FormMergeBranch"/>.</summary>
         /// <param name="defaultBranch">Branch to merge into the current branch.</param>
         public FormMergeBranch(GitUICommands commands, string defaultBranch)
@@ -29,12 +37,9 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Visible = !AppSettings.DontShowHelpImages;
             _defaultBranch = defaultBranch;
 
-            if (commands != null)
-            {
-                noFastForward.Checked = Module.EffectiveSettings.NoFastForwardMerge;
-                addLogMessages.Checked = Module.EffectiveSettings.Detailed.AddMergeLogMessages.ValueOrDefault;
-                nbMessages.Value = Module.EffectiveSettings.Detailed.MergeLogMessagesCount.ValueOrDefault;
-            }
+            noFastForward.Checked = Module.EffectiveSettings.NoFastForwardMerge;
+            addLogMessages.Checked = Module.EffectiveSettings.Detailed.AddMergeLogMessages.ValueOrDefault;
+            nbMessages.Value = Module.EffectiveSettings.Detailed.MergeLogMessagesCount.ValueOrDefault;
 
             advanced.Checked = AppSettings.AlwaysShowAdvOpt;
             advanced_CheckedChanged(null, null);

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -13,9 +13,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly string _filename;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormMergeSubmodule()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -13,6 +13,14 @@ namespace GitUI.CommandsDialogs
 
         private readonly string _filename;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormMergeSubmodule()
+        {
+            InitializeComponent();
+        }
+
         public FormMergeSubmodule(GitUICommands commands, string filename)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -108,6 +108,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ErrorOccurred { get; private set; }
 
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormPull()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -112,7 +112,6 @@ namespace GitUI.CommandsDialogs
         private FormPull()
         {
             InitializeComponent();
-            InitializeComplete();
         }
 
         public FormPull(GitUICommands commands, string defaultRemoteBranch, string defaultRemote)

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -82,12 +82,15 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormPush()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        public FormPush([CanBeNull] GitUICommands commands)
+        public FormPush([NotNull] GitUICommands commands)
             : base(commands)
         {
             InitializeComponent();
@@ -114,11 +117,8 @@ namespace GitUI.CommandsDialogs
 
             // can't be set in OnLoad, because after PushAndShowDialogWhenFailed()
             // they are reset to false
-            if (commands != null)
-            {
-                _remoteManager = new GitRemoteManager(() => Module);
-                Init();
-            }
+            _remoteManager = new GitRemoteManager(() => Module);
+            Init();
 
             void Init()
             {

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -82,9 +82,7 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormPush()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -28,14 +28,18 @@ namespace GitUI.CommandsDialogs
         private readonly string _defaultToBranch;
         private readonly bool _startRebaseImmediately;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormRebase()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        private FormRebase(GitUICommands commands)
+        public FormRebase(GitUICommands commands, string defaultBranch)
             : base(commands)
         {
+            _defaultBranch = defaultBranch;
             InitializeComponent();
             InitializeComplete();
             helpImageDisplayUserControl1.Visible = !AppSettings.DontShowHelpImages;
@@ -44,12 +48,6 @@ namespace GitUI.CommandsDialogs
             {
                 ShowOptions_LinkClicked(null, null);
             }
-        }
-
-        public FormRebase(GitUICommands commands, string defaultBranch)
-            : this(commands)
-        {
-            _defaultBranch = defaultBranch;
         }
 
         public FormRebase(GitUICommands commands, string from, string to, string defaultBranch, bool interactive = false,

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -28,9 +28,7 @@ namespace GitUI.CommandsDialogs
         private readonly string _defaultToBranch;
         private readonly bool _startRebaseImmediately;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormRebase()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -23,9 +23,7 @@ namespace GitUI.CommandsDialogs
         private bool _isDirtyDir;
         private int _lastHitRowIndex;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormReflog()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -23,6 +23,14 @@ namespace GitUI.CommandsDialogs
         private bool _isDirtyDir;
         private int _lastHitRowIndex;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormReflog()
+        {
+            InitializeComponent();
+        }
+
         public FormReflog(GitUICommands uiCommands)
             : base(uiCommands)
         {

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -84,9 +84,7 @@ Inactive remote is completely invisible to git.");
             new TranslationString("Inactive");
         #endregion
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormRemotes()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -84,6 +84,14 @@ Inactive remote is completely invisible to git.");
             new TranslationString("Inactive");
         #endregion
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormRemotes()
+        {
+            InitializeComponent();
+        }
+
         public FormRemotes(GitUICommands commands)
             : base(commands)
         {
@@ -306,11 +314,6 @@ Inactive remote is completely invisible to git.");
             label1.MinimumSize = label1.MaximumSize = widestLabelMinSize;        // Name
             label2.MinimumSize = label2.MaximumSize = widestLabelMinSize;        // Url
             labelPushUrl.MinimumSize = labelPushUrl.MaximumSize = widestLabelMinSize;  // Push URL
-
-            if (Module == null)
-            {
-                return;
-            }
 
             _remoteManager = new GitRemoteManager(() => Module);
 

--- a/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -15,6 +15,14 @@ namespace GitUI.CommandsDialogs
         private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
         private readonly string _oldName;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormRenameBranch()
+        {
+            InitializeComponent();
+        }
+
         public FormRenameBranch(GitUICommands commands, string defaultBranch)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -15,9 +15,7 @@ namespace GitUI.CommandsDialogs
         private readonly GitBranchNameOptions _gitBranchNameOptions = new GitBranchNameOptions(AppSettings.AutoNormaliseSymbol);
         private readonly string _oldName;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormRenameBranch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -94,9 +94,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly IFullPathResolver _fullPathResolver;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormResolveConflicts()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -94,6 +94,14 @@ namespace GitUI.CommandsDialogs
 
         private readonly IFullPathResolver _fullPathResolver;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormResolveConflicts()
+        {
+            InitializeComponent();
+        }
+
         public FormResolveConflicts(GitUICommands commands, bool offerCommit = true)
             : base(commands)
         {
@@ -104,11 +112,6 @@ namespace GitUI.CommandsDialogs
 
             FileName.DataPropertyName = nameof(ConflictData.Filename);
             authorDataGridViewTextBoxColumn1.DataPropertyName = "Author"; // TODO this property does not exist on the target type
-        }
-
-        private FormResolveConflicts()
-            : this(null)
-        {
         }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -13,6 +13,14 @@ namespace GitUI.CommandsDialogs
 
         private bool _isMerge;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormRevertCommit()
+        {
+            InitializeComponent();
+        }
+
         public FormRevertCommit(GitUICommands commands, GitRevision revision)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -13,9 +13,7 @@ namespace GitUI.CommandsDialogs
 
         private bool _isMerge;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormRevertCommit()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -36,24 +36,21 @@ namespace GitUI.CommandsDialogs
 
         private IEnumerable<ISettingsPage> SettingsPages => settingsTreeView.SettingsPages;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormSettings()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        public FormSettings([CanBeNull] GitUICommands commands, SettingsPageReference initialPage = null)
+        public FormSettings([NotNull] GitUICommands commands, SettingsPageReference initialPage = null)
             : base(commands)
         {
             InitializeComponent();
             _translatedTitle = Text;
 
             settingsTreeView.SuspendLayout();
-
-            // if form is created for translation purpose
-            if (commands == null)
-            {
-                return;
-            }
 
 #if DEBUG
             buttonDiscard.Visible = true;

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -36,9 +36,7 @@ namespace GitUI.CommandsDialogs
 
         private IEnumerable<ISettingsPage> SettingsPages => settingsTreeView.SettingsPages;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormSettings()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -16,14 +16,16 @@ namespace GitUI.CommandsDialogs
         [CanBeNull]
         private IDisposable _disposable1;
 
-        public FormSparseWorkingCopy([CanBeNull] GitUICommands commands /* Translation tests set it to NULL */)
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormSparseWorkingCopy()
+        {
+        }
+
+        public FormSparseWorkingCopy([NotNull] GitUICommands commands)
             : base(commands)
         {
-            if (commands == null)
-            {
-                return;
-            }
-
             var sparse = new FormSparseWorkingCopyViewModel(commands);
             BindToViewModelGlobal(sparse);
             CreateView(sparse);

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -16,9 +16,7 @@ namespace GitUI.CommandsDialogs
         [CanBeNull]
         private IDisposable _disposable1;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormSparseWorkingCopy()
         {
         }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -29,9 +29,12 @@ namespace GitUI.CommandsDialogs
         public bool ManageStashes { get; set; }
         private GitStash _currentWorkingDirStashItem;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormStash()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         public FormStash(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -29,9 +29,7 @@ namespace GitUI.CommandsDialogs
         public bool ManageStashes { get; set; }
         private GitStash _currentWorkingDirStashItem;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormStash()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -18,6 +18,14 @@ namespace GitUI.CommandsDialogs
         private readonly BindingList<IGitSubmoduleInfo> _modules = new BindingList<IGitSubmoduleInfo>();
         private GitSubmoduleInfo _oldSubmoduleInfo;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormSubmodules()
+        {
+            InitializeComponent();
+        }
+
         public FormSubmodules(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -18,9 +18,7 @@ namespace GitUI.CommandsDialogs
         private readonly BindingList<IGitSubmoduleInfo> _modules = new BindingList<IGitSubmoduleInfo>();
         private GitSubmoduleInfo _oldSubmoduleInfo;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormSubmodules()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -26,9 +26,7 @@ namespace GitUI.CommandsDialogs
         private readonly DataGridViewCheckBoxHeaderCell _selectedItemsHeader = new DataGridViewCheckBoxHeaderCell();
         private readonly IGitTagController _gitTagController;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormVerify()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -26,12 +26,15 @@ namespace GitUI.CommandsDialogs
         private readonly DataGridViewCheckBoxHeaderCell _selectedItemsHeader = new DataGridViewCheckBoxHeaderCell();
         private readonly IGitTagController _gitTagController;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormVerify()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        public FormVerify([CanBeNull] GitUICommands commands)
+        public FormVerify([NotNull] GitUICommands commands)
             : base(commands)
         {
             InitializeComponent();
@@ -58,10 +61,7 @@ namespace GitUI.CommandsDialogs
             columnHash.DataPropertyName = nameof(LostObject.ObjectId);
             columnParent.DataPropertyName = nameof(LostObject.Parent);
 
-            if (commands != null)
-            {
-                _gitTagController = new GitTagController(commands);
-            }
+            _gitTagController = new GitTagController(commands);
         }
 
         [CanBeNull]

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -10,11 +10,16 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormViewPatch : GitModuleForm
     {
-        private readonly TranslationString _patchFileFilterString =
-            new TranslationString("Patch file (*.Patch)");
+        private readonly TranslationString _patchFileFilterString = new TranslationString("Patch file (*.Patch)");
+        private readonly TranslationString _patchFileFilterTitle = new TranslationString("Select patch file");
 
-        private readonly TranslationString _patchFileFilterTitle =
-            new TranslationString("Select patch file");
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormViewPatch()
+        {
+            InitializeComponent();
+        }
 
         public FormViewPatch(GitUICommands commands)
             : base(commands)

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -13,9 +13,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _patchFileFilterString = new TranslationString("Patch file (*.Patch)");
         private readonly TranslationString _patchFileFilterTitle = new TranslationString("Select patch file");
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormViewPatch()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -29,9 +29,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private string _prevTitle;
         private readonly AsyncLoader _remoteLoader = new AsyncLoader();
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private CreatePullRequestForm()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -29,6 +29,14 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private string _prevTitle;
         private readonly AsyncLoader _remoteLoader = new AsyncLoader();
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private CreatePullRequestForm()
+        {
+            InitializeComponent();
+        }
+
         public CreatePullRequestForm(GitUICommands commands, IRepositoryHostPlugin repoHost, string chooseRemote, string chooseBranch)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -28,10 +28,12 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private bool _isFirstLoad;
         private readonly AsyncLoader _loader = new AsyncLoader();
 
-        // only for translation
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private ViewPullRequestsForm()
-            : this(null)
         {
+            InitializeComponent();
         }
 
         private ViewPullRequestsForm(GitUICommands commands)

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -28,9 +28,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private bool _isFirstLoad;
         private readonly AsyncLoader _loader = new AsyncLoader();
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private ViewPullRequestsForm()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -21,7 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             ListIncludedEncodings.BeginUpdate();
             try
             {
-                ListIncludedEncodings.Items.AddRange(includedEncoding.Values.ToArray());
+                ListIncludedEncodings.Items.AddRange(includedEncoding.Values.ToArray<object>());
                 ListIncludedEncodings.DisplayMember = nameof(Encoding.EncodingName);
             }
             finally
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             ListAvailableEncodings.BeginUpdate();
             try
             {
-                ListAvailableEncodings.Items.AddRange(availableEncoding.ToArray());
+                ListAvailableEncodings.Items.AddRange(availableEncoding.ToArray<object>());
                 ListAvailableEncodings.DisplayMember = nameof(Encoding.EncodingName);
             }
             finally
@@ -58,9 +58,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (ListAvailableEncodings.SelectedItem != null)
             {
-                var indx = ListAvailableEncodings.SelectedIndex;
+                var index = ListAvailableEncodings.SelectedIndex;
                 ListIncludedEncodings.Items.Add(ListAvailableEncodings.SelectedItem);
-                ListAvailableEncodings.Items.RemoveAt(indx);
+                ListAvailableEncodings.Items.RemoveAt(index);
             }
         }
 
@@ -84,9 +84,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (ListIncludedEncodings.SelectedItem != null)
             {
-                var indx = ListIncludedEncodings.SelectedIndex;
+                var index = ListIncludedEncodings.SelectedIndex;
                 ListAvailableEncodings.Items.Add(ListIncludedEncodings.SelectedItem);
-                ListIncludedEncodings.Items.RemoveAt(indx);
+                ListIncludedEncodings.Items.RemoveAt(index);
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -6,7 +6,7 @@ using GitCommands;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
-    public partial class FormAvailableEncodings : GitModuleForm
+    public partial class FormAvailableEncodings : GitExtensionsForm
     {
         public FormAvailableEncodings()
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text;
 using System.Windows.Forms;
 using GitCommands.Config;
 using GitCommands.Settings;

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -13,6 +13,14 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
         private readonly TranslationString _remoteAndLocalPathRequired
             = new TranslationString("A remote path and local path are required");
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormAddSubmodule()
+        {
+            InitializeComponent();
+        }
+
         public FormAddSubmodule(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -13,9 +13,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
         private readonly TranslationString _remoteAndLocalPathRequired
             = new TranslationString("A remote path and local path are required");
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormAddSubmodule()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -21,6 +21,14 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         public IReadOnlyList<IGitRef> ExistingBranches { get; set; }
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormCreateWorktree()
+        {
+            InitializeComponent();
+        }
+
         public FormCreateWorktree(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -21,9 +21,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         public IReadOnlyList<IGitRef> ExistingBranches { get; set; }
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCreateWorktree()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -12,9 +12,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
     {
         private List<WorkTree> _worktrees;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormManageWorktree()
         {
             InitializeComponent();

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -12,6 +12,14 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
     {
         private List<WorkTree> _worktrees;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormManageWorktree()
+        {
+            InitializeComponent();
+        }
+
         public FormManageWorktree(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -70,7 +70,7 @@ namespace GitUI.CommitInfo
             InitializeComponent();
             InitializeComplete();
 
-            UICommandsSourceSet += delegate { ReloadCommitInfo(); };
+            UICommandsSourceSet += delegate { this.InvokeAsync(() => ReloadCommitInfo()).FileAndForget(); };
 
             _commitDataManager = new CommitDataManager(() => Module);
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -185,10 +185,7 @@ namespace GitUI.CommitInfo
 
             UpdateRevisionInfo();
 
-            if (Module != null)
-            {
-                StartAsyncDataLoad();
-            }
+            StartAsyncDataLoad();
 
             return;
 

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -47,7 +47,7 @@ namespace GitUI
         /// </remarks>
         /// <exception cref="InvalidOperationException">Unable to initialise the source as
         /// no ancestor of type <see cref="IGitUICommandsSource"/> was found.</exception>
-        [CanBeNull]
+        [NotNull]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
         public IGitUICommandsSource UICommandsSource
@@ -68,6 +68,7 @@ namespace GitUI
                     }
                 }
 
+                // ReSharper disable once AssignNullToNotNullAttribute
                 return _uiCommandsSource;
             }
             set
@@ -83,9 +84,9 @@ namespace GitUI
         }
 
         /// <summary>Gets the <see cref="UICommandsSource"/>'s <see cref="GitUICommands"/> reference.</summary>
-        [CanBeNull]
+        [NotNull]
         [Browsable(false)]
-        public GitUICommands UICommands => UICommandsSource?.UICommands;
+        public GitUICommands UICommands => UICommandsSource.UICommands;
 
         /// <summary>
         /// Gets the UI commands, if they've initialised.
@@ -105,10 +106,10 @@ namespace GitUI
         }
 
         /// <summary>Gets the <see cref="UICommands"/>' <see cref="GitModule"/> reference.</summary>
-        [CanBeNull]
+        [NotNull]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
-        public GitModule Module => UICommands?.Module;
+        public GitModule Module => UICommands.Module;
 
         protected GitModuleControl()
         {

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -37,9 +37,6 @@ namespace GitUI
             }
         }
 
-        /// <summary>true if <see cref="UICommands"/> has been initialized.</summary>
-        protected bool IsUICommandsInitialized => _uiCommands != null;
-
         /// <summary>Gets a <see cref="GitModule"/> reference.</summary>
         [NotNull]
         [Browsable(false)]

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -50,17 +50,9 @@ namespace GitUI
         }
 
         protected GitModuleForm([NotNull] GitUICommands commands)
-            : this(true, commands)
+            : base(enablePositionRestore: true)
         {
-        }
-
-        protected GitModuleForm(bool enablePositionRestore, [NotNull] GitUICommands commands)
-            : base(enablePositionRestore)
-        {
-            if (commands != null)
-            {
-                UICommands = commands;
-            }
+            _uiCommands = commands;
         }
 
         protected override bool ExecuteCommand(int command)

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -7,8 +7,9 @@ using JetBrains.Annotations;
 
 namespace GitUI
 {
-    /// <summary>Base class for a <see cref="Form"/> requiring
-    /// <see cref="GitModule"/> and <see cref="GitUICommands"/>.</summary>
+    // NOTE do not make this class abstract as it breaks the WinForms designer in VS
+
+    /// <summary>Base <see cref="Form"/> that provides access to <see cref="GitModule"/> and <see cref="GitUICommands"/>.</summary>
     public class GitModuleForm : GitExtensionsForm, IGitUICommandsSource
     {
         /// <inheritdoc />

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -31,8 +31,8 @@ namespace GitUI
             }
             protected set
             {
-                GitUICommands oldCommands = _uiCommands;
-                _uiCommands = value;
+                var oldCommands = _uiCommands;
+                _uiCommands = value ?? throw new ArgumentNullException(nameof(value));
                 UICommandsChanged?.Invoke(this, new GitUICommandsChangedEventArgs(oldCommands));
             }
         }
@@ -41,20 +41,23 @@ namespace GitUI
         protected bool IsUICommandsInitialized => _uiCommands != null;
 
         /// <summary>Gets a <see cref="GitModule"/> reference.</summary>
-        [CanBeNull]
+        [NotNull]
         [Browsable(false)]
-        public GitModule Module => _uiCommands?.Module;
+        public GitModule Module => UICommands.Module;
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         protected GitModuleForm()
         {
         }
 
-        protected GitModuleForm([CanBeNull] GitUICommands commands)
+        protected GitModuleForm([NotNull] GitUICommands commands)
             : this(true, commands)
         {
         }
 
-        protected GitModuleForm(bool enablePositionRestore, [CanBeNull] GitUICommands commands)
+        protected GitModuleForm(bool enablePositionRestore, [NotNull] GitUICommands commands)
             : base(enablePositionRestore)
         {
             if (commands != null)

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -43,9 +43,7 @@ namespace GitUI
         [Browsable(false)]
         public GitModule Module => UICommands.Module;
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         protected GitModuleForm()
         {
         }

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -15,6 +15,8 @@ namespace GitUI
         /// <inheritdoc />
         public event EventHandler<GitUICommandsChangedEventArgs> UICommandsChanged;
 
+        internal static bool IsUnitTestActive { get; set; }
+
         [CanBeNull] private GitUICommands _uiCommands;
 
         /// <inheritdoc />
@@ -46,6 +48,11 @@ namespace GitUI
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         protected GitModuleForm()
         {
+            if (LicenseManager.UsageMode != LicenseUsageMode.Designtime && !IsUnitTestActive)
+            {
+                throw new InvalidOperationException(
+                    "This constructor is only to be called by the Visual Studio designer, and the translation unit tests.");
+            }
         }
 
         protected GitModuleForm([NotNull] GitUICommands commands)

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -22,12 +22,12 @@ namespace GitUI
         {
             get
             {
-                if (_uiCommands == null)
-                {
-                    throw new InvalidOperationException("UICommands is null");
-                }
-
-                return _uiCommands;
+                // If this exception is seen, it's because the parameterless constructor was called.
+                // That constructor is only for use by the VS designer, and translation unit tests.
+                // Using it at run time is an error.
+                return _uiCommands
+                       ?? throw new InvalidOperationException(
+                           $"{nameof(UICommands)} is null. {GetType().FullName} was constructed incorrectly.");
             }
             protected set
             {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -22,13 +22,15 @@ namespace GitUI
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
 
+        [NotNull]
         public GitModule Module { get; private set; }
         public ILockableNotifier RepoChangedNotifier { get; }
         [CanBeNull] public IBrowseRepo BrowseRepo { get; set; }
 
         public GitUICommands([NotNull] GitModule module)
         {
-            Module = module;
+            Module = module ?? throw new ArgumentNullException(nameof(module));
+
             _commitTemplateManager = new CommitTemplateManager(module);
             RepoChangedNotifier = new ActionNotifier(
                 () => InvokeEvent(null, PostRepositoryChanged));

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -9,19 +9,22 @@ namespace GitUI.HelperDialogs
 {
     public partial class FormChooseCommit : GitModuleForm
     {
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
         private FormChooseCommit()
-            : this(null)
         {
+            InitializeComponent();
         }
 
-        private FormChooseCommit(GitUICommands commands)
+        private FormChooseCommit([NotNull] GitUICommands commands)
             : base(commands)
         {
             InitializeComponent();
             InitializeComplete();
         }
 
-        public FormChooseCommit(GitUICommands commands, [CanBeNull] string preselectCommit, bool showArtificial = false)
+        public FormChooseCommit([NotNull] GitUICommands commands, [CanBeNull] string preselectCommit, bool showArtificial = false)
             : this(commands)
         {
             revisionGrid.MultiSelect = false;

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -9,9 +9,7 @@ namespace GitUI.HelperDialogs
 {
     public partial class FormChooseCommit : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormChooseCommit()
         {
             InitializeComponent();

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -1,13 +1,12 @@
-﻿using GitUIPluginInterfaces;
+﻿using System;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.HelperDialogs
 {
     public sealed partial class FormCommitDiff : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCommitDiff()
         {
             InitializeComponent();

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -1,24 +1,24 @@
 ﻿using GitUIPluginInterfaces;
+using JetBrains.Annotations;
 
 namespace GitUI.HelperDialogs
 {
     public sealed partial class FormCommitDiff : GitModuleForm
     {
-        private FormCommitDiff(GitUICommands commands)
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormCommitDiff()
+        {
+            InitializeComponent();
+        }
+
+        public FormCommitDiff([NotNull] GitUICommands commands, [CanBeNull] ObjectId objectId)
             : base(commands)
         {
             InitializeComponent();
             InitializeComplete();
-        }
 
-        private FormCommitDiff()
-            : this(null)
-        {
-        }
-
-        public FormCommitDiff(GitUICommands commands, ObjectId objectId)
-            : this(commands)
-        {
             CommitDiff.TextChanged += (s, e) => Text = CommitDiff.Text;
 
             CommitDiff.SetRevision(objectId, fileToSelect: null);

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -11,7 +11,7 @@
         }
 
         public FormEdit(GitUICommands commands, string text)
-            : base(true, commands)
+            : base(commands)
         {
             InitializeComponent();
             InitializeComplete();

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -1,10 +1,10 @@
-﻿namespace GitUI.HelperDialogs
+﻿using System;
+
+namespace GitUI.HelperDialogs
 {
     public partial class FormEdit : GitModuleForm
     {
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormEdit()
         {
             InitializeComponent();

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -2,6 +2,14 @@
 {
     public partial class FormEdit : GitModuleForm
     {
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormEdit()
+        {
+            InitializeComponent();
+        }
+
         public FormEdit(GitUICommands commands, string text)
             : base(true, commands)
         {

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -18,9 +18,7 @@ namespace GitUI.HelperDialogs
             Hard
         }
 
-        /// <summary>
-        /// For VS designer and translation test.
-        /// </summary>
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormResetCurrentBranch()
         {
             InitializeComponent();

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -18,6 +18,14 @@ namespace GitUI.HelperDialogs
             Hard
         }
 
+        /// <summary>
+        /// For VS designer and translation test.
+        /// </summary>
+        private FormResetCurrentBranch()
+        {
+            InitializeComponent();
+        }
+
         public FormResetCurrentBranch(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Mixed)
             : base(commands)
         {

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -195,7 +195,7 @@ namespace GitUI.SpellChecker
             set => TextBox.SelectedText = value;
         }
 
-        protected RepoDistSettings Settings => Module?.EffectiveSettings ?? AppSettings.SettingsContainer;
+        protected RepoDistSettings Settings => Module.EffectiveSettings ?? AppSettings.SettingsContainer;
 
         public void SelectAll()
         {
@@ -553,7 +553,7 @@ namespace GitUI.SpellChecker
             // if a Module is available, then always change the "repository local" setting
             // it will set a dictionary only for this Module (repository) locally
 
-            var settings = Module?.LocalSettings ?? Settings;
+            var settings = Module.LocalSettings ?? Settings;
 
             settings.Dictionary = ((ToolStripItem)sender).Text;
             LoadDictionary();

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -121,7 +121,7 @@ namespace GitUI.UserControls
             else
             {
                 var branchName = SelectedBranchName;
-                var currentCheckout = CommitToCompare ?? Module?.GetCurrentCheckout();
+                var currentCheckout = CommitToCompare ?? Module.GetCurrentCheckout();
 
                 if (currentCheckout == null)
                 {

--- a/GitUI/UserControls/RevisionGrid/FormQuickGitRefSelector.cs
+++ b/GitUI/UserControls/RevisionGrid/FormQuickGitRefSelector.cs
@@ -9,7 +9,7 @@ using ResourceManager;
 
 namespace GitUI.UserControls.RevisionGrid
 {
-    public partial class FormQuickGitRefSelector : GitModuleForm
+    public partial class FormQuickGitRefSelector : GitExtensionsForm
     {
         private readonly TranslationString _actionRename = new TranslationString("Rename");
         private readonly TranslationString _actionDelete = new TranslationString("Delete");

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using JetBrains.Annotations;
 
 namespace GitUIPluginInterfaces
 {
@@ -13,7 +14,9 @@ namespace GitUIPluginInterfaces
         event EventHandler<GitUIEventArgs> PostRegisterPlugin;
         event EventHandler<GitUIEventArgs> PreCommit;
 
+        [NotNull]
         IGitModule GitModule { get; }
+
         IGitRemoteCommand CreateRemoteCommand();
 
         /// <summary>

--- a/UnitTests/GitUITests/TranslationTest.cs
+++ b/UnitTests/GitUITests/TranslationTest.cs
@@ -10,15 +10,24 @@ using ResourceManager.Xliff;
 namespace GitUITests
 {
     [TestFixture]
-    public class TranslationTest
+    public sealed class TranslationTest
     {
+        [SetUp]
+        public void SetUp()
+        {
+            GitModuleForm.IsUnitTestActive = true;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GitModuleForm.IsUnitTestActive = false;
+        }
+
         [Test]
         [Apartment(ApartmentState.STA)]
         public void CreateInstanceOfClass()
         {
-            // just reference to GitUI
-            MouseWheelRedirector.Active = true;
-
             var translatableTypes = TranslationUtil.GetTranslatableTypes();
 
             var problems = new List<(string typeName, Exception exception)>();


### PR DESCRIPTION
This PR deals with the initialisation cycle of `GitModuleForm` and `GitModuleControl` subclasses. It fixes an entire class of errors _by design_ regarding the use of certain properties before they are initialised.

Before this change, the following properties were annotated as `[CanBeNull]`, which caused warnings in the many places that didn't check for `null` values.

- `GitModuleForm.Module` (402 usages)
- `GitModuleControl.UICommands` (66 usages)
- `GitModuleControl.UICommandsSource` (6 usages)
- `GitModuleControl.Module` (133 usages)
- `GitUICommands.Module` (62 usages)
- `IGitUICommands.GitModule` (19 usages)

Only five (0.7%) usages defended against `null`.

If you can't beat em, join em.

This change ensures these properties are not `null`. If somehow an access occurs when they would be `null`, an `InvalidOperationException` is thrown.

All forms deriving from `GitModuleForm` must pass an instance of `GitUICommands` to the base constructor. This PR introduces private constructors and explains that they only exist to service the VS designer and translation unit tests.

A redundant `GitModuleForm` constructor was removed. No subclasses ever called down passing `false` for `enablePositionRestore`.

In the case of `GitModuleControl` there is unfortunately less certainty than for `GitModuleForm`. This is because they are constructed by designer generated code. These controls may need access to `Module` or `UICommands` properties from the base, and these properties are only accessible once the control is nestled in the form's control tree. This PR adds explanatory comments at the site of exceptions being thrown to explain to developers why the exception occurs, and what they have to do to fix the code.

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
