### PR TITLE
Show diff for last selected file

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -57,6 +57,7 @@
     <Compile Include="GitUI\ControlThreadingExtensions.cs" />
     <Compile Include="GitUI\ControlUtil.cs" />
     <Compile Include="GitUI\DpiUtil.cs" />
+    <Compile Include="GitUI\ListViewExtensions.cs" />
     <Compile Include="GitUI\TableLayoutPanelExtensions.cs" />
     <Compile Include="GitUI\ThreadHelper.cs" />
     <Compile Include="GitUI\UIExtensions.cs" />

--- a/GitExtUtils/GitUI/ListViewExtensions.cs
+++ b/GitExtUtils/GitUI/ListViewExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+
+namespace GitUI
+{
+    public static class ListViewExtensions
+    {
+        public static IEnumerable<ListViewItem> SelectedItems(this ListView listView) =>
+            listView.SelectedItems.Cast<ListViewItem>();
+
+        public static IEnumerable<ListViewItem> Items(this ListView listView) =>
+            listView.Items.Cast<ListViewItem>();
+
+        public static IEnumerable<ListViewGroup> Groups(this ListView listView) =>
+            listView.Groups.Cast<ListViewGroup>();
+
+        public static T Tag<T>(this ListViewItem item) =>
+            (T)item.Tag;
+
+        public static T Tag<T>(this ListViewGroup grp) =>
+            (T)grp.Tag;
+
+        public static IEnumerable<T> ItemTags<T>(this ListView listView) =>
+            listView.Items().Select(Tag<T>);
+
+        public static IEnumerable<T> SelectedItemTags<T>(this ListView listView) =>
+            listView.SelectedItems().Select(Tag<T>);
+
+        /// <summary>
+        /// <para>For practical purposes: The last <see cref="ListViewItem"/> added to selection.</para>
+        /// <para>Actually: Focused item if selected, otherwise last item in <see cref="SelectedItems"/> list</para>
+        /// </summary>
+        public static ListViewItem LastSelectedItem(this ListView listView)
+        {
+            if (listView.FocusedItem?.Selected == true)
+            {
+                return listView.FocusedItem;
+            }
+
+            if (listView.SelectedItems.Count == 0)
+            {
+                return null;
+            }
+
+            return listView.SelectedItems[listView.SelectedItems.Count - 1];
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1062,6 +1062,7 @@ namespace GitUI.CommandsDialogs
             this.SelectedDiff.TabIndex = 0;
             this.SelectedDiff.TabStop = false;
             this.SelectedDiff.ContextMenuOpening += new System.ComponentModel.CancelEventHandler(this.SelectedDiff_ContextMenuOpening);
+            this.SelectedDiff.TextLoaded += new System.EventHandler(this.SelectedDiff_TextLoaded); 
             //
             // tableLayoutPanel1
             //

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1461,7 +1461,7 @@ namespace GitUI.CommandsDialogs
             Staged.ClearSelected();
 
             _currentSelection = Unstaged.SelectedItems.ToList();
-            GitItemStatus item = _currentSelection.LastOrDefault();
+            GitItemStatus item = Unstaged.SelectedItem;
             ShowChanges(item, false);
 
             if (!item.IsSubmodule)
@@ -1718,7 +1718,7 @@ namespace GitUI.CommandsDialogs
 
             Unstaged.ClearSelected();
             _currentSelection = Staged.SelectedItems.ToList();
-            GitItemStatus item = _currentSelection.LastOrDefault();
+            GitItemStatus item = Staged.SelectedItem;
             ShowChanges(item, true);
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -520,6 +520,11 @@ namespace GitUI.CommandsDialogs
             _resetSelectedLinesToolStripMenuItem.Enabled = _stageSelectedLinesToolStripMenuItem.Enabled;
         }
 
+        private void SelectedDiff_TextLoaded(object sender, EventArgs e)
+        {
+            _selectedDiffReloaded = true;
+        }
+
         #region Hotkey commands
 
         public static readonly string HotkeySettingsName = "Commit";


### PR DESCRIPTION
Fixes #3510

Purpose:
> Expected Behavior
The more desirable behavior is that the last clicked file will always be the file that is shown in the right diff view pane.

Changes proposed in this pull request:
- show the focused item if it is selected
- show any other selected item otherwise

Tested on Windows 7