### PR TITLE
fix ExListView group header collapse-expand button

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -370,6 +370,7 @@
     <Compile Include="SpellChecker\WordAtCursorExtractor.cs" />
     <Compile Include="TaskbarProgress.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
+    <Compile Include="UserControls\ListViewGroupHitInfo.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionColorProvider.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionStyler.cs" />
     <Compile Include="UserControls\RevisionGrid\Columns\MultilineIndicator.cs" />

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.UserControls;
+﻿using System;
+using GitUI.UserControls;
 namespace GitUI
 {
     partial class FileStatusList
@@ -64,6 +65,7 @@ namespace GitUI
             this.FileStatusListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FileStatusListView_KeyDown);
             this.FileStatusListView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FileStatusListView_MouseDown);
             this.FileStatusListView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.FileStatusListView_MouseMove);
+            this.FileStatusListView.GroupMouseDown += new System.EventHandler<ListViewGroupMouseEventArgs>(this.FileStatusListView_GroupMouseDown);
             // 
             // columnHeader1
             // 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -506,6 +506,15 @@ namespace GitUI
             }
         }
 
+        private void FileStatusListView_GroupMouseDown(object sender, ListViewGroupMouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Left)
+            {
+                // prevent selecting all sub-items when left-clicking group
+                e.Handled = true;
+            }
+        }
+
         public int UnfilteredItemsCount => GitItemStatusesWithParents?.Sum(tuple => tuple.statuses.Count) ?? 0;
 
         public int AllItemsCount => FileStatusListView.Items.Count;

--- a/GitUI/UserControls/ListViewGroupHitInfo.cs
+++ b/GitUI/UserControls/ListViewGroupHitInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace GitUI.UserControls
+{
+    public class ListViewGroupHitInfo
+    {
+        public ListViewGroupHitInfo(ListViewGroup @group, bool isCollapseButton, Point location)
+        {
+            Group = @group;
+            IsCollapseButton = isCollapseButton;
+            Location = location;
+        }
+
+        public ListViewGroup Group { get; }
+        public bool IsCollapseButton { get; }
+        public Point Location { get; }
+    }
+}

--- a/GitUI/UserControls/ListViewGroupMouseEventArgs.cs
+++ b/GitUI/UserControls/ListViewGroupMouseEventArgs.cs
@@ -5,12 +5,13 @@ namespace GitUI.UserControls
     /// <inheritdoc />
     internal class ListViewGroupMouseEventArgs : MouseEventArgs
     {
-        public ListViewGroupMouseEventArgs(MouseButtons button, ListViewGroup group, int clicks, int x, int y, int delta)
-            : base(button, clicks, x, y, delta)
+        public ListViewGroupMouseEventArgs(MouseButtons button, ListViewGroupHitInfo groupHitInfo, int clicks, int delta)
+            : base(button, clicks, groupHitInfo.Location.X, groupHitInfo.Location.Y, delta)
         {
-            Group = group;
+            GroupInfo = groupHitInfo;
         }
 
-        public ListViewGroup Group { get; }
+        public ListViewGroupHitInfo GroupInfo { get; }
+        public bool Handled { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #5427
Fixes #5332 (not clickable part)
Fixes #4886

![image](https://user-images.githubusercontent.com/12046452/45525284-f7073b80-b7da-11e8-94b1-515bcf495834.png)

Has been tested on
- Windows 7