### PR TITLE
Ignore exception when fetching tooltip. It's not worth crashing for.

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
@@ -49,17 +50,24 @@ namespace GitUI
 
             string GetToolTipText()
             {
-                if (_gridView.Columns[e.ColumnIndex].Tag is ColumnProvider provider &&
-                    provider.TryGetToolTip(e, revision, out var toolTip) &&
-                    !string.IsNullOrWhiteSpace(toolTip))
+                try
                 {
-                    return toolTip;
-                }
+                    if (_gridView.Columns[e.ColumnIndex].Tag is ColumnProvider provider &&
+                        provider.TryGetToolTip(e, revision, out var toolTip) &&
+                        !string.IsNullOrWhiteSpace(toolTip))
+                    {
+                        return toolTip;
+                    }
 
-                if (_isTruncatedByCellPos.TryGetValue(new Point(e.ColumnIndex, e.RowIndex), out var showToolTip)
-                    && showToolTip)
+                    if (_isTruncatedByCellPos.TryGetValue(new Point(e.ColumnIndex, e.RowIndex), out var showToolTip)
+                        && showToolTip)
+                    {
+                        return _gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].FormattedValue?.ToString() ?? "";
+                    }
+                }
+                catch (Exception)
                 {
-                    return _gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].FormattedValue?.ToString() ?? "";
+                    // Ignore exception when fetching tooltip. It's not worth crashing for.
                 }
 
                 // no tooltip unless always active or truncated


### PR DESCRIPTION
Fixes the application to crash occasionally when rendering tooltip. Tooltips are nice, but it isn't worth crashing the application for.

Changes proposed in this pull request:
- The DataGridView of .Net is not threadsafe. This sometimes causes the exceptions when the indexer property on Rows or Cells are used. Added a try/catch.

What did I do to test the code and ensure quality:
- I got various exceptions before (null reference, index of of bounds, argument exception). After this change, the exceptions are no longer there.

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
