### PR TITLE
Quote file paths to avoid errors in paths with spaces

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1456,7 +1456,7 @@ namespace GitCommands
                     { force, "--force" },
                     revision,
                     "--",
-                    files
+                    files.Select(f => f.ToPosixPath().Quote())
                 });
         }
 
@@ -1473,7 +1473,7 @@ namespace GitCommands
                     "rm",
                     { force, "--force" },
                     "--",
-                    files
+                    files.Select(f => f.ToPosixPath().Quote())
                 });
         }
 
@@ -3828,7 +3828,7 @@ namespace GitCommands
                 revisionOfMergeCommit.Guid,
                 { AppSettings.UsePatienceDiffAlgorithm, "--patience" },
                 "--",
-                filePath
+                filePath.ToPosixPath().Quote()
             };
 
             var patch = _gitExecutable.GetOutput(args, cache: GitCommandCache, outputEncoding: LosslessEncoding);
@@ -3850,7 +3850,7 @@ namespace GitCommands
 
         public bool StopTrackingFile(string filename)
         {
-            return _gitExecutable.Execute($"rm --cached {filename}").ExitedSuccessfully;
+            return _gitExecutable.Execute($"rm --cached {filename.ToPosixPath().Quote()}").ExitedSuccessfully;
         }
 
         [CanBeNull]


### PR DESCRIPTION
I've noticed that I couldn't get combined diff for a file. Investigation into the problem showed that file paths were not quoted and the diff would end up in error and fallback to regular diff.

Going through code I've found some more bugs of this nature. Weird that this hasn't been found earlier :)