### PR TITLE
Apply FormBrowse filter textbox filter on Enter

### DIFF
--- a/GitUI/FilterRevisionsHelper.cs
+++ b/GitUI/FilterRevisionsHelper.cs
@@ -88,9 +88,9 @@ namespace GitUI
 
             label.Click += delegate { ApplyFilter(); };
             _NO_TRANSLATE_textBox.Leave += delegate { ApplyFilter(); };
-            _NO_TRANSLATE_textBox.KeyPress += (sender, e) =>
+            _NO_TRANSLATE_textBox.KeyUp += (sender, e) =>
             {
-                if (e.KeyChar == (char)Keys.Enter)
+                if (e.KeyValue == (char)Keys.Enter)
                 {
                     ApplyFilter();
                 }


### PR DESCRIPTION
Right now FormBrowse filter box doesn't apply the filter on Enter. Some googling has revealed that ToolStripTextBox.KeyPress doesn't work with Enter and suggestion is to use KeyUp thus this PR.