### PR TITLE
Leave only two rebase options in RevisionGridControl

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -726,12 +726,6 @@ namespace GitCommands
             set => SetBool("RebaseAutostash", value);
         }
 
-        public static bool SkipRebaseDialog
-        {
-            get => GetBool("SkipRebaseDialog", false);
-            set => SetBool("SkipRebaseDialog", value);
-        }
-
         public static LocalChangesAction CheckoutBranchAction
         {
             get => GetEnum("checkoutbranchaction", LocalChangesAction.DontChange);
@@ -808,6 +802,12 @@ namespace GitCommands
         {
             get => GetBool("DontConfirmSecondAbortConfirmation", false);
             set => SetBool("DontConfirmSecondAbortConfirmation", value);
+        }
+
+        public static bool DontConfirmRebase
+        {
+            get => GetBool("DontConfirmRebase", false);
+            set => SetBool("DontConfirmRebase", value);
         }
 
         public static bool DontConfirmResolveConflicts

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -55,6 +55,7 @@ namespace GitUI.CommandsDialogs
             txtFrom.Text = from;
             _defaultToBranch = to;
             chkInteractive.Checked = interactive;
+            chkAutosquash.Enabled = interactive;
             _startRebaseImmediately = startRebaseImmediately;
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
@@ -31,9 +31,6 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AdvancedSettingsPage));
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.grpRebase = new System.Windows.Forms.GroupBox();
-            this.tableLayoutOfRebase = new System.Windows.Forms.TableLayoutPanel();
-            this.chkRebaseConfirmation = new System.Windows.Forms.CheckBox();
             this.grpCommit = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
             this.chkCommitAndPushForcedWhenAmend = new System.Windows.Forms.CheckBox();
@@ -53,8 +50,6 @@
             this.cboAutoNormaliseSymbol = new System.Windows.Forms.ComboBox();
             this.tooltip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel2.SuspendLayout();
-            this.grpRebase.SuspendLayout();
-            this.tableLayoutOfRebase.SuspendLayout();
             this.grpCommit.SuspendLayout();
             this.tableLayoutPanel5.SuspendLayout();
             this.CheckoutGB.SuspendLayout();
@@ -70,60 +65,19 @@
             this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel2.ColumnCount = 1;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.grpRebase, 0, 3);
             this.tableLayoutPanel2.Controls.Add(this.grpCommit, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this.CheckoutGB, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.GeneralGB, 0, 1);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(8, 8);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 4;
+            this.tableLayoutPanel2.RowCount = 3;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.Size = new System.Drawing.Size(1600, 753);
             this.tableLayoutPanel2.TabIndex = 1;
-            // 
-            // grpRebase
-            // 
-            this.grpRebase.AutoSize = true;
-            this.grpRebase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.grpRebase.Controls.Add(this.tableLayoutOfRebase);
-            this.grpRebase.Dock = System.Windows.Forms.DockStyle.Top;
-            this.grpRebase.Location = new System.Drawing.Point(3, 335);
-            this.grpRebase.Name = "grpRebase";
-            this.grpRebase.Padding = new System.Windows.Forms.Padding(8);
-            this.grpRebase.Size = new System.Drawing.Size(1594, 53);
-            this.grpRebase.TabIndex = 4;
-            this.grpRebase.TabStop = false;
-            this.grpRebase.Text = "Rebase";
-            // 
-            // tableLayoutOfRebase
-            // 
-            this.tableLayoutOfRebase.AutoSize = true;
-            this.tableLayoutOfRebase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutOfRebase.ColumnCount = 1;
-            this.tableLayoutOfRebase.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutOfRebase.Controls.Add(this.chkRebaseConfirmation, 0, 0);
-            this.tableLayoutOfRebase.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutOfRebase.Location = new System.Drawing.Point(8, 22);
-            this.tableLayoutOfRebase.Name = "tableLayoutOfRebase";
-            this.tableLayoutOfRebase.RowCount = 2;
-            this.tableLayoutOfRebase.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutOfRebase.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutOfRebase.Size = new System.Drawing.Size(1578, 23);
-            this.tableLayoutOfRebase.TabIndex = 1;
-            // 
-            // chkRebaseConfirmation
-            // 
-            this.chkRebaseConfirmation.AutoSize = true;
-            this.chkRebaseConfirmation.Location = new System.Drawing.Point(3, 3);
-            this.chkRebaseConfirmation.Name = "chkRebaseConfirmation";
-            this.chkRebaseConfirmation.Size = new System.Drawing.Size(353, 17);
-            this.chkRebaseConfirmation.TabIndex = 12;
-            this.chkRebaseConfirmation.Text = "Don\'t show the rebase dialog unless rebasing with advanced options";
-            this.chkRebaseConfirmation.UseVisualStyleBackColor = true;
             // 
             // grpCommit
             // 
