### PR TITLE
FormBrowse: Command menu incorrect for artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2277,29 +2277,38 @@ namespace GitUI.CommandsDialogs
         {
             // Most options do not make sense for artificial commits or no revision selected at all
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            bool enabled = selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial;
+            bool singleNormalCommit = selectedRevisions.Count == 1 && !selectedRevisions[0].IsArtificial;
 
+            // Some commands like stash, undo commit etc has no relation to selections
+
+            // Require that a single commit is selected
+            // Some commands like delete branch could be available for artificial as no default is used,
+            // but hide for consistency
             branchToolStripMenuItem.Enabled =
             deleteBranchToolStripMenuItem.Enabled =
             mergeBranchToolStripMenuItem.Enabled =
             rebaseToolStripMenuItem.Enabled =
-            stashToolStripMenuItem.Enabled =
-              selectedRevisions.Count > 0 && !Module.IsBareRepository();
-
-            undoLastCommitToolStripMenuItem.Enabled =
-            resetToolStripMenuItem.Enabled =
             checkoutBranchToolStripMenuItem.Enabled =
-            runMergetoolToolStripMenuItem.Enabled =
             cherryPickToolStripMenuItem.Enabled =
             checkoutToolStripMenuItem.Enabled =
-            toolStripMenuItemReflog.Enabled =
             bisectToolStripMenuItem.Enabled =
-              enabled && !Module.IsBareRepository();
+                singleNormalCommit && !Module.IsBareRepository();
 
             tagToolStripMenuItem.Enabled =
             deleteTagToolStripMenuItem.Enabled =
             archiveToolStripMenuItem.Enabled =
-              enabled;
+                singleNormalCommit;
+
+            // Not operating on selected revision
+            commitToolStripMenuItem.Enabled =
+            undoLastCommitToolStripMenuItem.Enabled =
+            runMergetoolToolStripMenuItem.Enabled =
+            stashToolStripMenuItem.Enabled =
+            resetToolStripMenuItem.Enabled =
+            cleanupToolStripMenuItem.Enabled =
+            toolStripMenuItemReflog.Enabled =
+            applyPatchToolStripMenuItem.Enabled =
+                !Module.IsBareRepository();
         }
 
         private void PullToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
Some updates for bare repo too
Hiding irrelevant commands

Fixes #5557

Changes proposed in this pull request:
- Hide irrelevant items in the Command menu
 
Screenshots before and after (if PR changes UI):
- Artificial
![image](https://user-images.githubusercontent.com/6248932/47118016-520ed100-d266-11e8-92a9-9754e3f3ff93.png)

![image](https://user-images.githubusercontent.com/6248932/47183650-dc1f6e00-d328-11e8-8427-241f151172af.png)


- Bare repo (unchanged)
![image](https://user-images.githubusercontent.com/6248932/47118067-7c608e80-d266-11e8-814f-3d7921154967.png)


What did I do to test the code and ensure quality:
- Manual test - visual
Tests are not relevant here, 

Has been tested on (remove any that don't apply):
