### PR TITLE
Command log call stacks

### DIFF
--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -2,7 +2,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using GitUI;
+using JetBrains.Annotations;
 
 namespace GitCommands.Logging
 {
@@ -55,6 +57,7 @@ namespace GitCommands.Logging
         public TimeSpan? Duration { get; internal set; }
         public int? ProcessId { get; set; }
         public int? ExitCode { get; set; }
+        [CanBeNull] public StackTrace CallStack { get; set; }
 
         internal CommandLogEntry(string fileName, string arguments, DateTime startedAt, bool isOnMainThread)
         {
@@ -64,23 +67,53 @@ namespace GitCommands.Logging
             IsOnMainThread = isOnMainThread;
         }
 
-        public override string ToString()
+        public string ColumnLine
         {
-            var duration = Duration == null
-                ? "running"
-                : $"{((TimeSpan)Duration).TotalMilliseconds:0}ms";
-
-            var fileName = FileName;
-
-            if (fileName.EndsWith("git.exe"))
+            get
             {
-                fileName = "git";
+                var duration = Duration == null
+                    ? "running"
+                    : $"{((TimeSpan)Duration).TotalMilliseconds:0}ms";
+
+                var fileName = FileName;
+
+                if (fileName.EndsWith("git.exe"))
+                {
+                    fileName = "git";
+                }
+
+                var pid = ProcessId == null ? "     " : $"{ProcessId,5}";
+                var exit = ExitCode == null ? "  " : $"{ExitCode,2}";
+
+                return $"{StartedAt:HH:mm:ss.fff} {duration,7} {pid} {(IsOnMainThread ? "UI" : "  ")} {exit} {fileName} {Arguments}";
             }
+        }
 
-            var pid = ProcessId == null ? "     " : $"{ProcessId,5}";
-            var exit = ExitCode == null ? "  " : $"{ExitCode,2}";
+        public string Detail
+        {
+            get
+            {
+                var s = new StringBuilder();
 
-            return $"{StartedAt:HH:mm:ss.fff} {duration,7} {pid} {(IsOnMainThread ? "UI" : "  ")} {exit} {fileName} {Arguments}";
+                s.Append("File name:  ").AppendLine(FileName);
+                s.Append("Arguments:  ").AppendLine(Arguments);
+                s.Append("Process ID: ").Append(ProcessId == null ? "unknown" : ProcessId.ToString()).AppendLine();
+                s.Append("Started at: ").Append(StartedAt.ToString("O")).AppendLine();
+                s.Append("UI Thread?: ").Append(IsOnMainThread).AppendLine();
+                s.Append("Duration:   ").Append(Duration == null ? "still running" : $"{Duration.Value.TotalMilliseconds:0.###} ms").AppendLine();
+                s.Append("Exit code:  ").Append(ExitCode == null ? "unknown" : ExitCode.ToString()).AppendLine();
+
+                if (CallStack != null)
+                {
+                    s.AppendLine("Call stack: ").Append(CallStack);
+                }
+                else
+                {
+                    s.Append("Call stack: not captured");
+                }
+
+                return s.ToString();
+            }
         }
     }
 
@@ -90,6 +123,8 @@ namespace GitCommands.Logging
 
         private static ConcurrentQueue<CommandLogEntry> _queue = new ConcurrentQueue<CommandLogEntry>();
 
+        public static bool CaptureCallStacks { get; set; }
+
         public static IEnumerable<CommandLogEntry> Commands => _queue;
 
         public static ProcessOperation LogProcessStart(string fileName, string arguments = "")
@@ -97,6 +132,11 @@ namespace GitCommands.Logging
             const int MaxEntryCount = 500;
 
             var entry = new CommandLogEntry(fileName, arguments, DateTime.Now, ThreadHelper.JoinableTaskContext.IsOnMainThread);
+
+            if (CaptureCallStacks)
+            {
+                entry.CallStack = new StackTrace();
+            }
 
             _queue.Enqueue(entry);
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
@@ -45,6 +45,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.chkAlwaysOnTop = new System.Windows.Forms.CheckBox();
             this.chkWordWrap = new System.Windows.Forms.CheckBox();
             this.mnuClear = new System.Windows.Forms.ToolStripMenuItem();