@@ -378,10 +332,6 @@
             this.Size = new System.Drawing.Size(1616, 769);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
-            this.grpRebase.ResumeLayout(false);
-            this.grpRebase.PerformLayout();
-            this.tableLayoutOfRebase.ResumeLayout(false);
-            this.tableLayoutOfRebase.PerformLayout();
             this.grpCommit.ResumeLayout(false);
             this.grpCommit.PerformLayout();
             this.tableLayoutPanel5.ResumeLayout(false);
@@ -422,8 +372,5 @@
         private System.Windows.Forms.GroupBox grpCommit;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
         private System.Windows.Forms.CheckBox chkCommitAndPushForcedWhenAmend;
-        private System.Windows.Forms.GroupBox grpRebase;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutOfRebase;
-        private System.Windows.Forms.CheckBox chkRebaseConfirmation;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
@@ -34,7 +34,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             cboAutoNormaliseSymbol.Enabled = chkAutoNormaliseBranchName.Checked;
             cboAutoNormaliseSymbol.SelectedValue = AppSettings.AutoNormaliseSymbol;
             chkCommitAndPushForcedWhenAmend.Checked = AppSettings.CommitAndPushForcedWhenAmend;
-            chkRebaseConfirmation.Checked = AppSettings.SkipRebaseDialog;
         }
 
         protected override void PageToSettings()
@@ -48,7 +47,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.AutoNormaliseBranchName = chkAutoNormaliseBranchName.Checked;
             AppSettings.AutoNormaliseSymbol = (string)cboAutoNormaliseSymbol.SelectedValue;
             AppSettings.CommitAndPushForcedWhenAmend = chkCommitAndPushForcedWhenAmend.Checked;
-            AppSettings.SkipRebaseDialog = chkRebaseConfirmation.Checked;
         }
 
         public static SettingsPageReference GetPageReference()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -31,6 +31,9 @@
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.CheckoutGB = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.chkFetchAndPruneAllConfirmation = new System.Windows.Forms.CheckBox();
+            this.chkUndoLastCommitConfirmation = new System.Windows.Forms.CheckBox();
+            this.chkRebaseOnTopOfSelectedCommit = new System.Windows.Forms.CheckBox();
             this.chkSecondAbortConfirmation = new System.Windows.Forms.CheckBox();
             this.chkCommitAfterConflictsResolved = new System.Windows.Forms.CheckBox();
             this.chkResolveConflicts = new System.Windows.Forms.CheckBox();
@@ -41,8 +44,6 @@
             this.chkAddTrackingRef = new System.Windows.Forms.CheckBox();
             this.chkPushNewBranch = new System.Windows.Forms.CheckBox();
             this.chkUpdateModules = new System.Windows.Forms.CheckBox();
-            this.chkUndoLastCommitConfirmation = new System.Windows.Forms.CheckBox();
-            this.chkFetchAndPruneAllConfirmation = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2.SuspendLayout();
             this.CheckoutGB.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
@@ -60,7 +61,7 @@
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(459, 298);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(500, 372);
             this.tableLayoutPanel2.TabIndex = 2;
             // 
             // CheckoutGB
@@ -71,7 +72,7 @@
             this.CheckoutGB.Dock = System.Windows.Forms.DockStyle.Top;
             this.CheckoutGB.Location = new System.Drawing.Point(3, 3);
             this.CheckoutGB.Name = "CheckoutGB";
-            this.CheckoutGB.Size = new System.Drawing.Size(453, 292);
+            this.CheckoutGB.Size = new System.Drawing.Size(494, 366);
             this.CheckoutGB.TabIndex = 0;
             this.CheckoutGB.TabStop = false;
             this.CheckoutGB.Text = "Don\'t ask to confirm to (use with caution)";
@@ -82,8 +83,9 @@
             this.tableLayoutPanel3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel3.ColumnCount = 1;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel3.Controls.Add(this.chkFetchAndPruneAllConfirmation, 0, 11);
