### PR TITLE
Add shortcuts to CopyContextMenuItem

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -27,7 +27,6 @@ namespace GitUI.CommandsDialogs
             this.followFileHistoryRenamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fullHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.copyToClipboardToolStripMenuItem = new GitUI.UserControls.RevisionGrid.CopyContextMenuItem();
             this.tabControl1 = new GitUI.CommandsDialogs.FullBleedTabControl();
             this.CommitInfoTabPage = new System.Windows.Forms.TabPage();
             this.CommitDiff = new GitUI.UserControls.CommitDiff();
@@ -100,7 +99,7 @@ namespace GitUI.CommandsDialogs
             // FileHistoryContextMenu
             // 
             this.FileHistoryContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.copyToClipboardToolStripMenuItem,
+            FileChanges.CopyToClipboardToolStripMenuItem,
             this.separatorAfterCopySubmenu,
             this.openWithDifftoolToolStripMenuItem,
             this.diffToolRemoteLocalStripMenuItem,
@@ -200,12 +199,6 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(336, 6);
-            // 
-            // copyToClipboardToolStripMenuItem
-            // 
-            this.copyToClipboardToolStripMenuItem.Name = "copyToClipboardToolStripMenuItem";
-            this.copyToClipboardToolStripMenuItem.Size = new System.Drawing.Size(491, 30);
-            this.copyToClipboardToolStripMenuItem.Text = "Copy to clipboard";
             // 
             // tabControl1
             // 
