### PR TITLE
Diff options improvements

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -148,7 +148,7 @@ namespace GitUI.Editor
             this.increaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesIncrease;
             this.increaseNumberOfLinesToolStripMenuItem.Name = "increaseNumberOfLinesToolStripMenuItem";
             this.increaseNumberOfLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.increaseNumberOfLinesToolStripMenuItem.Text = "Increase number of lines visible";
+            this.increaseNumberOfLinesToolStripMenuItem.Text = "Increase the number of lines of context";
             this.increaseNumberOfLinesToolStripMenuItem.Click += new System.EventHandler(this.IncreaseNumberOfLinesToolStripMenuItemClick);
             // 
             // descreaseNumberOfLinesToolStripMenuItem
@@ -156,7 +156,7 @@ namespace GitUI.Editor
             this.decreaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
             this.decreaseNumberOfLinesToolStripMenuItem.Name = "decreaseNumberOfLinesToolStripMenuItem";
             this.decreaseNumberOfLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.decreaseNumberOfLinesToolStripMenuItem.Text = "Decrease number of lines visible";
+            this.decreaseNumberOfLinesToolStripMenuItem.Text = "Decrease the number of lines of context";
             this.decreaseNumberOfLinesToolStripMenuItem.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
             // 
             // showEntireFileToolStripMenuItem
@@ -253,7 +253,7 @@ namespace GitUI.Editor
             this.increaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.increaseNumberOfLines.Name = "increaseNumberOfLines";
             this.increaseNumberOfLines.Size = new System.Drawing.Size(23, 20);
-            this.increaseNumberOfLines.ToolTipText = "Increase number of visible lines";
+            this.increaseNumberOfLines.ToolTipText = "Increase the number of lines of context";
             this.increaseNumberOfLines.Click += new System.EventHandler(this.IncreaseNumberOfLinesToolStripMenuItemClick);
             // 
             // DecreaseNumberOfLines
@@ -263,7 +263,7 @@ namespace GitUI.Editor
             this.DecreaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.DecreaseNumberOfLines.Name = "DecreaseNumberOfLines";
             this.DecreaseNumberOfLines.Size = new System.Drawing.Size(23, 20);
-            this.DecreaseNumberOfLines.ToolTipText = "Decrease number of visible lines";
+            this.DecreaseNumberOfLines.ToolTipText = "Decrease the number of lines of context";
             this.DecreaseNumberOfLines.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
             // 
             // toolStripSeparator4

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -40,7 +40,7 @@ namespace GitUI.Editor
             this.previousChangeButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.increaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
-            this.DecreaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
+            this.decreaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.showEntireFileButton = new System.Windows.Forms.ToolStripButton();
             this.showNonPrintChars = new System.Windows.Forms.ToolStripButton();
@@ -205,7 +205,7 @@ namespace GitUI.Editor
             this.previousChangeButton,
             this.toolStripSeparator3,
             this.increaseNumberOfLines,
-            this.DecreaseNumberOfLines,
+            this.decreaseNumberOfLines,
             this.toolStripSeparator4,
             this.showEntireFileButton,
             this.showNonPrintChars,
@@ -258,13 +258,13 @@ namespace GitUI.Editor
             // 
             // DecreaseNumberOfLines
             // 
-            this.DecreaseNumberOfLines.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.DecreaseNumberOfLines.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
-            this.DecreaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.DecreaseNumberOfLines.Name = "DecreaseNumberOfLines";
-            this.DecreaseNumberOfLines.Size = new System.Drawing.Size(23, 20);
-            this.DecreaseNumberOfLines.ToolTipText = "Decrease the number of lines of context";
-            this.DecreaseNumberOfLines.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
+            this.decreaseNumberOfLines.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.decreaseNumberOfLines.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
+            this.decreaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.decreaseNumberOfLines.Name = "decreaseNumberOfLines";
+            this.decreaseNumberOfLines.Size = new System.Drawing.Size(23, 20);
+            this.decreaseNumberOfLines.ToolTipText = "Decrease the number of lines of context";
+            this.decreaseNumberOfLines.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
             // 
             // toolStripSeparator4
             // 
@@ -399,7 +399,7 @@ namespace GitUI.Editor
         private System.Windows.Forms.ToolStripButton previousChangeButton;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripButton increaseNumberOfLines;