-            this.tableLayoutPanel3.Controls.Add(this.chkUndoLastCommitConfirmation, 0, 10);
+            this.tableLayoutPanel3.Controls.Add(this.chkFetchAndPruneAllConfirmation, 0, 12);
+            this.tableLayoutPanel3.Controls.Add(this.chkUndoLastCommitConfirmation, 0, 11);
+            this.tableLayoutPanel3.Controls.Add(this.chkRebaseOnTopOfSelectedCommit, 0, 10);
             this.tableLayoutPanel3.Controls.Add(this.chkSecondAbortConfirmation, 0, 9);
             this.tableLayoutPanel3.Controls.Add(this.chkCommitAfterConflictsResolved, 0, 8);
             this.tableLayoutPanel3.Controls.Add(this.chkResolveConflicts, 0, 7);
@@ -96,7 +98,7 @@
             this.tableLayoutPanel3.Controls.Add(this.chkUpdateModules, 0, 6);
             this.tableLayoutPanel3.Location = new System.Drawing.Point(5, 19);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 12;
+            this.tableLayoutPanel3.RowCount = 13;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -109,15 +111,48 @@
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(442, 253);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(483, 325);
             this.tableLayoutPanel3.TabIndex = 1;
+            // 
+            // chkFetchAndPruneAllConfirmation
+            // 
+            this.chkFetchAndPruneAllConfirmation.AutoSize = true;
+            this.chkFetchAndPruneAllConfirmation.Location = new System.Drawing.Point(3, 303);
+            this.chkFetchAndPruneAllConfirmation.Name = "chkFetchAndPruneAllConfirmation";
+            this.chkFetchAndPruneAllConfirmation.Size = new System.Drawing.Size(127, 19);
+            this.chkFetchAndPruneAllConfirmation.TabIndex = 13;
+            this.chkFetchAndPruneAllConfirmation.Text = "Fetch and prune all";
+            this.chkFetchAndPruneAllConfirmation.UseVisualStyleBackColor = true;
+            // 
+            // chkUndoLastCommitConfirmation
+            // 
+            this.chkUndoLastCommitConfirmation.AutoSize = true;
+            this.chkUndoLastCommitConfirmation.Location = new System.Drawing.Point(3, 278);
+            this.chkUndoLastCommitConfirmation.Name = "chkUndoLastCommitConfirmation";
+            this.chkUndoLastCommitConfirmation.Size = new System.Drawing.Size(121, 19);
+            this.chkUndoLastCommitConfirmation.TabIndex = 12;
+            this.chkUndoLastCommitConfirmation.Text = "Undo last commit";
+            this.chkUndoLastCommitConfirmation.ThreeState = true;
+            this.chkUndoLastCommitConfirmation.UseVisualStyleBackColor = true;
+            // 
+            // chkRebaseOnTopOfSelectedCommit
+            // 
+            this.chkRebaseOnTopOfSelectedCommit.AutoSize = true;
+            this.chkRebaseOnTopOfSelectedCommit.Location = new System.Drawing.Point(3, 253);
+            this.chkRebaseOnTopOfSelectedCommit.Name = "chkRebaseOnTopOfSelectedCommit";
+            this.chkRebaseOnTopOfSelectedCommit.Size = new System.Drawing.Size(206, 19);
+            this.chkRebaseOnTopOfSelectedCommit.TabIndex = 11;
+            this.chkRebaseOnTopOfSelectedCommit.Text = "Rebase on top of selected commit";
+            this.chkRebaseOnTopOfSelectedCommit.ThreeState = true;
+            this.chkRebaseOnTopOfSelectedCommit.UseVisualStyleBackColor = true;
             // 
             // chkSecondAbortConfirmation
             // 
             this.chkSecondAbortConfirmation.AutoSize = true;
-            this.chkSecondAbortConfirmation.Location = new System.Drawing.Point(3, 210);
+            this.chkSecondAbortConfirmation.Location = new System.Drawing.Point(3, 228);
             this.chkSecondAbortConfirmation.Name = "chkSecondAbortConfirmation";
-            this.chkSecondAbortConfirmation.Size = new System.Drawing.Size(243, 17);
+            this.chkSecondAbortConfirmation.Size = new System.Drawing.Size(267, 19);
             this.chkSecondAbortConfirmation.TabIndex = 10;
             this.chkSecondAbortConfirmation.Text = "Confirm for the second time to abort a merge";
             this.chkSecondAbortConfirmation.ThreeState = true;
