### PR TITLE
Check %LocalAppData%\Programs for editors/merge programs

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -65,6 +65,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return fullName;
                 }
 
+                string localAppDataProgramsPath = Path.Combine(localAppDataPath, "Programs");
+
+                if (CheckFileExists(localAppDataProgramsPath))
+                {
+                    return fullName;
+                }
+
                 bool CheckFileExists(string path)
                 {
                     fullName = Path.Combine(path, location, fileName);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5343

Changes proposed in this pull request:
Modify MergeToolsHelper.cs to check `%LocalAppData%\Programs` for possible candidates.
 
Screenshots before and after (if PR changes UI):
non-UI change

I'd love to test the change but i'm not allowed to install the required software on the computer supplied by my company.