### PR TITLE
Fix blocking UI when drawing superproject refs

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1227,18 +1227,12 @@ namespace GitUI
             }
         }
 
+        [ContractAnnotation("=>false,spi:null")]
+        [ContractAnnotation("=>true,spi:notnull")]
         internal bool TryGetSuperProjectInfo(out SuperProjectInfo spi)
         {
-            if (_superprojectCurrentCheckout.Task.IsCompleted)
-            {
-                spi = default;
-                return false;
-            }
-
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            spi = _superprojectCurrentCheckout.Task.Result;
-#pragma warning restore VSTHRD002
-            return true;
+            spi = _superprojectCurrentCheckout.Task.CompletedOrDefault();
+            return spi != null;
         }
 
         private void OnGridViewDoubleClick(object sender, MouseEventArgs e)


### PR DESCRIPTION
Fixes #5166

Refactor in ef2e4794cad2b755a984c6bb592027c17b6cf966 broke this. There was a missing `!`. This change reuses an existing extension method to keep things simple.
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
