### PR TITLE
Add default action for "Rename branch" context menu item when only one branch selected

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -242,6 +242,7 @@ namespace GitUI
             this.renameBranchToolStripMenuItem.Name = "renameBranchToolStripMenuItem";
             this.renameBranchToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
             this.renameBranchToolStripMenuItem.Text = "Rename branch";
+            this.renameBranchToolStripMenuItem.Click += new System.EventHandler(this.renameBranchToolStripMenuItem_Click);
             // 
             // deleteBranchToolStripMenuItem
             // 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2216,6 +2216,16 @@ namespace GitUI
             }
         }
 
+        private void renameBranchToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var item = (ToolStripMenuItem)sender;
+
+            if (item.DropDown != null && item.DropDown.Items.Count == 1)
+            {
+                item.DropDown.Items[0].PerformClick();
+            }
+        }
+
         private void deleteBranchTagToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var item = (ToolStripMenuItem)sender;


### PR DESCRIPTION
If selected commit contains only in one branch, then click on menu item "Rename branch" acted like click on the one sub item

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5630

Changes proposed in this pull request:
- added default action for "Rename branch" context menu item when only one branch selected
 
What did I do to test the code and ensure quality:
- select the branch in revision grid that has no other branches for this commit
- open context menu
- choose "Rename branch"
- the "Rename branch" dialog appears for the branch


