### PR TITLE
fix: Diff viewer not redrawing correctly

### DIFF
--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -119,8 +119,13 @@ namespace GitUI.Editor
             }
 
             TextEditor.BeginUpdate();
-            TextEditor.ShowLineNumbers = !isDiff;
+
             TextEditor.Text = text;
+
+            // important to set after the text was changed
+            // otherwise the may be rendering artifacts as noted in #5568
+            TextEditor.ShowLineNumbers = !isDiff;
+
             TextEditor.EndUpdate();
 
             _currentViewPositionCache.Restore(isDiff);


### PR DESCRIPTION
Force the internal file viewer to re-render the content.
The fix is a courtesy of @NikolayXHD.

Fixes #5568

What did I do to test the code and ensure quality:
- selected commit 1792cf9
- reproduced the bug
- applied the fix
- checked that the diff is displayed correctly
