### PR TITLE
WIP Fix 5328 commit dialog  go to line  does not work

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -164,6 +164,7 @@ namespace GitUI.Editor
             contextMenu.Opening += (sender, e) =>
             {
                 copyToolStripMenuItem.Enabled = _internalFileViewer.GetSelectionLength() > 0;
+                goToLineToolStripMenuItem.Enabled = _internalFileViewer.IsGotoLineUIApplicable();
                 ContextMenuOpening?.Invoke(sender, e);
             };
 
@@ -387,9 +388,9 @@ namespace GitUI.Editor
                 using (var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 using (var reader = new StreamReader(stream, Module.FilesEncoding))
                 {
-                    #pragma warning disable VSTHRD103 // Call async methods when in an async method
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     var content = reader.ReadToEnd();
-                    #pragma warning restore VSTHRD103 // Call async methods when in an async method
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                     FilePreamble = reader.CurrentEncoding.GetPreamble();
                     return content;
                 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -164,7 +164,7 @@ namespace GitUI.Editor
             contextMenu.Opening += (sender, e) =>
             {
                 copyToolStripMenuItem.Enabled = _internalFileViewer.GetSelectionLength() > 0;
-                goToLineToolStripMenuItem.Enabled = _internalFileViewer.IsGotoLineUIApplicable();
+                goToLineToolStripMenuItem.Enabled = _internalFileViewer.CanGotoLine;
 
                 goToLineToolStripMenuItem.ShortcutKeys = GetShortcutKeys((int)Commands.GoToLine);
 
@@ -1237,7 +1237,7 @@ namespace GitUI.Editor
 
         private void goToLineToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!_internalFileViewer.IsGotoLineUIApplicable())
+            if (!_internalFileViewer.CanGotoLine)
             {
                 return;
             }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -165,6 +165,9 @@ namespace GitUI.Editor
             {
                 copyToolStripMenuItem.Enabled = _internalFileViewer.GetSelectionLength() > 0;
                 goToLineToolStripMenuItem.Enabled = _internalFileViewer.IsGotoLineUIApplicable();
+
+                goToLineToolStripMenuItem.ShortcutKeys = GetShortcutKeys((int)Commands.GoToLine);
+
                 ContextMenuOpening?.Invoke(sender, e);
             };
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -87,6 +87,8 @@ namespace GitUI.Editor
         public event EventHandler ScrollPosChanged;
         public new event EventHandler TextChanged;
 
+        public bool CanGotoLine => _isGotoLineUIApplicable;
+
         public string GetText()
         {
             return TextEditor.Text;
@@ -270,12 +272,12 @@ namespace GitUI.Editor
 
         public void GoToLine(int lineNumber)
         {
-            TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(0, lineNumber);
-        }
+            if (!CanGotoLine)
+            {
+                return;
+            }
 
-        public bool IsGotoLineUIApplicable()
-        {
-            return _isGotoLineUIApplicable;
+            TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(0, lineNumber);
         }
 
         public int LineAtCaret => TextEditor.ActiveTextAreaControl.Caret.Position.Line;

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -124,7 +124,7 @@ namespace GitUI.Editor
             }
 
             TextEditor.Text = text;
-            _isGotoLineUIApplicable = !isDiff;
+            _isGotoLineUIApplicable = isDiff;
 
             if (isDiff)
             {

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -43,7 +43,7 @@ namespace GitUI.Editor
         int GetSelectionPosition();
         int GetSelectionLength();
         void AddPatchHighlighting();
-        Action OpenWithDifftool { get;  }
+        Action OpenWithDifftool { get; }
         int ScrollPos { get; set; }
 
         bool ShowLineNumbers { get; set; }
@@ -67,7 +67,7 @@ namespace GitUI.Editor
         /// Indicates if the Goto line UI is applicable or not.
         /// Code-behind goto line function is always availabe, so we can goto next diff section.
         /// </summary>
-        bool IsGotoLineUIApplicable();
+        bool CanGotoLine { get; }
 
         Font Font { get; set; }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5328

Changes proposed in this pull request:
- "Go to line" feature now works for text-based files, and not binary files.
- Enable "Go to line" menu only to text-based files
- Display shortcut for "Go to line" menu
 
Screenshots after (if PR changes UI):


What did I do to test the code and ensure quality:
- manual
