### PR TITLE
5327 retain diff view position

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -817,38 +817,8 @@ namespace GitUI.CommandsDialogs
                 Unstaged.StoreNextIndexToSelect();
             }
 
-            ScheduleGoToLine();
             _selectedDiffReloaded = false;
             RescanChanges();
-
-            return;
-
-            void ScheduleGoToLine()
-            {
-                int selectedDiffLineToSelect = SelectedDiff.GetText().Substring(0, SelectedDiff.GetSelectionPosition()).Count(c => c == '\n');
-                int scrollPosition = SelectedDiff.ScrollPos;
-                string selectedFileName = _currentItem.Name;
-
-                OnStageAreaLoaded += StageAreaLoaded;
-
-                void StageAreaLoaded()
-                {
-                    void TextLoaded(object a, EventArgs b)
-                    {
-                        if (_currentItem != null && _currentItem.Name == selectedFileName)
-                        {
-                            SelectedDiff.GoToLine(selectedDiffLineToSelect);
-                            SelectedDiff.ScrollPos = scrollPosition;
-                        }
-
-                        SelectedDiff.TextLoaded -= TextLoaded;
-                        _selectedDiffReloaded = true;
-                    }
-
-                    SelectedDiff.TextLoaded += TextLoaded;
-                    OnStageAreaLoaded -= StageAreaLoaded;
-                }
-            }
         }
 
         private void ResetSelectedLinesToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -287,9 +287,6 @@ namespace GitUI.CommandsDialogs
 
         private void FileChangesSelectionChanged(object sender, EventArgs e)
         {
-            View.SaveCurrentScrollPos();
-            Diff.SaveCurrentScrollPos();
-
             UpdateSelectedFileViewers();
         }
 
@@ -366,11 +363,8 @@ namespace GitUI.CommandsDialogs
             }
             else if (tabControl1.SelectedTab == ViewTab)
             {
-                var scrollPos = View.ScrollPos;
-
                 View.Encoding = Diff.Encoding;
                 View.ViewGitItemRevisionAsync(fileName, revision.ObjectId);
-                View.ScrollPos = scrollPos;
             }
             else if (tabControl1.SelectedTab == DiffTab)
             {

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -140,7 +140,6 @@ namespace GitUI.CommandsDialogs
 
         public void DisplayDiffTab()
         {
-            DiffText.SaveCurrentScrollPos();
             var revisions = _revisionGrid.GetSelectedRevisions();
             DiffFiles.SetDiffs(revisions);
             if (_oldDiffItem != null && DiffFiles.Revision?.Guid == _oldRevision)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -150,7 +150,6 @@ See the changes in the commit form.");
                 if (tvGitTree.SelectedNode != null)
                 {
                     var node = tvGitTree.SelectedNode;
-                    FileText.SaveCurrentScrollPos();
                     _lastSelectedNodes.Clear();
                     while (node != null)
                     {
@@ -196,12 +195,6 @@ See the changes in the commit form.");
                             lastMatchedNode = matchedNode;
                             currentNodes = matchedNode.Nodes;
                         }
-                    }
-
-                    // if there is no exact match, don't restore scroll position
-                    if (lastMatchedNode != matchedNode)
-                    {
-                        FileText.ResetCurrentScrollPos();
                     }
 
                     tvGitTree.SelectedNode = lastMatchedNode;

--- a/GitUI/Editor/Diff/DiffLineInfo.cs
+++ b/GitUI/Editor/Diff/DiffLineInfo.cs
@@ -1,0 +1,11 @@
+﻿namespace GitUI.Editor.Diff
+{
+    public class DiffLineInfo
+    {
+        public static readonly int NotApplicableLineNum = -1;
+        public int LineNumInDiff { get; set; }
+        public int LeftLineNumber { get; set; }
+        public int RightLineNumber { get; set; }
+        public DiffLineType LineType { get; set; }
+    }
+}

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Patches;
@@ -12,25 +11,6 @@ namespace GitUI.Editor.Diff
         private static readonly Regex regex = new Regex(
             @"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-        public sealed class DiffLinesInfo
-        {
-            private readonly Dictionary<int, DiffLineInfo> _diffLines = new Dictionary<int, DiffLineInfo>();
-
-            public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
-
-            /// <summary>
-            /// Gets the maximum line number from either left or right version.
-            /// </summary>
-            public int MaxLineNumber { get; private set; }
-
-            public void Add(DiffLineInfo diffLine)
-            {
-                _diffLines.Add(diffLine.LineNumInDiff, diffLine);
-                MaxLineNumber = Math.Max(MaxLineNumber,
-                    Math.Max(diffLine.LeftLineNumber, diffLine.RightLineNumber));
-            }
-        }
 
         [NotNull]
         public DiffLinesInfo Analyze([NotNull] string diffContent)
@@ -58,7 +38,7 @@ namespace GitUI.Editor.Diff
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
                         RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        LineType = DiffLineInfo.DiffLineType.Header
+                        LineType = DiffLineType.Header
                     };
 
                     var lineNumbers = regex.Match(line);
@@ -79,17 +59,17 @@ namespace GitUI.Editor.Diff
 
                     if (IsMinusLineInCombinedDiff(line))
                     {
-                        meta.LineType = DiffLineInfo.DiffLineType.Minus;
+                        meta.LineType = DiffLineType.Minus;
                     }
                     else if (IsPlusLineInCombinedDiff(line))
                     {
-                        meta.LineType = DiffLineInfo.DiffLineType.Plus;
+                        meta.LineType = DiffLineType.Plus;
                         meta.RightLineNumber = rightLineNum;
                         rightLineNum++;
                     }
                     else
                     {
-                        meta.LineType = DiffLineInfo.DiffLineType.Context;
+                        meta.LineType = DiffLineType.Context;
                         meta.RightLineNumber = rightLineNum;
                         rightLineNum++;
                     }
@@ -103,7 +83,7 @@ namespace GitUI.Editor.Diff
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = leftLineNum,
                         RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        LineType = DiffLineInfo.DiffLineType.Minus
+                        LineType = DiffLineType.Minus
                     };
                     ret.Add(meta);
 
@@ -116,7 +96,7 @@ namespace GitUI.Editor.Diff
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
                         RightLineNumber = rightLineNum,
-                        LineType = DiffLineInfo.DiffLineType.Plus,
+                        LineType = DiffLineType.Plus,
                     };
                     ret.Add(meta);
                     rightLineNum++;
@@ -128,7 +108,7 @@ namespace GitUI.Editor.Diff
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
                         RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        LineType = DiffLineInfo.DiffLineType.Header
+                        LineType = DiffLineType.Header
                     };
                     ret.Add(meta);
                 }
@@ -139,7 +119,7 @@ namespace GitUI.Editor.Diff
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = leftLineNum,
                         RightLineNumber = rightLineNum,
-                        LineType = DiffLineInfo.DiffLineType.Context,
+                        LineType = DiffLineType.Context,
                     };
                     ret.Add(meta);
 
@@ -170,22 +150,5 @@ namespace GitUI.Editor.Diff
         {
             return line.StartsWith("--") || line.StartsWith("- ") || line.StartsWith(" -");
         }
-    }
-
-    public class DiffLineInfo
-    {
-        public enum DiffLineType
-        {
-            Header,
-            Plus,
-            Minus,
-            Context
-        }
-
-        public static readonly int NotApplicableLineNum = -1;
-        public int LineNumInDiff { get; set; }
-        public int LeftLineNumber { get; set; }
-        public int RightLineNumber { get; set; }
-        public DiffLineType LineType { get; set; }
     }
 }

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -13,27 +13,33 @@ namespace GitUI.Editor.Diff
             @"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public class Result
+        public sealed class DiffLinesInfo
         {
-            public Dictionary<int, DiffLineNum> LineNumbers { get; } = new Dictionary<int, DiffLineNum>();
-            public int MaxLineNumber;
-        }
+            private readonly Dictionary<int, DiffLineInfo> _diffLines = new Dictionary<int, DiffLineInfo>();
 
