### PR TITLE
Fix duplicate CRLF when copying

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.sln text eol=crlf
 *.sh text eol=lf
 *.py text eol=lf
+*.bin binary
+*.approved.* binary

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ packages/
 GitExtensions.*.sln.VisualState.xml
 GitExtensions.settings.backup
 /Setup/*.zip
+*.received.*

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -475,5 +475,19 @@ namespace GitUI.Editor
             internal bool CaretVisible; // if not, FirstVisibleLine has priority for restoring
             internal DiffLineInfo ActiveLineNum;
         }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FileViewerInternal _control;
+
+            public TestAccessor(FileViewerInternal control)
+            {
+                _control = control;
+            }
+
+            public TextEditorControl TextEditor => _control.TextEditor;
+        }
     }
 }

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.MacLines.false.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.MacLines.false.approved.txt
@@ -1,0 +1,1 @@
+﻿Line 1Line 2Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.MacLines.input.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.MacLines.input.approved.txt
@@ -1,0 +1,1 @@
+﻿Line 1Line 2Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.MacLines.true.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.MacLines.true.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.UnixLines.false.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.UnixLines.false.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.UnixLines.input.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.UnixLines.input.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.UnixLines.true.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.UnixLines.true.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.WindowsLines.false.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.WindowsLines.false.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.WindowsLines.input.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.WindowsLines.input.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.WindowsLines.true.approved.txt
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending.ForScenario.WindowsLines.true.approved.txt
@@ -1,0 +1,4 @@
+﻿Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Reflection;
+using System.Threading;
+using System.Windows.Forms;
+using ApprovalTests;
+using ApprovalTests.Namers;
+using CommonTestUtils;
+using GitCommands.Settings;
+using GitUI;
+using GitUI.Editor;
+using ICSharpCode.TextEditor;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.Editor
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public class FileViewerTextTests
+    {
+        private IGitUICommandsSource _uiCommandsSource;
+        private FileViewer _fileViewer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _uiCommandsSource = Substitute.For<IGitUICommandsSource>();
+            _fileViewer = new FileViewer();
+        }
+
+        [Test]
+        [TestCase(AutoCRLFType.@true, "UnixLines")]
+        [TestCase(AutoCRLFType.@true, "MacLines")]
+        [TestCase(AutoCRLFType.@true, "WindowsLines")]
+        [TestCase(AutoCRLFType.@false, "UnixLines")]
+        [TestCase(AutoCRLFType.@false, "MacLines")]
+        [TestCase(AutoCRLFType.@false, "WindowsLines")]
+        [TestCase(AutoCRLFType.input, "UnixLines")]
+        [TestCase(AutoCRLFType.input, "MacLines")]
+        [TestCase(AutoCRLFType.input, "WindowsLines")]
+        public void DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending(AutoCRLFType autoCRLFType, string file)
+        {
+            using (var testHelper = new GitModuleTestHelper())
+            {
+                testHelper.CreateRepoFile(@".git\config", $"[core]\n\tautocrlf = {autoCRLFType}");
+                var content = EmbeddedResourceLoader.Load(Assembly.GetExecutingAssembly(), $"{GetType().Namespace}.MockData.{file}.bin");
+
+                var uiCommands = new GitUICommands(testHelper.Module);
+                _uiCommandsSource.UICommands.Returns(x => uiCommands);
+                _fileViewer.UICommandsSource = _uiCommandsSource;
+
+                var fvi = _fileViewer.GetTestAccessor().FileViewerInternal;
+                fvi.SetText(content, null, false);
+                var doc = fvi.GetTestAccessor().TextEditor.Document;
+                var end = doc.OffsetToPosition(content.Length);
+                fvi.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(new TextLocation(0, 0), end);
+
+                // act - 'copy to selection' menu click will call through to DoAutoCRLF
+                _fileViewer.GetTestAccessor().CopyToolStripMenuItem.PerformClick();
+
+                // assert
+                var text = Clipboard.GetText();
+                using (ApprovalResults.ForScenario(file, autoCRLFType))
+                {
+                    Approvals.Verify(text);
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/GitUITests/Editor/MockData/MacLines.bin
+++ b/UnitTests/GitUITests/Editor/MockData/MacLines.bin
@@ -1,0 +1,1 @@
+Line 1Line 2Line 3

--- a/UnitTests/GitUITests/Editor/MockData/UnixLines.bin
+++ b/UnitTests/GitUITests/Editor/MockData/UnixLines.bin
@@ -1,0 +1,4 @@
+Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/Editor/MockData/WindowsLines.bin
+++ b/UnitTests/GitUITests/Editor/MockData/WindowsLines.bin
@@ -1,0 +1,4 @@
+Line 1
+Line 2
+
+Line 3

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
@@ -67,6 +68,7 @@
     <Compile Include="CommandsDialogs\RevisionDiffControllerTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />
+    <Compile Include="Editor\FileViewerTextTests.cs" />
     <Compile Include="FindFilePredicateProviderTest.cs" />
     <Compile Include="Helpers\DiffKindRevisionTests.cs" />
     <Compile Include="ControlUtilTests.cs" />
@@ -99,6 +101,7 @@
     <None Include="Editor\Diff\SampleCombined.diff">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <EmbeddedResource Include="Editor\MockData\MacLines.bin" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Externals\conemu-inside\ConEmuWinForms\ConEmuWinForms.csproj">
@@ -133,6 +136,10 @@
       <Project>{7B1F2FA0-E17D-499B-AF86-D49DBEF8C548}</Project>
       <Name>CommonTestUtils</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Editor\MockData\UnixLines.bin" />
+    <EmbeddedResource Include="Editor\MockData\WindowsLines.bin" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/UnitTests/GitUITests/Properties/AssemblyInfo.cs
+++ b/UnitTests/GitUITests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using ApprovalTests.Reporters;
 using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
@@ -36,3 +37,4 @@ using CommonTestUtils;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ConfigureJoinableTaskFactory]
+[assembly: UseReporter(typeof(DiffReporter))]


### PR DESCRIPTION
Fixes #5440

Sometimes, somehow the repository (or the text that is displayed in the UI) contains Windows line endings while AutoCRLF is set to true.

Changes proposed in this pull request:
- Fix the annoying bug that sometimes line breaks are duplicated if a text is copy'pasted

What did I do to test the code and ensure quality:
- Used the test repo from the issue to reproduce the bug and made sure that the change fixes the bug
- Tried copy&paste at a repo where the bug didn't occur (the GitExtensions repo actually) - no change in behavior

Has been tested on (remove any that don't apply):
- GIT 2.18.0
- Windows 10 1803 64 Bit

Questions:
- Should the fix also be applied to the 2.51 branch? If yes, what would be the best way? Cherry-pick of this commit? Who should do this?
- Is it possible to write an automatic test for this without too much complexity? If someone says "yes" I would add an automatic test.