### PR TITLE
Allow typing to filter Branches

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
@@ -30,6 +30,7 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.Ok = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
@@ -54,12 +55,14 @@ namespace GitUI.CommandsDialogs
             this.rbResetBranch = new System.Windows.Forms.RadioButton();
             this.rbCreateBranchWithCustomName = new System.Windows.Forms.RadioButton();
             this.branchName = new System.Windows.Forms.Label();
+            this.Errors = new System.Windows.Forms.ErrorProvider(this.components);
             this.tableLayoutPanel1.SuspendLayout();
             this.setBranchPanel.SuspendLayout();
             this.localChangesPanel.SuspendLayout();
             this.localChangesGB.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
             this.remoteOptionsPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.Errors)).BeginInit();
             this.SuspendLayout();
             // 
             // flowLayoutPanel1
@@ -137,6 +140,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.LocalBranch.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.LocalBranch.AutoSize = true;
+            this.LocalBranch.CausesValidation = false;
             this.LocalBranch.Checked = true;
             this.LocalBranch.Location = new System.Drawing.Point(2, 2);
             this.LocalBranch.Margin = new System.Windows.Forms.Padding(2);
@@ -153,6 +157,7 @@ namespace GitUI.CommandsDialogs
             this.Remotebranch.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.Remotebranch.AutoSize = true;
             this.Remotebranch.Location = new System.Drawing.Point(91, 2);
+            this.Remotebranch.CausesValidation = false;
             this.Remotebranch.Margin = new System.Windows.Forms.Padding(2);
             this.Remotebranch.Name = "Remotebranch";
             this.Remotebranch.Padding = new System.Windows.Forms.Padding(6, 0, 0, 0);
@@ -184,11 +189,13 @@ namespace GitUI.CommandsDialogs
             this.Branches.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.Branches.FormattingEnabled = true;
             this.Branches.Location = new System.Drawing.Point(92, 24);
+            this.Errors.SetIconAlignment(this.Branches, System.Windows.Forms.ErrorIconAlignment.MiddleLeft);
             this.Branches.Name = "Branches";
             this.Branches.Size = new System.Drawing.Size(433, 21);
-            this.Branches.DropDownStyle = ComboBoxStyle.DropDownList;
             this.Branches.TabIndex = 3;
             this.Branches.SelectedIndexChanged += new System.EventHandler(this.Branches_SelectedIndexChanged);
+            this.Branches.TextChanged += new System.EventHandler(this.Branches_TextChanged);
+            this.Branches.Validating += new System.ComponentModel.CancelEventHandler(this.Branches_Validating);
             // 
             // lbChanges
             // 
@@ -423,6 +430,10 @@ namespace GitUI.CommandsDialogs
             this.branchName.TabIndex = 24;
             this.branchName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
+            // Errors
+            // 
+            this.Errors.ContainerControl = this;
+            // 
             // FormCheckoutBranch
             // 
             this.AcceptButton = this.Ok;
@@ -448,6 +459,7 @@ namespace GitUI.CommandsDialogs
             this.flowLayoutPanel2.PerformLayout();
             this.remoteOptionsPanel.ResumeLayout(false);
             this.remoteOptionsPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.Errors)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -478,5 +490,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Label lbChanges;
         private System.Windows.Forms.CheckBox chkSetLocalChangesActionAsDefault;
         private FlowLayoutPanel flowLayoutPanel2;
+        private ErrorProvider Errors;
     }
 }

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -41,6 +41,7 @@ namespace GitUI.CommandsDialogs
         private readonly IReadOnlyList<ObjectId> _containRevisions;
         private readonly bool _isLoading;
         private readonly string _rbResetBranchDefaultText;
+        private TranslationString _invalidBranchName = new TranslationString("An existing branch must be selected.");
         private bool? _isDirtyDir;
         private string _remoteName = "";
         private string _newLocalBranchName = "";
@@ -577,6 +578,17 @@ namespace GitUI.CommandsDialogs
             var normalisedBranchName = _branchNameNormaliser.Normalise(txtCustomBranchName.Text, _gitBranchNameOptions);
             txtCustomBranchName.Text = normalisedBranchName;
             txtCustomBranchName.SelectionStart = caretPosition;
+        }
+
+        private void Branches_Validating(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            e.Cancel = Branches.SelectedIndex == -1 || !Branches.Items.Contains(Branches.Text);
+            Errors.SetError(Branches, e.Cancel ? _invalidBranchName.ToString() : "");
+        }
+
+        private void Branches_TextChanged(object sender, EventArgs e)
+        {
+            Errors.SetError(Branches, "");
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.resx
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="Errors.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Reverts #5184
Prevents invalid branch names from being used and allows user to type to filter combobox.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5415 

Changes proposed in this pull request:
- Allow typing in branch combobox
- prevent user from using a value that is a partial branch name

 
Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
Ran it. Verified user can't type a branch name that does not exist and try to check it out.  
Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
