### PR TITLE
fix: Open fails if recent repository doesn't exists

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -437,7 +437,7 @@ namespace GitUI.CommandsDialogs
             LayoutRevisionInfo();
             InternalInitialize(false);
 
-            if (_startWithDashboard)
+            if (_startWithDashboard || !Module.IsValidGitWorkingDir())
             {
                 base.OnLoad(e);
                 return;


### PR DESCRIPTION
If the app is configured to open the most recent repository, but it no longer exists, the app will fail.
Ensure the most recent repository path is a valid working dir, and if not - show the dashboard instead.

Fixes #5515

What did I do to test the code and ensure quality:
- manual
