### PR TITLE
#5206 FileList: Space between path and file

### DIFF
--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
 using JetBrains.Annotations;
@@ -51,7 +52,7 @@ namespace GitUI
             {
                 result = FormatString(name, oldName, step, isNameBeingTruncated);
 
-                if (_graphics.MeasureString(result, _font).Width <= width)
+                if (MeasureString(result, withPadding: true).Width <= width)
                 {
                     break;
                 }
@@ -77,6 +78,25 @@ namespace GitUI
 
             return fileName.Combine(" ", oldFileName.AddParenthesesNE());
         }
+
+        public Size MeasureString(string str, bool withPadding = false)
+        {
+            var formatFlags = FilePathStringFormat;
+            if (!withPadding)
+            {
+                formatFlags |= TextFormatFlags.NoPadding;
+            }
+
+            return TextRenderer.MeasureText(
+                _graphics,
+                str,
+                _font,
+                new Size(int.MaxValue, int.MaxValue),
+                formatFlags);
+        }
+
+        public void DrawString(string str, Rectangle rect, Color color) =>
+            TextRenderer.DrawText(_graphics, str, _font, rect, color, FilePathStringFormat);
 
         private static string FormatString(string name, string oldName, int step, bool isNameTruncated)
         {
@@ -122,5 +142,11 @@ namespace GitUI
                 return path;
             }
         }
+
+        private const TextFormatFlags FilePathStringFormat =
+            TextFormatFlags.NoClipping |
+            TextFormatFlags.NoPrefix |
+            TextFormatFlags.VerticalCenter |
+            TextFormatFlags.TextBoxControl;
     }
 }


### PR DESCRIPTION
Fixes #5206, fixes #4104

### Solution

Used `System.Windows.Forms.TextRenderer` to measure and draw strings

### Problem with empty space

To observe the difference
- set Application Font Tahoma 8
- open gitextensions commit 2e3afdac6b2b1d0a161be82d00176b2df2fdf48d

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/12046452/44948374-1e4a2a00-ae25-11e8-8ac7-e237b6b510e9.png)

After

![image](https://user-images.githubusercontent.com/12046452/44948389-4fc2f580-ae25-11e8-81ab-aae100d7d829.png)

### Problem with horizontal scroll

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/12046452/44950546-2ae57700-ae53-11e8-87f8-868dea8db8bd.png)

After

![image](https://user-images.githubusercontent.com/12046452/44950547-3173ee80-ae53-11e8-9c62-bcf8543cfec2.png)

### Test

Windows 7 with default DPI 96