### PR TITLE
Fix branch filter crash

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3028,6 +3028,11 @@ namespace GitUI.CommandsDialogs
 
         private void toolStripBranchFilterComboBox_Click(object sender, EventArgs e)
         {
+            if (toolStripBranchFilterComboBox.Items.Count == 0)
+            {
+                return;
+            }
+
             toolStripBranchFilterComboBox.DroppedDown = true;
         }
 


### PR DESCRIPTION
Fixes #4370 Branch filter not working (fix only crash)

Changes proposed in this pull request:
- Fix GE crash when there is no branch name contains branch filter text.
 
Screenshots before and after (if PR changes UI):
![shot_180926_114453](https://user-images.githubusercontent.com/5438647/46068371-b071f380-c181-11e8-8a74-99f54a9edbbf.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10 x64
