### PR TITLE
Fix SubmoduleInfoResult having no CurrentSubmoduleName for submodules…

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -465,7 +465,7 @@ namespace GitCommands
                     var submodule = GetSubmodule(submodules[i]);
 
                     var subSubmodules = GetSubmodulePaths(submodule)
-                        .Select(p => Path.Combine(submodules[i], p))
+                        .Select(p => Path.Combine(submodules[i], p).ToPosixPath())
                         .ToList();
 
                     submodules.InsertRange(i + 1, subSubmodules);


### PR DESCRIPTION
… of submodules

Problem is that when GetSubmodulesLocalPaths builds recursive paths, it doesn't convert the path to a posix path, which is done everywhere else. Later, in GetSuperProjectRepositorySubmodulesStatusAsync, when it compares paths to determine the CurrentSubmoduleName, the paths are not in the same form, and thus fail the comparison.

As a side effect/benefit, the names of sub-submodules now look better in the display as they no longer contain backslashes.

Screenshots before and after (if PR changes UI):

Before:
![image](https://user-images.githubusercontent.com/6893883/47125087-6bf0e980-d24f-11e8-9cd8-6b6ea7b4c4b2.png)

After:
![image](https://user-images.githubusercontent.com/6893883/47125021-1ddbe600-d24f-11e8-9589-57afca19bcfb.png)

What did I do to test the code and ensure quality:
- Tested submodule operations. This change should be safe, and only help fix bugs.

Has been tested on (remove any that don't apply):
- Windows 10
