### PR TITLE
Feature: add a Submodules tree to the left panel

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -158,8 +158,25 @@ namespace GitCommands
         /// <summary>
         /// If this module is a submodule, returns its superproject <see cref="GitModule"/>, otherwise <c>null</c>.
         /// </summary>
+        /// TODO: Add to IGitModule and return IGitModule
         [CanBeNull]
         public GitModule SuperprojectModule { get; }
+
+        /// <summary>
+        /// If this module is a submodule, returns the top-most parent module, otherwise it returns itself.
+        /// </summary>
+        /// TODO: Add to IGitModule and return IGitModule
+        [NotNull]
+        public GitModule GetTopModule()
+        {
+            GitModule topModule = this;
+            while (topModule.SuperprojectModule != null)
+            {
+                topModule = topModule.SuperprojectModule;
+            }
+
+            return topModule;
+        }
 
         private RepoDistSettings _effectiveSettings;
 

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Submodules\DetailedSubmoduleInfo.cs" />
     <Compile Include="Submodules\SubmoduleInfo.cs" />
     <Compile Include="Submodules\SubmoduleInfoResult.cs" />
+    <Compile Include="Submodules\SubmoduleStatusEventArgs.cs" />
     <Compile Include="Submodules\SubmoduleStatusProvider.cs" />
     <Compile Include="UserRepositoryHistory\IRepositoryManager.cs" />
     <Compile Include="UserRepositoryHistory\IRepositorySerialiser.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1591,6 +1591,12 @@ namespace GitCommands
             set => SetBool("RepoObjectsTree.ShowTags", value);
         }
 
+        public static bool RepoObjectsTreeShowSubmodules
+        {
+            get => GetBool("RepoObjectsTree.ShowSubmodules", true);
+            set => SetBool("RepoObjectsTree.ShowSubmodules", value);
+        }
+
         public static bool IsPortable()
         {
             return Properties.Settings.Default.IsPortable;

--- a/GitCommands/Submodules/SubmoduleInfoResult.cs
+++ b/GitCommands/Submodules/SubmoduleInfoResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitCommands.Submodules
@@ -8,6 +9,9 @@ namespace GitCommands.Submodules
     /// </summary>
     public class SubmoduleInfoResult
     {
+        // Module that was used to gather submodule info
+        public IGitModule Module { get; internal set; }
+
         // List of SubmoduleInfo for all submodules (recursively) under current module.
         public IList<SubmoduleInfo> OurSubmodules { get; } = new List<SubmoduleInfo>();
 

--- a/GitCommands/Submodules/SubmoduleStatusEventArgs.cs
+++ b/GitCommands/Submodules/SubmoduleStatusEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace GitCommands.Submodules
+{
+    public class SubmoduleStatusEventArgs : EventArgs
+    {
+        [NotNull]
+        public SubmoduleInfoResult Info { get; }
+
+        [NotNull]
+        public CancellationToken Token { get; }
+
+        public SubmoduleStatusEventArgs(SubmoduleInfoResult info, CancellationToken token)
+        {
+            Info = info;
+            Token = token;
+        }
+    }
+}

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -111,7 +111,6 @@ namespace GitCommands.Submodules
 
         private void OnStatusUpdated(SubmoduleStatusEventArgs submoduleStatusEventArgs)
         {
-            _lastStatusEventArgs = null;
             StatusUpdated?.Invoke(this, submoduleStatusEventArgs);
         }
 

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -144,7 +144,10 @@ namespace GitCommands.Submodules
 
                 // Don't access Module directly because it's not thread-safe.  Use a thread-local version:
                 var threadModule = new GitModule(workingDirectory);
-                var result = new SubmoduleInfoResult();
+                var result = new SubmoduleInfoResult
+                {
+                    Module = threadModule
+                };
 
                 // Add all submodules inside the current repository:
                 var submodulesTask = GetRepositorySubmodulesStatusAsync(updateStatus, result, threadModule, cancelToken, noBranchText);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -37,6 +37,14 @@ namespace GitUI.BranchTreePanel
             //    Collapse All
             //    Expand All
 
+            if (contextMenu == menuMain)
+            {
+                contextMenu.Items.Clear();
+                contextMenu.Items.Add(mnubtnCollapseAll);
+                contextMenu.Items.Add(mnubtnExpandAll);
+                return;
+            }
+
             if (!contextMenu.Items.Contains(tsmiSpacer1))
             {
                 contextMenu.Items.Add(tsmiSpacer1);
@@ -152,8 +160,6 @@ namespace GitUI.BranchTreePanel
             RegisterClick(mnubtnCollapseAll, () => treeMain.CollapseAll());
             RegisterClick(mnubtnExpandAll, () => treeMain.ExpandAll());
 
-            RegisterClick(mnubtnReload, () => RefreshTreeAsync().FileAndForget());
-
             treeMain.NodeMouseClick += OnNodeMouseClick;
 
             RegisterClick<LocalBranchNode>(mnubtnFilterLocalBranchInRevisionGrid, FilterInRevisionGrid);
@@ -205,6 +211,10 @@ namespace GitUI.BranchTreePanel
             ContextMenuBranchSpecific(contextMenu);
             ContextMenuRemoteRepoSpecific(contextMenu);
             ContextMenuSubmoduleSpecific(contextMenu);
+
+            // Set Cancel to false.  It is optimized to true based on empty entry.
+            // See https://docs.microsoft.com/en-us/dotnet/framework/winforms/controls/how-to-handle-the-contextmenustrip-opening-event
+            e.Cancel = false;
         }
 
         /// <inheritdoc />

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -93,6 +93,36 @@ namespace GitUI.BranchTreePanel
             mnubtnEnableRemoteAndFetch.Visible = !node.Enabled;
         }
 
+        private void ContextMenuSubmoduleSpecific(ContextMenuStrip contextMenu)
+        {
+            TreeNode selectedNode = (contextMenu.SourceControl as TreeView)?.SelectedNode;
+            if (selectedNode == null)
+            {
+                return;
+            }
+
+            if (contextMenu == menuAllSubmodules)
+            {
+                if (!(selectedNode.Tag is SubmoduleTree submoduleTree))
+                {
+                    return;
+                }
+            }
+            else if (contextMenu == menuSubmodule)
+            {
+                if (!(selectedNode.Tag is SubmoduleNode submoduleNode))
+                {
+                    return;
+                }
+
+                bool bareRepository = Module.IsBareRepository();
+                mnubtnOpenSubmodule.Visible = submoduleNode.CanOpen;
+                mnubtnUpdateSubmodule.Visible = true;
+                mnubtnManageSubmodules.Visible = !bareRepository && submoduleNode.IsCurrent;
+                mnubtnSynchronizeSubmodules.Visible = !bareRepository && submoduleNode.IsCurrent;
+            }
+        }
+
         private void OnNodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
         {
             _lastRightClickedNode = e.Button == MouseButtons.Right ? e.Node : null;
@@ -150,6 +180,12 @@ namespace GitUI.BranchTreePanel
             Node.RegisterContextMenu(typeof(TagNode), menuTag);
 
             RegisterClick(mnuBtnManageRemotesFromRootNode, () => _remotesTree.PopupManageRemotesForm(remoteName: null));
+
+            RegisterClick<SubmoduleNode>(mnubtnManageSubmodules, _ => _submoduleTree.ManageSubmodules(this));
+            RegisterClick<SubmoduleNode>(mnubtnSynchronizeSubmodules, _ => _submoduleTree.SynchronizeSubmodules(this));
+            RegisterClick<SubmoduleNode>(mnubtnOpenSubmodule, node => _submoduleTree.OpenSubmodule(this, node));
+            RegisterClick<SubmoduleNode>(mnubtnUpdateSubmodule, node => _submoduleTree.UpdateSubmodule(this, node));
+            Node.RegisterContextMenu(typeof(SubmoduleNode), menuSubmodule);
         }
 
         private void FilterInRevisionGrid(BaseBranchNode branch)
@@ -168,6 +204,7 @@ namespace GitUI.BranchTreePanel
             ContextMenuAddExpandCollapseTree(contextMenu);
             ContextMenuBranchSpecific(contextMenu);
             ContextMenuRemoteRepoSpecific(contextMenu);
+            ContextMenuSubmoduleSpecific(contextMenu);
         }
 
         /// <inheritdoc />

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -152,7 +152,7 @@ namespace GitUI.BranchTreePanel
             RegisterClick(mnubtnCollapseAll, () => treeMain.CollapseAll());
             RegisterClick(mnubtnExpandAll, () => treeMain.ExpandAll());
 
-            RegisterClick(mnubtnReload, () => RefreshTree());
+            RegisterClick(mnubtnReload, () => RefreshTreeAsync().FileAndForget());
 
             treeMain.NodeMouseClick += OnNodeMouseClick;
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -49,7 +49,6 @@ namespace GitUI.BranchTreePanel
             this.components = new System.ComponentModel.Container();
             this.treeMain = new GitUI.UserControls.NativeTreeView();
             this.menuMain = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.mnubtnReload = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiSpacer1 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnCollapseAll = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnExpandAll = new System.Windows.Forms.ToolStripMenuItem();
@@ -128,21 +127,11 @@ namespace GitUI.BranchTreePanel
             // menuMain
             // 
             this.menuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnubtnReload,
-            this.tsmiSpacer1,
             this.mnubtnCollapseAll,
             this.mnubtnExpandAll});
             this.menuMain.Name = "menuMain";
             this.menuMain.Size = new System.Drawing.Size(137, 76);
             this.menuMain.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
-            // 
-            // mnubtnReload
-            // 
-            this.mnubtnReload.Image = global::GitUI.Properties.Images.ReloadRevisions;
-            this.mnubtnReload.Name = "mnubtnReload";
-            this.mnubtnReload.Size = new System.Drawing.Size(136, 22);
-            this.mnubtnReload.Text = "Reload";
-            this.mnubtnReload.ToolTipText = "Reload the tree";
             // 
             // tsmiSpacer1
             // 
@@ -607,7 +596,6 @@ namespace GitUI.BranchTreePanel
         private ContextMenuStrip menuMain;
         private ToolStripMenuItem mnubtnCollapseAll;
         private ToolStripMenuItem mnubtnExpandAll;
