### PR TITLE
FormCreateTag should prefill commit picker with latest selected revision

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1409,7 +1409,9 @@ namespace GitUI.CommandsDialogs
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)
         {
-            UICommands.StartCreateTagDialog(this);
+            var revision = RevisionGrid.LatestSelectedRevision;
+
+            UICommands.StartCreateTagDialog(this, revision);
         }
 
         private void RefreshButtonClick(object sender, EventArgs e)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -791,11 +791,11 @@ namespace GitUI
             return DoActionOnRepo(owner, true, false, null, null, Action);
         }
 
-        public bool StartCreateTagDialog(IWin32Window owner = null)
+        public bool StartCreateTagDialog(IWin32Window owner = null, GitRevision revision = null)
         {
             bool Action()
             {
-                using (var form = new FormCreateTag(this, null))
+                using (var form = new FormCreateTag(this, revision?.ObjectId))
                 {
                     return form.ShowDialog(owner) == DialogResult.OK;
                 }


### PR DESCRIPTION
Fixes #5564

Changes proposed in this pull request:
- Pass the latest selected revision to `GitUICommands.StartCreateTagDialog` when initializing `FormCreateTag` from `FormBrowse`

What did I do to test the code and ensure quality:
- Pressed Ctrl+T on commit other than current HEAD and saw commit picker have commit's hash