### PR TITLE
Update commit info panel layout

### DIFF
--- a/GitUI/ColorHelper.cs
+++ b/GitUI/ColorHelper.cs
@@ -15,7 +15,7 @@ namespace GitUI
         }
 
         /// <remarks>0.05 is subtle. 0.3 is quite strong.</remarks>
-        public static Color MakeColorDarker(Color color, double amount)
+        public static Color MakeColorDarker(this Color color, double amount)
         {
             var hsl = new HslColor(color);
             return hsl.WithBrightness(hsl.L - amount).ToColor();

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -759,7 +759,7 @@ namespace GitUI.CommandsDialogs
             this.RevisionInfo.ShowBranchesAsLinks = true;
             this.RevisionInfo.Size = new System.Drawing.Size(646, 264);
             this.RevisionInfo.TabIndex = 0;
-            this.RevisionInfo.CommandClick += new System.EventHandler<GitUI.CommitInfo.CommandEventArgs>(this.RevisionInfo_CommandClick);
+            this.RevisionInfo.CommandClicked += new System.EventHandler<GitUI.CommitInfo.CommandEventArgs>(this.RevisionInfo_CommandClicked);
             // 
             // TreeTabPage
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -750,9 +750,11 @@ namespace GitUI.CommandsDialogs
             // 
             // RevisionInfo
             // 
+            this.RevisionInfo.AutoSize = true;
+            this.RevisionInfo.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.RevisionInfo.BackColor = System.Drawing.SystemColors.Window;
             this.RevisionInfo.Cursor = System.Windows.Forms.Cursors.IBeam;
-            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Top;
             this.RevisionInfo.Location = new System.Drawing.Point(0, 0);
             this.RevisionInfo.Margin = new System.Windows.Forms.Padding(0);
             this.RevisionInfo.Name = "RevisionInfo";

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1209,6 +1209,11 @@ namespace GitUI.CommandsDialogs
 
             var children = RevisionGrid.GetRevisionChildren(revision.ObjectId);
             RevisionInfo.SetRevisionWithChildren(revision, children);
+            if (RevisionInfo.Parent is Panel parent)
+            {
+                parent.AutoScroll = true;
+                parent.AutoScrollMinSize = RevisionInfo.PreferredSize;
+            }
         }
 
         private async Task FillGpgInfoAsync()
@@ -2999,6 +3004,7 @@ namespace GitUI.CommandsDialogs
                 RevisionsSplitContainer.Panel2Collapsed = false;
             }
 
+            RevisionInfo.Parent.BackColor = RevisionInfo.BackColor;
             RevisionInfo.ResumeLayout(performLayout: true);
             CommitInfoTabControl.ResumeLayout(performLayout: true);
             RevisionsSplitContainer.ResumeLayout(performLayout: true);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2436,7 +2436,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void RevisionInfo_CommandClick(object sender, CommitInfo.CommandEventArgs e)
