### PR TITLE
#5125 RevisionGrid Graph: Branches and tags in tooltip.

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="System.IO.Abstractions" Version="2.0.0.144" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -77,7 +77,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="System.ValueTuple">
-      <Version>4.4.0</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -376,6 +376,8 @@
     <Compile Include="UserControls\GitItemStatusWithParent.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
     <Compile Include="UserControls\ListViewGroupHitInfo.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProvider.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneNodeLocator.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionColorProvider.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionStyler.cs" />
     <Compile Include="UserControls\RevisionGrid\Columns\MultilineIndicator.cs" />

--- a/GitUI/UserControls/RevisionGrid/Graph/GraphModel.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/GraphModel.cs
@@ -9,7 +9,12 @@ using JetBrains.Annotations;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
-    internal sealed class GraphModel
+    internal interface ILaneRowProvider
+    {
+        ILaneRow GetLaneRow(int row);
+    }
+
+    internal sealed class GraphModel : ILaneRowProvider
     {
         public event Action Updated;
 

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using ResourceManager;
+
+namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    internal sealed class LaneInfoProvider
+    {
+        private static readonly TranslationString NoInfoText = new TranslationString("Sorry, this commit seems to be not loaded.");
+        private readonly ILaneNodeLocator _nodeLocator;
+
+        internal readonly struct TestAccessor
+        {
+            internal static TranslationString NoInfoText => LaneInfoProvider.NoInfoText;
+        }
+
+        public LaneInfoProvider(ILaneNodeLocator nodeLocator)
+        {
+            _nodeLocator = nodeLocator;
+        }
+
+        public string GetLaneInfo(int x, int rowIndex, int laneWidth)
+        {
+            (var node, bool isAtNode) = _nodeLocator.FindPrevNode(x, rowIndex, laneWidth);
+            if (node == null)
+            {
+                return string.Empty;
+            }
+
+            if (node.Revision == null)
+            {
+                return NoInfoText.Text;
+            }
+
+            var laneInfoText = new StringBuilder();
+            if (!node.Revision.IsArtificial)
+            {
+                if (isAtNode)
+                {
+                    laneInfoText.Append("* ");
+                }
+
+                laneInfoText.AppendLine(node.Revision.Guid);
+
+                var branch = new BranchFinder(node);
+                if (branch.CommittedTo.IsNotNullOrWhitespace())
+                {
+                    laneInfoText.AppendFormat("\nBranch: {0}", branch.CommittedTo);
+                    if (branch.MergedWith.IsNotNullOrWhitespace())
+                    {
+                        laneInfoText.AppendFormat(" (merged with {0})", branch.MergedWith);
+                    }
+                }
+
+                laneInfoText.AppendLine();
+            }
+
+            if (node.Revision.Body != null)
+            {
+                laneInfoText.Append(node.Revision.Body.TrimEnd());
+            }
+            else
+            {
+                laneInfoText.Append(node.Revision.Subject);
+                if (node.Revision.HasMultiLineMessage)
+                {
+                    laneInfoText.Append("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
+                }
+            }
+
+            return laneInfoText.ToString();
+        }
+
+        private class BranchFinder
+        {
+            private static readonly Regex MergeRegex = new Regex("(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$",
+                                                                 RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            private readonly HashSet<Node> _visitedNodes = new HashSet<Node>();
+
+            internal BranchFinder([NotNull] Node node)
+            {
+                FindBranchRecursively(node, previousDescJunction: null);
+            }
+
+            internal string CommittedTo { get; private set; }
+            internal string MergedWith { get; private set; }
+
+            private bool FindBranchRecursively([NotNull] Node node, [CanBeNull] Junction previousDescJunction)
+            {
+                if (!_visitedNodes.Add(node))
+                {
+                    return false;
+                }
+
+                if (CheckForMerge(node, previousDescJunction) || FindBranch(node))
+                {
+                    return true;
+                }
+
+                foreach (var descJunction in node.Descendants)
+                {
+                    // iterate the inner nodes (i.e. excluding the youngest) beginning with the oldest
+                    bool nodeFound = false;
+                    for (int nodeIndex = descJunction.NodeCount - 1; nodeIndex > 0; --nodeIndex)
+                    {
+                        var innerNode = descJunction[nodeIndex];
+                        if (nodeFound)
+                        {
+                            if (CheckForMerge(innerNode, descJunction) || FindBranch(innerNode))
+                            {
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            nodeFound = innerNode == node;
+                        }
+                    }
+
+                    // handle the youngest and its descendants
+                    if (FindBranchRecursively(descJunction.Youngest, descJunction))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private bool FindBranch([NotNull] Node node)
+            {
+                foreach (var gitReference in node.Revision.Refs)
+                {
+                    if (gitReference.IsHead || gitReference.IsRemote || gitReference.IsStash)
+                    {
+                        CommittedTo = gitReference.Name;
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// Checks whether the commit message is a merge message
+            /// and then if its a merge message, sets CommittedTo and MergedWith.
+            ///
+            /// MergedWith is set if it is the current node, i.e. on the first call.
+            /// MergedWith is set to string.Empty if it is no merge.
+            /// First/second branch does not matter because it is the message of the current node.
+            /// </summary>
+            /// <param name="node">the node of the revision to evaluate</param>
+            /// <param name="descJunction">
+            /// the descending junction the node is part of
+            /// (used for the decision whether the node belongs the first or second branch of the merge)
+            /// </param>
+            private bool CheckForMerge([NotNull] Node node, [CanBeNull] Junction descJunction)
+            {
+                bool isTheFirstBranch = descJunction == null || node.Ancestors.Count == 0 || node.Ancestors.First() == descJunction;
+                string mergedInto;
+                string mergedWith;
+                (mergedInto, mergedWith) = ParseMergeMessage(node.Revision.Subject, appendPullRequest: isTheFirstBranch);
+
+                if (mergedInto != null)
+                {
+                    CommittedTo = isTheFirstBranch ? mergedInto : mergedWith;
+                }
+
+                if (MergedWith == null)
+                {
+                    MergedWith = mergedWith ?? string.Empty;
+                }
+
+                return CommittedTo != null;
+            }
+
+            private static (string into, string with) ParseMergeMessage([NotNull] string commitSubject, bool appendPullRequest)
+            {
+                string into = null;
+                string with = null;
+                var match = MergeRegex.Match(commitSubject);
+                if (match.Success)
+                {
+                    var matchPullRequest = match.Groups[2];
+                    var matchWith = match.Groups[4];
+                    var matchInto = match.Groups[7];
+                    into = matchInto.Success ? matchInto.Value : "master";
+                    with = matchWith.Success ? matchWith.Value : "?";
+                    if (appendPullRequest && matchPullRequest.Success)
+                    {
+                        with += string.Format(" by pull request {0}", matchPullRequest);
+                    }
+                }
+
+                return (into, with);
+            }
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneNodeLocator.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneNodeLocator.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+
+namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    internal interface ILaneNodeLocator
+    {
+        (Node, bool isAtNode) FindPrevNode(int x, int rowIndex, int laneWidth);
+    }
+
+    internal sealed class LaneNodeLocator : ILaneNodeLocator
+    {
+        private readonly ILaneRowProvider _laneRowProvider;
+
+        public LaneNodeLocator(ILaneRowProvider laneRowProvider)
+        {
+            _laneRowProvider = laneRowProvider;
+        }
+
+        public (Node, bool isAtNode) FindPrevNode(int x, int rowIndex, int laneWidth)
+        {
+            if (x < 0 || rowIndex < 0 || laneWidth < 1)
+            {
+                // as unlikely as it may be...
+                // don't throw, just pretend we couldn't find it
+            }
+            else
+            {
+                int lane = x / laneWidth;
+                lock (_laneRowProvider)
+                {
+                    var laneRow = _laneRowProvider.GetLaneRow(rowIndex);
+                    if (laneRow != null)
+                    {
+                        if (lane == laneRow.NodeLane)
+                        {
+                            return (laneRow.Node, isAtNode: true);
+                        }
+
+                        if (lane < laneRow.Count)
+                        {
+                            for (int laneInfoIndex = 0, laneInfoCount = laneRow.LaneInfoCount(lane); laneInfoIndex < laneInfoCount; ++laneInfoIndex)
+                            {
+                                // search for next node below this row
+                                var laneInfo = laneRow[lane, laneInfoIndex];
+                                var firstJunction = laneInfo.Junctions.First();
+                                for (int nodeIndex = 0, nodeCount = firstJunction.NodeCount; nodeIndex < nodeCount; ++nodeIndex)
+                                {
+                                    var laneNode = firstJunction[nodeIndex];
+                                    if (laneNode.Index > rowIndex)
+                                    {
+                                        return (laneNode, isAtNode: false);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return (null, false);
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -56,6 +56,15 @@ namespace GitUI
                         provider.TryGetToolTip(e, revision, out var toolTip) &&
                         !string.IsNullOrWhiteSpace(toolTip))
                     {
+                        int lineCount = 0;
+                        for (int pos = 0; pos < toolTip.Length; ++pos)
+                        {
+                            if (toolTip[pos] == '\n' && ++lineCount == 30)
+                            {
+                                return toolTip.Substring(0, pos + 1) + ">>> TOOLTIP TRUNCATED <<<";
+                            }
+                        }
+
                         return toolTip;
                     }
 

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -49,7 +49,7 @@
   <ItemGroup>
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />
     <PackageReference Include="System.ValueTuple">
-      <Version>4.4.0</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -87,8 +87,10 @@
     <Compile Include="UserControls\RepoStateVisualiserTests.cs" />
     <Compile Include="UserControls\RevisionGrid\CopyContextMenuItemTests.cs" />
     <Compile Include="UserControls\RevisionGrid\GitRefListsForRevisionTests.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneNodeLocatorTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionColorProviderTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionStylerTests.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProviderTests.cs" />
     <Compile Include="UserManual\SingleHtmlUserManualFixture.cs" />
     <Compile Include="UserManual\StandardHtmlUserManualFixture.cs" />
   </ItemGroup>

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -1,0 +1,469 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GitCommands;
+using GitUI.UserControls.RevisionGrid.Graph;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls.RevisionGrid.Graph
+{
+    [TestFixture]
+    public class LaneInfoProviderTests
+    {
+        /// <summary>
+        /// triples of merge subject, merged branch and destination branch ("into")
+        /// for testing the LaneInfoProvider.References.MergeRegex
+        /// "(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$"
+        /// </summary>
+        private static readonly List<string> MergeSubjectsWithDecoding = new List<string>()
+        {
+            "Merge Branch xxx", // case-insignificance
+            "xxx", "master",
+
+            "merge branch xxx", // imperative
+            "xxx", "master",
+
+            "merged branch xxx", // past tense
+            "xxx", "master",
+
+            "merge pull request #1234 from xxx", // pull request
+            "xxx by pull request #1234", "master",
+
+            "merge tag yyy of remote/branch", // tag with (ignored) remote branch
+            "yyy", "master",
+
+            "merge tag yyy", // tag without ''
+            "yyy", "master",
+
+            "merge tag 'yyy'", // tag in ''
+            "yyy", "master",
+
+            "merge branch 'xxx'", // branch in ''
+            "xxx", "master",
+
+            "merge remote tracking branch xxx", // any text before branch
+            "xxx", "master",
+
+            "merge the branch xxx", // any text before branch
+            "xxx", "master",
+
+            "merge branch xxx into zzz", // into
+            "xxx", "zzz",
+
+            "Merged branch xxx.", // sentence
+            "xxx", "master",
+
+            "Merged branch xx.x.", // sentence with dot in branch
+            "xx.x", "master",
+
+            "Merged branch xxx into zzz.", // sentence with into
+            "xxx", "zzz",
+
+            "Merged branch xxx into zz.z.", // sentence with dot in into
+            "xxx", "zz.z",
+
+            "Merged tag yyy.", // sentence with tag
+            "yyy", "master",
+
+            "Merged tag yy.y.", // sentence with dot in tag
+            "yy.y", "master",
+
+            "Merged tag yyy of remote/branch.", // sentence with tag and remote
+            "yyy", "master",
+
+            "Merged tag yyy of remote/branc.h.", // sentence with tag and dot in remote
+            "yyy", "master",
+
+            "Merged tag yyy of remote/branch into zzz.", // sentence with tag, remote and into
+            "yyy", "zzz",
+
+            "Merged tag yyy of remote/branch into zz.z.", // sentence with tag, remote and dot in into
+            "yyy", "zz.z"
+        };
+
+        private Node _artificialCommitNode;
+        private Node _realCommitNode;
+        private Node _mergeCommitNode;
+        private Node _undetectedMergeCommitNode;
+        private Node _innerCommitNode;
+        private ILaneNodeLocator _laneNodeLocator;
+        private LaneInfoProvider _infoProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _artificialCommitNode = new Node(ObjectId.WorkTreeId)
+            {
+                Revision = new GitCommands.GitRevision(ObjectId.WorkTreeId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Body = "WIP: fixing bugs"
+                }
+            };
+            var realCommitObjectId = ObjectId.Parse("a48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _realCommitNode = new Node(realCommitObjectId)
+            {
+                Revision = new GitCommands.GitRevision(realCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "fix: bugs",
+                    Body = "fix: bugs\r\n\r\nall bugs fixed"
+                }
+            };
+            var mergeCommitObjectId = ObjectId.Parse("b48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _mergeCommitNode = new Node(mergeCommitObjectId)
+            {
+                Revision = new GitCommands.GitRevision(mergeCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "merge remote tracking branch upstream/branch",
+                    Body = "merge commit's subject here will not be parsed\r\n\r\nmerge commit's body might list details and/or conflicts...",
+                    HasMultiLineMessage = true
+                }
+            };
+            var undetectedMergeCommitObjectId = ObjectId.Parse("c48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _undetectedMergeCommitNode = new Node(undetectedMergeCommitObjectId)
+            {
+                Revision = new GitCommands.GitRevision(undetectedMergeCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "special merge",
+                    Body = "merge commit's subject here will not be parsed\r\n\r\nmerge commit's body might list details and/or conflicts...",
+                    HasMultiLineMessage = true
+                }
+            };
+            var innerCommitObjectId = ObjectId.Parse("d48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _innerCommitNode = new Node(innerCommitObjectId)
+            {
+                Revision = new GitCommands.GitRevision(innerCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "fix: further bugs",
+                    Body = "fix: further bugs"
+                }
+            };
+            _laneNodeLocator = Substitute.For<ILaneNodeLocator>();
+            _infoProvider = new LaneInfoProvider(_laneNodeLocator);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_return_empty_if_node_null()
+        {
+            _infoProvider.GetLaneInfo(0, 0, 0).Should().BeEmpty();
+        }
+
+        [Test]
+        public void GetLaneInfo_should_return_no_info_if_node_revision_null()
+        {
+            var nodeWithoutRevision = new Node(ObjectId.WorkTreeId);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (nodeWithoutRevision, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should().Be(LaneInfoProvider.TestAccessor.NoInfoText.Text);
+        }
+
+        [Test]
+        public void GetLaneInfo_for_non_artificial_commit_should_contain_guid_and_mark_if_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: true));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("* {0}{1}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Body));
+        }
+
+        [Test]
+        public void GetLaneInfo_for_non_artificial_commit_should_contain_guid_and_no_mark_if_not_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Body));
+        }
+
+        [Test]
+        public void GetLaneInfo_for_artificial_commit_should_not_add_guid_and_mark_if_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_artificialCommitNode, isAtNode: true));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should().Be(_artificialCommitNode.Revision.Body);
+        }
+
+        [Test]
+        public void GetLaneInfo_for_artificial_commit_should_not_add_guid_and_mark_if_not_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_artificialCommitNode, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should().Be(_artificialCommitNode.Revision.Body);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_the_subject_if_singleline_body_null()
+        {
+            _realCommitNode.Revision.Body = null;
+            _realCommitNode.Revision.HasMultiLineMessage = false;
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Subject));
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_the_subject_and_hint_if_multiline_body_null()
+        {
+            _realCommitNode.Revision.Body = null;
+            _realCommitNode.Revision.HasMultiLineMessage = true;
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}{1}{2}{3}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Subject,
+                    "\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message."));
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_branch_and_source_from_merge_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_mergeCommitNode, isAtNode: false));
+
+            for (int index = 0; index < MergeSubjectsWithDecoding.Count; index += 3)
+            {
+                string subject = MergeSubjectsWithDecoding[index + 0];
+                string mergedWith = MergeSubjectsWithDecoding[index + 1];
+                string into = MergeSubjectsWithDecoding[index + 2];
+                _mergeCommitNode.Revision.Subject = subject;
+
+                _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                    .Be(string.Format("{0}{1}\nBranch: {3} (merged with {4}){1}{2}",
+                        _mergeCommitNode.Revision.Guid,
+                        Environment.NewLine,
+                        _mergeCommitNode.Revision.Body,
+                        into,
+                        mergedWith));
+            }
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_only_the_branch_from_next_merge_node()
+        {
+            _realCommitNode.Descendants.Add(new Junction(_mergeCommitNode, _realCommitNode));
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            for (int index = 0; index < MergeSubjectsWithDecoding.Count; index += 3)
+            {
+                string subject = MergeSubjectsWithDecoding[index + 0];
+                string mergedWith = MergeSubjectsWithDecoding[index + 1];
+                string into = MergeSubjectsWithDecoding[index + 2];
+                _mergeCommitNode.Revision.Subject = subject;
+
+                _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                    .Be(string.Format("{0}{1}\nBranch: {3}{1}{2}",
+                        _realCommitNode.Revision.Guid,
+                        Environment.NewLine,
+                        _realCommitNode.Revision.Body,
+                        into,
+                        mergedWith));
+            }
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_only_the_branch_from_detected_merge_node_in_a_tree()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // artificial
+            // |  merge
+            // |  |     \
+            // |  inner  (omitted)
+            // |  |
+            // undetected merge
+            // |               \
+            // real             (omitted)
+            var junctionAU = new Junction(_artificialCommitNode, _undetectedMergeCommitNode);
+            var junctionMIU = new Junction(_mergeCommitNode, _innerCommitNode);
+            junctionMIU.Add(_undetectedMergeCommitNode);
+            var junctionUR = new Junction(_undetectedMergeCommitNode, _realCommitNode);
+            _undetectedMergeCommitNode.Descendants.Add(junctionAU);
+            _undetectedMergeCommitNode.Descendants.Add(junctionMIU);
+            _realCommitNode.Descendants.Add(junctionUR);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.Revision.Subject = subject;
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}\nBranch: {3}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Body,
+                    into,
+                    mergedWith));
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_only_the_branch_from_inner_node_in_a_tree()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // merge
+            // |    \
+            // inner (omitted)
+            // |
+            // real
+            var junctionMIR = new Junction(_mergeCommitNode, _innerCommitNode);
+            junctionMIR.Add(_realCommitNode);
+            _realCommitNode.Descendants.Add(junctionMIR);
+            _realCommitNode.Revision.Refs = new GitRef[] { new GitRef(null, null, GitRefName.RefsTagsPrefix + "tag_shall_be_ignored") };
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            Check(new GitRef(null, null, GitRefName.RefsHeadsPrefix + "local_branch"));
+            Check(new GitRef(null, null, GitRefName.RefsRemotesPrefix + "remote_branch", "origin"));
+            Check(new GitRef(null, null, GitRefName.RefsStashPrefix + "@0"));
+
+            return;
+
+            void Check(GitRef gitRef)
+            {
+                _innerCommitNode.Revision.Refs = new GitRef[] { gitRef };
+
+                _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                    .Be(string.Format("{0}{1}\nBranch: {3}{1}{2}",
+                        _realCommitNode.Revision.Guid,
+                        Environment.NewLine,
+                        _realCommitNode.Revision.Body,
+                        gitRef.Name));
+            }
+        }
+
+        [Test]
+        public void GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef__at_junction_node()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // merge
+            // |    \
+            // real  (omitted)
+            var junctionMR = new Junction(_mergeCommitNode, _realCommitNode);
+            _realCommitNode.Descendants.Add(junctionMR);
+
+            GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef();
+        }
+
+        [Test]
+        public void GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef__at_inner_node()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // artificial
+            // |
+            // merge
+            // |    \
+            // real  (omitted or maybe even missing)
+            var junctionAMR = new Junction(_artificialCommitNode, _mergeCommitNode);
+            junctionAMR.Add(_realCommitNode);
+            _realCommitNode.Descendants.Add(junctionAMR);
+
+            GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef();
+        }
+
+        private void GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.Revision.Subject = subject;
+
+            var gitRef = new GitRef(null, null, GitRefName.RefsHeadsPrefix + "local_branch");
+            _mergeCommitNode.Revision.Refs = new GitRef[] { gitRef };
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}\nBranch: {3}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Body,
+                    into));
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_the_merged_branch()
+        {
+            // test tree
+            //
+            // merge
+            // |    \
+            // inner real
+            var junctionMI = new Junction(_mergeCommitNode, _innerCommitNode);
+            var junctionMR = new Junction(_mergeCommitNode, _realCommitNode);
+            _mergeCommitNode.Ancestors.Add(junctionMI);
+            _mergeCommitNode.Ancestors.Add(junctionMR);
+            _innerCommitNode.Descendants.Add(junctionMI);
+            _realCommitNode.Descendants.Add(junctionMR);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.Revision.Subject = subject;
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}\nBranch: {3}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Body,
+                    mergedWith));
+        }
+
+        [Test]
+        public void GetLaneInfo_should_not_display_a_branch_if_none_to_detect()
+        {
+            // synthetic test tree
+            //
+            // artificial
+            // |
+            // undetected merge
+            // |   \
+            // |    inner
+            // |   /
+            // real
+            var junctionAU = new Junction(_artificialCommitNode, _undetectedMergeCommitNode);
+            var junctionUR = new Junction(_undetectedMergeCommitNode, _realCommitNode);
+            var junctionUIR = new Junction(_undetectedMergeCommitNode, _innerCommitNode);
+            junctionUIR.Add(_realCommitNode);
+            _undetectedMergeCommitNode.Descendants.Add(junctionAU);
+            _realCommitNode.Descendants.Add(junctionUR);
+            _realCommitNode.Descendants.Add(junctionUIR);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0, 0).Should()
+                .Be(string.Format("{0}{1}{1}{2}",
+                    _realCommitNode.Revision.Guid,
+                    Environment.NewLine,
+                    _realCommitNode.Revision.Body));
+        }
+    }
+}

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
@@ -1,0 +1,188 @@
+﻿using FluentAssertions;
+using GitUI.UserControls.RevisionGrid.Graph;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls.RevisionGrid.Graph
+{
+    [TestFixture]
+    public class LaneNodeLocatorTests
+    {
+        private ILaneRowProvider _laneRowProvider;
+        private LaneNodeLocator _laneNodeLocator;
+
+        [SetUp]
+        public void Setup()
+        {
+            _laneRowProvider = Substitute.For<ILaneRowProvider>();
+            _laneNodeLocator = new LaneNodeLocator(_laneRowProvider);
+        }
+
+        private Node SetupLaneRow(int row, int laneCount, int nodeLane = -1)
+        {
+            var node = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId);
+            var laneRow = Substitute.For<ILaneRow>();
+            laneRow.Count.Returns(laneCount);
+            laneRow.NodeLane.Returns(nodeLane);
+            laneRow.Node.Returns(node);
+            _laneRowProvider.GetLaneRow(row).Returns(x => laneRow);
+            return node;
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_x_negative()
+        {
+            _laneNodeLocator.FindPrevNode(-1, 0, 1).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_rowIndex_negative()
+        {
+            _laneNodeLocator.FindPrevNode(0, -1, 1).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_laneWidth_less_than_one()
+        {
+            _laneNodeLocator.FindPrevNode(0, 0, 0).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_model_does_not_have_row()
+        {
+            const int row = 100;
+            _laneRowProvider.GetLaneRow(row).Returns(x => null);
+            _laneNodeLocator.FindPrevNode(0, row, 1).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_rowIndex_exceeds_model_row_count()
+        {
+            // It is not up to FindPrevNode() to check this, because:
+            // The model does not provide a property "Count". Tough it returns null in this case.
+            FindPrevNode_should_return_null_if_model_does_not_have_row();
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_node_if_it_is_at_the_node_lane_although_lane_count_is_0()
+        {
+            const int row = 100;
+            const int lane = 0;
+            const int width = 5;
+            var node = SetupLaneRow(row, laneCount: 0, lane);
+
+            // lane == laneRow.NodeLane
+            _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((node, true));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_lane_exceeds_lane_count_and_lane_is_not_the_node_lane()
+        {
+            const int row = 100;
+            const int lane = 10;
+            const int width = 5;
+            SetupLaneRow(row, laneCount: lane);
+
+            // lane >= _laneRowProvider.GetLaneRow(rowIndex).Count
+            _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_there_is_no_lane_info()
+        {
+            const int row = 100;
+            const int lane = 3;
+            const int width = 5;
+            SetupLaneRow(row, laneCount: lane + 1);
+            _laneRowProvider.GetLaneRow(row).LaneInfoCount(lane).Returns(x => 0);
+
+            // empty loop "for (laneInfoIndex)"
+            _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_the_junction_is_empty()
+        {
+            // const int row = 100;
+            // const int lane = 3;
+            // const int width = 5;
+
+            // empty loop "for (nodeIndex)"
+            // not testable since Junction cannot be mocked up without nodes
+            // _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_first_junction_node_of_the_first_LaneInfo()
+        {
+            const int row = 100;
+            const int lane = 3;
+            const int width = 5;
+            var laneNode = SetupLaneRow(row, laneCount: lane + 1);
+            var junctionNode0 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId);
+            var junctionNode1 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId);
+            var junction = new Junction(junctionNode0, junctionNode1);
+            var laneInfo = new LaneInfo(lane, junction);
+            var laneRow = _laneRowProvider.GetLaneRow(row);
+            laneRow.LaneInfoCount(lane).Returns(x => 2);
+            laneRow[lane, 0].Returns(x => laneInfo);
+
+            // match in the first iteration of the loop "for (laneInfoIndex)"
+            // match in the first iteration of the loop "for (nodeIndex)"
+            _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((junctionNode0, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_second_junction_node_of_the_first_LaneInfo()
+        {
+            const int row = 100;
+            const int lane = 3;
+            const int width = 5;
+            var laneNode = SetupLaneRow(row, laneCount: lane + 1);
+            var junctionNode0 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId)
+            {
+                Index = row
+            };
+            var junctionNode1 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId);
+            var junction = new Junction(junctionNode0, junctionNode1);
+            var laneInfo = new LaneInfo(lane, junction);
+            var laneRow = _laneRowProvider.GetLaneRow(row);
+            laneRow.LaneInfoCount(lane).Returns(x => 2);
+            laneRow[lane, 0].Returns(x => laneInfo);
+
+            // match in the first iteration of the loop "for (laneInfoIndex)"
+            // match in the second iteration of the loop "for (nodeIndex)"
+            _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((junctionNode1, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_first_junction_node_of_the_second_LaneInfo()
+        {
+            const int row = 100;
+            const int lane = 3;
+            const int width = 5;
+            var laneNode = SetupLaneRow(row, laneCount: lane + 1);
+            var junctionNode0 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId)
+            {
+                Index = row
+            };
+            var junctionNode1 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId)
+            {
+                Index = row
+            };
+            var junctionNode2 = new Node(GitUIPluginInterfaces.ObjectId.WorkTreeId);
+            var junction0 = new Junction(junctionNode0, junctionNode1);
+            var junction1 = new Junction(junctionNode2);
+            var laneInfo0 = new LaneInfo(lane, junction0);
+            var laneInfo1 = new LaneInfo(lane, junction1);
+            var laneRow = _laneRowProvider.GetLaneRow(row);
+            laneRow.LaneInfoCount(lane).Returns(x => 2);
+            laneRow[lane, 0].Returns(x => laneInfo0);
+            laneRow[lane, 1].Returns(x => laneInfo1);
+
+            // match in the second iteration of the loop "for (laneInfoIndex)"
+            // match in the first iteration of the loop "for (nodeIndex)"
+            _laneNodeLocator.FindPrevNode(lane * width, row, width).Should().Be((junctionNode2, false));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5125 
Fixes #4450

#### Changes proposed in this pull request:
- extend tooltips for the Revision Graph with
  - commit hash for all lanes (prefixed with `*` if it is the lane of the commit in the current row)
  - branch to which was committed (as far as possible to determine)
  - branches and tags the commit is contained in
- limit the number of lines in tooltips to 30
- insert litte spaces into the commit hash
 
#### Screenshots before and after (if PR changes UI):
- before:
![grafik](https://user-images.githubusercontent.com/36601201/45591245-7583ea80-b94d-11e8-8567-e5e279e706c2.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591251-b7ad2c00-b94d-11e8-9e08-5c0354a23701.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591274-2c806600-b94e-11e8-9163-4e60e21ba03f.png)
- after:
![grafik](https://user-images.githubusercontent.com/36601201/45591276-48840780-b94e-11e8-847c-12bd7f06ffea.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591225-b5969d80-b94c-11e8-888f-8dcbd9159766.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591263-f17e3280-b94d-11e8-8c85-30e8ec9c705f.png)
- before: too long tooltip flashes for short time
- after:
![grafik](https://user-images.githubusercontent.com/36601201/45591303-35256c00-b94f-11e8-907f-632a4b562e08.png)
- after: branch committed to
![grafik](https://user-images.githubusercontent.com/36601201/45591317-d57b9080-b94f-11e8-8a81-e6bebf33f4e6.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591327-212e3a00-b950-11e8-9b96-e8ca058ebba4.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591333-43c05300-b950-11e8-9d79-7f537c38a925.png)
- before: no tooltips on lines with artificial commits not even for other lanes
- after:
![grafik](https://user-images.githubusercontent.com/36601201/45591413-62bfe480-b952-11e8-9529-a8cc4c9d42d5.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591411-3efc9e80-b952-11e8-8d21-432396feebcf.png)
![grafik](https://user-images.githubusercontent.com/36601201/45591424-c3e7b800-b952-11e8-854f-1392179b0705.png)

#### What did I do to test the code and ensure quality:
- compared branches and tags contained in with the commit info of many revisions
- checked with artificial commits and stash
- created test repository with non-standard merge commit messages

#### Has been tested on (remove any that don't apply):
- GIT: 2.18.0.w.x64
- Windows 7