### PR TITLE
Most commits do not have link; do not switch to main thread if not needed

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -254,6 +254,12 @@ namespace GitUI.CommitInfo
                     await TaskScheduler.Default;
                     var linksInfo = GetLinksForRevision();
 
+                    // Most commits do not have link; do not switch to main thread if nothing is changed
+                    if (_linksInfo == linksInfo)
+                    {
+                        return;
+                    }
+
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _linksInfo = linksInfo;
                     UpdateRevisionInfo();


### PR DESCRIPTION
Changes proposed in this pull request:
- Check if rebuilding commitinfo is needed
 
What did I do to test the code and ensure quality:
- Performance profiling
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