@@ -126,9 +161,9 @@
             // chkCommitAfterConflictsResolved
             // 
             this.chkCommitAfterConflictsResolved.AutoSize = true;
-            this.chkCommitAfterConflictsResolved.Location = new System.Drawing.Point(3, 187);
+            this.chkCommitAfterConflictsResolved.Location = new System.Drawing.Point(3, 203);
             this.chkCommitAfterConflictsResolved.Name = "chkCommitAfterConflictsResolved";
-            this.chkCommitAfterConflictsResolved.Size = new System.Drawing.Size(271, 17);
+            this.chkCommitAfterConflictsResolved.Size = new System.Drawing.Size(296, 19);
             this.chkCommitAfterConflictsResolved.TabIndex = 9;
             this.chkCommitAfterConflictsResolved.Text = "Commit changes after conflicts have been resolved";
             this.chkCommitAfterConflictsResolved.ThreeState = true;
@@ -137,9 +172,9 @@
             // chkResolveConflicts
             // 
             this.chkResolveConflicts.AutoSize = true;
-            this.chkResolveConflicts.Location = new System.Drawing.Point(3, 164);
+            this.chkResolveConflicts.Location = new System.Drawing.Point(3, 178);
             this.chkResolveConflicts.Name = "chkResolveConflicts";
-            this.chkResolveConflicts.Size = new System.Drawing.Size(106, 17);
+            this.chkResolveConflicts.Size = new System.Drawing.Size(114, 19);
             this.chkResolveConflicts.TabIndex = 8;
             this.chkResolveConflicts.Text = "Resolve conflicts";
             this.chkResolveConflicts.ThreeState = true;
@@ -150,7 +185,7 @@
             this.chkAmend.AutoSize = true;
             this.chkAmend.Location = new System.Drawing.Point(3, 3);
             this.chkAmend.Name = "chkAmend";
-            this.chkAmend.Size = new System.Drawing.Size(115, 17);
+            this.chkAmend.Size = new System.Drawing.Size(131, 19);
             this.chkAmend.TabIndex = 1;
             this.chkAmend.Text = "Amend last commit";
             this.chkAmend.UseVisualStyleBackColor = true;
@@ -158,9 +193,9 @@
             // chkCommitIfNoBranch
             // 
             this.chkCommitIfNoBranch.AutoSize = true;
-            this.chkCommitIfNoBranch.Location = new System.Drawing.Point(3, 26);
+            this.chkCommitIfNoBranch.Location = new System.Drawing.Point(3, 28);
             this.chkCommitIfNoBranch.Name = "chkCommitIfNoBranch";
-            this.chkCommitIfNoBranch.Size = new System.Drawing.Size(339, 17);
+            this.chkCommitIfNoBranch.Size = new System.Drawing.Size(372, 19);
             this.chkCommitIfNoBranch.TabIndex = 2;
             this.chkCommitIfNoBranch.Text = "Commit when no branch is currently checked out (headless state)";
             this.chkCommitIfNoBranch.UseVisualStyleBackColor = true;
@@ -168,9 +203,9 @@
             // chkAutoPopStashAfterPull
             // 
             this.chkAutoPopStashAfterPull.AutoSize = true;
-            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 49);
+            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 53);
             this.chkAutoPopStashAfterPull.Name = "chkAutoPopStashAfterPull";
-            this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(409, 17);
+            this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(448, 19);
             this.chkAutoPopStashAfterPull.TabIndex = 3;
             this.chkAutoPopStashAfterPull.Text = "Apply stashed changes after successful pull (stash will be popped automatically)";
             this.chkAutoPopStashAfterPull.ThreeState = true;
@@ -179,9 +214,9 @@
             // chkAutoPopStashAfterCheckout
             // 
             this.chkAutoPopStashAfterCheckout.AutoSize = true;
-            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 72);
+            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 78);
             this.chkAutoPopStashAfterCheckout.Name = "chkAutoPopStashAfterCheckout";
-            this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(436, 17);
+            this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(477, 19);
             this.chkAutoPopStashAfterCheckout.TabIndex = 4;
             this.chkAutoPopStashAfterCheckout.Text = "Apply stashed changes after successful checkout (stash will be popped automatical" +
     "ly)";
