### PR TITLE
DPI and other tweaks to FormReflog and FormStash

### DIFF
--- a/GitUI/CommandsDialogs/FormReflog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormReflog.Designer.cs
@@ -226,7 +226,7 @@ namespace GitUI.CommandsDialogs
             this.createABranchOnThisCommitToolStripMenuItem.Image = global::GitUI.Properties.Images.BranchCreate;
             this.createABranchOnThisCommitToolStripMenuItem.Name = "createABranchOnThisCommitToolStripMenuItem";
             this.createABranchOnThisCommitToolStripMenuItem.Size = new System.Drawing.Size(322, 26);
-            this.createABranchOnThisCommitToolStripMenuItem.Text = "Create a branch on this commit";
+            this.createABranchOnThisCommitToolStripMenuItem.Text = "Create a branch on this commit...";
             this.createABranchOnThisCommitToolStripMenuItem.Click += new System.EventHandler(this.createABranchOnThisCommitToolStripMenuItem_Click);
             // 
             // resetCurrentBranchOnThisCommitToolStripMenuItem
@@ -234,7 +234,7 @@ namespace GitUI.CommandsDialogs
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetCurrentBranchToHere;
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Name = "resetCurrentBranchOnThisCommitToolStripMenuItem";
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Size = new System.Drawing.Size(322, 26);
-            this.resetCurrentBranchOnThisCommitToolStripMenuItem.Text = "Reset current branch on this commit";
+            this.resetCurrentBranchOnThisCommitToolStripMenuItem.Text = "Reset current branch to this commit...";
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Click += new System.EventHandler(this.resetCurrentBranchOnThisCommitToolStripMenuItem_Click);
             // 
             // lblDirtyWorkingDirectory

--- a/GitUI/CommandsDialogs/FormReflog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormReflog.Designer.cs
@@ -215,6 +215,7 @@ namespace GitUI.CommandsDialogs
             // 
             // copySha1ToolStripMenuItem
             // 
+            this.copySha1ToolStripMenuItem.Image = global::GitUI.Properties.Images.CommitId;
             this.copySha1ToolStripMenuItem.Name = "copySha1ToolStripMenuItem";
             this.copySha1ToolStripMenuItem.Size = new System.Drawing.Size(322, 26);
             this.copySha1ToolStripMenuItem.Text = "Copy SHA-1";
@@ -222,6 +223,7 @@ namespace GitUI.CommandsDialogs
             // 
             // createABranchOnThisCommitToolStripMenuItem
             // 
+            this.createABranchOnThisCommitToolStripMenuItem.Image = global::GitUI.Properties.Images.BranchCreate;
             this.createABranchOnThisCommitToolStripMenuItem.Name = "createABranchOnThisCommitToolStripMenuItem";
             this.createABranchOnThisCommitToolStripMenuItem.Size = new System.Drawing.Size(322, 26);
             this.createABranchOnThisCommitToolStripMenuItem.Text = "Create a branch on this commit";
@@ -229,6 +231,7 @@ namespace GitUI.CommandsDialogs
             // 
             // resetCurrentBranchOnThisCommitToolStripMenuItem
             // 
+            this.resetCurrentBranchOnThisCommitToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetCurrentBranchToHere;
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Name = "resetCurrentBranchOnThisCommitToolStripMenuItem";
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Size = new System.Drawing.Size(322, 26);
             this.resetCurrentBranchOnThisCommitToolStripMenuItem.Text = "Reset current branch on this commit";

--- a/GitUI/CommandsDialogs/FormReflog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormReflog.Designer.cs
@@ -167,7 +167,6 @@ namespace GitUI.CommandsDialogs
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.gridReflog.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCellsExceptHeader;
-            this.gridReflog.ColumnHeadersHeight = 30;
             this.gridReflog.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Sha,
             this.Ref,
