### PR TITLE
Add shortcuts to CopyContextMenuItem

### DIFF
--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.Properties;
@@ -13,111 +12,164 @@ namespace GitUI.UserControls.RevisionGrid
 {
     public sealed class CopyContextMenuItem : ToolStripMenuItem
     {
+        private readonly TranslationString _copyToClipboardText = new TranslationString("&Copy to clipboard");
         [CanBeNull] private Func<IReadOnlyList<GitRevision>> _revisionFunc;
+        private uint _itemNumber;
 
         public CopyContextMenuItem()
         {
             Image = Images.CopyToClipboard;
-            Text = "Copy to clipboard";
+            Text = _copyToClipboardText.Text;
 
-            // Action template
-            Action<Func<GitRevision, string>> extractText = (Func<GitRevision, string> extractRevisionText) =>
-            {
-                var gitRevisions = _revisionFunc?.Invoke();
-                var sb = new StringBuilder();
-                foreach (var revision in gitRevisions)
-                {
-                    sb.AppendLine(extractRevisionText(revision));
-                }
-
-                Clipboard.SetText(sb.ToString());
-            };
-
-            // Add a dummy copy item, so that the shortcut key works.
-            // This item will never be seen by the user, as the submenu is rebuilt on opening.
-            AddItem("Dummy item", () => extractText(r => r.Guid), image: null, Keys.Control | Keys.C, showShortcutKeys: false);
+            // Create a dummy menu, so that the shortcut keys work.
+            OnDropDownOpening(null, null);
 
             DropDownOpening += OnDropDownOpening;
-
-            void OnDropDownOpening(object sender, EventArgs e)
-            {
-                var revisions = _revisionFunc?.Invoke();
-                if (revisions == null || revisions.Count == 0)
-                {
-                    HideDropDown();
-                    return;
-                }
-
-                DropDownItems.Clear();
-
-                List<string> branchNames = new List<string>();
-                List<string> tagNames = new List<string>();
-                foreach (var revision in revisions)
-                {
-                    var refLists = new GitRefListsForRevision(revision);
-                    branchNames.AddRange(refLists.GetAllBranchNames());
-                    tagNames.AddRange(refLists.GetAllTagNames());
-                }
-
-                // Add items for branches
-                if (branchNames.Any())
-                {
-                    var caption = new ToolStripMenuItem { Text = Strings.Branches };
-                    MenuUtil.SetAsCaptionMenuItem(caption, Owner);
-                    DropDownItems.Add(caption);
-
-                    foreach (var name in branchNames)
-                    {
-                        AddItem(name, () => Clipboard.SetText(name), Images.Branch);
-                    }
-
-                    DropDownItems.Add(new ToolStripSeparator());
-                }
-
-                // Add items for tags
-                if (tagNames.Any())
-                {
-                    var caption = new ToolStripMenuItem { Text = Strings.Tags };
-                    MenuUtil.SetAsCaptionMenuItem(caption, Owner);
-                    DropDownItems.Add(caption);
-
-                    foreach (var name in tagNames)
-                    {
-                        AddItem(name, () => Clipboard.SetText(name), Images.Tag);
-                    }
-
-                    DropDownItems.Add(new ToolStripSeparator());
-                }
-
-                var count = revisions.Count();
-                AddItem(Strings.GetCommitHash(count), () => extractText(r => r.Guid), Images.CommitId, Keys.Control | Keys.C);
-                AddItem(Strings.GetMessage(count), () => extractText(r => r.Body ?? r.Subject), Images.Message);
-                AddItem(Strings.GetAuthor(count), () => extractText(r => r.Author), Images.Author);
-                AddItem(Strings.GetAuthorDate(count), () => extractText(r => r.AuthorDate.ToString()), Images.Date);
-                AddItem(Strings.GetCommitDate(count), () => extractText(r => r.CommitDate.ToString()), Images.Date);
-            }
-
-            void AddItem(string displayText, Action clickAction, Image image, Keys shortcutKeys = Keys.None, bool showShortcutKeys = true)
-            {
-                var item = new ToolStripMenuItem
-                {
-                    Text = displayText,
-                    ShortcutKeys = shortcutKeys,
-                    ShowShortcutKeys = showShortcutKeys,
-                    Image = image
-                };
-                item.Click += delegate
-                {
-                    clickAction();
-                };
-
-                DropDownItems.Add(item);
-            }
         }
 
         public void SetRevisionFunc(Func<IReadOnlyList<GitRevision>> revisionFunc)
         {
             _revisionFunc = revisionFunc;
+        }
+
+        private void OnDropDownOpening(object sender, EventArgs e)
+        {
+            var revisions = _revisionFunc?.Invoke();
+            if (revisions == null || revisions.Count == 0)
+            {
+                if (sender == null)
+                {
+                    // create the initial dummy menu on a dummy revision
+                    revisions = new List<GitRevision> { new GitRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId) };
+                }
+                else
+                {
+                    HideDropDown();
+                    return;
+                }
+            }
+
+            DropDownItems.Clear();
+
+            List<string> branchNames = new List<string>();
+            List<string> tagNames = new List<string>();
+            foreach (var revision in revisions)
+            {
+                var refLists = new GitRefListsForRevision(revision);
+                branchNames.AddRange(refLists.GetAllBranchNames());
+                tagNames.AddRange(refLists.GetAllTagNames());
+            }
+
+            _itemNumber = 0;
+
+            // Add items for branches
+            if (branchNames.Any())
+            {
+                var caption = new ToolStripMenuItem { Text = Strings.Branches };
+                MenuUtil.SetAsCaptionMenuItem(caption, Owner);
+                DropDownItems.Add(caption);
+
+                foreach (var name in branchNames)
+                {
+                    AddItem(name, extractRevisionText: null, Images.Branch, hotkey: null);
+                }
+
+                DropDownItems.Add(new ToolStripSeparator());
+            }
+
+            // Add items for tags
+            if (tagNames.Any())
+            {
+                var caption = new ToolStripMenuItem { Text = Strings.Tags };
+                MenuUtil.SetAsCaptionMenuItem(caption, Owner);
+                DropDownItems.Add(caption);
+
+                foreach (var name in tagNames)
+                {
+                    AddItem(name, extractRevisionText: null, Images.Tag, hotkey: null);
+                }
+
+                DropDownItems.Add(new ToolStripSeparator());
+            }
+
+            // Add other items
+            int count = revisions.Count();
+            AddItem(Strings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C', Keys.Control | Keys.C);
+            AddItem(Strings.GetMessage(count), r => r.Body ?? r.Subject, Images.Message, 'M');
+            AddItem(Strings.GetAuthor(count), r => r.Author, Images.Author, 'A');
+
+            if (count == 1 && revisions.First().AuthorDate == revisions.First().CommitDate)
+            {
+                AddItem(Strings.Date, r => r.AuthorDate.ToString(), Images.Date, 'D');
+            }
+            else
+            {
+                AddItem(Strings.GetAuthorDate(count), r => r.AuthorDate.ToString(), Images.Date, 'T');
+                AddItem(Strings.GetCommitDate(count), r => r.CommitDate.ToString(), Images.Date, 'D');
+            }
+        }
+
+        private IEnumerable<string> ExtractRevisionTexts(Func<GitRevision, string> extractRevisionText)
+        {
+            if (extractRevisionText == null)
+            {
+                return null;
+            }
+
+            var gitRevisions = _revisionFunc?.Invoke();
+            if (gitRevisions == null || gitRevisions.Count == 0)
+            {
+                return null;
+            }
+
+            return gitRevisions.Select(extractRevisionText).Distinct();
+        }
+
+        private void AddItem(string displayText, Func<GitRevision, string> extractRevisionText, Image image, char? hotkey, Keys shortcutKeys = Keys.None)
+        {
+            if (hotkey.HasValue)
+            {
+                int position = displayText.IndexOf(hotkey.Value.ToString(), StringComparison.InvariantCultureIgnoreCase);
+                if (position >= 0)
+                {
+                    displayText = displayText.Insert(position, "&");
+                }
+            }
+            else
+            {
+                displayText = PrependItemNumber(displayText);
+            }
+
+            var texts = ExtractRevisionTexts(extractRevisionText);
+            if (texts != null)
+            {
+                displayText += ":   " + texts.Select(t => t.SubstringUntil('\n')).Join(", ").ShortenTo(40);
+            }
+
+            var item = new ToolStripMenuItem
+            {
+                Text = displayText,
+                ShortcutKeys = shortcutKeys,
+                ShowShortcutKeys = true,
+                Image = image
+            };
+            item.Click += delegate
+            {
+                var textToCopy = ExtractRevisionTexts(extractRevisionText);
+                if (textToCopy == null)
+                {
+                    return;
+                }
+
+                Clipboard.SetText(textToCopy.Join("\n"));
+            };
+
+            DropDownItems.Add(item);
+        }
+
+        private string PrependItemNumber(string name)
+        {
+            return ++_itemNumber > 10 ? name : "&" + (_itemNumber % 10) + ":   " + name;
         }
     }
 }


### PR DESCRIPTION
Resolve the regression introduced in #5422

The initial work is done by @mstv in 768e6457e2fb882f7a867bae18c7120d5a5fa598
This PR closes #5444

Changes proposed in this pull request:
- add shortcuts (`&`) to the menu items provided by `CopyContextMenuItem`
 
Screenshots before and after (if PR changes UI):
- before
![grafik](https://user-images.githubusercontent.com/36601201/45649624-2ca67000-bacc-11e8-9e13-e726cf69ccc2.png)
![grafik](https://user-images.githubusercontent.com/36601201/45649741-7f802780-bacc-11e8-9329-71f9e8f1a0ff.png)
- after
![image](https://user-images.githubusercontent.com/4403806/46859245-fc4abb00-ce58-11e8-9686-b794e42df7ab.png)



What did I do to test the code and ensure quality:
- manually

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
