### PR TITLE
Static code analysis with PVS studio

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2389,10 +2389,10 @@ namespace GitCommands
             };
 
             var cache = cacheResult &&
-                        !secondRevision.IsArtificial() &&
-                        !firstRevision.IsArtificial() &&
                         !secondRevision.IsNullOrEmpty() &&
-                        !firstRevision.IsNullOrEmpty()
+                        !firstRevision.IsNullOrEmpty() &&
+                        !secondRevision.IsArtificial() &&
+                        !firstRevision.IsArtificial()
                 ? GitCommandCache
                 : null;
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3728,7 +3728,7 @@ namespace GitCommands
             var cmd = Path.Combine(AppSettings.GitBinDir, "ps");
             var lines = new Executable(cmd).GetOutput("x").Split('\n');
 
-            if (lines.Length >= 2)
+            if (lines.Length <= 2)
             {
                 return false;
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2154,7 +2154,7 @@ namespace GitCommands
                             key = m.Groups[1].Value;
                             value = m.Groups[2].Value;
                         }
-                        else
+                        else if (!string.IsNullOrEmpty(line))
                         {
                             value = AppendQuotedString(value, line.Trim());
                         }

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -380,18 +380,24 @@ namespace GitCommands
             var committerEmail = reader.ReadLine(stringPool);
 
             var subject = reader.ReadLine(advance: false);
-            Debug.Assert(subject != null, "subject != null");
+
+            if (author == null || authorEmail == null || committer == null || committerEmail == null || subject == null)
+            {
+                // TODO log this parse error
+                Debug.Fail("Unable to read an entry from the log -- this should not happen");
+                revision = default;
+                return false;
+            }
 
             // NOTE the convention is that the Subject string is duplicated at the start of the Body string
             // Therefore we read the subject twice.
             // If there are not enough characters remaining for a body, then just assign the subject string directly.
             var body = reader.Remaining - subject.Length == 2 ? subject : reader.ReadToEnd();
-            Debug.Assert(body != null, "body != null");
 
