### PR TITLE
fix: Branch Tree Panel initially empty

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -151,12 +151,12 @@ namespace GitUI.BranchTreePanel
 
         public async Task ReloadAsync()
         {
+            var currentBranch = Module.GetSelectedBranch();
             await this.SwitchToMainThreadAsync();
 
             var token = CancelBackgroundTasks();
             Enabled = false;
 
-            var currentBranch = Module.GetSelectedBranch();
             try
             {
                 var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();


### PR DESCRIPTION
Whenever the left panel is opened for the first time it would remain empty until refreshed. It appears the loading sequence would be cancelled due to an incorrect order of events.
Whenever the left panel is refreshed a new cancellation token is obtained.
Few lines later, while attempting to determine the current local branch a new cancellation token would be provisioned cancelling the previously issued one.

The fix reorders the sequence, getting the local branch before obtaining a cancellation token for the left panel data loading.

Fixes #5326