-        private ToolStripMenuItem mnubtnReload;
         private ContextMenuStrip menuRemoteRepoNode;
         private ToolStripMenuItem mnubtnFetchOneBranch;
         private TableLayoutPanel repoTreePanel;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -208,7 +208,8 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnManageRemotesFromRootNode.Image = global::GitUI.Properties.Images.Remotes;
             this.mnuBtnManageRemotesFromRootNode.Name = "mnuBtnManageRemotesFromRootNode";
             this.mnuBtnManageRemotesFromRootNode.Size = new System.Drawing.Size(172, 22);
-            this.mnuBtnManageRemotesFromRootNode.Text = "&Manage remotes...";
+            this.mnuBtnManageRemotesFromRootNode.Text = "&Manage...";
+            this.mnuBtnManageRemotesFromRootNode.ToolTipText = "Manage remotes";
             // 
             // pruneAllRemotesToolStripMenuItem
             // 
@@ -325,7 +326,8 @@ namespace GitUI.BranchTreePanel
             this.mnubtnManageRemotes.Image = global::GitUI.Properties.Images.Remotes;
             this.mnubtnManageRemotes.Name = "mnubtnManageRemotes";
             this.mnubtnManageRemotes.Size = new System.Drawing.Size(172, 22);
-            this.mnubtnManageRemotes.Text = "&Manage remotes...";
+            this.mnubtnManageRemotes.Text = "&Manage...";
+            this.mnubtnManageRemotes.ToolTipText = "Manage remotes";
             // 
             // tsmiSpacer3
             // 
@@ -517,9 +519,9 @@ namespace GitUI.BranchTreePanel
             // menuSubmodule
             // 
             this.menuSubmodule.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnubtnManageSubmodules,
             this.mnubtnOpenSubmodule,
             this.mnubtnUpdateSubmodule,
-            this.mnubtnManageSubmodules,
             this.mnubtnSynchronizeSubmodules});
             this.menuSubmodule.Name = "contextmenuSubmodule";
             this.menuSubmodule.Size = new System.Drawing.Size(177, 26);
@@ -531,7 +533,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnOpenSubmodule.Name = "mnubtnOpenSubmodule";
             this.mnubtnOpenSubmodule.Size = new System.Drawing.Size(342, 38);
             this.mnubtnOpenSubmodule.Text = "&Open";
-            this.mnubtnOpenSubmodule.ToolTipText = "Open this submodule";
+            this.mnubtnOpenSubmodule.ToolTipText = "Open selected submodule";
             // 
             // mnubtnUpdateSubmodule
             // 
@@ -539,7 +541,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnUpdateSubmodule.Name = "mnubtnUpdateSubmodule";
             this.mnubtnUpdateSubmodule.Size = new System.Drawing.Size(176, 22);
             this.mnubtnUpdateSubmodule.Text = "&Update";
-            this.mnubtnOpenSubmodule.ToolTipText = "Update this submodule";
+            this.mnubtnUpdateSubmodule.ToolTipText = "Update selected submodule recursively";
             // 
             // menuAllSubmodules
             // 
@@ -561,8 +563,8 @@ namespace GitUI.BranchTreePanel
             this.mnubtnSynchronizeSubmodules.Image = global::GitUI.Properties.Images.SubmodulesSync;
             this.mnubtnSynchronizeSubmodules.Name = "mnubtnSynchronizeSubmodules";
             this.mnubtnSynchronizeSubmodules.Size = new System.Drawing.Size(195, 22);
-            this.mnubtnSynchronizeSubmodules.Text = "Synchronize all";
-            this.mnubtnSynchronizeSubmodules.ToolTipText = "Synchronize all submodules";
+            this.mnubtnSynchronizeSubmodules.Text = "Synchronize";
+            this.mnubtnSynchronizeSubmodules.ToolTipText = "Synchronize selected submodule recursively";
             // 
             // RepoObjectsTree
             // 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -89,8 +89,13 @@ namespace GitUI.BranchTreePanel
             this.tsmiShowBranches = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowTags = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowRemotes = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.mnuBtnUpdateAllRemotes = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiShowSubmodules = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuSubmodule = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.mnubtnUpdateSubmodule = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuAllSubmodules = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.mnubtnManageSubmodules = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnSynchronizeSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMain.SuspendLayout();
             this.menuBranch.SuspendLayout();
             this.menuRemotes.SuspendLayout();
@@ -101,6 +106,9 @@ namespace GitUI.BranchTreePanel
             this.repoTreePanel.SuspendLayout();
             this.branchSearchPanel.SuspendLayout();
             this.menuSettings.SuspendLayout();
+            this.menuSubmodule.SuspendLayout();
+            this.menuAllSubmodules.SuspendLayout();
+            this.mnubtnOpenSubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.SuspendLayout();
             // 
             // treeMain
@@ -458,7 +466,8 @@ namespace GitUI.BranchTreePanel
             this.menuSettings.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsmiShowBranches,
             this.tsmiShowRemotes,
-            this.tsmiShowTags});
+            this.tsmiShowTags,
+            this.tsmiShowSubmodules});
             this.menuSettings.Name = "menuSettings";
             this.menuSettings.Size = new System.Drawing.Size(155, 70);
             // 
@@ -496,6 +505,65 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnUpdateAllRemotes.Text = "Update all remotes";
             this.mnuBtnUpdateAllRemotes.Click += new System.EventHandler(this.mnuBtnUpdateAllRemotes_Click);
             // 
+            // tsmiShowRemotes
+            // 
+            this.tsmiShowSubmodules.CheckOnClick = true;
+            this.tsmiShowSubmodules.Image = global::GitUI.Properties.Images.BranchRemoteRoot;
+            this.tsmiShowSubmodules.Name = "tsmiShowSubmodules";
+            this.tsmiShowSubmodules.Size = new System.Drawing.Size(154, 22);
+            this.tsmiShowSubmodules.Text = "&Submodules";
+            this.tsmiShowSubmodules.Click += new System.EventHandler(this.tsmiShowSubmodules_Click);
+            // 
+            // menuSubmodule
+            // 
+            this.menuSubmodule.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnubtnOpenSubmodule,
+            this.mnubtnUpdateSubmodule,
+            this.mnubtnManageSubmodules,
+            this.mnubtnSynchronizeSubmodules});
+            this.menuSubmodule.Name = "contextmenuSubmodule";
+            this.menuSubmodule.Size = new System.Drawing.Size(177, 26);
+            this.menuSubmodule.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
+            // 
+            // mnubtnOpenSubmodule
+            // 
+            this.mnubtnOpenSubmodule.Image = global::GitUI.Properties.Images.FolderOpen;
+            this.mnubtnOpenSubmodule.Name = "mnubtnOpenSubmodule";
+            this.mnubtnOpenSubmodule.Size = new System.Drawing.Size(342, 38);
+            this.mnubtnOpenSubmodule.Text = "&Open";
+            this.mnubtnOpenSubmodule.ToolTipText = "Open this submodule";
+            // 
+            // mnubtnUpdateSubmodule
+            // 
+            this.mnubtnUpdateSubmodule.Image = global::GitUI.Properties.Images.SubmodulesUpdate;
+            this.mnubtnUpdateSubmodule.Name = "mnubtnUpdateSubmodule";
+            this.mnubtnUpdateSubmodule.Size = new System.Drawing.Size(176, 22);
+            this.mnubtnUpdateSubmodule.Text = "&Update";
+            this.mnubtnOpenSubmodule.ToolTipText = "Update this submodule";
+            // 
+            // menuAllSubmodules
+            // 
+            this.menuAllSubmodules.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {});
+            this.menuAllSubmodules.Name = "contextmenuSubmodules";
+            this.menuAllSubmodules.Size = new System.Drawing.Size(196, 26);
+            this.menuAllSubmodules.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
+            // 
+            // mnubtnManageSubmodules
+            // 
+            this.mnubtnManageSubmodules.Image = global::GitUI.Properties.Images.SubmodulesManage;
+            this.mnubtnManageSubmodules.Name = "mnubtnManageSubmodules";
+            this.mnubtnManageSubmodules.Size = new System.Drawing.Size(195, 22);
+            this.mnubtnManageSubmodules.Text = "&Manage...";
+            this.mnubtnManageSubmodules.ToolTipText = "Manage submodules";
+            // 
+            // mnubtnSynchronizeSubmodules
+            // 
+            this.mnubtnSynchronizeSubmodules.Image = global::GitUI.Properties.Images.SubmodulesSync;
+            this.mnubtnSynchronizeSubmodules.Name = "mnubtnSynchronizeSubmodules";
+            this.mnubtnSynchronizeSubmodules.Size = new System.Drawing.Size(195, 22);
+            this.mnubtnSynchronizeSubmodules.Text = "Synchronize all";
+            this.mnubtnSynchronizeSubmodules.ToolTipText = "Synchronize all submodules";
+            // 
             // RepoObjectsTree
             // 
             this.Controls.Add(this.repoTreePanel);
@@ -514,6 +582,8 @@ namespace GitUI.BranchTreePanel
             this.branchSearchPanel.ResumeLayout(false);
             this.branchSearchPanel.PerformLayout();
             this.menuSettings.ResumeLayout(false);
+            this.menuSubmodule.ResumeLayout(false);
+            this.menuAllSubmodules.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -563,5 +633,12 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnuBtnPruneAllRemotes;
         private ToolStripMenuItem mnuBtnPrune;
         private ToolStripMenuItem mnuBtnUpdateAllRemotes;
+        private ToolStripMenuItem tsmiShowSubmodules;
+        private ContextMenuStrip menuSubmodule;
+        private ContextMenuStrip menuAllSubmodules;
+        private ToolStripMenuItem mnubtnManageSubmodules;
+        private ToolStripMenuItem mnubtnSynchronizeSubmodules;
+        private ToolStripMenuItem mnubtnUpdateSubmodule;
+        private ToolStripMenuItem mnubtnOpenSubmodule;
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -35,6 +35,14 @@ namespace GitUI.BranchTreePanel
                 _explorerNavigationDecorator = null;
             }
 
+            if (disposing)
+            {
+                _branchesTree.Dispose();
+                _remotesTree.Dispose();
+                _tagTree.Dispose();
+                _submoduleTree.Dispose();
+            }
+
             base.Dispose(disposing);
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -225,12 +225,12 @@ namespace GitUI.BranchTreePanel
 
             protected override void PostRepositoryChanged()
             {
-                RefreshTreeAsync().FileAndForget();
+                StartAsyncRefreshTree();
             }
 
