### PR TITLE
Performance fixes for large repos (responsive grid during loading)

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -162,8 +162,8 @@ namespace GitCommands
                 {
                     "-z",
                     $"--pretty=format:\"{fullFormat}\"",
-                    { AppSettings.OrderRevisionByDate, "--date-order", "--topo-order" },
-                    { AppSettings.ShowReflogReferences, "--reflog" },
+                    { AppSettings.OrderRevisionByDate, "--date-order" },
+                    { AppSettings.ShowReflogReferences, "--reflog --topo-order" }, // if reflog is used, the revisions are not returned in topo-order. Force topo order, since we require topo order for the revision graph.
                     {
                         refFilterOptions.HasFlag(RefFilterOptions.All),
                         "--all",

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -842,7 +842,7 @@ namespace GitCommands
 
         public static bool OrderRevisionByDate
         {
-            get => GetBool("orderrevisionbydate", true);
+            get => GetBool("orderrevisionbydate", false); // Set default value to false. Date order us not needed for most use-cases but the ordering costs a lot of performance.
             set => SetBool("orderrevisionbydate", value);
         }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Security" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -29,7 +29,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
                 Resizable = DataGridViewTriState.False,
-                Width = DpiUtil.Scale(32)
+                Width = DpiUtil.Scale(32),
+                Visible = AppSettings.ShowAuthorAvatarColumn
             };
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -27,7 +27,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 SortMode = DataGridViewColumnSortMode.NotSortable,
                 Resizable = DataGridViewTriState.True,
                 Width = DpiUtil.Scale(60),
-                MinimumWidth = DpiUtil.Scale(32)
+                MinimumWidth = DpiUtil.Scale(32),
+                Visible = AppSettings.ShowObjectIdColumn
             };
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/GraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/GraphColumnProvider.cs
@@ -49,7 +49,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
-                Resizable = DataGridViewTriState.False
+                Resizable = DataGridViewTriState.False,
+                MinimumWidth = DpiUtil.Scale(10)
             };
         }
 
@@ -424,7 +425,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             lock (_graphModel)
             {
                 _graphModel.Clear();
-                ////_graphDataCount = 0;
                 _cacheHead = -1;
                 _cacheHeadRow = 0;
                 ClearDrawCache();

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneJunctionDetail.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneJunctionDetail.cs
@@ -37,7 +37,23 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         }
 
         [CanBeNull]
-        public Node Current => _node ?? (_index < Junction.NodeCount ? Junction[_index] : null);
+        public Node Current
+        {
+            get
+            {
+                if (_node != null)
+                {
+                    return _node;
+                }
+
+                if (Junction == null)
+                {
+                    return null;
+                }
+
+                return _index < Junction.NodeCount ? Junction[_index] : null;
+            }
+        }
 
         public bool IsClear => Junction == null && _node == null;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -416,26 +416,23 @@ namespace GitUI.UserControls.RevisionGrid
                 return;
             }
 
-            lock (_backgroundThread)
-            {
-                UpdatingVisibleRows = true;
+            UpdatingVisibleRows = true;
 
-                try
+            try
+            {
+                if (CurrentCell == null)
                 {
-                    if (CurrentCell == null)
-                    {
-                        RowCount = count;
-                        CurrentCell = null;
-                    }
-                    else
-                    {
-                        RowCount = count;
-                    }
+                    RowCount = count;
+                    CurrentCell = null;
                 }
-                finally
+                else
                 {
-                    UpdatingVisibleRows = false;
+                    RowCount = count;
                 }
+            }
+            finally
+            {
+                UpdatingVisibleRows = false;
             }
         }
 
@@ -463,11 +460,7 @@ namespace GitUI.UserControls.RevisionGrid
                     {
                         lock (_backgroundEvent)
                         {
-                            int scrollTo;
-                            lock (_backgroundThread)
-                            {
-                                scrollTo = _backgroundScrollTo;
-                            }
+                            int scrollTo = _backgroundScrollTo;
 
                             int curCount = _graphDataCount;
                             _graphDataCount = _graphModel.CachedCount;
@@ -498,10 +491,7 @@ namespace GitUI.UserControls.RevisionGrid
                     if (!_graphModel.CacheTo(rowIndex))
                     {
                         Debug.WriteLine("Cached item FAILED {0}", rowIndex);
-                        lock (_backgroundThread)
-                        {
-                            _backgroundScrollTo = rowIndex;
-                        }
+                        _backgroundScrollTo = rowIndex;
 
                         break;
                     }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -479,14 +479,6 @@ namespace GitUI.UserControls.RevisionGrid
                         if (!keepRunning)
                         {
                             this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
-
-                            void NotifyProvidersVisibleRowRangeChanged()
-                            {
-                                foreach (var provider in _columnProviders)
-                                {
-                                    provider.OnVisibleRowsChanged(_visibleRowRange);
-                                }
-                            }
                         }
                     }
                     else
@@ -577,6 +569,16 @@ namespace GitUI.UserControls.RevisionGrid
                     _backgroundScrollTo = toIndex;
                     _backgroundEvent.Set();
                 }
