### PR TITLE
test failed for local drive letter

### DIFF
--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -249,14 +249,19 @@ namespace GitCommandsTests.Helpers
 
                 if (actual)
                 {
+                    string expectedPath;
                     if (expectedExactPaths.TryGetValue(path, out var expectedExactPath))
                     {
-                        Assert.AreEqual(expectedExactPath, exactPath);
+                        expectedPath = expectedExactPath;
                     }
                     else
                     {
-                        Assert.AreEqual(path, exactPath);
+                        expectedPath = path;
                     }
+
+                    var lowercaseDriveExpected = char.ToLower(expectedPath[0]).ToString() + expectedPath.Substring(1);
+                    var lowercaseDriveExact = char.ToLower(exactPath[0]).ToString() + exactPath.Substring(1);
+                    Assert.AreEqual(lowercaseDriveExpected, lowercaseDriveExact);
                 }
                 else
                 {


### PR DESCRIPTION
Test TryGetExactPathName failed:

Message:   String lengths are both 69. Strings differ at index 0.
  Expected: "f:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community..."
  But was:  "F:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community..."
  -----------^


Changes proposed in this pull request:
- Lowercase driveletters when comparing files on local should be set to lowercase
 
What did I do to test the code and ensure quality:
- fixed the test

Has been tested on (remove any that don't apply):
- Windows 10