-            public override async Task RefreshTreeAsync()
+            protected override async Task RefreshTreeAsync(CancellationToken token)
             {
-                await ReloadNodesAsync(LoadNodesAsync);
+                await ReloadNodesAsync(LoadNodesAsync, token);
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -223,9 +223,14 @@ namespace GitUI.BranchTreePanel
                 _aheadBehindDataProvider = aheadBehindDataProvider;
             }
 
-            public override void RefreshTree()
+            protected override void PostRepositoryChanged()
             {
-                ReloadNodes(LoadNodesAsync);
+                RefreshTreeAsync().FileAndForget();
+            }
+
+            public override async Task RefreshTreeAsync()
+            {
+                await ReloadNodesAsync(LoadNodesAsync);
             }
 
             private async Task LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -97,7 +97,7 @@ namespace GitUI.BranchTreePanel
                 return result;
             }
 
-            public override string DisplayText()
+            protected override string DisplayText()
             {
                 return string.IsNullOrEmpty(AheadBehind) ? Name : $"{Name} ({AheadBehind})";
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -223,14 +223,9 @@ namespace GitUI.BranchTreePanel
                 _aheadBehindDataProvider = aheadBehindDataProvider;
             }
 
-            protected override void PostRepositoryChanged()
+            protected override Task PostRepositoryChangedAsync()
             {
-                StartAsyncRefreshTree();
-            }
-
-            protected override async Task RefreshTreeAsync(CancellationToken token)
-            {
-                await ReloadNodesAsync(LoadNodesAsync, token);
+                return ReloadNodesAsync(LoadNodesAsync);
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -223,6 +223,11 @@ namespace GitUI.BranchTreePanel
                 _aheadBehindDataProvider = aheadBehindDataProvider;
             }
 
