### PR TITLE
#5331 FileStatusList: highlighted file name is too pale

### DIFF
--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -58,7 +58,7 @@ namespace GitUI
             this.FileStatusListView.TabIndex = 1;
             this.FileStatusListView.UseCompatibleStateImageBehavior = false;
             this.FileStatusListView.View = System.Windows.Forms.View.Details;
-            this.FileStatusListView.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.FileStatusListView_DrawItem);
+            this.FileStatusListView.DrawSubItem += new System.Windows.Forms.DrawListViewSubItemEventHandler(this.FileStatusListView_DrawSubItem);
             this.FileStatusListView.SizeChanged += new System.EventHandler(this.FileStatusListView_SizeChanged);
             this.FileStatusListView.DoubleClick += new System.EventHandler(this.FileStatusListView_DoubleClick);
             this.FileStatusListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FileStatusListView_KeyDown);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -300,7 +300,7 @@ namespace GitUI
             }
         }
 
-        private void FileStatusListView_DrawItem(object sender, DrawListViewItemEventArgs e)
+        private void FileStatusListView_DrawSubItem(object sender, DrawListViewSubItemEventArgs e)
         {
             if (!(e.Item?.Tag is GitItemStatus gitItemStatus))
             {


### PR DESCRIPTION
Fixes #5331

**Screenshots**

Selection rendering change when focused

![image](https://user-images.githubusercontent.com/12046452/44959128-a4807200-aef2-11e8-9cc4-e5c470b26c12.png)

Selection rendering change when non-focused

![image](https://user-images.githubusercontent.com/12046452/44959133-ad714380-aef2-11e8-903c-64224c3dcb45.png)

**Tested**

on Windows 7