### PR TITLE
Optimize performance of selecting current revision

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/GraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/GraphColumnProvider.cs
@@ -50,7 +50,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
                 Resizable = DataGridViewTriState.False,
-                MinimumWidth = DpiUtil.Scale(10)
+                MinimumWidth = DpiUtil.Scale(5)
             };
         }
 
@@ -469,7 +469,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 return;
             }
 
-            int laneCount = 1;
+            int laneCount = 0;
             lock (_graphModel)
             {
                 foreach (var index in range)
@@ -492,7 +492,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     ? 1
                     : MaxLanes;
 
-            laneCount = Math.Min(Math.Max(1, laneCount), maxLanes);
+            laneCount = Math.Min(laneCount, maxLanes);
             var columnWidth = (_laneWidth * laneCount) + ColumnLeftMargin;
             if (Column.Width != columnWidth && columnWidth > Column.MinimumWidth)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -449,11 +449,18 @@ namespace GitUI.UserControls.RevisionGrid
                         int toBeSelectedRowIndex = ToBeSelectedRowIndexes.ElementAt(i);
                         if (count > toBeSelectedRowIndex)
                         {
-                            Rows[toBeSelectedRowIndex].Selected = true;
-                            ToBeSelectedRowIndexes.Remove(toBeSelectedRowIndex);
-                            if (CurrentCell == null)
+                            try
                             {
-                                CurrentCell = Rows[toBeSelectedRowIndex].Cells[1];
+                                ToBeSelectedRowIndexes.Remove(toBeSelectedRowIndex);
+                                Rows[toBeSelectedRowIndex].Selected = true;
+                                if (CurrentCell == null)
+                                {
+                                    CurrentCell = Rows[toBeSelectedRowIndex].Cells[1];
+                                }
+                            }
+                            catch (ArgumentOutOfRangeException)
+                            {
+                                // Not worth crashing for. Ignore exception.
                             }
 
                             break;

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -351,6 +351,7 @@ namespace GitUI.UserControls.RevisionGrid
             _graphDataCount = 0;
             _revisionByRowIndex.Clear();
             _isRelativeByIndex.Clear();
+            ToBeSelectedRowIndexes = new HashSet<int>();
 
             // The graphdata is stored in one of the columnproviders, clear this last
             foreach (var columnProvider in _columnProviders)
@@ -443,8 +444,9 @@ namespace GitUI.UserControls.RevisionGrid
                     RowCount = count;
                     }
 
-                    foreach (int toBeSelectedRowIndex in ToBeSelectedRowIndexes)
+                    for (int i = 0; i < ToBeSelectedRowIndexes.Count; i++)
                     {
+                        int toBeSelectedRowIndex = ToBeSelectedRowIndexes.ElementAt(i);
                         if (count > toBeSelectedRowIndex)
                         {
                             Rows[toBeSelectedRowIndex].Selected = true;

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -478,7 +478,7 @@ namespace GitUI.UserControls.RevisionGrid
                     return;
                 }
 
-                if (keepRunning || _backgroundEvent.WaitOne(500))
+                if (keepRunning || _backgroundEvent.WaitOne(200))
                 {
                     keepRunning = false;
 
@@ -505,6 +505,13 @@ namespace GitUI.UserControls.RevisionGrid
                     if (!keepRunning)
                     {
                         this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
+                    }
+                }
+                else
+                {
+                    if (RowCount < _graphModel.Count)
+                    {
+                        this.InvokeAsync(() => { SetRowCount(_graphModel.Count); }).FileAndForget();
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -517,17 +517,24 @@ namespace GitUI
 
         private void SetSelectedIndex(int index)
         {
-            if (_gridView.Rows[index].Selected)
+            try
             {
-                return;
+                if (_gridView.Rows[index].Selected)
+                {
+                    return;
+                }
+
+                _gridView.ClearSelection();
+
+                _gridView.Rows[index].Selected = true;
+                _gridView.CurrentCell = _gridView.Rows[index].Cells[1];
+
+                _gridView.Select();
             }
-
-            _gridView.ClearSelection();
-
-            _gridView.Rows[index].Selected = true;
-            _gridView.CurrentCell = _gridView.Rows[index].Cells[1];
-
-            _gridView.Select();
+            catch (ArgumentException)
+            {
+                // Ignore if selection failed. Datagridview is not threadsafe
+            }
         }
 
         /// <summary>
@@ -1192,17 +1199,17 @@ namespace GitUI
             {
                 case Keys.BrowserBack:
                 case Keys.Left when e.Modifiers.HasFlag(Keys.Alt):
-                {
-                    NavigateBackward();
-                    break;
-                }
+                    {
+                        NavigateBackward();
+                        break;
+                    }
 
                 case Keys.BrowserForward:
                 case Keys.Right when e.Modifiers.HasFlag(Keys.Alt):
-                {
-                    NavigateForward();
-                    break;
-                }
+                    {
+                        NavigateForward();
+                        break;
+                    }
             }
         }
 
@@ -1218,36 +1225,36 @@ namespace GitUI
             switch (e.KeyCode)
             {
                 case Keys.F2:
-                {
-                    InitiateRefAction(
-                        new GitRefListsForRevision(selectedRevision).GetRenameableLocalBranches(),
-                        gitRef => UICommands.StartRenameDialog(this, gitRef.Name),
-                        FormQuickGitRefSelector.Action.Rename);
-                    break;
-                }
+                    {
+                        InitiateRefAction(
+                            new GitRefListsForRevision(selectedRevision).GetRenameableLocalBranches(),
+                            gitRef => UICommands.StartRenameDialog(this, gitRef.Name),
+                            FormQuickGitRefSelector.Action.Rename);
+                        break;
+                    }
 
                 case Keys.Delete:
-                {
-                    InitiateRefAction(
-                        new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch()),
-                        gitRef =>
-                        {
-                            if (gitRef.IsTag)
+                    {
+                        InitiateRefAction(
+                            new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch()),
+                            gitRef =>
                             {
-                                UICommands.StartDeleteTagDialog(this, gitRef.Name);
-                            }
-                            else if (gitRef.IsRemote)
-                            {
-                                UICommands.StartDeleteRemoteBranchDialog(this, gitRef.Name);
-                            }
-                            else
-                            {
-                                UICommands.StartDeleteBranchDialog(this, gitRef.Name);
-                            }
-                        },
-                        FormQuickGitRefSelector.Action.Delete);
-                    break;
-                }
+                                if (gitRef.IsTag)
+                                {
+                                    UICommands.StartDeleteTagDialog(this, gitRef.Name);
+                                }
+                                else if (gitRef.IsRemote)
+                                {
+                                    UICommands.StartDeleteRemoteBranchDialog(this, gitRef.Name);
+                                }
+                                else
+                                {
+                                    UICommands.StartDeleteBranchDialog(this, gitRef.Name);
+                                }
+                            },
+                            FormQuickGitRefSelector.Action.Delete);
+                        break;
+                    }
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1082,16 +1082,18 @@ namespace GitUI
 
         private void CheckAndRepairInitialRevision()
         {
-            if (_gridView.ToBeSelectedObjectIds.Any())
+            // Check if there is any commit that couldn't be selected.
+            if (!_gridView.ToBeSelectedObjectIds.Any())
             {
-                int index = SearchRevision(_gridView.ToBeSelectedObjectIds.First());
-                if (index >= 0)
-                {
-                    SetSelectedIndex(index);
-                }
+                return;
             }
 
-            return;
+            // Search for the commitid that was not selected in the grid. If not found, select the first parent.
+            int index = SearchRevision(_gridView.ToBeSelectedObjectIds.First());
+            if (index >= 0)
+            {
+                SetSelectedIndex(index);
+            }
 
             int SearchRevision(ObjectId objectId)
             {


### PR DESCRIPTION
Optimizes the code to initially select the correct selected revision. This was done after the complete revision log is loaded. This change selects the commit as soon as the commit to select is loaded. Also, it optimizes the code that searches for the fist parent of the current checkout, if the current checkout is not visible (e.g. in file history).

This Pull Request is on top of pr5473. Seperate pr, because I do not wanted to block the main performance fixes for this. Hope you like this change! On small repo's you probably won't notice any difference/

Changes proposed in this pull request:
- The 'SearchRevision' function is a lot faster. In the linux repo from 6 seconds to 0.3 seconds (depending on how far it needs to search in history). This is only visible when filtering, or in the file history. Both only when the current checkout is filtered out.
- The initial selection is done immediately when this commit is loaded. Instead of waiting for entire list to be loaded. This removes the wait for ~10 seconds on the linux repo. Also, if you started scrolling, the grid scrolled back after 10 seconds to the selected commit. This behaviour is fixed.
- When refreshing (f5) the previous selected commits are remembered and reselected. Multiple select is still possible.
 
What did I do to test the code and ensure quality:
- Tested for about 10 days. Did not extensively tested the SearchRevision code. This code is not modified, only put back after code review in pr5473. I did test it briefly in the file history and it seems to work.

Pros/Cons
+ It is fast!
+ No more sudden scrolling after x seconds
- Code is more complex

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
