### PR TITLE
Resolve DIR properly when gitext.sh is symlinked on Linux

### DIFF
--- a/Bin/gitext.sh
+++ b/Bin/gitext.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$( cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )" && pwd )
 mono "$DIR/GitExtensions.exe" "$@" &
 


### PR DESCRIPTION
In case gitext.sh is symlinked (e.g. into $HOME/bin directory) on Linux the DIR variable currently resolves to the directory where the symlink is placed. We need it, however, to resolve to the directory where the actual script is placed, together with the actual executable. This minor change fixes it.