### PR TITLE
#4978 Diff view options are positioned wrong, cannot be selected

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -213,7 +213,7 @@ namespace GitUI.Editor
             this.ignoreAllWhitespaces,
             this.encodingToolStripComboBox,
             this.settingsButton});
-            this.fileviewerToolbar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+            this.fileviewerToolbar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.StackWithOverflow;
             this.fileviewerToolbar.Location = new System.Drawing.Point(458, 0);
             this.fileviewerToolbar.Name = "fileviewerToolbar";
             this.fileviewerToolbar.Size = new System.Drawing.Size(393, 23);


### PR DESCRIPTION
Fixes #4978 

Tested 
- on Ubuntu 18.04 with Mono 5.10 and Mono 5.14 (with gitextensions release 2.51)
- on Windows 7
