### PR TITLE
FormCommit: fix icon branch display in status bar

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -251,6 +251,7 @@ namespace GitUI.CommandsDialogs
             ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowCheckMargin = false;
 
             selectionFilter.Size = DpiUtil.Scale(selectionFilter.Size);
+            toolStripStatusBranchIcon.Size = DpiUtil.Scale(toolStripStatusBranchIcon.Size);
 
             _splitterManager.AddSplitter(splitMain, "splitMain");
             _splitterManager.AddSplitter(splitRight, "splitRight");


### PR DESCRIPTION
Changes proposed in this pull request:
- fix display of the icon that was no more visible in hdpi
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/460196/46535536-021a2c80-c8ac-11e8-95f3-bed9b9ac5f29.png)

Has been tested on (remove any that don't apply):
- GIT 2.17 and above
- Windows 10 (hdpi)
