### PR TITLE
RevisionGrid: Add icons in contextual menu

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -407,24 +407,28 @@ namespace GitUI
             // 
             // navigateToolStripMenuItem
             // 
+            this.navigateToolStripMenuItem.Image = global::GitUI.Properties.Images.GotoCommit;
             this.navigateToolStripMenuItem.Name = "navigateToolStripMenuItem";
             this.navigateToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
             this.navigateToolStripMenuItem.Text = "Navigate";
             // 
             // viewToolStripMenuItem
             // 
+            this.viewToolStripMenuItem.Image = global::GitUI.Properties.Images.AdvancedSettings;
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
             this.viewToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
             this.viewToolStripMenuItem.Text = "View";
             // 
             // runScriptToolStripMenuItem
             // 
+            this.runScriptToolStripMenuItem.Image = global::GitUI.Properties.Images.Console;
             this.runScriptToolStripMenuItem.Name = "runScriptToolStripMenuItem";
             this.runScriptToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
             this.runScriptToolStripMenuItem.Text = "Run script";
             // 
             // openBuildReportToolStripMenuItem
             // 
+            this.openBuildReportToolStripMenuItem.Image = global::GitUI.Properties.Images.Integration;
             this.openBuildReportToolStripMenuItem.Name = "openBuildReportToolStripMenuItem";
             this.openBuildReportToolStripMenuItem.Size = new System.Drawing.Size(301, 26);
             this.openBuildReportToolStripMenuItem.Text = "Open build report in the browser";


### PR DESCRIPTION
for the ones that don't have one

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Follow up of #5495

Changes proposed in this pull request:
- Icons used are the same than the ones used in the settings to keep consistency


 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/460196/46535347-67215280-c8ab-11e8-903c-1a498cb4940a.png)

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