@@ -191,9 +226,9 @@
             // chkAddTrackingRef
             // 
             this.chkAddTrackingRef.AutoSize = true;
-            this.chkAddTrackingRef.Location = new System.Drawing.Point(3, 95);
+            this.chkAddTrackingRef.Location = new System.Drawing.Point(3, 103);
             this.chkAddTrackingRef.Name = "chkAddTrackingRef";
-            this.chkAddTrackingRef.Size = new System.Drawing.Size(267, 17);
+            this.chkAddTrackingRef.Size = new System.Drawing.Size(289, 19);
             this.chkAddTrackingRef.TabIndex = 5;
             this.chkAddTrackingRef.Text = "Add a tracking reference for newly pushed branch";
             this.chkAddTrackingRef.UseVisualStyleBackColor = true;
@@ -201,9 +236,9 @@
             // chkPushNewBranch
             // 
             this.chkPushNewBranch.AutoSize = true;
-            this.chkPushNewBranch.Location = new System.Drawing.Point(3, 118);
+            this.chkPushNewBranch.Location = new System.Drawing.Point(3, 128);
             this.chkPushNewBranch.Name = "chkPushNewBranch";
-            this.chkPushNewBranch.Size = new System.Drawing.Size(190, 17);
+            this.chkPushNewBranch.Size = new System.Drawing.Size(205, 19);
             this.chkPushNewBranch.TabIndex = 6;
             this.chkPushNewBranch.Text = "Push a new branch for the remote";
             this.chkPushNewBranch.UseVisualStyleBackColor = true;
@@ -211,41 +246,20 @@
             // chkUpdateModules
             // 
             this.chkUpdateModules.AutoSize = true;
-            this.chkUpdateModules.Location = new System.Drawing.Point(3, 141);
+            this.chkUpdateModules.Location = new System.Drawing.Point(3, 153);
             this.chkUpdateModules.Name = "chkUpdateModules";
-            this.chkUpdateModules.Size = new System.Drawing.Size(181, 17);
+            this.chkUpdateModules.Size = new System.Drawing.Size(201, 19);
             this.chkUpdateModules.TabIndex = 7;
             this.chkUpdateModules.Text = "Update submodules on checkout";
             this.chkUpdateModules.ThreeState = true;
             this.chkUpdateModules.UseVisualStyleBackColor = true;
-            // 
-            // chkUndoLastCommitConfirmation
-            // 
-            this.chkUndoLastCommitConfirmation.AutoSize = true;
-            this.chkUndoLastCommitConfirmation.Location = new System.Drawing.Point(3, 233);
-            this.chkUndoLastCommitConfirmation.Name = "chkUndoLastCommitConfirmation";
-            this.chkUndoLastCommitConfirmation.Size = new System.Drawing.Size(107, 17);
-            this.chkUndoLastCommitConfirmation.TabIndex = 10;
-            this.chkUndoLastCommitConfirmation.Text = "Undo last commit";
-            this.chkUndoLastCommitConfirmation.ThreeState = true;
-            this.chkUndoLastCommitConfirmation.UseVisualStyleBackColor = true;
-            // 
-            // chkFetchAllAndPruneConfirmation
-            // 
-            this.chkFetchAndPruneAllConfirmation.AutoSize = true;
-            this.chkFetchAndPruneAllConfirmation.Location = new System.Drawing.Point(3, 246);
-            this.chkFetchAndPruneAllConfirmation.Name = "chkUndoLastCommitConfirmation";
-            this.chkFetchAndPruneAllConfirmation.Size = new System.Drawing.Size(107, 17);
-            this.chkFetchAndPruneAllConfirmation.TabIndex = 11;
-            this.chkFetchAndPruneAllConfirmation.Text = "Fetch and prune all";
-            this.chkFetchAndPruneAllConfirmation.UseVisualStyleBackColor = true;
             // 
             // ConfirmationsSettingsPage
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.Controls.Add(this.tableLayoutPanel2);
             this.Name = "ConfirmationsSettingsPage";
-            this.Size = new System.Drawing.Size(1453, 919);
+            this.Size = new System.Drawing.Size(1506, 978);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.CheckoutGB.ResumeLayout(false);
@@ -272,6 +286,7 @@
         private System.Windows.Forms.CheckBox chkCommitAfterConflictsResolved;
         private System.Windows.Forms.CheckBox chkResolveConflicts;
         private System.Windows.Forms.CheckBox chkSecondAbortConfirmation;
