### PR TITLE
#4978 Diff view options are positioned wrong, cannot be selected

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -205,7 +205,7 @@
             this.ignoreAllWhitespaces,
             this.encodingToolStripComboBox,
             this.settingsButton});
-            this.fileviewerToolbar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+            this.fileviewerToolbar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.StackWithOverflow;
             this.fileviewerToolbar.Location = new System.Drawing.Point(458, 0);
             this.fileviewerToolbar.Name = "fileviewerToolbar";
             this.fileviewerToolbar.Size = new System.Drawing.Size(393, 23);


### PR DESCRIPTION
Fixes #4978

Tested on 
- Ubuntu 18.04
- Mono 5.10: issue was reproduced and fixed
- Mono 5.14: issue did not reproduce before & after the fix