### PR TITLE
Fixed crash when disable artificial commit when it was selected.

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1110,12 +1110,15 @@ namespace GitUI
                     return exactIndex;
                 }
 
-                // Not found, so search for its parents
-                foreach (var parentId in TryGetParents(objectId))
+                if (!objectId.IsArtificial)
                 {
-                    if (_gridView.TryGetRevisionIndex(parentId) is int parentIndex)
+                    // Not found, so search for its parents
+                    foreach (var parentId in TryGetParents(objectId))
                     {
-                        return parentIndex;
+                        if (_gridView.TryGetRevisionIndex(parentId) is int parentIndex)
+                        {
+                            return parentIndex;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixed crash when disable artificial commit when it was selected.

To reproduce:
- Enable 'show current working directory changes as an artificial commit'
- Select this commit in the browse dialog
- Disable 'show current working directory changes as an artificial commit'
- Boom

Changes proposed in this pull request:
- Add guard to not attempt to find parents of artificial commit
 
What did I do to test the code and ensure quality:
- I was trying to reproduce #5167

Has been tested on (remove any that don't apply):
- GIT 2.19.1
- Windows 10
