### PR TITLE
Use monospace font for Commit Id column

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1218,6 +1218,12 @@ namespace GitCommands
             set => SetFont("commitfont", value);
         }
 
+        public static Font MonospaceFont
+        {
+            get => GetFont("monospacefont", new Font("Consolas", 9));
+            set => SetFont("monospacefont", value);
+        }
+
         public static Font Font
         {
             get => GetFont("font", SystemFonts.MessageBoxFont);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
@@ -31,13 +31,16 @@
             this.gbFonts = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label56 = new System.Windows.Forms.Label();
+            this.monospaceFontChangeButton = new System.Windows.Forms.Button();
             this.commitFontChangeButton = new System.Windows.Forms.Button();
             this.diffFontChangeButton = new System.Windows.Forms.Button();
             this.applicationFontChangeButton = new System.Windows.Forms.Button();
+            this.label36 = new System.Windows.Forms.Label();
             this.label34 = new System.Windows.Forms.Label();
             this.label26 = new System.Windows.Forms.Label();
             this.diffFontDialog = new System.Windows.Forms.FontDialog();
             this.applicationDialog = new System.Windows.Forms.FontDialog();
+            this.monospaceFontDialog = new System.Windows.Forms.FontDialog();
             this.commitFontDialog = new System.Windows.Forms.FontDialog();
             this.gbFonts.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -66,20 +69,23 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.label56, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.monospaceFontChangeButton, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.commitFontChangeButton, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.diffFontChangeButton, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.applicationFontChangeButton, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label36, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.label34, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.label26, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 22);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowCount = 4;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(2116, 87);
-            this.tableLayoutPanel1.TabIndex = 6;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(2116, 116);
+            this.tableLayoutPanel1.TabIndex = 7;
             // 
             // label56
             // 
@@ -153,6 +159,30 @@
             this.label26.Text = "Application font";
             this.label26.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
+            // label36
+            // 
+            this.label36.AutoSize = true;
+            this.label36.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label36.Location = new System.Drawing.Point(3, 0);
+            this.label36.Name = "label36";
+            this.label36.Size = new System.Drawing.Size(82, 29);
+            this.label36.TabIndex = 0;
+            this.label36.Text = "Monospace font";
+            this.label36.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // monospaceFontChangeButton
+            // 
+            this.monospaceFontChangeButton.AutoSize = true;
+            this.monospaceFontChangeButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.monospaceFontChangeButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.monospaceFontChangeButton.Location = new System.Drawing.Point(91, 61);
+            this.monospaceFontChangeButton.Name = "monospaceFontChangeButton";
+            this.monospaceFontChangeButton.Size = new System.Drawing.Size(66, 23);
+            this.monospaceFontChangeButton.TabIndex = 6;
+            this.monospaceFontChangeButton.Text = "font name";
+            this.monospaceFontChangeButton.UseVisualStyleBackColor = true;
+            this.monospaceFontChangeButton.Click += new System.EventHandler(this.monospaceFontChangeButton_Click);
+            // 
             // diffFontDialog
             // 
             this.diffFontDialog.AllowVerticalFonts = false;
@@ -163,6 +193,11 @@
             // 
             this.applicationDialog.AllowVerticalFonts = false;
             this.applicationDialog.Color = System.Drawing.SystemColors.ControlText;
+            // 
+            // monospaceFontDialog
+            // 
+            this.monospaceFontDialog.AllowVerticalFonts = false;
+            this.monospaceFontDialog.Color = System.Drawing.SystemColors.ControlText;
             // 
             // commitFontDialog
             // 
@@ -192,11 +227,14 @@
         private System.Windows.Forms.Button diffFontChangeButton;
         private System.Windows.Forms.Button applicationFontChangeButton;
         private System.Windows.Forms.Label label26;
+        private System.Windows.Forms.Label label36;
         private System.Windows.Forms.Label label56;
         private System.Windows.Forms.FontDialog diffFontDialog;
         private System.Windows.Forms.FontDialog applicationDialog;
