### PR TITLE
Correctly copy e-mail address with author

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -86,7 +86,7 @@
             this.RevisionInfo.Text = "";
             this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
             this.RevisionInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
-            this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyEvent);
+            this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
             // 
             // commitInfoContextMenuStrip
             // 
@@ -187,7 +187,7 @@
             this._RevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this._RevisionHeader_ContentsResized);
             this._RevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
             this._RevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
-            this._RevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyEvent);
+            this._RevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
             // 
             // avatarControl
             // 

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -86,6 +86,7 @@
             this.RevisionInfo.Text = "";
             this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
             this.RevisionInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
+            this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyEvent);
             // 
             // commitInfoContextMenuStrip
             // 
@@ -186,6 +187,7 @@
             this._RevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this._RevisionHeader_ContentsResized);
             this._RevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
             this._RevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
+            this._RevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyEvent);
             // 
             // avatarControl
             // 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -681,16 +681,17 @@ namespace GitUI.CommitInfo
             }
         }
 
-        private void RichTextBox_KeyEvent(object sender, KeyEventArgs e)
+        private void RichTextBox_KeyDown(object sender, KeyEventArgs e)
         {
             var rtb = sender as RichTextBox;
+            if (rtb == null || !e.Control || e.KeyCode != Keys.C)
+            {
+                return;
+            }
 
             // Override RichTextBox Ctrl-c handling to copy plain text
-            if (rtb != null && e.Control && e.KeyCode == Keys.C)
-            {
-                Clipboard.SetText(rtb.GetSelectionPlainText());
-                e.Handled = true;
-            }
+            Clipboard.SetText(rtb.GetSelectionPlainText());
+            e.Handled = true;
         }
 
         private void _RevisionHeader_ContentsResized(object sender, ContentsResizedEventArgs e)

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -636,7 +636,7 @@ namespace GitUI.CommitInfo
 
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var commitInfo = $"{_RevisionHeader.GetPlaintText()}{Environment.NewLine}{RevisionInfo.GetPlaintText()}";
+            var commitInfo = $"{_RevisionHeader.GetPlainText()}{Environment.NewLine}{RevisionInfo.GetPlainText()}";
             Clipboard.SetText(commitInfo);
         }
 
@@ -678,6 +678,18 @@ namespace GitUI.CommitInfo
             void DoCommandClick(string command)
             {
                 CommandClick?.Invoke(this, new CommandEventArgs(command, null));
+            }
+        }
+
+        private void RichTextBox_KeyEvent(object sender, KeyEventArgs e)
+        {
+            var rtb = sender as RichTextBox;
+
+            // Override RichTextBox Ctrl-c handling to copy plain text
+            if (rtb != null && e.Control && e.KeyCode == Keys.C)
+            {
+                Clipboard.SetText(rtb.GetSelectionPlainText());
+                e.Handled = true;
             }
         }
 

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1097,8 +1097,23 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
         }
 
-        public static string GetPlaintText(this RichTextBox rtb)
+        public static string GetPlainText(this RichTextBox rtb)
         {
+            return GetPlainText(rtb, 0, rtb.TextLength);
+        }
+
+        public static string GetSelectionPlainText(this RichTextBox rtb)
+        {
+            return GetPlainText(rtb, rtb.SelectionStart, rtb.SelectionStart + rtb.SelectionLength);
+        }
+
+        public static string GetPlainText(this RichTextBox rtb, int from, int to)
+        {
+            if (to == 0)
+            {
+                return string.Empty;
+            }
+
             ////rtb.HideSelection = true;
             IntPtr oldMask = rtb.BeginUpdate();
 
@@ -1113,7 +1128,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                 // but RichTextBox doesn't provide another method to
                 // get something like an array of charformat and paraformat
                 //--------------------------------
-                for (int i = 0; i < rtb.TextLength; i++)
+                for (int i = from; i < to; i++)
                 {
                     // select one character
                     rtb.Select(i, 1);

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -154,7 +154,7 @@ namespace GitUI.UserControls.RevisionGrid
             int count = revisions.Count();
             AddItem(Strings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C', Keys.Control | Keys.C);
             AddItem(Strings.GetMessage(count), r => r.Body ?? r.Subject, Images.Message, 'M');
-            AddItem(Strings.GetAuthor(count), r => r.Author, Images.Author, 'A');
+            AddItem(Strings.GetAuthor(count), r => $"{r.Author} <{r.AuthorEmail}>", Images.Author, 'A');
 
             if (count == 1 && revisions.First().AuthorDate == revisions.First().CommitDate)
             {


### PR DESCRIPTION
Fixes #5558

Changes proposed in this pull request:
- Include e-mail address in RevisionGrid Copy -> Author context menu
- Override Ctrl-c handling in Commit tab RichText areas, to only copy plain text
 
Screenshots before and after (if PR changes UI):
- Before
![gitextensions-5558-before](https://user-images.githubusercontent.com/28189926/46981893-180cc600-d0d2-11e8-93aa-90507f50563f.png)
- After
![gitextensions-5558-after](https://user-images.githubusercontent.com/28189926/46981898-1c38e380-d0d2-11e8-92b0-91e070a5f360.png)

What did I do to test the code and ensure quality:
- Manual UI testing

Has been tested on (remove any that don't apply):
- GIT 2.13
- Windows 10
