### PR TITLE
fix: Crash on launch when git not installed

### DIFF
--- a/GitCommands/ExceptionUtils.cs
+++ b/GitCommands/ExceptionUtils.cs
@@ -8,6 +8,41 @@ namespace GitCommands
 {
     public static class ExceptionUtils
     {
+        /// <summary>
+        /// Determines whether the <paramref name="ex"/> contains an inner exception of the desired type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Desired exception type.</typeparam>
+        /// <param name="ex">The exception to inspect.</param>
+        /// <returns><see langword="true"/> if one of the inner exceptions are of desired type; otherwise <see langword="false"/>.</returns>
+        public static bool HasInnerOfType<T>(this Exception ex)
+           where T : Exception
+        {
+            return ex.InnerOfType<T>() != null;
+        }
+
+        /// <summary>
+        /// Determines whether the <paramref name="ex"/> contains an inner exception of the desired type <typeparamref name="T"/> and returns it, if found.
+        /// </summary>
+        /// <typeparam name="T">Desired exception type.</typeparam>
+        /// <param name="ex">The exception to inspect.</param>
+        /// <returns>The inner exceptions are of desired type; otherwise <see langword="null"/>.</returns>
+        public static T InnerOfType<T>(this Exception ex)
+             where T : Exception
+        {
+            var iex = ex.InnerException;
+            while (iex != null)
+            {
+                if (iex is T variable)
+                {
+                    return variable;
+                }
+
+                iex = iex.InnerException;
+            }
+
+            return null;
+        }
+
         public static void ShowException(Exception e, bool canIgnore = true)
         {
             ShowException(e, string.Empty, canIgnore);
@@ -22,7 +57,7 @@ namespace GitCommands
         {
             if (!(canIgnore && IsIgnorable(e)))
             {
-                MessageBox.Show(owner, string.Join(Environment.NewLine + Environment.NewLine, info, e.ToStringWithData()), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(owner, string.Join(info, Environment.NewLine + Environment.NewLine, e.ToStringWithData()), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -34,7 +69,7 @@ namespace GitCommands
         public static string ToStringWithData(this Exception e)
         {
             var sb = new StringBuilder();
-            sb.AppendLine(e.ToString());
+            sb.AppendLine(e.Message);
             sb.AppendLine();
             foreach (DictionaryEntry entry in e.Data)
             {

--- a/GitCommands/ExecutableNotFoundException.cs
+++ b/GitCommands/ExecutableNotFoundException.cs
@@ -1,0 +1,24 @@
+using System;
+using JetBrains.Annotations;
+
+namespace GitCommands
+{
+    public class ExecutableNotFoundException : Exception
+    {
+        public ExecutableNotFoundException([NotNull]string fileName)
+            : base("Executable not found")
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentException(nameof(fileName));
+            }
+
+            FileName = fileName;
+        }
+
+        /// <summary>
+        /// Gets the name of the executable file which could not be found.
+        /// </summary>
+        public string FileName { get; }
+    }
+}

--- a/GitCommands/FileDeleteException.cs
+++ b/GitCommands/FileDeleteException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace GitCommands.Git
+namespace GitCommands
 {
     public class FileDeleteException : Exception
     {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -105,7 +105,7 @@ namespace GitCommands
             WorkingDirGitDir = GitDirectoryResolverInstance.Resolve(WorkingDir);
             _indexLockManager = new IndexLockManager(this);
             _commitDataManager = new CommitDataManager(() => this);
-            _gitExecutable = executable ?? new Executable(() => AppSettings.GitCommand, WorkingDir);
+            _gitExecutable = executable ?? new Executable(AppSettings.GitCommand, WorkingDir);
 
             // If this is a submodule, populate relevant properties.
             // If this is not a submodule, these will all be null.

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -74,6 +74,7 @@
     <Compile Include="EnvironmentAbstraction.cs" />
     <Compile Include="EnvironmentPathsProvider.cs" />
     <Compile Include="ExceptionUtils.cs" />
+    <Compile Include="ExecutableNotFoundException.cs" />
     <Compile Include="ExternalLinks\ConfiguredLinkDefinitionsProvider.cs" />
     <Compile Include="ExternalLinks\ExternalLinkDefinition.cs" />
     <Compile Include="ExternalLinks\ExternalLinkFormat.cs" />
@@ -89,7 +90,7 @@
     <Compile Include="Git\GitDescribeProvider.cs" />
     <Compile Include="Git\DetachedHeadParser.cs" />
     <Compile Include="Git\EnvironmentConfiguration.cs" />
-    <Compile Include="Git\FileDeleteException.cs" />
+    <Compile Include="FileDeleteException.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />
     <Compile Include="Git\GitBranchNameOptions.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensions.cs" />

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -10,6 +10,7 @@ using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
+using ResourceManager;
 
 namespace GitExtensions
 {
@@ -93,8 +94,8 @@ namespace GitExtensions
                 // or AppSettings.CheckSettings is set to false.
                 if (!(args.Length >= 2 && args[1] == "uninstall")
                     && (AppSettings.CheckSettings
-                    || string.IsNullOrEmpty(AppSettings.GitCommandValue)
-                    || !File.Exists(AppSettings.GitCommandValue)))
+                        || string.IsNullOrEmpty(AppSettings.GitCommandValue)
+                        || !File.Exists(AppSettings.GitCommandValue)))
                 {
                     var uiCommands = new GitUICommands("");
                     var commonLogic = new CommonLogic(uiCommands.Module);
@@ -111,6 +112,14 @@ namespace GitExtensions
                         }
                     }
                 }
+            }
+            catch (Exception ex) when (ex.HasInnerOfType<ExecutableNotFoundException>())
+            {
+                var iex = ex.InnerOfType<ExecutableNotFoundException>();
+                string messageTemplate = iex.FileName.Contains("git") ? Strings.GitExecutableNotFound : Strings.ExecutableNotFound;
+                MessageBox.Show(null, string.Format(messageTemplate, iex.FileName), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+                Environment.Exit(-1);
             }
             catch
             {

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -25,6 +25,9 @@ namespace ResourceManager
             }
         }
 
+        public static string ExecutableNotFound => _instance.Value._executableNotFoundText.Text;
+        public static string GitExecutableNotFound => _instance.Value._gitExecutableNotFoundText.Text;
+
         public static string Date => _instance.Value._dateText.Text;
         public static string Author => GetAuthor(1);
         public static string AuthorDate => GetAuthorDate(1);
@@ -41,23 +44,27 @@ namespace ResourceManager
         public static string Remotes => _instance.Value._remotesText.Text;
         public static string Tags => _instance.Value._tagsText.Text;
 
-        private readonly TranslationString _dateText       = new TranslationString("Date");
-        private readonly TranslationString _authorText     = new TranslationString("{0:Author|Authors}");
+        private readonly TranslationString _executableNotFoundText = new TranslationString("Executable '{0}' not found");
+        private readonly TranslationString _gitExecutableNotFoundText =
+            new TranslationString("Git executable was expected at '{0}'.\r\n\r\nHave you installed git?");
+
+        private readonly TranslationString _dateText = new TranslationString("Date");
+        private readonly TranslationString _authorText = new TranslationString("{0:Author|Authors}");
         private readonly TranslationString _authorDateText = new TranslationString("{0:Author date|Author dates}");
-        private readonly TranslationString _committerText  = new TranslationString("Committer");
+        private readonly TranslationString _committerText = new TranslationString("Committer");
         private readonly TranslationString _commitDateText = new TranslationString("{0:Commit date|Commits dates}");
         private readonly TranslationString _commitHashText = new TranslationString("{0:Commit hash|Commits hashs}");
-        private readonly TranslationString _messageText    = new TranslationString("{0:Message|Messages}");
-        private readonly TranslationString _workspaceText  = new TranslationString("Working directory");
-        private readonly TranslationString _indexText      = new TranslationString("Commit index");
+        private readonly TranslationString _messageText = new TranslationString("{0:Message|Messages}");
+        private readonly TranslationString _workspaceText = new TranslationString("Working directory");
+        private readonly TranslationString _indexText = new TranslationString("Commit index");
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
-        private readonly TranslationString _branchesText   = new TranslationString("Branches");
-        private readonly TranslationString _remotesText    = new TranslationString("Remotes");
-        private readonly TranslationString _tagsText       = new TranslationString("Tags");
+        private readonly TranslationString _branchesText = new TranslationString("Branches");
+        private readonly TranslationString _remotesText = new TranslationString("Remotes");
+        private readonly TranslationString _tagsText = new TranslationString("Tags");
 
-        private readonly TranslationString _parentsText    = new TranslationString("{0:Parent|Parents}");
-        private readonly TranslationString _childrenText   = new TranslationString("{0:Child|Children}");
+        private readonly TranslationString _parentsText = new TranslationString("{0:Parent|Parents}");
+        private readonly TranslationString _childrenText = new TranslationString("{0:Child|Children}");
 
         public static string GetParents(int value)
         {
@@ -132,10 +139,10 @@ namespace ResourceManager
 
         private readonly TranslationString _secondsAgo = new TranslationString("{0} {1:second|seconds} ago");
         private readonly TranslationString _minutesAgo = new TranslationString("{0} {1:minute|minutes} ago");
-        private readonly TranslationString _hoursAgo   = new TranslationString("{0} {1:hour|hours} ago");
-        private readonly TranslationString _daysAgo    = new TranslationString("{0} {1:day|days} ago");
-        private readonly TranslationString _weeksAgo   = new TranslationString("{0} {1:week|weeks} ago");
-        private readonly TranslationString _monthsAgo  = new TranslationString("{0} {1:month|months} ago");
-        private readonly TranslationString _yearsAgo   = new TranslationString("{0} {1:year|years} ago");
+        private readonly TranslationString _hoursAgo = new TranslationString("{0} {1:hour|hours} ago");
+        private readonly TranslationString _daysAgo = new TranslationString("{0} {1:day|days} ago");
+        private readonly TranslationString _weeksAgo = new TranslationString("{0} {1:week|weeks} ago");
+        private readonly TranslationString _monthsAgo = new TranslationString("{0} {1:month|months} ago");
+        private readonly TranslationString _yearsAgo = new TranslationString("{0} {1:year|years} ago");
     }
 }

--- a/UnitTests/GitCommandsTests/ExceptionUtilsTests.cs
+++ b/UnitTests/GitCommandsTests/ExceptionUtilsTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public class ExceptionUtilsTests
+    {
+        [Test]
+        public void HasInnerOfType()
+        {
+            var ex1 = new DivideByZeroException("boom");
+            var ex2 = new ArgumentException("far", ex1);
+            var ex3 = new FileNotFoundException("opps", ex2);
+
+            ex3.HasInnerOfType<ArgumentException>().Should().BeTrue();
+            ex3.HasInnerOfType<DivideByZeroException>().Should().BeTrue();
+        }
+
+        [Test]
+        public void InnerOfType()
+        {
+            var ex1 = new DivideByZeroException("boom");
+            var ex2 = new ArgumentException("far", ex1);
+            var ex3 = new FileNotFoundException("opps", ex2);
+
+            ex3.InnerOfType<ArgumentException>().Should().Be(ex2);
+            ex3.InnerOfType<DivideByZeroException>().Should().Be(ex1);
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="CommitTemplateManagerTests.cs" />
     <Compile Include="Config\ConfigFileTest.cs" />
     <Compile Include="EnvironmentPathsProviderTests.cs" />
+    <Compile Include="ExceptionUtilsTests.cs" />
     <Compile Include="ExternalLinks\ConfiguredLinkDefinitionsProviderTests.cs" />
     <Compile Include="ExternalLinks\ExternalLinkRevisionParserTests.cs" />
     <Compile Include="ExternalLinks\ExternalLinksManagerIntegrationTests.cs" />

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -193,6 +193,15 @@ namespace GitCommandsTests.Helpers
             PathUtil.TryFindFullPath(fileName, out _).Should().BeFalse();
         }
 
+        [Platform(Include = "Win")]
+        [TestCase("git.exe")]
+        [TestCase("cmd.exe")]
+        public void TryFindFullPath_resolve_global_tools(string fileName)
+        {
+            PathUtil.TryFindFullPath(fileName, out var fullPath).Should().BeTrue();
+            fullPath.Should().NotBeEmpty();
+        }
+
         private static IEnumerable<string> GetInvalidPaths()
         {
             if (Path.DirectorySeparatorChar == '\\')


### PR DESCRIPTION
Fixes #5562

Changes proposed in this pull request:
- check whether git (or any other executable for that matter) is installed before attempting to execute it
- if the executable is missing, an error message is shown to the user:
![image](https://user-images.githubusercontent.com/4403806/47149076-47177780-d31e-11e8-95ee-92668890b15b.png)


What did I do to test the code and ensure quality:
- I uninstalled git and experienced the pain of development without git
- I repro the issue
- I had it fixed
- Added some unit tests
