### PR TITLE
Browse: Go to common ancestor w multiple selections

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -111,7 +111,7 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     Name = "GotoMergeBaseCommit",
                     Text = "Go to common ancestor (merge base)",
-                    ToolTipText = "Go to the common ancestor (merge base) commit, which is the best common commit between the currently checked out commit (HEAD) and the currently selected commit",
+                    ToolTipText = "Go to the common ancestor (merge base) commit, which is the best common commit for the selected commits (with one selected commit: to the currently checked out commit (HEAD))",
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Commands.GoToMergeBaseCommit),
                     ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Commands.GoToMergeBaseCommit)
                 },


### PR DESCRIPTION
Previously just the selected commit was compared to HEAD
(behavior not changed if only one selected commit)

System.FormatException when an artificial commit was selected.
Artificial commits are now replaced with HEAD, which is normally what you want
(rather than a popup informing that this is illegal)
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- GIT 2.19