### PR TITLE
Fix an exception swallowing in UI thread under debugger #5507

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Configuration;
+using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 using GitCommands;
@@ -36,8 +37,11 @@ namespace GitExtensions
                 NBug.Settings.SleepBeforeSend = 30;
                 NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
 
-                AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
-                Application.ThreadException += NBug.Handler.ThreadException;
+                if (!Debugger.IsAttached)
+                {
+                    AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
+                    Application.ThreadException += NBug.Handler.ThreadException;
+                }
             }
             catch (TypeInitializationException tie)
             {

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -33,8 +34,11 @@ namespace TranslationApp
                 NBug.Settings.SleepBeforeSend = 30;
                 NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
 
-                AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
-                Application.ThreadException += NBug.Handler.ThreadException;
+                if (!Debugger.IsAttached)
+                {
+                    AppDomain.CurrentDomain.UnhandledException += NBug.Handler.UnhandledException;
+                    Application.ThreadException += NBug.Handler.ThreadException;
+                }
             }
 
             // This form created for obtain UI synchronization context only


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5507 Swallow the exceptions in UI thread under VS debugger

Changes proposed in this pull request:
- Make behaviour under VS debugger and without it the same.

What did I do to test the code and ensure quality:
- Manual testing 

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10 x64
