### PR TITLE
Fix broken revision grid content filter

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -409,7 +409,7 @@ namespace GitUI
                 {
                     if (cmdLineSafe)
                     {
-                        revListArgs += "\"-S" + filter + "\" ";
+                        revListArgs += "-S " + filter.Quote();
                     }
                     else
                     {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -409,7 +409,7 @@ namespace GitUI
                 {
                     if (cmdLineSafe)
                     {
-                        revListArgs += "-S " + filter.Quote();
+                        revListArgs += "-G" + filter.Quote();
                     }
                     else
                     {


### PR DESCRIPTION
Searching for `Foo Bar` would execute:

```
git log "-SFoo Bar"
```

That argument list should be:

```
git log -S "Foo Bar"
```

### Changes proposed in this pull request:

- Adds a space between `-S` and the filter text
- Fix the quotes so they enclose only the filter text
 
### Screenshots before and after (if PR changes UI):

No UI change, but fixing this allows searching by content to work properly, so you see more result rows.

Note, to get this to work you must use this option:

![image](https://user-images.githubusercontent.com/350947/45695831-2c54b600-bb5a-11e8-8179-5793271e5443.png)

### What did I do to test the code and ensure quality:
- Manual testing and reviewing in the command log

### Has been tested on
- GIT 2.19
- Windows 10