+        private void RevisionInfo_CommandClicked(object sender, CommitInfo.CommandEventArgs e)
         {
             // TODO this code duplicated in FormFileHistory.Blame_CommandClick
             switch (e.Command)
@@ -2962,9 +2962,6 @@ namespace GitUI.CommandsDialogs
             RevisionsSplitContainer.SuspendLayout();
 
             var commitInfoPosition = AppSettings.CommitInfoPosition;
-
-            RevisionInfo.SetAvatarPosition(right: commitInfoPosition == CommitInfoPosition.RightwardFromList);
-
             if (commitInfoPosition == CommitInfoPosition.BelowList)
             {
                 CommitInfoTabControl.InsertIfNotExists(0, CommitInfoTabPage);

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.tableLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayout = new GitUI.UserControls.DoubleBufferedTableLayoutPanel();
             this.pnlCommitMessage = new System.Windows.Forms.Panel();
             this.rtbxCommitMessage = new System.Windows.Forms.RichTextBox();
             this.commitInfoContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -248,6 +248,6 @@
         private CommitInfoHeader commitInfoHeader;
         private System.Windows.Forms.Panel pnlCommitMessage;
         private System.Windows.Forms.RichTextBox rtbxCommitMessage;
-        private System.Windows.Forms.TableLayoutPanel tableLayout;
+        private GitUI.UserControls.DoubleBufferedTableLayoutPanel tableLayout;
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -29,9 +29,9 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.tableLayout = new System.Windows.Forms.TableLayoutPanel();
-            this.avatarControl = new GitUI.AvatarControl();
-            this.RevisionInfo = new System.Windows.Forms.RichTextBox();
+            System.Windows.Forms.TableLayoutPanel tableLayout;
+            this.pnlCommitMessage = new System.Windows.Forms.Panel();
+            this.rtbxCommitMessage = new System.Windows.Forms.RichTextBox();
             this.commitInfoContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyCommitInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -43,53 +43,66 @@
             this.showTagThisCommitDerivesFromMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.addNoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._RevisionHeader = new System.Windows.Forms.RichTextBox();
-            this.tableLayout.SuspendLayout();
+            this.commitInfoHeader = new GitUI.CommitInfo.CommitInfoHeader();
+            this.RevisionInfo = new System.Windows.Forms.RichTextBox();
+            tableLayout = new System.Windows.Forms.TableLayoutPanel();
+            tableLayout.SuspendLayout();
+            this.pnlCommitMessage.SuspendLayout();
             this.commitInfoContextMenuStrip.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayout
             // 
-            this.tableLayout.AutoSize = true;
-            this.tableLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayout.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayout.ColumnCount = 2;
-            this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayout.Controls.Add(this.avatarControl, 0, 0);
-            this.tableLayout.Controls.Add(this.RevisionInfo, 1, 1);
-            this.tableLayout.Controls.Add(this._RevisionHeader, 1, 0);
-            this.tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayout.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
-            this.tableLayout.Location = new System.Drawing.Point(0, 0);
-            this.tableLayout.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayout.Name = "tableLayout";
-            this.tableLayout.RowCount = 2;
-            this.tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayout.Size = new System.Drawing.Size(893, 386);
-            this.tableLayout.TabIndex = 3;
+            tableLayout.AutoSize = true;
+            tableLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            tableLayout.BackColor = System.Drawing.SystemColors.Window;
+            tableLayout.ColumnCount = 1;
+            tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayout.Controls.Add(this.pnlCommitMessage, 0, 1);
+            tableLayout.Controls.Add(this.commitInfoHeader, 0, 0);
+            tableLayout.Controls.Add(this.RevisionInfo, 0, 2);
+            tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayout.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            tableLayout.Location = new System.Drawing.Point(8, 8);
+            tableLayout.Margin = new System.Windows.Forms.Padding(0);
+            tableLayout.Name = "tableLayout";
+            tableLayout.Padding = new System.Windows.Forms.Padding(4);
+            tableLayout.RowCount = 3;
+            tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayout.Size = new System.Drawing.Size(435, 282);
+            tableLayout.TabIndex = 0;
             // 
-            // RevisionInfo
+            // pnlCommitMessage
             // 
-            this.RevisionInfo.BackColor = System.Drawing.SystemColors.Window;
-            this.RevisionInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.RevisionInfo.ContextMenuStrip = this.commitInfoContextMenuStrip;
-            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.RevisionInfo.Location = new System.Drawing.Point(96, 98);
-            this.RevisionInfo.Margin = new System.Windows.Forms.Padding(0);
-            this.RevisionInfo.Name = "RevisionInfo";
-            this.RevisionInfo.ReadOnly = true;
-            this.RevisionInfo.Size = new System.Drawing.Size(797, 288);
-            this.RevisionInfo.TabIndex = 0;
-            this.RevisionInfo.Text = "";
-            this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
-            this.RevisionInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
-            this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
+            this.pnlCommitMessage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.pnlCommitMessage.Controls.Add(this.rtbxCommitMessage);
+            this.pnlCommitMessage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlCommitMessage.Location = new System.Drawing.Point(4, 112);
+            this.pnlCommitMessage.Margin = new System.Windows.Forms.Padding(0);
+            this.pnlCommitMessage.Name = "pnlCommitMessage";
+            this.pnlCommitMessage.Padding = new System.Windows.Forms.Padding(8);
+            this.pnlCommitMessage.Size = new System.Drawing.Size(427, 36);
+            this.pnlCommitMessage.TabIndex = 0;
+            // 
+            // rtbxCommitMessage
+            // 
+            this.rtbxCommitMessage.AutoSize = true;
+            this.rtbxCommitMessage.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.rtbxCommitMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.rtbxCommitMessage.ContextMenuStrip = this.commitInfoContextMenuStrip;
+            this.rtbxCommitMessage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.rtbxCommitMessage.Location = new System.Drawing.Point(8, 8);
+            this.rtbxCommitMessage.Margin = new System.Windows.Forms.Padding(0);
+            this.rtbxCommitMessage.Name = "rtbxCommitMessage";
+            this.rtbxCommitMessage.Size = new System.Drawing.Size(411, 20);
+            this.rtbxCommitMessage.TabIndex = 1;
+            this.rtbxCommitMessage.Text = "";
             // 
             // commitInfoContextMenuStrip
             // 
+            this.commitInfoContextMenuStrip.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.commitInfoContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyCommitInfoToolStripMenuItem,
             this.toolStripSeparator1,
@@ -170,43 +183,48 @@
             this.addNoteToolStripMenuItem.Text = "Add notes";
             this.addNoteToolStripMenuItem.Click += new System.EventHandler(this.addNoteToolStripMenuItem_Click);
             // 
-            // _RevisionHeader
+            // commitInfoHeader
             // 
-            this._RevisionHeader.BackColor = System.Drawing.SystemColors.ControlLight;
-            this._RevisionHeader.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this._RevisionHeader.ContextMenuStrip = this.commitInfoContextMenuStrip;
-            this._RevisionHeader.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._RevisionHeader.Location = new System.Drawing.Point(96, 0);
-            this._RevisionHeader.Margin = new System.Windows.Forms.Padding(0);
-            this._RevisionHeader.Name = "_RevisionHeader";
-            this._RevisionHeader.ReadOnly = true;
-            this._RevisionHeader.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this._RevisionHeader.Size = new System.Drawing.Size(797, 98);
-            this._RevisionHeader.TabIndex = 0;
-            this._RevisionHeader.Text = "";
-            this._RevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this._RevisionHeader_ContentsResized);
-            this._RevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
-            this._RevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
-            this._RevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
+            this.commitInfoHeader.AutoSize = true;
+            this.commitInfoHeader.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.commitInfoHeader.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commitInfoHeader.Location = new System.Drawing.Point(4, 4);
+            this.commitInfoHeader.Margin = new System.Windows.Forms.Padding(0);
+            this.commitInfoHeader.Name = "commitInfoHeader";
+            this.commitInfoHeader.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.commitInfoHeader.Size = new System.Drawing.Size(427, 108);
+            this.commitInfoHeader.TabIndex = 0;
             // 
-            // avatarControl
+            // RevisionInfo
             // 
-            this.avatarControl.BackColor = System.Drawing.SystemColors.Window;
-            this.avatarControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.avatarControl.Location = new System.Drawing.Point(0, 0);
-            this.avatarControl.Margin = new System.Windows.Forms.Padding(0);
-            this.avatarControl.Name = "avatarControl";
-            this.avatarControl.Size = new System.Drawing.Size(96, 98);
-            this.avatarControl.TabIndex = 1;
+            this.RevisionInfo.BackColor = System.Drawing.SystemColors.Window;
+            this.RevisionInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.RevisionInfo.ContextMenuStrip = this.commitInfoContextMenuStrip;
+            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RevisionInfo.Location = new System.Drawing.Point(4, 148);
+            this.RevisionInfo.Margin = new System.Windows.Forms.Padding(0);
+            this.RevisionInfo.Name = "RevisionInfo";
+            this.RevisionInfo.ReadOnly = true;
+            this.RevisionInfo.Size = new System.Drawing.Size(427, 130);
+            this.RevisionInfo.TabIndex = 2;
+            this.RevisionInfo.Text = "";
+            this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
+            this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
+            this.RevisionInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 
             // CommitInfo
             // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            this.Controls.Add(this.tableLayout);
-            this.Margin = new System.Windows.Forms.Padding(4);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(tableLayout);
+            this.DoubleBuffered = true;
             this.Name = "CommitInfo";
-            this.Size = new System.Drawing.Size(893, 386);
-            this.tableLayout.ResumeLayout(false);
+            this.Padding = new System.Windows.Forms.Padding(8);
+            this.Size = new System.Drawing.Size(451, 298);
+            tableLayout.ResumeLayout(false);
+            tableLayout.PerformLayout();
+            this.pnlCommitMessage.ResumeLayout(false);
+            this.pnlCommitMessage.PerformLayout();
             this.commitInfoContextMenuStrip.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -215,13 +233,10 @@
 
         #endregion
 
-        private System.Windows.Forms.TableLayoutPanel tableLayout;
-        private AvatarControl avatarControl;
         private System.Windows.Forms.RichTextBox RevisionInfo;
         private System.Windows.Forms.ContextMenuStrip commitInfoContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem showContainedInBranchesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showContainedInTagsToolStripMenuItem;
-        private System.Windows.Forms.RichTextBox _RevisionHeader;
         private System.Windows.Forms.ToolStripMenuItem copyCommitInfoToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem showContainedInBranchesRemoteToolStripMenuItem;
@@ -230,5 +245,8 @@
         private System.Windows.Forms.ToolStripMenuItem addNoteToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showMessagesOfAnnotatedTagsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showTagThisCommitDerivesFromMenuItem;
+        private CommitInfoHeader commitInfoHeader;
+        private System.Windows.Forms.Panel pnlCommitMessage;
+        private System.Windows.Forms.RichTextBox rtbxCommitMessage;
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.TableLayoutPanel tableLayout;
+            this.tableLayout = new System.Windows.Forms.TableLayoutPanel();
             this.pnlCommitMessage = new System.Windows.Forms.Panel();
             this.rtbxCommitMessage = new System.Windows.Forms.RichTextBox();
             this.commitInfoContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -45,41 +45,41 @@
             this.addNoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.commitInfoHeader = new GitUI.CommitInfo.CommitInfoHeader();
             this.RevisionInfo = new System.Windows.Forms.RichTextBox();
-            tableLayout = new System.Windows.Forms.TableLayoutPanel();
-            tableLayout.SuspendLayout();
+            this.tableLayout.SuspendLayout();
             this.pnlCommitMessage.SuspendLayout();
             this.commitInfoContextMenuStrip.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayout
             // 
-            tableLayout.AutoSize = true;
-            tableLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            tableLayout.BackColor = System.Drawing.SystemColors.Window;
-            tableLayout.ColumnCount = 1;
-            tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            tableLayout.Controls.Add(this.pnlCommitMessage, 0, 1);
-            tableLayout.Controls.Add(this.commitInfoHeader, 0, 0);
-            tableLayout.Controls.Add(this.RevisionInfo, 0, 2);
-            tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
-            tableLayout.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
-            tableLayout.Location = new System.Drawing.Point(8, 8);
-            tableLayout.Margin = new System.Windows.Forms.Padding(0);
-            tableLayout.Name = "tableLayout";
-            tableLayout.Padding = new System.Windows.Forms.Padding(4);
-            tableLayout.RowCount = 3;
-            tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            tableLayout.Size = new System.Drawing.Size(435, 282);
-            tableLayout.TabIndex = 0;
+            this.tableLayout.AutoSize = true;
+            this.tableLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayout.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayout.ColumnCount = 1;
+            this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayout.Controls.Add(this.pnlCommitMessage, 0, 1);
+            this.tableLayout.Controls.Add(this.commitInfoHeader, 0, 0);
+            this.tableLayout.Controls.Add(this.RevisionInfo, 0, 2);
+            this.tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayout.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
+            this.tableLayout.Location = new System.Drawing.Point(8, 8);
+            this.tableLayout.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayout.Name = "tableLayout";
+            this.tableLayout.Padding = new System.Windows.Forms.Padding(4);
+            this.tableLayout.RowCount = 3;
+            this.tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayout.Size = new System.Drawing.Size(435, 282);
+            this.tableLayout.TabIndex = 0;
+            this.tableLayout.Visible = false;
             // 
             // pnlCommitMessage
             // 
             this.pnlCommitMessage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.pnlCommitMessage.Controls.Add(this.rtbxCommitMessage);
             this.pnlCommitMessage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlCommitMessage.Location = new System.Drawing.Point(4, 112);
+            this.pnlCommitMessage.Location = new System.Drawing.Point(4, 108);
             this.pnlCommitMessage.Margin = new System.Windows.Forms.Padding(0);
             this.pnlCommitMessage.Name = "pnlCommitMessage";
             this.pnlCommitMessage.Padding = new System.Windows.Forms.Padding(8);
@@ -192,7 +192,7 @@
             this.commitInfoHeader.Margin = new System.Windows.Forms.Padding(0);
             this.commitInfoHeader.Name = "commitInfoHeader";
             this.commitInfoHeader.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
-            this.commitInfoHeader.Size = new System.Drawing.Size(427, 108);
+            this.commitInfoHeader.Size = new System.Drawing.Size(427, 104);
             this.commitInfoHeader.TabIndex = 0;
             // 
             // RevisionInfo
@@ -201,11 +201,11 @@
             this.RevisionInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.RevisionInfo.ContextMenuStrip = this.commitInfoContextMenuStrip;
             this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.RevisionInfo.Location = new System.Drawing.Point(4, 148);
+            this.RevisionInfo.Location = new System.Drawing.Point(4, 144);
             this.RevisionInfo.Margin = new System.Windows.Forms.Padding(0);
             this.RevisionInfo.Name = "RevisionInfo";
             this.RevisionInfo.ReadOnly = true;
-            this.RevisionInfo.Size = new System.Drawing.Size(427, 130);
+            this.RevisionInfo.Size = new System.Drawing.Size(427, 134);
             this.RevisionInfo.TabIndex = 2;
             this.RevisionInfo.Text = "";
             this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
@@ -216,13 +216,13 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(tableLayout);
+            this.Controls.Add(this.tableLayout);
             this.DoubleBuffered = true;
             this.Name = "CommitInfo";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(451, 298);
-            tableLayout.ResumeLayout(false);
-            tableLayout.PerformLayout();
+            this.tableLayout.ResumeLayout(false);
+            this.tableLayout.PerformLayout();
             this.pnlCommitMessage.ResumeLayout(false);
             this.pnlCommitMessage.PerformLayout();
             this.commitInfoContextMenuStrip.ResumeLayout(false);
@@ -248,5 +248,6 @@
         private CommitInfoHeader commitInfoHeader;
         private System.Windows.Forms.Panel pnlCommitMessage;
         private System.Windows.Forms.RichTextBox rtbxCommitMessage;
+        private System.Windows.Forms.TableLayoutPanel tableLayout;
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -144,6 +144,13 @@ namespace GitUI.CommitInfo
             _revision = revision;
             _children = children;
 
+            if (revision == null)
+            {
+                tableLayout.Visible = false;
+                return;
+            }
+
+            tableLayout.Visible = true;
             commitInfoHeader.ShowCommitInfo(revision, children);
             ReloadCommitInfo();
         }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -481,6 +481,10 @@ namespace GitUI.CommitInfo
             RevisionInfo.SetXHTMLText(body);
             RevisionInfo.SelectionStart = 0; // scroll up
             RevisionInfo.ScrollToCaret();    // scroll up
