### PR TITLE
gitk would not start if Git path was set to cmd/git.exe

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -928,9 +928,10 @@ namespace GitCommands
             {
                 // locate gitk based on location of git executable
                 var cmd = AppSettings.GitCommand
-                    .Replace("git.cmd", "gitk")
                     .Replace("bin\\git.exe", "cmd\\gitk")
-                    .Replace("bin/git.exe", "cmd/gitk");
+                    .Replace("bin/git.exe", "cmd/gitk")
+                    .Replace("git.exe", "gitk")
+                    .Replace("git.cmd", "gitk");
 
                 new Executable("cmd.exe", WorkingDir).Start($"/c \"\"{cmd}\" --branches --tags --remotes\"");
             }


### PR DESCRIPTION
Mentioned in #5281

Changes proposed in this pull request:
- gitk would not start if Git path was set to "git root"/cmd/git.exe

What did I do to test the code and ensure quality:
- Manual test

Has been tested on (remove any that don't apply):
- Windows 10