### PR TITLE
Performance improvements for object tree rendering

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitUI.Properties;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
@@ -110,7 +111,7 @@ namespace GitUI.BranchTreePanel
                 TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.BranchDocument);
                 if (IsActive)
                 {
-                    TreeViewNode.NodeFont = new Font(TreeViewNode.NodeFont, FontStyle.Bold);
+                    TreeViewNode.NodeFont = new Font(AppSettings.Font, FontStyle.Bold);
                 }
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -220,7 +220,6 @@ namespace GitUI.BranchTreePanel
 
             protected virtual void ApplyStyle()
             {
-                TreeViewNode.NodeFont = AppSettings.Font;
             }
 
             internal virtual void OnSelected()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
@@ -159,6 +160,7 @@ namespace GitUI.BranchTreePanel
 
             try
             {
+                treeMain.BeginUpdate();
                 var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
@@ -176,6 +178,8 @@ namespace GitUI.BranchTreePanel
                     _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                     treeMain.SelectedNode.EnsureVisible();
                 }
+
+                treeMain.EndUpdate();
             }
         }
 
@@ -232,6 +236,7 @@ namespace GitUI.BranchTreePanel
             tree.TreeViewNode.SelectedImageKey = tree.TreeViewNode.ImageKey;
             tree.TreeViewNode.Tag = tree;
             treeMain.Nodes.Add(tree.TreeViewNode);
+            treeMain.Font = AppSettings.Font;
             _rootNodes.Add(tree);
         }
 


### PR DESCRIPTION
Fixes:
- The object tree is rendered 3 times, causing a flicker
- The object tree was very slow to load (2 remotes/6000 branches/800 tags)

Changes proposed in this pull request:
- Added beginupdate/endupdate around the rootnodes instead inside the rootnodes
- Do not set font on every node, set on tree instead
 
What did I do to test the code and ensure quality:
- Performance profiling with Ants
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
