### PR TITLE
Delete unused branches one at the time.

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -163,18 +163,17 @@ namespace DeleteUnusedBranches
             {
                 await TaskScheduler.Default.SwitchTo(alwaysYield: true);
 
-                if (remoteBranches.Count > 0)
+                foreach (var remoteBranch in remoteBranches)
                 {
-                    // TODO: use GitCommandHelpers.PushMultipleCmd after moving this window to GE (see FormPush as example)
+                    // Delete branches one by one, because it is possible one fails
                     var remoteBranchNameOffset = remoteBranchPrefix.Length;
-                    var remoteBranchNames = string.Join(" ", remoteBranches.Select(branch => ":" + branch.Name.Substring(remoteBranchNameOffset)));
-                    _gitCommands.RunGitCmd($"push {remoteName} {remoteBranchNames}");
+                    _gitCommands.RunGitCmd($"push {remoteName} :{remoteBranch.Name.Substring(remoteBranchNameOffset)}");
                 }
 
-                if (localBranches.Count > 0)
+                foreach (var localBranch in localBranches)
                 {
-                    var localBranchNames = string.Join(" ", localBranches.Select(branch => branch.Name));
-                    _gitCommands.RunGitCmd("branch -d " + localBranchNames);
+                    // Delete branches one by one, because it is possible one fails
+                    _gitCommands.RunGitCmd("branch -d " + localBranch.Name);
                 }
 
                 await this.SwitchToMainThreadAsync();


### PR DESCRIPTION
Deleting branches one at the time is slower, but sometimes a branch cannot be deleted for some reason. The entire process will then stop. Since there is no proper error handling showing what went wrong, this makes the plugin unusable.

Changes proposed in this pull request:
- Delete branches 1 at the time instead of 1 command.
- I expect this plugin to be used occasionally. That the performance is not top-notch is ok. I use this once every 6 months, to clean up not-deleted feature branches. Usually I delete ~1500 branches in 1 batch.
 
What did I do to test the code and ensure quality:
- I used the plugin. Before, the process stopped. I needed to debug the code to see what went wrong.

Could it be improved?
- It would be nice if there is some kind of progress indicator
- It would be nice to see what went wrong, if a branch could not be deleted

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