+            this.chkCaptureCallStacks = new System.Windows.Forms.CheckBox();
             this.TabControl.SuspendLayout();
             this.tabPageCommandLog.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
@@ -127,7 +128,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             // mnuSaveToFile
             // 
-            this.mnuSaveToFile.Image = GitUI.Properties.Images.SaveAs;
+            this.mnuSaveToFile.Image = global::GitUI.Properties.Images.SaveAs;
             this.mnuSaveToFile.Name = "mnuSaveToFile";
             this.mnuSaveToFile.Size = new System.Drawing.Size(131, 22);
             this.mnuSaveToFile.Text = "Save to file";
@@ -135,7 +136,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             // mnuClear
             // 
-            this.mnuClear.Image = GitUI.Properties.Images.ClearLog;
+            this.mnuClear.Image = global::GitUI.Properties.Images.ClearLog;
             this.mnuClear.Name = "mnuClear";
             this.mnuClear.Size = new System.Drawing.Size(131, 22);
             this.mnuClear.Text = "Clear";
@@ -231,11 +232,23 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.chkWordWrap.Text = "Word wrap";
             this.chkWordWrap.UseVisualStyleBackColor = true;
             // 
+            // chkCaptureCallStacks
+            // 
+            this.chkCaptureCallStacks.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.chkCaptureCallStacks.AutoSize = true;
+            this.chkCaptureCallStacks.Location = new System.Drawing.Point(191, 450);
+            this.chkCaptureCallStacks.Name = "chkCaptureCallStacks";
+            this.chkCaptureCallStacks.Size = new System.Drawing.Size(122, 17);
+            this.chkCaptureCallStacks.TabIndex = 4;
+            this.chkCaptureCallStacks.Text = "Capture call stacks";
+            this.chkCaptureCallStacks.UseVisualStyleBackColor = true;
+            // 
             // FormGitCommandLog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(659, 470);
+            this.Controls.Add(this.chkCaptureCallStacks);
             this.Controls.Add(this.chkWordWrap);
             this.Controls.Add(this.chkAlwaysOnTop);
             this.Controls.Add(this.TabControl);
@@ -274,5 +287,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private ToolStripMenuItem mnuSaveToFile;
         private CheckBox chkWordWrap;
         private ToolStripMenuItem mnuClear;
+        private CheckBox chkCaptureCallStacks;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -21,11 +20,16 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             InitializeComponent();
             InitializeComplete();
 
+            LogItems.DisplayMember = nameof(CommandLogEntry.ColumnLine);
+
             var font = new Font(FontFamily.GenericMonospace, 9);
             LogItems.Font = font;
             CommandCacheItems.Font = font;
             LogOutput.Font = font;
             commandCacheOutput.Font = font;
+
+            chkCaptureCallStacks.Checked = CommandLog.CaptureCallStacks;
+            chkCaptureCallStacks.CheckedChanged += delegate { CommandLog.CaptureCallStacks = chkCaptureCallStacks.Checked; };
 
             chkWordWrap.CheckedChanged += delegate
             {
@@ -74,7 +78,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             if (TabControl.SelectedTab == tabPageCommandLog)
             {
-                RefreshListBox(LogItems, CommandLog.Commands.Select(cle => cle.ToString()).ToArray());
+                RefreshListBox(LogItems, CommandLog.Commands.ToArray());
             }
         }
 
@@ -86,7 +90,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
         }
 
-        private static void RefreshListBox(ListBox log, IReadOnlyList<string> items)
+        private static void RefreshListBox(ListBox log, object dataSource)
         {
             var isLastIndexSelected = log.Items.Count == 0 || log.SelectedIndex == log.Items.Count - 1;
             var lastIndex = -1;
@@ -98,7 +102,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             try
             {
                 log.BeginUpdate();
-                log.DataSource = items;
+                log.DataSource = dataSource;
             }
             finally
             {
@@ -142,7 +146,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void LogItems_SelectedIndexChanged(object sender, EventArgs e)
         {
-            LogOutput.Text = (string)LogItems.SelectedItem;
+            var entry = (CommandLogEntry)LogItems.SelectedItem;
+
+            LogOutput.Text = entry.Detail;
         }
 
         private void TabControl_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -143,39 +143,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 "Programs", "Git\\");
         }
 
