### PR TITLE
Fix blame options mismatch name and function

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -116,8 +116,8 @@ namespace GitUI.CommandsDialogs
             if (blameTabExists)
             {
                 ignoreWhitespaceToolStripMenuItem.Checked = AppSettings.IgnoreWhitespaceOnBlame;
-                detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
-                detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
+                detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
+                detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
             }
 
             if (filterByRevision && revision?.Guid != null)
@@ -558,15 +558,15 @@ namespace GitUI.CommandsDialogs
 
         private void detectMoveAndCopyInAllFilesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.DetectCopyInFileOnBlame = !AppSettings.DetectCopyInFileOnBlame;
-            detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
+            AppSettings.DetectCopyInAllOnBlame = !AppSettings.DetectCopyInAllOnBlame;
+            detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
             UpdateSelectedFileViewers(true);
         }
 
         private void detectMoveAndCopyInThisFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.DetectCopyInAllOnBlame = !AppSettings.DetectCopyInAllOnBlame;
-            detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
+            AppSettings.DetectCopyInFileOnBlame = !AppSettings.DetectCopyInFileOnBlame;
+            detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
             UpdateSelectedFileViewers(true);
         }
 


### PR DESCRIPTION
Fixes #5485 Fix blame options mismatch name and function

Changes proposed in this pull request:
- Make option "Detect move and copy in **this** file" use -M insted -C
- Make option "Detect move and copy in **all** file" use -C insted -M
 
Screenshots before and after (if PR changes UI):
![shot_180926_165742](https://user-images.githubusercontent.com/5438647/46084871-538c3280-c1ad-11e8-9406-147c6fc8507e.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.18 and above
- Windows 10 x64