+
+            var rtbSize = TextRenderer.MeasureText(RevisionInfo.GetPlainText(), RevisionInfo.Font, RevisionInfo.Size, TextFormatFlags.WordBreak);
+            RevisionInfo.Height = rtbSize.Height;
+
             RevisionInfo.ResumeLayout(true);
 
             return;

--- a/GitUI/CommitInfo/CommitInfo.resx
+++ b/GitUI/CommitInfo/CommitInfo.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="tableLayout.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
   <metadata name="commitInfoContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
@@ -29,11 +29,11 @@
         private void InitializeComponent()
         {
             System.Windows.Forms.Panel pnlAvatar;
-            System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+            GitUI.UserControls.DoubleBufferedTableLayoutPanel tableLayoutPanel1;
             this.avatarControl = new GitUI.AvatarControl();
             this.rtbRevisionHeader = new System.Windows.Forms.RichTextBox();
             pnlAvatar = new System.Windows.Forms.Panel();
-            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            tableLayoutPanel1 = new GitUI.UserControls.DoubleBufferedTableLayoutPanel();
             pnlAvatar.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();

--- a/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
@@ -90,6 +90,7 @@
             this.rtbRevisionHeader.Size = new System.Drawing.Size(156, 100);
             this.rtbRevisionHeader.TabIndex = 0;
             this.rtbRevisionHeader.Text = "";
+            this.rtbRevisionHeader.WordWrap = false;
             this.rtbRevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this.rtbRevisionHeader_ContentsResized);
             this.rtbRevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbRevisionHeader_LinkClicked);
             this.rtbRevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rtbRevisionHeader_KeyDown);

