### PR TITLE
fix: GPG tab icons not scaled

### DIFF
--- a/GitUI/CommandsDialogs/RevisionGpgInfoControl.cs
+++ b/GitUI/CommandsDialogs/RevisionGpgInfoControl.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows.Forms;
 using GitCommands.Gpg;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 using GitUI.Properties;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -56,15 +57,15 @@ namespace GitUI.CommandsDialogs
                 switch (commitStatus)
                 {
                     case CommitStatus.GoodSignature:
-                        commitSignPicture.Image = Images.CommitSignatureOk;
+                        commitSignPicture.Image = DpiUtil.Scale(Images.CommitSignatureOk);
                         commitSignPicture.Visible = true;
                         break;
                     case CommitStatus.MissingPublicKey:
-                        commitSignPicture.Image = Images.CommitSignatureWarning;
+                        commitSignPicture.Image = DpiUtil.Scale(Images.CommitSignatureWarning);
                         commitSignPicture.Visible = true;
                         break;
                     case CommitStatus.SignatureError:
-                        commitSignPicture.Image = Images.CommitSignatureError;
+                        commitSignPicture.Image = DpiUtil.Scale(Images.CommitSignatureError);
                         commitSignPicture.Visible = true;
                         break;
                     case CommitStatus.NoSignature:
@@ -80,25 +81,25 @@ namespace GitUI.CommandsDialogs
                 switch (tagStatus)
                 {
                     case TagStatus.OneGood:
-                        tagSignPicture.Image = Images.TagOk;
+                        tagSignPicture.Image = DpiUtil.Scale(Images.TagOk);
                         tagSignPicture.Visible = true;
                         /* This shows the Tag row in ApplyLayout */
                         txtTagGpgInfo.Visible = true;
                         break;
                     case TagStatus.OneBad:
-                        tagSignPicture.Image = Images.TagError;
+                        tagSignPicture.Image = DpiUtil.Scale(Images.TagError);
                         tagSignPicture.Visible = true;
                         /* This shows the Tag row in ApplyLayout */
                         txtTagGpgInfo.Visible = true;
                         break;
                     case TagStatus.Many:
-                        tagSignPicture.Image = Images.TagMany;
+                        tagSignPicture.Image = DpiUtil.Scale(Images.TagMany);
                         tagSignPicture.Visible = true;
                         /* This shows the Tag row in ApplyLayout */
                         txtTagGpgInfo.Visible = true;
                         break;
                     case TagStatus.NoPubKey:
-                        tagSignPicture.Image = Images.TagWarning;
+                        tagSignPicture.Image = DpiUtil.Scale(Images.TagWarning);
                         tagSignPicture.Visible = true;
                         /* This shows the Tag row in ApplyLayout */
                         txtTagGpgInfo.Visible = true;


### PR DESCRIPTION
Part of #4775 

Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/4403806/47080797-ad37c800-d254-11e8-9faf-4de69c9834d4.png)
![image](https://user-images.githubusercontent.com/4403806/47080775-9d1fe880-d254-11e8-8a82-9f95d6f05180.png)

- after
![image](https://user-images.githubusercontent.com/4403806/47080579-1703a200-d254-11e8-88d2-e10e35ad414d.png)
![image](https://user-images.githubusercontent.com/4403806/47080541-fc312d80-d253-11e8-9bf8-fe3b37f533d4.png)


Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 10 scale 200%
