### PR TITLE
fix: Graph column width appears too narrow

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/GraphModel.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/GraphModel.cs
@@ -37,6 +37,79 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             if (row < _nodes.Count)
             {
+                #region refresh the cache and recalculate nodes' edges
+                // Whenever we refresh we trigger clear sequence that clears the model and
+                // all claculated information about rows edges.
+                // Without this information we are unable to correctly render the graph...
+                // The recalculation is typically done on a background thread by the RevisionDataGridView,
+                // however here for us it is too late, and as a work around we must kick off the recalculation manually.
+                // This feels dirty but it addresses a major regression https://github.com/gitextensions/gitextensions/issues/5167
+                //
+                // The method seems to be pretty snappy, when measured in Debug build with StopWatch the timings were
+                // typically in vicinity of ns:
+                //
+                //  Loaded GitExtensions repo:
+                //
+                //     00:00:00.0005014 : 1
+                //     00:00:00.0016211 : 6
+                //     00:00:00.0000095 : 7
+                //     00:00:00.0000079 : 8
+                //     00:00:00.0000167 : 9
+                //     00:00:00.0001133 : 10
+                //     00:00:00.0000553 : 11
+                //     00:00:00.0000402 : 12
+                //     00:00:00.0000388 : 13
+                //     00:00:00.0000362 : 14
+                //
+                // Fast scroll with mouse to an arbitrary commit:
+                //
+                //     00:00:00.0229141 : 1057
+                //     00:00:00.0000355 : 1058
+                //     00:00:00.0000332 : 1068
+                //     00:00:00.0000330 : 1069
+                //     00:00:00.0000320 : 1070
+                //     00:00:00.0000328 : 1071
+                //     ...snip few brewity...
+                //     00:00:00.0632790 : 2959
+                //     00:00:00.0001009 : 2960
+                //     00:00:00.0000907 : 2961
+                //     ...snip few brewity...
+                //     00:00:00.0000684 : 2971
+                //     00:00:00.0001053 : 2972
+                //     00:00:00.0000941 : 2973
+                //     00:00:00.2486322 : 8245
+                //     00:00:00.0000229 : 8246
+                //     ...snip few brewity...
+                //     00:00:00.0000206 : 8258
+                //     00:00:00.0000165 : 8259
+                //     00:00:00.0108505 : 9038
+                //     00:00:00.0000314 : 9039
+                //     00:00:00.0000178 : 9040
+                //     ...snip few brewity...
+                //     00:00:00.0000215 : 9050
+                //     00:00:00.0000211 : 9051
+                //     00:00:00.0000180 : 9052
+                //
+                // Refresh at commit #9049:
+                //
+                //     00:00:00.0000180 : 0
+                //     00:00:00.0000117 : 1
+                //     00:00:00.0000827 : 2
+                //     00:00:00.0000681 : 3
+                //     00:00:00.0001763 : 4
+                //     00:00:00.0000702 : 5
+                //     00:00:00.0000783 : 8
+                //     00:00:00.0000236 : 11
+                //     00:00:00.0000189 : 12
+                //     00:00:00.0000250 : 13
+                //     00:00:00.0000112 : 14
+                //     00:00:00.7471912 : 9048
+                //     00:00:00.0000723 : 9049
+                //
+                //
+                CacheTo(row);
+                #endregion
+
                 return new SavedLaneRow(_nodes[row]);
             }
 


### PR DESCRIPTION
Fixes #5167

Whenever we refresh we trigger clear sequence that clears the model and all claculated information about rows edges.
Without this information we are unable to correctly render the graph...
The recalculation is typically done on a background thread by the `RevisionDataGridView`, however here for us it is too late, and as a work around we must kick off the recalculation manually.
This feels dirty but it addresses a major regression.

The method seems to be pretty snappy, when measured in Debug build with `StopWatch` the timings were typically in vicinity of ns:

```
Loaded GitExtensions repo (timing : row index):

    00:00:00.0005014 : 1
    00:00:00.0016211 : 6
    00:00:00.0000095 : 7
    00:00:00.0000079 : 8
    00:00:00.0000167 : 9
    00:00:00.0001133 : 10
    00:00:00.0000553 : 11
    00:00:00.0000402 : 12
    00:00:00.0000388 : 13
    00:00:00.0000362 : 14

Fast scroll with mouse to an arbitrary commit:

    00:00:00.0229141 : 1057
    00:00:00.0000355 : 1058
    00:00:00.0000317 : 1059
    00:00:00.0000321 : 1060
    00:00:00.0000331 : 1061
    00:00:00.0000322 : 1062
    00:00:00.0000332 : 1063
    00:00:00.0000315 : 1064
    00:00:00.0000331 : 1065
    00:00:00.0000321 : 1066
    00:00:00.0000332 : 1067
    00:00:00.0000332 : 1068
    00:00:00.0000330 : 1069
    00:00:00.0000320 : 1070
    00:00:00.0000328 : 1071
    00:00:00.0632790 : 2959
    00:00:00.0001009 : 2960
    00:00:00.0000907 : 2961
    00:00:00.0001853 : 2962
    00:00:00.0000878 : 2963
    00:00:00.0000622 : 2964
    00:00:00.0000857 : 2965
    00:00:00.0000780 : 2966
    00:00:00.0000996 : 2967
    00:00:00.0001008 : 2968
    00:00:00.0001021 : 2969
    00:00:00.0000795 : 2970
    00:00:00.0000684 : 2971
    00:00:00.0001053 : 2972
    00:00:00.0000941 : 2973
    00:00:00.2486322 : 8245
    00:00:00.0000229 : 8246
    00:00:00.0000133 : 8247
    00:00:00.0000157 : 8248
    00:00:00.0000133 : 8249
    00:00:00.0000316 : 8250
    00:00:00.0000154 : 8251
    00:00:00.0000177 : 8252
    00:00:00.0000145 : 8253
    00:00:00.0000199 : 8254
    00:00:00.0000319 : 8255
    00:00:00.0000228 : 8256
    00:00:00.0000226 : 8257
    00:00:00.0000206 : 8258
    00:00:00.0000165 : 8259
    00:00:00.0108505 : 9038
    00:00:00.0000314 : 9039
    00:00:00.0000178 : 9040
    00:00:00.0000243 : 9041
    00:00:00.0000292 : 9042
    00:00:00.0000154 : 9043
    00:00:00.0000175 : 9044
    00:00:00.0000156 : 9045
    00:00:00.0000273 : 9046
    00:00:00.0000394 : 9047
    00:00:00.0000165 : 9048
    00:00:00.0000205 : 9049
    00:00:00.0000215 : 9050
    00:00:00.0000211 : 9051
    00:00:00.0000180 : 9052

Refresh at commit #9049:

    00:00:00.0000180 : 0
    00:00:00.0000117 : 1
    00:00:00.0000827 : 2
    00:00:00.0000681 : 3
    00:00:00.0001763 : 4
    00:00:00.0000702 : 5
    00:00:00.0000783 : 8
    00:00:00.0000236 : 11
    00:00:00.0000189 : 12
    00:00:00.0000250 : 13
    00:00:00.0000112 : 14
    00:00:00.7471912 : 9048
    00:00:00.0000723 : 9049
```
