### PR TITLE
Change default Pull button action using a submenu

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -696,12 +696,6 @@ namespace GitCommands
             set => SetEnum("DefaultPullAction", value);
         }
 
-        public static bool SetNextPullActionAsDefault
-        {
-            get => !GetBool("DonSetAsLastPullAction", true);
-            set => SetBool("DonSetAsLastPullAction", !value);
-        }
-
         public static string SmtpServer
         {
             get => GetString("SmtpServer", "smtp.gmail.com");

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
             this.pullToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.fetchAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fetchPruneAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.setNextPullActionAsDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setDefaultPullButtonActionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripButtonPush = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripFileExplorer = new System.Windows.Forms.ToolStripButton();
@@ -466,7 +466,7 @@ namespace GitUI.CommandsDialogs
             this.fetchAllToolStripMenuItem,
             this.fetchPruneAllToolStripMenuItem,
             toolStripSeparator14,
-            this.setNextPullActionAsDefaultToolStripMenuItem});
+            this.setDefaultPullButtonActionToolStripMenuItem});
             this.toolStripButtonPull.Image = global::GitUI.Properties.Images.Pull;
             this.toolStripButtonPull.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonPull.Name = "toolStripButtonPull";
@@ -532,14 +532,11 @@ namespace GitUI.CommandsDialogs
             this.fetchPruneAllToolStripMenuItem.ToolTipText = "Fetch branches and tags from all remote repositories also prune deleted refs";
             this.fetchPruneAllToolStripMenuItem.Click += new System.EventHandler(this.fetchPruneAllToolStripMenuItem_Click);
             // 
-            // setNextPullActionAsDefaultToolStripMenuItem
+            // setDefaultPullButtonActionToolStripMenuItem
             // 
-            this.setNextPullActionAsDefaultToolStripMenuItem.Checked = true;
-            this.setNextPullActionAsDefaultToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.setNextPullActionAsDefaultToolStripMenuItem.Name = "setNextPullActionAsDefaultToolStripMenuItem";
-            this.setNextPullActionAsDefaultToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-            this.setNextPullActionAsDefaultToolStripMenuItem.Text = "Set the next selection as default";
-            this.setNextPullActionAsDefaultToolStripMenuItem.Click += new System.EventHandler(this.dontSetAsDefaultToolStripMenuItem_Click);
+            this.setDefaultPullButtonActionToolStripMenuItem.Name = "setDefaultPullButtonActionToolStripMenuItem";
+            this.setDefaultPullButtonActionToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
+            this.setDefaultPullButtonActionToolStripMenuItem.Text = "Set default Pull button action";
             // 
             // toolStripButtonPush
             // 
@@ -1906,7 +1903,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem rebaseToolStripMenuItem1;
         private ToolStripMenuItem fetchToolStripMenuItem;
         private ToolStripMenuItem pullToolStripMenuItem1;
-        private ToolStripMenuItem setNextPullActionAsDefaultToolStripMenuItem;
+        private ToolStripMenuItem setDefaultPullButtonActionToolStripMenuItem;
         private ToolStripMenuItem fetchAllToolStripMenuItem;
         private ToolStripMenuItem fetchPruneAllToolStripMenuItem;
         private ToolStripMenuItem resetToolStripMenuItem;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2314,8 +2314,8 @@ Do you want to remove it from the recent repositories list?</source>
         <source>Solve merge conflicts...</source>
         <target />
       </trans-unit>
-      <trans-unit id="setNextPullActionAsDefaultToolStripMenuItem.Text">
-        <source>Set the next selection as default</source>
+      <trans-unit id="setDefaultPullButtonActionToolStripMenuItem.Text">
+        <source>Set default Pull button action</source>
         <target />
       </trans-unit>
       <trans-unit id="settingsToolStripMenuItem.Text">


### PR DESCRIPTION
Fixes #5374

Changes proposed in this pull request:
- Instead of having a checkbox indicating that next pull button action would be set as default, allow the user to make this selection from a sub-menu
 
Screenshots before:
![image](https://user-images.githubusercontent.com/483659/45138763-51d6dc80-b1b6-11e8-906a-07ac23b565ec.png)


Screenshots after:
![](http://spurgius.com/interwebs/img/20180906091753_SetDefaultPullAction3.gif)

What did I do to test the code and ensure quality:
- Manual testing