+        private System.Windows.Forms.CheckBox chkRebaseOnTopOfSelectedCommit;
         private System.Windows.Forms.CheckBox chkUndoLastCommitConfirmation;
         private System.Windows.Forms.CheckBox chkFetchAndPruneAllConfirmation;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -24,6 +24,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkResolveConflicts.Checked = AppSettings.DontConfirmResolveConflicts;
             chkCommitAfterConflictsResolved.Checked = AppSettings.DontConfirmCommitAfterConflictsResolved;
             chkSecondAbortConfirmation.Checked = AppSettings.DontConfirmSecondAbortConfirmation;
+            chkRebaseOnTopOfSelectedCommit.Checked = AppSettings.DontConfirmRebase;
             chkUndoLastCommitConfirmation.Checked = AppSettings.DontConfirmUndoLastCommit;
             chkFetchAndPruneAllConfirmation.Checked = AppSettings.DontConfirmFetchAndPruneAll;
         }
@@ -40,6 +41,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.DontConfirmResolveConflicts = chkResolveConflicts.Checked;
             AppSettings.DontConfirmCommitAfterConflictsResolved = chkCommitAfterConflictsResolved.Checked;
             AppSettings.DontConfirmSecondAbortConfirmation = chkSecondAbortConfirmation.Checked;
+            AppSettings.DontConfirmRebase = chkRebaseOnTopOfSelectedCommit.Checked;
             AppSettings.DontConfirmUndoLastCommit = chkUndoLastCommitConfirmation.Checked;
             AppSettings.DontConfirmFetchAndPruneAll = chkFetchAndPruneAllConfirmation.Checked;
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -953,7 +953,7 @@ namespace GitUI
         public bool StartRebase(IWin32Window owner, string onto)
         {
             return StartRebaseDialog(owner, from: "", to: null, onto: onto,
-                interactive: false, startRebaseImmediately: AppSettings.SkipRebaseDialog);
+                interactive: false, startRebaseImmediately: true);
         }
 
         public bool StartTheContinueRebaseDialog(IWin32Window owner)
@@ -964,7 +964,7 @@ namespace GitUI
         public bool StartInteractiveRebase(IWin32Window owner, string onto)
         {
             return StartRebaseDialog(owner, from: "", to: null, onto: onto,
-                interactive: true, startRebaseImmediately: AppSettings.SkipRebaseDialog);
+                interactive: true, startRebaseImmediately: true);
         }
 
         public bool StartRebaseDialogWithAdvOptions(IWin32Window owner, string onto)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -68,6 +68,7 @@ namespace GitUI
             this.editCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rebaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rebaseInteractivelyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.rebaseWithAdvOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this._gridView)).BeginInit();
             this.mainContextMenu.SuspendLayout();
@@ -207,6 +208,7 @@ namespace GitUI
             this.rebaseOnToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.rebaseToolStripMenuItem,
             this.rebaseInteractivelyToolStripMenuItem,
+            this.toolStripSeparator10,
             this.rebaseWithAdvOptionsToolStripMenuItem});
             this.rebaseOnToolStripMenuItem.Image = global::GitUI.Properties.Images.Rebase;
             this.rebaseOnToolStripMenuItem.Name = "rebaseOnToolStripMenuItem";
@@ -466,9 +468,14 @@ namespace GitUI
             this.rebaseInteractivelyToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.rebaseInteractivelyToolStripMenuItem.Text = "Selected commit interactively";
             this.rebaseInteractivelyToolStripMenuItem.Click += new System.EventHandler(this.OnRebaseInteractivelyClicked);
-            //
+            // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            this.toolStripSeparator10.Size = new System.Drawing.Size(195, 6);
+            // 
             // rebaseWithAdvOptionsToolStripMenuItem
-            //
+            // 
             this.rebaseWithAdvOptionsToolStripMenuItem.Name = "rebaseWithAdvOptionsToolStripMenuItem";
             this.rebaseWithAdvOptionsToolStripMenuItem.Size = new System.Drawing.Size(307, 22);
             this.rebaseWithAdvOptionsToolStripMenuItem.Text = "Selected commit with advanced options...";
