### PR TITLE
Show more prominent loading indicator when waiting for first revision…

### DIFF
--- a/GitUI/UserControls/WaitSpinner.cs
+++ b/GitUI/UserControls/WaitSpinner.cs
@@ -51,7 +51,7 @@ namespace GitUI.UserControls
             _angles = GetAngles();
             UpdateCentre();
 
-            _timer = new Timer { Interval = 1000 / 60 }; // 60 fps
+            _timer = new Timer { Interval = 1000 / 30 }; // 30 fps
             _timer.Tick += delegate
             {
                 _progress = (_progress + 1) % _dotCount;
@@ -70,7 +70,7 @@ namespace GitUI.UserControls
 
             IReadOnlyList<Brush> GetBrushes()
             {
-                var alphaDelta = byte.MaxValue / _dotCount;
+                var alphaDelta = (byte.MaxValue / 2) / _dotCount;
 
                 var brushes = new Brush[_dotCount];
                 var alpha = 0;
@@ -130,8 +130,8 @@ namespace GitUI.UserControls
                 ref var angle = ref _angles[p];
                 e.Graphics.FillEllipse(
                     _brushes[i],
-                    _centre.X + (_circleRadius * angle.cos),
-                    _centre.Y + (_circleRadius * angle.sin),
+                    (_centre.X - (_dotRadius / 2)) + (_circleRadius * angle.cos),
+                    (_centre.Y - (_dotRadius / 2)) + (_circleRadius * angle.sin),
                     _dotRadius,
                     _dotRadius);
                 p++;


### PR DESCRIPTION
Fixes the too subtle loading indicator

Changes proposed in this pull request:
- Show spinner when waiting for git.exe to return first commits. When 'Order Revision By Date' or 'Show Reflog References' is turned on, it takes a while before git.exe returns the first value. When both settings are turned off the spinner is hardly seen. Thats why I changed the background to be the same as the grid. This reduces the flickering of the screen.
- When the history is not completely loaded, show a very subtle indicator in the top right corner.
 
Screenshots before and after (if PR changes UI):
During loading first commit:
![image](https://user-images.githubusercontent.com/38675/46831494-e202d580-cda3-11e8-9ff6-076d7c589bd2.png)

When fist commits are loaded, but still loading history
![image](https://user-images.githubusercontent.com/38675/46831513-f3e47880-cda3-11e8-9d48-93ae3b6151bd.png)


What did I do to test the code and ensure quality:
- Visual testing

Known issue:
- The waitspinner is not transparent. This is sometimes noticeable when for example the row behind the spinner was selected before refreshing. WinForms can't really do transparency well. And it not that bad in my opinion.
- When resizing the window, both loading indicators will not relocate.

Has been tested on (remove any that don't apply):
- GIT 2.19.1
- Windows 19