+        private System.Windows.Forms.Button monospaceFontChangeButton;
         private System.Windows.Forms.Button commitFontChangeButton;
         private System.Windows.Forms.Label label34;
+        private System.Windows.Forms.FontDialog monospaceFontDialog;
         private System.Windows.Forms.FontDialog commitFontDialog;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
@@ -10,6 +10,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private Font _diffFont;
         private Font _applicationFont;
         private Font _commitFont;
+        private Font _monospaceFont;
 
         public AppearanceFontsSettingsPage()
         {
@@ -23,6 +24,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             SetCurrentApplicationFont(AppSettings.Font);
             SetCurrentDiffFont(AppSettings.FixedWidthFont);
             SetCurrentCommitFont(AppSettings.CommitFont);
+            SetCurrentMonospaceFont(AppSettings.MonospaceFont);
         }
 
         protected override void PageToSettings()
@@ -30,6 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.FixedWidthFont = _diffFont;
             AppSettings.Font = _applicationFont;
             AppSettings.CommitFont = _commitFont;
+            AppSettings.MonospaceFont = _monospaceFont;
         }
 
         private void diffFontChangeButton_Click(object sender, EventArgs e)
@@ -65,6 +68,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
         }
 
+        private void monospaceFontChangeButton_Click(object sender, EventArgs e)
+        {
+            monospaceFontDialog.Font = _monospaceFont;
+            DialogResult result = monospaceFontDialog.ShowDialog(this);
+
+            if (result == DialogResult.OK || result == DialogResult.Yes)
+            {
+                SetCurrentMonospaceFont(monospaceFontDialog.Font);
+            }
+        }
+
         private void SetCurrentDiffFont(Font newFont)
         {
             _diffFont = newFont;
@@ -81,6 +95,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             _commitFont = newFont;
             SetFontButtonText(newFont, commitFontChangeButton);
+        }
+
+        private void SetCurrentMonospaceFont(Font newFont)
+        {
+            _monospaceFont = newFont;
+            SetFontButtonText(newFont, monospaceFontChangeButton);
         }
 
         private static void SetFontButtonText(Font font, Button button)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -369,6 +369,7 @@
     <Compile Include="SpellChecker\SpellCheckerHelper.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractor.cs" />
     <Compile Include="TaskbarProgress.cs" />
+    <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionColorProvider.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionStyler.cs" />
     <Compile Include="UserControls\RevisionGrid\Columns\MultilineIndicator.cs" />