+            protected override Task OnAttachedAsync()
+            {
+                return ReloadNodesAsync(LoadNodesAsync);
+            }
+
             protected override Task PostRepositoryChangedAsync()
             {
                 return ReloadNodesAsync(LoadNodesAsync);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -291,7 +291,7 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode(bool firstTime)
+            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
             {
                 if (firstTime)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -294,7 +294,7 @@ namespace GitUI.BranchTreePanel
                 return nodes;
             }
 
-            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
+            protected override void PostFillTreeViewNode(bool firstTime)
             {
                 if (firstTime)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -26,6 +26,11 @@ namespace GitUI.BranchTreePanel
             {
             }
 
+            protected override Task OnAttachedAsync()
+            {
+                return ReloadNodesAsync(LoadNodesAsync);
+            }
+
             protected override Task PostRepositoryChangedAsync()
             {
                 return ReloadNodesAsync(LoadNodesAsync);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -341,7 +341,7 @@ namespace GitUI.BranchTreePanel
                 TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.FolderClosed);
             }
 
-            public override string DisplayText()
+            protected override string DisplayText()
             {
                 return Name;
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -117,7 +117,7 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
+            protected override void PostFillTreeViewNode(bool firstTime)
             {
                 if (firstTime)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -116,7 +116,7 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode(bool firstTime)
+            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
             {
                 if (firstTime)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -26,14 +26,9 @@ namespace GitUI.BranchTreePanel
             {
             }
 
-            protected override void PostRepositoryChanged()
+            protected override Task PostRepositoryChangedAsync()
             {
-                StartAsyncRefreshTree();
-            }
-
-            protected override async Task RefreshTreeAsync(CancellationToken token)
-            {
-                await ReloadNodesAsync(LoadNodesAsync, token);
+                return ReloadNodesAsync(LoadNodesAsync);
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -36,11 +36,12 @@ namespace GitUI.BranchTreePanel
                 await ReloadNodesAsync(LoadNodesAsync);
             }
 
-            private async Task LoadNodesAsync(CancellationToken token)
+            private async Task<Nodes> LoadNodesAsync(CancellationToken token)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
-                var nodes = new Dictionary<string, BaseBranchNode>();
+                var nodes = new Nodes(this);
+                var pathToNodes = new Dictionary<string, BaseBranchNode>();
 
                 var branches = Module.GetRefs(tags: true, branches: true, noLocks: true)
                     .Where(branch => branch.IsRemote && !branch.IsTag)
@@ -63,7 +64,7 @@ namespace GitUI.BranchTreePanel
                     {
                         var remoteBranchNode = new RemoteBranchNode(this, branchPath);
                         var parent = remoteBranchNode.CreateRootNode(
-                            nodes,
+                            pathToNodes,
                             (tree, parentPath) => CreateRemoteBranchPathNode(tree, parentPath, remote));
 
                         if (parent != null)
@@ -87,7 +88,7 @@ namespace GitUI.BranchTreePanel
                 // Add enabled remote nodes in order
                 enabledRemoteRepoNodes
                     .OrderBy(node => node.FullPath)
-                    .ForEach(node => Nodes.AddNode(node));
+                    .ForEach(node => nodes.AddNode(node));
 
                 // Add disabled remotes, if any
                 var disabledRemotes = gitRemoteManager.GetDisabledRemotes();
@@ -105,10 +106,10 @@ namespace GitUI.BranchTreePanel
                         .OrderBy(node => node.FullPath)
                         .ForEach(node => disabledFolderNode.Nodes.AddNode(node));
 
-                    Nodes.AddNode(disabledFolderNode);
+                    nodes.AddNode(disabledFolderNode);
                 }
 
-                return;
+                return nodes;
 
                 BaseBranchNode CreateRemoteBranchPathNode(Tree tree, string parentPath, Remote remote)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -26,9 +26,14 @@ namespace GitUI.BranchTreePanel
             {
             }
 
-            public override void RefreshTree()
+            protected override void PostRepositoryChanged()
             {
-                ReloadNodes(LoadNodesAsync);
+                RefreshTreeAsync().FileAndForget();
+            }
+
+            public override async Task RefreshTreeAsync()
+            {
+                await ReloadNodesAsync(LoadNodesAsync);
             }
 
             private async Task LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -28,12 +28,12 @@ namespace GitUI.BranchTreePanel
 
             protected override void PostRepositoryChanged()
             {
-                RefreshTreeAsync().FileAndForget();
+                StartAsyncRefreshTree();
             }
 
-            public override async Task RefreshTreeAsync()
+            protected override async Task RefreshTreeAsync(CancellationToken token)
             {
-                await ReloadNodesAsync(LoadNodesAsync);
+                await ReloadNodesAsync(LoadNodesAsync, token);
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -1,0 +1,418 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Git;
+using GitCommands.Submodules;
+using GitUI.Properties;
+using JetBrains.Annotations;
+using Microsoft.VisualStudio.Threading;
+using ResourceManager;
+
+namespace GitUI.BranchTreePanel
+{
+    partial class RepoObjectsTree
+    {
+        // If true, display submodules as a tree of folders and nodes; otherwise, display a single node per module
+        // as in the Submodules menu.
+        // TODO: Possibly expose this as a user option, or just get rid of it.
+        private static bool UseFolderTree = true;
+
+        // Top-level nodes used to group SubmoduleNodes
+        private class SubmoduleFolderNode : Node
+        {
+            private string _name;
+
+            public SubmoduleFolderNode(Tree tree, string name)
+                : base(tree)
+            {
+                _name = name;
+            }
+
+            public override string DisplayText()
+            {
+                return string.Format(_name);
+            }
+
+            protected override void ApplyStyle()
+            {
+                base.ApplyStyle();
+                TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.FolderClosed);
+                SetNodeFont(FontStyle.Italic);
+            }
+        }
+
+        // Node representing a submodule
+        private class SubmoduleNode : Node
+        {
+            private DetailedSubmoduleInfo _details;
+
+            public SubmoduleInfo Info { get; }
+            public bool IsCurrent { get; }
+            public string LocalPath { get; }
+            public string SuperPath { get; }
+
+            public SubmoduleNode(Tree tree, SubmoduleInfo submoduleInfo, bool isCurrent, string localPath, string superPath)
+                : base(tree)
+            {
+                Info = submoduleInfo;
+                IsCurrent = isCurrent;
+                LocalPath = localPath;
+                SuperPath = superPath;
+            }
+
+            public async Task LoadDetailsAsync(CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+
+                if (Info.Detailed == null)
+                {
+                    return;
+                }
+
+                _details = await Info.Detailed.GetValueAsync(token);
+                if (_details != null)
+                {
+                    await Tree.TreeViewNode.TreeView.InvokeAsync(() =>
+                    {
+                        ApplyText();
+                        ApplyStyle();
+                    }, token);
+                }
+            }
+
+            public bool CanOpen => !IsCurrent;
+
+            public override string DisplayText()
+            {
+                if (!UseFolderTree)
+                {
+                    return Info.Text;
+                }
+
+                // Display the submodule name, not full path, along with active branch (if any)
+                // e.g. Info.Text = "Externals/conemu-inside [no branch]"
+                // Note that the branch portion won't be there if the user hasn't yet init'd + updated the submodule.
+                var pathAndBranch = Info.Text.Split(new char[] { ' ' }, 2);
+                Trace.Assert(pathAndBranch.Length >= 1);
+                var submoduleName = pathAndBranch[0].SubstringAfterLast('/'); // Remove path
+                var branch = pathAndBranch.Length == 2 ? " " + pathAndBranch[1] : "";
+                return submoduleName + branch + _details?.AddedAndRemovedText;
+            }
+
+            public void Open()
+            {
+                UICommands.BrowseSetWorkingDir(Info.Path);
+            }
+
+            internal override void OnSelected()
+            {
+                if (Tree.IgnoreSelectionChangedEvent)
+                {
+                    return;
+                }
+
+                base.OnSelected();
+            }
+
+            internal override void OnDoubleClick()
+            {
+                Open();
+            }
+
+            protected override void ApplyStyle()
+            {
+                base.ApplyStyle();
+
+                Trace.Assert(TreeViewNode != null);
+
+                if (IsCurrent)
+                {
+                    TreeViewNode.NodeFont = new Font(AppSettings.Font, FontStyle.Bold);
+                }
+
+                if (_details == null)
+                {
+                    TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.FolderSubmodule);
+                }
+                else
+                {
+                    TreeViewNode.ImageKey = GetSubmoduleItemImage(_details);
+                }
+
+                TreeViewNode.SelectedImageKey = TreeViewNode.ImageKey;
+
+                return;
+
+                // NOTE: Copied and adapated from FormBrowse.GetSubmoduleItemImage
+                string GetSubmoduleItemImage(DetailedSubmoduleInfo details)
+                {
+                    if (details.Status == null)
+                    {
+                        return nameof(Images.FolderSubmodule);
+                    }
+
+                    if (details.Status == SubmoduleStatus.FastForward)
+                    {
+                        return details.IsDirty ? nameof(Images.SubmoduleRevisionUpDirty) : nameof(Images.SubmoduleRevisionUp);
+                    }
+
+                    if (details.Status == SubmoduleStatus.Rewind)
+                    {
+                        return details.IsDirty ? nameof(Images.SubmoduleRevisionDownDirty) : nameof(Images.SubmoduleRevisionDown);
+                    }
+
+                    if (details.Status == SubmoduleStatus.NewerTime)
+                    {
+                        return details.IsDirty ? nameof(Images.SubmoduleRevisionSemiUpDirty) : nameof(Images.SubmoduleRevisionSemiUp);
+                    }
+
+                    if (details.Status == SubmoduleStatus.OlderTime)
+                    {
+                        return details.IsDirty ? nameof(Images.SubmoduleRevisionSemiDownDirty) : nameof(Images.SubmoduleRevisionSemiDown);
+                    }
+
+                    return details.IsDirty ? nameof(Images.SubmoduleDirty) : nameof(Images.FileStatusModified);
+                }
+            }
+        }
+
+        // Used temporarily to faciliate building a tree
+        private class DummyNode : Node
+        {
+            public DummyNode() : base(null)
+            {
+            }
+        }
+
+        private sealed class SubmoduleTree : Tree
+        {
+            private SubmoduleInfo _topProjectInfo;
+
+            public SubmoduleTree(TreeNode treeNode, IGitUICommandsSource uiCommands)
+                : base(treeNode, uiCommands)
+            {
+                SubmoduleStatusProvider.Default.StatusUpdating += Provider_StatusUpdating;
+                SubmoduleStatusProvider.Default.StatusUpdated += Provider_StatusUpdated;
+            }
+
+            public override void RefreshTree()
+            {
+                SubmoduleStatusProvider.Default.ResendCachedStatus();
+            }
+
+            private void Provider_StatusUpdating(object sender, EventArgs e)
+            {
+                // TODO: Do we need this? Maybe disable treeview?
+            }
+
+            private void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
+            {
+                TreeViewNode.TreeView?.InvokeAsync(() => ReloadNodes((token) => LoadNodesAsync(e.Info, token))).FileAndForget();
+            }
+
+            private async Task LoadNodesAsync(SubmoduleInfoResult info, CancellationToken token)
+            {
+                await TaskScheduler.Default;
+                token.ThrowIfCancellationRequested();
+
+                FillSubmoduleTree(info);
+            }
+
+            private async Task LoadNodeDetailsAsync(CancellationToken token)
+            {
+                token.ThrowIfCancellationRequested();
+                var tasks = Nodes.DepthEnumerator<SubmoduleNode>().Select(node => node.LoadDetailsAsync(token)).ToList();
+                await Task.WhenAll(tasks);
+            }
+
+            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
+            {
+                if (firstTime)
+                {
+                    TreeViewNode.ExpandAll();
+                }
+
+                TreeViewNode.Text = Strings.Submodules;
+
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () => await LoadNodeDetailsAsync(token)).FileAndForget();
+            }
+
+            private void FillSubmoduleTree(SubmoduleInfoResult result)
+            {
+                _topProjectInfo = result.TopProject;
+
+                var nodes = new List<SubmoduleNode>();
+
+                // We always want to display submodules rooted from the top project. If the currently open project is the top project,
+                // OurSubmodules contains all child submodules recursively; otherwise, if we're currently in a submodule, SuperSubmodules
+                // contains all submodule info relative to the top project.
+                if (result.SuperSubmodules?.Count > 0)
+                {
+                    CreateSubmoduleNodes(result.SuperSubmodules, ref nodes);
+                }
+                else
+                {
+                    CreateSubmoduleNodes(result.OurSubmodules, ref nodes);
+                }
+
+                AddNodesToTree(nodes);
+            }
+
+            private void CreateSubmoduleNodes(IEnumerable<SubmoduleInfo> submodules, ref List<SubmoduleNode> nodes)
+            {
+                // result.OurSubmodules/SuperSubmodules contain a recursive list of submodules, but don't provide info about the super
+                // project path. So we deduce these by substring matching paths against an ordered list of all paths.
+                var modulePaths = submodules.Select(info => info.Path).ToList();
+
+                // Add current and parent module paths
+                var parentModule = Module;
+                while (parentModule != null)
+                {
+                    modulePaths.Add(parentModule.WorkingDir);
+                    parentModule = parentModule.SuperprojectModule;
+                }
+
+                // Sort descending so we find the nearest outer folder first
+                modulePaths = modulePaths.OrderByDescending(path => path).ToList();
+
+                foreach (var submoduleInfo in submodules)
+                {
+                    string superPath = GetSubmoduleSuperPath(submoduleInfo.Path);
+                    string localPath = PathUtil.GetDirectoryName(submoduleInfo.Path.Substring(superPath.Length).ToPosixPath());
+
+                    var isCurrent = submoduleInfo.Bold;
+                    nodes.Add(new SubmoduleNode(this, submoduleInfo, isCurrent, localPath, superPath));
+                }
+
+                return;
+
+                string GetSubmoduleSuperPath(string submodulePath)
+                {
+                    var superPath = modulePaths.Find(path => submodulePath != path && submodulePath.Contains(path));
+                    Trace.Assert(superPath != null);
+                    return superPath;
+                }
+            }
+
+            private string GetNodeRelativePath(GitModule topModule, SubmoduleNode node)
+            {
+                return node.SuperPath.SubstringAfter(topModule.WorkingDir).ToPosixPath() + node.LocalPath;
+            }
+
+            private void AddNodesToTree(List<SubmoduleNode> nodes)
+            {
+                if (!UseFolderTree)
+                {
+                    Nodes.AddNodes(nodes);
+                    return;
+                }
+
+                // Create tree of SubmoduleFolderNode for each path directory and add input SubmoduleNodes as leaves.
+
+                // Example of (SuperPath + LocalPath).ToPosixPath() for all nodes:
+                //
+                // C:/code/gitextensions2/Externals/conemu-inside
+                // C:/code/gitextensions2/Externals/Git.hub
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor/gitextensions
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor/gitextensions/Externals/conemu-inside
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor/gitextensions/Externals/Git.hub
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor/gitextensions/Externals/ICSharpCode.TextEditor
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor/gitextensions/Externals/NBug
+                // C:/code/gitextensions2/Externals/ICSharpCode.TextEditor/gitextensions/GitExtensionsDoc
+                // C:/code/gitextensions2/Externals/NBug
+                // C:/code/gitextensions2/GitExtensionsDoc
+                //
+                // What we want to do is first remove the topModule portion, "C:/code/gitextensions2/", and
+                // then build our tree by breaking up each path into parts, separated by '/'.
+                //
+                // Note that when we break up the paths, some parts are just directories, the others are submodule nodes:
+                //
+                // Externals / ICSharpCode.TextEditor / gitextensions / Externals / Git.hub
+                //  folder          submodule             submodule      folder     submodule
+                //
+                // Input 'nodes' is an array of SubmoduleNodes for all the submodules; now we need to create SubmoduleFolderNodes
+                // and insert everything into a tree.
+
+                var topModule = Module.GetTopModule();
+
+                // Build a mapping of top-module-relative path to node
+                var pathToNodes = new Dictionary<string, Node>();
+
+                // Add existing SubmoduleNodes
+                foreach (var node in nodes)
+                {
+                    pathToNodes[GetNodeRelativePath(topModule, node)] = node;
+                }
+
+                // Create and add missing SubmoduleFolderNodes
+                foreach (var node in nodes)
+                {
+                    var parts = GetNodeRelativePath(topModule, node).Split('/');
+                    for (int i = 0; i < parts.Length - 1; ++i)
+                    {
+                        var path = string.Join("/", parts.Take(i + 1));
+                        if (!pathToNodes.ContainsKey(path))
+                        {
+                            pathToNodes[path] = new SubmoduleFolderNode(this, parts[i]);
+                        }
+                    }
+                }
+
+                // Now build the tree
+                var rootNode = new DummyNode();
+                var nodesInTree = new List<Node>();
+                foreach (var node in nodes)
+                {
+                    Node parentNode = rootNode;
+                    var parts = GetNodeRelativePath(topModule, node).Split('/');
+                    for (int i = 0; i < parts.Length; ++i)
+                    {
+                        var path = string.Join("/", parts.Take(i + 1));
+                        var nodeToAdd = pathToNodes[path];
+
+                        // If node is not already in the tree, add it
+                        if (nodesInTree.FirstOrDefault(n => n == nodeToAdd) == default(Node))
+                        {
+                            parentNode.Nodes.AddNode(nodeToAdd);
+                            nodesInTree.Add(nodeToAdd);
+                        }
+
+                        parentNode = nodeToAdd;
+                    }
+                }
+
+                // Add top-module node, and move children of root to it
+                var topModuleNode = new SubmoduleNode(this, _topProjectInfo, _topProjectInfo.Bold, "", _topProjectInfo.Path);
+                topModuleNode.Nodes.AddNodes(rootNode.Nodes);
+                Nodes.AddNode(topModuleNode);
+            }
+
+            public void UpdateSubmodule(IWin32Window owner, SubmoduleNode node)
+            {
+                UICommands.StartUpdateSubmoduleDialog(owner, node.LocalPath, node.SuperPath);
+            }
+
+            public void OpenSubmodule(IWin32Window owner, SubmoduleNode node)
+            {
+                node.Open();
+            }
+
+            public void ManageSubmodules(IWin32Window owner)
+            {
+                UICommands.StartSubmodulesDialog(owner);
+            }
+
+            public void SynchronizeSubmodules(IWin32Window owner)
+            {
+                UICommands.StartSyncSubmodulesDialog(owner);
+            }
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -408,7 +408,7 @@ namespace GitUI.BranchTreePanel
 
                 // Now build the tree
                 var rootNode = new DummyNode();
-                var nodesInTree = new List<Node>();
+                var nodesInTree = new HashSet<Node>();
                 foreach (var node in submoduleNodes)
                 {
                     Node parentNode = rootNode;
@@ -419,7 +419,7 @@ namespace GitUI.BranchTreePanel
                         var nodeToAdd = pathToNodes[path];
 
                         // If node is not already in the tree, add it
-                        if (nodesInTree.FirstOrDefault(n => n == nodeToAdd) == default(Node))
+                        if (!nodesInTree.Contains(nodeToAdd))
                         {
                             parentNode.Nodes.AddNode(nodeToAdd);
                             nodesInTree.Add(nodeToAdd);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -77,6 +77,11 @@ namespace GitUI.BranchTreePanel
             {
             }
 
+            protected override Task OnAttachedAsync()
+            {
+                return ReloadNodesAsync(LoadNodesAsync);
+            }
+
             protected override Task PostRepositoryChangedAsync()
             {
                 return ReloadNodesAsync(LoadNodesAsync);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -108,7 +108,7 @@ namespace GitUI.BranchTreePanel
                 return nodes;
             }
 
-            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
+            protected override void PostFillTreeViewNode(bool firstTime)
             {
                 if (firstTime)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -77,9 +77,14 @@ namespace GitUI.BranchTreePanel
             {
             }
 
-            public override void RefreshTree()
+            protected override void PostRepositoryChanged()
             {
-                ReloadNodes(LoadNodesAsync);
+                RefreshTreeAsync().FileAndForget();
+            }
+
+            public override async Task RefreshTreeAsync()
+            {
+                await ReloadNodesAsync(LoadNodesAsync);
             }
 
             private async Task LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -105,7 +105,7 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode(bool firstTime)
+            protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)
             {
                 if (firstTime)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -77,14 +77,9 @@ namespace GitUI.BranchTreePanel
             {
             }
 
-            protected override void PostRepositoryChanged()
+            protected override Task PostRepositoryChangedAsync()
             {
-                StartAsyncRefreshTree();
-            }
-
-            protected override async Task RefreshTreeAsync(CancellationToken token)
-            {
-                await ReloadNodesAsync(LoadNodesAsync, token);
+                return ReloadNodesAsync(LoadNodesAsync);
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -87,27 +87,30 @@ namespace GitUI.BranchTreePanel
                 await ReloadNodesAsync(LoadNodesAsync);
             }
 
-            private async Task LoadNodesAsync(CancellationToken token)
+            private async Task<Nodes> LoadNodesAsync(CancellationToken token)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
-                FillTagTree(Module.GetTagRefs(GitModule.GetTagRefsSortOrder.ByName), token);
+                return FillTagTree(Module.GetTagRefs(GitModule.GetTagRefsSortOrder.ByName), token);
             }
 
-            private void FillTagTree(IEnumerable<IGitRef> tags, CancellationToken token)
+            private Nodes FillTagTree(IEnumerable<IGitRef> tags, CancellationToken token)
             {
-                var nodes = new Dictionary<string, BaseBranchNode>();
+                var nodes = new Nodes(this);
+                var pathToNodes = new Dictionary<string, BaseBranchNode>();
                 foreach (var tag in tags)
                 {
                     token.ThrowIfCancellationRequested();
                     var branchNode = new TagNode(this, tag.Name, tag);
-                    var parent = branchNode.CreateRootNode(nodes,
+                    var parent = branchNode.CreateRootNode(pathToNodes,
                         (tree, parentPath) => new BasePathNode(tree, parentPath));
                     if (parent != null)
                     {
-                        Nodes.AddNode(parent);
+                        nodes.AddNode(parent);
                     }
                 }
+
+                return nodes;
             }
 
             protected override void PostFillTreeViewNode(CancellationToken token, bool firstTime)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -79,12 +79,12 @@ namespace GitUI.BranchTreePanel
 
             protected override void PostRepositoryChanged()
             {
-                RefreshTreeAsync().FileAndForget();
+                StartAsyncRefreshTree();
             }
 
-            public override async Task RefreshTreeAsync()
+            protected override async Task RefreshTreeAsync(CancellationToken token)
             {
-                await ReloadNodesAsync(LoadNodesAsync);
+                await ReloadNodesAsync(LoadNodesAsync, token);
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -175,22 +175,19 @@ namespace GitUI.BranchTreePanel
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
+                    Nodes.Clear();
+
+                    var token = _reloadCancellationTokenSequence.Next();
+                    await loadNodesTask(token);
+                    token.ThrowIfCancellationRequested();
+
                     var repoObjectTree = TreeViewNode.TreeView.Parent;
 
                     try
                     {
-                        var token = _reloadCancellationTokenSequence.Next();
-
                         repoObjectTree.Enabled = false;
                         TreeViewNode.TreeView.BeginUpdate();
                         IgnoreSelectionChangedEvent = true;
-                        Nodes.Clear();
-
-                        await loadNodesTask(token);
-
-                        token.ThrowIfCancellationRequested();
-                        await TreeViewNode.TreeView.SwitchToMainThreadAsync();
-
                         FillTreeViewNode(token, _firstReloadNodesSinceModuleChanged);
                     }
                     finally

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -309,9 +309,15 @@ namespace GitUI.BranchTreePanel
                 return TreeViewNode.TreeView.FindForm();
             }
 
-            public virtual string DisplayText()
+            protected virtual string DisplayText()
             {
                 return ToString();
+            }
+
+            // Override to provide a unique node name (key), otherwise DisplayText is used
+            protected virtual string NodeName()
+            {
+                return DisplayText();
             }
 
             protected void SetNodeFont(FontStyle style)
@@ -344,7 +350,7 @@ namespace GitUI.BranchTreePanel
 
             protected void ApplyText()
             {
-                _treeViewNode.Name = DisplayText();
+                _treeViewNode.Name = NodeName();
                 _treeViewNode.Text = DisplayText();
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -174,17 +174,18 @@ namespace GitUI.BranchTreePanel
             // Invoke from child class to reload nodes for the current Tree. Clears Nodes, invokes
             // input async function that should populate Nodes, then fills the tree view with its contents,
             // making sure to disable/enable the control.
-            protected async Task ReloadNodesAsync(Func<CancellationToken, Task> loadNodesTask)
+            protected async Task ReloadNodesAsync(Func<CancellationToken, Task<Nodes>> loadNodesTask)
             {
                 await TaskScheduler.Default;
 
-                Nodes.Clear();
-
                 var token = _reloadCancellationTokenSequence.Next();
-                await loadNodesTask(token);
+                var newNodes = await loadNodesTask(token);
+
+                await TreeViewNode.TreeView.SwitchToMainThreadAsync(token);
                 token.ThrowIfCancellationRequested();
 
-                await TreeViewNode.TreeView.SwitchToMainThreadAsync();
+                Nodes.Clear();
+                Nodes.AddNodes(newNodes);
 
                 try
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -189,7 +189,7 @@ namespace GitUI.BranchTreePanel
 
             protected virtual Task OnAttachedAsync()
             {
-                return PostRepositoryChangedAsync();
+                return Task.CompletedTask;
             }
 
             public void Detached()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -5,18 +5,41 @@ namespace GitUI.BranchTreePanel
 {
     public partial class RepoObjectsTree
     {
+        private void ShowEnabledTrees()
+        {
+            if (tsmiShowBranches.Checked)
+            {
+                AddTree(_branchesTree, 0);
+            }
+
+            if (tsmiShowRemotes.Checked)
+            {
+                AddTree(_remotesTree, 1);
+            }
+
+            if (tsmiShowTags.Checked)
+            {
+                AddTree(_tagTree, 2);
+            }
+
+            if (tsmiShowSubmodules.Checked)
+            {
+                AddTree(_submoduleTree, 3);
+            }
+        }
+
         private void tsmiShowBranches_Click(object sender, EventArgs e)
         {
             AppSettings.RepoObjectsTreeShowBranches = tsmiShowBranches.Checked;
             _searchResult = null;
             if (tsmiShowBranches.Checked)
             {
-                AddBranches();
+                AddTree(_branchesTree, 0);
+                _searchResult = null;
             }
             else
             {
-                _rootNodes.Remove(_branchesTree);
-                treeMain.Nodes.Remove(_branchesTreeRootNode);
+                RemoveTree(_branchesTree);
             }
         }
 
@@ -26,12 +49,12 @@ namespace GitUI.BranchTreePanel
             _searchResult = null;
             if (tsmiShowRemotes.Checked)
             {
-                AddRemotes();
+                AddTree(_remotesTree, 1);
+                _searchResult = null;
             }
             else
             {
-                _rootNodes.Remove(_remotesTree);
-                treeMain.Nodes.Remove(_remotesTreeRootNode);
+                RemoveTree(_remotesTree);
             }
         }
 
@@ -41,12 +64,27 @@ namespace GitUI.BranchTreePanel
             _searchResult = null;
             if (tsmiShowTags.Checked)
             {
-                AddTags();
+                AddTree(_tagTree, 2);
+                _searchResult = null;
             }
             else
             {
-                _rootNodes.Remove(_tagTree);
-                treeMain.Nodes.Remove(_tagTreeRootNode);
+                RemoveTree(_tagTree);
+            }
+        }
+
+        private void tsmiShowSubmodules_Click(object sender, EventArgs e)
+        {
+            AppSettings.RepoObjectsTreeShowSubmodules = tsmiShowSubmodules.Checked;
+            _searchResult = null;
+            if (tsmiShowSubmodules.Checked)
+            {
+                AddTree(_submoduleTree, 3);
+                _searchResult = null;
+            }
+            else
+            {
+                RemoveTree(_submoduleTree);
             }
         }
     }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -298,12 +298,16 @@ namespace GitUI.BranchTreePanel
 
             treeMain.Font = AppSettings.Font;
             _rootNodes.Add(tree);
-            tree.StartAsyncRefreshTree();
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await tree.AttachedAsync();
+            }).FileAndForget();
         }
 
         private void RemoveTree(Tree tree)
         {
-            tree.CancelReloadNodes();
+            tree.Detached();
             _rootNodes.Remove(tree);
             treeMain.Nodes.Remove(tree.TreeViewNode);
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -298,7 +298,7 @@ namespace GitUI.BranchTreePanel
 
             treeMain.Font = AppSettings.Font;
             _rootNodes.Add(tree);
-            tree.RefreshTreeAsync().FileAndForget();
+            tree.StartAsyncRefreshTree();
         }
 
         private void RemoveTree(Tree tree)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -215,17 +215,6 @@ namespace GitUI.BranchTreePanel
             _ = UICommandsSource;
         }
 
-        private async Task RefreshTreeAsync()
-        {
-            var tasks = new List<Task>();
-            foreach (var n in _rootNodes)
-            {
-                tasks.Add(n.RefreshTreeAsync());
-            }
-
-            await Task.WhenAll(tasks);
-        }
-
         protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
         {
             base.OnUICommandsSourceSet(source);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
@@ -214,12 +215,15 @@ namespace GitUI.BranchTreePanel
             _ = UICommandsSource;
         }
 
-        public void RefreshTree()
+        private async Task RefreshTreeAsync()
         {
+            var tasks = new List<Task>();
             foreach (var n in _rootNodes)
             {
-                n.RefreshTree();
+                tasks.Add(n.RefreshTreeAsync());
             }
+
+            await Task.WhenAll(tasks);
         }
 
         protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
@@ -305,7 +309,7 @@ namespace GitUI.BranchTreePanel
 
             treeMain.Font = AppSettings.Font;
             _rootNodes.Add(tree);
-            tree.RefreshTree();
+            tree.RefreshTreeAsync().FileAndForget();
         }
 
         private void RemoveTree(Tree tree)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.resx
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="menuMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
+    <value>874, 17</value>
   </metadata>
   <metadata name="menuBranch.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>161, 17</value>
@@ -139,7 +139,7 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="menuRemoteRepoNode.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>127, 56</value>
+    <value>984, 17</value>
   </metadata>
   <metadata name="menuSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>389, 17</value>
@@ -147,7 +147,13 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>311, 56</value>
   </metadata>
+  <metadata name="menuSubmodule.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1168, 17</value>
+  </metadata>
+  <metadata name="menuAllSubmodules.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1313, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>123</value>
+    <value>498</value>
   </metadata>
 </root>

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -1031,7 +1031,7 @@ namespace GitUI.CommandsDialogs
             this.manageSubmodulesToolStripMenuItem.Image = global::GitUI.Properties.Images.SubmodulesManage;
             this.manageSubmodulesToolStripMenuItem.Name = "manageSubmodulesToolStripMenuItem";
             this.manageSubmodulesToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.manageSubmodulesToolStripMenuItem.Text = "Submodules...";
+            this.manageSubmodulesToolStripMenuItem.Text = "Manage submodules...";
             this.manageSubmodulesToolStripMenuItem.Click += new System.EventHandler(this.ManageSubmodulesToolStripMenuItemClick);
             // 
             // updateAllSubmodulesToolStripMenuItem

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1322,8 +1322,8 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshToolStripMenuItemClick(object sender, EventArgs e)
         {
-            RefreshRevisions();
-            RefreshStatus();
+            // Broadcast RepoChanged in case repo was changed outside of GE
+            UICommands.RepoChangedNotifier.Notify();
         }
 
         private void RefreshDashboardToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -234,7 +234,10 @@ namespace GitUI.CommandsDialogs
             UICommands.BrowseRepo = this;
             _controller = new FormBrowseController(new GitGpgController(() => Module));
             _commitDataManager = new CommitDataManager(() => Module);
-            _submoduleStatusProvider = new SubmoduleStatusProvider();
+
+            _submoduleStatusProvider = SubmoduleStatusProvider.Default;
+            _submoduleStatusProvider.StatusUpdating += SubmoduleStatusProvider_StatusUpdating;
+            _submoduleStatusProvider.StatusUpdated += SubmoduleStatusProvider_StatusUpdated;
 
             FillBuildReport(); // Ensure correct page visibility
             RevisionGrid.ShowBuildServerInfo = true;
@@ -461,7 +464,6 @@ namespace GitUI.CommandsDialogs
             {
                 // ReSharper disable ConstantConditionalAccessQualifier - these can be null if run from under the TranslatioApp
 
-                _submoduleStatusProvider?.Dispose();
                 _formBrowseMenus?.Dispose();
                 _filterRevisionsHelper?.Dispose();
                 _filterBranchHelper?.Dispose();
@@ -1322,7 +1324,6 @@ namespace GitUI.CommandsDialogs
         {
             RefreshRevisions();
             RefreshStatus();
-            repoObjectsTree.RefreshTree();
         }
 
         private void RefreshDashboardToolStripMenuItemClick(object sender, EventArgs e)
@@ -2658,15 +2659,21 @@ namespace GitUI.CommandsDialogs
             updateStatus = updateStatus || (AppSettings.ShowSubmoduleStatus && _gitStatusMonitor.Active && (Module.SuperprojectModule != null));
 
             toolStripButtonLevelUp.ToolTipText = "";
-            _submoduleStatusProvider.UpdateSubmodulesStatus(
-                updateStatus,
-                Module.WorkingDir, _noBranchTitle.Text,
-                () =>
-                {
-                    RemoveSubmoduleButtons();
-                    toolStripButtonLevelUp.DropDownItems.Add(_loading.Text);
-                },
-                PopulateToolbarAsync);
+            _submoduleStatusProvider.UpdateSubmodulesStatus(updateStatus, Module.WorkingDir, _noBranchTitle.Text);
+        }
+
+        private void SubmoduleStatusProvider_StatusUpdating(object sender, EventArgs e)
+        {
+            RemoveSubmoduleButtons();
+            toolStripButtonLevelUp.DropDownItems.Add(_loading.Text);
+        }
+
+        private void SubmoduleStatusProvider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await PopulateToolbarAsync(e.Info, e.Token);
+            });
         }
 
         private async Task PopulateToolbarAsync(SubmoduleInfoResult result, CancellationToken cancelToken)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2664,8 +2664,12 @@ namespace GitUI.CommandsDialogs
 
         private void SubmoduleStatusProvider_StatusUpdating(object sender, EventArgs e)
         {
-            RemoveSubmoduleButtons();
-            toolStripButtonLevelUp.DropDownItems.Add(_loading.Text);
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await this.SwitchToMainThreadAsync();
+                RemoveSubmoduleButtons();
+                toolStripButtonLevelUp.DropDownItems.Add(_loading.Text);
+            }).FileAndForget();
         }
 
         private void SubmoduleStatusProvider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
