### PR TITLE
Use git argument builder

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -170,7 +170,8 @@ namespace GitCommands
             return new CommitData(revision.ObjectId, revision.TreeGuid, revision.ParentIds,
                 string.Format("{0} <{1}>", revision.Author, revision.AuthorEmail), revision.AuthorDate,
                 string.Format("{0} <{1}>", revision.Committer, revision.CommitterEmail), revision.CommitDate,
-                revision.Body ?? revision.Subject) { ChildIds = children };
+                revision.Body ?? revision.Subject)
+            { ChildIds = children };
         }
 
         [NotNull]
@@ -197,7 +198,12 @@ namespace GitCommands
                 return false;
             }
 
-            var arguments = $"log -1 --pretty=\"format:{format}\" {commitId}";
+            var arguments = new GitArgumentBuilder("log")
+            {
+                "-1",
+                $"--pretty=\"format:{format}\"",
+                commitId
+            };
 
             // Do not cache this command, since notes can be added
             data = GetModule().RunGitCmd(arguments, GitModule.LosslessEncoding);

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -64,7 +64,16 @@ namespace GitCommands
         private static bool? IsBinaryAccordingToGitAttributes(GitModule module, string fileName)
         {
             string[] diffValues = { "set", "astextplain", "ada", "bibtext", "cpp", "csharp", "fortran", "html", "java", "matlab", "objc", "pascal", "perl", "php", "python", "ruby", "tex" };
-            string cmd = "check-attr -z diff text crlf eol -- " + fileName.Quote();
+            var cmd = new GitArgumentBuilder("check-attr")
+            {
+                "-z",
+                "diff",
+                "text",
+                "crlf",
+                "eol",
+                "--",
+                fileName.Quote()
+            };
             string result = module.RunGitCmd(cmd);
             var lines = result.Split('\n', '\0');
             var attributes = new Dictionary<string, string>();

--- a/GitCommands/Git/GitCheckoutBranchCmd.cs
+++ b/GitCommands/Git/GitCheckoutBranchCmd.cs
@@ -37,9 +37,8 @@ namespace GitCommands.Git
 
         protected override ArgumentString BuildArguments()
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("checkout")
             {
-                "checkout",
                 { LocalChanges == LocalChangesAction.Merge, "--merge" },
                 { LocalChanges == LocalChangesAction.Reset, "--force" },
                 { Remote && NewBranchMode == CheckoutNewBranchMode.Create, $"-b {NewBranchName.Quote()}" },

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -105,9 +105,8 @@ namespace GitCommands
 
         public static ArgumentString CherryPickCmd(ObjectId commitId, bool commit, string arguments)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("cherry-pick")
             {
-                "cherry-pick",
                 { !commit, "--no-commit" },
                 arguments,
                 commitId
@@ -127,23 +126,29 @@ namespace GitCommands
 
         private static ArgumentString SubmoduleUpdateCommand(string name)
         {
-            return "submodule update --init --recursive " + name;
+            return new GitArgumentBuilder("submodule")
+            {
+                "update",
+                "--init",
+                "--recursive",
+                name
+            };
         }
 
         public static ArgumentString SubmoduleSyncCmd([CanBeNull] string name)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("submodule")
             {
-                "submodule sync",
+                "sync",
                 name?.Trim().QuoteNE()
             };
         }
 
         public static ArgumentString AddSubmoduleCmd(string remotePath, string localPath, string branch, bool force)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("submodule")
             {
-                "submodule add",
+                "add",
                 { force, "-f" },
                 { !string.IsNullOrEmpty(branch), $"-b \"{branch?.Trim()}\"" },
                 remotePath.ToPosixPath().Quote(),
@@ -153,9 +158,8 @@ namespace GitCommands
 
         public static ArgumentString RevertCmd(ObjectId commitId, bool autoCommit, int parentIndex)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("revert")
             {
-                "revert",
                 { !autoCommit, "--no-commit" },
                 { parentIndex > 0, $"-m {parentIndex}" },
                 commitId
@@ -164,17 +168,29 @@ namespace GitCommands
 
         public static ArgumentString ResetSoftCmd(string commit)
         {
-            return "reset --soft \"" + commit + "\"";
+            return new GitArgumentBuilder("reset")
+            {
+                "--soft",
+                commit.QuoteNE()
+            };
         }
 
         public static ArgumentString ResetMixedCmd(string commit)
         {
-            return "reset --mixed \"" + commit + "\"";
+            return new GitArgumentBuilder("reset")
+            {
+                "--mixed",
+                commit.QuoteNE()
+            };
         }
 
         public static ArgumentString ResetHardCmd(string commit)
         {
-            return "reset --hard \"" + commit + "\"";
+            return new GitArgumentBuilder("reset")
+            {
+                "--hard",
+                commit.QuoteNE()
+            };
         }
 
         /// <summary>
@@ -197,10 +213,9 @@ namespace GitCommands
         {
             var from = PathUtil.IsLocalFile(fromPath) ? fromPath.ToPosixPath() : fromPath;
 
-            return new ArgumentBuilder
+            return new GitArgumentBuilder(lfs ? "lfs" : "clone")
             {
-                { lfs, "lfs" },
-                "clone",
+                { lfs, "clone" },
                 "-v",
                 { central, "--bare" },
                 { initSubmodules, "--recurse-submodules" },
@@ -217,9 +232,8 @@ namespace GitCommands
 
         public static ArgumentString CheckoutCmd(string branchOrRevisionName, LocalChangesAction changesAction)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("checkout")
             {
-                "checkout",
                 { changesAction == LocalChangesAction.Merge, "--merge" },
                 { changesAction == LocalChangesAction.Reset, "--force" },
                 branchOrRevisionName.Quote()
@@ -229,7 +243,12 @@ namespace GitCommands
         /// <summary>Create a new orphan branch from <paramref name="startPoint"/> and switch to it.</summary>
         public static ArgumentString CreateOrphanCmd(string newBranchName, ObjectId startPoint = null)
         {
-            return $"checkout --orphan {newBranchName} {startPoint}";
+            return new GitArgumentBuilder("checkout")
+            {
+                "--orphan",
+                newBranchName,
+                startPoint
+            };
         }
 
         /// <summary>Remove files from the working tree and from the index. <remarks>git rm</remarks></summary>
@@ -238,9 +257,8 @@ namespace GitCommands
         /// <param name="files">Files to remove. File globs can be given to remove matching files.</param>
         public static ArgumentString RemoveCmd(bool force = true, bool isRecursive = true, params string[] files)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("rm")
             {
-                "rm",
                 { force, "--force" },
                 { isRecursive, "-r" },
                 { files.Length == 0, "." },
@@ -250,9 +268,9 @@ namespace GitCommands
 
         public static ArgumentString BranchCmd(string branchName, string revision, bool checkout)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder(checkout ? "checkout" : "branch")
             {
-                { checkout, "checkout -b", "branch" },
+                { checkout, "-b" },
                 branchName.Trim().Quote(),
                 revision?.Trim().QuoteNE()
             };
@@ -260,9 +278,11 @@ namespace GitCommands
 
         public static ArgumentString MergedBranches(bool includeRemote = false)
         {
-            return includeRemote
-                ? "branch -a --merged"
-                : "branch --merged";
+            return new GitArgumentBuilder("branch")
+            {
+                { includeRemote, "-a" },
+                "--merged"
+            };
         }
 
         /// <summary>Pushes multiple sets of local branches to remote branches.</summary>
@@ -282,9 +302,8 @@ namespace GitCommands
                 return "";
             }
 
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("push")
             {
-                "push",
                 force,
                 { GitVersion.Current.PushCanAskForProgress, "--progress" },
                 path.ToPosixPath().Trim().Quote(),
@@ -297,9 +316,8 @@ namespace GitCommands
         {
             var isPartialStash = selectedFiles != null && selectedFiles.Any();
 
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("stash")
             {
-                "stash",
                 { isPartialStash, "push", "save" },
                 { untracked && GitVersion.Current.StashUntrackedFilesSupported, "-u" },
                 { keepIndex, "--keep-index" },
@@ -311,24 +329,23 @@ namespace GitCommands
 
         public static ArgumentString ContinueRebaseCmd()
         {
-            return "rebase --continue";
+            return new GitArgumentBuilder("rebase") { "--continue" };
         }
 
         public static ArgumentString SkipRebaseCmd()
         {
-            return "rebase --skip";
+            return new GitArgumentBuilder("rebase") { "--skip" };
         }
 
         public static ArgumentString StartBisectCmd()
         {
-            return "bisect start";
+            return new GitArgumentBuilder("bisect") { "start" };
         }
 
         public static ArgumentString ContinueBisectCmd(GitBisectOption bisectOption, params ObjectId[] revisions)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("bisect")
             {
-                "bisect",
                 bisectOption,
                 revisions
             };
@@ -336,7 +353,7 @@ namespace GitCommands
 
         public static ArgumentString StopBisectCmd()
         {
-            return "bisect reset";
+            return new GitArgumentBuilder("bisect") { "reset" };
         }
 
         public static ArgumentString RebaseCmd(string branch, bool interactive, bool preserveMerges, bool autosquash, bool autoStash, string from = null, string onto = null)
@@ -366,24 +383,35 @@ namespace GitCommands
 
         public static ArgumentString ResolvedCmd()
         {
-            return "am --3way --resolved";
+            return new GitArgumentBuilder("am")
+            {
+                "--3way",
+                "--resolved"
+            };
         }
 
         public static ArgumentString SkipCmd()
         {
-            return "am --3way --skip";
+            return new GitArgumentBuilder("am")
+            {
+                "--3way",
+                "--skip"
+            };
         }
 
         public static ArgumentString AbortCmd()
         {
-            return "am --3way --abort";
+            return new GitArgumentBuilder("am")
+            {
+                "--3way",
+                "--abort"
+            };
         }
 
         public static ArgumentString ApplyMailboxPatchCmd(bool ignoreWhiteSpace, string patchFile = null)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("am")
             {
-                "am",
                 "--3way",
                 "--signoff",
                 { ignoreWhiteSpace, "--ignore-whitespace" },
@@ -393,9 +421,8 @@ namespace GitCommands
 
         public static ArgumentString ApplyDiffPatchCmd(bool ignoreWhiteSpace, [NotNull] string patchFile)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("apply")
             {
-                "apply",
                 { ignoreWhiteSpace, "--ignore-whitespace" },
                 patchFile.ToPosixPath().Quote()
             };
@@ -403,9 +430,8 @@ namespace GitCommands
 
         public static ArgumentString CleanUpCmd(bool dryRun, bool directories, bool nonIgnored, bool ignored, string paths = null)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("clean")
             {
-                "clean",
                 { directories, "-d" },
                 { !nonIgnored && !ignored, "-x" },
                 { ignored, "-X" },
@@ -417,10 +443,12 @@ namespace GitCommands
 
         public static ArgumentString GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None, bool noLocks = false)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder(
+                noLocks && GitVersion.Current.SupportNoOptionalLocks
+                    ? "--no-optional-locks status"
+                    : "status")
             {
-                { noLocks && GitVersion.Current.SupportNoOptionalLocks, "--no-optional-locks" },
-                $"status --porcelain={(GitVersion.Current.SupportStatusPorcelainV2 ? 2 : 1)} -z",
+                $"--porcelain={(GitVersion.Current.SupportStatusPorcelainV2 ? 2 : 1)} -z",
                 untrackedFiles,
                 ignoreSubmodules,
                 { !excludeIgnoredFiles, "--ignored" }
@@ -926,9 +954,8 @@ namespace GitCommands
         {
             // TODO Quote should (optionally?) escape any " characters, at least for usages like the below
 
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("merge")
             {
-                "merge",
                 { !allowFastForward, "--no-ff" },
                 { !string.IsNullOrEmpty(strategy), $"--strategy={strategy}" },
                 { squash, "--squash" },

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -443,10 +443,10 @@ namespace GitCommands
 
         public static ArgumentString GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None, bool noLocks = false)
         {
-            return new GitArgumentBuilder(
+            return new GitArgumentBuilder("status", gitOptions:
                 noLocks && GitVersion.Current.SupportNoOptionalLocks
-                    ? "--no-optional-locks status"
-                    : "status")
+                    ? (ArgumentString)"--no-optional-locks"
+                    : default)
             {
                 $"--porcelain={(GitVersion.Current.SupportStatusPorcelainV2 ? 2 : 1)} -z",
                 untrackedFiles,

--- a/GitCommands/Git/GitDeleteBranchCmd.cs
+++ b/GitCommands/Git/GitDeleteBranchCmd.cs
@@ -24,9 +24,8 @@ namespace GitCommands
             var hasRemoteBranch = _branches.Any(branch => branch.IsRemote);
             var hasNonRemoteBranch = _branches.Any(branch => !branch.IsRemote);
 
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("branch")
             {
-                "branch",
                 { _force, "-D", "-d" },
                 { hasRemoteBranch && hasNonRemoteBranch, "-a" },
                 { hasRemoteBranch && !hasNonRemoteBranch, "-r" },

--- a/GitCommands/Git/GitDeleteRemoteBranchesCmd.cs
+++ b/GitCommands/Git/GitDeleteRemoteBranchesCmd.cs
@@ -31,9 +31,8 @@ namespace GitCommands.Git
 
         protected override ArgumentString BuildArguments()
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("push")
             {
-                "push",
                 _remote,
                 _branches.Select(branch => $":refs/heads/{branch.Quote()}")
             };

--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -102,10 +102,15 @@ namespace GitCommands.Gpg
             return await Task.Run(() =>
             {
                 CommitStatus cmtStatus;
+                var args = new GitArgumentBuilder("log")
+                {
+                    "--pretty=\"format:%G?\"",
+                    "-1",
+                    revision.Guid
+                };
+                string gpg = module.RunGitCmd(args);
 
-                string gpg = module.RunGitCmd($"log --pretty=\"format:%G?\" -1 {revision.Guid}");
-
-                #pragma warning disable SA1025 // Code should not contain multiple whitespace in a row
+#pragma warning disable SA1025 // Code should not contain multiple whitespace in a row
                 switch (gpg)
                 {
                     case GoodSign:         // "G" for a good (valid) signature
@@ -126,7 +131,7 @@ namespace GitCommands.Gpg
                         cmtStatus = CommitStatus.NoSignature;
                         break;
                 }
-                #pragma warning restore SA1025 // Code should not contain multiple whitespace in a row
+#pragma warning restore SA1025 // Code should not contain multiple whitespace in a row
 
                 return cmtStatus;
             });
@@ -198,7 +203,13 @@ namespace GitCommands.Gpg
             }
 
             var module = GetModule();
-            return module.RunGitCmd($"log --pretty=\"format:%GG\" -1 {revision.Guid}");
+            var args = new GitArgumentBuilder("log")
+            {
+                "--pretty=\"format:%GG\"",
+                "-1",
+                revision.Guid
+            };
+            return module.RunGitCmd(args);
         }
 
         /// <summary>
@@ -224,10 +235,13 @@ namespace GitCommands.Gpg
                 return null;
             }
 
-            string rawFlag = raw ? "--raw" : "";
-
             var module = GetModule();
-            return module.RunGitCmd($"verify-tag {rawFlag} {tagName}");
+            var args = new GitArgumentBuilder("verify-tag")
+            {
+                { raw, "--raw" },
+                tagName
+            };
+            return module.RunGitCmd(args);
         }
 
         private string EvaluateTagVerifyMessage(IReadOnlyList<IGitRef> usefulTagRefs)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -566,7 +566,7 @@ namespace GitCommands
 
         public bool EditNotes(ObjectId commitId)
         {
-            var arguments = new ArgumentBuilder { "notes", "edit", commitId };
+            var arguments = new GitArgumentBuilder("notes") { "edit", commitId };
             var editor = GetEffectiveSetting("core.editor").ToLower();
             var createWindow = !editor.Contains("gitextensions") && !editor.Contains("notepad");
 
@@ -1610,9 +1610,8 @@ namespace GitCommands
 
         public ArgumentString FetchCmd([CanBeNull] string remote, [CanBeNull] string remoteBranch, [CanBeNull] string localBranch, bool? fetchTags = false, bool isUnshallow = false, bool prune = false)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("fetch")
             {
-                "fetch",
                 { GitVersion.Current.FetchCanAskForProgress, "--progress" },
                 {
                     !string.IsNullOrEmpty(remote) || !string.IsNullOrEmpty(remoteBranch) || !string.IsNullOrEmpty(localBranch),
@@ -1623,9 +1622,8 @@ namespace GitCommands
 
         public ArgumentString PullCmd(string remote, string remoteBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false, bool prune = false)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("pull")
             {
-                "pull",
                 { rebase, "--rebase" },
                 { GitVersion.Current.FetchCanAskForProgress, "--progress" },
                 GetFetchArgs(remote, remoteBranch, null, fetchTags, isUnshallow, prune && !rebase)
@@ -1702,9 +1700,8 @@ namespace GitCommands
         public ArgumentString PushAllCmd(string remote, ForcePushOptions force, bool track, int recursiveSubmodules)
         {
             // TODO make an enum for RecursiveSubmodulesOption and add to ArgumentBuilderExtensions
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("push")
             {
-                "push",
                 force,
                 { track, "-u" },
                 { recursiveSubmodules == 1, "--recurse-submodules=check" },
@@ -1737,9 +1734,8 @@ namespace GitCommands
             }
 
             // TODO make an enum for RecursiveSubmodulesOption and add to ArgumentBuilderExtensions
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("push")
             {
-                "push",
                 force,
                 { track, "-u" },
                 { recursiveSubmodules == 1, "--recurse-submodules=check" },
@@ -3043,9 +3039,8 @@ namespace GitCommands
             }
 
             var output = _gitExecutable.GetOutput(
-                new ArgumentBuilder
+                new GitArgumentBuilder("branch")
                 {
-                    "branch",
                     { getRemote && getLocal, "-a" },
                     { getRemote && !getLocal, "-r" },
                     "--contains",
@@ -3186,9 +3181,8 @@ namespace GitCommands
 
         public IEnumerable<IGitItem> GetTree(ObjectId commitId, bool full)
         {
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("ls-tree")
             {
-                "ls-tree",
                 "-z",
                 { full, "-r" },
                 commitId
@@ -3201,9 +3195,8 @@ namespace GitCommands
 
         public GitBlame Blame(string fileName, string from, Encoding encoding, string lines = null)
         {
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("blame")
             {
-                "blame",
                 "--porcelain",
                 { AppSettings.DetectCopyInFileOnBlame, "-M" },
                 { AppSettings.DetectCopyInAllOnBlame, "-C" },

--- a/GitCommands/Git/GitPushAction.cs
+++ b/GitCommands/Git/GitPushAction.cs
@@ -69,9 +69,8 @@ namespace GitCommands
         /// <summary>Creates the 'push' command string. <example>"push --progress origin master:master"</example></summary>
         public override string ToString()
         {
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("push")
             {
-                "push",
                 { ReportProgress, "--progress" },
                 Remote.Quote(),
                 PushActions.Select(action => action.ToString())

--- a/GitCommands/Git/Tag/GitCreateTagCmd.cs
+++ b/GitCommands/Git/Tag/GitCreateTagCmd.cs
@@ -21,9 +21,8 @@ namespace GitCommands.Git.Tag
 
         protected override ArgumentString BuildArguments()
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("tag")
             {
-                "tag",
                 { CreateTagArguments.Force, "-f" },
                 GetArgumentForOperation(),
                 { CreateTagArguments.Operation.CanProvideMessage(), $"-F {TagMessageFileName.Quote()}" },

--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
@@ -60,6 +62,19 @@ namespace GitCommands
             }
 
             _arguments.Append(s);
+        }
+
+        /// <summary>
+        /// Adds a range of arguments
+        /// </summary>
+        /// <param name="args">The arguments to add to this builder</param>
+        public void AddRange(IEnumerable<string> args)
+        {
+            args = args.Where(a => !string.IsNullOrEmpty(a));
+            foreach (string s in args)
+            {
+                Add(s);
+            }
         }
 
         /// <summary>

--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -37,6 +37,7 @@ namespace GitCommands
         private readonly StringBuilder _arguments = new StringBuilder(capacity: 16);
 
         public bool IsEmpty => _arguments.Length == 0;
+        public int Length => _arguments.Length;
 
         /// <summary>
         /// Adds <paramref name="s"/> to the argument list.

--- a/GitExtUtils/ArgumentString.cs
+++ b/GitExtUtils/ArgumentString.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using JetBrains.Annotations;
 
 namespace GitCommands
@@ -7,6 +8,7 @@ namespace GitCommands
     public readonly struct ArgumentString
     {
         [CanBeNull] public string Arguments { get; }
+        public int Length { get => Arguments?.Length ?? 0; }
 
         private ArgumentString([NotNull] string arguments)
         {

--- a/GitExtUtils/ArgumentString.cs
+++ b/GitExtUtils/ArgumentString.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Diagnostics;
-using GitCommands;
+﻿using System.Diagnostics;
 using JetBrains.Annotations;
 
-namespace GitUIPluginInterfaces
+namespace GitCommands
 {
     [DebuggerDisplay("{" + nameof(Arguments) + "}")]
     public readonly struct ArgumentString

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -47,6 +47,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ArgumentBuilder.cs" />
+    <Compile Include="ArgumentString.cs" />
     <Compile Include="ArrayExtensions.cs" />
     <Compile Include="GitArgumentBuilder.cs" />
     <Compile Include="GitUI\CancellationTokenSequence.cs" />

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3034,7 +3034,12 @@ namespace GitUI.CommandsDialogs
         {
             if (AppSettings.DontConfirmUndoLastCommit || MessageBox.Show(this, _undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
-                Module.RunGitCmd("reset --soft HEAD~1");
+                var args = new GitArgumentBuilder("reset")
+                {
+                    "--soft",
+                    "HEAD~1"
+                };
+                Module.RunGitCmd(args);
                 RefreshRevisions();
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -463,29 +463,29 @@ namespace GitUI.CommandsDialogs
             switch (e.KeyData)
             {
                 case Keys.Control | Keys.Enter when !Message.ContainsFocus:
-                {
-                    FocusCommitMessage();
-                    e.Handled = true;
-                    break;
-                }
+                    {
+                        FocusCommitMessage();
+                        e.Handled = true;
+                        break;
+                    }
 
                 case Keys.Control | Keys.P:
                 case Keys.Alt | Keys.Up:
                 case Keys.Alt | Keys.Left:
-                {
-                    MoveSelection(-1);
-                    e.Handled = true;
-                    break;
-                }
+                    {
+                        MoveSelection(-1);
+                        e.Handled = true;
+                        break;
+                    }
 
                 case Keys.Control | Keys.N:
                 case Keys.Alt | Keys.Down:
                 case Keys.Alt | Keys.Right:
-                {
-                    MoveSelection(+1);
-                    e.Handled = true;
-                    break;
-                }
+                    {
+                        MoveSelection(+1);
+                        e.Handled = true;
+                        break;
+                    }
             }
 
             base.OnKeyUp(e);
@@ -787,9 +787,8 @@ namespace GitUI.CommandsDialogs
 
             if (patch != null && patch.Length > 0)
             {
-                var args = new ArgumentBuilder
+                var args = new GitArgumentBuilder("apply")
                 {
-                    "apply",
                     "--cached",
                     "--whitespace=nowarn",
                     { _currentItemStaged,  "--reverse" }
@@ -860,9 +859,8 @@ namespace GitUI.CommandsDialogs
 
             if (patch != null && patch.Length > 0)
             {
-                var args = new ArgumentBuilder
+                var args = new GitArgumentBuilder("apply")
                 {
-                    "apply",
                     "--whitespace=nowarn",
                     { _currentItemStaged,  "--reverse --index" }
                 };
@@ -2230,8 +2228,14 @@ namespace GitUI.CommandsDialogs
 
             foreach (var (path, name) in modules)
             {
-                string diff = Module.RunGitCmd(
-                     string.Format("diff --cached -z -- {0}", name));
+                var args = new GitArgumentBuilder("diff")
+                {
+                    "--cached",
+                    "-z",
+                    "--",
+                    name.QuoteNE()
+                };
+                string diff = Module.RunGitCmd(args);
                 var lines = diff.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 const string subprojectCommit = "Subproject commit ";
                 var from = lines.Single(s => s.StartsWith("-" + subprojectCommit)).Substring(subprojectCommit.Length + 1);
@@ -2240,8 +2244,15 @@ namespace GitUI.CommandsDialogs
                 {
                     sb.AppendLine("Submodule " + path + ":");
                     var module = new GitModule(_fullPathResolver.Resolve(name.EnsureTrailingPathSeparator()));
-                    string log = module.RunGitCmd(
-                         string.Format("log --pretty=format:\"    %m %h - %s\" --no-merges {0}...{1}", from, to));
+                    args = new GitArgumentBuilder("log")
+                    {
+                        "--pretty = format:\"    %m %h - %s\"",
+                        "--no-merges",
+                        $"{from}...{to}"
+                    };
+
+                    string log = module.RunGitCmd(args);
+
                     if (log.Length != 0)
                     {
                         sb.AppendLine(log);

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Windows.Forms;
+using GitCommands;
 using GitUIPluginInterfaces;
 using ResourceManager;
 
@@ -53,7 +54,12 @@ namespace GitUI.CommandsDialogs
             void ProcessStart(FormStatus form)
             {
                 form.AddMessageLine(string.Format(_stageFilename.Text, _filename));
-                string output = Module.RunGitCmd($"add -- \"{_filename}\"");
+                var args = new GitArgumentBuilder("add")
+                {
+                    "--",
+                    _filename.QuoteNE()
+                };
+                string output = Module.RunGitCmd(args);
                 form.AddMessageLine(output);
                 form.Done(isSuccess: string.IsNullOrWhiteSpace(output));
             }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -721,7 +721,12 @@ namespace GitUI.CommandsDialogs
             string remoteBranchName = Module.GetSetting(string.Format("branch.{0}.merge", _branch));
             if (!remoteBranchName.IsNullOrEmpty())
             {
-                remoteBranchName = Module.RunGitCmd(string.Format("name-rev --name-only \"{0}\"", remoteBranchName)).Trim();
+                var args = new GitArgumentBuilder("name=rev")
+                {
+                    "--name-only",
+                    remoteBranchName.QuoteNE()
+                };
+                remoteBranchName = Module.RunGitCmd(args).Trim();
             }
 
             return remoteBranchName;

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -71,7 +72,11 @@ namespace GitUI.CommandsDialogs
             {
                 var item = (string)Branches.SelectedItem;
                 await TaskScheduler.Default;
-                var arguments = $"reflog --no-abbrev {item}";
+                var arguments = new GitArgumentBuilder("reflog")
+                {
+                    "--no-abbrev",
+                    item
+                };
                 var output = UICommands.GitModule.RunGitCmd(arguments);
                 var refLines = ConvertReflogOutput().ToList();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -895,7 +895,12 @@ namespace GitUI.CommandsDialogs
                 if (frm.KeepBase)
                 {
                     // delete
-                    Module.RunGitCmd("rm -- \"" + item.Filename + "\"");
+                    var args = new GitArgumentBuilder("rm")
+                    {
+                        "--",
+                        item.Filename.QuoteNE()
+                    };
+                    Module.RunGitCmd(args);
                 }
 
                 if (frm.KeepLocal)
@@ -942,7 +947,12 @@ namespace GitUI.CommandsDialogs
                 if (frm.KeepLocal)
                 {
                     // delete
-                    Module.RunGitCmd("rm -- \"" + item.Filename + "\"");
+                    var args = new GitArgumentBuilder("rm")
+                    {
+                        "--",
+                        item.Filename.QuoteNE()
+                    };
+                    Module.RunGitCmd(args);
                 }
 
                 if (frm.KeepRemote)
@@ -989,7 +999,12 @@ namespace GitUI.CommandsDialogs
                 if (frm.KeepRemote)
                 {
                     // remote
-                    Module.RunGitCmd("rm -- \"" + item.Filename + "\"");
+                    var args = new GitArgumentBuilder("rm")
+                    {
+                        "--",
+                        item.Filename.QuoteNE()
+                    };
+                    Module.RunGitCmd(args);
                 }
             }
 
@@ -1184,7 +1199,12 @@ namespace GitUI.CommandsDialogs
             void ProcessStart(FormStatus form)
             {
                 form.AddMessageLine(string.Format(_stageFilename.Text, filename));
-                string output = Module.RunGitCmd("add -- \"" + filename + "\"");
+                var args = new GitArgumentBuilder("add")
+                {
+                    "--",
+                    filename.QuoteNE()
+                };
+                string output = Module.RunGitCmd(args);
                 form.AddMessageLine(output);
                 form.Done(isSuccess: string.IsNullOrWhiteSpace(output));
             }

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -28,9 +28,17 @@ namespace GitUI.CommandsDialogs
             /// %s  - subject.
             /// %ct - committer date, UNIX timestamp (easy to parse format).
             /// </summary>
-            private const string LogCommandArgumentsFormat = "log -n1 --pretty=format:\"%aN, %e, %s, %ct, %P\" {0}";
+            private static readonly string LogCommandArgumentsFormat = (ArgumentString)new GitArgumentBuilder("log")
+            {
+                "-n1",
+                "--pretty=format:\"%aN, %e, %s, %ct, %P\" {0}"
+            };
 
-            private const string TagCommandArgumentsFormat = "cat-file -p {0}";
+            private static readonly string TagCommandArgumentsFormat = (ArgumentString)new GitArgumentBuilder("cat-file")
+            {
+                "-p",
+                "{0}"
+            };
 
             private static readonly Regex RawDataRegex = new Regex(@"^((dangling|missing|unreachable) (commit|blob|tree|tag)|warning in tree) ([a-f\d]{40})(.)*$", RegexOptions.Compiled);
             private static readonly Regex LogRegex = new Regex(@"^([^,]+), (.*), (.+), (\d+), (.+)?$", RegexOptions.Compiled | RegexOptions.Singleline);
@@ -145,7 +153,7 @@ namespace GitUI.CommandsDialogs
                 string GetLostCommitLog() => VerifyHashAndRunCommand(LogCommandArgumentsFormat);
                 string GetLostTagData() => VerifyHashAndRunCommand(TagCommandArgumentsFormat);
 
-                string VerifyHashAndRunCommand(string commandFormat)
+                string VerifyHashAndRunCommand(ArgumentString commandFormat)
                 {
                     return module.RunGitCmd(string.Format(commandFormat, objectId), GitModule.LosslessEncoding);
                 }

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -105,9 +105,8 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         {
             // https://git-scm.com/docs/git-worktree
 
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("worktree")
             {
-                "worktree",
                 "add",
                 WorktreeDirectory.Quote(),
                 { radioButtonCreateNewBranch.Checked, $"-b {textBoxNewBranchName.Text}", ((GitRef)comboBoxBranches.SelectedItem).Name }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1308,7 +1308,11 @@ namespace GitUI.Editor
         private void applySelectedLines(int selectionStart, int selectionLength, bool reverse)
         {
             // Prepare git command
-            const string args = "apply --3way --whitespace=nowarn";
+            var args = new GitArgumentBuilder("apply")
+            {
+                "--3way",
+                "--whitespace=nowarn"
+            };
 
             byte[] patch;
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -623,7 +623,12 @@ namespace GitUI
             {
                 if (onlyWorkTree)
                 {
-                    Module.RunGitCmd("checkout -- .");
+                    var args = new GitArgumentBuilder("checkout")
+                    {
+                        "--",
+                        "."
+                    };
+                    Module.RunGitCmd(args);
                 }
                 else
                 {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1149,9 +1149,8 @@ namespace GitUI
         [NotNull]
         private IEnumerable<ObjectId> TryGetParents(ObjectId objectId)
         {
-            var args = new ArgumentBuilder
+            var args = new GitArgumentBuilder("rev-list")
             {
-                "rev-list",
                 { AppSettings.OrderRevisionByDate, "--date-order" },
                 { AppSettings.MaxRevisionGraphCommits > 0, $"--max-count={AppSettings.MaxRevisionGraphCommits}" },
                 objectId

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubmodules.csproj
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubmodules.csproj
@@ -56,6 +56,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{d3440fd7-afc5-4351-8741-6cdbf15ce944}</Project>
       <Name>ResourceManager</Name>

--- a/Plugins/BackgroundFetch/BackgroundFetch.csproj
+++ b/Plugins/BackgroundFetch/BackgroundFetch.csproj
@@ -63,6 +63,10 @@
       <Name>GitCommands</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{D3440FD7-AFC5-4351-8741-6CDBF15CE944}</Project>
       <Name>ResourceManager</Name>

--- a/Plugins/CreateLocalBranches/CreateLocalBranches.csproj
+++ b/Plugins/CreateLocalBranches/CreateLocalBranches.csproj
@@ -62,6 +62,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
       <Project>{27559302-F35E-4B62-A6EC-11FF21A5FA6F}</Project>
       <Name>GitUIPluginInterfaces</Name>

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using GitCommands;
 using GitUIPluginInterfaces;
 
 namespace CreateLocalBranches
@@ -18,7 +19,8 @@ namespace CreateLocalBranches
 
         private void button1_Click(object sender, EventArgs e)
         {
-            string[] references = _gitUiCommands.GitModule.RunGitCmd("branch -a")
+            var args = new GitArgumentBuilder("branch") { "-a" };
+            string[] references = _gitUiCommands.GitModule.RunGitCmd(args)
                 .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             if (references.Length == 0)
@@ -36,7 +38,13 @@ namespace CreateLocalBranches
 
                     if (branchName.StartsWith("remotes/" + _NO_TRANSLATE_Remote.Text + "/"))
                     {
-                        _gitUiCommands.GitModule.RunGitCmd(string.Concat("branch --track ", branchName.Replace("remotes/" + _NO_TRANSLATE_Remote.Text + "/", ""), " ", branchName));
+                        args = new GitArgumentBuilder("branch")
+                        {
+                            "--track",
+                            branchName.Replace($"remotes/{_NO_TRANSLATE_Remote.Text}/", ""),
+                            branchName
+                        };
+                        _gitUiCommands.GitModule.RunGitCmd(args);
                     }
                 }
                 catch

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
@@ -67,6 +67,10 @@
     <Compile Include="SortableBranchesList.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <Project>{bd6aa2a2-997d-4aff-acc7-b64f6e51d181}</Project>
+      <Name>GitCommands</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
       <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
       <Name>GitExtUtils</Name>

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -42,9 +42,8 @@ namespace Gerrit
 
         private static ArgumentString PushCmd(string remote, string toBranch)
         {
-            return new ArgumentBuilder
+            return new GitArgumentBuilder("push")
             {
-                "push",
                 { GitVersion.Current.PushCanAskForProgress, "--progress" },
                 remote.ToPosixPath().Trim().Quote(),
                 $"HEAD:{GitRefName.GetFullBranchName(toBranch)?.Replace(" ", "")}"

--- a/Plugins/Gerrit/GerritUtil.cs
+++ b/Plugins/Gerrit/GerritUtil.cs
@@ -24,7 +24,14 @@ namespace Gerrit
 
         public static Uri GetFetchUrl(IGitModule module, string remote)
         {
-            string remotes = module.RunGitCmd("remote show -n \"" + remote + "\"");
+            var args = new GitArgumentBuilder("remote")
+            {
+                "show",
+                "-n",
+                remote.QuoteNE()
+            };
+
+            string remotes = module.RunGitCmd(args);
 
             string fetchUrlLine = remotes.Split('\n').Select(p => p.Trim()).First(p => p.StartsWith("Push"));
 

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -56,7 +56,6 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="ArgumentString.cs" />
     <Compile Include="BuildServerIntegration\BuildDurationFormatter.cs" />
     <Compile Include="BuildServerIntegration\BuildInfo.cs" />
     <Compile Include="BuildServerIntegration\BuildServerAdapterMetadataAttribute.cs" />

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using GitCommands;
 using JetBrains.Annotations;
 
 namespace GitUIPluginInterfaces

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using GitCommands;
 using JetBrains.Annotations;
 
 namespace GitUIPluginInterfaces

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitUI;
 using GitUI.Avatars;
 using GitUIPluginInterfaces;
@@ -87,7 +88,8 @@ namespace Gource
                 File.Delete(file);
             }
 
-            var lines = GitUIArgs.GitModule.RunGitCmd("log --pretty=format:\"%aE|%aN\"").Split('\n');
+            var args = new GitArgumentBuilder("log") { "--pretty=format:\"%aE|%aN\"" };
+            var lines = GitUIArgs.GitModule.RunGitCmd(args).Split('\n');
 
             var authors = lines.Select(
                 line =>

--- a/Plugins/ProxySwitcher/ProxySwitcher.csproj
+++ b/Plugins/ProxySwitcher/ProxySwitcher.csproj
@@ -67,6 +67,10 @@
       <Name>GitCommands</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{D3440FD7-AFC5-4351-8741-6CDBF15CE944}</Project>
       <Name>ResourceManager</Name>

--- a/Plugins/ProxySwitcher/ProxySwitcherForm.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherForm.cs
@@ -2,9 +2,9 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using GitCommands;
 using GitUIPluginInterfaces;
 using ResourceManager;
-using Settings = GitCommands.AppSettings;
 
 namespace ProxySwitcher
 {
@@ -55,8 +55,19 @@ namespace ProxySwitcher
 
         private void RefreshProxy()
         {
-            LocalHttpProxy_TextBox.Text = HidePassword(_gitCommands.RunGitCmd("config --get http.proxy"));
-            GlobalHttpProxy_TextBox.Text = HidePassword(_gitCommands.RunGitCmd("config --global --get http.proxy"));
+            var args = new GitArgumentBuilder("config")
+            {
+                "--get",
+                "http.proxy"
+            };
+            LocalHttpProxy_TextBox.Text = HidePassword(_gitCommands.RunGitCmd(args));
+            args = new GitArgumentBuilder("config")
+            {
+                "--global",
+                "--get",
+                "http.proxy"
+            };
+            GlobalHttpProxy_TextBox.Text = HidePassword(_gitCommands.RunGitCmd(args));
             ApplyGlobally_CheckBox.Checked = string.Equals(LocalHttpProxy_TextBox.Text, GlobalHttpProxy_TextBox.Text);
         }
 
@@ -99,11 +110,13 @@ namespace ProxySwitcher
         {
             var httpProxy = BuildHttpProxy();
 
-            var arguments = ApplyGlobally_CheckBox.Checked
-                ? $"config --global http.proxy {httpProxy}"
-                : $"config http.proxy {httpProxy}";
-
-            _gitCommands.RunGitCmd(arguments);
+            var args = new GitArgumentBuilder("config")
+            {
+                { ApplyGlobally_CheckBox.Checked, "--global" },
+                "http.proxy",
+                httpProxy
+            };
+            _gitCommands.RunGitCmd(args);
 
             RefreshProxy();
         }

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGenerator.csproj
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGenerator.csproj
@@ -70,6 +70,10 @@
       <Project>{BD6AA2A2-997D-4AFF-ACC7-B64F6E51D181}</Project>
       <Name>GitCommands</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
+      <Name>GitExtUtils</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
       <Project>{D3440FD7-AFC5-4351-8741-6CDBF15CE944}</Project>
       <Name>ResourceManager</Name>

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Windows.Forms;
+using GitCommands;
 using GitCommands.Utils;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -58,8 +59,12 @@ namespace ReleaseNotesGenerator
                 return;
             }
 
-            string logArgs = string.Format(_NO_TRANSLATE_textBoxGitLogArguments.Text, textBoxRevFrom.Text, textBoxRevTo.Text);
-            string result = _gitUiCommands.GitModule.RunGitCmd("log " + logArgs);
+            var args = new GitArgumentBuilder("log")
+            {
+                string.Format(_NO_TRANSLATE_textBoxGitLogArguments.Text, textBoxRevFrom.Text, textBoxRevTo.Text)
+            };
+
+            string result = _gitUiCommands.GitModule.RunGitCmd(args);
 
             if (EnvUtils.RunningOnWindows())
             {

--- a/UnitTests/GitCommandsTests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommandsTests/Config/ConfigFileTest.cs
@@ -55,13 +55,26 @@ namespace GitCommandsTests.Config
 
         private void AddConfigValue(string cfgFile, string section, string value)
         {
-            string args = "config -f " + "\"" + cfgFile + "\"" + " --add " + section + " " + value;
+            var args = new GitArgumentBuilder("config")
+            {
+                "-f",
+                cfgFile.QuoteNE(),
+                "--add",
+                section,
+                value
+            };
             Module.RunGitCmd(args);
         }
 
         private string GetConfigValue(string cfgFile, string key)
         {
-            string args = "config -f " + "\"" + cfgFile + "\"" + " --get " + key.Quote();
+            var args = new GitArgumentBuilder("config")
+            {
+                "-f",
+                cfgFile.QuoteNE(),
+                "--get",
+                key.Quote()
+            };
             return Module.RunGitCmd(args).TrimEnd('\n');
         }
 

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -370,8 +370,15 @@ namespace GitCommandsTests
         [Test]
         public void GetParents_calls_correct_command_and_parses_response()
         {
+            var args = new GitArgumentBuilder("log")
+            {
+                "-n 1",
+                "--format=format:%P",
+                Sha1
+            };
+
             using (_executable.StageOutput(
-                $"log -n 1 --format=format:%P \"{Sha1}\"",
+                args.ToString(),
                 $"{Sha2} {Sha3}"))
             {
                 var parents = _gitModule.GetParents(Sha1);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5479 

Changes proposed in this pull request:
- [x] Use GitArgumentBuilder for ALL RunGitCmd... calls
- [x] Use GitArgumentBuilder for ALL _gitExecutable.Execute calls
- [x] Replace Git arguments created by using ArgumentBuilder with GitArgumentBuilder
- [x] Use GitArgumnentBuilder for all other ways of running git comands not found yet.

Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
Not there yet
Has been tested on (remove any that don't apply):
- GIT 2.19 and above

