### PR TITLE
fix: FormDeleteTag incorrect height in HiDPI

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteTag.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.Designer.cs
@@ -65,7 +65,7 @@
             // 
             // Tags
             // 
-            this.Tags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.Tags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.Tags.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.Tags.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
@@ -150,9 +150,7 @@
             this.Controls.Add(this.Tags);
             this.Controls.Add(this.label1);
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(1000, 210);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(470, 210);
             this.Name = "FormDeleteTag";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Delete tag";

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using GitUI.Script;
 using GitUIPluginInterfaces;
 
@@ -18,6 +20,11 @@ namespace GitUI.CommandsDialogs
             : base(commands)
         {
             InitializeComponent();
+
+            // scale up for hi DPI
+            MaximumSize = DpiUtil.Scale(new Size(1000, 210));
+            MinimumSize = DpiUtil.Scale(new Size(470, 210));
+
             InitializeComplete();
             Tag = tag;
         }


### PR DESCRIPTION
Fixes #5380

Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/4403806/44952342-94e83580-aec0-11e8-8b37-e82aea0a4fba.png)

- after
![image](https://user-images.githubusercontent.com/4403806/44952398-c9102600-aec1-11e8-8279-9d920ab8ba7c.png)