@@ -2673,7 +2677,7 @@ namespace GitUI.CommandsDialogs
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await PopulateToolbarAsync(e.Info, e.Token);
-            });
+            }).FileAndForget();
         }
 
         private async Task PopulateToolbarAsync(SubmoduleInfoResult result, CancellationToken cancelToken)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -111,6 +111,10 @@
       <SubType>UserControl</SubType>
       <DependentUpon>RepoObjectsTree.Nodes.cs</DependentUpon>
     </Compile>
+    <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Submodules.cs">
+      <SubType>UserControl</SubType>
+      <DependentUpon>RepoObjectsTree.Nodes.cs</DependentUpon>
+    </Compile>
     <Compile Include="BranchTreePanel\RepoObjectsTree.Nodes.Tags.cs">
       <SubType>UserControl</SubType>
       <DependentUpon>RepoObjectsTree.Nodes.cs</DependentUpon>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1075,11 +1075,22 @@ namespace GitUI
             return DoActionOnRepo(owner, true, true, null, null, Action);
         }
 
-        public bool StartUpdateSubmodulesDialog(IWin32Window owner)
+        public bool StartUpdateSubmodulesDialog(IWin32Window owner, string submoduleLocalPath = "")
         {
             bool Action()
             {
-                return FormProcess.ShowDialog(owner, Module, GitCommandHelpers.SubmoduleUpdateCmd(""));
+                return FormProcess.ShowDialog(owner, Module, GitCommandHelpers.SubmoduleUpdateCmd(submoduleLocalPath));
+            }
+
+            return DoActionOnRepo(owner, true, true, null, PostUpdateSubmodules, Action);
+        }
+
+        public bool StartUpdateSubmoduleDialog(IWin32Window owner, string submoduleLocalPath, string submoduleParentPath)
+        {
+            bool Action()
+            {
+                // Execute the submodule update comment from the submodule's parent directory
+                return FormProcess.ShowDialog(owner, null, GitCommandHelpers.SubmoduleUpdateCmd(submoduleLocalPath), submoduleParentPath, null, true);
             }
 
             return DoActionOnRepo(owner, true, true, null, PostUpdateSubmodules, Action);
@@ -1829,6 +1840,11 @@ namespace GitUI
         public void BrowseGoToRef(string refName, bool showNoRevisionMsg)
         {
             BrowseRepo?.GoToRef(refName, showNoRevisionMsg);
+        }
+
+        public void BrowseSetWorkingDir(string path)
+        {
+            BrowseRepo?.SetWorkingDir(path);
         }
 
         public IGitRemoteCommand CreateRemoteCommand()

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -202,22 +203,22 @@ namespace GitUI
             }
         }
 
