### PR TITLE
Tidy FileStatusList up

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -260,7 +260,6 @@ namespace GitUI.CommandsDialogs
             // 
             // Stashed
             // 
-            this.Stashed.DescribeRevision = null;
             this.Stashed.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Stashed.FilterVisible = false;
             this.Stashed.Location = new System.Drawing.Point(0, 0);

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs
         public RevisionDiffControl()
         {
             InitializeComponent();
-            DiffFiles.AlwaysRevisionGroups = true;
+            DiffFiles.GroupByRevision = true;
             InitializeComplete();
             HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -369,6 +369,7 @@
     <Compile Include="SpellChecker\SpellCheckerHelper.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractor.cs" />
     <Compile Include="TaskbarProgress.cs" />
+    <Compile Include="UserControls\GitItemStatusWithParent.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
     <Compile Include="UserControls\ListViewGroupHitInfo.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\JunctionColorProvider.cs" />

--- a/GitUI/UserControls/GitItemStatusWithParent.cs
+++ b/GitUI/UserControls/GitItemStatusWithParent.cs
@@ -1,0 +1,16 @@
+﻿using GitCommands;
+
+namespace GitUI.UserControls
+{
+    public sealed class GitItemStatusWithParent
+    {
+        public GitItemStatusWithParent(GitRevision parent, GitItemStatus item)
+        {
+            ParentRevision = parent;
+            Item = item;
+        }
+
+        public GitRevision ParentRevision { get; }
+        public GitItemStatus Item { get; }
+    }
+}


### PR DESCRIPTION
No functional changes

* Reorder `FileStatusList` members
* Extracted `GitItemStatusWithParent` into own file
* Renamed `AlwaysRevisionGroups` to `GroupByRevision`, added getter
