### PR TITLE
FormBrowse: Add some missing icons in menus

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -944,6 +944,7 @@ namespace GitUI.CommandsDialogs
             // 
             // closeToolStripMenuItem
             // 
+            this.closeToolStripMenuItem.Image = global::GitUI.Properties.Images.DashboardFolderGit;
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.closeToolStripMenuItem.Text = "Close (go to Dashboard)";
@@ -1033,6 +1034,7 @@ namespace GitUI.CommandsDialogs
             // 
             // updateAllSubmodulesToolStripMenuItem
             // 
+            this.updateAllSubmodulesToolStripMenuItem.Image = global::GitUI.Properties.Images.SubmodulesUpdate;
             this.updateAllSubmodulesToolStripMenuItem.Name = "updateAllSubmodulesToolStripMenuItem";
             this.updateAllSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.updateAllSubmodulesToolStripMenuItem.Text = "Update all submodules";
@@ -1040,6 +1042,7 @@ namespace GitUI.CommandsDialogs
             // 
             // synchronizeAllSubmodulesToolStripMenuItem
             // 
+            this.synchronizeAllSubmodulesToolStripMenuItem.Image = global::GitUI.Properties.Images.SubmodulesSync;
             this.synchronizeAllSubmodulesToolStripMenuItem.Name = "synchronizeAllSubmodulesToolStripMenuItem";
             this.synchronizeAllSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.synchronizeAllSubmodulesToolStripMenuItem.Text = "Synchronize all submodules";
@@ -1081,6 +1084,7 @@ namespace GitUI.CommandsDialogs
             // 
             // editgitignoreToolStripMenuItem1
             // 
+            this.editgitignoreToolStripMenuItem1.Image = global::GitUI.Properties.Images.EditGitIgnore;
             this.editgitignoreToolStripMenuItem1.Name = "editgitignoreToolStripMenuItem1";
             this.editgitignoreToolStripMenuItem1.Size = new System.Drawing.Size(221, 22);
             this.editgitignoreToolStripMenuItem1.Text = "Edit .gitignore";
@@ -1349,6 +1353,7 @@ namespace GitUI.CommandsDialogs
             // 
             // runMergetoolToolStripMenuItem
             // 
+            this.runMergetoolToolStripMenuItem.Image = global::GitUI.Properties.Images.Conflict;
             this.runMergetoolToolStripMenuItem.Name = "runMergetoolToolStripMenuItem";
             this.runMergetoolToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
             this.runMergetoolToolStripMenuItem.Text = "Solve merge conflicts...";

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2016,7 +2016,7 @@ namespace GitUI.CommandsDialogs
 
             void AddCheckoutBranchMenuItem()
             {
-                var checkoutBranchItem = new ToolStripMenuItem(checkoutBranchToolStripMenuItem.Text)
+                var checkoutBranchItem = new ToolStripMenuItem(checkoutBranchToolStripMenuItem.Text, Images.BranchCheckout)
                 {
                     ShortcutKeys = checkoutBranchToolStripMenuItem.ShortcutKeys,
                     ShortcutKeyDisplayString = checkoutBranchToolStripMenuItem.ShortcutKeyDisplayString
@@ -2631,7 +2631,7 @@ namespace GitUI.CommandsDialogs
 
             newItems.Add(new ToolStripSeparator());
 
-            var mi = new ToolStripMenuItem(updateAllSubmodulesToolStripMenuItem.Text);
+            var mi = new ToolStripMenuItem(updateAllSubmodulesToolStripMenuItem.Text, Images.SubmodulesUpdate);
             mi.Click += UpdateAllSubmodulesToolStripMenuItemClick;
             newItems.Add(mi);
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add some missing icons in the menu
 
Screenshots before and after (if PR changes UI):

![image](https://user-images.githubusercontent.com/460196/46535852-e7948300-c8ac-11e8-93d1-bdd4974ad48b.png)

![image](https://user-images.githubusercontent.com/460196/46535891-06931500-c8ad-11e8-8d85-7f9777321e30.png)

![image](https://user-images.githubusercontent.com/460196/46535906-1ad71200-c8ad-11e8-9908-a6bc00fc5a52.png)

![image](https://user-images.githubusercontent.com/460196/46535934-35a98680-c8ad-11e8-8196-0c347d6eb8dd.png)

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
