### PR TITLE
Settings: display in the tree only the plugins having settings to set

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -112,6 +112,7 @@ namespace GitUI.CommandsDialogs
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<PluginRootIntroductionPage>(this), pluginsPageRef, icon: null, asRoot: true);
 
             var pluginEntries = PluginRegistry.Plugins
+                .Where(p => p.GetSettings().Any())
                 .Select(plugin => (Plugin: plugin, Page: PluginSettingsPage.CreateSettingsPageFromPlugin(this, plugin)))
                 .OrderBy(entry => entry.Page.GetTitle(), StringComparer.CurrentCultureIgnoreCase);
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Show only plugins with settings in the settings  tree view (the others are not displayed)
 
Screenshots before and after (if PR changes UI):

![image](https://user-images.githubusercontent.com/460196/46540356-5d065080-c8b9-11e8-86bc-345764f360c2.png)

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
