### PR TITLE
GitModule eagerly loads submodule properties

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -107,11 +107,13 @@ namespace GitCommands
             _indexLockManager = new IndexLockManager(this);
             _commitDataManager = new CommitDataManager(() => this);
 
-            (SuperprojectModule, SubmodulePath, SubmoduleName) = TryInitSubmodule();
+            // If this is a submodule, populate relevant properties.
+            // If this is not a submodule, these will all be null.
+            (SuperprojectModule, SubmodulePath, SubmoduleName) = InitialiseSubmoduleProperties();
 
             return;
 
-            (GitModule superprojectModule, string submodulePath, string submoduleName) TryInitSubmodule()
+            (GitModule superprojectModule, string submodulePath, string submoduleName) InitialiseSubmoduleProperties()
             {
                 if (!IsValidGitWorkingDir())
                 {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -127,10 +127,11 @@ namespace GitCommands
         public Version AppVersion => AppSettings.AppVersion;
 
         private bool _superprojectInit;
-        private GitModule _superprojectModule;
-        private string _submoduleName;
-        private string _submodulePath;
+        [CanBeNull] private GitModule _superprojectModule;
+        [CanBeNull] private string _submoduleName;
+        [CanBeNull] private string _submodulePath;
 
+        [CanBeNull]
         public string SubmoduleName
         {
             get
@@ -140,6 +141,7 @@ namespace GitCommands
             }
         }
 
+        [CanBeNull]
         public string SubmodulePath
         {
             get
@@ -149,6 +151,7 @@ namespace GitCommands
             }
         }
 