-        private static void AddToResult(Result result, DiffLineNum diffLine)
-        {
-            result.LineNumbers.Add(diffLine.LineNumInDiff, diffLine);
-            result.MaxLineNumber = Math.Max(result.MaxLineNumber,
-                Math.Max(diffLine.LeftLineNum, diffLine.RightLineNum));
+            public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
+
+            /// <summary>
+            /// Gets the maximum line number from either left or right version.
+            /// </summary>
+            public int MaxLineNumber { get; private set; }
+
+            public void Add(DiffLineInfo diffLine)
+            {
+                _diffLines.Add(diffLine.LineNumInDiff, diffLine);
+                MaxLineNumber = Math.Max(MaxLineNumber,
+                    Math.Max(diffLine.LeftLineNumber, diffLine.RightLineNumber));
+            }
         }
 
         [NotNull]
-        public Result Analyze([NotNull] string diffContent)
+        public DiffLinesInfo Analyze([NotNull] string diffContent)
         {
-            var ret = new Result();
+            var ret = new DiffLinesInfo();
             var isCombinedDiff = PatchProcessor.IsCombinedDiff(diffContent);
             var lineNumInDiff = 0;
-            var leftLineNum = DiffLineNum.NotApplicableLineNum;
-            var rightLineNum = DiffLineNum.NotApplicableLineNum;
+            var leftLineNum = DiffLineInfo.NotApplicableLineNum;
+            var rightLineNum = DiffLineInfo.NotApplicableLineNum;
             var isHeaderLineLocated = false;
             string[] lines = diffContent.Split('\n');
             for (int i = 0; i < lines.Length; i++)
@@ -47,95 +53,95 @@ namespace GitUI.Editor.Diff
                 lineNumInDiff++;
                 if (line.StartsWith("@"))
                 {
-                    var meta = new DiffLineNum
+                    var meta = new DiffLineInfo
                     {
                         LineNumInDiff = lineNumInDiff,
-                        LeftLineNum = DiffLineNum.NotApplicableLineNum,
-                        RightLineNum = DiffLineNum.NotApplicableLineNum,
-                        Style = DiffLineNum.DiffLineStyle.Header
+                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        LineType = DiffLineInfo.DiffLineType.Header
                     };
 
                     var lineNumbers = regex.Match(line);
                     leftLineNum = int.Parse(lineNumbers.Groups["leftStart"].Value);
                     rightLineNum = int.Parse(lineNumbers.Groups["rightStart"].Value);
 
-                    AddToResult(ret, meta);
+                    ret.Add(meta);
                     isHeaderLineLocated = true;
                 }
                 else if (isHeaderLineLocated && isCombinedDiff)
                 {
-                    var meta = new DiffLineNum
+                    var meta = new DiffLineInfo
                     {
                         LineNumInDiff = lineNumInDiff,
-                        LeftLineNum = DiffLineNum.NotApplicableLineNum,
-                        RightLineNum = DiffLineNum.NotApplicableLineNum,
+                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
                     };
 
                     if (IsMinusLineInCombinedDiff(line))
                     {
-                        meta.Style = DiffLineNum.DiffLineStyle.Minus;
+                        meta.LineType = DiffLineInfo.DiffLineType.Minus;
                     }
                     else if (IsPlusLineInCombinedDiff(line))
                     {
-                        meta.Style = DiffLineNum.DiffLineStyle.Plus;
-                        meta.RightLineNum = rightLineNum;
+                        meta.LineType = DiffLineInfo.DiffLineType.Plus;
+                        meta.RightLineNumber = rightLineNum;
                         rightLineNum++;
                     }
                     else
                     {
-                        meta.Style = DiffLineNum.DiffLineStyle.Context;
-                        meta.RightLineNum = rightLineNum;
+                        meta.LineType = DiffLineInfo.DiffLineType.Context;
+                        meta.RightLineNumber = rightLineNum;
                         rightLineNum++;
                     }
 
-                    AddToResult(ret, meta);
+                    ret.Add(meta);
                 }
                 else if (isHeaderLineLocated && IsMinusLine(line))
                 {
-                    var meta = new DiffLineNum
+                    var meta = new DiffLineInfo
                     {
                         LineNumInDiff = lineNumInDiff,
-                        LeftLineNum = leftLineNum,
-                        RightLineNum = DiffLineNum.NotApplicableLineNum,
-                        Style = DiffLineNum.DiffLineStyle.Minus
+                        LeftLineNumber = leftLineNum,
+                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        LineType = DiffLineInfo.DiffLineType.Minus
                     };
-                    AddToResult(ret, meta);
+                    ret.Add(meta);
 
                     leftLineNum++;
                 }
                 else if (isHeaderLineLocated && IsPlusLine(line))
                 {
-                    var meta = new DiffLineNum
+                    var meta = new DiffLineInfo
                     {
                         LineNumInDiff = lineNumInDiff,
-                        LeftLineNum = DiffLineNum.NotApplicableLineNum,
-                        RightLineNum = rightLineNum,
-                        Style = DiffLineNum.DiffLineStyle.Plus,
+                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        RightLineNumber = rightLineNum,
+                        LineType = DiffLineInfo.DiffLineType.Plus,
                     };
-                    AddToResult(ret, meta);
+                    ret.Add(meta);
                     rightLineNum++;
                 }
                 else if (line.StartsWith(GitModule.NoNewLineAtTheEnd))
                 {
-                    var meta = new DiffLineNum
+                    var meta = new DiffLineInfo
                     {
                         LineNumInDiff = lineNumInDiff,
-                        LeftLineNum = DiffLineNum.NotApplicableLineNum,
-                        RightLineNum = DiffLineNum.NotApplicableLineNum,
-                        Style = DiffLineNum.DiffLineStyle.Header
+                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                        LineType = DiffLineInfo.DiffLineType.Header
                     };
-                    AddToResult(ret, meta);
+                    ret.Add(meta);
                 }
                 else if (isHeaderLineLocated)
                 {
-                    var meta = new DiffLineNum
+                    var meta = new DiffLineInfo
                     {
                         LineNumInDiff = lineNumInDiff,
-                        LeftLineNum = leftLineNum,
-                        RightLineNum = rightLineNum,
-                        Style = DiffLineNum.DiffLineStyle.Context,
+                        LeftLineNumber = leftLineNum,
+                        RightLineNumber = rightLineNum,
+                        LineType = DiffLineInfo.DiffLineType.Context,
                     };
-                    AddToResult(ret, meta);
+                    ret.Add(meta);
 
                     leftLineNum++;
                     rightLineNum++;
@@ -166,9 +172,9 @@ namespace GitUI.Editor.Diff
         }
     }
 
-    public class DiffLineNum
+    public class DiffLineInfo
     {
-        public enum DiffLineStyle
+        public enum DiffLineType
         {
             Header,
             Plus,
@@ -178,8 +184,8 @@ namespace GitUI.Editor.Diff
 
         public static readonly int NotApplicableLineNum = -1;
         public int LineNumInDiff { get; set; }
-        public int LeftLineNum { get; set; }
-        public int RightLineNum { get; set; }
-        public DiffLineStyle Style { get; set; }
+        public int LeftLineNumber { get; set; }
+        public int RightLineNumber { get; set; }
+        public DiffLineType LineType { get; set; }
     }
 }

--- a/GitUI/Editor/Diff/DiffLineType.cs
+++ b/GitUI/Editor/Diff/DiffLineType.cs
@@ -1,0 +1,10 @@
+﻿namespace GitUI.Editor.Diff
+{
+    public enum DiffLineType
+    {
+        Header,
+        Plus,
+        Minus,
+        Context
+    }
+}

--- a/GitUI/Editor/Diff/DiffLinesInfo.cs
+++ b/GitUI/Editor/Diff/DiffLinesInfo.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GitUI.Editor.Diff
+{
+    public sealed class DiffLinesInfo
+    {
+        private readonly Dictionary<int, DiffLineInfo> _diffLines = new Dictionary<int, DiffLineInfo>();
+
+        public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
+
+        /// <summary>
+        /// Gets the maximum line number from either left or right version.
+        /// </summary>
+        public int MaxLineNumber { get; private set; }
+
+        public void Add(DiffLineInfo diffLine)
+        {
+            _diffLines.Add(diffLine.LineNumInDiff, diffLine);
+            MaxLineNumber = Math.Max(MaxLineNumber,
+                Math.Max(diffLine.LeftLineNumber, diffLine.RightLineNumber));
+        }
+    }
+}

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -14,12 +14,24 @@ namespace GitUI.Editor.Diff
 
         private Dictionary<int, DiffLineNum> DiffLines { get; set; }
 