--- a/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
@@ -1,0 +1,123 @@
+﻿namespace GitUI.CommitInfo
+{
+    partial class CommitInfoHeader
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.Windows.Forms.Panel pnlAvatar;
+            System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+            this.avatarControl = new GitUI.AvatarControl();
+            this.rtbRevisionHeader = new System.Windows.Forms.RichTextBox();
+            pnlAvatar = new System.Windows.Forms.Panel();
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            pnlAvatar.SuspendLayout();
+            tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // pnlAvatar
+            // 
+            pnlAvatar.AutoSize = true;
+            pnlAvatar.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            pnlAvatar.Controls.Add(this.avatarControl);
+            pnlAvatar.Location = new System.Drawing.Point(0, 0);
+            pnlAvatar.Margin = new System.Windows.Forms.Padding(0);
+            pnlAvatar.Name = "pnlAvatar";
+            pnlAvatar.Padding = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            pnlAvatar.Size = new System.Drawing.Size(104, 96);
+            pnlAvatar.TabIndex = 0;
+            // 
+            // avatarControl
+            // 
+            this.avatarControl.AutoSize = true;
+            this.avatarControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.avatarControl.Location = new System.Drawing.Point(0, 0);
+            this.avatarControl.Margin = new System.Windows.Forms.Padding(0);
+            this.avatarControl.Name = "avatarControl";
+            this.avatarControl.Size = new System.Drawing.Size(96, 96);
+            this.avatarControl.TabIndex = 0;
+            // 
+            // tableLayoutPanel1
+            // 
+            tableLayoutPanel1.AutoSize = true;
+            tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            tableLayoutPanel1.Controls.Add(pnlAvatar, 0, 0);
+            tableLayoutPanel1.Controls.Add(this.rtbRevisionHeader, 1, 0);
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 1;
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            tableLayoutPanel1.Size = new System.Drawing.Size(260, 100);
+            tableLayoutPanel1.TabIndex = 0;
+            // 
+            // rtbRevisionHeader
+            // 
+            this.rtbRevisionHeader.BackColor = System.Drawing.SystemColors.Window;
+            this.rtbRevisionHeader.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.rtbRevisionHeader.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.rtbRevisionHeader.Location = new System.Drawing.Point(104, 0);
+            this.rtbRevisionHeader.Margin = new System.Windows.Forms.Padding(0);
+            this.rtbRevisionHeader.Name = "rtbRevisionHeader";
+            this.rtbRevisionHeader.ReadOnly = true;
+            this.rtbRevisionHeader.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.rtbRevisionHeader.Size = new System.Drawing.Size(156, 100);
+            this.rtbRevisionHeader.TabIndex = 0;
+            this.rtbRevisionHeader.Text = "";
+            this.rtbRevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this.rtbRevisionHeader_ContentsResized);
+            this.rtbRevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbRevisionHeader_LinkClicked);
+            this.rtbRevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rtbRevisionHeader_KeyDown);
+            this.rtbRevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this.rtbRevisionHeader_MouseDown);
+            // 
+            // CommitInfoHeader
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.Controls.Add(tableLayoutPanel1);
+            this.DoubleBuffered = true;
+            this.Margin = new System.Windows.Forms.Padding(0);
+            this.Name = "CommitInfoHeader";
+            this.Size = new System.Drawing.Size(260, 100);
+            pnlAvatar.ResumeLayout(false);
+            pnlAvatar.PerformLayout();
+            tableLayoutPanel1.ResumeLayout(false);
+            tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.RichTextBox rtbRevisionHeader;
+        private AvatarControl avatarControl;
+    }
+}

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitExtUtils.GitUI;
+using GitUI.Editor.RichTextBoxExtension;
+using GitUIPluginInterfaces;
+using ResourceManager;
+using ResourceManager.CommitDataRenders;
+
+namespace GitUI.CommitInfo
+{
+    public partial class CommitInfoHeader : GitModuleControl
+    {
+        private readonly IDateFormatter _dateFormatter = new DateFormatter();
+        private readonly ILinkFactory _linkFactory = new LinkFactory();
+        private readonly ICommitDataManager _commitDataManager;
+        private readonly ICommitDataHeaderRenderer _commitDataHeaderRenderer;
+
+        public event EventHandler<CommandEventArgs> CommandClicked;
+
+        public CommitInfoHeader()
+        {
+            InitializeComponent();
+            InitializeComplete();
+
+            var labelFormatter = new TabbedHeaderLabelFormatter();
+            var headerRenderer = new TabbedHeaderRenderStyleProvider();
+
+            _commitDataManager = new CommitDataManager(() => Module);
+            _commitDataHeaderRenderer = new CommitDataHeaderRenderer(labelFormatter, _dateFormatter, headerRenderer, _linkFactory);
+
+            using (var g = CreateGraphics())
+            {
+                rtbRevisionHeader.Font = _commitDataHeaderRenderer.GetFont(g);
+            }
+
+            rtbRevisionHeader.SelectionTabs = _commitDataHeaderRenderer.GetTabStops().ToArray();
+        }
+
+        public void ShowCommitInfo(GitRevision revision, IReadOnlyList<ObjectId> children)
+        {
+            this.InvokeAsync(() =>
+            {
+                rtbRevisionHeader.Clear();
+
+                var data = _commitDataManager.CreateFromRevision(revision, children);
+                var header = _commitDataHeaderRenderer.Render(data, showRevisionsAsLinks: CommandClicked != null);
+                rtbRevisionHeader.SetXHTMLText(header);
+                LoadAuthorImage(revision);
+            }).FileAndForget();
+        }
+
+        public string GetPlainText()
+        {
+            return rtbRevisionHeader.GetPlainText();
+        }
+
+        private void LoadAuthorImage(GitRevision revision)
+        {
+            var showAvatar = AppSettings.ShowAuthorAvatarInCommitInfo;
+            avatarControl.Visible = showAvatar;
+
+            if (!showAvatar)
+            {
+                return;
+            }
+
+            if (revision == null)
+            {
+                avatarControl.LoadImage(null);
+                return;
+            }
+
+            avatarControl.LoadImage(revision.AuthorEmail ?? revision.CommitterEmail);
+        }
+
+        private void rtbRevisionHeader_ContentsResized(object sender, ContentsResizedEventArgs e)
+        {
+            rtbRevisionHeader.Height = Math.Max(e.NewRectangle.Height, DpiUtil.Scale(AppSettings.AuthorImageSizeInCommitInfo));
+        }
+
+        private void rtbRevisionHeader_KeyDown(object sender, KeyEventArgs e)
+        {
+            var rtb = sender as RichTextBox;
+            if (rtb == null || !e.Control || e.KeyCode != Keys.C)
+            {
+                return;
+            }
+
+            // Override RichTextBox Ctrl-c handling to copy plain text
+            Clipboard.SetText(rtb.GetSelectionPlainText());
+            e.Handled = true;
+        }
+
+        private void rtbRevisionHeader_LinkClicked(object sender, LinkClickedEventArgs e)
+        {
+            var link = _linkFactory.ParseLink(e.LinkText);
+
+            try
+            {
+                var result = new Uri(link);
+                if (result.Scheme == "gitext")
+                {
+                    CommandClicked?.Invoke(sender, new CommandEventArgs(result.Host, result.AbsolutePath.TrimStart('/')));
+                }
+                else
+                {
+                    using (var process = new Process
+                    {
+                        EnableRaisingEvents = false,
+                        StartInfo = { FileName = result.AbsoluteUri }
+                    })
+                    {
+                        process.Start();
+                    }
+                }
+            }
+            catch (UriFormatException)
+            {
+            }
+        }
+
+        private void rtbRevisionHeader_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.XButton1)
+            {
+                DoCommandClick("navigatebackward");
+            }
+            else if (e.Button == MouseButtons.XButton2)
+            {
+                DoCommandClick("navigateforward");
+            }
+
+            void DoCommandClick(string command)
+            {
+                CommandClicked?.Invoke(this, new CommandEventArgs(command, null));
+            }
+        }
+    }
+}

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -48,7 +48,13 @@ namespace GitUI.CommitInfo
 
                 var data = _commitDataManager.CreateFromRevision(revision, children);
                 var header = _commitDataHeaderRenderer.Render(data, showRevisionsAsLinks: CommandClicked != null);
