### PR TITLE
More uses of ObjectId

### DIFF
--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -226,5 +226,27 @@ namespace GitCommands
 
             builder.Add(objectId.ToString());
         }
+
+        /// <summary>
+        /// Adds a sequence of <paramref name="objectIds"/> to the builder.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="objectIds"/> is <c>null</c> then no change is made to the arguments.
+        /// </remarks>
+        /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
+        /// <param name="objectIds">A sequence of SHA-1 object IDs to add to the builder, or <c>null</c>.</param>
+        /// <exception cref="ArgumentException"><paramref name="objectIds"/> contains an artificial commit.</exception>
+        public static void Add(this ArgumentBuilder builder, [CanBeNull, ItemCanBeNull] IEnumerable<ObjectId> objectIds)
+        {
+            if (objectIds == null)
+            {
+                return;
+            }
+
+            foreach (var objectId in objectIds)
+            {
+                builder.Add(objectId);
+            }
+        }
     }
 }

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -315,14 +315,14 @@ namespace GitCommands
             }
         }
 
-        public static string CherryPickCmd(string cherry, bool commit, string arguments)
+        public static string CherryPickCmd(ObjectId commitId, bool commit, string arguments)
         {
             var args = new ArgumentBuilder
             {
                 "cherry-pick",
                 { !commit, "--no-commit" },
                 arguments,
-                cherry.Quote()
+                commitId
             };
 
             return args.ToString();

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -375,14 +375,14 @@ namespace GitCommands
             return args.ToString();
         }
 
-        public static string RevertCmd(string commit, bool autoCommit, int parentIndex)
+        public static string RevertCmd(ObjectId commitId, bool autoCommit, int parentIndex)
         {
             var args = new ArgumentBuilder
             {
                 "revert",
                 { !autoCommit, "--no-commit" },
                 { parentIndex > 0, $"-m {parentIndex}" },
-                commit
+                commitId
             };
 
             return args.ToString();

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -585,7 +585,7 @@ namespace GitCommands
             return "bisect start";
         }
 
-        public static string ContinueBisectCmd(GitBisectOption bisectOption, params string[] revisions)
+        public static string ContinueBisectCmd(GitBisectOption bisectOption, params ObjectId[] revisions)
         {
             var args = new ArgumentBuilder
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2973,7 +2973,7 @@ namespace GitCommands
             }
 
             // BUG this sorting logic has no effect as CommitDate is not set by the GitRevision constructor
-            DateTime GetDate(IGitRef head) => new GitRevision(ObjectId.Parse(head.Guid)).CommitDate;
+            DateTime GetDate(IGitRef head) => new GitRevision(head.ObjectId).CommitDate;
         }
 
         public enum GetTagRefsSortOrder

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3037,7 +3037,7 @@ namespace GitCommands
             foreach (Match match in matches)
             {
                 var refName = match.Groups["refname"].Value;
-                var objectId = ObjectId.Parse(match.Groups["objectid"].Value);
+                var objectId = ObjectId.Parse(refList, match.Groups["objectid"]);
                 var remoteName = GitRefName.GetRemoteName(refName);
                 var head = new GitRef(this, objectId, refName, remoteName);
 
@@ -3356,7 +3356,7 @@ namespace GitCommands
 
                 if (match.Success)
                 {
-                    objectId = ObjectId.Parse(match.Groups["objectid"].Value);
+                    objectId = ObjectId.Parse(line, match.Groups["objectid"]);
                     finalLineNumber = int.Parse(match.Groups["finallinenum"].Value);
                     originLineNumber = int.Parse(match.Groups["origlinenum"].Value);
                 }

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -62,7 +62,7 @@ namespace GitCommands.Git
 
             var mode = int.Parse(match.Groups["mode"].Value);
             var typeName = match.Groups["type"].Value;
-            var objectId = ObjectId.Parse(match.Groups["objectid"].Value);
+            var objectId = ObjectId.Parse(rawItem, match.Groups["objectid"]);
             var name = match.Groups["name"].Value;
 
             Enum.TryParse(typeName, ignoreCase: true, out GitObjectType type);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -35,7 +35,7 @@ namespace GitUI.BranchTreePanel
 
             public void CreateBranch()
             {
-                UICommands.StartCreateBranchDialog(TreeViewNode.TreeView, ObjectId.Parse(_tagInfo.Guid));
+                UICommands.StartCreateBranchDialog(TreeViewNode.TreeView, _tagInfo.ObjectId);
             }
 
             public void Delete()

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
@@ -55,13 +56,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             {
                 if (MessageBox.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
-                    BisectRange(revisions.First().Guid, revisions.Last().Guid);
+                    BisectRange(revisions.First().ObjectId, revisions.Last().ObjectId);
                     Close();
                 }
             }
         }
 
