### PR TITLE
FormFormatPatch: Do not show artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -44,6 +44,7 @@ namespace GitUI.CommandsDialogs
             : base(commands)
         {
             InitializeComponent();
+            RevisionGrid.ShowUncommittedChangesIfPossible = false;
             InitializeComplete();
 
             MailFrom.Text = Module.GetEffectiveSetting(SettingKeyString.UserEmail);


### PR DESCRIPTION
git-format-patch do not handle worktree/index commits

part of #5557

Changes proposed in this pull request:
- Do not show artificial commits in FormFormatPatch as they cannot be handled by git-format-patch
 
Screenshots before and after (if PR changes UI):
![image](https://user-images.githubusercontent.com/6248932/47116288-7f0cb500-d261-11e8-80fb-4f12a7bd64ce.png)

![image](https://user-images.githubusercontent.com/6248932/47116429-f6dadf80-d261-11e8-8bab-069dcc267d59.png)


What did I do to test the code and ensure quality:
- Enable artificial commits
- FormBrowse, commands, Format Patch. This form is not operating on a specific revision and should open regardless of the currently selected revision.
- Artificial commands are not shown

Has been tested on (remove any that don't apply):