+
+                this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
+            }
+        }
+
+        private void NotifyProvidersVisibleRowRangeChanged()
+        {
+            foreach (var provider in _columnProviders)
+            {
+                provider.OnVisibleRowsChanged(_visibleRowRange);
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -483,8 +483,7 @@ namespace GitUI.UserControls.RevisionGrid
                     }
                     else
                     {
-                        // Graph is not visible, so sleep a little while to prevent wasting time do nothing... do not cache, the graph is invisible
-                        Thread.Sleep(10);
+                        UpdateGraph(_graphModel.Count, _graphModel.Count);
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -345,7 +345,7 @@ namespace GitUI.UserControls.RevisionGrid
                 columnProvider.Clear();
             }
 
-            ////// Redraw
+            // Redraw
             UpdateVisibleRowRange();
             Invalidate(invalidateChildren: true);
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -459,15 +459,15 @@ namespace GitUI.UserControls.RevisionGrid
 
                         UpdateGraph(curCount, Math.Min(curCount + 150, scrollTo));
                         keepRunning = curCount < scrollTo;
-
-                        if (!keepRunning)
-                        {
-                            this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
-                        }
                     }
                     else
                     {
                         UpdateGraph(_graphModel.Count, _graphModel.Count);
+                    }
+
+                    if (!keepRunning)
+                    {
+                        this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -526,12 +526,12 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (fromIndex >= _graphModel.Count)
             {
-                fromIndex = _graphModel.Count;
+                fromIndex = _graphModel.Count - 1;
             }
 
             if (toIndex >= _graphModel.Count)
             {
-                toIndex = _graphModel.Count;
+                toIndex = _graphModel.Count - 1;
             }
 
             if (toIndex > 0)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -140,7 +140,7 @@ namespace GitUI
                 BorderStyle = BorderStyle.None,
                 ForeColor = SystemColors.InfoText,
                 BackColor = SystemColors.Info,
-                Font = new Font(FontFamily.GenericSansSerif, 11, FontStyle.Bold),
+                Font = AppSettings.Font,
                 Visible = false,
                 UseMnemonic = false,
                 AutoSize = true,

--- a/GitUI/UserControls/RevisionGrid/VisibleRowRange.cs
+++ b/GitUI/UserControls/RevisionGrid/VisibleRowRange.cs
@@ -21,7 +21,7 @@ namespace GitUI.UserControls.RevisionGrid
             ToIndex = toIndex;
         }
 
-        public int Count => ToIndex - FromIndex + 1;
+        public int Count => ToIndex - FromIndex;
 
         public bool Contains(int index) => index >= FromIndex && index <= ToIndex;
 

--- a/GitUI/UserControls/RevisionGrid/VisibleRowRange.cs
+++ b/GitUI/UserControls/RevisionGrid/VisibleRowRange.cs
@@ -21,7 +21,7 @@ namespace GitUI.UserControls.RevisionGrid
             ToIndex = toIndex;
         }
 
-        public int Count => ToIndex - FromIndex;
+        public int Count => ToIndex - FromIndex + 1;
 
         public bool Contains(int index) => index >= FromIndex && index <= ToIndex;
 


### PR DESCRIPTION
This is an experimental branch with an attempt to improve performance. It is not stable/finished yet. I mainly want to discuss the changes made so far. The code has not been cleaned, some commented code is still there. The changes where initially done in the 2.51 version, then ported to the 3.00.01 version.

For comparison the Linux repository loads in < 1 second, compared to ~10 seconds (https://github.com/torvalds/linux.git).

Fixes #

Changes proposed in this pull request:
- Do not use topo-order when loading revision log. Its performance is equal to date-order and a lot slower then let git return the log in the order it is in the index.
- Remove locks in the revision graph to improve responsiveness
- Draw revisions as soon as the first commits are loaded, do not wait untill everything is ready
- Stop caching revision graph as soon as visible section is cached to decrease memory usage and not waste cpu cycles. Continue after scrolling down, stop when scrolling up.
 
What has been changed in de UI
- I did remove loading the body text to save some memory, but this can be reverted.
- I removed the loading panel for now. Reason is that I could not find an easy way to remove it on the exact right time.

What needs more work
- (Re)Selecting the revisions. It just doesn't feel right.
- Revision graph column doesn't always resize to the correct width.
- Stability has not been tested enough on version 3.00.01.

What did I do to test the code and ensure quality:
- Several weeks of testing/using the new version.
- Tested with medium sized repositories (500k commits, 5k branches, 5k tags, 2gb index size)

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