--- a/GitUI/UserControls/RevisionGrid/CellStyle.cs
+++ b/GitUI/UserControls/RevisionGrid/CellStyle.cs
@@ -1,0 +1,22 @@
+﻿using System.Drawing;
+
+namespace GitUI.UserControls.RevisionGrid
+{
+    internal readonly struct CellStyle
+    {
+        public readonly Brush BackBrush;
+        public readonly Color ForeColor;
+        public readonly Font NormalFont;
+        public readonly Font BoldFont;
+        public readonly Font MonospaceFont;
+
+        public CellStyle(Brush backBrush, Color foreColor, Font normalFont, Font boldFont, Font monospaceFont)
+        {
+            BackBrush = backBrush;
+            ForeColor = foreColor;
+            NormalFont = normalFont;
+            BoldFont = boldFont;
+            MonospaceFont = monospaceFont;
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
 
@@ -29,13 +28,13 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowAuthorNameColumn;
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
             if (!revision.IsArtificial)
             {
-                var font = _authorHighlighting.IsHighlighted(revision) ? style.boldFont : style.normalFont;
+                var font = _authorHighlighting.IsHighlighted(revision) ? style.BoldFont : style.NormalFont;
 
-                _grid.DrawColumnText(e, (string)e.FormattedValue, font, style.foreColor, e.CellBounds.ReduceLeft(ColumnLeftMargin));
+                _grid.DrawColumnText(e, (string)e.FormattedValue, font, style.ForeColor, e.CellBounds.ReduceLeft(ColumnLeftMargin));
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -35,7 +35,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowAuthorAvatarColumn;
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
             if (revision.IsArtificial)
             {
@@ -84,17 +84,17 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             e.Graphics.DrawImage(image, rect);
             e.Graphics.EndContainer(container);
 
-            e.Graphics.FillRectangle(style.backBrush, rect.Left, rect.Top, 2, 1);
-            e.Graphics.FillRectangle(style.backBrush, rect.Left, rect.Top, 1, 2);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Top, 2, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Top, 1, 2);
 
-            e.Graphics.FillRectangle(style.backBrush, rect.Right - 2, rect.Top, 2, 1);
-            e.Graphics.FillRectangle(style.backBrush, rect.Right - 1, rect.Top, 1, 2);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 2, rect.Top, 2, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 1, rect.Top, 1, 2);
 
-            e.Graphics.FillRectangle(style.backBrush, rect.Left, rect.Bottom - 1, 2, 1);
-            e.Graphics.FillRectangle(style.backBrush, rect.Left, rect.Bottom - 2, 1, 2);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Bottom - 1, 2, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Bottom - 2, 1, 2);
 
-            e.Graphics.FillRectangle(style.backBrush, rect.Right - 2, rect.Bottom - 1, 2, 1);
-            e.Graphics.FillRectangle(style.backBrush, rect.Right - 1, rect.Bottom - 2, 1, 2);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 2, rect.Bottom - 1, 2, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 1, rect.Bottom - 2, 1, 2);
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -69,7 +69,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             }
         }
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
             if (revision.BuildStatus == null)
             {
@@ -101,8 +101,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 _grid.DrawColumnText(
                     e,
                     (string)e.FormattedValue,
-                    style.normalFont,
-                    GetColor(style.foreColor),
+                    style.NormalFont,
+                    GetColor(style.ForeColor),
                     bounds: e.CellBounds.ReduceLeft(size.Width * 2));
             }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
@@ -26,7 +26,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         public int Index => Column.Index;
 
         /// <summary>Renders the content of a cell in this column.</summary>
