### PR TITLE
Bugfix/i5493 history artificial

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -210,8 +210,8 @@ namespace GitUI.CommandsDialogs
             // tabControl1
             // 
             this.tabControl1.Controls.Add(this.CommitInfoTabPage);
-            this.tabControl1.Controls.Add(this.ViewTab);
             this.tabControl1.Controls.Add(this.DiffTab);
+            this.tabControl1.Controls.Add(this.ViewTab);
             this.tabControl1.Controls.Add(this.BlameTab);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tabControl1.Location = new System.Drawing.Point(0, 0);

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -328,6 +329,36 @@ namespace GitUI.CommandsDialogs
             }
 
             SetTitle(fileName);
+
+            if (revision.IsArtificial)
+            {
+                tabControl1.SelectedTab = DiffTab;
+
+                CommitInfoTabPage.Parent = null;
+                BlameTab.Parent = null;
+                ViewTab.Parent = null;
+            }
+            else
+            {
+                if (CommitInfoTabPage.Parent == null)
+                {
+                    tabControl1.TabPages.Insert(0, CommitInfoTabPage);
+                }
+
+                if (ViewTab.Parent == null)
+                {
+                    var index = tabControl1.TabPages.IndexOf(DiffTab);
+                    Debug.Assert(index != -1, "TabControl should contain diff tab page");
+                    tabControl1.TabPages.Insert(index + 1, ViewTab);
+                }
+
+                if (BlameTab.Parent == null)
+                {
+                    var index = tabControl1.TabPages.IndexOf(ViewTab);
+                    Debug.Assert(index != -1, "TabControl should contain view tab page");
+                    tabControl1.TabPages.Insert(index + 1, BlameTab);
+                }
+            }
 
             if (tabControl1.SelectedTab == BlameTab)
             {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -70,8 +70,8 @@ namespace GitUI.CommandsDialogs
                     Images =
                     {
                         Images.CommitSummary,
-                        Images.ViewFile,
                         Images.Diff,
+                        Images.ViewFile,
                         Images.Blame
                     }
                 };


### PR DESCRIPTION
Fixes #5493 

Changes proposed in this pull request:
- For artificial commits in FileHistory, only show the FileHistory
See issue for motivations
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/46377075-f9e9a380-c697-11e8-9f3f-6c35d5495fc8.png)
Crash selecting other tabs

- 
![image](https://user-images.githubusercontent.com/6248932/46377140-184f9f00-c698-11e8-8409-b3cd14156aac.png)

What did I do to test the code and ensure quality:
- See issue for testing
- Code is similar to Browse handling of tabs

Has been tested on (remove any that don't apply):
- GIT 2.19