@@ -541,7 +534,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem ignoreWhitespaceToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem detectMoveAndCopyInThisFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem detectMoveAndCopyInAllFilesToolStripMenuItem;
-        private GitUI.UserControls.RevisionGrid.CopyContextMenuItem copyToClipboardToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator separatorAfterCopySubmenu;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs
             _commitDataManager = new CommitDataManager(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
 
-            copyToClipboardToolStripMenuItem.SetRevisionFunc(() => FileChanges.GetSelectedRevisions());
+            FileChanges.CopyToClipboardToolStripMenuItem.SetRevisionFunc(() => FileChanges.GetSelectedRevisions());
 
             InitializeComplete();
 
@@ -484,7 +484,7 @@ namespace GitUI.CommandsDialogs
             manipulateCommitToolStripMenuItem.Enabled =
                 selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial;
             saveAsToolStripMenuItem.Enabled = selectedRevisions.Count == 1;
-            copyToClipboardToolStripMenuItem.Enabled =
+            FileChanges.CopyToClipboardToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && !selectedRevisions[0].IsArtificial;
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -14,6 +14,16 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         private readonly Dictionary<Font, int[]> _widthByLengthByFont = new Dictionary<Font, int[]>(capacity: 4);
         private readonly RevisionGridControl _grid;
 
+        /// <summary>
+        /// fallback value for the property Length in the case that this column has not been shown
+        /// </summary>
+        public const int DefaultLength = 7;
+
+        /// <summary>
+        /// the current length of the commit hashs displayed
+        /// </summary>
+        public int Length { get; private set; } = DefaultLength;
+
         public CommitIdColumnProvider(RevisionGridControl grid)
             : base("Commit ID")
         {
@@ -49,11 +59,14 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 if (i == -1 && Column.Width > widthByLength[widthByLength.Length - 1])
                 {
-                    _grid.DrawColumnText(e, revision.ObjectId.ToString(), monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
+                    string objectId = revision.ObjectId.ToString();
+                    Length = objectId.Length;
+                    _grid.DrawColumnText(e, objectId, monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
                 }
                 else if (i > 1)
                 {
-                    _grid.DrawColumnText(e, revision.ObjectId.ToShortString(i - 1), monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
+                    Length = i - 1;
+                    _grid.DrawColumnText(e, revision.ObjectId.ToShortString(Length), monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
                 }
             }
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -1,6 +1,7 @@
 using System.Windows.Forms;
 using GitUI.Hotkey;
 using GitUI.UserControls.RevisionGrid;
+using GitUI.UserControls.RevisionGrid.Columns;
 
 namespace GitUI
 {
@@ -28,7 +29,7 @@ namespace GitUI
             this.bisectSkipRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stopBisectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bisectSeparator = new System.Windows.Forms.ToolStripSeparator();
-            this.copyToClipboardToolStripMenuItem = new GitUI.UserControls.RevisionGrid.CopyContextMenuItem();
+            this.copyToClipboardToolStripMenuItem = new GitUI.UserControls.RevisionGrid.CopyContextMenuItem(() => _commitIdColumnProvider?.Length ?? CommitIdColumnProvider.DefaultLength);
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.checkoutBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mergeBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -64,6 +64,7 @@ namespace GitUI
         private readonly BuildServerWatcher _buildServerWatcher;
         private readonly Timer _selectionTimer;
         private readonly GraphColumnProvider _graphColumnProvider;
+        private readonly CommitIdColumnProvider _commitIdColumnProvider;
         private readonly List<DataGridViewColumn> _resizableColumns;
         private readonly DataGridViewColumn _maximizedColumn;
         private DataGridViewColumn _lastVisibleResizableColumn = null;
@@ -112,6 +113,7 @@ namespace GitUI
         internal bool ShowUncommittedChangesIfPossible { get; set; } = true;
         internal bool ShowBuildServerInfo { get; set; }
         internal bool DoubleClickDoesNotOpenCommitInfo { get; set; }
+        internal CopyContextMenuItem CopyToClipboardToolStripMenuItem => copyToClipboardToolStripMenuItem;
 
         [CanBeNull]
         internal ObjectId InitialObjectId { private get; set; }
@@ -183,12 +185,13 @@ namespace GitUI
             _buildServerWatcher = new BuildServerWatcher(this, _gridView, () => Module);
 
             _graphColumnProvider = new GraphColumnProvider(this, _gridView._graphModel);
+            _commitIdColumnProvider = new CommitIdColumnProvider(this);
             _gridView.AddColumn(_graphColumnProvider);
             _gridView.AddColumn(new MessageColumnProvider(this));
             _gridView.AddColumn(new AvatarColumnProvider(_gridView, AvatarService.Default));
             _gridView.AddColumn(new AuthorNameColumnProvider(this, _authorHighlighting));
             _gridView.AddColumn(new DateColumnProvider(this));
-            _gridView.AddColumn(new CommitIdColumnProvider(this));
+            _gridView.AddColumn(_commitIdColumnProvider);
             _gridView.AddColumn(_buildServerWatcher.ColumnProvider);
             _resizableColumns = _gridView.Columns.Cast<DataGridViewColumn>().Where(column => column.Resizable == DataGridViewTriState.True).ToList();
             _maximizedColumn = _resizableColumns.FirstOrDefault(column => column.AutoSizeMode == DataGridViewAutoSizeColumnMode.Fill);

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -47,6 +47,7 @@ namespace ResourceManager
         private readonly TranslationString _committerText  = new TranslationString("Committer");
         private readonly TranslationString _commitDateText = new TranslationString("{0:Commit date|Commits dates}");
         private readonly TranslationString _commitHashText = new TranslationString("{0:Commit hash|Commits hashs}");
+        private readonly TranslationString _commitHashShortenedText = new TranslationString("{0:Commit hash shortened|Commits hashs shortened}");
         private readonly TranslationString _messageText    = new TranslationString("{0:Message|Messages}");
         private readonly TranslationString _workspaceText  = new TranslationString("Working directory");
         private readonly TranslationString _indexText      = new TranslationString("Commit index");
@@ -78,6 +79,11 @@ namespace ResourceManager
         public static string GetCommitHash(int value)
         {
             return Smart.Format(AppSettings.CurrentCultureInfo, _instance.Value._commitHashText.Text, value, Math.Abs(value));
+        }
+
+        public static string GetCommitHashShortened(int value)
+        {
+            return Smart.Format(AppSettings.CurrentCultureInfo, _instance.Value._commitHashShortenedText.Text, value, Math.Abs(value));
         }
 
         public static string GetMessage(int value)


### PR DESCRIPTION
Changes proposed in this pull request:
- add shortcuts (`&`) to the menu items provided by `CopyContextMenuItem`
- add menu item to copy the shortened hash to the clipboard
(The length is determined by the width of the `CommitIdColumn`.)
- do not create two instances of `CopyContextMenuItem` for the `FormFileHistory`
 
Screenshots before and after (if PR changes UI):
- before
![grafik](https://user-images.githubusercontent.com/36601201/45649624-2ca67000-bacc-11e8-9e13-e726cf69ccc2.png)
![grafik](https://user-images.githubusercontent.com/36601201/45649741-7f802780-bacc-11e8-9329-71f9e8f1a0ff.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/45649777-9fafe680-bacc-11e8-8795-8ebb8bf15bf1.png)
![grafik](https://user-images.githubusercontent.com/36601201/45649803-b3f3e380-bacc-11e8-8d9e-0e2d96cf1da6.png)

What did I do to test the code and ensure quality:
- opened the context menu for several revisions in `RevisionGrid` and `FileHistory`
- hit Ctrl+C and Ctrl+H without opening the `CopyContextMenuItem`

Has been tested on (remove any that don't apply):
- GIT: (2.18.0.w.x64)
- Windows 7