### PR TITLE
Fix #5618 FileViewer: Find next/previous change

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1044,11 +1044,13 @@ namespace GitUI.Editor
         {
             Focus();
 
-            var firstVisibleLine = internalFileViewer.LineAtCaret;
+            var currentVisibleLine = internalFileViewer.LineAtCaret;
             var totalNumberOfLines = internalFileViewer.TotalNumberOfLines;
             var emptyLineCheck = false;
 
-            for (var line = firstVisibleLine + 1; line < totalNumberOfLines; line++)
+            // skip the first pseudo-change containing the file names
+            var startLine = Math.Max(4, currentVisibleLine + 1);
+            for (var line = startLine; line < totalNumberOfLines; line++)
             {
                 var lineContent = internalFileViewer.GetLineText(line);
 
@@ -1057,7 +1059,7 @@ namespace GitUI.Editor
                     if (emptyLineCheck)
                     {
                         internalFileViewer.FirstVisibleLine = Math.Max(line - 4, 0);
-                        GoToLine(line);
+                        internalFileViewer.LineAtCaret = line;
                         return;
                     }
                 }
@@ -1084,17 +1086,17 @@ namespace GitUI.Editor
         {
             Focus();
 
-            var firstVisibleLine = internalFileViewer.LineAtCaret;
+            var startLine = internalFileViewer.LineAtCaret;
             var emptyLineCheck = false;
 
             // go to the top of change block
-            while (firstVisibleLine > 0 &&
-                internalFileViewer.GetLineText(firstVisibleLine).StartsWithAny(new[] { "+", "-" }))
+            while (startLine > 0 &&
+                internalFileViewer.GetLineText(startLine).StartsWithAny(new[] { "+", "-" }))
             {
-                firstVisibleLine--;
+                startLine--;
             }
 
-            for (var line = firstVisibleLine; line > 0; line--)
+            for (var line = startLine; line > 0; line--)
             {
                 var lineContent = internalFileViewer.GetLineText(line);
 
@@ -1108,7 +1110,7 @@ namespace GitUI.Editor
                     if (emptyLineCheck)
                     {
                         internalFileViewer.FirstVisibleLine = Math.Max(0, line - 3);
-                        GoToLine(line + 1);
+                        internalFileViewer.LineAtCaret = line + 1;
                         return;
                     }
                 }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -297,7 +297,11 @@ namespace GitUI.Editor
 
         public int MaxLineNumber => TextEditor.ShowLineNumbers ? TotalNumberOfLines : _lineNumbersControl.MaxLineNumber;
 
-        public int LineAtCaret => TextEditor.ActiveTextAreaControl.Caret.Position.Line;
+        public int LineAtCaret
+        {
+            get => TextEditor.ActiveTextAreaControl.Caret.Position.Line;
+            set => TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(TextEditor.ActiveTextAreaControl.Caret.Position.Column, value);
+        }
 
         public void HighlightLine(int line, Color color)
         {

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -56,7 +56,7 @@ namespace GitUI.Editor
 
         int FirstVisibleLine { get; set; }
         int GetLineFromVisualPosY(int visualPosY);
-        int LineAtCaret { get; }
+        int LineAtCaret { get; set; }
         string GetLineText(int line);
         int TotalNumberOfLines { get; }
 


### PR DESCRIPTION
Fixes #5618

Changes proposed in this pull request:
- `Find next/previous change` must not use GoToLine() anymore.
- It must set the caret line directly.
 
Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- GIT (2.18.0.w.x64)
- Windows 7