+
+                rtbRevisionHeader.SuspendLayout();
                 rtbRevisionHeader.SetXHTMLText(header);
+                rtbRevisionHeader.SelectionStart = 0; // scroll up
+                rtbRevisionHeader.ScrollToCaret();    // scroll up
+                rtbRevisionHeader.ResumeLayout(true);
+
                 LoadAuthorImage(revision);
             }).FileAndForget();
         }

--- a/GitUI/CommitInfo/CommitInfoHeader.resx
+++ b/GitUI/CommitInfo/CommitInfoHeader.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="tableLayout.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="pnlAvatar.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="commitInfoContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="tableLayoutPanel1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
   </metadata>
 </root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -279,6 +279,12 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommitInfo\CommitInfoHeader.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommitInfo\CommitInfoHeader.Designer.cs">
+      <DependentUpon>CommitInfoHeader.cs</DependentUpon>
+    </Compile>
     <Compile Include="Editor\Diff\DiffLineInfo.cs" />
     <Compile Include="Editor\Diff\DiffLinesInfo.cs" />
     <Compile Include="Editor\Diff\DiffLineType.cs" />
@@ -1238,6 +1244,9 @@
     <EmbeddedResource Include="CommandsDialogs\WorktreeDialog\FormManageWorktree.resx">
       <DependentUpon>FormManageWorktree.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommitInfo\CommitInfoHeader.resx">