-        public static async Task InvokeAsync(this Control control, Action action)
+        public static async Task InvokeAsync(this Control control, Action action, CancellationToken token = default)
         {
-            await control.SwitchToMainThreadAsync();
+            await control.SwitchToMainThreadAsync(token);
             action();
         }
 
-        public static async Task InvokeAsync<T>(this Control control, Action<T> action, T state)
+        public static async Task InvokeAsync<T>(this Control control, Action<T> action, T state, CancellationToken token = default)
         {
-            await control.SwitchToMainThreadAsync();
+            await control.SwitchToMainThreadAsync(token);
             action(state);
         }
 
 #pragma warning disable VSTHRD100 // Avoid async void methods
         /// <summary>
-        /// Use <see cref="InvokeAsync(Control, Action)"/> instead. If the result of
-        /// <see cref="InvokeAsync(Control, Action)"/> is not awaited, use
+        /// Use <see cref="InvokeAsync(Control, Action, CancellationToken)"/> instead. If the result of
+        /// <see cref="InvokeAsync(Control, Action, CancellationToken)"/> is not awaited, use
         /// <see cref="ThreadHelper.FileAndForget(Task, Func{Exception, bool})"/> to ignore it.
         /// </summary>
         public static async void InvokeAsyncDoNotUseInNewCode(this Control control, Action action)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -556,6 +556,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
   </file>
   <file datatype="plaintext" original="ColorsSettingsPage" source-language="en">
     <body>
