### PR TITLE
Fix commitInfo scroll on mouse wheel

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -754,7 +754,7 @@ namespace GitUI.CommandsDialogs
             this.RevisionInfo.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             this.RevisionInfo.BackColor = System.Drawing.SystemColors.Window;
             this.RevisionInfo.Cursor = System.Windows.Forms.Cursors.IBeam;
-            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Top;
+            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RevisionInfo.Location = new System.Drawing.Point(0, 0);
             this.RevisionInfo.Margin = new System.Windows.Forms.Padding(0);
             this.RevisionInfo.Name = "RevisionInfo";

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1214,11 +1214,6 @@ namespace GitUI.CommandsDialogs
 
             var children = RevisionGrid.GetRevisionChildren(revision.ObjectId);
             RevisionInfo.SetRevisionWithChildren(revision, children);
-            if (RevisionInfo.Parent is Panel parent)
-            {
-                parent.AutoScroll = true;
-                parent.AutoScrollMinSize = RevisionInfo.PreferredSize;
-            }
         }
 
         private async Task FillGpgInfoAsync()

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommitInfo
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommitInfo
 {
     partial class CommitInfo
     {
@@ -57,10 +59,9 @@
             this.tableLayout.BackColor = System.Drawing.SystemColors.Window;
             this.tableLayout.ColumnCount = 1;
             this.tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayout.Controls.Add(this.pnlCommitMessage, 0, 1);
             this.tableLayout.Controls.Add(this.commitInfoHeader, 0, 0);
+            this.tableLayout.Controls.Add(this.pnlCommitMessage, 0, 1);
             this.tableLayout.Controls.Add(this.RevisionInfo, 0, 2);
-            this.tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayout.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
             this.tableLayout.Location = new System.Drawing.Point(8, 8);
             this.tableLayout.Margin = new System.Windows.Forms.Padding(0);
@@ -76,26 +77,26 @@
             // 
             // pnlCommitMessage
             // 
+            this.pnlCommitMessage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pnlCommitMessage.AutoSize = true;
             this.pnlCommitMessage.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.pnlCommitMessage.Controls.Add(this.rtbxCommitMessage);
-            this.pnlCommitMessage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlCommitMessage.Location = new System.Drawing.Point(4, 108);
             this.pnlCommitMessage.Margin = new System.Windows.Forms.Padding(0);
             this.pnlCommitMessage.Name = "pnlCommitMessage";
-            this.pnlCommitMessage.Padding = new System.Windows.Forms.Padding(8);
             this.pnlCommitMessage.Size = new System.Drawing.Size(427, 36);
             this.pnlCommitMessage.TabIndex = 0;
             // 
             // rtbxCommitMessage
             // 
-            this.rtbxCommitMessage.AutoSize = true;
             this.rtbxCommitMessage.BackColor = System.Drawing.SystemColors.ControlLight;
             this.rtbxCommitMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.rtbxCommitMessage.ContextMenuStrip = this.commitInfoContextMenuStrip;
-            this.rtbxCommitMessage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.rtbxCommitMessage.Location = new System.Drawing.Point(8, 8);
-            this.rtbxCommitMessage.Margin = new System.Windows.Forms.Padding(0);
+            this.rtbxCommitMessage.Margin = new System.Windows.Forms.Padding(8);
             this.rtbxCommitMessage.Name = "rtbxCommitMessage";
+            this.rtbxCommitMessage.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
             this.rtbxCommitMessage.Size = new System.Drawing.Size(411, 20);
             this.rtbxCommitMessage.TabIndex = 1;
             this.rtbxCommitMessage.Text = "";
@@ -187,24 +188,24 @@
             // 
             this.commitInfoHeader.AutoSize = true;
             this.commitInfoHeader.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.commitInfoHeader.Dock = System.Windows.Forms.DockStyle.Fill;
             this.commitInfoHeader.Location = new System.Drawing.Point(4, 4);
             this.commitInfoHeader.Margin = new System.Windows.Forms.Padding(0);
             this.commitInfoHeader.Name = "commitInfoHeader";
             this.commitInfoHeader.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
-            this.commitInfoHeader.Size = new System.Drawing.Size(427, 104);
+            this.commitInfoHeader.Size = new System.Drawing.Size(118, 104);
             this.commitInfoHeader.TabIndex = 0;
             // 
             // RevisionInfo
             // 
+            this.RevisionInfo.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left);
             this.RevisionInfo.BackColor = System.Drawing.SystemColors.Window;
             this.RevisionInfo.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.RevisionInfo.ContextMenuStrip = this.commitInfoContextMenuStrip;
-            this.RevisionInfo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RevisionInfo.Location = new System.Drawing.Point(4, 144);
             this.RevisionInfo.Margin = new System.Windows.Forms.Padding(0);
             this.RevisionInfo.Name = "RevisionInfo";
             this.RevisionInfo.ReadOnly = true;
+            this.RevisionInfo.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
             this.RevisionInfo.Size = new System.Drawing.Size(427, 134);
             this.RevisionInfo.TabIndex = 2;
             this.RevisionInfo.Text = "";
@@ -216,6 +217,8 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoScroll = true;
+            this.BackColor = System.Drawing.SystemColors.Window;
             this.Controls.Add(this.tableLayout);
             this.DoubleBuffered = true;
             this.Name = "CommitInfo";

--- a/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.Designer.cs
@@ -53,6 +53,7 @@
             // avatarControl
             // 
             this.avatarControl.AutoSize = true;
+            this.avatarControl.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.avatarControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.avatarControl.Location = new System.Drawing.Point(0, 0);
             this.avatarControl.Margin = new System.Windows.Forms.Padding(0);
@@ -71,6 +72,7 @@
             tableLayoutPanel1.Controls.Add(this.rtbRevisionHeader, 1, 0);
             tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 1;
             tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -81,9 +83,7 @@
             // 
             this.rtbRevisionHeader.BackColor = System.Drawing.SystemColors.Window;
             this.rtbRevisionHeader.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.rtbRevisionHeader.Dock = System.Windows.Forms.DockStyle.Fill;
             this.rtbRevisionHeader.Location = new System.Drawing.Point(104, 0);
-            this.rtbRevisionHeader.Margin = new System.Windows.Forms.Padding(0);
             this.rtbRevisionHeader.Name = "rtbRevisionHeader";
             this.rtbRevisionHeader.ReadOnly = true;
             this.rtbRevisionHeader.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
@@ -91,7 +91,6 @@
             this.rtbRevisionHeader.TabIndex = 0;
             this.rtbRevisionHeader.Text = "";
             this.rtbRevisionHeader.WordWrap = false;
-            this.rtbRevisionHeader.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this.rtbRevisionHeader_ContentsResized);
             this.rtbRevisionHeader.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbRevisionHeader_LinkClicked);
             this.rtbRevisionHeader.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rtbRevisionHeader_KeyDown);
             this.rtbRevisionHeader.MouseDown += new System.Windows.Forms.MouseEventHandler(this.rtbRevisionHeader_MouseDown);


### PR DESCRIPTION
Fixes not working scroll on mouse wheel in `CommitInfo` control, hhe issue was reported in #5611.

Changes proposed in this pull request:
- `CommitInfoHeader` is resized to fit content. Prior to this change, scrolling `CommitInfo` horizontally to the rightmost position did not guarantee seeng the rightmost edge of `CommitInfoHeader` text
- MouseWheelRedirector skips RichTextBox with hidden Scrollbar
 
Tested on Windows 7