### PR TITLE
Fixed issue #5594: Setting order revisions by date has no effect

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -162,8 +162,9 @@ namespace GitCommands
                 {
                     "-z",
                     $"--pretty=format:\"{fullFormat}\"",
+                    { AppSettings.ShowReflogReferences, "--reflog" },
                     { AppSettings.OrderRevisionByDate, "--date-order" },
-                    { AppSettings.ShowReflogReferences, "--reflog --topo-order" }, // if reflog is used, the revisions are not returned in topo-order. Force topo order, since we require topo order for the revision graph.
+                    { AppSettings.ShowReflogReferences && !AppSettings.OrderRevisionByDate, "--topo-order" }, // if reflog is used, the revisions are not returned in topo-order. Force topo order, since we require topo order for the revision graph.
                     {
                         refFilterOptions.HasFlag(RefFilterOptions.All),
                         "--all",


### PR DESCRIPTION
Fixes #5594 

Changes proposed in this pull request:
- Arguments topo-order and date-order should not be applied at the same tima
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