+      <DependentUpon>CommitInfoHeader.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="HelperDialogs\FormBuildServerCredentials.resx">
       <DependentUpon>FormBuildServerCredentials.cs</DependentUpon>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -379,6 +379,9 @@
     <Compile Include="SpellChecker\SpellCheckerHelper.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractor.cs" />
     <Compile Include="TaskbarProgress.cs" />
+    <Compile Include="UserControls\DoubleBufferedTableLayoutPanel.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="UserControls\GitItemStatusWithParent.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
     <Compile Include="UserControls\ListViewGroupHitInfo.cs" />

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -52,7 +52,7 @@ namespace GitUI.Blame
             BlameFile.RequestDiffView += ActiveTextAreaControlDoubleClick;
             BlameFile.MouseMove += BlameFile_MouseMove;
 
-            CommitInfo.CommandClick += commitInfo_CommandClick;
+            CommitInfo.CommandClicked += commitInfo_CommandClicked;
         }
 
         public void LoadBlame(GitRevision revision, [CanBeNull] IReadOnlyList<ObjectId> children, string fileName, RevisionGridControl revGrid, Control controlToMask, Encoding encoding, int? initialLine = null, bool force = false)
@@ -81,7 +81,7 @@ namespace GitUI.Blame
                 () => ProcessBlame(revision, children, controlToMask, line, scrollPos));
         }
 
