### PR TITLE
prevent crashes in submodule changes list

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2260,7 +2260,7 @@ namespace GitUI.CommandsDialogs
             foreach (var (path, name) in modules)
             {
                 string diff = Module.RunGitCmd(
-                     string.Format("diff --cached -z -- {0}", name));
+                     string.Format("diff --submodule=short --cached -z -- {0}", name));
                 var lines = diff.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 const string subprojectCommit = "Subproject commit ";
                 var from = lines.Single(s => s.StartsWith("-" + subprojectCommit)).Substring(subprojectCommit.Length + 1);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4684

Changes proposed in this pull request:
sets diff.submodule=short explicitly which may not match repo config
 
What did I do to test the code and ensure quality:
It's a single line change, guys :roll_eyes: 

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
