### PR TITLE
Fix selection from pull menu always performing default action rather …

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -478,41 +478,31 @@ namespace GitUI
             return DoActionOnRepo(owner, false, true, null, null, Action);
         }
 
-        public bool StartPullDialogAndPullImmediately(IWin32Window owner = null, string remoteBranch = null, string remote = null, bool fetchAll = false, bool prune = false)
+        public bool StartPullDialogAndPullImmediately(IWin32Window owner = null, string remoteBranch = null, string remote = null, AppSettings.PullAction pullAction = AppSettings.PullAction.None)
         {
-            return StartPullDialogAndPullImmediately(out _, owner, remoteBranch, remote, fetchAll, prune);
+            return StartPullDialogAndPullImmediately(out _, owner, remoteBranch, remote, pullAction);
         }
 
         /// <param name="pullCompleted">true if pull completed with no errors</param>
         /// <returns>if revision grid should be refreshed</returns>
-        public bool StartPullDialogAndPullImmediately(out bool pullCompleted, IWin32Window owner = null, string remoteBranch = null, string remote = null, bool fetchAll = false, bool prune = false)
+        public bool StartPullDialogAndPullImmediately(out bool pullCompleted, IWin32Window owner = null, string remoteBranch = null, string remote = null, AppSettings.PullAction pullAction = AppSettings.PullAction.None)
         {
-            return StartPullDialogInternal(owner, pullOnShow: true, out pullCompleted, remoteBranch, remote, fetchAll, prune);
+            return StartPullDialogInternal(owner, pullOnShow: true, out pullCompleted, remoteBranch, remote, pullAction);
         }
 
-        public bool StartPullDialog(IWin32Window owner = null, string remoteBranch = null, string remote = null, bool fetchAll = false, bool prune = false)
+        public bool StartPullDialog(IWin32Window owner = null, string remoteBranch = null, string remote = null, AppSettings.PullAction pullAction = AppSettings.PullAction.None)
         {
-            return StartPullDialogInternal(owner, pullOnShow: false, out _, remoteBranch, remote, fetchAll, prune);
+            return StartPullDialogInternal(owner, pullOnShow: false, out _, remoteBranch, remote, pullAction);
         }
 
-        private bool StartPullDialogInternal(IWin32Window owner, bool pullOnShow, out bool pullCompleted, string remoteBranch, string remote, bool fetchAll, bool prune)
+        private bool StartPullDialogInternal(IWin32Window owner, bool pullOnShow, out bool pullCompleted, string remoteBranch, string remote, AppSettings.PullAction pullAction)
         {
             var pulled = false;
 
             bool Action()
             {
-                using (var formPull = new FormPull(this, remoteBranch, remote))
+                using (var formPull = new FormPull(this, remoteBranch, remote, pullAction))
                 {
-                    if (fetchAll)
-                    {
-                        formPull.SetForFetchAll();
-                    }
-
-                    if (prune)
-                    {
-                        formPull.SetPrune();
-                    }
-
                     var dlgResult = pullOnShow
                         ? formPull.PullAndShowDialogWhenFailed(owner)
                         : formPull.ShowDialog(owner);


### PR DESCRIPTION
…than selected action

Fixes #5420 

Changes proposed in this pull request:
- This change is in the same spirit as the old code that used to set the next default action. The old code would set Module.LastPullAction to whichever action you selected from the menu (e.g. Settings.PullAction.Merge). Now, the behaviour isn't to set the next action to the last one you chose. Instead, we select a default action. So we can't just change the default action. Instead, we temporarily change the default action, perform the action, then bring it back.
 
Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- I tested all the combinations, I believe.

Has been tested on (remove any that don't apply):
- Windows 10
