### PR TITLE
Compare item in revision grid context menu now uses Diff icon

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -299,6 +299,7 @@ namespace GitUI
             // 
             // compareToolStripMenuItem
             // 
+            this.compareToolStripMenuItem.Image = global::GitUI.Properties.Images.Diff;
             this.compareToolStripMenuItem.Name = "compareToolStripMenuItem";
             this.compareToolStripMenuItem.Size = new System.Drawing.Size(230, 22);
             this.compareToolStripMenuItem.Text = "Compare";


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5432

Changes proposed in this pull request:
- Add icon to Compare menu item in revision grid context menu
 
Screenshots before and after (if PR changes UI):

**Before**

![before](https://user-images.githubusercontent.com/483470/46272657-f1835280-c549-11e8-9ddc-c0c48aedeb1c.png)

**After**

![after](https://user-images.githubusercontent.com/483470/46272671-04962280-c54a-11e8-9b60-39c5522efc0a.png)

What did I do to test the code and ensure quality:
- Manually tested by building the app and using the browse dialog

Has been tested on (remove any that don't apply):
- GIT 2.11 and above (2.18)
- Windows 7 and above (Win 10)
