### PR TITLE
When ordering is unspecified use "topo-order" to prevent parents showing before all of their children are shown

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -163,8 +163,7 @@ namespace GitCommands
                     "-z",
                     $"--pretty=format:\"{fullFormat}\"",
                     { AppSettings.ShowReflogReferences, "--reflog" },
-                    { AppSettings.OrderRevisionByDate, "--date-order" },
-                    { AppSettings.ShowReflogReferences && !AppSettings.OrderRevisionByDate, "--topo-order" }, // if reflog is used, the revisions are not returned in topo-order. Force topo order, since we require topo order for the revision graph.
+                    { AppSettings.OrderRevisionByDate, "--date-order", "--topo-order" },
                     {
                         refFilterOptions.HasFlag(RefFilterOptions.All),
                         "--all",


### PR DESCRIPTION
When ordering revs by date use "topo-order" to prevent parents showing before all of their children are shown

Reverting parts of 20fada493bf8b59e9c2fe9e06710ec187abad9c4 `Revision grid should be responsive before entire graph is loaded...`

Fixes #5593

Changes proposed in this pull request:
- Revert parts of optimization in 20fada493bf8b59e9c2fe9e06710ec187abad9c4 The nature of the rev-graph is such that commits must be ordered so that parents can't be shown before their children or you get weird results.
 
Screenshots before:
![image](https://user-images.githubusercontent.com/483659/47229939-ada99d80-d3d1-11e8-95c1-08d9171a3ea6.png)

Screenshots after:
![image](https://user-images.githubusercontent.com/483659/47230006-cb770280-d3d1-11e8-9fde-c0e8041fbdf5.png)

What did I do to test the code and ensure quality:
- Manual testing when ordering by date and not

Has been tested on
- Latest master