@@ -178,7 +177,6 @@ namespace GitUI.CommandsDialogs
             this.gridReflog.MultiSelect = false;
             this.gridReflog.Name = "gridReflog";
             this.gridReflog.ReadOnly = true;
-            this.gridReflog.RowTemplate.Height = 24;
             this.gridReflog.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.gridReflog.Size = new System.Drawing.Size(825, 509);
             this.gridReflog.TabIndex = 33;

--- a/GitUI/CommandsDialogs/FormReflog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormReflog.Designer.cs
@@ -206,7 +206,6 @@ namespace GitUI.CommandsDialogs
             // 
             // contextMenuStripReflog
             // 
-            this.contextMenuStripReflog.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStripReflog.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copySha1ToolStripMenuItem,
             this.createABranchOnThisCommitToolStripMenuItem,

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
@@ -34,6 +35,9 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             InitializeComplete();
+
+            gridReflog.RowTemplate.Height = DpiUtil.Scale(24);
+            gridReflog.ColumnHeadersHeight = DpiUtil.Scale(30);
 
             Sha.DataPropertyName = nameof(RefLine.Sha);
             Ref.DataPropertyName = nameof(RefLine.Ref);

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs
         private void gridReflog_MouseMove(object sender, MouseEventArgs e)
         {
             DataGridView.HitTestInfo hit = gridReflog.HitTest(e.X, e.Y);
-            if (hit.Type == DataGridViewHitTestType.Cell)
+            if (hit.Type == DataGridViewHitTestType.Cell && _lastHitRowIndex != hit.RowIndex)
             {
                 gridReflog.Rows[_lastHitRowIndex].Selected = false;
                 _lastHitRowIndex = hit.RowIndex;

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -113,16 +113,13 @@ namespace GitUI.CommandsDialogs
             var row = GetSelectedRow();
             var refLine = (RefLine)row.DataBoundItem;
             return refLine.Sha;
-        }
 
-        private DataGridViewRow GetSelectedRow()
-        {
-            if (gridReflog.SelectedRows.Count > 0)
+            DataGridViewRow GetSelectedRow()
             {
-                return gridReflog.SelectedRows[0];
+                return gridReflog.SelectedRows.Count > 0
+                    ? gridReflog.SelectedRows[0]
+                    : gridReflog.Rows[gridReflog.SelectedCells[0].RowIndex];
             }
-
-            return gridReflog.Rows[gridReflog.SelectedCells[0].RowIndex];
         }
 
         private void resetCurrentBranchOnThisCommitToolStripMenuItem_Click(object sender, EventArgs e)
@@ -161,7 +158,8 @@ namespace GitUI.CommandsDialogs
 
         private void gridReflog_MouseMove(object sender, MouseEventArgs e)
         {
-            DataGridView.HitTestInfo hit = gridReflog.HitTest(e.X, e.Y);
+            var hit = gridReflog.HitTest(e.X, e.Y);
+
             if (hit.Type == DataGridViewHitTestType.Cell && _lastHitRowIndex != hit.RowIndex)
             {
                 gridReflog.Rows[_lastHitRowIndex].Selected = false;

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormReflog : GitModuleForm
     {
-        private readonly TranslationString _continueResetCurrentBranchEvenWithChangesText = new TranslationString("You've got changes in your working directory that could be lost.\n\nDo you want to continue?");
+        private readonly TranslationString _continueResetCurrentBranchEvenWithChangesText = new TranslationString("You have changes in your working directory that could be lost.\n\nDo you want to continue?");
         private readonly TranslationString _continueResetCurrentBranchCaptionText = new TranslationString("Changes not committed...");
 
         private readonly Regex _regexReflog = new Regex("^([^ ]+) ([^:]+): (.+)$", RegexOptions.Compiled);

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -1,5 +1,4 @@
 using System.Windows.Forms;
-using GitCommands.Git;
 using GitUI.Editor;
 using GitUI.UserControls.RevisionGrid;
 
@@ -277,7 +276,6 @@ namespace GitUI.CommandsDialogs
             this.toolStrip1.ClickThrough = true;
             this.toolStrip1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showToolStripLabel,
             this.Stashes,

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -8,7 +8,6 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Patches;
 using GitExtUtils.GitUI;
-using GitUI.Properties;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -6967,7 +6967,7 @@ Není potřeba nic přeskládávat.</target>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -6977,7 +6977,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>Vytvořit větev z tohoto odevzdání</target>
         
       </trans-unit>
@@ -7004,7 +7004,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>Zahodit současnou větev na toto odevzdání</target>
         
       </trans-unit>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -7105,7 +7105,7 @@ Er is niets te doen.</target>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target>U heeft wijzigingen in uw werk directory de verloren kunnen gaan.
@@ -7118,7 +7118,7 @@ Wilt u doorgaan?</target>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>Maak een branch op deze commit</target>
         
       </trans-unit>
@@ -7148,7 +7148,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>Reset de huidige branch op deze commit</target>
         
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5563,7 +5563,7 @@ Nothing to rebase.</source>
         <target />
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target />
@@ -5573,7 +5573,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -5598,7 +5598,7 @@ Stash them before if you don't want to lose them.</source>
         <target />
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -7103,7 +7103,7 @@ Rien à rebaser.</target>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target>Vous avez des modifications dans votre espace de travail qui peuvent être perdues.
@@ -7117,7 +7117,7 @@ Voulez-vous continuer?</target>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>Créer un branche sur ce commit</target>
         
       </trans-unit>
@@ -7149,7 +7149,7 @@ Réservez les avant si vous ne voulez pas les perdre.</target>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>Réinitialiser la branche courante à ce commit</target>
         
       </trans-unit>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -7073,7 +7073,7 @@ Kein Rebase nötig.</target>
 
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target>Sie haben Änderungen in Ihrem Arbeitsverzeichnis, die verloren gehen könnten.
@@ -7086,7 +7086,7 @@ Möchten Sie fortfahren?</target>
 
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>Einen Branch auf diesem Commit erzeugen</target>
 
       </trans-unit>
@@ -7116,7 +7116,7 @@ Stash them before if you don't want to lose them.</source>
 
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>Setze den aktuellen Branch auf diesen Commit zurück</target>
 
       </trans-unit>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -6779,7 +6779,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -6789,7 +6789,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -6814,7 +6814,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -7045,7 +7045,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -7056,7 +7056,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>このコミットでブランチを作成</target>
         
       </trans-unit>
@@ -7086,7 +7086,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -6706,7 +6706,7 @@ Rebase 할 사항이 없습니다.</target>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -6716,7 +6716,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -6741,7 +6741,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -6984,7 +6984,7 @@ Zmiana bazy niepotrzebna.</target>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -6994,7 +6994,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>Stwórz gałąź na tym zatwierdzeniu</target>
         
       </trans-unit>
@@ -7021,7 +7021,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>Zresetuj bieżącą gałąź na tym zatwierdzeniu</target>
         
       </trans-unit>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -6835,7 +6835,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -6845,7 +6845,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -6872,7 +6872,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -5789,7 +5789,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -5799,7 +5799,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -5824,7 +5824,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -7057,7 +7057,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -7068,7 +7068,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>Создать ветку с этого коммита</target>
         
       </trans-unit>
@@ -7097,7 +7097,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>Сбросить текущую ветвь на коммит</target>
         
       </trans-unit>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -7092,7 +7092,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target>工作目录中的更改有可能丢失。
@@ -7105,7 +7105,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>从这个提交处创建一个分支</target>
         
       </trans-unit>
@@ -7137,7 +7137,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>复位当前分支到这里提交</target>
         
       </trans-unit>

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -7006,7 +7006,7 @@ Nada para rebase.</target>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -7016,7 +7016,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -7044,7 +7044,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -6746,7 +6746,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         
@@ -6756,7 +6756,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -6781,7 +6781,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         
       </trans-unit>
     </body>

--- a/GitUI/Translation/en_pseudo.Plugins.xlf
+++ b/GitUI/Translation/en_pseudo.Plugins.xlf
@@ -7080,7 +7080,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target>[Ẏǿŭ'ṽḗ ɠǿŧ ƈħȧƞɠḗş īƞ ẏǿŭř ẇǿřķīƞɠ ḓīřḗƈŧǿřẏ ŧħȧŧ ƈǿŭŀḓ ƀḗ ŀǿşŧ.
@@ -7094,7 +7094,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>[Ƈřḗȧŧḗ ȧ ƀřȧƞƈħ ǿƞ ŧħīş ƈǿḿḿīŧ ϵ鶱ϕǲΰΐ ς ſ]</target>
         
       </trans-unit>
@@ -7126,7 +7126,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>[Řḗşḗŧ ƈŭřřḗƞŧ ƀřȧƞƈħ ǿƞ ŧħīş ƈǿḿḿīŧ ςẛǋϑǅ ǅǲẛ靐ϑ]</target>
         
       </trans-unit>

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -7115,7 +7115,7 @@ Nothing to rebase.</source>
         
       </trans-unit>
       <trans-unit id="_continueResetCurrentBranchEvenWithChangesText.Text">
-        <source>You've got changes in your working directory that could be lost.
+        <source>You have changes in your working directory that could be lost.
 
 Do you want to continue?</source>
         <target>[Ẏǿŭ'ṽḗ ɠǿŧ ƈħȧƞɠḗş īƞ ẏǿŭř ẇǿřķīƞɠ ḓīřḗƈŧǿřẏ ŧħȧŧ ƈǿŭŀḓ ƀḗ ŀǿşŧ.
@@ -7129,7 +7129,7 @@ Do you want to continue?</source>
         
       </trans-unit>
       <trans-unit id="createABranchOnThisCommitToolStripMenuItem.Text">
-        <source>Create a branch on this commit</source>
+        <source>Create a branch on this commit...</source>
         <target>[Ƈřḗȧŧḗ ȧ ƀřȧƞƈħ ǿƞ ŧħīş ƈǿḿḿīŧ ϐ靐ϖϕ鶱ϰ ς 鶱]</target>
         
       </trans-unit>
@@ -7161,7 +7161,7 @@ Stash them before if you don't want to lose them.</source>
         
       </trans-unit>
       <trans-unit id="resetCurrentBranchOnThisCommitToolStripMenuItem.Text">
-        <source>Reset current branch on this commit</source>
+        <source>Reset current branch to this commit...</source>
         <target>[Řḗşḗŧ ƈŭřřḗƞŧ ƀřȧƞƈħ ǿƞ ŧħīş ƈǿḿḿīŧ ǈ鶱ϰǲǋ ςǅ靐ıϵ]</target>
         
       </trans-unit>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Relates to #5305 (possibly fixes it).

## Changes
- Remove all references to `ImageScalingSize`, changing `FormReflog` and `FormStash` (#5305)
- Fix vertically compressed reflog grid rows at high scaling
- Add icons to reflog context menu
- Suffix reflog context menu items with "..." as they prompt the user
- Fix flickering in reflog grid during mouse move
 
## Screenshots

I don't include screenshots of `FormStash` because the icons look identical before/after. My theory is that they'll look better at 100% scaling though. My docking station (and hence external 96dpi monitor) is still kaput so it's hard for me to test at 100% scaling right now without rebooting a bunch of times. These changes are benign in the worst case. If merged could someone please verify against #5305?

### Before

![image](https://user-images.githubusercontent.com/350947/43921333-53cbca2c-9c13-11e8-8992-81abf4f91d15.png)

### After

![image](https://user-images.githubusercontent.com/350947/43921177-e9a75dd2-9c12-11e8-8df1-ea044f7ae113.png)

## Testing steps
- Manual testing at 200%

## Tested on
- 200% scaling
- Windows 10
