### PR TITLE
Txt change: "Show in folder"

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -208,7 +208,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             this.tsmiOpenFolder.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.tsmiOpenFolder.Name = "tsmiOpenFolder";
             this.tsmiOpenFolder.Size = new System.Drawing.Size(224, 22);
-            this.tsmiOpenFolder.Text = "Open containing folder";
+            this.tsmiOpenFolder.Text = "Show in folder";
             this.tsmiOpenFolder.Click += new System.EventHandler(this.tsmiOpenFolder_Click);
             // 
             // tsmiCategoryRename

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -275,7 +275,7 @@ namespace GitUI.CommandsDialogs
             this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
-            this.openContainingFolderToolStripMenuItem.Text = "Open containing folder";
+            this.openContainingFolderToolStripMenuItem.Text = "Show in folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
             //
             // toolStripSeparator8
@@ -467,7 +467,7 @@ namespace GitUI.CommandsDialogs
             this.stagedOpenFolderToolStripMenuItem10.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.stagedOpenFolderToolStripMenuItem10.Name = "stagedOpenFolderToolStripMenuItem10";
             this.stagedOpenFolderToolStripMenuItem10.Size = new System.Drawing.Size(232, 22);
-            this.stagedOpenFolderToolStripMenuItem10.Text = "Open containing folder";
+            this.stagedOpenFolderToolStripMenuItem10.Text = "Show in folder";
             this.stagedOpenFolderToolStripMenuItem10.Click += new System.EventHandler(this.openFolderToolStripMenuItem10_Click);
             //
             // stagedToolStripSeparator17
@@ -575,7 +575,7 @@ namespace GitUI.CommandsDialogs
             this.openFolderMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.openFolderMenuItem.Name = "openFolderMenuItem";
             this.openFolderMenuItem.Size = new System.Drawing.Size(228, 22);
-            this.openFolderMenuItem.Text = "Open containing folder";
+            this.openFolderMenuItem.Text = "Show in folder";
             this.openFolderMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
             //
             // openDiffMenuItem

--- a/GitUI/CommandsDialogs/FormDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDiff.Designer.cs
@@ -428,7 +428,7 @@ namespace GitUI.CommandsDialogs
             this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
-            this.openContainingFolderToolStripMenuItem.Text = "Open containing folder(s)";
+            this.openContainingFolderToolStripMenuItem.Text = "Show in folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
             // 
             // toolStripSeparator33

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -338,7 +338,7 @@ namespace GitUI.CommandsDialogs
             this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(228, 22);
-            this.openContainingFolderToolStripMenuItem.Text = "Open containing folder(s)";
+            this.openContainingFolderToolStripMenuItem.Text = "Show in folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
             // 
             // diffShowInFileTreeToolStripMenuItem

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -186,7 +186,7 @@
             this.fileTreeOpenContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.fileTreeOpenContainingFolderToolStripMenuItem.Name = "fileTreeOpenContainingFolderToolStripMenuItem";
             this.fileTreeOpenContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.fileTreeOpenContainingFolderToolStripMenuItem.Text = "Open containing folder";
+            this.fileTreeOpenContainingFolderToolStripMenuItem.Text = "Show in folder";
             this.fileTreeOpenContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.fileTreeOpenContainingFolderToolStripMenuItem_Click);
             // 
             // fileTreeArchiveToolStripMenuItem

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3302,7 +3302,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openDiffMenuItem.Text">
@@ -3310,7 +3310,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="openFolderMenuItem.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openSubmoduleMenuItem.Text">
@@ -3402,7 +3402,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="stagedOpenFolderToolStripMenuItem10.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="stagedOpenToolStripMenuItem7.Text">
@@ -3936,7 +3936,7 @@ in order to recover the lost commits.</source>
         <target />
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder(s)</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
@@ -7715,7 +7715,7 @@ This will just checkout on the submodule the commit determined by the superproje
         <target />
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder(s)</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
@@ -7881,7 +7881,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="fileTreeOpenContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="findToolStripMenuItem.Text">
@@ -7947,7 +7947,7 @@ Do you want to remove it from the recent repositories list?</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiOpenFolder.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiCategories.Text">

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -4237,7 +4237,7 @@ You can unset the template:
         
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target>[Ǿƥḗƞ ƈǿƞŧȧīƞīƞɠ ƒǿŀḓḗř ϑϑϕı ẛϱϑϰϐǋ]</target>
         
       </trans-unit>
@@ -4247,7 +4247,7 @@ You can unset the template:
         
       </trans-unit>
       <trans-unit id="openFolderMenuItem.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target>[Ǿƥḗƞ ƈǿƞŧȧīƞīƞɠ ƒǿŀḓḗř 靐ϱϵſ ǅǅ靐ǅϵ鶱]</target>
         
       </trans-unit>
@@ -4362,7 +4362,7 @@ You can unset the template:
         
       </trans-unit>
       <trans-unit id="stagedOpenFolderToolStripMenuItem10.Text">
-        <source>Open containing folder</source>
+        <source>Show in folder</source>
         <target>[Ǿƥḗƞ ƈǿƞŧȧīƞīƞɠ ƒǿŀḓḗř ϑ鶱衋ẛ ϕϖϕı衋ǋ]</target>
         
       </trans-unit>
@@ -5024,7 +5024,7 @@ in order to recover the lost commits.</source>
         
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder(s)</source>
+        <source>Show in folder</source>
         <target>[Ǿƥḗƞ ƈǿƞŧȧīƞīƞɠ ƒǿŀḓḗř(ş) ϑϰǅϕ ΰǋǋϖẛς]</target>
         
       </trans-unit>
@@ -9821,7 +9821,7 @@ This will just checkout on the submodule the commit determined by the superproje
         
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Open containing folder(s)</source>
+        <source>Show in folder</source>
         <target>[Ǿƥḗƞ ƈǿƞŧȧīƞīƞɠ ƒǿŀḓḗř(ş) 衋ϵǈı ϱſϱςϑϵ]</target>
         
       </trans-unit>


### PR DESCRIPTION
instead of "Open containing folder"
Discussion from #5523
The name were aligned to "Open containing folder" in https://github.com/gitextensions/gitextensions/pull/5523#issuecomment-427840592, some reviewers did not find that the best name. "Show in folder" (used for instance in Chrome download) was considered better.

Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/47248180-e6b13480-d408-11e8-886d-724332c18ae1.png)

- 
![image](https://user-images.githubusercontent.com/6248932/47248205-ff214f00-d408-11e8-99dd-f50c1de4f351.png)


What did I do to test the code and ensure quality:
- Manual test 

Has been tested on (remove any that don't apply):
- Windows 10
