### PR TITLE
fix: Clone from FormBrowse does not prompt to open

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -237,6 +237,7 @@ namespace GitUI
                 return;
             }
 
+            var openFormsCount = Application.OpenForms.Count;
             Form form = provideForm();
 
             void FormClosed(object sender, FormClosedEventArgs e)
@@ -248,7 +249,7 @@ namespace GitUI
             form.FormClosed += FormClosed;
             form.ShowInTaskbar = true;
 
-            if (Application.OpenForms.Count > 0)
+            if (openFormsCount > 0)
             {
                 form.Show();
             }

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -26,7 +26,8 @@ namespace ResourceManager
         {
             _initialiser = new GitExtensionsControlInitialiser(this);
 
-            ShowInTaskbar = Application.OpenForms.Count <= 0;
+            var openFormCount = Application.OpenForms.Count;
+            ShowInTaskbar = openFormCount <= 0;
             Icon = Resources.GitExtensionsLogoIcon;
         }
 


### PR DESCRIPTION
`Application.OpenForms.Count` intermittently is 0, thus causing certain forms to be shown in the taskbar and breaking certain codepaths. For example, whenever `FormClone` is invoked and a new repo is cloned the user must be prompted to open the new repository. This prompt is driven by a check to see whether the `FormClone` is shown in the taskbar or not.

There are also suggestions the observed behaviour is caused by a WinForms' bug https://stackoverflow.com/a/3751748/2338036.

Fixes #5274

What did I do to test the code and ensure quality:
- manual

Has been tested on (remove any that don't apply):
- Windows 10 and above