-            if (author == null || authorEmail == null || committer == null || committerEmail == null || subject == null || body == null)
+            if (body == null)
             {
                 // TODO log this parse error
-                Debug.Fail("Unable to read an entry from the log -- this should not happen");
+                Debug.Fail("Unable to read body from the log -- this should not happen");
                 revision = default;
                 return false;
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2091,12 +2091,12 @@ namespace GitUI.CommandsDialogs
                 {
                     // When a committemplate is used, skip comments
                     // otherwise: "#" is probably not used for comment but for issue number
-                    if (!line.StartsWith("#") ||
+                    if ((!string.IsNullOrEmpty(line) && !line.StartsWith("#")) ||
                         string.IsNullOrEmpty(_commitTemplate))
                     {
                         if (addNewlineToCommitMessageWhenMissing)
                         {
-                            if (lineNumber == 1 && !string.IsNullOrEmpty(line))
+                            if (lineNumber == 1)
                             {
                                 textWriter.WriteLine();
                             }

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -47,7 +47,7 @@ namespace GitUI.CommandsDialogs
                 {
                     _mergedBranches.Add(branch.Trim());
                 }
-                else if (!branch.StartsWith("* ") || (branch.StartsWith("* ") && !DetachedHeadParser.IsDetachedHead(branch.Substring(2))))
+                else if (!branch.StartsWith("* ") || !DetachedHeadParser.IsDetachedHead(branch.Substring(2)))
                 {
                     _currentBranch = branch.Trim('*', ' ');
                 }

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -116,11 +116,10 @@ namespace GitUI.CommandsDialogs
             var baseCommit = ckCompareToMergeBase.Checked ? _mergeBase : _baseRevision;
 
             var items = new List<GitRevision> { _headRevision, baseCommit };
-
-            // TODO this can never be true
-            if (items.Count == 1)
+            if (baseCommit == null)
             {
-                items.Add(DiffFiles.SelectedItemParent);
+                // This should not happen
+                items = new List<GitRevision> { _headRevision, DiffFiles.SelectedItemParent };
             }
 
             DiffText.ViewChangesAsync(items, DiffFiles.SelectedItem, string.Empty);

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -21,9 +21,9 @@ namespace GitUI.CommandsDialogs
             new TranslationString("You need to enter a mail subject.");
         private readonly TranslationString _wrongSmtpSettingsText =
             new TranslationString("You need to enter a valid smtp in the settings dialog.");
-        private readonly TranslationString _twoRevisionsNeededText =
-            new TranslationString("You need to select two revisions");
-        private readonly TranslationString _twoRevisionsNeededCaption =
+        private readonly TranslationString _revisionsNeededText =
+            new TranslationString("You need to select at least one revision");
+        private readonly TranslationString _revisionsNeededCaption =
             new TranslationString("Patch error");
         private readonly TranslationString _sendMailResult =
             new TranslationString("Send to:");
@@ -157,9 +157,9 @@ namespace GitUI.CommandsDialogs
                     }
                 }
             }
-            else if (string.IsNullOrEmpty(rev1) || string.IsNullOrEmpty(rev2))
+            else
             {
-                MessageBox.Show(this, _twoRevisionsNeededText.Text, _twoRevisionsNeededCaption.Text);
+                MessageBox.Show(this, _revisionsNeededText.Text, _revisionsNeededCaption.Text);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -349,7 +349,7 @@ Inactive remote is completely invisible to git.");
                 tabControl1.Enabled = false;
 
                 if ((string.IsNullOrEmpty(remotePushUrl) && checkBoxSepPushUrl.Checked) ||
-                    remotePushUrl.Equals(remoteUrl, StringComparison.OrdinalIgnoreCase))
+                    (!string.IsNullOrEmpty(remotePushUrl) && remotePushUrl.Equals(remoteUrl, StringComparison.OrdinalIgnoreCase)))
                 {
                     checkBoxSepPushUrl.Checked = false;
                 }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -577,7 +577,7 @@ namespace GitUI.CommandsDialogs
                 _mergetoolCmd = Module.GetEffectiveSetting($"mergetool.{_mergetool}.cmd");
                 _mergetoolPath = Module.GetEffectiveSetting($"mergetool.{_mergetool}.path");
 
-                if (string.IsNullOrEmpty(_mergetool) || _mergetool == "kdiff3")
+                if (_mergetool == "kdiff3")
                 {
                     if (string.IsNullOrEmpty(_mergetoolPath))
                     {

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -217,7 +217,7 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void SaveChangesTurningOffSparseSpecialCase()
         {
-            if (IsSparseCheckoutEnabled || (IsSparseCheckoutEnabled == _isSparseCheckoutEnabledAsSaved))
+            if (IsSparseCheckoutEnabled || !_isSparseCheckoutEnabledAsSaved)
             {
                 return; // Not turning off
             }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -373,7 +373,7 @@ namespace GitUI.CommandsDialogs
             {
                 StashMessage.ReadOnly = true;
             }
-            else if (button.Enabled && button.Checked)
+            else if (button.Checked)
             {
                 StashMessage.ReadOnly = false;
             }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -363,8 +363,8 @@ namespace GitUI.CommandsDialogs
             if (Warnings != null && Warnings.SelectedRows.Count != 0 && Warnings.SelectedRows[0].DataBoundItem != null)
             {
                 var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
-                var isCommit = lostObject != null && lostObject.ObjectType == LostObjectType.Commit;
-                var isBlob = lostObject != null && lostObject.ObjectType == LostObjectType.Blob;
+                var isCommit = lostObject.ObjectType == LostObjectType.Commit;
+                var isBlob = lostObject.ObjectType == LostObjectType.Blob;
                 var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
                 contextMenu.Items[1].Enabled = isCommit;
                 contextMenu.Items[2].Enabled = isCommit;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -442,7 +442,6 @@ namespace GitUI.CommandsDialogs
             diffCommitSubmoduleChanges.Visible =
                 diffResetSubmoduleChanges.Visible =
                 diffStashSubmoduleChangesToolStripMenuItem.Visible =
-                diffUpdateSubmoduleMenuItem.Visible =
                 diffSubmoduleSummaryMenuItem.Visible =
                 diffUpdateSubmoduleMenuItem.Visible = _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo);
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -727,7 +727,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 var selectedItems = DiffFiles.SelectedItems;
-                if (DiffFiles.Revision?.ObjectId == ObjectId.IndexId)
+                if (DiffFiles.Revision.ObjectId == ObjectId.IndexId)
                 {
                     var files = new List<GitItemStatus>();
                     var stagedItems = selectedItems.Where(item => item.Staged == StagedStatus.Index);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ControlHotkeys.cs
@@ -10,8 +10,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     /// </summary>
     public partial class ControlHotkeys : GitExtensionsControl
     {
-        private readonly TranslationString _hotkeyNotSet = new TranslationString("None");
-
         #region Settings
         private HotkeySettings[] _settings;
         private HotkeySettings[] Settings
@@ -96,7 +94,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     if (cmd != null)
                     {
                         listMappings.Items.Add(
-                            new ListViewItem(new[] { cmd.Name, cmd.KeyData.ToText() ?? _hotkeyNotSet.Text })
+                            new ListViewItem(new[] { cmd.Name, cmd.KeyData.ToText() })
                             {
                                 Tag = cmd
                             });

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -160,7 +160,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return;
             }
 
-            CurrentSettings.SetPathValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()), MergetoolPath.Text.Trim());
+            CurrentSettings.SetPathValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()), MergetoolPath.Text?.Trim() ?? "");
             string exeName;
             string exeFile;
             if (!string.IsNullOrEmpty(MergetoolPath.Text))
@@ -218,7 +218,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return;
             }
 
-            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text.Trim()), DifftoolPath.Text.Trim());
+            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text.Trim()), DifftoolPath.Text?.Trim() ?? "");
             string exeName;
             string exeFile;
             if (!string.IsNullOrEmpty(DifftoolPath.Text))

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
                 // TODO: do not change text color on already assigned keys, which occur only once
                 ForeColor = HotkeySettingsManager.IsUniqueKey(_keyData) ? System.Drawing.Color.Red : System.Drawing.Color.Black;
