### PR TITLE
Don't lowercase URLs

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -64,7 +64,7 @@ namespace GitCommands.ExternalLinks
                 {
                     if (remote.Url.IsNotNullOrWhitespace())
                     {
-                        remoteUrls.Add(remote.Url.ToLower());
+                        remoteUrls.Add(remote.Url);
                     }
                 }
 
@@ -72,7 +72,7 @@ namespace GitCommands.ExternalLinks
                 {
                     if (remote.PushUrl.IsNotNullOrWhitespace())
                     {
-                        remoteUrls.Add(remote.PushUrl.ToLower());
+                        remoteUrls.Add(remote.PushUrl);
                     }
                 }
             }


### PR DESCRIPTION
Changing the case of the path segment of a URL changes its meaning

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5409

Changes proposed in this pull request:
- Remove `.toLower()`

Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- Nothing

Has been tested on (remove any that don't apply):
- Nothing