+      <trans-unit id="$this.Text">
+        <source>Colors</source>
+        <target />
+      </trans-unit>
       <trans-unit id="DrawNonRelativesGray.Text">
         <source>Draw non relatives graph gray</source>
         <target />
@@ -2257,7 +2261,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="manageSubmodulesToolStripMenuItem.Text">
-        <source>Submodules...</source>
+        <source>Manage submodules...</source>
         <target />
       </trans-unit>
       <trans-unit id="manageWorktreeToolStripMenuItem.Text">
@@ -2766,6 +2770,10 @@ revision:</source>
         <source>Clean working directory</source>
         <target />
       </trans-unit>
+      <trans-unit id="AddPath.Text">
+        <source>Add a path...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="Cancel.Text">
         <source>Cancel</source>
         <target />
@@ -3198,6 +3206,10 @@ Suitable for some config files modified locally.</source>
         <source>Stage selected line(s)</source>
         <target />
       </trans-unit>
+      <trans-unit id="_statusBarBranchWithoutRemote.Text">
+        <source>(remote not configured)</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_stopTrackingFail.Text">
         <source>Fail to stop tracking the file '{0}'.</source>
         <target />
@@ -3221,6 +3233,10 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="_unstageSelectedLines.Text">
         <source>Unstage selected line(s)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_untrackedRemote.Text">
+        <source>(untracked)</source>
         <target />
       </trans-unit>
       <trans-unit id="addFileToGitIgnoreToolStripMenuItem.Text">
@@ -3361,6 +3377,10 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="refreshDialogOnFormFocusToolStripMenuItem.Text">
         <source>Refresh dialog on form focus</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="remoteNameLabel.Text">
+        <source>(Remote name)</source>
         <target />
       </trans-unit>
       <trans-unit id="resetAllTrackedChangesToolStripMenuItem.Text">
@@ -4959,6 +4979,14 @@ Are you sure you want to rebase this merge?</source>
       </trans-unit>
       <trans-unit id="_areYouSureYouWantToRebaseMergeCaption.Text">
         <source>Rebase merge commit?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_buttonFetch.Text">
+        <source>&amp;Fetch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_buttonPull.Text">
+        <source>&amp;Pull</source>
         <target />
       </trans-unit>
       <trans-unit id="_dontShowAgain.Text">
@@ -7547,6 +7575,10 @@ This will just checkout on the submodule the commit determined by the superproje
   </file>
   <file datatype="plaintext" original="RecentRepositoriesList" source-language="en">
     <body>
+      <trans-unit id="_cannotOpenTheFolder.Text">
+        <source>Cannot open the folder</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_clearRecentCategoryCaption.Text">
         <source>Clear recent repositories</source>
         <target />
@@ -7579,6 +7611,10 @@ Do you want to remove it from the recent repositories list?</source>
       </trans-unit>
       <trans-unit id="_groupRecentRepositories.Text">
         <source>Recent repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_notAValidRepository.Text">
+        <source>Not a valid git repository</source>
         <target />
       </trans-unit>
       <trans-unit id="clmhdrBranch.Text">
@@ -7667,7 +7703,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="mnuBtnManageRemotesFromRootNode.Text">
-        <source>&amp;Manage remotes...</source>
+        <source>&amp;Manage...</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnBranchCheckout.Text">
@@ -7743,11 +7779,19 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="mnubtnManageRemotes.Text">
-        <source>&amp;Manage remotes...</source>
+        <source>&amp;Manage...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnManageSubmodules.Text">
+        <source>&amp;Manage...</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnMergeBranch.Text">
         <source>&amp;Merge</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnOpenSubmodule.Text">
+        <source>&amp;Open</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnPullFromRemoteBranch.Text">
@@ -7770,12 +7814,24 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Re&amp;set</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnSynchronizeSubmodules.Text">
+        <source>Synchronize</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnUpdateSubmodule.Text">
+        <source>&amp;Update</source>
+        <target />
+      </trans-unit>
       <trans-unit id="tsmiShowBranches.Text">
         <source>&amp;Branches</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowRemotes.Text">
         <source>&amp;Remotes</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiShowSubmodules.Text">
+        <source>&amp;Submodules</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowTags.Text">
@@ -8962,6 +9018,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_secondsAgo.Text">
         <source>{0} {1:second|seconds} ago</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_submodulesText.Text">
+        <source>Submodules</source>
         <target />
       </trans-unit>
       <trans-unit id="_tagsText.Text">