-                Text = value.ToText() ?? _hotkeyNotSet.Text;
+                Text = _keyData.ToText();
             }
         }
         #endregion

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -110,7 +110,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     }
                 }
 
-                SettingsPageSelected(this, new SettingsPageSelectedEventArgs { SettingsPage = page, IsTriggeredByGoto = _isSelectionChangeTriggeredByGoto });
+                SettingsPageSelected?.Invoke(this, new SettingsPageSelectedEventArgs { SettingsPage = page, IsTriggeredByGoto = _isSelectionChangeTriggeredByGoto });
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -178,7 +178,7 @@ namespace GitUI.CommitInfo
 
             var data = _commitDataManager.CreateFromRevision(_revision, _children);
 
-            if (_revision.Body == null)
+            if (_revision != null && _revision.Body == null)
             {
                 _commitDataManager.UpdateBody(data, out _);
                 _revision.Body = data.Body;

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -88,6 +88,8 @@ namespace GitUI.Editor.Diff
                     var brush = default(Brush);
                     switch (diffLine.LineType)
                     {
+                        case DiffLineType.Context:
+                            break;
                         case DiffLineType.Plus:
                             brush = new SolidBrush(AppSettings.DiffAddedColor);
                             break;

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -83,7 +83,7 @@ namespace GitUI.Hotkey
 
         public static string ToShortcutKeyDisplayString(this Keys key)
         {
-            return key.ToText() ?? "";
+            return key.ToText();
         }
 
         [CanBeNull]

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -145,7 +145,6 @@ namespace GitUI.Script
                 else if (option.StartsWith("{s") && selectedRevision == null && revisionGrid != null)
                 {
                     allSelectedRevisions = revisionGrid.GetSelectedRevisions();
-                    allSelectedRevisions.Reverse(); // Put first clicked revisions first
                     selectedRevision = CalculateSelectedRevision(revisionGrid, selectedRemoteBranches, selectedRemotes, selectedLocalBranches, selectedBranches, selectedTags);
                 }
 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1050,7 +1050,7 @@ namespace GitUI
             }
             else
             {
-                DoubleClick(sender, e);
+                DoubleClick?.Invoke(sender, e);
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -485,12 +485,10 @@ namespace GitUI.UserControls.RevisionGrid
 
             void UpdateGraph(int fromIndex, in int toIndex)
             {
-                var rowIndex = fromIndex;
-
                 // Cache the next item
                 _revisionGraph.CacheTo(toIndex, Math.Min(fromIndex + 1500, toIndex));
 
-                rowIndex = _revisionGraph.GetCachedCount();
+                var rowIndex = _revisionGraph.GetCachedCount();
 
                 this.InvokeAsync(UpdateRowCount, toIndex).FileAndForget();
                 return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -232,10 +232,7 @@ namespace GitUI
                 {
                     _indexWatcher.Value.Dispose();
                 }
-            }
 
-            if (disposing)
-            {
                 components?.Dispose();
             }
 

--- a/GitUI/UserControls/WaitSpinner.cs
+++ b/GitUI/UserControls/WaitSpinner.cs
@@ -130,8 +130,8 @@ namespace GitUI.UserControls
                 ref var angle = ref _angles[p];
                 e.Graphics.FillEllipse(
                     _brushes[i],
-                    (_centre.X - (_dotRadius / 2)) + (_circleRadius * angle.cos),
-                    (_centre.Y - (_dotRadius / 2)) + (_circleRadius * angle.sin),
+                    (_centre.X - (_dotRadius / 2f)) + (_circleRadius * angle.cos),
+                    (_centre.Y - (_dotRadius / 2f)) + (_circleRadius * angle.sin),
                     _dotRadius,
                     _dotRadius);
                 p++;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -283,8 +283,8 @@ namespace DeleteUnusedBranches
                 mergedIntoBranch.Text,
                 _NO_TRANSLATE_Remote.Text,
                 useRegexFilter.Checked ? regexFilter.Text : null,
-                useRegexCaseInsensitive.Checked && useRegexCaseInsensitive.Checked,
-                regexDoesNotMatch.Checked && regexDoesNotMatch.Checked,
+                useRegexCaseInsensitive.Checked,
+                regexDoesNotMatch.Checked,
                 TimeSpan.FromDays((int)olderThanDays.Value),
                 _refreshCancellation.Token);
 

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -362,7 +362,7 @@ namespace GitImpact
                     h_max = Math.Max(h_max, y);
 
                     // Add week date label
-                    _weekLabels.Add((new PointF(x + (BlockWidth / 2), y), weekDate));
+                    _weekLabels.Add((new PointF(x + (BlockWidth / 2f), y), weekDate));
 
                     // Increase x for next week
                     x += BlockWidth + TransitionWidth;

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -34,14 +34,12 @@ namespace GitStatistics
 
                 AddFile(file);
 
-                if (Updated != null && DateTime.Now - lastUpdate > timer)
+                if (DateTime.Now - lastUpdate > timer)
                 {
                     lastUpdate = DateTime.Now;
-                    Updated(this, EventArgs.Empty);
+                    Updated?.Invoke(this, EventArgs.Empty);
                 }
             }
