### PR TITLE
Allow esc key in commit diff to close FormCommit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -264,6 +264,8 @@ namespace GitUI.CommandsDialogs
             splitRight.Panel2MinSize = Math.Max(splitRight.Panel2MinSize, flowCommitButtons.PreferredSize.Height);
             splitRight.SplitterDistance = Math.Min(splitRight.SplitterDistance, splitRight.Height - splitRight.Panel2MinSize);
 
+            SelectedDiff.EscapePressed += () => DialogResult = DialogResult.Cancel;
+
             InitializeComplete();
 
             // By calling this in the constructor, we prevent flickering caused by resizing the

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -264,7 +264,7 @@ namespace GitUI.CommandsDialogs
             splitRight.Panel2MinSize = Math.Max(splitRight.Panel2MinSize, flowCommitButtons.PreferredSize.Height);
             splitRight.SplitterDistance = Math.Min(splitRight.SplitterDistance, splitRight.Height - splitRight.Panel2MinSize);
 
-            SelectedDiff.EscapePressed += () => DialogResult = DialogResult.Cancel;
+            SelectedDiff.EscapePressed += delegate { DialogResult = DialogResult.Cancel; };
 
             InitializeComplete();
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -264,7 +264,7 @@ namespace GitUI.CommandsDialogs
             splitRight.Panel2MinSize = Math.Max(splitRight.Panel2MinSize, flowCommitButtons.PreferredSize.Height);
             splitRight.SplitterDistance = Math.Min(splitRight.SplitterDistance, splitRight.Height - splitRight.Panel2MinSize);
 
-            SelectedDiff.EscapePressed += delegate { DialogResult = DialogResult.Cancel; };
+            SelectedDiff.EscapePressed += () => DialogResult = DialogResult.Cancel;
 
             InitializeComplete();
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -17,7 +17,6 @@ using GitUI.Hotkey;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
-using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 
 namespace GitUI.Editor
@@ -25,6 +24,11 @@ namespace GitUI.Editor
     [DefaultEvent("SelectedLineChanged")]
     public partial class FileViewer : GitModuleControl
     {
+        /// <summary>
+        /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
+        /// </summary>
+        public event Action EscapePressed;
+
         private readonly TranslationString _largeFileSizeWarning = new TranslationString("This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.");
 
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
@@ -71,6 +75,7 @@ namespace GitUI.Editor
             internalFileViewer.MouseLeave += (_, e) => OnMouseLeave(e);
             internalFileViewer.MouseMove += (_, e) => OnMouseMove(e);
             internalFileViewer.KeyUp += (_, e) => OnKeyUp(e);
+            internalFileViewer.EscapePressed += () => EscapePressed?.Invoke();
 
             _async = new AsyncLoader();
             _async.LoadingError +=

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -27,7 +27,7 @@ namespace GitUI.Editor
         /// <summary>
         /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
         /// </summary>
-        public event Action EscapePressed;
+        public event EventHandler<EventArgs> EscapePressed;
 
         private readonly TranslationString _largeFileSizeWarning = new TranslationString("This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.");
 
@@ -75,7 +75,7 @@ namespace GitUI.Editor
             internalFileViewer.MouseLeave += (_, e) => OnMouseLeave(e);
             internalFileViewer.MouseMove += (_, e) => OnMouseMove(e);
             internalFileViewer.KeyUp += (_, e) => OnKeyUp(e);
-            internalFileViewer.EscapePressed += () => EscapePressed?.Invoke();
+            internalFileViewer.EscapePressed += (_, e) => EscapePressed?.Invoke(this, e);
 
             _async = new AsyncLoader();
             _async.LoadingError +=

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -27,7 +27,7 @@ namespace GitUI.Editor
         /// <summary>
         /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
         /// </summary>
-        public event EventHandler<EventArgs> EscapePressed;
+        public event Action EscapePressed;
 
         private readonly TranslationString _largeFileSizeWarning = new TranslationString("This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.");
 
@@ -75,7 +75,7 @@ namespace GitUI.Editor
             internalFileViewer.MouseLeave += (_, e) => OnMouseLeave(e);
             internalFileViewer.MouseMove += (_, e) => OnMouseMove(e);
             internalFileViewer.KeyUp += (_, e) => OnKeyUp(e);
-            internalFileViewer.EscapePressed += (_, e) => EscapePressed?.Invoke(this, e);
+            internalFileViewer.EscapePressed += () => EscapePressed?.Invoke();
 
             _async = new AsyncLoader();
             _async.LoadingError +=

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -11,6 +11,11 @@ namespace GitUI.Editor
 {
     public partial class FileViewerInternal : GitModuleControl, IFileViewer
     {
+        /// <summary>
+        /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
+        /// </summary>
+        public event Action EscapePressed;
+
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
         public new event MouseEventHandler MouseMove;
         public new event EventHandler MouseEnter;
@@ -29,6 +34,14 @@ namespace GitUI.Editor
             InitializeComplete();
 
             _currentViewPositionCache = new CurrentViewPositionCache(this);
+
+            TextEditor.ActiveTextAreaControl.TextArea.PreviewKeyDown += (s, e) =>
+            {
+                if (e.KeyCode == Keys.Escape && !TextEditor.ActiveTextAreaControl.SelectionManager.HasSomethingSelected)
+                {
+                    EscapePressed?.Invoke();
+                }
+            };
 
             TextEditor.TextChanged += (s, e) => TextChanged?.Invoke(s, e);
             TextEditor.ActiveTextAreaControl.VScrollBar.ValueChanged += (s, e) => ScrollPosChanged?.Invoke(s, e);

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -14,7 +14,7 @@ namespace GitUI.Editor
         /// <summary>
         /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
         /// </summary>
-        public event Action EscapePressed;
+        public event EventHandler<EventArgs> EscapePressed;
 
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
         public new event MouseEventHandler MouseMove;
@@ -39,7 +39,7 @@ namespace GitUI.Editor
             {
                 if (e.KeyCode == Keys.Escape && !TextEditor.ActiveTextAreaControl.SelectionManager.HasSomethingSelected)
                 {
-                    EscapePressed?.Invoke();
+                    EscapePressed?.Invoke(this, EventArgs.Empty);
                 }
             };
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -14,7 +14,7 @@ namespace GitUI.Editor
         /// <summary>
         /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
         /// </summary>
-        public event EventHandler<EventArgs> EscapePressed;
+        public event Action EscapePressed;
 
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
         public new event MouseEventHandler MouseMove;
@@ -39,7 +39,7 @@ namespace GitUI.Editor
             {
                 if (e.KeyCode == Keys.Escape && !TextEditor.ActiveTextAreaControl.SelectionManager.HasSomethingSelected)
                 {
-                    EscapePressed?.Invoke(this, EventArgs.Empty);
+                    EscapePressed?.Invoke();
                 }
             };
 


### PR DESCRIPTION
#### Changes proposed in this pull request:
- <kbd>Esc</kbd> dismisses `FormCommit` if diff view focussed

Previously, pressing <kbd>Esc</kbd> in either file list of the message box would dismiss `FormCommit`. However if focus was in the diff view, escape would not.

This commit fixes this behaviour. It also ensures if text is selected, the first keypress clears the selection, as previously happened.

This event is currently only used in FormCommit but may be useful elsewhere.

#### What did I do to test the code and ensure quality:
- Manual testing

#### Has been tested on:
- Windows 10