-        private void commitInfo_CommandClick(object sender, CommandEventArgs e)
+        private void commitInfo_CommandClicked(object sender, CommandEventArgs e)
         {
             CommandClick?.Invoke(sender, e);
         }

--- a/GitUI/UserControls/DoubleBufferedTableLayoutPanel.cs
+++ b/GitUI/UserControls/DoubleBufferedTableLayoutPanel.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace GitUI.UserControls
+{
+    public class DoubleBufferedTableLayoutPanel : TableLayoutPanel
+    {
+        public DoubleBufferedTableLayoutPanel()
+        {
+            SetStyle(ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer, true);
+        }
+    }
+}

--- a/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
@@ -40,7 +40,7 @@ namespace ResourceManager.CommitDataRenders
                 throw new ArgumentNullException(nameof(commitData));
             }
 
-            var body = "\n" + WebUtility.HtmlEncode((commitData.Body ?? "").Trim());
+            var body = WebUtility.HtmlEncode((commitData.Body ?? "").Trim());
 
             if (showRevisionsAsLinks)
             {

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -57,7 +57,7 @@ namespace ResourceManagerTests.CommitDataRenders
 
             var result = _rendererReal.Render(data, true);
 
-            result.Should().Be("\nfix\n\nAllow cherry-picking multiple commits from FormBrowse menu\r\n\r\nThe ability to do so from the RevisionGrid context menu has been added in commit\r\n<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944792</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>");
+            result.Should().Be("fix\n\nAllow cherry-picking multiple commits from FormBrowse menu\r\n\r\nThe ability to do so from the RevisionGrid context menu has been added in commit\r\n<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944792</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>");
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _rendererReal.Render(data, false);
 
             // TODO remove leading newline and achieve padding at the top via the control layout
-            result.Should().Be("\nfix\n\nAllow cherry-picking multiple commits from FormBrowse menu\r\n\r\nThe ability to do so from the RevisionGrid context menu has been added in commit\r\nb3e79447928051cfb3494c9c0ef1a1d0ecde56a8");
+            result.Should().Be("fix\n\nAllow cherry-picking multiple commits from FormBrowse menu\r\n\r\nThe ability to do so from the RevisionGrid context menu has been added in commit\r\nb3e79447928051cfb3494c9c0ef1a1d0ecde56a8");
         }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
