### PR TITLE
Add setting to maximize the commit message column

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
@@ -22,7 +22,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 HeaderText = "Author Name",
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
-                Width = DpiUtil.Scale(130)
+                Width = DpiUtil.Scale(130),
+                MinimumWidth = DpiUtil.Scale(25)
             };
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
@@ -22,7 +22,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 HeaderText = "Date",
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
-                Width = DpiUtil.Scale(130)
+                Width = DpiUtil.Scale(130),
+                MinimumWidth = DpiUtil.Scale(25)
             };
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -29,7 +29,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 HeaderText = "Message",
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
-                Width = DpiUtil.Scale(500)
+                Width = DpiUtil.Scale(500),
+                MinimumWidth = DpiUtil.Scale(25)
             };
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -25,7 +25,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             Column = new DataGridViewTextBoxColumn
             {
-                AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+                AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
                 HeaderText = "Message",
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -64,6 +64,9 @@ namespace GitUI
         private readonly BuildServerWatcher _buildServerWatcher;
         private readonly Timer _selectionTimer;
         private readonly GraphColumnProvider _graphColumnProvider;
+        private readonly List<DataGridViewColumn> _resizableColumns;
+        private readonly DataGridViewColumn _maximizedColumn;
+        private DataGridViewColumn _lastVisibleResizableColumn = null;
 
         private RefFilterOptions _refFilterOptions = RefFilterOptions.All | RefFilterOptions.Boundary;
 
@@ -187,6 +190,8 @@ namespace GitUI
             _gridView.AddColumn(new DateColumnProvider(this));
             _gridView.AddColumn(new CommitIdColumnProvider(this));
             _gridView.AddColumn(_buildServerWatcher.ColumnProvider);
+            _resizableColumns = _gridView.Columns.Cast<DataGridViewColumn>().Where(column => column.Resizable == DataGridViewTriState.True).ToList();
+            _maximizedColumn = _resizableColumns.FirstOrDefault(column => column.AutoSizeMode == DataGridViewAutoSizeColumnMode.Fill);
         }
 
         protected override void Dispose(bool disposing)
@@ -449,6 +454,19 @@ namespace GitUI
             base.Refresh();
 
             _toolTipProvider.Clear();
+
+            if (_maximizedColumn != null)
+            {
+                // restore the resizable state
+                _resizableColumns.ForEach(column => column.Resizable = DataGridViewTriState.True);
+
+                // suppress the manual resizing of the last visible column because it will be resized when the maximized column is resized
+                _lastVisibleResizableColumn = _gridView.Columns.GetLastColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Resizable, DataGridViewElementStates.None);
+                if (_lastVisibleResizableColumn != null)
+                {
+                    _lastVisibleResizableColumn.Resizable = DataGridViewTriState.False;
+                }
+            }
         }
 
         protected override void OnCreateControl()
@@ -1221,13 +1239,23 @@ namespace GitUI
 
         private void OnGridViewMouseDown(object sender, MouseEventArgs e)
         {
-            if (e.Button == MouseButtons.XButton1)
+            switch (e.Button)
             {
-                NavigateBackward();
-            }
-            else if (e.Button == MouseButtons.XButton2)
-            {
-                NavigateForward();
+                case MouseButtons.XButton1: NavigateBackward(); break;
+                case MouseButtons.XButton2: NavigateForward();  break;
+                case MouseButtons.Left when _maximizedColumn != null && _lastVisibleResizableColumn != null:
+                    // make resizing of the maximized column work and restore the settings afterwards
+                    void OnGridViewMouseCaptureChanged(object ignoredSender, EventArgs ignoredArgs)
+                    {
+                        _gridView.MouseCaptureChanged -= OnGridViewMouseCaptureChanged;
+                        _lastVisibleResizableColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+                        _maximizedColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+                    }
+
+                    _gridView.MouseCaptureChanged += OnGridViewMouseCaptureChanged;
+                    _maximizedColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+                    _lastVisibleResizableColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+                    break;
             }
         }
 


### PR DESCRIPTION
Fixes #5337

Changes proposed in this pull request:
- make the commit message column fill the remaining width
- suppress the non-working resizing of the last visible column
  which is resized by resizing the message column
  (Microsoft states, it was by design)
 
Screenshots before and after (if PR changes UI):
- after
![grafik](https://user-images.githubusercontent.com/36601201/44496086-1fd06100-a673-11e8-831c-357862f7c1e2.png)
- before
![grafik](https://user-images.githubusercontent.com/36601201/44496174-9b321280-a673-11e8-9084-8a0ecbd2a8a8.png)

What did I do to test the code and ensure quality:
- switch on/off the visibility of other columns
- resize columns

Has been tested on (remove any that don't apply):
- GIT: (2.17.1.w.2-x64)
- Windows 7