### PR TITLE
Remove currents repository and branch from recent lists

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1832,7 +1832,10 @@ namespace GitUI.CommandsDialogs
 
             foreach (var repo in mostRecentRepos)
             {
-                AddRecentRepositories(repo.Repo, repo.Caption);
+                if (repo.ShortName != _NO_TRANSLATE_WorkingDir.Text)
+                {
+                    AddRecentRepositories(repo.Repo, repo.Caption);
+                }
             }
 
             if (lessRecentRepos.Count > 0)
@@ -1844,7 +1847,10 @@ namespace GitUI.CommandsDialogs
 
                 foreach (var repo in lessRecentRepos)
                 {
-                    AddRecentRepositories(repo.Repo, repo.Caption);
+                    if (repo.ShortName != _NO_TRANSLATE_WorkingDir.Text)
+                    {
+                        AddRecentRepositories(repo.Repo, repo.Caption);
+                    }
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2028,7 +2028,8 @@ namespace GitUI.CommandsDialogs
 
             void AddBranchesMenuItems()
             {
-                foreach (var branchName in GetBranchNames())
+                var currentBranch = UICommands.GitModule.GetSelectedBranch();
+                foreach (var branchName in GetBranchNames().Where(b => b != currentBranch))
                 {
                     var toolStripItem = branchSelect.DropDownItems.Add(branchName);
                     toolStripItem.Click


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove current repository from recent lists
- Remove current branch from list of branches

because that make no sense to select it (and it clutter the GUI as it is the first in the list)
 
Screenshots before and after (if PR changes UI):
- The current repository is no more in the list (on top)
![image](https://user-images.githubusercontent.com/460196/46564241-68cc3400-c906-11e8-82a4-ace636a23be2.png)

- The current branch is no more in the list (on top)
![image](https://user-images.githubusercontent.com/460196/46564329-e2fcb880-c906-11e8-993c-ae32f2847e18.png)


Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