* Move header into own control
* Do not display commit info unless commit supplied
* Rename CommandClick event to CommandClicked
* Fixed scrolling issues

Screenshots:
* 100%
![image](https://user-images.githubusercontent.com/4403806/47564373-8114f900-d970-11e8-9574-1bd5eed16912.png)


* 200%
![image](https://user-images.githubusercontent.com/4403806/47564888-4ad87900-d972-11e8-8f8c-ac2bc4bb058a.png)


Other layouts (at 200%):
* left:
![image](https://user-images.githubusercontent.com/4403806/47597829-c96b0000-d9de-11e8-83b1-4b20a9d3005f.png)

* right:
![image](https://user-images.githubusercontent.com/4403806/47597825-bb1ce400-d9de-11e8-8e8c-6f0ce58322ba.png)

Scrolling (at 100%):
There is a caveat, revision info may need to be reloaded after layout change.

* center:
![image](https://user-images.githubusercontent.com/4403806/47599678-9cc6e080-d9fe-11e8-963e-b47770cb356c.png)

* left:
![image](https://user-images.githubusercontent.com/4403806/47599652-4b1e5600-d9fe-11e8-8ed7-99fa093c6f26.png)

* right:
![image](https://user-images.githubusercontent.com/4403806/47599661-5ec9bc80-d9fe-11e8-8e77-b0d3a5948f5f.png)


Has been tested on (remove any that don't apply):
- Windows 10 100% and 200%