-        private IEnumerable<string> GetWindowsCommandLocations(string possibleNewPath = null)
-        {
-            if (!string.IsNullOrEmpty(possibleNewPath) && File.Exists(possibleNewPath))
-            {
-                yield return possibleNewPath;
-            }
-
-            if (!string.IsNullOrEmpty(AppSettings.GitCommandValue) && File.Exists(AppSettings.GitCommandValue))
-            {
-                yield return AppSettings.GitCommandValue;
-            }
-
-            foreach (var path in GetGitLocations())
-            {
-                if (Directory.Exists(path + @"bin\"))
-                {
-                    yield return path + @"bin\git.exe";
-                }
-            }
-
-            foreach (var path in GetGitLocations())
-            {
-                if (Directory.Exists(path + @"cmd\"))
-                {
-                    yield return path + @"cmd\git.exe";
-                    yield return path + @"cmd\git.cmd";
-                }
-            }
-
-            yield return "git";
-            yield return "git.cmd";
-        }
-
         public bool SolveGitExtensionsDir()
         {
             string fileName = AppSettings.GetGitExtensionsDirectory();
@@ -193,7 +160,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (EnvUtils.RunningOnWindows())
             {
-                var command = (from cmd in GetWindowsCommandLocations(possibleNewPath)
+                var command = (from cmd in GetWindowsCommandLocations()
                                let output = new Executable(cmd).GetOutput()
                                where !string.IsNullOrEmpty(output)
                                select cmd).FirstOrDefault();
@@ -209,6 +176,39 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             AppSettings.GitCommandValue = "git";
             return !string.IsNullOrEmpty(Module.RunGitCmd(""));
+
+            IEnumerable<string> GetWindowsCommandLocations()
+            {
+                if (File.Exists(possibleNewPath))
+                {
+                    yield return possibleNewPath;
+                }
+
+                if (File.Exists(AppSettings.GitCommandValue))
+                {
+                    yield return AppSettings.GitCommandValue;
+                }
+
+                foreach (var path in GetGitLocations())
+                {
+                    if (Directory.Exists(path + @"bin\"))
+                    {
+                        yield return path + @"bin\git.exe";
+                    }
+                }
+
+                foreach (var path in GetGitLocations())
+                {
+                    if (Directory.Exists(path + @"cmd\"))
+                    {
+                        yield return path + @"cmd\git.exe";
+                        yield return path + @"cmd\git.cmd";
+                    }
+                }
+
+                yield return "git";
+                yield return "git.cmd";
+            }
         }
 
         public static bool CheckIfFileIsInPath(string fileName)

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -109,7 +109,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (LimitCheck.Checked && _NO_TRANSLATE_Limit.Value > 0)
             {
-                filter.Add($"--max-count=\"{(int)_NO_TRANSLATE_Limit.Value}\"");
+                filter.Add($"--max-count={(int)_NO_TRANSLATE_Limit.Value}");
             }
 
             return filter;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1085,7 +1085,7 @@ namespace GitUI
             {
                 "rev-list",
                 { AppSettings.OrderRevisionByDate, "--date-order", "--topo-order" },
-                { AppSettings.MaxRevisionGraphCommits > 0, $"--max-count=\"{AppSettings.MaxRevisionGraphCommits}\"" },
+                { AppSettings.MaxRevisionGraphCommits > 0, $"--max-count={AppSettings.MaxRevisionGraphCommits}" },
                 objectId
             };
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1085,7 +1085,7 @@ namespace GitUI
             {
                 "rev-list",
                 { AppSettings.OrderRevisionByDate, "--date-order", "--topo-order" },
-                { AppSettings.MaxRevisionGraphCommits > 0, $"--max-count=\"{AppSettings.MaxRevisionGraphCommits}\" " },
+                { AppSettings.MaxRevisionGraphCommits > 0, $"--max-count=\"{AppSettings.MaxRevisionGraphCommits}\"" },
                 objectId
             };
 


### PR DESCRIPTION
Follows #5281.

Changes proposed in this pull request:

- Add option to the Git Command Log form that allows capturing call stacks for process launches in order to aid debugging
- Tidy some argument lists
- Use local function and simplify code a little
 
Screenshots:

![](https://user-images.githubusercontent.com/350947/44036817-a1d10256-9f0a-11e8-93d1-7e8cda69f10d.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- GIT 2.18
- Windows 10
