### PR TITLE
Browse Stash Count: Only count, remove Text

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -37,10 +37,6 @@ namespace GitUI.CommandsDialogs
     {
         #region Translation
 
-        private readonly TranslationString _stashCount = new TranslationString("{0} saved {1}");
-        private readonly TranslationString _stashPlural = new TranslationString("stashes");
-        private readonly TranslationString _stashSingular = new TranslationString("stash");
-
         private readonly TranslationString _warningMiddleOfBisect = new TranslationString("You are in the middle of a bisect");
         private readonly TranslationString _warningMiddleOfRebase = new TranslationString("You are in the middle of a rebase");
         private readonly TranslationString _warningMiddleOfPatchApply = new TranslationString("You are in the middle of a patch apply");
@@ -953,8 +949,7 @@ namespace GitUI.CommandsDialogs
 
                         await this.SwitchToMainThreadAsync();
 
-                        toolStripSplitStash.Text = string.Format(_stashCount.Text, result,
-                            result != 1 ? _stashPlural.Text : _stashSingular.Text);
+                        toolStripSplitStash.Text = $"({result})";
                     }).FileAndForget();
                 }
                 else


### PR DESCRIPTION
Instead of showing "{} saved stashes", just show count.
This is similar to Commit button
(zero commits are shown as green button, not showing (0))

Part of #1931 

Note: Current implementation is incorrect for languages with plurals other than one/many, for instance Polish.

Changes proposed in this pull request:
- How count is displayed for Stash, if enabled in settings
![image](https://user-images.githubusercontent.com/6248932/44632568-53660080-a97d-11e8-89ec-cc02545e2900.png)
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/44632571-68429400-a97d-11e8-9c89-d428955c99d9.png)

- 
![image](https://user-images.githubusercontent.com/6248932/44632577-7d1f2780-a97d-11e8-8f07-a8b66b16c293.png)


What did I do to test the code and ensure quality:
- Activate the setting
- Open Browse

Has been tested on (remove any that don't apply):
- Windows 7 and 10
