### PR TITLE
Add script prefix for navigation in the revision grid

### DIFF
--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -442,6 +442,22 @@ namespace GitUI.Script
                 return false;
             }
 
+            if (command.StartsWith(NavigateToPrefix))
+            {
+                command = command.Replace(NavigateToPrefix, string.Empty);
+                if (!command.IsNullOrEmpty())
+                {
+                    var revisionRef = new Executable(command, module.WorkingDir).GetOutputLines(argument).FirstOrDefault();
+
+                    if (revisionRef != null)
+                    {
+                        revisionGrid.GoToRef(revisionRef, true);
+                    }
+                }
+
+                return false;
+            }
+
             if (!scriptInfo.RunInBackground)
             {
                 FormProcess.ShowStandardProcessDialog(owner, command, argument, module.WorkingDir, null, true);
@@ -577,6 +593,7 @@ namespace GitUI.Script
         };
 
         private const string PluginPrefix = "plugin:";
+        private const string NavigateToPrefix = "navigateTo:";
 
         private static string OverrideCommandWhenNecessary(string originalCommand)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5615.

Changes proposed in this pull request:
Introduced new user script prefix `navigateTo:`. The script (minus the prefix) is executed normally (and synchronously). The first line of its output (if any) is used as a target revision to navigate to in the revision grid. The grid is **not** refreshed after that (it is assumed the script has no side effects).
 
What did I do to test the code and ensure quality:
Manual testing with various scripts (both valid and invalid).

Has been tested on (remove any that don't apply):
- git version 2.19.1.windows.1
- Windows 10