-        public abstract void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style);
+        public abstract void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style);
 
         /// <summary>Formats the textual representation of a cell in this column.</summary>
         /// <remarks>Implementations may set <c>e.Value</c> to the required string, and then set <c>e.FormattingApplied</c> to <c>true</c>.</remarks>

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -13,7 +13,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
     {
         private readonly Dictionary<Font, int[]> _widthByLengthByFont = new Dictionary<Font, int[]>(capacity: 4);
         private readonly RevisionGridControl _grid;
-        private readonly Font _monospaceFont = AppSettings.MonospaceFont;
 
         public CommitIdColumnProvider(RevisionGridControl grid)
             : base("Commit ID")
@@ -34,14 +33,14 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowObjectIdColumn;
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
-            if (!_widthByLengthByFont.TryGetValue(_monospaceFont, out var widthByLength))
+            var monospaceFont = style.MonospaceFont;
+            if (!_widthByLengthByFont.TryGetValue(monospaceFont, out var widthByLength))
             {
-                var normalFont = _monospaceFont;
-                widthByLength = Enumerable.Range(0, ObjectId.Sha1CharCount + 1).Select(c => TextRenderer.MeasureText(new string('8', c), normalFont).Width).ToArray();
+                widthByLength = Enumerable.Range(0, ObjectId.Sha1CharCount + 1).Select(c => TextRenderer.MeasureText(new string('8', c), monospaceFont).Width).ToArray();
 
-                _widthByLengthByFont[_monospaceFont] = widthByLength;
+                _widthByLengthByFont[monospaceFont] = widthByLength;
             }
 
             if (!revision.IsArtificial)
@@ -50,11 +49,11 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 if (i == -1 && Column.Width > widthByLength[widthByLength.Length - 1])
                 {
-                    _grid.DrawColumnText(e, revision.ObjectId.ToString(), _monospaceFont, style.foreColor, e.CellBounds, useEllipsis: false);
+                    _grid.DrawColumnText(e, revision.ObjectId.ToString(), monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
                 }
                 else if (i > 1)
                 {
-                    _grid.DrawColumnText(e, revision.ObjectId.ToShortString(i - 1), _monospaceFont, style.foreColor, e.CellBounds, useEllipsis: false);
+                    _grid.DrawColumnText(e, revision.ObjectId.ToShortString(i - 1), monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
                 }
             }
         }

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -13,6 +13,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
     {
         private readonly Dictionary<Font, int[]> _widthByLengthByFont = new Dictionary<Font, int[]>(capacity: 4);
         private readonly RevisionGridControl _grid;
+        private readonly Font _monospaceFont = AppSettings.MonospaceFont;
 
         public CommitIdColumnProvider(RevisionGridControl grid)
             : base("Commit ID")
@@ -35,12 +36,12 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
         {
-            if (!_widthByLengthByFont.TryGetValue(style.normalFont, out var widthByLength))
+            if (!_widthByLengthByFont.TryGetValue(_monospaceFont, out var widthByLength))
             {
-                var normalFont = style.normalFont;
+                var normalFont = _monospaceFont;
                 widthByLength = Enumerable.Range(0, ObjectId.Sha1CharCount + 1).Select(c => TextRenderer.MeasureText(new string('8', c), normalFont).Width).ToArray();
 
-                _widthByLengthByFont[style.normalFont] = widthByLength;
+                _widthByLengthByFont[_monospaceFont] = widthByLength;
             }
 
             if (!revision.IsArtificial)
@@ -49,11 +50,11 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 if (i == -1 && Column.Width > widthByLength[widthByLength.Length - 1])
                 {
-                    _grid.DrawColumnText(e, revision.ObjectId.ToString(), style.normalFont, style.foreColor, e.CellBounds, useEllipsis: false);
+                    _grid.DrawColumnText(e, revision.ObjectId.ToString(), _monospaceFont, style.foreColor, e.CellBounds, useEllipsis: false);
                 }
                 else if (i > 1)
                 {
-                    _grid.DrawColumnText(e, revision.ObjectId.ToShortString(i - 1), style.normalFont, style.foreColor, e.CellBounds, useEllipsis: false);
+                    _grid.DrawColumnText(e, revision.ObjectId.ToShortString(i - 1), _monospaceFont, style.foreColor, e.CellBounds, useEllipsis: false);
                 }
             }
         }

--- a/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
@@ -29,9 +28,9 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowDateColumn;
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
-            _grid.DrawColumnText(e, e.FormattedValue.ToString(), style.normalFont, style.foreColor, e.CellBounds);
+            _grid.DrawColumnText(e, e.FormattedValue.ToString(), style.NormalFont, style.ForeColor, e.CellBounds);
         }
 
         public override void OnCellFormatting(DataGridViewCellFormattingEventArgs e, GitRevision revision)

--- a/GitUI/UserControls/RevisionGrid/Columns/GraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/GraphColumnProvider.cs
@@ -72,7 +72,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             set { _revisionGraphDrawStyle = value; }
         }
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
             if (AppSettings.ShowRevisionGridGraphColumn &&
                 e.State.HasFlag(DataGridViewElementStates.Visible) &&

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -38,7 +38,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         private readonly Image _bisectBadImage = DpiUtil.Scale(Images.BisectBad);
         private readonly Image _fixupAndSquashImage = DpiUtil.Scale(Images.FixupAndSquashMessageMarker);
 
-        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in (Brush backBrush, Color foreColor, Font normalFont, Font boldFont) style)
+        public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
             var isRowSelected = e.State.HasFlag(DataGridViewElementStates.Selected);
 
