### PR TITLE
fix: Prevent LeftPanel from changing commit selection

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -131,6 +131,12 @@ namespace GitUI.BranchTreePanel
 
             internal override void OnSelected()
             {
+                if (Tree.IgnoreSelectionChangedEvent)
+                {
+                    return;
+                }
+
+                base.OnSelected();
                 SelectRevision();
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -82,6 +82,11 @@ namespace GitUI.BranchTreePanel
 
             internal override void OnSelected()
             {
+                if (Tree.IgnoreSelectionChangedEvent)
+                {
+                    return;
+                }
+
                 base.OnSelected();
                 SelectRevision();
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -24,6 +24,11 @@ namespace GitUI.BranchTreePanel
 
             internal override void OnSelected()
             {
+                if (Tree.IgnoreSelectionChangedEvent)
+                {
+                    return;
+                }
+
                 base.OnSelected();
                 SelectRevision();
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -99,9 +99,6 @@ namespace GitUI.BranchTreePanel
         {
             protected readonly Nodes Nodes;
             private readonly IGitUICommandsSource _uiCommandsSource;
-            public GitUICommands UICommands => _uiCommandsSource.UICommands;
-            protected GitModule Module => UICommands.Module;
-            public TreeNode TreeViewNode { get; }
 
             protected Tree(TreeNode treeNode, IGitUICommandsSource uiCommands)
             {
@@ -109,6 +106,16 @@ namespace GitUI.BranchTreePanel
                 _uiCommandsSource = uiCommands;
                 TreeViewNode = treeNode;
             }
+
+            public TreeNode TreeViewNode { get; }
+            public GitUICommands UICommands => _uiCommandsSource.UICommands;
+
+            /// <summary>
+            /// A flag to indicate that node SelectionChanged event is not user-originated and
+            /// must not trigger the event handling sequence.
+            /// </summary>
+            public bool IgnoreSelectionChangedEvent { get; set; }
+            protected GitModule Module => UICommands.Module;
 
             public async Task ReloadAsync(CancellationToken token)
             {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -171,7 +171,9 @@ namespace GitUI.BranchTreePanel
                     _rootNodes.Any(rn => $"{rn.TreeViewNode.FullPath}{treeMain.PathSeparator}{currentBranch}" == n.FullPath));
                 if (selectedNode != null)
                 {
+                    _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = true);
                     treeMain.SelectedNode = selectedNode;
+                    _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                     treeMain.SelectedNode.EnsureVisible();
                 }
             }


### PR DESCRIPTION
The LeftPanel would override the user's commit selection whenever its content would get refreshed. The tree is handling `AfterSelect` event and that causes the user's selection to change to whatever branch or tag is being selected in the LeftPanel's tree.

Stop this from happening by ignoring the event handling sequence whenever the tree is reloaded.

Fixes #5144.