### PR TITLE
Localized exception message.

### DIFF
--- a/UnitTests/GitCommandsTests/Git/GitBranchNameOptionsTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitBranchNameOptionsTest.cs
@@ -5,8 +5,8 @@ using NUnit.Framework;
 
 namespace GitCommandsTests.Git
 {
-    [SetCulture("")]
-    [SetUICulture("")]
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     [TestFixture]
     public class GitBranchNameOptionsTest
     {

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -10,8 +10,8 @@ using NUnit.Framework;
 
 namespace GitCommandsTests.Remote
 {
-    [SetCulture("")]
-    [SetUICulture("")]
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     [TestFixture]
     internal class GitRemoteManagerTests
     {

--- a/UnitTests/GitExtUtils/TableLayoutPanelExtensionsTests.cs
+++ b/UnitTests/GitExtUtils/TableLayoutPanelExtensionsTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace GitExtUtilsTests
 {
     [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     [TestFixture]
     public class TableLayoutPanelExtensionsTests
     {

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
@@ -8,8 +8,8 @@ using ResourceManager.CommitDataRenders;
 
 namespace ResourceManagerTests.CommitDataRenders
 {
-    [SetCulture("")]
-    [SetUICulture("")]
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     [TestFixture]
     public class CommitDataHeaderRendererIntegrationTests
     {

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -11,8 +11,8 @@ using ResourceManager.CommitDataRenders;
 
 namespace ResourceManagerTests.CommitDataRenders
 {
-    [SetCulture("")]
-    [SetUICulture("")]
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     [TestFixture]
     public class CommitDataHeaderRendererTests
     {


### PR DESCRIPTION
On my machine the exception messages are written in Polish. That causes a failure for tests that verify the exact messages.