### PR TITLE
AppVeyor: No more need to query GitHub to support pull requests

### DIFF
--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/Settings/AppVeyorSettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/Settings/AppVeyorSettingsUserControl.Designer.cs
@@ -37,26 +37,23 @@ namespace AppVeyorIntegration.Settings
             this.AppVeyorProjectName = new System.Windows.Forms.TextBox();
             this.AppVeyorAccountName = new System.Windows.Forms.TextBox();
             this.cbLoadTestResults = new System.Windows.Forms.CheckBox();
-            this.txtGitHubToken = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.cbGitHubPullRequest = new System.Windows.Forms.CheckBox();
             lblApiToken = new System.Windows.Forms.Label();
             lblAccountName = new System.Windows.Forms.Label();
             lblProjects = new System.Windows.Forms.Label();
             label1 = new System.Windows.Forms.Label();
             label2 = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // lblApiToken
             // 
             lblApiToken.Anchor = System.Windows.Forms.AnchorStyles.Left;
             lblApiToken.AutoSize = true;
-            lblApiToken.Location = new System.Drawing.Point(3, 31);
+            lblApiToken.Location = new System.Drawing.Point(3, 33);
             lblApiToken.Name = "lblApiToken";
-            lblApiToken.Size = new System.Drawing.Size(52, 13);
+            lblApiToken.Size = new System.Drawing.Size(58, 15);
             lblApiToken.TabIndex = 0;
             lblApiToken.Text = "Api token";
             // 
@@ -66,7 +63,7 @@ namespace AppVeyorIntegration.Settings
             lblAccountName.AutoSize = true;
             lblAccountName.Location = new System.Drawing.Point(3, 6);
             lblAccountName.Name = "lblAccountName";
-            lblAccountName.Size = new System.Drawing.Size(75, 13);
+            lblAccountName.Size = new System.Drawing.Size(85, 15);
             lblAccountName.TabIndex = 2;
             lblAccountName.Text = "Account name";
             // 
@@ -74,9 +71,9 @@ namespace AppVeyorIntegration.Settings
             // 
             lblProjects.Anchor = System.Windows.Forms.AnchorStyles.Left;
             lblProjects.AutoSize = true;
-            lblProjects.Location = new System.Drawing.Point(3, 79);
+            lblProjects.Location = new System.Drawing.Point(3, 85);
             lblProjects.Name = "lblProjects";
-            lblProjects.Size = new System.Drawing.Size(97, 13);
+            lblProjects.Size = new System.Drawing.Size(105, 15);
             lblProjects.TabIndex = 4;
             lblProjects.Text = "Project(s) Name(s)";
             // 
@@ -84,10 +81,10 @@ namespace AppVeyorIntegration.Settings
             // 
             label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
             label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(106, 98);
+            label1.Location = new System.Drawing.Point(114, 106);
             label1.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
             label1.Name = "label1";
-            label1.Size = new System.Drawing.Size(480, 13);
+            label1.Size = new System.Drawing.Size(508, 15);
             label1.TabIndex = 4;
             label1.Text = "If you want to use the result of different projects, separate your different proj" +
     "ects names by a \'|\'.";
@@ -96,10 +93,10 @@ namespace AppVeyorIntegration.Settings
             // 
             label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
             label2.AutoSize = true;
-            label2.Location = new System.Drawing.Point(106, 50);
+            label2.Location = new System.Drawing.Point(114, 54);
             label2.Margin = new System.Windows.Forms.Padding(3, 0, 3, 10);
             label2.Name = "label2";
-            label2.Size = new System.Drawing.Size(457, 13);
+            label2.Size = new System.Drawing.Size(499, 15);
             label2.TabIndex = 4;
             label2.Text = "Token used to be able to query AppVeyor rest Api. You will find out in the user a" +
     "ccount menu.";
@@ -107,50 +104,42 @@ namespace AppVeyorIntegration.Settings
             // AppVeyorAccountToken
             // 
             this.AppVeyorAccountToken.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AppVeyorAccountToken.Location = new System.Drawing.Point(106, 27);
+            this.AppVeyorAccountToken.Location = new System.Drawing.Point(114, 29);
             this.AppVeyorAccountToken.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.AppVeyorAccountToken.Name = "AppVeyorAccountToken";
-            this.AppVeyorAccountToken.Size = new System.Drawing.Size(504, 21);
+            this.AppVeyorAccountToken.Size = new System.Drawing.Size(508, 23);
             this.AppVeyorAccountToken.TabIndex = 1;
             // 
             // AppVeyorProjectName
             // 
             this.AppVeyorProjectName.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AppVeyorProjectName.Location = new System.Drawing.Point(106, 75);
+            this.AppVeyorProjectName.Location = new System.Drawing.Point(114, 81);
             this.AppVeyorProjectName.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.AppVeyorProjectName.Name = "AppVeyorProjectName";
-            this.AppVeyorProjectName.Size = new System.Drawing.Size(504, 21);
+            this.AppVeyorProjectName.Size = new System.Drawing.Size(508, 23);
             this.AppVeyorProjectName.TabIndex = 3;
             // 
             // AppVeyorAccountName
             // 
             this.AppVeyorAccountName.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AppVeyorAccountName.Location = new System.Drawing.Point(106, 2);
+            this.AppVeyorAccountName.Location = new System.Drawing.Point(114, 2);
             this.AppVeyorAccountName.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.AppVeyorAccountName.Name = "AppVeyorAccountName";
-            this.AppVeyorAccountName.Size = new System.Drawing.Size(504, 21);
+            this.AppVeyorAccountName.Size = new System.Drawing.Size(508, 23);
             this.AppVeyorAccountName.TabIndex = 5;
             // 
             // cbLoadTestResults
             // 
             this.cbLoadTestResults.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.cbLoadTestResults.AutoSize = true;
