### PR TITLE
Add GitArgumentBuilder for baseline command configuration

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -346,9 +346,8 @@ namespace GitCommands
                 throw new ArgumentException($"For arguments \"{nameof(from)}\" and \"{nameof(onto)}\", either both must have values, or neither may.");
             }
 
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("rebase")
             {
-                "rebase",
                 { interactive, "-i" },
                 { interactive && autosquash, "--autosquash" },
                 { interactive && !autosquash, "--no-autosquash" },
@@ -362,7 +361,7 @@ namespace GitCommands
 
         public static ArgumentString AbortRebaseCmd()
         {
-            return "rebase --abort";
+            return new GitArgumentBuilder("rebase") { "--abort" };
         }
 
         public static ArgumentString ResolvedCmd()

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -86,8 +86,6 @@ namespace GitCommands
     [DebuggerDisplay("GitModule ( {" + nameof(WorkingDir) + "} )")]
     public sealed class GitModule : IGitModule
     {
-        private const string DiffCommandWithStandardArgs = "-c diff.submodule=short -c diff.noprefix=false diff --no-color ";
-
         private static readonly Regex CpEncodingPattern = new Regex("cp\\d+", RegexOptions.Compiled);
         private static readonly IGitDirectoryResolver GitDirectoryResolverInstance = new GitDirectoryResolver();
 
@@ -1054,9 +1052,8 @@ namespace GitCommands
 
             var format = formatString + (shortFormat ? "%s" : "%B%nNotes:%n%-N");
 
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("log")
             {
-                "log",
                 "-n1",
                 $"--format={format}",
                 objectId
@@ -2281,9 +2278,9 @@ namespace GitCommands
 
             string diffOptions = _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked);
 
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("diff")
             {
-                DiffCommandWithStandardArgs,
+                "--no-color",
                 extraDiffArguments,
                 { AppSettings.UsePatienceDiffAlgorithm, "--patience" },
                 "-M -C",
@@ -2336,11 +2333,14 @@ namespace GitCommands
 
         public string GetDiffFilesText(string firstRevision, string secondRevision, bool noCache = false)
         {
-            var args = DiffCommandWithStandardArgs + "-M -C --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
-
-            var cache = noCache ? null : GitCommandCache;
-
-            return _gitExecutable.GetOutput(args, cache: cache);
+            return _gitExecutable.GetOutput(
+                new GitArgumentBuilder("diff")
+                {
+                    "--no-color",
+                    "-M -C --name-status",
+                    _revisionDiffProvider.Get(firstRevision, secondRevision)
+                },
+                cache: noCache ? null : GitCommandCache);
         }
 
         public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(string firstRevision, string secondRevision, string parentToSecond)
@@ -2354,11 +2354,14 @@ namespace GitCommands
         {
             noCache = noCache || firstRevision.IsArtificial() || secondRevision.IsArtificial();
 
-            var args = DiffCommandWithStandardArgs + "-M -C -z --name-status " + _revisionDiffProvider.Get(firstRevision, secondRevision);
-
-            var cache = noCache ? null : GitCommandCache;
-
-            var output = _gitExecutable.GetOutput(args, cache: cache);
+            var output = _gitExecutable.GetOutput(
+                new GitArgumentBuilder("diff")
+                {
+                    "--no-color",
+                    "-M -C -z --name-status",
+                    _revisionDiffProvider.Get(firstRevision, secondRevision)
+                },
+                cache: noCache ? null : GitCommandCache);
 
             var resultCollection = GitCommandHelpers.GetDiffChangedFilesFromString(this, output, firstRevision, secondRevision, parentToSecond).ToList();
 
@@ -2517,21 +2520,25 @@ namespace GitCommands
 
         public IReadOnlyList<GitItemStatus> GetIndexFiles()
         {
-            var status = _gitExecutable.GetOutput(DiffCommandWithStandardArgs + "-M -C -z --cached --name-status");
+            var output = _gitExecutable.GetOutput(
+                new GitArgumentBuilder("diff")
+                {
+                    "--no-color -M -C -z --cached --name-status"
+                });
 
-            if (status.Length < 50 && status.Contains("fatal: No HEAD commit to compare"))
+            if (output.Length < 50 && output.Contains("fatal: No HEAD commit to compare"))
             {
                 // This command is a little more expensive because it will return both staged and unstaged files
                 var command = GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.No);
 
-                status = _gitExecutable.GetOutput(command);
+                output = _gitExecutable.GetOutput(command);
 
-                return GitCommandHelpers.GetStatusChangedFilesFromString(this, status)
+                return GitCommandHelpers.GetStatusChangedFilesFromString(this, output)
                     .Where(item => item.Staged == StagedStatus.Index)
                     .ToList();
             }
 
-            return GitCommandHelpers.GetDiffChangedFilesFromString(this, status, "HEAD", GitRevision.IndexGuid, "HEAD");
+            return GitCommandHelpers.GetDiffChangedFilesFromString(this, output, "HEAD", GitRevision.IndexGuid, "HEAD");
         }
 
         public IReadOnlyList<GitItemStatus> GetIndexFilesWithSubmodulesStatus()
@@ -2569,9 +2576,9 @@ namespace GitCommands
         public Patch GetCurrentChanges(string fileName, [CanBeNull] string oldFileName, bool staged, string extraDiffArguments, Encoding encoding)
         {
             var output = _gitExecutable.GetOutput(
-                new ArgumentBuilder
+                new GitArgumentBuilder("diff")
                 {
-                    DiffCommandWithStandardArgs,
+                    "--no-color",
                     { staged, "-M -C --cached" },
                     extraDiffArguments,
                     { AppSettings.UsePatienceDiffAlgorithm, "--patience" },

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -62,7 +62,6 @@
     </Compile>
     <Compile Include="AppTitleGenerator.cs" />
     <Compile Include="ArgumentBuilderExtensions.cs" />
-    <Compile Include="ArrayExtensions.cs" />
     <Compile Include="AsyncLoader.cs" />
     <Compile Include="CommitData.cs" />
     <Compile Include="CommitDataManager.cs" />

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -158,9 +158,8 @@ namespace GitCommands
 
             ArgumentBuilder BuildArguments()
             {
-                return new ArgumentBuilder
+                return new GitArgumentBuilder("log")
                 {
-                    "log",
                     "-z",
                     $"--pretty=format:\"{fullFormat}\"",
                     { AppSettings.OrderRevisionByDate, "--date-order", "--topo-order" },

--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -34,9 +34,9 @@ namespace GitCommands
     /// </example>
     public sealed class ArgumentBuilder : IEnumerable
     {
-        private readonly StringBuilder _command = new StringBuilder(capacity: 16);
+        private readonly StringBuilder _arguments = new StringBuilder(capacity: 16);
 
-        public bool IsEmpty => _command.Length == 0;
+        public bool IsEmpty => _arguments.Length == 0;
 
         /// <summary>
         /// Adds <paramref name="s"/> to the argument list.
@@ -53,12 +53,12 @@ namespace GitCommands
                 return;
             }
 
-            if (_command.Length != 0)
+            if (_arguments.Length != 0)
             {
-                _command.Append(' ');
+                _arguments.Append(' ');
             }
 
-            _command.Append(s);
+            _arguments.Append(s);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace GitCommands
         /// </summary>
         public override string ToString()
         {
-            return _command.ToString();
+            return _arguments.ToString();
         }
 
         /// <summary>

--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -32,7 +32,7 @@ namespace GitCommands
     /// };
     /// </code>
     /// </example>
-    public sealed class ArgumentBuilder : IEnumerable
+    public class ArgumentBuilder : IEnumerable
     {
         private readonly StringBuilder _arguments = new StringBuilder(capacity: 16);
 

--- a/GitExtUtils/ArrayExtensions.cs
+++ b/GitExtUtils/ArrayExtensions.cs
@@ -12,5 +12,14 @@ namespace GitCommands
             Array.Copy(array, index, sub, 0, length);
             return sub;
         }
+
+        [MustUseReturnValue]
+        public static T[] Append<T>([NotNull] this T[] array, T element)
+        {
+            var larger = new T[array.Length + 1];
+            Array.Copy(array, larger, array.Length);
+            larger[array.Length] = element;
+            return larger;
+        }
     }
 }

--- a/GitExtUtils/GitArgumentBuilder.cs
+++ b/GitExtUtils/GitArgumentBuilder.cs
@@ -158,7 +158,7 @@ namespace GitCommands
         public void Add(GitConfigItem configItem)
         {
             // Append or replace config item based upon its key
-            var index = _configItems.IndexOf(item => item.Key == configItem.Key);
+            var index = _configItems.IndexOf(item => string.Equals(item.Key, configItem.Key, StringComparison.OrdinalIgnoreCase));
 
             if (index == -1)
             {

--- a/GitExtUtils/GitArgumentBuilder.cs
+++ b/GitExtUtils/GitArgumentBuilder.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+
+namespace GitCommands
+{
+    /// <summary>
+    /// A configuration key/value pair for use in git command lines.
+    /// </summary>
+    public readonly struct GitConfigItem
+    {
+        public string Key { get; }
+        public string Value { get; }
+
+        public GitConfigItem(string key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public void Deconstruct(out string key, out string value)
+        {
+            key = Key;
+            value = Value;
+        }
+    }
+
+    public sealed class GitCommandConfiguration
+    {
+        private readonly ConcurrentDictionary<string, GitConfigItem[]> _configByCommand
+            = new ConcurrentDictionary<string, GitConfigItem[]>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the default configuration for git commands used by Git Extensions.
+        /// </summary>
+        public static GitCommandConfiguration Default { get; }
+
+        static GitCommandConfiguration()
+        {
+            // The set of default configuration items for Git Extensions
+            Default = new GitCommandConfiguration();
+
+            Default.Add(new GitConfigItem("rebase.autoSquash", "false"), "rebase");
+
+            Default.Add(new GitConfigItem("log.showSignature", "false"), "log", "show", "whatchanged");
+
+            Default.Add(new GitConfigItem("diff.submodule", "short"), "diff");
+            Default.Add(new GitConfigItem("diff.noprefix", "false"), "diff");
+        }
+
+        /// <summary>
+        /// Registers <paramref name="configItem"/> against one or more command names.
+        /// </summary>
+        /// <param name="configItem">The config item to register.</param>
+        /// <param name="commands">One or more command names to register this config item against.</param>
+        public void Add(GitConfigItem configItem, params string[] commands)
+        {
+            foreach (var command in commands)
+            {
+                _configByCommand.AddOrUpdate(
+                    command,
+                    addValueFactory: _ => new[] { configItem },
+                    updateValueFactory: (_, items) => items.Append(configItem));
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the set of default config items for the given <paramref name="command"/>.
+        /// </summary>
+        /// <param name="command">The command to retrieve default config items for.</param>
+        /// <returns>The default config items for <paramref name="command"/>.</returns>
+        public IReadOnlyList<GitConfigItem> Get(string command)
+        {
+            return _configByCommand.TryGetValue(command, out var items)
+                ? items
+                : Array.Empty<GitConfigItem>();
+        }
+    }
+
+    /// <summary>
+    /// Builds a git command line string from config items, a command name and that command's arguments.
+    /// </summary>
+    /// <remarks>
+    /// <para>Derives from <see cref="ArgumentBuilder"/>, so read that class's documentation to learn more about
+    /// its usage.</para>
+    ///
+    /// <para>
+    /// A git command line is built from:
+    /// <list type="number">
+    ///   <item>Zero or more config items, each of form <c>-c key=value</c></item>
+    ///   <item>A command name, such as <c>log</c></item>
+    ///   <item>Zero or more arguments specific to that command</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>Git Extensions defines a set of config items per command in the <see cref="GitCommandConfiguration"/> class.</para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var args = new GitArgumentBuilder("commit")
+    /// {
+    ///     "-S",                       // added unconditionally
+    ///     { isAmend, "--amend" },     // adds the option only if isAmend == true
+    ///     { isUp, "--up", "--down" }, // selects the option based on the value of isUp
+    /// };
+    /// </code>
+    /// </example>
+    public sealed class GitArgumentBuilder : ArgumentBuilder
+    {
+        private static readonly Regex _commandRegex = new Regex("^[a-z0-9_.-]+$", RegexOptions.Compiled);
+
+        private readonly List<GitConfigItem> _configItems;
+        private readonly string _command;
+
+        /// <summary>
+        /// Initialises a new <see cref="GitArgumentBuilder"/> for the given <paramref name="command"/>.
+        /// </summary>
+        /// <param name="command">The git command this builder is compiling arguments for.</param>
+        /// <param name="commandConfiguration">Optional source for default command configuration items. Pass <c>null</c> to use the Git Extensions defaults.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="command"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="command"/> is an invalid string.</exception>
+        public GitArgumentBuilder([NotNull] string command, [CanBeNull] GitCommandConfiguration commandConfiguration = null)
+        {
+            if (command == null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
+
+            if (!_commandRegex.IsMatch(command))
+            {
+                throw new ArgumentException($"Git command \"{command}\" contains invalid characters.", nameof(command));
+            }
+
+            _command = command;
+
+            commandConfiguration = commandConfiguration ?? GitCommandConfiguration.Default;
+
+            var defaultConfig = commandConfiguration.Get(command);
+            _configItems = new List<GitConfigItem>(capacity: defaultConfig.Count + 2);
+            if (defaultConfig.Count != 0)
+            {
+                _configItems.AddRange(defaultConfig);
+            }
+        }
+
+        /// <summary>
+        /// Add <paramref name="configItem"/> to this builder.
+        /// </summary>
+        /// <remarks>
+        /// Any prior config item with the same key will be replaced.
+        /// </remarks>
+        /// <param name="configItem">The config item to add to the builder.</param>
+        public void Add(GitConfigItem configItem)
+        {
+            // Append or replace config item based upon its key
+            var index = _configItems.IndexOf(item => item.Key == configItem.Key);
+
+            if (index == -1)
+            {
+                _configItems.Add(configItem);
+            }
+            else
+            {
+                _configItems[index] = configItem;
+            }
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var arguments = base.ToString();
+
+            var capacity = _command.Length + 1 + arguments.Length + 1 + _configItems.Sum(i => i.Key.Length + i.Value.Length + 5);
+
+            var str = new StringBuilder(capacity);
+
+            foreach (var (key, value) in _configItems)
+            {
+                str.Append("-c ").Append(key).Append('=').Append(value);
+                str.Append(' ');
+            }
+
+            str.Append(_command);
+
+            if (arguments.Length != 0)
+            {
+                str.Append(' ').Append(arguments);
+            }
+
+            Debug.Assert(str.Capacity == capacity, $"Did not allocate enough capacity for string buffer. Allocated {capacity} but final capacity was {str.Capacity}.");
+
+            return str.ToString();
+        }
+    }
+}

--- a/GitExtUtils/GitArgumentBuilder.cs
+++ b/GitExtUtils/GitArgumentBuilder.cs
@@ -175,14 +175,14 @@ namespace GitCommands
         {
             var arguments = base.ToString();
 
-            var capacity = _command.Length + 1 + arguments.Length + 1 + _configItems.Sum(i => i.Key.Length + i.Value.Length + 5);
+            // 7 = "-c " + "=" + " " + 2 (for possible quotes of value)
+            var capacity = _configItems.Sum(i => i.Key.Length + i.Value.Length + 7) + _command.Length + 1 + arguments.Length;
 
             var str = new StringBuilder(capacity);
 
             foreach (var (key, value) in _configItems)
             {
-                str.Append("-c ").Append(key).Append('=').Append(value);
-                str.Append(' ');
+                str.Append("-c ").Append(key).Append('=').AppendQuoted(value).Append(' ');
             }
 
             str.Append(_command);

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -47,6 +47,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ArgumentBuilder.cs" />
+    <Compile Include="ArrayExtensions.cs" />
     <Compile Include="GitUI\CancellationTokenSequence.cs" />
     <Compile Include="GitUI\ComboBoxExtensions.cs" />
     <Compile Include="GitUI\ControlDpiExtensions.cs" />

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -48,6 +48,7 @@
     </Compile>
     <Compile Include="ArgumentBuilder.cs" />
     <Compile Include="ArrayExtensions.cs" />
+    <Compile Include="GitArgumentBuilder.cs" />
     <Compile Include="GitUI\CancellationTokenSequence.cs" />
     <Compile Include="GitUI\ComboBoxExtensions.cs" />
     <Compile Include="GitUI\ControlDpiExtensions.cs" />
@@ -73,6 +74,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.4.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Linq\LinqExtensions.cs" />
     <Compile Include="MruCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StringBuilderExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -181,6 +181,27 @@ namespace System.Linq
 
         [Pure]
         [MustUseReturnValue]
+        public static int IndexOf<T>(
+            [NotNull] this IEnumerable<T> source,
+            [NotNull, InstantHandle] Func<T, bool> predicate)
+        {
+            var index = 0;
+
+            foreach (var element in source)
+            {
+                if (predicate(element))
+                {
+                    return index;
+                }
+
+                index++;
+            }
+
+            return -1;
+        }
+
+        [Pure]
+        [MustUseReturnValue]
         public static TResult[] ToArray<TSource, TResult>(
             [NotNull] this IReadOnlyList<TSource> source,
             [NotNull, InstantHandle] Func<TSource, TResult> map)

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -44,13 +44,6 @@ namespace System.Linq
             return result;
         }
 
-        [NotNull]
-        public static IEnumerable<TValue> SelectMany<TValue>(
-            [NotNull] this IEnumerable<IEnumerable<TValue>> source)
-        {
-            return source.SelectMany(i => i);
-        }
-
         [Pure]
         [NotNull]
         public static string Join([NotNull] this IEnumerable<string> source, [NotNull] string separator)

--- a/GitExtUtils/StringBuilderExtensions.cs
+++ b/GitExtUtils/StringBuilderExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System.Text;
+using JetBrains.Annotations;
+
+namespace GitCommands
+{
+    public static class StringBuilderExtensions
+    {
+        private static readonly char[] _whiteSpaceChars = { ' ', '\r', '\n', '\t' };
+
+        [NotNull]
+        public static StringBuilder AppendQuoted([NotNull] this StringBuilder builder, [NotNull] string s)
+        {
+            if (NeedsEscaping())
+            {
+                builder.Append('"').Append(s).Append('"');
+            }
+            else
+            {
+                builder.Append(s);
+            }
+
+            return builder;
+
+            bool NeedsEscaping()
+            {
+                if (string.IsNullOrWhiteSpace(s))
+                {
+                    // Quote empty or white space strings
+                    return true;
+                }
+
+                if (s.IndexOfAny(_whiteSpaceChars) == -1)
+                {
+                    // Doesn't contain any white space
+                    return false;
+                }
+
+                if (s.Length > 1 && s[0] == '"' && s[s.Length - 1] == '"')
+                {
+                    // String is already quoted
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/GitExtensions.sln.DotSettings
+++ b/GitExtensions.sln.DotSettings
@@ -90,6 +90,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HOMEDRIVE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ignorecase/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Infos/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ints/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Janusz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jira/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kdiff/@EntryIndexedValue">True</s:Boolean>
@@ -115,6 +116,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=multichar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nbug/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=networkshare/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=noprefix/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ntlm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NTUSER/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nuget/@EntryIndexedValue">True</s:Boolean>
@@ -190,6 +192,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=vscode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=vsdiffmerge/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=vsdx/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=whatchanged/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winmerge/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winstore/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=wscript/@EntryIndexedValue">True</s:Boolean>

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -232,9 +232,8 @@ namespace GitUI.CommandsDialogs
                     // note: This implementation is quite a quick hack (by someone who does not speak C# fluently).
                     //
 
-                    var args = new ArgumentBuilder
+                    var args = new GitArgumentBuilder("log")
                     {
-                        "log",
                         "--format=\"%n\"",
                         "--name-only",
                         "--format",

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -553,31 +553,31 @@ namespace GitCommandsTests.Git
         public void RebaseCmd()
         {
             Assert.AreEqual(
-                "rebase \"branch\"",
+                "-c rebase.autoSquash=false rebase \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: false, autosquash: false, autoStash: false).Arguments);
             Assert.AreEqual(
-                "rebase -i --no-autosquash \"branch\"",
+                "-c rebase.autoSquash=false rebase -i --no-autosquash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: false, autosquash: false, autoStash: false).Arguments);
             Assert.AreEqual(
-                "rebase --preserve-merges \"branch\"",
+                "-c rebase.autoSquash=false rebase --preserve-merges \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: true, autosquash: false, autoStash: false).Arguments);
             Assert.AreEqual(
-                "rebase \"branch\"",
+                "-c rebase.autoSquash=false rebase \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: false, autosquash: true, autoStash: false).Arguments);
             Assert.AreEqual(
-                "rebase --autostash \"branch\"",
+                "-c rebase.autoSquash=false rebase --autostash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: false, autosquash: false, autoStash: true).Arguments);
             Assert.AreEqual(
-                "rebase -i --autosquash \"branch\"",
+                "-c rebase.autoSquash=false rebase -i --autosquash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: false, autosquash: true, autoStash: false).Arguments);
             Assert.AreEqual(
-                "rebase -i --autosquash --preserve-merges --autostash \"branch\"",
+                "-c rebase.autoSquash=false rebase -i --autosquash --preserve-merges --autostash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: true, autosquash: true, autoStash: true).Arguments);
 
             // TODO quote 'onto'?
 
             Assert.AreEqual(
-                "rebase \"from\" \"branch\" --onto onto",
+                "-c rebase.autoSquash=false rebase \"from\" \"branch\" --onto onto",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: false, autosquash: false, autoStash: false, "from", "onto").Arguments);
 
             Assert.Throws<ArgumentException>(

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -50,7 +50,6 @@
   <ItemGroup>
     <Compile Include="AppTitleGeneratorTests.cs" />
     <Compile Include="ArgumentBuilderExtensionsTests.cs" />
-    <Compile Include="ArrayExtensionsTests.cs" />
     <Compile Include="CommitDataManagerTest.cs" />
     <Compile Include="CommitTemplateManagerTests.cs" />
     <Compile Include="Config\ConfigFileTest.cs" />

--- a/UnitTests/GitExtUtils/ArrayExtensionsTests.cs
+++ b/UnitTests/GitExtUtils/ArrayExtensionsTests.cs
@@ -32,5 +32,19 @@ namespace GitCommandsTests
                 Array.Empty<int>(),
                 nums.Subsequence(9, 0));
         }
+
+        [Test]
+        public void Append()
+        {
+            Assert.AreEqual(
+                new[] { 0, 1 },
+                new[] { 0 }.Append(1));
+            Assert.AreEqual(
+                new[] { 0 },
+                Array.Empty<int>().Append(0));
+            Assert.AreEqual(
+                new[] { 0, 1, 2 },
+                Array.Empty<int>().Append(0).Append(1).Append(2));
+        }
     }
 }

--- a/UnitTests/GitExtUtils/GitArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils/GitArgumentBuilderTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitExtUtilsTests
+{
+    [TestFixture]
+    public sealed class GitArgumentBuilderTests
+    {
+        [Test]
+        public void Command_with_one_argument()
+        {
+            Assert.AreEqual(
+                "foo --bar",
+                new GitArgumentBuilder("foo") { "--bar" }.ToString());
+        }
+
+        [Test]
+        public void Command_with_no_arguments()
+        {
+            Assert.AreEqual(
+                "foo",
+                new GitArgumentBuilder("foo").ToString());
+        }
+
+        [Test]
+        public void Command_with_default_config_item()
+        {
+            var args = new GitArgumentBuilder("log")
+            {
+                "-n 1"
+            };
+
+            Assert.AreEqual(
+                "-c log.showSignature=false log -n 1",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_custom_config_item()
+        {
+            var args = new GitArgumentBuilder("foo")
+            {
+                new GitConfigItem("bar", "baz")
+            };
+
+            Assert.AreEqual(
+                "-c bar=baz foo",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_custom_config_item_and_argument()
+        {
+            var args = new GitArgumentBuilder("foo")
+            {
+                new GitConfigItem("bar", "baz"),
+                "--arg"
+            };
+
+            Assert.AreEqual(
+                "-c bar=baz foo --arg",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_custom_config_item_defined_after_argument()
+        {
+            var args = new GitArgumentBuilder("foo")
+            {
+                "--arg",
+                new GitConfigItem("bar", "baz") // order doesn't matter
+            };
+
+            Assert.AreEqual(
+                "-c bar=baz foo --arg",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_default_and_custom_config_items()
+        {
+            var args = new GitArgumentBuilder("log")
+            {
+                new GitConfigItem("bar", "baz"),
+                "-n 1"
+            };
+
+            Assert.AreEqual(
+                "-c log.showSignature=false -c bar=baz log -n 1",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_default_and_custom_config_items_and_argument()
+        {
+            var args = new GitArgumentBuilder("log")
+            {
+                new GitConfigItem("bar", "baz"),
+                "-n 1"
+            };
+
+            Assert.AreEqual(
+                "-c log.showSignature=false -c bar=baz log -n 1",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_config_item_that_overrides_default()
+        {
+            var args = new GitArgumentBuilder("log")
+            {
+                new GitConfigItem("log.showSignature", "true"),
+                "-n 1"
+            };
+
+            Assert.AreEqual(
+                "-c log.showSignature=true log -n 1",
+                args.ToString());
+        }
+
+        [Test]
+        public void Throws_for_invalid_command_strings()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GitArgumentBuilder(null));
+            Assert.Throws<ArgumentException>(() => new GitArgumentBuilder(""));
+            Assert.Throws<ArgumentException>(() => new GitArgumentBuilder(" "));
+            Assert.Throws<ArgumentException>(() => new GitArgumentBuilder(" a banana "));
+            Assert.Throws<ArgumentException>(() => new GitArgumentBuilder("!£$%^&*("));
+        }
+    }
+}

--- a/UnitTests/GitExtUtils/GitArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils/GitArgumentBuilderTests.cs
@@ -50,6 +50,32 @@ namespace GitExtUtilsTests
         }
 
         [Test]
+        public void Command_with_custom_config_item_quoted()
+        {
+            var args = new GitArgumentBuilder("foo")
+            {
+                new GitConfigItem("bar", "baz bax")
+            };
+
+            Assert.AreEqual(
+                "-c bar=\"baz bax\" foo",
+                args.ToString());
+        }
+
+        [Test]
+        public void Command_with_custom_config_item_already_quoted()
+        {
+            var args = new GitArgumentBuilder("foo")
+            {
+                new GitConfigItem("bar", "\"baz bax\"")
+            };
+
+            Assert.AreEqual(
+                "-c bar=\"baz bax\" foo",
+                args.ToString());
+        }
+
+        [Test]
         public void Command_with_custom_config_item_and_argument()
         {
             var args = new GitArgumentBuilder("foo")

--- a/UnitTests/GitExtUtils/GitArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils/GitArgumentBuilderTests.cs
@@ -120,6 +120,20 @@ namespace GitExtUtilsTests
         }
 
         [Test]
+        public void Command_with_config_item_that_overrides_default_different_case()
+        {
+            var args = new GitArgumentBuilder("log")
+            {
+                new GitConfigItem("LOG.showSIGNATURE", "true"),
+                "-n 1"
+            };
+
+            Assert.AreEqual(
+                "-c LOG.showSIGNATURE=true log -n 1",
+                args.ToString());
+        }
+
+        [Test]
         public void Throws_for_invalid_command_strings()
         {
             Assert.Throws<ArgumentNullException>(() => new GitArgumentBuilder(null));

--- a/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
+++ b/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ArgumentBuilderTests.cs" />
     <Compile Include="ArrayExtensionsTests.cs" />
     <Compile Include="ComboBoxExtensionsTests.cs" />
+    <Compile Include="GitArgumentBuilderTests.cs" />
     <Compile Include="MruCacheTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TableLayoutPanelExtensionsTests.cs" />

--- a/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
+++ b/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgumentBuilderTests.cs" />
+    <Compile Include="ArrayExtensionsTests.cs" />
     <Compile Include="ComboBoxExtensionsTests.cs" />
     <Compile Include="MruCacheTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="LinqExtensionsTests.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractorTests.cs" />
     <Compile Include="SplitterManagerTest.cs" />
+    <Compile Include="StringBuilderExtensionsTests.cs" />
     <Compile Include="ThreadHelperTests.cs" />
     <Compile Include="TranslationTest.cs" />
     <Compile Include="UITest.cs" />

--- a/UnitTests/GitUITests/LinqExtensionsTests.cs
+++ b/UnitTests/GitUITests/LinqExtensionsTests.cs
@@ -43,5 +43,17 @@ namespace GitUITests
                 }
             }
         }
+
+        [Test]
+        public void IndexOf()
+        {
+            var ints = new[] { 0, 1, 2, 3 };
+
+            Assert.AreEqual(0, ints.IndexOf(i => i == 0));
+            Assert.AreEqual(1, ints.IndexOf(i => i == 1));
+            Assert.AreEqual(2, ints.IndexOf(i => i == 2));
+            Assert.AreEqual(3, ints.IndexOf(i => i == 3));
+            Assert.AreEqual(-1, ints.IndexOf(i => i == 4));
+        }
     }
 }

--- a/UnitTests/GitUITests/StringBuilderExtensionsTests.cs
+++ b/UnitTests/GitUITests/StringBuilderExtensionsTests.cs
@@ -1,0 +1,20 @@
+﻿using System.Text;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitUITests
+{
+    public sealed class StringBuilderExtensionsTests
+    {
+        [TestCase("foo", "foo")]
+        [TestCase("\"foo bar\"", "foo bar")]
+        [TestCase("\"foo\tbar\"", "foo\tbar")]
+        [TestCase("\"foo bar\"", "\"foo bar\"")]
+        [TestCase("\"\"", "")]
+        [TestCase("\" \"", " ")]
+        public void AppendQuoted(string expected, string source)
+        {
+            Assert.AreEqual(expected, new StringBuilder().AppendQuoted(source).ToString());
+        }
+    }
+}


### PR DESCRIPTION
Follows #5281.

This PR was co-authored with @vbjay in drewnoakes/gitextensions#6 as an alternative approach to #5182, while waiting for #5281 to merge.

Fixes #5179.

Also fixes untracked issue relating to `rebase.autoSquash` setting overriding the checkbox in the UI.

Changes proposed in this pull request:
- Introduce `GitArgumentBuilder` as a means of having default configuration in git command line arguments in a standard way, based upon the particular command in use
 
`GitArgumentBuilder` derives from `ArgumentBuilder` and so leverages existing extension methods for building arguments. It may be used anywhere `ArgumentBuilder` was used, allowing introduction as needed throughout the codebase. 

What did I do to test the code and ensure quality:
- Unit tests
- Manual tests

Has been tested on:
- GIT 2.18
- Windows 10