-        private System.Windows.Forms.ToolStripButton DecreaseNumberOfLines;
+        private System.Windows.Forms.ToolStripButton decreaseNumberOfLines;
         private System.Windows.Forms.ToolStripButton showEntireFileButton;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripButton showNonPrintChars;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -104,6 +104,7 @@ namespace GitUI.Editor
             ShowEntireFile = AppSettings.ShowEntireFile;
             showEntireFileButton.Checked = ShowEntireFile;
             showEntireFileToolStripMenuItem.Checked = ShowEntireFile;
+            SetStateOfContextLinesButtons();
 
             showNonPrintChars.Checked = AppSettings.ShowNonPrintingChars;
             showNonprintableCharactersToolStripMenuItem.Checked = AppSettings.ShowNonPrintingChars;
@@ -911,8 +912,17 @@ namespace GitUI.Editor
             ShowEntireFile = !ShowEntireFile;
             showEntireFileButton.Checked = ShowEntireFile;
             showEntireFileToolStripMenuItem.Checked = ShowEntireFile;
+            SetStateOfContextLinesButtons();
             AppSettings.ShowEntireFile = ShowEntireFile;
             OnExtraDiffArgumentsChanged();
+        }
+
+        private void SetStateOfContextLinesButtons()
+        {
+            increaseNumberOfLines.Enabled = !ShowEntireFile;
+            DecreaseNumberOfLines.Enabled = !ShowEntireFile;
+            increaseNumberOfLinesToolStripMenuItem.Enabled = !ShowEntireFile;
+            decreaseNumberOfLinesToolStripMenuItem.Enabled = !ShowEntireFile;
         }
 
         private void TreatAllFilesAsTextToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -48,7 +48,7 @@ namespace GitUI.Editor
         public bool IgnoreWhitespaceChanges { get; set; }
         [Description("Show diffs with <n> lines of context.")]
         [DefaultValue(3)]
-        public int NumberOfVisibleLines { get; set; }
+        public int NumberOfContextLines { get; set; }
         [Description("Show diffs with entire file.")]
         [DefaultValue(false)]
         public bool ShowEntireFile { get; set; }
@@ -62,7 +62,7 @@ namespace GitUI.Editor
         {
             TreatAllFilesAsText = false;
             ShowEntireFile = false;
-            NumberOfVisibleLines = AppSettings.NumberOfContextLines;
+            NumberOfContextLines = AppSettings.NumberOfContextLines;
             InitializeComponent();
             InitializeComplete();
 
@@ -314,7 +314,7 @@ namespace GitUI.Editor
             {
                 { ignoreAllWhitespaces.Checked, "--ignore-all-space" },
                 { !ignoreAllWhitespaces.Checked && IgnoreWhitespaceChanges, "--ignore-space-change" },
-                { ShowEntireFile, "--inter-hunk-context=9000 --unified=9000", $"--unified={NumberOfVisibleLines}" },
+                { ShowEntireFile, "--inter-hunk-context=9000 --unified=9000", $"--unified={NumberOfContextLines}" },
                 { TreatAllFilesAsText, "--text" }
             };
         }
@@ -886,23 +886,23 @@ namespace GitUI.Editor
 
         private void IncreaseNumberOfLinesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            NumberOfVisibleLines++;
-            AppSettings.NumberOfContextLines = NumberOfVisibleLines;
+            NumberOfContextLines++;
+            AppSettings.NumberOfContextLines = NumberOfContextLines;
             OnExtraDiffArgumentsChanged();
         }
 
         private void DecreaseNumberOfLinesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (NumberOfVisibleLines > 0)
+            if (NumberOfContextLines > 0)
             {
-                NumberOfVisibleLines--;
+                NumberOfContextLines--;
             }
             else
             {
-                NumberOfVisibleLines = 0;
+                NumberOfContextLines = 0;
             }
 
-            AppSettings.NumberOfContextLines = NumberOfVisibleLines;
+            AppSettings.NumberOfContextLines = NumberOfContextLines;
             OnExtraDiffArgumentsChanged();
         }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -920,7 +920,7 @@ namespace GitUI.Editor
         private void SetStateOfContextLinesButtons()
         {
             increaseNumberOfLines.Enabled = !ShowEntireFile;
-            DecreaseNumberOfLines.Enabled = !ShowEntireFile;
+            decreaseNumberOfLines.Enabled = !ShowEntireFile;
             increaseNumberOfLinesToolStripMenuItem.Enabled = !ShowEntireFile;
             decreaseNumberOfLinesToolStripMenuItem.Enabled = !ShowEntireFile;
         }

--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -1539,7 +1539,7 @@ Chcete jí otevřít?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Snížit počet viditelných řádků</target>
         

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -1566,7 +1566,7 @@ Wilt u het toch openen?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Verlaag aantal zichtbare regels</target>
         

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1168,7 +1168,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
       <trans-unit id="DecreaseNumberOfLines.ToolTipText">