-        private int _maxValueOfLineNum;
+        public int MaxValueOfLineNum { get; private set; }
+
         private bool _visible = true;
 
         public DiffViewerLineNumberControl(TextArea textArea) : base(textArea)
         {
             DiffLines = new Dictionary<int, DiffLineNum>();
+        }
+
+        /// <summary>
+        /// returns the according line numbers or null if the caretLine is not mapped
+        /// </summary>
+        /// <param name="caretLine">0-based (in contrast to the displayed line numbers which are 1-based)</param>
+        public DiffLineNum GetLineNum(int caretLine)
+        {
+            DiffLineNum diffLine;
+            DiffLines.TryGetValue(caretLine + 1, out diffLine);
+            return diffLine;
         }
 
         public override int Width
@@ -28,7 +40,7 @@ namespace GitUI.Editor.Diff
             {
                 if (_visible && DiffLines.Any())
                 {
-                    return textArea.TextView.WideSpaceWidth * ((int)Math.Log10(_maxValueOfLineNum) + TextHorizontalMargin + 3);
+                    return textArea.TextView.WideSpaceWidth * ((int)Math.Log10(MaxValueOfLineNum) + TextHorizontalMargin + 3);
                 }
 
                 return 0;
@@ -113,7 +125,7 @@ namespace GitUI.Editor.Diff
         {
             var result = new DiffLineNumAnalyzer().Analyze(diff);
             DiffLines = result.LineNumbers;
-            _maxValueOfLineNum = result.MaxLineNumber;
+            MaxValueOfLineNum = result.MaxLineNumber;
         }
 
         public void Clear(bool forDiff)

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -83,18 +83,18 @@ namespace GitUI.Editor.Diff
                 }
 
                 var diffLine = _diffLines[curLine + 1];