--- a/GitUI/UserControls/TreeViewExtensions.cs
+++ b/GitUI/UserControls/TreeViewExtensions.cs
@@ -1,10 +1,42 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 using System.Windows.Forms;
 
 namespace GitUI.UserControls
 {
     public static class TreeViewExtensions
     {
+        /// <summary>
+        /// Similar to TreeNode.FullPath, this function returns a full path made up of TreeNode.Name rather
+        /// than TreeNode.Text, if the former is non-empty. This is useful as it allows the node's Text to
+        /// be changed, while the node's Name can remain a key for operations such as getting and restoring
+        /// the expanded node state.
+        /// </summary>
+        public static string GetFullNamePath(this TreeNode node)
+        {
+            var sep = node.TreeView != null ? node.TreeView.PathSeparator : "\\";
+
+            string result = GetNameOrText(node);
+            var currNode = node;
+            while (currNode.Parent != null)
+            {
+                currNode = currNode.Parent;
+                result = GetNameOrText(currNode) + sep + result;
+            }
+
+            return result;
+
+            string GetNameOrText(TreeNode n)
+            {
+                return n.Name.Length > 0 ? n.Name : n.Text;
+            }
+        }
+
+        /// <summary>
+        /// Returns a set of expanded node paths to be used with RestoreExpandedNodeState starting from the input node.
+        /// This function makes use of GetFullNamePath, rather than TreeNode.FullPath, so you can vary the node's Text,
+        /// as long as the node's Name remains stable.
+        /// </summary>
         public static HashSet<string> GetExpandedNodesState(this TreeNode node)
         {
             var result = new HashSet<string>();
@@ -12,19 +44,9 @@ namespace GitUI.UserControls
             return result;
         }
 
-        private static void DoGetExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
-        {
-            if (node.IsExpanded)
-            {
-                expandedNodes.Add(node.FullPath);
-            }
-
-            foreach (TreeNode childNode in node.Nodes)
-            {
-                DoGetExpandedNodesState(childNode, expandedNodes);
-            }
-        }
-
+        /// <summary>
+        /// Restores the expanded state of nodes under the input node using the set returned by GetExpandedNodesState
+        /// </summary>
         public static void RestoreExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
         {
             foreach (var path in expandedNodes)
@@ -34,9 +56,22 @@ namespace GitUI.UserControls
             }
         }
 
+        private static void DoGetExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
+        {
+            if (node.IsExpanded)
+            {
+                expandedNodes.Add(GetFullNamePath(node));
+            }
+
+            foreach (TreeNode childNode in node.Nodes)
+            {
+                DoGetExpandedNodesState(childNode, expandedNodes);
+            }
+        }
+
         private static TreeNode GetNodeFromPath(TreeNode node, string path)
         {
-            if (node.FullPath == path)
+            if (GetFullNamePath(node) == path)
             {
                 return node;
             }

--- a/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
+++ b/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
@@ -3,5 +3,6 @@
     public interface IBrowseRepo
     {
         void GoToRef(string refName, bool showNoRevisionMsg);
+        void SetWorkingDir(string path);
     }
 }

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -44,6 +44,7 @@ namespace ResourceManager
         public static string Branches => _instance.Value._branchesText.Text;
         public static string Remotes => _instance.Value._remotesText.Text;
         public static string Tags => _instance.Value._tagsText.Text;
+        public static string Submodules => _instance.Value._submodulesText.Text;
 
         public static string BodyNotLoaded => _instance.Value._bodyNotLoaded.Text;
 
@@ -66,6 +67,7 @@ namespace ResourceManager
         private readonly TranslationString _branchesText = new TranslationString("Branches");
         private readonly TranslationString _remotesText = new TranslationString("Remotes");
         private readonly TranslationString _tagsText = new TranslationString("Tags");
+        private readonly TranslationString _submodulesText = new TranslationString("Submodules");
         private readonly TranslationString _bodyNotLoaded  = new TranslationString("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
 
         private readonly TranslationString _parentsText = new TranslationString("{0:Parent|Parents}");

--- a/UnitTests/CommonTestUtils/AsyncTestHelper.cs
+++ b/UnitTests/CommonTestUtils/AsyncTestHelper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitUI;
+
+namespace CommonTestUtils
+{
+    public static class AsyncTestHelper
+    {
+        public static void RunAndWaitForPendingOperations(Func<Task> asyncMethod)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(asyncMethod);
+
+            WaitForPendingOperations();
+        }
+
+        public static T RunAndWaitForPendingOperations<T>(Func<Task<T>> asyncMethod)
+        {
+            var result = ThreadHelper.JoinableTaskFactory.Run(asyncMethod);
+
+            WaitForPendingOperations();
+
+            return result;
+        }
+
+        public static void WaitForPendingOperations()
+        {
+            try
+            {
+                ThreadHelper.JoinableTaskContext?.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync());
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+}

--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncTestHelper.cs" />
     <Compile Include="SubmoduleTestHelpers.cs" />
     <Compile Include="ConfigureJoinableTaskFactoryAttribute.cs" />
     <Compile Include="EmbeddedResourceLoader.cs" />

--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SubmoduleTestHelpers.cs" />
     <Compile Include="ConfigureJoinableTaskFactoryAttribute.cs" />
     <Compile Include="EmbeddedResourceLoader.cs" />
     <Compile Include="GitModuleTestHelper.cs" />

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using GitCommands;
+using GitCommands.Submodules;
+
+namespace CommonTestUtils
+{
+    public class SubmoduleTestHelpers
+    {
+        public static SubmoduleInfoResult UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        {
+            SubmoduleInfoResult result = null;
+            SemaphoreSlim onUpdateCompleteSignal = new SemaphoreSlim(0, 1);
+
+            provider.StatusUpdating += Provider_StatusUpdating;
+            provider.StatusUpdated += Provider_StatusUpdated;
+
+            provider.UpdateSubmodulesStatus(
+                updateStatus: updateStatus,
+                workingDirectory: module.WorkingDir,
+                noBranchText: string.Empty);
+
+            onUpdateCompleteSignal.Wait();
+
+            provider.StatusUpdating -= Provider_StatusUpdating;
+            provider.StatusUpdated -= Provider_StatusUpdated;
+
+            return result;
+
+            void Provider_StatusUpdating(object sender, System.EventArgs e)
+            {
+            }
+
+            void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
+            {
+                result = e.Info;
+                onUpdateCompleteSignal.Release();
+            }
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -18,6 +18,7 @@ namespace GitCommandsTests.Submodules
     [TestFixture]
     internal class SubmoduleStatusProviderTests
     {
+        [Apartment(ApartmentState.STA)]
         public class IntegrationTests
         {
             private GitModuleTestHelper _repo1;

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -147,20 +147,30 @@ namespace GitCommandsTests.Submodules
                 SubmoduleInfoResult result = null;
                 SemaphoreSlim onUpdateCompleteSignal = new SemaphoreSlim(0, 1);
 
+                provider.StatusUpdating += Provider_StatusUpdating;
+                provider.StatusUpdated += Provider_StatusUpdated;
+
                 provider.UpdateSubmodulesStatus(
                     updateStatus: false,
                     workingDirectory: module.WorkingDir,
-                    noBranchText: string.Empty,
-                    onUpdateBegin: () => { },
-                    onUpdateCompleteAsync: async (SubmoduleInfoResult submoduleInfoResult, CancellationToken token) =>
-                    {
-                        await TaskScheduler.Default;
-                        result = submoduleInfoResult;
-                        onUpdateCompleteSignal.Release();
-                    });
+                    noBranchText: string.Empty);
 
                 onUpdateCompleteSignal.Wait();
+
+                provider.StatusUpdating -= Provider_StatusUpdating;
+                provider.StatusUpdated -= Provider_StatusUpdated;
+
                 return result;
+
+                void Provider_StatusUpdating(object sender, System.EventArgs e)
+                {
+                }
+
+                void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
+                {
+                    result = e.Info;
+                    onUpdateCompleteSignal.Release();
+                }
             }
 
             private static IReadOnlyList<GitItemStatus> GetStatusChangedFiles(IGitModule module)

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Remotes.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Remotes.cs
@@ -14,7 +14,7 @@ using ResourceManager;
 namespace GitUITests.CommandsDialogs.CommitDialog
 {
     [Apartment(ApartmentState.STA)]
-    public class FormBrowseLeftPanelTests
+    public class FormBrowseLeftPanelRemotesTests
     {
         // Created once for the fixture
         private ReferenceRepository _referenceRepository;

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Submodules.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Remotes;
+using GitCommands.Submodules;
+using GitUI;
+using GitUI.CommandsDialogs;
+using GitUI.Properties;
+using NUnit.Framework;
+using ResourceManager;
+
+namespace GitUITests.CommandsDialogs.CommitDialog
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormBrowseLeftPanelSubmodulesTests
+    {
+        // Created once for each test
+        private GitUICommands _commands;
+        private bool _originalShowAuthorAvatarColumn;
+
+        private GitModuleTestHelper _repo1;
+        private GitModuleTestHelper _repo2;
+        private GitModuleTestHelper _repo3;
+
+        // Note that _repo2Module and _repo3Module point to the submodules under _repo1Module,
+        // not _repo2.Module and _repo3.Module respectively. In general, the tests should here
+        // should interact with these modules, not with _repo2 and _repo3.
+        private GitModule _repo1Module;
+        private GitModule _repo2Module;
+        private GitModule _repo3Module;
+
+        private ISubmoduleStatusProvider _provider;
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            _originalShowAuthorAvatarColumn = AppSettings.ShowAuthorAvatarColumn;
+
+            // we don't want avatars during tests, otherwise we will be attempting to download them from gravatar....
+            AppSettings.ShowAuthorAvatarColumn = false;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            AppSettings.ShowAuthorAvatarColumn = _originalShowAuthorAvatarColumn;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repo1 = new GitModuleTestHelper("repo1");
+            _repo2 = new GitModuleTestHelper("repo2");
+            _repo3 = new GitModuleTestHelper("repo3");
+
+            _repo2.AddSubmodule(_repo3, "repo3");
+            _repo1.AddSubmodule(_repo2, "repo2");
+            var submodules = _repo1.GetSubmodulesRecursive();
+
+            _repo1Module = _repo1.Module;
+            _repo2Module = submodules.ElementAt(0);
+            _repo3Module = submodules.ElementAt(1);
+
+            // Use the singleton provider, which is also used by the left panel, so we can synchronize on updates
+            _provider = SubmoduleStatusProvider.Default;
+
+            _commands = new GitUICommands(_repo1Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _commands = null;
+
+            _repo1.Dispose();
+            _repo2.Dispose();
+            _repo3.Dispose();
+        }
+
+        [Test]
+        public void RepoObjectTree_should_show_all_submodules()
+        {
+            RunFormTest(
+                form =>
+                {
+                    // act
+                    SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo1Module);
+
+                    // assert
+                    var submodulesNode = GetSubmoduleNode(form);
+
+                    submodulesNode.Nodes.Count.Should().Be(1);
+
+                    var repo1Node = submodulesNode.Nodes[0];
+                    repo1Node.Name.Should().StartWith("repo1");
+                    repo1Node.Nodes.Count.Should().Be(1);
+
+                    var repo2Node = repo1Node.Nodes[0];
+                    repo2Node.Name.Should().StartWith("repo2");
+                    repo2Node.Nodes.Count.Should().Be(1);
+
+                    var repo3Node = repo2Node.Nodes[0];
+                    repo3Node.Name.Should().StartWith("repo3");
+                    repo3Node.Nodes.Count.Should().Be(0);
+                });
+        }
+
+        private TreeNode GetSubmoduleNode(FormBrowse form)
+        {
+            var treeView = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor().TreeView;
+            var remotesNode = treeView.Nodes.OfType<TreeNode>().FirstOrDefault(n => n.Text == Strings.Submodules);
+            remotesNode.Should().NotBeNull();
+            return remotesNode;
+        }
+
+        private void RunFormTest(Action<FormBrowse> testDriver)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                });
+        }
+
+        private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    Assert.True(_commands.StartBrowseDialog(owner: null));
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -63,7 +63,8 @@
     <Compile Include="Avatars\BackupAvatarProviderTests.cs" />
     <Compile Include="BranchTreePanel\GitRefMenuItemsTest.cs" />
     <Compile Include="CancellationTokenSequenceTests.cs" />
-    <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.cs" />
+    <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.Submodules.cs" />
+    <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.Remotes.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormPullTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormInitTests.cs" />

--- a/UnitTests/GitUITests/UserControls/TreeViewExtensionsTests.cs
+++ b/UnitTests/GitUITests/UserControls/TreeViewExtensionsTests.cs
@@ -93,14 +93,14 @@ namespace GitUITests.UserControls
         {
             var expandedNodes = new HashSet<string>
             {
-                $"{_root.FullPath}",
-                $"{_a.FullPath}",
-                $"{_b.FullPath}",
-                $"{_b1.FullPath}",
-                $"{_b2.FullPath}",
-                $"{_b2_1.FullPath}",
-                $"{_b3.FullPath}",
-                $"{_c.FullPath}",
+                $"{_root.GetFullNamePath()}",
+                $"{_a.GetFullNamePath()}",
+                $"{_b.GetFullNamePath()}",
+                $"{_b1.GetFullNamePath()}",
+                $"{_b2.GetFullNamePath()}",
+                $"{_b2_1.GetFullNamePath()}",
+                $"{_b3.GetFullNamePath()}",
+                $"{_c.GetFullNamePath()}",
             };
 
             _root.RestoreExpandedNodesState(expandedNodes);
@@ -108,6 +108,15 @@ namespace GitUITests.UserControls
             var expandedNodesPost = _root.GetExpandedNodesState();
             Assert.AreEqual(8, expandedNodesPost.Count);
             Assert.AreEqual(expandedNodes, expandedNodesPost);
+        }
+
+        [Test]
+        public void GetFullNamePath_should_return_node_names_if_set()
+        {
+            // Only override the names for 2 of the 4 nodes
+            _b.Name = "B_Name";
+            _b2_1.Name = "B_2_1_Name";
+            _b2_1.GetFullNamePath().Should().Be(@"Root\B_Name\B_2\B_2_1_Name");
         }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a Submodules tree to the left panel
- This tree offers the same functionality as the Submodule menu, but also adds more:
  - Context-menu actions on specific submodules (e.g. you can update any submodule, not just the current)
  - Double-click a submodule to open it
  - Possibility for more context-based actions in the future

This is related to the discussion here: https://github.com/gitextensions/gitextensions/issues/5569
 
Screenshots before and after (if PR changes UI):

(Edit: screenshot of the entire window):
![image](https://user-images.githubusercontent.com/6893883/47449055-aac2fa00-d78f-11e8-8256-52d6405b488c.png)

The main view:
![image](https://user-images.githubusercontent.com/6893883/47439902-2f574d80-d77b-11e8-951a-6d4b22094258.png)

Context menu on the top node to update all, go to super or top project:
![image](https://user-images.githubusercontent.com/6893883/47439928-3b430f80-d77b-11e8-861c-0f74709ee77b.png)

Context menu on a sibling submodule node that allows us to open it (can also double-click), and to update it, even if it's not current:
![image](https://user-images.githubusercontent.com/6893883/47439952-45fda480-d77b-11e8-92bf-58ebb2369759.png)

When there are no submodules, we display the top node with the count at 0:
![image](https://user-images.githubusercontent.com/6893883/47440034-6f1e3500-d77b-11e8-97c7-ebe099450012.png)

What did I do to test the code and ensure quality:

I mainly tested within the gitextensions repo, and added a submodule to one of the existing submodules to make sure nested submodules worked. However, if someone can point me to a repo with many more submodules, especially deeply nested, it would be nice to test that too.

I also tested a repo with no submodules.

Has been tested on (remove any that don't apply):
- GIT 2.9.0.windows.1
- Windows 10




