### PR TITLE
GoToSuperproject and GoToSubmodule hotkeys

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2106,7 +2106,9 @@ namespace GitUI.CommandsDialogs
             FocusFilter = 18,
             OpenWithDifftool = 19,
             OpenSettings = 20,
-            ToggleBranchTreePanel = 21
+            ToggleBranchTreePanel = 21,
+            GoToSuperproject = 27,
+            GoToSubmodule = 28
         }
 
         internal Keys GetShortcutKeys(Commands cmd)
@@ -2179,6 +2181,8 @@ namespace GitUI.CommandsDialogs
                 case Commands.OpenWithDifftool: OpenWithDifftool(); break;
                 case Commands.OpenSettings: OnShowSettingsClick(null, null); break;
                 case Commands.ToggleBranchTreePanel: toggleBranchTreePanel_Click(null, null); break;
+                case Commands.GoToSuperproject: toolStripButtonLevelUp_ButtonClick(null, null); break;
+                case Commands.GoToSubmodule: toolStripButtonLevelUp.ShowDropDown(); break;
                 default: return base.ExecuteCommand(cmd);
             }
 

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -271,7 +271,9 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Commands.CloseRepository, Keys.Control | Keys.W),
                     Hk(FormBrowse.Commands.OpenSettings, Keys.Control | Keys.Oemcomma),
                     Hk(FormBrowse.Commands.OpenWithDifftool, OpenWithDifftoolHotkey),
-                    Hk(FormBrowse.Commands.ToggleBranchTreePanel, Keys.Control | Keys.Alt | Keys.C)),
+                    Hk(FormBrowse.Commands.ToggleBranchTreePanel, Keys.Control | Keys.Alt | Keys.C),
+                    Hk(FormBrowse.Commands.GoToSubmodule, Keys.None),
+                    Hk(FormBrowse.Commands.GoToSuperproject, Keys.None)),
                 new HotkeySettings(
                     RevisionGridControl.HotkeySettingsName,
                     Hk(RevisionGridControl.Commands.RevisionFilter, Keys.Control | Keys.F),


### PR DESCRIPTION
Changes proposed in this pull request:
- GoToSuperproject hotkey - changes the current repo to the superproject repo
- GoToSubmodule  hotkey - opens submodules drop down list
 
What did I do to test the code and ensure quality:
- Manual tests.

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