-                if (diffLine.LineType != DiffLineInfo.DiffLineType.Context)
+                if (diffLine.LineType != DiffLineType.Context)
                 {
                     var brush = default(Brush);
                     switch (diffLine.LineType)
                     {
-                        case DiffLineInfo.DiffLineType.Plus:
+                        case DiffLineType.Plus:
                             brush = new SolidBrush(AppSettings.DiffAddedColor);
                             break;
-                        case DiffLineInfo.DiffLineType.Minus:
+                        case DiffLineType.Minus:
                             brush = new SolidBrush(AppSettings.DiffRemovedColor);
                             break;
-                        case DiffLineInfo.DiffLineType.Header:
+                        case DiffLineType.Header:
                             brush = new SolidBrush(AppSettings.DiffSectionColor);
                             break;
                     }

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -11,40 +11,42 @@ namespace GitUI.Editor.Diff
     internal class DiffViewerLineNumberControl : AbstractMargin
     {
         private const int TextHorizontalMargin = 4;
-
-        private Dictionary<int, DiffLineNum> DiffLines { get; set; }
-
-        public int MaxValueOfLineNum { get; private set; }
-
+        private static readonly IReadOnlyDictionary<int, DiffLineInfo> Empty = new Dictionary<int, DiffLineInfo>();
+        private IReadOnlyDictionary<int, DiffLineInfo> _diffLines = Empty;
         private bool _visible = true;
 
-        public DiffViewerLineNumberControl(TextArea textArea) : base(textArea)
+        public DiffViewerLineNumberControl(TextArea textArea)
+            : base(textArea)
         {
-            DiffLines = new Dictionary<int, DiffLineNum>();
+        }
+
+        /// <summary>
+        /// Gets the maximum line number from either left or right version.
+        /// </summary>
+        public int MaxLineNumber { get; private set; }
+
+        public override int Width
+        {
+            get
+            {
+                if (_visible && _diffLines.Any())
+                {
+                    return textArea.TextView.WideSpaceWidth * ((int)Math.Log10(MaxLineNumber) + TextHorizontalMargin + 3);
+                }
+
+                return 0;
+            }
         }
 
         /// <summary>
         /// returns the according line numbers or null if the caretLine is not mapped
         /// </summary>
         /// <param name="caretLine">0-based (in contrast to the displayed line numbers which are 1-based)</param>
-        public DiffLineNum GetLineNum(int caretLine)
+        public DiffLineInfo GetLineInfo(int caretLine)
         {
-            DiffLineNum diffLine;
-            DiffLines.TryGetValue(caretLine + 1, out diffLine);
+            DiffLineInfo diffLine;
+            _diffLines.TryGetValue(caretLine + 1, out diffLine);
             return diffLine;
-        }
-
-        public override int Width
-        {
-            get
-            {
-                if (_visible && DiffLines.Any())
-                {
-                    return textArea.TextView.WideSpaceWidth * ((int)Math.Log10(MaxValueOfLineNum) + TextHorizontalMargin + 3);
-                }
-
-                return 0;
-            }
         }
 
         public override void Paint(Graphics g, Rectangle rect)
@@ -75,45 +77,45 @@ namespace GitUI.Editor.Diff
                     continue;
                 }
 
-                if (!DiffLines.ContainsKey(curLine + 1))
+                if (!_diffLines.ContainsKey(curLine + 1))
                 {
                     continue;
                 }
 
-                var diffLine = DiffLines[curLine + 1];
-                if (diffLine.Style != DiffLineNum.DiffLineStyle.Context)
+                var diffLine = _diffLines[curLine + 1];
+                if (diffLine.LineType != DiffLineInfo.DiffLineType.Context)
                 {
                     var brush = default(Brush);
-                    switch (diffLine.Style)
+                    switch (diffLine.LineType)
                     {
-                        case DiffLineNum.DiffLineStyle.Plus:
+                        case DiffLineInfo.DiffLineType.Plus:
                             brush = new SolidBrush(AppSettings.DiffAddedColor);
                             break;
-                        case DiffLineNum.DiffLineStyle.Minus:
+                        case DiffLineInfo.DiffLineType.Minus:
                             brush = new SolidBrush(AppSettings.DiffRemovedColor);
                             break;
-                        case DiffLineNum.DiffLineStyle.Header:
+                        case DiffLineInfo.DiffLineType.Header:
                             brush = new SolidBrush(AppSettings.DiffSectionColor);
                             break;
                     }
 
-                    Debug.Assert(brush != null, string.Format("brush != null, unknow diff line style {0}", diffLine.Style));
+                    Debug.Assert(brush != null, string.Format("brush != null, unknow diff line style {0}", diffLine.LineType));
                     g.FillRectangle(brush, new Rectangle(0, backgroundRectangle.Top, leftWidth, backgroundRectangle.Height));
 
                     g.FillRectangle(brush, new Rectangle(leftWidth, backgroundRectangle.Top, rightWidth, backgroundRectangle.Height));
                 }
 
-                if (diffLine.LeftLineNum != DiffLineNum.NotApplicableLineNum)
+                if (diffLine.LeftLineNumber != DiffLineInfo.NotApplicableLineNum)
                 {
-                    g.DrawString(diffLine.LeftLineNum.ToString(),
+                    g.DrawString(diffLine.LeftLineNumber.ToString(),
                         lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
                         drawBrush,
                         new Point(TextHorizontalMargin, backgroundRectangle.Top));
                 }
 
-                if (diffLine.RightLineNum != DiffLineNum.NotApplicableLineNum)
+                if (diffLine.RightLineNumber != DiffLineInfo.NotApplicableLineNum)
                 {
-                    g.DrawString(diffLine.RightLineNum.ToString(),
+                    g.DrawString(diffLine.RightLineNumber.ToString(),
                         lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
                         drawBrush,
                         new Point(TextHorizontalMargin + (totalWidth / 2), backgroundRectangle.Top));
@@ -124,13 +126,13 @@ namespace GitUI.Editor.Diff
         public void DisplayLineNumFor(string diff)
         {
             var result = new DiffLineNumAnalyzer().Analyze(diff);
-            DiffLines = result.LineNumbers;
-            MaxValueOfLineNum = result.MaxLineNumber;
+            _diffLines = result.DiffLines;
+            MaxLineNumber = result.MaxLineNumber;
         }
 
         public void Clear(bool forDiff)
         {
-            DiffLines.Clear();
+            _diffLines = Empty;
         }
 
         public void SetVisibility(bool visible)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -384,9 +384,9 @@ namespace GitUI.Editor
                 using (var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 using (var reader = new StreamReader(stream, Module.FilesEncoding))
                 {
-                    #pragma warning disable VSTHRD103 // Call async methods when in an async method
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     var content = reader.ReadToEnd();
-                    #pragma warning restore VSTHRD103 // Call async methods when in an async method
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                     FilePreamble = reader.CurrentEncoding.GetPreamble();
                     return content;
                 }
@@ -1238,7 +1238,7 @@ namespace GitUI.Editor
         {
             using (var formGoToLine = new FormGoToLine())
             {
-                formGoToLine.SetMaxLineNumber(_internalFileViewer.MaxLineNumber);
+                formGoToLine.SetMaxLineNumber(internalFileViewer.MaxLineNumber);
                 if (formGoToLine.ShowDialog(this) == DialogResult.OK)
                 {
                     GoToLine(formGoToLine.GetLineNumber());

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -37,7 +37,6 @@ namespace GitUI.Editor
 
         private readonly AsyncLoader _async;
         private readonly IFullPathResolver _fullPathResolver;
-        private int _currentScrollPos = -1;
         private bool _currentViewIsPatch;
         private bool _patchHighlighting;
         private Encoding _encoding;
@@ -338,27 +337,6 @@ namespace GitUI.Editor
             };
         }
 
-        public void SaveCurrentScrollPos()
-        {
-            _currentScrollPos = ScrollPos;
-        }
-
-        public void ResetCurrentScrollPos()
-        {
-            _currentScrollPos = 0;
-        }
-
-        private void RestoreCurrentScrollPos()
-        {
-            if (_currentScrollPos < 0)
-            {
-                return;
-            }
-
-            ScrollPos = _currentScrollPos;
-            ResetCurrentScrollPos();
-        }
-
         public Task ViewFileAsync(string fileName)
         {
             return ShowOrDeferAsync(
@@ -545,7 +523,6 @@ namespace GitUI.Editor
                         ResetForDiff();
                         internalFileViewer.SetText(text, openWithDifftool, isDiff: true);
                         TextLoaded?.Invoke(this, null);
-                        RestoreCurrentScrollPos();
                         return Task.CompletedTask;
                     }));
         }
@@ -581,8 +558,6 @@ namespace GitUI.Editor
             {
                 internalFileViewer.SetText(text, openWithDifftool);
                 TextLoaded?.Invoke(this, null);
-
-                RestoreCurrentScrollPos();
             }
 
             async Task<string> SummariseBinaryFileAsync()
@@ -1261,17 +1236,12 @@ namespace GitUI.Editor
 
         private void goToLineToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!internalFileViewer.IsGotoLineUIApplicable())
-            {
-                return;
-            }
-
             using (var formGoToLine = new FormGoToLine())
             {
-                formGoToLine.SetMaxLineNumber(internalFileViewer.TotalNumberOfLines);
+                formGoToLine.SetMaxLineNumber(_internalFileViewer.MaxLineNumber);
                 if (formGoToLine.ShowDialog(this) == DialogResult.OK)
                 {
-                    GoToLine(formGoToLine.GetLineNumber() - 1);
+                    GoToLine(formGoToLine.GetLineNumber());
                 }
             }
         }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -20,9 +20,7 @@ namespace GitUI.Editor
 
         private readonly FindAndReplaceForm _findAndReplaceForm = new FindAndReplaceForm();
         private readonly DiffViewerLineNumberControl _lineNumbersControl;
-
         private DiffHighlightService _diffHighlightService = DiffHighlightService.Instance;
-
         private ViewPosition _previousViewPosition;
 
         public Action OpenWithDifftool { get; private set; }
@@ -34,10 +32,10 @@ namespace GitUI.Editor
             internal TextLocation CaretPosition;
             internal int FirstVisibleLine;
             internal bool CaretVisible; // if not, FirstVisibleLine has priority for restoring
-            internal DiffLineNum ActiveLineNum;
+            internal DiffLineInfo ActiveLineNum;
         }
 
-        public FileViewerInternal(Func<GitModule> moduleProvider)
+        public FileViewerInternal()
         {
             InitializeComponent();
             InitializeComplete();
@@ -123,11 +121,11 @@ namespace GitUI.Editor
                 {
                     void SetActiveLineNum(int line)
                     {
-                        _previousViewPosition.ActiveLineNum = _lineNumbersControl.GetLineNum(line);
+                        _previousViewPosition.ActiveLineNum = _lineNumbersControl.GetLineInfo(line);
                         if (_previousViewPosition.ActiveLineNum != null)
                         {
-                            if (_previousViewPosition.ActiveLineNum.LeftLineNum == DiffLineNum.NotApplicableLineNum
-                                && _previousViewPosition.ActiveLineNum.RightLineNum == DiffLineNum.NotApplicableLineNum)
+                            if (_previousViewPosition.ActiveLineNum.LeftLineNumber == DiffLineInfo.NotApplicableLineNum
+                                && _previousViewPosition.ActiveLineNum.RightLineNumber == DiffLineInfo.NotApplicableLineNum)
                             {
                                 _previousViewPosition.ActiveLineNum = null;
                             }
@@ -194,9 +192,9 @@ namespace GitUI.Editor
                 else if (isDiff && GetLineText(0) == _previousViewPosition.FirstLine && _previousViewPosition.ActiveLineNum != null)
                 {
                     // prefer the LeftLineNum because the base revision will not change
-                    int line = _previousViewPosition.ActiveLineNum.LeftLineNum != DiffLineNum.NotApplicableLineNum
-                               ? GetCaretLine(_previousViewPosition.ActiveLineNum.LeftLineNum, rightFile: false)
-                               : GetCaretLine(_previousViewPosition.ActiveLineNum.RightLineNum, rightFile: true);
+                    int line = _previousViewPosition.ActiveLineNum.LeftLineNumber != DiffLineInfo.NotApplicableLineNum
+                               ? GetCaretLine(_previousViewPosition.ActiveLineNum.LeftLineNumber, rightFile: false)
+                               : GetCaretLine(_previousViewPosition.ActiveLineNum.RightLineNumber, rightFile: true);
                     if (_previousViewPosition.CaretVisible)
                     {
                         TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(_previousViewPosition.CaretPosition.Column, line);
@@ -359,11 +357,11 @@ namespace GitUI.Editor
             {
                 for (int line = 0; line < TotalNumberOfLines; ++line)
                 {
-                    DiffLineNum diffLineNum = _lineNumbersControl.GetLineNum(line);
+                    DiffLineInfo diffLineNum = _lineNumbersControl.GetLineInfo(line);
                     if (diffLineNum != null)
                     {
-                        int diffLine = rightFile ? diffLineNum.RightLineNum : diffLineNum.LeftLineNum;
-                        if (diffLine != DiffLineNum.NotApplicableLineNum && diffLine >= lineNumber)
+                        int diffLine = rightFile ? diffLineNum.RightLineNumber : diffLineNum.LeftLineNumber;
+                        if (diffLine != DiffLineInfo.NotApplicableLineNum && diffLine >= lineNumber)
                         {
                             return line;
                         }
@@ -374,7 +372,7 @@ namespace GitUI.Editor
             return 0;
         }
 
-        public int MaxLineNumber => TextEditor.ShowLineNumbers ? TotalNumberOfLines : _lineNumbersControl.MaxValueOfLineNum;
+        public int MaxLineNumber => TextEditor.ShowLineNumbers ? TotalNumberOfLines : _lineNumbersControl.MaxLineNumber;
 
         public int LineAtCaret => TextEditor.ActiveTextAreaControl.Caret.Position.Line;
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -19,23 +19,16 @@ namespace GitUI.Editor
         public new event EventHandler DoubleClick;
 
         private readonly FindAndReplaceForm _findAndReplaceForm = new FindAndReplaceForm();
-        private readonly DiffViewerLineNumberControl _lineNumbersControl;
+        private readonly CurrentViewPositionCache _currentViewPositionCache;
+        private DiffViewerLineNumberControl _lineNumbersControl;
         private DiffHighlightService _diffHighlightService = DiffHighlightService.Instance;
-
-        private struct ViewPosition
-        {
-            internal string FirstLine; // contains the file names in case of a diff
-            internal int TotalNumberOfLines; // if changed, CaretPosition and FirstVisibleLine must be ignored and the line number must be searched
-            internal TextLocation CaretPosition;
-            internal int FirstVisibleLine;
-            internal bool CaretVisible; // if not, FirstVisibleLine has priority for restoring
-            internal DiffLineInfo ActiveLineNum;
-        }
 
         public FileViewerInternal()
         {
             InitializeComponent();
             InitializeComplete();
+
+            _currentViewPositionCache = new CurrentViewPositionCache(this);
 
             TextEditor.TextChanged += (s, e) => TextChanged?.Invoke(s, e);
             TextEditor.ActiveTextAreaControl.VScrollBar.ValueChanged += (s, e) => ScrollPosChanged?.Invoke(s, e);
@@ -104,7 +97,7 @@ namespace GitUI.Editor
 
         public void SetText(string text, Action openWithDifftool, bool isDiff = false)
         {
-            var viewPosition = GetCurrentViewPosition();
+            _currentViewPositionCache.Capture();
 
             OpenWithDifftool = openWithDifftool;
             _lineNumbersControl.Clear(isDiff);
@@ -125,11 +118,12 @@ namespace GitUI.Editor
                 _lineNumbersControl.DisplayLineNumFor(text);
             }
 
+            TextEditor.BeginUpdate();
             TextEditor.ShowLineNumbers = !isDiff;
             TextEditor.Text = text;
-            TextEditor.Refresh();
+            TextEditor.EndUpdate();
 
-            SetCurrentViewPosition(isDiff, viewPosition);
+            _currentViewPositionCache.Restore(isDiff);
         }
 
         public void SetHighlighting(string syntax)
@@ -331,99 +325,150 @@ namespace GitUI.Editor
 
         #endregion
 
-        private ViewPosition GetCurrentViewPosition()
+        internal sealed class CurrentViewPositionCache
         {
-            if (TotalNumberOfLines <= 1)
+            private readonly FileViewerInternal _viewer;
+            private ViewPosition _currentViewPosition;
+            internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+            public CurrentViewPositionCache(FileViewerInternal viewer)
             {
-                return new ViewPosition();
+                _viewer = viewer;
             }
 
-            // store the previous view position
-            var previousViewPosition = new ViewPosition
+            public void Capture()
             {
-                ActiveLineNum = null,
-                FirstLine = GetLineText(0),
-                TotalNumberOfLines = TotalNumberOfLines,
-                CaretPosition = TextEditor.ActiveTextAreaControl.Caret.Position,
-                FirstVisibleLine = FirstVisibleLine
-            };
-            previousViewPosition.CaretVisible = previousViewPosition.CaretPosition.Line >= previousViewPosition.FirstVisibleLine &&
-                                                previousViewPosition.CaretPosition.Line < previousViewPosition.FirstVisibleLine + TextEditor.ActiveTextAreaControl.TextArea.TextView.VisibleLineCount;
-
-            if (TextEditor.ShowLineNumbers)
-            {
-                // a diff was displayed
-                return previousViewPosition;
-            }
-
-            int initialActiveLine = previousViewPosition.CaretVisible ? previousViewPosition.CaretPosition.Line : previousViewPosition.FirstVisibleLine;
-
-            // search downwards for a code line, i.e. a line with line numbers
-            int activeLine = initialActiveLine;
-            while (activeLine < previousViewPosition.TotalNumberOfLines && previousViewPosition.ActiveLineNum == null)
-            {
-                SetActiveLineNum(activeLine);
-                ++activeLine;
-            }
-
-            // if none found, search upwards
-            activeLine = initialActiveLine - 1;
-            while (activeLine >= 0 && previousViewPosition.ActiveLineNum == null)
-            {
-                SetActiveLineNum(activeLine);
-                --activeLine;
-            }
-
-            return previousViewPosition;
-
-            void SetActiveLineNum(int line)
-            {
-                previousViewPosition.ActiveLineNum = _lineNumbersControl.GetLineInfo(line);
-                if (previousViewPosition.ActiveLineNum == null)
+                if (_viewer.TotalNumberOfLines <= 1)
                 {
                     return;
                 }
 
-                if (previousViewPosition.ActiveLineNum.LeftLineNumber == DiffLineInfo.NotApplicableLineNum &&
-                    previousViewPosition.ActiveLineNum.RightLineNumber == DiffLineInfo.NotApplicableLineNum)
+                // store the previous view position
+                var currentViewPosition = new ViewPosition
                 {
-                    previousViewPosition.ActiveLineNum = null;
+                    ActiveLineNum = null,
+                    FirstLine = _viewer.GetLineText(0),
+                    TotalNumberOfLines = _viewer.TotalNumberOfLines,
+                    CaretPosition = _viewer.TextEditor.ActiveTextAreaControl.Caret.Position,
+                    FirstVisibleLine = _viewer.FirstVisibleLine
+                };
+                currentViewPosition.CaretVisible = currentViewPosition.CaretPosition.Line >= currentViewPosition.FirstVisibleLine &&
+                                                   currentViewPosition.CaretPosition.Line < currentViewPosition.FirstVisibleLine + _viewer.TextEditor.ActiveTextAreaControl.TextArea.TextView.VisibleLineCount;
+
+                if (_viewer.TextEditor.ShowLineNumbers)
+                {
+                    // a diff was displayed
+                    _currentViewPosition = currentViewPosition;
+                    return;
+                }
+
+                int initialActiveLine = currentViewPosition.CaretVisible ?
+                                            currentViewPosition.CaretPosition.Line :
+                                            currentViewPosition.FirstVisibleLine;
+
+                // search downwards for a code line, i.e. a line with line numbers
+                int activeLine = initialActiveLine;
+                while (activeLine < currentViewPosition.TotalNumberOfLines && currentViewPosition.ActiveLineNum == null)
+                {
+                    SetActiveLineNum(activeLine);
+                    ++activeLine;
+                }
+
+                // if none found, search upwards
+                activeLine = initialActiveLine - 1;
+                while (activeLine >= 0 && currentViewPosition.ActiveLineNum == null)
+                {
+                    SetActiveLineNum(activeLine);
+                    --activeLine;
+                }
+
+                _currentViewPosition = currentViewPosition;
+                return;
+
+                void SetActiveLineNum(int line)
+                {
+                    currentViewPosition.ActiveLineNum = _viewer._lineNumbersControl.GetLineInfo(line);
+                    if (currentViewPosition.ActiveLineNum == null)
+                    {
+                        return;
+                    }
+
+                    if (currentViewPosition.ActiveLineNum.LeftLineNumber == DiffLineInfo.NotApplicableLineNum &&
+                        currentViewPosition.ActiveLineNum.RightLineNumber == DiffLineInfo.NotApplicableLineNum)
+                    {
+                        currentViewPosition.ActiveLineNum = null;
+                    }
+                }
+            }
+
+            public void Restore(bool isDiff)
+            {
+                if (_viewer.TotalNumberOfLines <= 1)
+                {
+                    return;
+                }
+
+                var viewPosition = _currentViewPosition;
+                if (_viewer.TotalNumberOfLines == viewPosition.TotalNumberOfLines)
+                {
+                    _viewer.FirstVisibleLine = viewPosition.FirstVisibleLine;
+                    _viewer.TextEditor.ActiveTextAreaControl.Caret.Position = viewPosition.CaretPosition;
+                    if (!viewPosition.CaretVisible)
+                    {
+                        _viewer.FirstVisibleLine = viewPosition.FirstVisibleLine;
+                    }
+                }
+                else if (isDiff && _viewer.GetLineText(0) == viewPosition.FirstLine && viewPosition.ActiveLineNum != null)
+                {
+                    // prefer the LeftLineNum because the base revision will not change
+                    int line = viewPosition.ActiveLineNum.LeftLineNumber != DiffLineInfo.NotApplicableLineNum
+                        ? _viewer.GetCaretLine(viewPosition.ActiveLineNum.LeftLineNumber, rightFile: false)
+                        : _viewer.GetCaretLine(viewPosition.ActiveLineNum.RightLineNumber, rightFile: true);
+                    if (viewPosition.CaretVisible)
+                    {
+                        _viewer.TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(viewPosition.CaretPosition.Column, line);
+                        _viewer.TextEditor.ActiveTextAreaControl.CenterViewOn(line, treshold: 5);
+                    }
+                    else
+                    {
+                        _viewer.FirstVisibleLine = line;
+                    }
+                }
+            }
+
+            public readonly struct TestAccessor
+            {
+                private readonly CurrentViewPositionCache _viewPositionCache;
+
+                public TestAccessor(CurrentViewPositionCache viewPositionCache)
+                {
+                    _viewPositionCache = viewPositionCache;
+                }
+
+                public ViewPosition ViewPosition
+                {
+                    get => _viewPositionCache._currentViewPosition;
+                    set => _viewPositionCache._currentViewPosition = value;
+                }
+
+                public TextEditorControl TextEditor => _viewPositionCache._viewer.TextEditor;
+
+                public DiffViewerLineNumberControl LineNumberControl
+                {
+                    get => _viewPositionCache._viewer._lineNumbersControl;
+                    set => _viewPositionCache._viewer._lineNumbersControl = value;
                 }
             }
         }
 
-        private void SetCurrentViewPosition(bool isDiff, ViewPosition viewPosition)
+        internal struct ViewPosition
         {
-            if (TotalNumberOfLines <= 1)
-            {
-                return;
-            }
-
-            if (TotalNumberOfLines == viewPosition.TotalNumberOfLines)
-            {
-                FirstVisibleLine = viewPosition.FirstVisibleLine;
-                TextEditor.ActiveTextAreaControl.Caret.Position = viewPosition.CaretPosition;
-                if (!viewPosition.CaretVisible)
-                {
-                    FirstVisibleLine = viewPosition.FirstVisibleLine;
-                }
-            }
-            else if (isDiff && GetLineText(0) == viewPosition.FirstLine && viewPosition.ActiveLineNum != null)
-            {
-                // prefer the LeftLineNum because the base revision will not change
-                int line = viewPosition.ActiveLineNum.LeftLineNumber != DiffLineInfo.NotApplicableLineNum
-                    ? GetCaretLine(viewPosition.ActiveLineNum.LeftLineNumber, rightFile: false)
-                    : GetCaretLine(viewPosition.ActiveLineNum.RightLineNumber, rightFile: true);
-                if (viewPosition.CaretVisible)
-                {
-                    TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(viewPosition.CaretPosition.Column, line);
-                    TextEditor.ActiveTextAreaControl.CenterViewOn(line, treshold: 5);
-                }
-                else
-                {
-                    FirstVisibleLine = line;
-                }
-            }
+            internal string FirstLine; // contains the file names in case of a diff
+            internal int TotalNumberOfLines; // if changed, CaretPosition and FirstVisibleLine must be ignored and the line number must be searched
+            internal TextLocation CaretPosition;
+            internal int FirstVisibleLine;
+            internal bool CaretVisible; // if not, FirstVisibleLine has priority for restoring
+            internal DiffLineInfo ActiveLineNum;
         }
     }
 }

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -60,14 +60,12 @@ namespace GitUI.Editor
         string GetLineText(int line);
         int TotalNumberOfLines { get; }
 
-        // lineNumber is 0 based
-        void GoToLine(int lineNumber);
-
         /// <summary>
-        /// Indicates if the Goto line UI is applicable or not.
-        /// Code-behind goto line function is always availabe, so we can goto next diff section.
+        /// positions to the given line number
         /// </summary>
-        bool IsGotoLineUIApplicable();
+        /// <param name="lineNumber">1..MaxLineNumber</param>
+        void GoToLine(int lineNumber);
+        int MaxLineNumber { get; }
 
         Font Font { get; set; }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -279,6 +279,9 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="Editor\Diff\DiffLineInfo.cs" />
+    <Compile Include="Editor\Diff\DiffLinesInfo.cs" />
+    <Compile Include="Editor\Diff\DiffLineType.cs" />
     <Compile Include="FontUtil.cs" />
     <Compile Include="Editor\GitHighlightingStrategyBase.cs" />
     <Compile Include="Editor\RebaseTodoHighlightingStrategy.cs" />

--- a/UnitTests/GitUITests/Editor/Diff/DiffLineNumAnalyzerFixture.cs
+++ b/UnitTests/GitUITests/Editor/Diff/DiffLineNumAnalyzerFixture.cs
@@ -7,14 +7,14 @@ using NUnit.Framework;
 namespace GitUITests.Editor.Diff
 {
     [TestFixture]
-    public class TestDiffLineNumAnalyzer
+    public class DiffLineNumAnalyzerFixture
     {
         private static readonly string TestDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
         private readonly string _sampleDiff;
         private readonly string _sampleCombinedDiff;
         private DiffLineNumAnalyzer _lineNumAnalyzer;
 
-        public TestDiffLineNumAnalyzer()
+        public DiffLineNumAnalyzerFixture()
         {
             // File copied from https://github.com/libgit2/libgit2sharp/pull/1034/files
             _sampleDiff = File.ReadAllText(Path.Combine(TestDataDir, "Sample.diff"));
@@ -35,8 +35,8 @@ namespace GitUITests.Editor.Diff
             var headerLines = new List<int> { 5, 17 };
             foreach (var header in headerLines)
             {
-                result.LineNumbers[header].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-                result.LineNumbers[header].RightLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
+                result.DiffLines[header].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+                result.DiffLines[header].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             }
         }
 
@@ -45,17 +45,17 @@ namespace GitUITests.Editor.Diff
         {
             var result = _lineNumAnalyzer.Analyze(_sampleDiff);
 
-            result.LineNumbers[6].LeftLineNum.Should().Be(9);
-            result.LineNumbers[6].RightLineNum.Should().Be(9);
+            result.DiffLines[6].LeftLineNumber.Should().Be(9);
+            result.DiffLines[6].RightLineNumber.Should().Be(9);
 
-            result.LineNumbers[14].LeftLineNum.Should().Be(15);
-            result.LineNumbers[14].RightLineNum.Should().Be(16);
+            result.DiffLines[14].LeftLineNumber.Should().Be(15);
+            result.DiffLines[14].RightLineNumber.Should().Be(16);
 
-            result.LineNumbers[18].LeftLineNum.Should().Be(33);
-            result.LineNumbers[18].RightLineNum.Should().Be(34);
+            result.DiffLines[18].LeftLineNumber.Should().Be(33);
+            result.DiffLines[18].RightLineNumber.Should().Be(34);
 
-            result.LineNumbers[25].LeftLineNum.Should().Be(39);
-            result.LineNumbers[25].RightLineNum.Should().Be(40);
+            result.DiffLines[25].LeftLineNumber.Should().Be(39);
+            result.DiffLines[25].RightLineNumber.Should().Be(40);
         }
 
         [Test]
@@ -63,11 +63,11 @@ namespace GitUITests.Editor.Diff
         {
             var result = _lineNumAnalyzer.Analyze(_sampleDiff);
 
-            result.LineNumbers[9].LeftLineNum.Should().Be(12);
-            result.LineNumbers[9].RightLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
+            result.DiffLines[9].LeftLineNumber.Should().Be(12);
+            result.DiffLines[9].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
 
-            result.LineNumbers[21].LeftLineNum.Should().Be(36);
-            result.LineNumbers[21].RightLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
+            result.DiffLines[21].LeftLineNumber.Should().Be(36);
+            result.DiffLines[21].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         }
 
         [Test]
@@ -75,14 +75,14 @@ namespace GitUITests.Editor.Diff
         {
             var result = _lineNumAnalyzer.Analyze(_sampleDiff);
 
-            result.LineNumbers[12].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[12].RightLineNum.Should().Be(14);
+            result.DiffLines[12].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[12].RightLineNumber.Should().Be(14);
 
-            result.LineNumbers[13].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[13].RightLineNum.Should().Be(15);
+            result.DiffLines[13].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[13].RightLineNumber.Should().Be(15);
 
-            result.LineNumbers[22].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[22].RightLineNum.Should().Be(37);
+            result.DiffLines[22].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[22].RightLineNumber.Should().Be(37);
         }
 
         [Test]
@@ -90,29 +90,29 @@ namespace GitUITests.Editor.Diff
         {
             var result = _lineNumAnalyzer.Analyze(_sampleCombinedDiff);
 
-            result.LineNumbers[6].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[6].RightLineNum.Should().Be(70);
-            result.LineNumbers[6].Style.Should().Be(DiffLineNum.DiffLineStyle.Context);
+            result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[6].RightLineNumber.Should().Be(70);
+            result.DiffLines[6].LineType.Should().Be(DiffLineInfo.DiffLineType.Context);
 
-            result.LineNumbers[9].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[9].RightLineNum.Should().Be(73);
-            result.LineNumbers[9].Style.Should().Be(DiffLineNum.DiffLineStyle.Plus);
+            result.DiffLines[9].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[9].RightLineNumber.Should().Be(73);
+            result.DiffLines[9].LineType.Should().Be(DiffLineInfo.DiffLineType.Plus);
 
-            result.LineNumbers[19].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[19].RightLineNum.Should().Be(83);
-            result.LineNumbers[19].Style.Should().Be(DiffLineNum.DiffLineStyle.Plus);
+            result.DiffLines[19].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[19].RightLineNumber.Should().Be(83);
+            result.DiffLines[19].LineType.Should().Be(DiffLineInfo.DiffLineType.Plus);
 
-            result.LineNumbers[34].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[34].RightLineNum.Should().Be(100);
-            result.LineNumbers[34].Style.Should().Be(DiffLineNum.DiffLineStyle.Context);
+            result.DiffLines[34].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[34].RightLineNumber.Should().Be(100);
+            result.DiffLines[34].LineType.Should().Be(DiffLineInfo.DiffLineType.Context);
 
-            result.LineNumbers[37].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[37].RightLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[37].Style.Should().Be(DiffLineNum.DiffLineStyle.Minus);
+            result.DiffLines[37].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[37].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[37].LineType.Should().Be(DiffLineInfo.DiffLineType.Minus);
 
-            result.LineNumbers[38].LeftLineNum.Should().Be(DiffLineNum.NotApplicableLineNum);
-            result.LineNumbers[38].RightLineNum.Should().Be(103);
-            result.LineNumbers[38].Style.Should().Be(DiffLineNum.DiffLineStyle.Plus);
+            result.DiffLines[38].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[38].RightLineNumber.Should().Be(103);
+            result.DiffLines[38].LineType.Should().Be(DiffLineInfo.DiffLineType.Plus);
         }
     }
 }

--- a/UnitTests/GitUITests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUITests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -7,14 +7,14 @@ using NUnit.Framework;
 namespace GitUITests.Editor.Diff
 {
     [TestFixture]
-    public class DiffLineNumAnalyzerFixture
+    public class DiffLineNumAnalyzerTests
     {
         private static readonly string TestDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
         private readonly string _sampleDiff;
         private readonly string _sampleCombinedDiff;
         private DiffLineNumAnalyzer _lineNumAnalyzer;
 
-        public DiffLineNumAnalyzerFixture()
+        public DiffLineNumAnalyzerTests()
         {
             // File copied from https://github.com/libgit2/libgit2sharp/pull/1034/files
             _sampleDiff = File.ReadAllText(Path.Combine(TestDataDir, "Sample.diff"));
@@ -92,27 +92,27 @@ namespace GitUITests.Editor.Diff
 
             result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[6].RightLineNumber.Should().Be(70);
-            result.DiffLines[6].LineType.Should().Be(DiffLineInfo.DiffLineType.Context);
+            result.DiffLines[6].LineType.Should().Be(DiffLineType.Context);
 
             result.DiffLines[9].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[9].RightLineNumber.Should().Be(73);
-            result.DiffLines[9].LineType.Should().Be(DiffLineInfo.DiffLineType.Plus);
+            result.DiffLines[9].LineType.Should().Be(DiffLineType.Plus);
 
             result.DiffLines[19].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[19].RightLineNumber.Should().Be(83);
-            result.DiffLines[19].LineType.Should().Be(DiffLineInfo.DiffLineType.Plus);
+            result.DiffLines[19].LineType.Should().Be(DiffLineType.Plus);
 
             result.DiffLines[34].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[34].RightLineNumber.Should().Be(100);
-            result.DiffLines[34].LineType.Should().Be(DiffLineInfo.DiffLineType.Context);
+            result.DiffLines[34].LineType.Should().Be(DiffLineType.Context);
 
             result.DiffLines[37].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[37].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[37].LineType.Should().Be(DiffLineInfo.DiffLineType.Minus);
+            result.DiffLines[37].LineType.Should().Be(DiffLineType.Minus);
 
             result.DiffLines[38].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[38].RightLineNumber.Should().Be(103);
-            result.DiffLines[38].LineType.Should().Be(DiffLineInfo.DiffLineType.Plus);
+            result.DiffLines[38].LineType.Should().Be(DiffLineType.Plus);
         }
     }
 }

--- a/UnitTests/GitUITests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -1,0 +1,192 @@
+﻿using System.Threading;
+using FluentAssertions;
+using GitUI.Editor;
+using GitUI.Editor.Diff;
+using ICSharpCode.TextEditor;
+using NUnit.Framework;
+
+namespace GitUITests.Editor
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public class CurrentViewPositionCacheTests
+    {
+        private FileViewerInternal _fileViewerInternal;
+        private FileViewerInternal.CurrentViewPositionCache _viewPositionCache;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fileViewerInternal = new FileViewerInternal();
+
+            _viewPositionCache = new FileViewerInternal.CurrentViewPositionCache(_fileViewerInternal);
+        }
+
+        [TestCase(null)]
+        [TestCase("a")]
+        public void Capture_should_not_change_capture_if_less_then_two_lines(string text)
+        {
+            var test = _viewPositionCache.GetTestAccessor();
+
+            var existingViewPosition = new FileViewerInternal.ViewPosition
+            {
+                FirstLine = "first line",
+                FirstVisibleLine = 24,
+                TotalNumberOfLines = 35
+            };
+            test.ViewPosition = existingViewPosition;
+
+            test.TextEditor.ShowLineNumbers = true;
+            test.TextEditor.Text = text;
+
+            _viewPositionCache.Capture();
+
+            test.ViewPosition.Should().Be(existingViewPosition);
+        }
+
+        [Test]
+        public void Capture_should_capture_current_position_if_ShowLineNumbers_true_start()
+        {
+            var test = _viewPositionCache.GetTestAccessor();
+            test.TextEditor.ShowLineNumbers = true;
+            test.TextEditor.Text = "a\r\nb\r\nc\r\n";
+
+            _viewPositionCache.Capture();
+
+            test.ViewPosition.ActiveLineNum.Should().BeNull();
+            test.ViewPosition.CaretPosition.Should().Be(new TextLocation(0, 0));
+            test.ViewPosition.CaretVisible.Should().BeTrue();
+            test.ViewPosition.FirstLine.Should().Be("a");
+            test.ViewPosition.FirstVisibleLine.Should().Be(0);
+            test.ViewPosition.TotalNumberOfLines.Should().Be(4);
+        }
+
+        [Test]
+        public void Capture_should_capture_current_position_if_ShowLineNumbers_true_scrolled()
+        {
+            var test = _viewPositionCache.GetTestAccessor();
+            test.TextEditor.ShowLineNumbers = true;
+            test.TextEditor.Text = "a\r\nb\r\nc\r\nd\r\ne\r\nf\r\ng\r\nh\r\ni\r\nj\r\nk\r\nl\r\nm\r\nn\r\no\r\np\r\nr\r\ns\r\nt\r\nu\r\nv\r\nw\r\nx\r\ny\r\nz\r\n0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\r\n0";
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Line = 23;
+            test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
+            test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 22;
+
+            _viewPositionCache.Capture();
+
+            test.ViewPosition.ActiveLineNum.Should().BeNull();
+            test.ViewPosition.CaretPosition.Should().Be(new TextLocation(0, 23));
+            test.ViewPosition.CaretVisible.Should().BeFalse();
+            test.ViewPosition.FirstLine.Should().Be("a");
+            test.ViewPosition.FirstVisibleLine.Should().Be(22);
+            test.ViewPosition.TotalNumberOfLines.Should().Be(36);
+        }
+
+        [Test]
+        public void Capture_should_capture_current_position_if_ShowLineNumbers_false_without_margin()
+        {
+            var test = _viewPositionCache.GetTestAccessor();
+            test.TextEditor.ShowLineNumbers = false;
+            test.TextEditor.Text = "a\r\nb\r\nc\r\nd\r\ne\r\nf\r\ng\r\nh\r\ni\r\nj\r\nk\r\nl\r\nm\r\nn\r\no\r\np\r\nr\r\ns\r\nt\r\nu\r\nv\r\nw\r\nx\r\ny\r\nz\r\n0\r\n1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\r\n0";
+            test.TextEditor.ActiveTextAreaControl.TextArea.TextView.DrawingPosition = new System.Drawing.Rectangle(0, 0, 100, 100);
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Line = 23;
+            test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
+            test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 22;
+
+            _viewPositionCache.Capture();
+
+            test.ViewPosition.ActiveLineNum.Should().BeNull();
+            test.ViewPosition.CaretPosition.Should().Be(new TextLocation(0, 23));
+            test.ViewPosition.CaretVisible.Should().BeTrue();
+            test.ViewPosition.FirstLine.Should().Be("a");
+            test.ViewPosition.FirstVisibleLine.Should().Be(22);
+            test.ViewPosition.TotalNumberOfLines.Should().Be(36);
+        }
+
+        [Test]
+        public void Capture_should_capture_current_position_and_calculate_active_line_if_ShowLineNumbers_false_with_line_margin()
+        {
+            var test = _viewPositionCache.GetTestAccessor();
+            test.TextEditor.ShowLineNumbers = false;
+            test.TextEditor.Text = Given.GitDiff;
+            test.TextEditor.ActiveTextAreaControl.TextArea.TextView.DrawingPosition = new System.Drawing.Rectangle(0, 0, 100, 100);
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Line = 19;
+            test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
+            test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 18;
+            test.LineNumberControl = new DiffViewerLineNumberControl(test.TextEditor.ActiveTextAreaControl.TextArea);
+            test.LineNumberControl.DisplayLineNumFor(test.TextEditor.Text);
+
+            _viewPositionCache.Capture();
+
+            test.ViewPosition.ActiveLineNum.Should().NotBeNull();
+            test.ViewPosition.ActiveLineNum.LeftLineNumber.Should().Be(57);
+            test.ViewPosition.ActiveLineNum.LineNumInDiff.Should().Be(20);
+            test.ViewPosition.ActiveLineNum.LineType.Should().Be(DiffLineType.Minus);
+            test.ViewPosition.ActiveLineNum.RightLineNumber.Should().Be(-1);
+            test.ViewPosition.CaretPosition.Should().Be(new TextLocation(0, 19));
+            test.ViewPosition.CaretVisible.Should().BeTrue();
+            test.ViewPosition.FirstLine.Should().Be("diff --git a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs");
+            test.ViewPosition.FirstVisibleLine.Should().Be(18);
+            test.ViewPosition.TotalNumberOfLines.Should().Be(23);
+        }
+
+        [Test]
+        public void Restore_should_restore_current_position()
+        {
+            var test = _viewPositionCache.GetTestAccessor();
+            test.TextEditor.Text = Given.GitDiff;
+            test.TextEditor.ActiveTextAreaControl.TextArea.TextView.DrawingPosition = new System.Drawing.Rectangle(0, 0, 100, 100);
+
+            var existingViewPosition = new FileViewerInternal.ViewPosition
+            {
+                ActiveLineNum = new DiffLineInfo
+                {
+                    LeftLineNumber = 57,
+                    LineNumInDiff = 20,
+                    LineType = DiffLineType.Minus,
+                    RightLineNumber = -1
+                },
+                CaretPosition = new TextLocation(0, 19),
+                CaretVisible = true,
+                FirstLine = "diff --git a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs",
+                FirstVisibleLine = 18,
+                TotalNumberOfLines = 23
+            };
+            test.ViewPosition = existingViewPosition;
+
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Line.Should().Be(0);
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Column.Should().Be(0);
+
+            _viewPositionCache.Restore(true);
+
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition);
+            test.TextEditor.ActiveTextAreaControl.TextArea.Caret.Position.Should().Be(existingViewPosition.CaretPosition);
+        }
+
+        private static class Given
+        {
+            public const string GitDiff = @"diff --git a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
+index 7ac22add9..77aa0364a 100644
+--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
++++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
+@@ -46,23 +46,24 @@ private void InitializeComponent()
+             // 
+             // panel1
+             // 
+-            panel1.AutoSize = true;
+             panel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
++            panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+             panel1.Controls.Add(this.labelPreview);
+             panel1.Controls.Add(this.label1);
+-            panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+-            panel1.Location = new System.Drawing.Point(323, 77);
++            panel1.Dock = System.Windows.Forms.DockStyle.Top;
++            panel1.Location = new System.Drawing.Point(540, 81);
+             panel1.Margin = new System.Windows.Forms.Padding(2);
+             panel1.Name = ""panel1"";
+-            panel1.Size = new System.Drawing.Size(317, 391);
++            panel1.Size = new System.Drawing.Size(533, 167);
+            panel1.TabIndex = 0;
+            ";
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -78,7 +78,7 @@
     <Compile Include="UITest.cs" />
     <Compile Include="UserControls\AuthorRevisionHighlightingFixture.cs" />
     <Compile Include="UserControls\ConsoleEmulatorOutputControlFixture.cs" />
-    <Compile Include="Editor\Diff\DiffLineNumAnalyzerFixture.cs" />
+    <Compile Include="Editor\Diff\DiffLineNumAnalyzerTests.cs" />
     <Compile Include="Editor\Diff\LinePrefixHelperFixture.cs" />
     <Compile Include="CommandsDialogs\BrowseDialog\FormUpdateFixture.cs" />
     <Compile Include="Hotkey\HotkeySettingsManagerFixture.cs" />

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffControllerTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
+    <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />
     <Compile Include="FindFilePredicateProviderTest.cs" />
     <Compile Include="Helpers\DiffKindRevisionTests.cs" />
     <Compile Include="ControlUtilTests.cs" />


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

The initial work is done by @mstv in #5474. 

Fixes #5327, base functionality for #5328
Supersedes and closes #5474


Changes proposed in this pull request:
- [x] retain the view position in FileViewerInternal.cs, not spread in every using ContainerControl/Form
  - [x] FormCommit works
  - [x] FormFileHistory works
  - [x] RevisionDiffControl works
  - [x] RevisionFileTreeControl works
- [x] retain the view position when updating the diff with caret visible
- [x] retain the view position when updating the diff with caret invisible
- [x] retain the view position when changing diff settings ![grafik](https://user-images.githubusercontent.com/36601201/44313914-0334ee80-a411-11e8-9594-e5efcd916435.png) with caret visible
- [x] retain the view position when changing diff settings ![grafik](https://user-images.githubusercontent.com/36601201/44313914-0334ee80-a411-11e8-9594-e5efcd916435.png) with caret invisible
- [x] retain the view position of a plain file (problem: how to distinguish between update and different file, simple heuristic: same TotalNumberOfLines)
- [x] retain the caret column
- [x] GoToLine works for a file diff
- [x] GoToLine works for a plain file if commit dialog does *not* refresh on form focus
- [x] GoToLine works for a plain file if commit dialog does refresh on form focus
- [ ] GotoNext/PreviousChange works if commit dialog does *not* refresh on form focus
- [ ] GotoNext/PreviousChange works if commit dialog does refresh on form focus

What did I do to test the code and ensure quality:
- manual testing see checklist above
- added some integration tests for `FileViewerInternal.CurrentViewPositionCache`

Has been tested on (remove any that don't apply):
- GIT 2.18.0.w.x64
- Windows 7
