### PR TITLE
Clear revisiongrid before start reading log

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -837,6 +837,15 @@ namespace GitUI
                 var refs = Module.GetRefs();
                 _ambiguousRefs = GitRef.GetAmbiguousRefNames(refs);
 
+                _gridView.SuspendLayout();
+                _gridView.SelectionChanged -= OnGridViewSelectionChanged;
+                _gridView.ClearSelection();
+                _gridView.Clear();
+                _gridView.Enabled = true;
+                _gridView.Focus();
+                _gridView.SelectionChanged += OnGridViewSelectionChanged;
+                _gridView.ResumeLayout();
+
                 _revisionReader.Execute(
                     Module,
                     refs,
@@ -846,15 +855,6 @@ namespace GitUI
                     _revisionFilter.GetRevisionFilter() + QuickRevisionFilter + _fixedRevisionFilter,
                     _revisionFilter.GetPathFilter() + _fixedPathFilter,
                     predicate);
-
-                _gridView.SuspendLayout();
-                _gridView.SelectionChanged -= OnGridViewSelectionChanged;
-                _gridView.ClearSelection();
-                _gridView.Clear();
-                _gridView.Enabled = true;
-                _gridView.Focus();
-                _gridView.SelectionChanged += OnGridViewSelectionChanged;
-                _gridView.ResumeLayout();
 
                 if (_initialLoad)
                 {


### PR DESCRIPTION
Fixes a crash in the odd case the log is read faster then clearing the old graphmodel

Changes proposed in this pull request:
- Clear graphmodel before starting async log reader
 
What did I do to test the code and ensure quality:
- Analysed the call stack when the crash occurred
- Some manual testing after the change

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
