### PR TITLE
fix: Remove 3rd line of text in Dashboard

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -277,7 +277,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                         SubItems =
                         {
                             { _controller.GetCurrentBranchName(repository.Repo.Path), BranchNameColor, BackColor, _secondaryFont },
-                            { repository.Repo.Category, SystemColors.GrayText, BackColor, _secondaryFont }
+                            //// NB: we can add a 3rd row as well: { repository.Repo.Category, SystemColors.GrayText, BackColor, _secondaryFont }
                         }
                     });
                 }
@@ -511,7 +511,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             var branchBounds = DrawText(e.Graphics, e.Item.SubItems[1].Text, _secondaryFont, _branchNameColorBrush, textWidth, pointBranch, spacing4 * 2);
 
             // render category
-            if (!string.IsNullOrWhiteSpace(e.Item.SubItems[2].Text))
+            if (e.Item.SubItems.Count > 2 && !string.IsNullOrWhiteSpace(e.Item.SubItems[2].Text))
             {
                 var pointCategory = string.IsNullOrWhiteSpace(e.Item.SubItems[1].Text) ?
                                     pointBranch :


### PR DESCRIPTION
Closes #5084

> Each repo in a category has a third line with a gray label (green light arrow) repeating the category name (green thick arrow)...
This is redudant, it doesn't add information and it is space consuming.