-        private void BisectRange(string startRevision, string endRevision)
+        private void BisectRange(ObjectId startRevision, ObjectId endRevision)
         {
             var command = GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Good, startRevision);
             var errorOccurred = !FormProcess.ShowDialog(this, command);

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -60,19 +60,21 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     Close();
                 }
             }
-        }
 
-        private void BisectRange(ObjectId startRevision, ObjectId endRevision)
-        {
-            var command = GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Good, startRevision);
-            var errorOccurred = !FormProcess.ShowDialog(this, command);
-            if (errorOccurred)
+            return;
+
+            void BisectRange(ObjectId startRevision, ObjectId endRevision)
             {
-                return;
-            }
+                var command = GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Good, startRevision);
+                var errorOccurred = !FormProcess.ShowDialog(this, command);
+                if (errorOccurred)
+                {
+                    return;
+                }
 
-            command = GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Bad, endRevision);
-            FormProcess.ShowDialog(this, command);
+                command = GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Bad, endRevision);
+                FormProcess.ShowDialog(this, command);
+            }
         }
 
         private void Good_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -105,7 +105,7 @@ namespace GitUI.CommandsDialogs
 
             if (canExecute)
             {
-                FormProcess.ShowDialog(this, GitCommandHelpers.CherryPickCmd(Revision.Guid, AutoCommit.Checked, string.Join(" ", argumentsList.ToArray())));
+                FormProcess.ShowDialog(this, GitCommandHelpers.CherryPickCmd(Revision.ObjectId, AutoCommit.Checked, string.Join(" ", argumentsList.ToArray()));
                 MergeConflictHandler.HandleMergeConflicts(UICommands, this, AutoCommit.Checked);
                 DialogResult = DialogResult.OK;
                 Close();

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -68,7 +68,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            FormProcess.ShowDialog(this, GitCommandHelpers.RevertCmd(Revision.Guid, AutoCommit.Checked, parentIndex));
+            FormProcess.ShowDialog(this, GitCommandHelpers.RevertCmd(Revision.ObjectId, AutoCommit.Checked, parentIndex));
             MergeConflictHandler.HandleMergeConflicts(UICommands, this, AutoCommit.Checked);
             DialogResult = DialogResult.OK;
             Close();

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -97,7 +97,7 @@ namespace GitUI.CommandsDialogs
                 var matchedGroups = patternMatch.Groups;
                 var rawType = matchedGroups[1].Value;
                 var objectType = GetObjectType(matchedGroups[3]);
-                var objectId = ObjectId.Parse(matchedGroups[4].Value);
+                var objectId = ObjectId.Parse(raw, matchedGroups[4]);
                 var result = new LostObject(objectType, rawType, objectId);
 
                 if (objectType == LostObjectType.Commit)
@@ -126,7 +126,7 @@ namespace GitUI.CommandsDialogs
                     var tagPatternMatch = TagRegex.Match(tagData);
                     if (tagPatternMatch.Success)
                     {
-                        result.Parent = ObjectId.Parse(tagPatternMatch.Groups[1].Value);
+                        result.Parent = ObjectId.Parse(tagData, tagPatternMatch.Groups[1]);
                         result.Author = module.ReEncodeStringFromLossless(tagPatternMatch.Groups[3].Value);
                         result.TagName = tagPatternMatch.Groups[2].Value;
                         result.Subject = result.TagName + ":" + tagPatternMatch.Groups[5].Value;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1878,7 +1878,7 @@ namespace GitUI
                 return;
             }
 
-            FormProcess.ShowDialog(this, Module, GitCommandHelpers.ContinueBisectCmd(bisectOption, LatestSelectedRevision.Guid), false);
+            FormProcess.ShowDialog(this, Module, GitCommandHelpers.ContinueBisectCmd(bisectOption, LatestSelectedRevision.ObjectId), false);
             RefreshRevisions();
         }
 

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -58,7 +58,7 @@ namespace AppVeyorIntegration
         private HttpClient _httpClientGitHub;
 
         private List<AppVeyorBuildInfo> _allBuilds = new List<AppVeyorBuildInfo>();
-        private HashSet<string> _fetchBuilds;
+        private HashSet<ObjectId> _fetchBuilds;
         private string _accountToken;
         private static readonly Dictionary<string, Project> Projects = new Dictionary<string, Project>();
         private Func<ObjectId, bool> _isCommitInRevisionGrid;
@@ -67,7 +67,8 @@ namespace AppVeyorIntegration
         private string _gitHubToken;
 
         public void Initialize(
-            IBuildServerWatcher buildServerWatcher, ISettingsSource config,
+            IBuildServerWatcher buildServerWatcher,
+            ISettingsSource config,
             Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
             if (_buildServerWatcher != null)
@@ -90,7 +91,7 @@ namespace AppVeyorIntegration
             _shouldDisplayGitHubPullRequestBuilds = config.GetBool("AppVeyorDisplayGitHubPullRequests", false)
                     && !string.IsNullOrWhiteSpace(_gitHubToken);
 
-            _fetchBuilds = new HashSet<string>();
+            _fetchBuilds = new HashSet<ObjectId>();
 
             _httpClientAppVeyor = GetHttpClient(WebSiteUrl, _accountToken);
 
@@ -273,7 +274,7 @@ namespace AppVeyorIntegration
                                 Id = version,
                                 BuildId = b["buildId"].ToObject<string>(),
                                 Branch = b["branch"].ToObject<string>(),
-                                CommitId = commitSha1,
+                                CommitId = objectId,
                                 CommitHashList = new[] { objectId },
                                 Status = status,
                                 StartDate = b["started"]?.ToObject<DateTime>() ?? DateTime.MinValue,
@@ -544,7 +545,7 @@ namespace AppVeyorIntegration
         private int _buildProgressCount;
 
         public string BuildId { get; set; }
-        public string CommitId { get; set; }
+        public ObjectId CommitId { get; set; }
         public string AppVeyorBuildReportUrl { get; set; }
         public string Branch { get; set; }
         public string BaseApiUrl { get; set; }

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -274,7 +274,7 @@ namespace AppVeyorIntegration
                                 BuildId = b["buildId"].ToObject<string>(),
                                 Branch = b["branch"].ToObject<string>(),
                                 CommitId = commitSha1,
-                                CommitHashList = new[] { ObjectId.Parse(commitSha1) },
+                                CommitHashList = new[] { objectId },
                                 Status = status,
                                 StartDate = b["started"]?.ToObject<DateTime>() ?? DateTime.MinValue,
                                 BaseWebUrl = baseWebUrl,

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using JetBrains.Annotations;
 
@@ -348,6 +349,29 @@ namespace GitUIPluginInterfaces
                 success = false;
                 return -1;
             }
+        }
+
+        /// <summary>
+        /// Parses an <see cref="ObjectId"/> from a regex <see cref="Capture"/> that was produced by matching against <paramref name="s"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method avoids the temporary string created by calling <see cref="Capture.Value"/>.</para>
+        /// <para>For parsing to succeed, <paramref name="s"/> must be a valid 40-character SHA-1 string.</para>
+        /// </remarks>
+        /// <param name="s">The string that the regex <see cref="Capture"/> was produced from.</param>
+        /// <param name="capture">The regex capture/group that describes the location of the SHA-1 hash within <paramref name="s"/>.</param>
+        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
+        /// <exception cref="FormatException"><paramref name="s"/> did not contain a valid 40-character SHA-1 hash.</exception>
+        [NotNull]
+        [MustUseReturnValue]
+        public static ObjectId Parse([NotNull] string s, [NotNull] Capture capture)
+        {
+            if (s == null || capture == null || capture.Length != Sha1CharCount || !TryParse(s, capture.Index, out var id))
+            {
+                throw new FormatException($"Unable to parse object ID \"{s}\".");
+            }
+
+            return id;
         }
 
         #endregion

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -610,6 +610,9 @@ namespace GitCommandsTests.Git
         [Test]
         public void ContinueBisectCmd()
         {
+            var id1 = ObjectId.Random();
+            var id2 = ObjectId.Random();
+
             Assert.AreEqual(
                 "bisect good",
                 GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Good));
