### PR TITLE
Browse: Change icon for submodule menu

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -355,12 +355,12 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripButtonLevelUp.AutoToolTip = false;
             this.toolStripButtonLevelUp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButtonLevelUp.Image = global::GitUI.Properties.Images.NavigateUp;
+            this.toolStripButtonLevelUp.Image = global::GitUI.Properties.Images.FolderSubmodule;
             this.toolStripButtonLevelUp.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonLevelUp.Name = "toolStripButtonLevelUp";
             this.toolStripButtonLevelUp.Size = new System.Drawing.Size(32, 22);
             this.toolStripButtonLevelUp.Text = "Go to superproject";
-            this.toolStripButtonLevelUp.ToolTipText = "Go to superproject";
+            this.toolStripButtonLevelUp.ToolTipText = "";
             this.toolStripButtonLevelUp.ButtonClick += new System.EventHandler(this.toolStripButtonLevelUp_ButtonClick);
             this.toolStripButtonLevelUp.DropDownOpening += new System.EventHandler(this.toolStripButtonLevelUp_DropDownOpening);
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -48,6 +48,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noSubmodulesPresent = new TranslationString("No submodules");
         private readonly TranslationString _topProjectModuleFormat = new TranslationString("Top project: {0}");
         private readonly TranslationString _superprojectModuleFormat = new TranslationString("Superproject: {0}");
+        private readonly TranslationString _goToSuperProject = new TranslationString("Go to superproject");
 
         private readonly TranslationString _indexLockCantDelete = new TranslationString("Failed to delete index.lock.");
 
@@ -80,7 +81,6 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _undoLastCommitText = new TranslationString("You will still be able to find all the commit's changes in the staging area\n\nDo you want to continue?");
         private readonly TranslationString _undoLastCommitCaption = new TranslationString("Undo last commit");
-
         #endregion
 
         private readonly SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("FormBrowse"));
@@ -2582,6 +2582,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
+            toolStripButtonLevelUp.ToolTipText = "";
             _submoduleStatusUpdateNeeded = false;
             _submoduleStatusProvider.UpdateSubmodulesStatus(
                 Module.WorkingDir, _noBranchTitle.Text,
@@ -2620,6 +2621,7 @@ namespace GitUI.CommandsDialogs
 
                 newItems.Add(CreateSubmoduleMenuItem(cancelToken, result.SuperProject, _superprojectModuleFormat.Text));
                 newItems.AddRange(result.SuperSubmodules.Select(submodule => CreateSubmoduleMenuItem(cancelToken, submodule)));
+                toolStripButtonLevelUp.ToolTipText = _goToSuperProject.Text;
             }
 
             newItems.Add(new ToolStripSeparator());


### PR DESCRIPTION
Fixes #5451
Only shows tooltip "Go to superproject" if there are superproject to the current repo

Screenshots before and after (if PR changes UI):

![image](https://user-images.githubusercontent.com/6248932/47185679-66b69c00-d32e-11e8-9225-9bad5514adc9.png)


What did I do to test the code and ensure quality:
- Manual test

Has been tested on (remove any that don't apply):
n/a