### PR TITLE
Fix #5605 Statistics plugin line stats broken

### DIFF
--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -29,6 +29,14 @@ namespace GitUIPluginInterfaces
         /// <param name="remoteName">The current remote name.</param>
         /// <param name="newName">The new remote name.</param>
         string RenameRemote(string remoteName, string newName);
+
+        /// <summary>
+        /// Parses the revisionExpression as a git reference and returns an <see cref="ObjectId"/>./>
+        /// </summary>
+        /// <param name="revisionExpression">An expression like HEAD or commit hash that can be parsed as a git reference.</param>
+        /// <returns>An ObjectID representing that git reference</returns>
+        ObjectId RevParse(string revisionExpression);
+
         void SetSetting(string setting, string value);
         void UnsetSetting(string setting);
 

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -190,7 +190,7 @@ namespace GitStatistics
             void LoadLinesOfCodeForModule(IGitModule module)
             {
                 var filesToCheck = module
-                    .GetTree(null, full: true)
+                    .GetTree(module.RevParse("HEAD"), full: true)
                     .Select(file => Path.Combine(module.WorkingDir, file.Name))
                     .ToList();
 


### PR DESCRIPTION
Running 'git ls-tree -z -r ' fails to return anything

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5605 

Changes proposed in this pull request:
- Pass in ObjectID that represents head
Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
Ran program and looked at line tabs
Has been tested on (remove any that don't apply):
- GIT 2.19.1 and above

