### PR TITLE
Fix FormCommit status branch icon width at high DPI

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -251,7 +251,7 @@ namespace GitUI.CommandsDialogs
             ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowCheckMargin = false;
 
             selectionFilter.Size = DpiUtil.Scale(selectionFilter.Size);
-            toolStripStatusBranchIcon.Size = DpiUtil.Scale(toolStripStatusBranchIcon.Size);
+            toolStripStatusBranchIcon.Width = DpiUtil.Scale(toolStripStatusBranchIcon.Width);
 
             _splitterManager.AddSplitter(splitMain, "splitMain");
             _splitterManager.AddSplitter(splitRight, "splitRight");


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix width of branch icon in `FormCommit` status bar.
 
Screenshots before and after:

Here shown at 150%.

![image](https://user-images.githubusercontent.com/350947/47153670-2b897e00-d2d8-11e8-826b-264b3fc04604.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- Windows 10