-
-            Updated?.Invoke(this, EventArgs.Empty);
 
             return;
 

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -253,7 +253,7 @@ namespace ResourceManager
                     }
                 }
 
-                string diffs = gitModule.GetDiffFilesText(status.OldCommit?.ToString(), status.Commit?.ToString());
+                string diffs = gitModule.GetDiffFilesText(status.OldCommit.ToString(), status.Commit.ToString());
                 if (!string.IsNullOrEmpty(diffs))
                 {
                     sb.AppendLine("\nDifferences:");

--- a/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommandsTests/Git/Gpg/GitGpgControllerTests.cs
@@ -173,7 +173,6 @@ namespace GitCommandsTests.Git.Gpg
                     {
                         // Two tag that's also IsDereference == true
                         var gitRef1 = new GitRef(_module(), objectId, "refs/tags/FirstTag^{}");
-                        revision.Refs = new[] { gitRef1 };
 
                         var args = new GitArgumentBuilder("verify-tag") { gitRef1.LocalName };
                         _module().RunGitCmd(args).Returns(gitRef1.LocalName);

--- a/UnitTests/GitCommandsTests/StringPoolTests.cs
+++ b/UnitTests/GitCommandsTests/StringPoolTests.cs
@@ -76,10 +76,7 @@ namespace GitCommandsTests
 
                     Assert.True(StringPool.EqualsAtIndex(s, index, s.Substring(index, length)), format, index, length);
 
-                    if (length < s.Length)
-                    {
-                        Assert.False(StringPool.EqualsAtIndex(s, index, s.Substring(index, length) + 'Z'), format, index, length);
-                    }
+                    Assert.False(StringPool.EqualsAtIndex(s, index, s.Substring(index, length) + 'Z'), format, index, length);
 
                     if (index > 0 && length > 0)
                     {


### PR DESCRIPTION
Fixes #5604

Changes proposed in this pull request:
Static analysis of code with PVS Studio.
See the issue for a discussion.

This is done with the demo license, so I am running out of clicks (how demo is licensed) and evaluation time eventually.
 
Screenshots before and after (if PR changes UI):
n/a

What did I do to test the code and ensure quality:
- Manual tests - most changes cannot be provoked though

Code review should be sufficient
Note: Similar PRs for submodules. None of those should be critical, but they decrease the noise when analyzing the solution if someone else tries out PVS Studio.

Has been tested on (remove any that don't apply):
- GIT 2.19.1 and above
- Windows 10