+        [CanBeNull]
         public GitModule SuperprojectModule
         {
             get

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -13,18 +13,21 @@ namespace GitCommands
         private static readonly IEnvironmentAbstraction EnvironmentAbstraction = new EnvironmentAbstraction();
         private static readonly IEnvironmentPathsProvider EnvironmentPathsProvider = new EnvironmentPathsProvider(EnvironmentAbstraction);
 
+        public static readonly char PosixDirectorySeparatorChar = '/';
+        public static readonly char NativeDirectorySeparatorChar = Path.DirectorySeparatorChar;
+
         /// <summary>Replaces native path separator with posix path separator.</summary>
         [NotNull]
         public static string ToPosixPath([NotNull] this string path)
         {
-            return path.Replace(Path.DirectorySeparatorChar, AppSettings.PosixPathSeparator);
+            return path.Replace(NativeDirectorySeparatorChar, PosixDirectorySeparatorChar);
         }
 
         /// <summary>Replaces '\' with '/'.</summary>
         [NotNull]
         public static string ToNativePath([NotNull] this string path)
         {
-            return path.Replace(AppSettings.PosixPathSeparator, Path.DirectorySeparatorChar);
+            return path.Replace(PosixDirectorySeparatorChar, NativeDirectorySeparatorChar);
         }
 
         /// <summary>
@@ -38,10 +41,10 @@ namespace GitCommands
         public static string EnsureTrailingPathSeparator([CanBeNull] this string dirPath)
         {
             if (!dirPath.IsNullOrEmpty() &&
-                dirPath[dirPath.Length - 1] != Path.DirectorySeparatorChar &&
-                dirPath[dirPath.Length - 1] != AppSettings.PosixPathSeparator)
+                dirPath[dirPath.Length - 1] != NativeDirectorySeparatorChar &&
+                dirPath[dirPath.Length - 1] != PosixDirectorySeparatorChar)
             {
-                dirPath += Path.DirectorySeparatorChar;
+                dirPath += NativeDirectorySeparatorChar;
             }
 
             return dirPath;
@@ -71,7 +74,7 @@ namespace GitCommands
         [NotNull]
         public static string GetFileName([NotNull] string fileName)
         {
-            var pathSeparators = new[] { Path.DirectorySeparatorChar, AppSettings.PosixPathSeparator };
+            var pathSeparators = new[] { NativeDirectorySeparatorChar, PosixDirectorySeparatorChar };
             var pos = fileName.LastIndexOfAny(pathSeparators);
             if (pos != -1)
             {
@@ -84,13 +87,13 @@ namespace GitCommands
         [NotNull]
         public static string GetDirectoryName([NotNull] string fileName)
         {
-            var pathSeparators = new[] { Path.DirectorySeparatorChar, AppSettings.PosixPathSeparator };
+            var pathSeparators = new[] { NativeDirectorySeparatorChar, PosixDirectorySeparatorChar };
             var pos = fileName.LastIndexOfAny(pathSeparators);
             if (pos != -1)
             {
-                if (pos == 0 && fileName[0] == AppSettings.PosixPathSeparator)
+                if (pos == 0 && fileName[0] == PosixDirectorySeparatorChar)
                 {
-                    return fileName.Length == 1 ? string.Empty : AppSettings.PosixPathSeparator.ToString();
+                    return fileName.Length == 1 ? "" : PosixDirectorySeparatorChar.ToString();
                 }
 
                 fileName = fileName.Substring(0, pos);

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -31,6 +31,23 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Removes any trailing path separator character from the end of <paramref name="dirPath"/>.
+        /// </summary>
+        [ContractAnnotation("dirPath:null=>null")]
+        [ContractAnnotation("dirPath:notnull=>notnull")]
+        public static string RemoveTrailingPathSeparator([CanBeNull] this string dirPath)
+        {
+            if (dirPath?.Length > 0 &&
+                (dirPath[dirPath.Length - 1] == NativeDirectorySeparatorChar ||
+                 dirPath[dirPath.Length - 1] == PosixDirectorySeparatorChar))
+            {
+                return dirPath.Substring(0, dirPath.Length - 1);
+            }
+
+            return dirPath;
+        }
+
+        /// <summary>
         /// Code guideline: "A directory path should always end with / or \.
         /// Better use Path.Combine instead of Setting.PathSeparator"
         ///

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -310,5 +310,28 @@ namespace GitCommands
 
             return null;
         }
+
+        [NotNull, ItemNotNull]
+        public static IEnumerable<string> FindAncestors([NotNull] string path)
+        {
+            path = path.RemoveTrailingPathSeparator();
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                yield break;
+            }
+
+            while (true)
+            {
+                path = Path.GetDirectoryName(path);
+
+                if (string.IsNullOrEmpty(path))
+                {
+                    yield break;
+                }
+
+                yield return path.EnsureTrailingPathSeparator();
+            }
+        }
     }
 }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -45,7 +45,6 @@ namespace GitCommands
     public static class AppSettings
     {
         // semi-constants
-        public static readonly char PosixPathSeparator = '/';
         public static Version AppVersion => Assembly.GetCallingAssembly().GetName().Version;
         public static string ProductVersion => Application.ProductVersion;
         public static readonly string SettingsFileName = "GitExtensions.settings";

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -66,7 +66,7 @@ namespace GitUI
         [CanBeNull]
         public static string FormatTextForFileNameOnly(string name, string oldName)
         {
-            name = name.TrimEnd(AppSettings.PosixPathSeparator);
+            name = name.TrimEnd(PathUtil.PosixDirectorySeparatorChar);
             var fileName = Path.GetFileName(name);
             var oldFileName = Path.GetFileName(oldName);
 

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using FluentAssertions;
 using GitCommands;
 using NUnit.Framework;
@@ -276,6 +277,18 @@ namespace GitCommandsTests.Helpers
             Assert.AreEqual("", PathUtil.GetFileExtension("..."));
             Assert.Null(PathUtil.GetFileExtension("foo"));
             Assert.Null(PathUtil.GetFileExtension(""));
+        }
+
+        [TestCase("/foo/bar", new[] { "\\foo\\", "\\" })]
+        [TestCase("/foo/bar/", new[] { "\\foo\\", "\\" })]
+        [TestCase("/foo", new[] { "\\" })]
+        [TestCase("/foo/", new[] { "\\" })]
+        [TestCase("/", new string[0])]
+        [TestCase("C:\\foo\\bar", new[] { "C:\\foo\\", "C:\\" })]
+        [TestCase("C:\\", new string[0])]
+        public void FindAncestors(string path, string[] expected)
+        {
+            Assert.AreEqual(expected, PathUtil.FindAncestors(path).ToArray());
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -46,24 +46,46 @@ namespace GitCommandsTests.Helpers
         [Test]
         public void EnsureTrailingPathSeparatorTest()
         {
+            Assert.IsNull(((string)null).EnsureTrailingPathSeparator());
+            Assert.AreEqual("".EnsureTrailingPathSeparator(), "");
+
             if (Path.DirectorySeparatorChar == '\\')
             {
-                Assert.AreEqual("".EnsureTrailingPathSeparator(), "");
                 Assert.AreEqual("C".EnsureTrailingPathSeparator(), "C\\");
                 Assert.AreEqual("C:".EnsureTrailingPathSeparator(), "C:\\");
                 Assert.AreEqual("C:\\".EnsureTrailingPathSeparator(), "C:\\");
                 Assert.AreEqual("C:\\Work\\GitExtensions".EnsureTrailingPathSeparator(), "C:\\Work\\GitExtensions\\");
                 Assert.AreEqual("C:\\Work\\GitExtensions\\".EnsureTrailingPathSeparator(), "C:\\Work\\GitExtensions\\");
                 Assert.AreEqual("C:/Work/GitExtensions/".EnsureTrailingPathSeparator(), "C:/Work/GitExtensions/");
+                Assert.AreEqual("\\".EnsureTrailingPathSeparator(), "\\");
+                Assert.AreEqual("/".EnsureTrailingPathSeparator(), "/");
             }
             else
             {
-                Assert.AreEqual("".EnsureTrailingPathSeparator(), "");
                 Assert.AreEqual("/".EnsureTrailingPathSeparator(), "/");
                 Assert.AreEqual("/Work/GitExtensions".EnsureTrailingPathSeparator(), "/Work/GitExtensions/");
                 Assert.AreEqual("/Work/GitExtensions/".EnsureTrailingPathSeparator(), "/Work/GitExtensions/");
                 Assert.AreEqual("/Work/GitExtensions\\".EnsureTrailingPathSeparator(), "/Work/GitExtensions\\/");
             }
+        }
+
+        [Test]
+        public void RemoveTrailingPathSeparatorTest()
+        {
+            Assert.IsNull(((string)null).RemoveTrailingPathSeparator());
+            Assert.AreEqual("".RemoveTrailingPathSeparator(), "");
+
+            var s = Path.DirectorySeparatorChar;
+
+            Assert.AreEqual($"C:{s}".RemoveTrailingPathSeparator(), "C:");
+            Assert.AreEqual("foo".RemoveTrailingPathSeparator(), "foo");
+            Assert.AreEqual($"foo{s}".RemoveTrailingPathSeparator(), "foo");
+            Assert.AreEqual($"foo{s}bar".RemoveTrailingPathSeparator(), $"foo{s}bar");
+            Assert.AreEqual($"foo{s}bar{s}".RemoveTrailingPathSeparator(), $"foo{s}bar");
+
+            Assert.AreEqual("foo/".RemoveTrailingPathSeparator(), "foo");
+            Assert.AreEqual("foo/bar".RemoveTrailingPathSeparator(), "foo/bar");
+            Assert.AreEqual("foo/bar/".RemoveTrailingPathSeparator(), "foo/bar");
         }
 
         [Test]


### PR DESCRIPTION
Changes proposed in this pull request:
- `GitModule` eagerly loads submodule properties. Prevents race conditions.
- Move path separator from `AppSettings` to `PathUtil` (it's a constant, not a setting).
- Add `PathUtil.RemoveTrailingSeparator` and unit tests, to complement `PathUtil.EnsureTrailingPathSeparator`.
` Add `PathUtil.FindAncestors` and unit tests.
- Annotate and document the three properties in question, `SuperprojectModule`, `SubmodulePath`, `SubmoduleName`.

This simplifies `GitModule` a bit. Testing shows that the laziness is not used as nearly every instance of `GitModule` initialises these fields after construction. Those that don't test to have a `WorkingDir` of `""` which short circuits the initialisation anyway.

Future work would bring in the `IFileSystem` abstraction to add more tests to this initialisation. That change is blocked behind #5281.
 
What did I do to test the code and ensure quality:
- Added unit tests
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
