### PR TITLE
fix: Colors settings get "squished"

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -17,6 +17,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             base.OnRuntimeLoad();
 
+            if (!IsSettingsLoaded)
+            {
+                SettingsToPage();
+            }
+
             // align 1st columns across all tables
             tlpnlRevisionGraph.AdjustWidthToSize(0, MulticolorBranches, lblColorLineRemoved);
             tlpnlDiffView.AdjustWidthToSize(0, MulticolorBranches, lblColorLineRemoved);

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -75,11 +75,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         /// </summary>
         protected bool IsLoadingSettings { get; private set; }
 
+        /// <summary>
+        /// Indicates that settings have been loaded to the page.
+        /// </summary>
+        protected bool IsSettingsLoaded { get; private set; }
+
         public void LoadSettings()
         {
             IsLoadingSettings = true;
             SettingsToPage();
             IsLoadingSettings = false;
+            IsSettingsLoaded = true;
         }
 
         public void SaveSettings()


### PR DESCRIPTION
Colors settings get "squished" when opening settings with Colors node selected because of the different order in which layout event fire.
The fix ensures that data is loaded to the page before layout calculations take place.

Fixes #5364
