### PR TITLE
Expand settings tree to show found nodes

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -152,6 +152,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             foreach (var node in _nodesFoundByTextBox)
             {
                 HighlightNode(node, true);
+                node.EnsureVisible();
             }
 
             if (_nodesFoundByTextBox.Any())


### PR DESCRIPTION
Fixes #5341

Changes proposed in this pull request:
- expand the settings tree so that all search hits are shown
 
Screenshots before and after (if PR changes UI):
- before
![grafik](https://user-images.githubusercontent.com/36601201/45625051-41fbaa00-ba8c-11e8-9259-0d120a9a912b.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/45625355-e4b42880-ba8c-11e8-82a2-f8bab9a899c8.png)

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- GIT: (2.18.0.w.x64)
- Windows 7