@@ -50,7 +50,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             var offset = ColumnLeftMargin;
 
-            var normalFont = style.normalFont;
+            var normalFont = style.NormalFont;
 
             #region Draw super project references (for submodules)
 
@@ -137,7 +137,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                             : RefArrowType.None;
 
                     var font = gitRef.IsSelected
-                        ? style.boldFont
+                        ? style.BoldFont
                         : normalFont;
 
                     var superprojectRef = superprojectRefs.FirstOrDefault(superGitRef => gitRef.CompleteName == superGitRef.CompleteName);
@@ -171,7 +171,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     : gitRef.IsSelectedHeadMergeSource
                         ? RefArrowType.NotFilled
                         : RefArrowType.None;
-                var font = gitRef.IsSelected ? style.boldFont : normalFont;
+                var font = gitRef.IsSelected ? style.BoldFont : normalFont;
 
                 RevisionGridRefRenderer.DrawRef(isRowSelected, font, ref offset, gitRefName, headColor, arrowType, messageBounds, e.Graphics, dashedLine: true);
             }
@@ -211,7 +211,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 // Draw the summary text
                 var bounds = messageBounds.ReduceLeft(offset);
-                _grid.DrawColumnText(e, text, hasSelectedRef ? style.boldFont : normalFont, style.foreColor, bounds);
+                _grid.DrawColumnText(e, text, hasSelectedRef ? style.BoldFont : normalFont, style.ForeColor, bounds);
 
                 // Draw the multi-line indicator
                 indicator.Render();

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -45,6 +45,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         private Font _normalFont;
         private Font _boldFont;
+        private Font _monospaceFont;
 
         public bool UpdatingVisibleRows { get; private set; }
 
@@ -58,6 +59,7 @@ namespace GitUI.UserControls.RevisionGrid
             _backgroundThread.Start();
 
             NormalFont = AppSettings.Font;
+            _monospaceFont = AppSettings.MonospaceFont;
 
             InitializeComponent();
 
@@ -311,7 +313,7 @@ namespace GitUI.UserControls.RevisionGrid
                 var backBrush = GetBackground(e.State, e.RowIndex);
                 var foreColor = GetForeground(e.State, e.RowIndex);
 
-                provider.OnCellPainting(e, revision, _rowHeight, (backBrush, foreColor, _normalFont, _boldFont));
+                provider.OnCellPainting(e, revision, _rowHeight, new CellStyle(backBrush, foreColor, _normalFont, _boldFont, _monospaceFont));
 
                 e.Handled = true;
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1228,7 +1228,7 @@ namespace GitUI
             switch (e.Button)
             {
                 case MouseButtons.XButton1: NavigateBackward(); break;
-                case MouseButtons.XButton2: NavigateForward();  break;
+                case MouseButtons.XButton2: NavigateForward(); break;
                 case MouseButtons.Left when _maximizedColumn != null && _lastVisibleResizableColumn != null:
                     // make resizing of the maximized column work and restore the settings afterwards
                     void OnGridViewMouseCaptureChanged(object ignoredSender, EventArgs ignoredArgs)


### PR DESCRIPTION
2.5 release uses monospace font for Sha column. Not sure if this has been removed by accident or intentionally but at least to me Sha Ids look better in monospace font. At least with monospace the column looks tidy.

Before (notice non-uniform width of Sha column values):
![image](https://user-images.githubusercontent.com/483659/45059446-ae49d700-b0a4-11e8-9fe2-c5b0d7727cfb.png)

After:
![image](https://user-images.githubusercontent.com/483659/45059452-b275f480-b0a4-11e8-9b3c-ea51ea87ce85.png)

As for code changes. `RevisionDataGridView` holds `NormalFont` and so it might seem a good idea to have a monospace font defined here but `CommitIdColumnProvider` which needs this font is instantiated in `RevisionGridControl` and doesn't have access to `RevisionDataGridView` so I settled with having this font defined in `CommitIdColumnProvider` itself.