### PR TITLE
WIP Use mathematical (Away from zero) rounding for scaling

### DIFF
--- a/GitExtUtils/GitUI/DpiUtil.cs
+++ b/GitExtUtils/GitUI/DpiUtil.cs
@@ -91,7 +91,7 @@ namespace GitExtUtils.GitUI
         /// </summary>
         public static int Scale(int i)
         {
-            return (int)Math.Round(i * ScaleX);
+            return (int)Math.Round(i * ScaleX, MidpointRounding.AwayFromZero);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace GitExtUtils.GitUI
         /// </summary>
         public static float Scale(float i)
         {
-            return (float)Math.Round(i * ScaleX);
+            return (float)Math.Round(i * ScaleX, MidpointRounding.AwayFromZero);
         }
 
         /// <summary>


### PR DESCRIPTION
I use 125% scaling on my laptop and while trying #5610 I noticed that the difference between thick and thin lanes was too big. As it turns out it's because of Rounding bug in DpiUtil.

By default .NET uses what's called "bankers rounding" which is good where you need to be fair (i.g. money) but not in other cases.

Have a look at this demo:
![image](https://user-images.githubusercontent.com/483659/47465229-b4327d80-d7f4-11e8-83e6-551f1f8b2acf.png)

Changes proposed in this pull request:
- Use mathematical rounding when calculating scaled value