### PR TITLE
Issue 5616: Provide a way to remove all invalid recent repositories.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -61,7 +61,9 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _configureWorkingDirMenu = new TranslationString("Configure this menu");
 
         private readonly TranslationString _directoryIsNotAValidRepositoryCaption = new TranslationString("Open");
-        private readonly TranslationString _directoryIsNotAValidRepository = new TranslationString("The selected item is not a valid git repository.\n\nDo you want to remove it from the recent repositories list?");
+        private readonly TranslationString _directoryIsNotAValidRepositoryMainInstruction = new TranslationString("The selected item is not a valid git repository.");
+        private readonly TranslationString _directoryIsNotAValidRepositoryRemoveSelectedRepoCommand = new TranslationString("Remove the selected invalid repository");
+        private readonly TranslationString _directoryIsNotAValidRepositoryRemoveAllCommand = new TranslationString("Remove all {0} invalid repositories");
 
         private readonly TranslationString _updateCurrentSubmodule = new TranslationString("Update current submodule");
 
@@ -1635,18 +1637,36 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            DialogResult dialogResult = MessageBox.Show(this, _directoryIsNotAValidRepository.Text,
-                                                        _directoryIsNotAValidRepositoryCaption.Text,
-                                                        MessageBoxButtons.YesNo,
-                                                        MessageBoxIcon.Exclamation,
-                                                        MessageBoxDefaultButton.Button1);
-
-            if (dialogResult != DialogResult.Yes)
+            int invalidPathCount = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync()).Count(repo => !GitModule.IsValidGitWorkingDir(repo.Path));
+            string commandButtonCaptions = _directoryIsNotAValidRepositoryRemoveSelectedRepoCommand.Text;
+            if (invalidPathCount > 1)
             {
-                return;
+                commandButtonCaptions =
+                    string.Format("{0}|{1}", commandButtonCaptions, string.Format(_directoryIsNotAValidRepositoryRemoveAllCommand.Text, invalidPathCount));
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.RemoveRecentAsync(path));
+            int dialogResult = PSTaskDialog.cTaskDialog.ShowCommandBox(
+                Title: _directoryIsNotAValidRepositoryCaption.Text,
+                MainInstruction: _directoryIsNotAValidRepositoryMainInstruction.Text,
+                Content: "",
+                CommandButtons: commandButtonCaptions,
+                ShowCancelButton: true);
+
+            if (dialogResult < 0)
+            {
+                /* Cancel */
+                return;
+            }
+            else if (PSTaskDialog.cTaskDialog.CommandButtonResult == 0)
+            {
+                /* Remove selected invalid repo */
+                ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.RemoveRecentAsync(path));
+            }
+            else if (PSTaskDialog.cTaskDialog.CommandButtonResult == 1)
+            {
+                /* Remove all invalid repos */
+                ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.RemoveInvalidRepositoriesAsync(repoPath => GitModule.IsValidGitWorkingDir(repoPath)));
+            }
         }
 
         private void tsmiFavouriteRepositories_DropDownOpening(object sender, EventArgs e)


### PR DESCRIPTION
	- Pop up a dialog that asks the user if they want to remove all X invalid repositories whenever the user agrees to removing one invalid repository from the recent repositories drop-down list

Fixes Issue #5616 

Changes proposed in this pull request:
- when the user agrees to remove an invalid repository from the recent repositories drop-down list, pop up a second dialog notifying them the existence of multiple invalid repositories (if they exist).
- if multiple repositories exist, offer the user to remove all of them, in addition to the one that was originally going to be removed from the list

 
Screenshots before and after (if PR changes UI):
- Before:
![first_dialog](https://user-images.githubusercontent.com/14078392/47475447-5d737680-d7e9-11e8-8aed-97097c1b9b68.JPG)


- After:
![first_dialog](https://user-images.githubusercontent.com/14078392/47475447-5d737680-d7e9-11e8-8aed-97097c1b9b68.JPG)

followed by:
![image](https://user-images.githubusercontent.com/14078392/47475445-577d9580-d7e9-11e8-9f18-374f15fc7f42.png)


What did I do to test the code and ensure quality:
- I did interactive testing to ensure that:
- - If the user disagrees with removing _all_ invalid repos from the list, then the first one they agreed to remove will still be removed
- - If the user agrees to remove _all_ invalid repos from the list, all invalid repos are indeed removed from the list
- - If the user does not agree to remove _any_ invalid repos from the list, then the list will remain unchanged

Has been tested on (remove any that don't apply):
- GIT 2.8.1.windows.1
- Windows 10
