### PR TITLE
fix: ArgumentException when scrolling revision grid

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -35,6 +35,11 @@ namespace GitUI
                 bounds.Y + outerMarginTopBottom,
                 Math.Min(bounds.Width - offset, textSize.Width + arrowWidth + paddingLeftRight + paddingLeftRight - 1),
                 backgroundHeight);
+            if (rect.Width == 0 || rect.Height == 0)
+            {
+                // it may happen, as observe in #5396
+                return;
+            }
 
             DrawRefBackground(
                 isRowSelected,


### PR DESCRIPTION
Users could experience random ArgumentException exceptions, and visual artifacts in the RevisionGrid when scrolling.
It appears that under certain circumstances a rectangle for rendering refs may be of zero width or height, that would lead to the exception.
Add safe guards to prevent rendering in such cases.

Addresses https://github.com/gitextensions/gitextensions/issues/5396#issuecomment-427799141

What did I do to test the code and ensure quality:
- none, looked at writing some tests but couldn't find a meaningful way without a refactor