### PR TITLE
Clarify "Go to merge base commit" menu option text

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -110,8 +110,8 @@ namespace GitUI.UserControls.RevisionGrid
                 new MenuCommand
                 {
                     Name = "GotoMergeBaseCommit",
-                    Text = "Go to merge base commit",
-                    ToolTipText = "Go to the merge base commit (last common commit) between the currently checked out commit (HEAD) and the currently selected commit",
+                    Text = "Go to common ancestor (merge base)",
+                    ToolTipText = "Go to the common ancestor (merge base) commit, which is the best common commit between the currently checked out commit (HEAD) and the currently selected commit",
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Commands.GoToMergeBaseCommit),
                     ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Commands.GoToMergeBaseCommit)
                 },


### PR DESCRIPTION
Based on follow-up discussion in #5538 I propose to change menu `Go to merge base commit` to **`Go to common ancestor (merge base)`**.
If not for fear of PR rejection, I'd loose the `(merge base)` part altogether and only mention `merge base` in the tooltip. Please consider this too. It would actually be closer to how we name menus/buttons today.

Completely agree with @drewnoakes 
> The trend among git UIs is towards making things easier and friendlier. We should be no different.

We also have quite a few labels which are friendly and clear and don't confuse neither novices nor pros.
`Undo last commit` instead of `Reset HEAD~1`
`Stage` instead of `Add`
`Unstage` instead of `Reset`
and so on..