### PR TITLE
WIP: Discussion to Save Grid column width on exit like Form Windows do

### DIFF
--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -150,6 +150,11 @@ namespace GitUI
             ResumeLayout();
         }
 
+        public WindowPosition LookupWindowPosition(string name)
+        {
+            return _windowPositionManager.LookupWindowPosition(name);
+        }
+
         // This is a base class for many forms, which have own GetTestAccessor() methods. This has to be unique
         internal GitExtensionsFormTestAccessor GetGitExtensionsFormTestAccessor() => new GitExtensionsFormTestAccessor(this);
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -301,6 +301,7 @@
     <Compile Include="Editor\GitHighlightingStrategyBase.cs" />
     <Compile Include="Editor\RebaseTodoHighlightingStrategy.cs" />
     <Compile Include="FindFilePredicateProvider.cs" />
+    <Compile Include="IControlPositionProvider.cs" />
     <Compile Include="Properties\Images.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/GitUI/IControlPositionProvider.cs
+++ b/GitUI/IControlPositionProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace GitUI
+{
+    public interface IControlPositionProvider
+    {
+        IEnumerable<WindowPosition> GetPositions();
+    }
+}


### PR DESCRIPTION
This is by no means a production ready solution. It's a prototype to open discussion and collect architecture proposals to implement this propper.

Basically this sollution piggy backs on WindowPosition so that when a Form saves its position it also queries its controls for their position settings.
While control upon loading asks for a position setting by Name and sizes it's components accordingly.

p.s. I really do hate resizing columns every single time :D