-            this.cbLoadTestResults.Location = new System.Drawing.Point(106, 123);
+            this.cbLoadTestResults.Location = new System.Drawing.Point(114, 133);
             this.cbLoadTestResults.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cbLoadTestResults.Name = "cbLoadTestResults";
-            this.cbLoadTestResults.Size = new System.Drawing.Size(434, 17);
+            this.cbLoadTestResults.Size = new System.Drawing.Size(472, 19);
             this.cbLoadTestResults.TabIndex = 6;
             this.cbLoadTestResults.Text = "display tests results in build status summary for each build result (network inte" +
     "nsive!)";
             this.cbLoadTestResults.UseVisualStyleBackColor = true;
-            // 
-            // txtGitHubToken
-            // 
-            this.txtGitHubToken.Location = new System.Drawing.Point(266, 2);
-            this.txtGitHubToken.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.txtGitHubToken.Name = "txtGitHubToken";
-            this.txtGitHubToken.Size = new System.Drawing.Size(241, 21);
-            this.txtGitHubToken.TabIndex = 3;
             // 
             // tableLayoutPanel1
             // 
@@ -181,33 +170,18 @@ namespace AppVeyorIntegration.Settings
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(613, 167);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(625, 154);
             this.tableLayoutPanel1.TabIndex = 7;
             // 
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.flowLayoutPanel1.Controls.Add(this.cbGitHubPullRequest);
-            this.flowLayoutPanel1.Controls.Add(this.txtGitHubToken);
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(103, 142);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(111, 154);
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(510, 25);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(0, 0);
             this.flowLayoutPanel1.TabIndex = 8;
-            // 
-            // cbGitHubPullRequest
-            // 
-            this.cbGitHubPullRequest.AutoSize = true;
-            this.cbGitHubPullRequest.Dock = System.Windows.Forms.DockStyle.Left;
-            this.cbGitHubPullRequest.Location = new System.Drawing.Point(3, 2);
-            this.cbGitHubPullRequest.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.cbGitHubPullRequest.Name = "cbGitHubPullRequest";
-            this.cbGitHubPullRequest.Size = new System.Drawing.Size(257, 21);
-            this.cbGitHubPullRequest.TabIndex = 6;
-            this.cbGitHubPullRequest.Text = "display GitHub pull requests builds. GitHubToken:";
-            this.cbGitHubPullRequest.UseVisualStyleBackColor = true;
-            this.cbGitHubPullRequest.CheckedChanged += new System.EventHandler(this.cbGitHubPullRequest_CheckedChanged);
             // 
             // AppVeyorSettingsUserControl
             // 
@@ -217,11 +191,9 @@ namespace AppVeyorIntegration.Settings
             this.Controls.Add(this.tableLayoutPanel1);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "AppVeyorSettingsUserControl";
-            this.Size = new System.Drawing.Size(613, 167);
+            this.Size = new System.Drawing.Size(625, 154);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -233,9 +205,7 @@ namespace AppVeyorIntegration.Settings
         private System.Windows.Forms.TextBox AppVeyorProjectName;
         private System.Windows.Forms.TextBox AppVeyorAccountName;
         private System.Windows.Forms.CheckBox cbLoadTestResults;
-        private System.Windows.Forms.TextBox txtGitHubToken;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.CheckBox cbGitHubPullRequest;
     }
 }

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/Settings/AppVeyorSettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/Settings/AppVeyorSettingsUserControl.cs
@@ -35,9 +35,6 @@ namespace AppVeyorIntegration.Settings
                 AppVeyorAccountName.Text = buildServerConfig.GetString("AppVeyorAccountName", string.Empty);
                 AppVeyorAccountToken.Text = buildServerConfig.GetString("AppVeyorAccountToken", string.Empty);
                 cbLoadTestResults.Checked = buildServerConfig.GetBool("AppVeyorLoadTestsResults", false);
-                cbGitHubPullRequest.Checked = buildServerConfig.GetBool("AppVeyorDisplayGitHubPullRequests", false);
-                txtGitHubToken.Text = buildServerConfig.GetString("AppVeyorGitHubToken", string.Empty);
-                txtGitHubToken.Enabled = cbGitHubPullRequest.Checked;
             }
         }
 
@@ -47,13 +44,6 @@ namespace AppVeyorIntegration.Settings
             buildServerConfig.SetString("AppVeyorAccountName", AppVeyorAccountName.Text);
             buildServerConfig.SetString("AppVeyorAccountToken", AppVeyorAccountToken.Text);
             buildServerConfig.SetBool("AppVeyorLoadTestsResults", cbLoadTestResults.Checked);
-            buildServerConfig.SetBool("AppVeyorDisplayGitHubPullRequests", cbGitHubPullRequest.Checked);
-            buildServerConfig.SetString("AppVeyorGitHubToken", txtGitHubToken.Text);
-        }
-
-        private void cbGitHubPullRequest_CheckedChanged(object sender, System.EventArgs e)
-        {
-            txtGitHubToken.Enabled = cbGitHubPullRequest.Checked;
         }
     }
 }


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #

Changes proposed in this pull request:
- Remove code that query GitHub for displaying build result of Pull Requests

now that AppVeyor provide the hash of the commit build when doing a pull request.
So everyone could see PR build result by default on opensource project \o/
(no need of GitHub token anymore!)
 
Screenshots before and after (if PR changes UI):
- AppVeyor Build result for PR are displayed:
![image](https://user-images.githubusercontent.com/460196/46565665-e77a9e80-c911-11e8-8680-211c111d09d3.png)

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
