### PR TITLE
#5084 mouse hover artifacts in dashboard

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -275,6 +275,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             this.listView1.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.listView1_DrawItem);
             this.listView1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseClick);
             this.listView1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseMove);
+            this.listView1.MouseLeave += new System.EventHandler(this.listView1_MouseLeave);
             this.listView1.GroupMouseUp += new System.EventHandler<ListViewGroupMouseEventArgs>(this.listView1_GroupMouseUp);
             // 
             // clmhdrPath

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private Brush _branchNameColorBrush = new SolidBrush(DefaultBranchNameColor);
         private Brush _favouriteColorBrush = new SolidBrush(DefaultFavouriteColor);
         private Brush _hoverColorBrush = new SolidBrush(SystemColors.InactiveCaption);
-        private ListViewItem _prevHoveredItem;
+        private ListViewItem _hoveredItem;
         private readonly ListViewGroup _lvgRecentRepositories;
         private readonly IUserRepositoriesListController _controller = new UserRepositoriesListController(RepositoryHistoryManager.Locals);
         private bool _hasInvalidRepos;
@@ -214,6 +214,30 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 _mainBackColor = value;
                 BackColor = value;
                 listView1.BackColor = value;
+            }
+        }
+
+        private ListViewItem HoveredItem
+        {
+            get => _hoveredItem;
+            set
+            {
+                if (value == _hoveredItem)
+                {
+                    return;
+                }
+
+                if (_hoveredItem != null)
+                {
+                    listView1.Invalidate(listView1.GetItemRect(_hoveredItem.Index));
+                }
+
+                if (value != null)
+                {
+                    listView1.Invalidate(listView1.GetItemRect(value.Index));
+                }
+
+                _hoveredItem = value;
             }
         }
 
@@ -480,7 +504,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             var textOffset = spacing2 + imageList1.ImageSize.Width + spacing2;
             int textWidth = AppSettings.RecentReposComboMinWidth > 0 ? AppSettings.RecentReposComboMinWidth : e.Bounds.Width;
 
-            if (e.Item == _prevHoveredItem)
+            if (e.Item == HoveredItem)
             {
                 e.Graphics.FillRectangle(_hoverColorBrush, e.Bounds);
             }
@@ -577,8 +601,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void listView1_MouseMove(object sender, MouseEventArgs e)
         {
-            var item = listView1.GetItemAt(e.X, e.Y);
-            _prevHoveredItem = item;
+            HoveredItem = listView1.GetItemAt(e.X, e.Y);
+        }
+
+        private void listView1_MouseLeave(object sender, EventArgs e)
+        {
+            HoveredItem = null;
         }
 
         private void mnuConfigure_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #5084 item 2

Hovered dashboard items were not redrawn if user quickly moved mouse out of the list.
As a result user could see incorrectly hovered item, and multiple items hovered at once.

Tested on Windows 7