-        <source>Decrease number of visible lines</source>
+        <source>Decrease the number of lines of context</source>
         <target />
       </trans-unit>
       <trans-unit id="cherrypickSelectedLinesToolStripMenuItem.Text">
@@ -1192,7 +1192,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="descreaseNumberOfLinesToolStripMenuItem.Text">
-        <source>Decrease number of lines visible</source>
+        <source>Decrease the number of lines of context</source>
         <target />
       </trans-unit>
       <trans-unit id="findToolStripMenuItem.Text">
@@ -1220,11 +1220,11 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="increaseNumberOfLines.ToolTipText">
-        <source>Increase number of visible lines</source>
+        <source>Increase the number of lines of context</source>
         <target />
       </trans-unit>
       <trans-unit id="increaseNumberOfLinesToolStripMenuItem.Text">
-        <source>Increase number of lines visible</source>
+        <source>Increase the number of lines of context</source>
         <target />
       </trans-unit>
       <trans-unit id="nextChangeButton.ToolTipText">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1167,7 +1167,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease the number of lines of context</source>
         <target />
       </trans-unit>

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -1569,7 +1569,7 @@ Voulez-vous l'ouvrir?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Diminuer le nombre de lignes visibles</target>
         

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -1570,7 +1570,7 @@ Wollen Sie es trotzdem öffnen?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="de">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Anzahl sichtbarer Zeilen verringern</target>
 

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -1537,7 +1537,7 @@ Vuoi aprirlo?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="it">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Diminuisci numero di righe visibili</target>
         

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -1557,7 +1557,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>変更点前後の行数を減らす</target>
         

--- a/GitUI/Translation/Korean.xlf
+++ b/GitUI/Translation/Korean.xlf
@@ -1511,7 +1511,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="ko">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>표시 줄 감소</target>
         

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -1546,7 +1546,7 @@ Chcesz go otworzyć?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Zmniejsz liczbę widocznych linii</target>
         

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -1542,7 +1542,7 @@ Quer abri-lo?</target>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="pt-BR">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Diminuir o número de linhas visíveis</target>
         

--- a/GitUI/Translation/Portuguese (Portugal).xlf
+++ b/GitUI/Translation/Portuguese (Portugal).xlf
@@ -1098,7 +1098,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
 
       </trans-unit>

--- a/GitUI/Translation/Romanian.xlf
+++ b/GitUI/Translation/Romanian.xlf
@@ -1308,7 +1308,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="ro">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         
       </trans-unit>

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -1566,7 +1566,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Уменьшить количество видимых строк</target>
         

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -1569,7 +1569,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>减少可见的行数</target>
         

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -1560,7 +1560,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="es">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>Disminuir el número de líneas visibles</target>
         

--- a/GitUI/Translation/Traditional Chinese.xlf
+++ b/GitUI/Translation/Traditional Chinese.xlf
@@ -1506,7 +1506,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en" target-language="zh-Hant">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>減少可視行數</target>
         

--- a/GitUI/Translation/en_pseudo.Plugins.xlf
+++ b/GitUI/Translation/en_pseudo.Plugins.xlf
@@ -1559,7 +1559,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>[Ḓḗƈřḗȧşḗ ƞŭḿƀḗř ǿƒ ṽīşīƀŀḗ ŀīƞḗş ſǅϵǅΰϐǅǲ 鶱ϐ]</target>
         

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -1569,7 +1569,7 @@ Do you want to open it?</source>
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
-      <trans-unit id="DecreaseNumberOfLines.ToolTipText">
+      <trans-unit id="decreaseNumberOfLines.ToolTipText">
         <source>Decrease number of visible lines</source>
         <target>[Ḓḗƈřḗȧşḗ ƞŭḿƀḗř ǿƒ ṽīşīƀŀḗ ŀīƞḗş 衋ǈǲǈſϖǈϕ ΰ衋]</target>
         


### PR DESCRIPTION
Changes proposed in this pull request:
- Better labels for the lines of context (see screenshot). Talking about "lines of context" which is consistent with variables names and is also the wording used by the diff documentation. It's better to use the name used by everyone... 
- Disable context buttons when showing all the file content (see screenshot)
- rename control to be consistent with others.
 
Screenshots before and after (if PR changes UI):
- button increase/decrease the number of lines of context is disabled when showing all the file content.
![image](https://user-images.githubusercontent.com/460196/46563853-273a8980-c904-11e8-8100-e8c4e8f9dd16.png)

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10