### PR TITLE
Fix bug where long branch names overflow list view

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -393,7 +393,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             var width = AppSettings.RecentReposComboMinWidth;
             if (width < 1)
             {
-                width = longestPath.Width;
+                width = longestPath.Width + imageList1.ImageSize.Width;
             }
 
             var height = longestPath.Height + (2 * branchTextSize.Height) +
@@ -414,9 +414,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static string ShortenText(string text, Font font, float maxWidth)
         {
+            var width = TextRenderer.MeasureText(text, font).Width;
+            if (width < maxWidth)
+            {
+               return text;
+            }
+
             while (text.Length > 1)
             {
-                var width = TextRenderer.MeasureText(text, font).Width;
+                width = TextRenderer.MeasureText(text + "...", font).Width;
                 if (width < maxWidth)
                 {
                     break;
@@ -425,7 +431,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 text = text.Substring(0, text.Length - 1);
             }
 
-            return text;
+            return text + "...";
         }
 
         private bool PromptCategoryName(List<string> categories, string originalName, out string name)
@@ -502,7 +508,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             var spacing6 = DpiUtil.Scale(6f);
 
             var textOffset = spacing2 + imageList1.ImageSize.Width + spacing2;
-            int textWidth = AppSettings.RecentReposComboMinWidth > 0 ? AppSettings.RecentReposComboMinWidth : e.Bounds.Width;
+            int textWidth = e.Bounds.Width - (int)textOffset;
 
             if (e.Item == HoveredItem)
             {

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -414,6 +414,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static string ShortenText(string text, Font font, float maxWidth)
         {
+            var ellipsis = '…';
             var width = TextRenderer.MeasureText(text, font).Width;
             if (width < maxWidth)
             {
@@ -422,7 +423,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             while (text.Length > 1)
             {
-                width = TextRenderer.MeasureText(text + "...", font).Width;
+                width = TextRenderer.MeasureText(text + ellipsis, font).Width;
                 if (width < maxWidth)
                 {
                     break;
@@ -431,7 +432,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 text = text.Substring(0, text.Length - 1);
             }
 
-            return text + "...";
+            return text + ellipsis;
         }
 
         private bool PromptCategoryName(List<string> categories, string originalName, out string name)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5625 

Changes proposed in this pull request:
 - Include icon width when calculating tile size
 - Add ellipsis when truncating branch names/repo paths
 
Screenshots:

Before:

![gitextensions-issue](https://user-images.githubusercontent.com/18647401/47608457-09a1a100-da26-11e8-8423-878556217d6a.png)

After:

![gitextensions-fixed](https://user-images.githubusercontent.com/18647401/47608460-11f9dc00-da26-11e8-8578-b83408f3c18d.png)

What did I do to test the code and ensure quality:
- Ran the tests
- Ran the linter

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 7