@@ -620,8 +623,8 @@ namespace GitCommandsTests.Git
                 "bisect skip",
                 GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Skip));
             Assert.AreEqual(
-                "bisect good rev1 rev2",
-                GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Good, "rev1", "rev2"));
+                $"bisect good {id1} {id2}",
+                GitCommandHelpers.ContinueBisectCmd(GitBisectOption.Good, id1, id2));
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -428,17 +428,19 @@ namespace GitCommandsTests.Git
         [Test]
         public void RevertCmd()
         {
-            Assert.AreEqual(
-                "revert commit",
-                GitCommandHelpers.RevertCmd("commit", autoCommit: true, parentIndex: 0));
+            var commitId = ObjectId.Random();
 
             Assert.AreEqual(
-                "revert --no-commit commit",
-                GitCommandHelpers.RevertCmd("commit", autoCommit: false, parentIndex: 0));
+                $"revert {commitId}",
+                GitCommandHelpers.RevertCmd(commitId, autoCommit: true, parentIndex: 0));
 
             Assert.AreEqual(
-                "revert -m 1 commit",
-                GitCommandHelpers.RevertCmd("commit", autoCommit: true, parentIndex: 1));
+                $"revert --no-commit {commitId}",
+                GitCommandHelpers.RevertCmd(commitId, autoCommit: false, parentIndex: 0));
+
+            Assert.AreEqual(
+                $"revert -m 1 {commitId}",
+                GitCommandHelpers.RevertCmd(commitId, autoCommit: true, parentIndex: 1));
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
@@ -98,6 +99,17 @@ namespace GitCommandsTests.Git
             Assert.AreEqual(
                 sha1.Substring(offset, 40),
                 ObjectId.Parse(sha1, offset).ToString());
+        }
+
+        [Test]
+        public void ParseFromRegexCapture()
+        {
+            var objectId = ObjectId.Random();
+            var str = "XYZ" + objectId + "XYZ";
+
+            Assert.AreEqual(objectId, ObjectId.Parse(str, Regex.Match(str, "[a-f0-9]{40}")));
+            Assert.Throws<FormatException>(() => ObjectId.Parse(str, Regex.Match(str, "[a-f0-9]{39}")));
+            Assert.Throws<FormatException>(() => ObjectId.Parse(str, Regex.Match(str, "[XYZa-f0-9]{39}")));
         }
 
         [Test]


### PR DESCRIPTION
Changes proposed in this pull request:
- `ArgumentBuilder` extension for `IEnumerable<ObjectId>`
- Bisect operations accept `ObjectId`
- Revert operations accept `ObjectId`
- Cherry pick operations accept `ObjectId`
- `AppVeyorBuildInfo` uses `ObjectId`
- Method and test for parsing `ObjectId` from a regex capture without allocating temporary string, and update usages
- Some formatting
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
