### PR TITLE
Add navigate towards "last common ancestor"

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -35,7 +35,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 Text = menuCommand.Text,
                 Image = menuCommand.Image,
                 ShortcutKeys = menuCommand.ShortcutKeys,
-                ShortcutKeyDisplayString = menuCommand.ShortcutKeyDisplayString
+                ShortcutKeyDisplayString = menuCommand.ShortcutKeyDisplayString,
+                ToolTipText = menuCommand.ToolTipText,
             };
 
             toolStripMenuItem.Click += (obj, sender) =>
@@ -69,6 +70,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         /// text of the menu item
         /// </summary>
         public string Text { get; set; }
+
+        /// <summary>
+        /// tooltip text of the menu item
+        /// </summary>
+        public string ToolTipText { get; set; }
 
         /// <summary>
         /// image of the menu item

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -57,6 +57,7 @@ namespace GitUI
         private readonly TranslationString _rebaseBranchInteractive = new TranslationString("Rebase branch interactively.");
         private readonly TranslationString _areYouSureRebase = new TranslationString("Are you sure you want to rebase? This action will rewrite commit history.");
         private readonly TranslationString _dontShowAgain = new TranslationString("Don't show me this message again.");
+        private readonly TranslationString _noMergeBaseCommit = new TranslationString("There is no merge base commit between these 2 commits.");
 
         private readonly FormRevisionFilter _revisionFilter = new FormRevisionFilter();
         private readonly NavigationHistory _navigationHistory = new NavigationHistory();
@@ -2192,6 +2193,24 @@ namespace GitUI
             }
         }
 
+        private void goToMergeBaseCommitToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var selectedRevision = LatestSelectedRevision;
+            if (selectedRevision == null)
+            {
+                return;
+            }
+
+            var mergeBaseCommitId = UICommands.GitModule.RunGitCmd("merge-base HEAD " + selectedRevision.Guid).TrimEnd('\n');
+            if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
+            {
+                MessageBox.Show(_noMergeBaseCommit.Text);
+                return;
+            }
+
+            SetSelectedRevision(ObjectId.Parse(mergeBaseCommitId));
+        }
+
         private void goToChildToolStripMenuItem_Click()
         {
             var r = LatestSelectedRevision;
@@ -2539,6 +2558,7 @@ namespace GitUI
             CompareToCurrentBranch = 28,
             CompareToBranch = 29,
             CompareSelectedCommits = 30,
+            GoToMergeBaseCommit = 31,
         }
 
         protected override bool ExecuteCommand(int cmd)
@@ -2562,6 +2582,7 @@ namespace GitUI
                 case Commands.SelectCurrentRevision: SetSelectedRevision(new GitRevision(CurrentCheckout)); break;
                 case Commands.GoToCommit: MenuCommands.GotoCommitExecute(); break;
                 case Commands.GoToParent: goToParentToolStripMenuItem_Click(); break;
+                case Commands.GoToMergeBaseCommit: goToMergeBaseCommitToolStripMenuItem_Click(null, null); break;
                 case Commands.GoToChild: goToChildToolStripMenuItem_Click(); break;
                 case Commands.ToggleHighlightSelectedBranch: ToggleHighlightSelectedBranch(); break;
                 case Commands.NextQuickSearch: _quickSearchProvider.NextResult(down: true); break;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -107,6 +107,14 @@ namespace GitUI.UserControls.RevisionGrid
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Commands.GoToParent),
                     ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Commands.GoToParent)
                 },
+                new MenuCommand
+                {
+                    Name = "GotoMergeBaseCommit",
+                    Text = "Go to merge base commit",
+                    ToolTipText = "Go to the merge base commit (last common commit) between the currently checked out commit (HEAD) and the currently selected commit",
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Commands.GoToMergeBaseCommit),
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Commands.GoToMergeBaseCommit)
+                },
                 MenuCommand.CreateSeparator(),
                 new MenuCommand
                 {
@@ -129,6 +137,7 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     Name = "QuickSearch",
                     Text = "Quick search",
+                    ToolTipText = _quickSearchQuickHelp.Text,
                     ExecuteAction = () => MessageBox.Show(_quickSearchQuickHelp.Text)
                 },
                 new MenuCommand


### PR DESCRIPTION
of the current checked out commit and the current selected revision

Changes proposed in this pull request:
- Add a new navigate option that allows to find the last common ancestor between the current checked out branch and the currently selected commit.
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/460196/46606244-7cd98680-cafc-11e8-8432-09e3cee273e6.png)

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10
