### PR TITLE
Browse: refresh git status count

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -185,6 +185,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
         }
 
+        public void RequestRefresh()
+        {
+            CalculateNextUpdateTime(UpdateDelay);
+        }
+
         public void Dispose()
         {
             _workTreeWatcher.Dispose();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1453,6 +1453,7 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshButtonClick(object sender, EventArgs e)
         {
+            _gitStatusMonitor.RequestRefresh();
             RefreshRevisions();
         }
 


### PR DESCRIPTION
Changes proposed in this pull request:
-  Refresh button should force a recalculation of the git-status count

One scenario is that if the update time is very long (the time is dynamic based on update time), the user expects the count to update by explicit refresh.
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Open Git Command Log
- Refresh button
- Verify that git-status runs in about a second, can be longer if git-status has run recently (will be improved with #5487) 

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