@@ -538,5 +545,6 @@ namespace GitUI
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
     }
 }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -52,6 +52,11 @@ namespace GitUI
         private readonly TranslationString _noRevisionFoundError = new TranslationString("No revision found.");
         private readonly TranslationString _baseForCompareNotSelectedError = new TranslationString("Base commit for compare is not selected.");
         private readonly TranslationString _strError = new TranslationString("Error");
+        private readonly TranslationString _rebaseConfirmTitle = new TranslationString("Rebase Confirmation");
+        private readonly TranslationString _rebaseBranch = new TranslationString("Rebase branch.");
+        private readonly TranslationString _rebaseBranchInteractive = new TranslationString("Rebase branch interactively.");
+        private readonly TranslationString _areYouSureRebase = new TranslationString("Are you sure you want to rebase? This action will rewrite commit history.");
+        private readonly TranslationString _dontShowAgain = new TranslationString("Don't show me this message again.");
 
         private readonly FormRevisionFilter _revisionFilter = new FormRevisionFilter();
         private readonly NavigationHistory _navigationHistory = new NavigationHistory();
@@ -1651,7 +1656,34 @@ namespace GitUI
         {
             if (_rebaseOnTopOf != null)
             {
-                UICommands.StartRebase(this, _rebaseOnTopOf);
+                if (!AppSettings.DontConfirmRebase)
+                {
+                    DialogResult res = PSTaskDialog.cTaskDialog.MessageBox(
+                        this,
+                        _rebaseConfirmTitle.Text,
+                        _rebaseBranch.Text,
+                        _areYouSureRebase.Text,
+                        "",
+                        "",
+                        _dontShowAgain.Text,
+                        PSTaskDialog.eTaskDialogButtons.OKCancel,
+                        PSTaskDialog.eSysIcons.Information,
+                        PSTaskDialog.eSysIcons.Information);
+
+                    if (res == DialogResult.OK)
+                    {
+                        UICommands.StartRebase(this, _rebaseOnTopOf);
+                    }
+
+                    if (PSTaskDialog.cTaskDialog.VerificationChecked)
+                    {
+                        AppSettings.DontConfirmRebase = true;
+                    }
+                }
+                else
+                {
+                    UICommands.StartRebase(this, _rebaseOnTopOf);
+                }
             }
         }
 
@@ -1659,7 +1691,34 @@ namespace GitUI
         {
             if (_rebaseOnTopOf != null)
             {
-                UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+                if (!AppSettings.DontConfirmRebase)
+                {
+                    DialogResult res = PSTaskDialog.cTaskDialog.MessageBox(
+                        this,
+                        _rebaseConfirmTitle.Text,
+                        _rebaseBranchInteractive.Text,
+                        _areYouSureRebase.Text,
+                        "",
+                        "",
+                        _dontShowAgain.Text,
+                        PSTaskDialog.eTaskDialogButtons.OKCancel,
+                        PSTaskDialog.eSysIcons.Information,
+                        PSTaskDialog.eSysIcons.Information);
+
+                    if (res == DialogResult.OK)
+                    {
+                        UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+                    }
+
+                    if (PSTaskDialog.cTaskDialog.VerificationChecked)
+                    {
+                        AppSettings.DontConfirmRebase = true;
+                    }
+                }
+                else
+                {
+                    UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+                }
             }
         }
 


### PR DESCRIPTION
- Problem
With addition of this advanced option (which is off by default!):
![image](https://user-images.githubusercontent.com/483659/45258506-8e2a5880-b3c1-11e8-8219-ba0625a24339.png)
These two menu items both open rebase dialog with the only difference of `Interactive Rebase` being checked or not. This seems sub-optimal and also three menu items for the same action with different params is overcomplicated.
![image](https://user-images.githubusercontent.com/483659/45258580-a5b61100-b3c2-11e8-8f11-ff8e79167a9f.png)

Changes proposed in this pull request:
- Leave only two rebase options in RevisionGridControl
  - `Selected commit` starting simple rebase immediately
  - `Selected commit with advanced options...` opening rebase dialog with `Interactive rebase` checked based on Advanced option
- Replace current advanced option with a new one showing whether Rebase dialog has Interactive checked by default or not
 
Screenshots after:
![image](https://user-images.githubusercontent.com/483659/45258619-3b51a080-b3c3-11e8-9fa0-48452c478f75.png)
![image](https://user-images.githubusercontent.com/483659/45258629-5a503280-b3c3-11e8-9071-88fd6753cd5b.png)
