### PR TITLE
Fixed null reference exception

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1453,7 +1453,7 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshButtonClick(object sender, EventArgs e)
         {
-            _gitStatusMonitor.RequestRefresh();
+            _gitStatusMonitor?.RequestRefresh();
             RefreshRevisions();
         }
 


### PR DESCRIPTION
Regression from #5491 , cherry picked from #5473
If commit count was not activated at all, Null exception when pressing Refresh

Changes proposed in this pull request:
- null check
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Deactivate count
![image](https://user-images.githubusercontent.com/6248932/46559861-f7828600-c8f1-11e8-8124-4273ba1099f9.png)

- Restart GE 
- Refresh
![image](https://user-images.githubusercontent.com/6248932/46559895-184adb80-c8f2-11e8-81f1-8bac7343849c.png)


Has been tested on (remove any that don't apply):
n/a
