### PR TITLE
File status list tweaks

### DIFF
--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GitUI.UserControls;
+﻿using GitUI.UserControls;
 namespace GitUI
 {
     partial class FileStatusList
@@ -37,6 +36,7 @@ namespace GitUI
             this.FilterComboBox = new System.Windows.Forms.ComboBox();
             this.FilterWatermarkLabel = new System.Windows.Forms.Label();
             this.FilterToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.lblSplitter = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // FileStatusListView
@@ -56,7 +56,7 @@ namespace GitUI
             this.FileStatusListView.ShowItemToolTips = true;
             this.FileStatusListView.Size = new System.Drawing.Size(682, 464);
             this.FileStatusListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.FileStatusListView.TabIndex = 1;
+            this.FileStatusListView.TabIndex = 2;
             this.FileStatusListView.UseCompatibleStateImageBehavior = false;
             this.FileStatusListView.View = System.Windows.Forms.View.Details;
             this.FileStatusListView.DrawSubItem += new System.Windows.Forms.DrawListViewSubItemEventHandler(this.FileStatusListView_DrawSubItem);
@@ -107,7 +107,7 @@ namespace GitUI
             this.FilterWatermarkLabel.Location = new System.Drawing.Point(4, 4);
             this.FilterWatermarkLabel.Name = "FilterWatermarkLabel";
             this.FilterWatermarkLabel.Size = new System.Drawing.Size(65, 13);
-            this.FilterWatermarkLabel.TabIndex = 3;
+            this.FilterWatermarkLabel.TabIndex = 0;
             this.FilterWatermarkLabel.Text = "Filter files...";
             this.FilterWatermarkLabel.Click += new System.EventHandler(this.FilterWatermarkLabel_Click);
             // 
@@ -120,12 +120,21 @@ namespace GitUI
             this.FilterToolTip.UseAnimation = false;
             this.FilterToolTip.UseFading = false;
             // 
+            // lblSplitter
+            // 
+            this.lblSplitter.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lblSplitter.Location = new System.Drawing.Point(0, 22);
+            this.lblSplitter.Name = "lblSplitter";
+            this.lblSplitter.Size = new System.Drawing.Size(682, 2);
+            this.lblSplitter.TabIndex = 1;
+            // 
             // FileStatusList
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.FileStatusListView);
+            this.Controls.Add(this.lblSplitter);
             this.Controls.Add(this.FilterWatermarkLabel);
             this.Controls.Add(this.NoFiles);
-            this.Controls.Add(this.FileStatusListView);
             this.Controls.Add(this.FilterComboBox);
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "FileStatusList";
@@ -143,5 +152,6 @@ namespace GitUI
         private System.Windows.Forms.ComboBox FilterComboBox;
         private System.Windows.Forms.Label FilterWatermarkLabel;
         private System.Windows.Forms.ToolTip FilterToolTip;
+        private System.Windows.Forms.Label lblSplitter;
     }
 }

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -60,7 +60,6 @@ namespace GitUI
             this.FileStatusListView.UseCompatibleStateImageBehavior = false;
             this.FileStatusListView.View = System.Windows.Forms.View.Details;
             this.FileStatusListView.DrawSubItem += new System.Windows.Forms.DrawListViewSubItemEventHandler(this.FileStatusListView_DrawSubItem);
-            this.FileStatusListView.SizeChanged += new System.EventHandler(this.FileStatusListView_SizeChanged);
             this.FileStatusListView.DoubleClick += new System.EventHandler(this.FileStatusListView_DoubleClick);
             this.FileStatusListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FileStatusListView_KeyDown);
             this.FileStatusListView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FileStatusListView_MouseDown);
@@ -131,10 +130,10 @@ namespace GitUI
             // FileStatusList
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            this.Controls.Add(this.FileStatusListView);
-            this.Controls.Add(this.lblSplitter);
             this.Controls.Add(this.FilterWatermarkLabel);
             this.Controls.Add(this.NoFiles);
+            this.Controls.Add(this.FileStatusListView);
+            this.Controls.Add(this.lblSplitter);
             this.Controls.Add(this.FilterComboBox);
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "FileStatusList";

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -45,6 +45,7 @@ namespace GitUI
             InitializeComponent();
             InitialiseFiltering();
             CreateOpenSubmoduleMenuItem();
+            lblSplitter.Height = DpiUtil.Scale(1);
             InitializeComplete();
             FilterVisible = false;
 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -927,8 +927,8 @@ namespace GitUI
                 }
             }
 
-            FileStatusListView_SizeChanged(null, null);
             FileStatusListView.SetGroupState(ListViewGroupState.Collapsible);
+            FileStatusListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
             FileStatusListView.EndUpdate();
 
             return;
@@ -1052,18 +1052,6 @@ namespace GitUI
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
         public GitRevision Revision { get; set; }
-
-        private void FileStatusListView_SizeChanged(object sender, EventArgs e)
-        {
-            NoFiles.Size = new Size(Size.Width - 10, Size.Height - 10);
-            Refresh();
-            FileStatusListView.BeginUpdate();
-
-            FileStatusListView.AutoResizeColumn(
-                0,
-                ColumnHeaderAutoResizeStyle.HeaderSize);
-            FileStatusListView.EndUpdate();
-        }
 
         private void FileStatusListView_KeyDown(object sender, KeyEventArgs e)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5437
Fixes #5438

Changes proposed in this pull request:
- Remove `SizeChanged` handler
The current implementation of the `SizeChanged` handler causes a bad distortion to the UI and renders the listview unusable.
The handler is removed and the column is resized at the time of bindings items to the list.
This adds a small artifact that if the list was resized after items have been bound, the column may no longer be of the full width of the list.

- Add separator between the dropdown and the list

What did I do to test the code and ensure quality:
- manual

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
