### PR TITLE
#5125 RevisionGrid Graph: Nearest branch in tooltip

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -11,6 +11,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     internal sealed class LaneInfoProvider
     {
         private static readonly TranslationString NoInfoText = new TranslationString("Sorry, this commit seems to be not loaded.");
+        private static readonly TranslationString MergedWithText = new TranslationString(" (merged with {0})");
+        internal static readonly TranslationString ByPullRequestText = new TranslationString(" by pull request {0}");
         private readonly ILaneNodeLocator _nodeLocator;
 
         public LaneInfoProvider(ILaneNodeLocator nodeLocator)
@@ -40,6 +42,17 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 }
 
                 laneInfoText.AppendLine(node.GitRevision.Guid);
+
+                var branch = new BranchFinder(node);
+                if (branch.CommittedTo.IsNotNullOrWhitespace())
+                {
+                    laneInfoText.AppendFormat("\n{0}: {1}", Strings.Branch, branch.CommittedTo);
+                    if (branch.MergedWith.IsNotNullOrWhitespace())
+                    {
+                        laneInfoText.AppendFormat(MergedWithText.Text, branch.MergedWith);
+                    }
+                }
+
                 laneInfoText.AppendLine();
             }
 
@@ -62,6 +75,96 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         internal readonly struct TestAccessor
         {
             internal static TranslationString NoInfoText => LaneInfoProvider.NoInfoText;
+            internal static TranslationString MergedWithText => LaneInfoProvider.MergedWithText;
+            internal static TranslationString ByPullRequestText => LaneInfoProvider.ByPullRequestText;
+        }
+    }
+
+    internal class BranchFinder
+    {
+        private static readonly Regex MergeRegex = new Regex("(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$",
+                                                             RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        internal BranchFinder([NotNull] RevisionGraphRevision node)
+        {
+            RevisionGraphRevision parent = null;
+            while (!CheckForMerge(node, parent) && !FindBranch(node) && node.Children.Any())
+            {
+                // try the first child and its children
+                parent = node;
+                node = node.Children.First();
+            }
+        }
+
+        internal string CommittedTo { get; private set; }
+        internal string MergedWith { get; private set; }
+
+        private bool FindBranch([NotNull] RevisionGraphRevision node)
+        {
+            foreach (var gitReference in node.GitRevision.Refs)
+            {
+                if (gitReference.IsHead || gitReference.IsRemote || gitReference.IsStash)
+                {
+                    CommittedTo = gitReference.Name;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether the commit message is a merge message
+        /// and then if its a merge message, sets CommittedTo and MergedWith.
+        ///
+        /// MergedWith is set if it is the current node, i.e. on the first call.
+        /// MergedWith is set to string.Empty if it is no merge.
+        /// First/second branch does not matter because it is the message of the current node.
+        /// </summary>
+        /// <param name="node">the node of the revision to evaluate</param>
+        /// <param name="parent">
+        /// the node's parent in the branch which is currently descended
+        /// (used for the decision whether the node belongs to the first or second branch of the merge)
+        /// </param>
+        private bool CheckForMerge([NotNull] RevisionGraphRevision node, [CanBeNull] RevisionGraphRevision parent)
+        {
+            bool isTheFirstBranch = parent == null || node.Parents.IsEmpty || node.Parents.First() == parent;
+            string mergedInto;
+            string mergedWith;
+            (mergedInto, mergedWith) = ParseMergeMessage(node.GitRevision.Subject, appendPullRequest: isTheFirstBranch);
+
+            if (mergedInto != null)
+            {
+                CommittedTo = isTheFirstBranch ? mergedInto : mergedWith;
+            }
+
+            if (MergedWith == null)
+            {
+                MergedWith = mergedWith ?? string.Empty;
+            }
+
+            return CommittedTo != null;
+        }
+
+        private static (string into, string with) ParseMergeMessage([NotNull] string commitSubject, bool appendPullRequest)
+        {
+            string into = null;
+            string with = null;
+            var match = MergeRegex.Match(commitSubject);
+            if (match.Success)
+            {
+                var matchPullRequest = match.Groups[2];
+                var matchWith = match.Groups[4];
+                var matchInto = match.Groups[7];
+                into = matchInto.Success ? matchInto.Value : "master";
+                with = matchWith.Success ? matchWith.Value : "?";
+                if (appendPullRequest && matchPullRequest.Success)
+                {
+                    with += string.Format(LaneInfoProvider.ByPullRequestText.Text, matchPullRequest);
+                }
+            }
+
+            return (into, with);
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -92,7 +92,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             {
                 // try the first child and its children
                 parent = node;
-                node = node.Children.First();
+                node = node.Children.Last(); // note: Children are stored in reverse order
             }
         }
 
@@ -128,7 +128,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// </param>
         private bool CheckForMerge([NotNull] RevisionGraphRevision node, [CanBeNull] RevisionGraphRevision parent)
         {
-            bool isTheFirstBranch = parent == null || node.Parents.IsEmpty || node.Parents.First() == parent;
+            bool isTheFirstBranch = parent == null || node.Parents.IsEmpty || node.Parents.Last() == parent; // note: Parents are stored in reverse order
             string mergedInto;
             string mergedWith;
             (mergedInto, mergedWith) = ParseMergeMessage(node.GitRevision.Subject, appendPullRequest: isTheFirstBranch);

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -13,8 +13,82 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
     [TestFixture]
     public class LaneInfoProviderTests
     {
+        /// <summary>
+        /// triples of merge subject, merged branch and destination branch ("into")
+        /// for testing the LaneInfoProvider.References.MergeRegex
+        /// "(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$"
+        /// </summary>
+        private static readonly List<string> MergeSubjectsWithDecoding = new List<string>()
+        {
+            "Merge Branch xxx", // case-insignificance
+            "xxx", "master",
+
+            "merge branch xxx", // imperative
+            "xxx", "master",
+
+            "merged branch xxx", // past tense
+            "xxx", "master",
+
+            "merge pull request #1234 from xxx", // pull request
+            "xxx" + string.Format(LaneInfoProvider.TestAccessor.ByPullRequestText.Text, "#1234"), "master",
+
+            "merge tag yyy of remote/branch", // tag with (ignored) remote branch
+            "yyy", "master",
+
+            "merge tag yyy", // tag without ''
+            "yyy", "master",
+
+            "merge tag 'yyy'", // tag in ''
+            "yyy", "master",
+
+            "merge branch 'xxx'", // branch in ''
+            "xxx", "master",
+
+            "merge remote tracking branch xxx", // any text before branch
+            "xxx", "master",
+
+            "merge the branch xxx", // any text before branch
+            "xxx", "master",
+
+            "merge branch xxx into zzz", // into
+            "xxx", "zzz",
+
+            "Merged branch xxx.", // sentence
+            "xxx", "master",
+
+            "Merged branch xx.x.", // sentence with dot in branch
+            "xx.x", "master",
+
+            "Merged branch xxx into zzz.", // sentence with into
+            "xxx", "zzz",
+
+            "Merged branch xxx into zz.z.", // sentence with dot in into
+            "xxx", "zz.z",
+
+            "Merged tag yyy.", // sentence with tag
+            "yyy", "master",
+
+            "Merged tag yy.y.", // sentence with dot in tag
+            "yy.y", "master",
+
+            "Merged tag yyy of remote/branch.", // sentence with tag and remote
+            "yyy", "master",
+
+            "Merged tag yyy of remote/branc.h.", // sentence with tag and dot in remote
+            "yyy", "master",
+
+            "Merged tag yyy of remote/branch into zzz.", // sentence with tag, remote and into
+            "yyy", "zzz",
+
+            "Merged tag yyy of remote/branch into zz.z.", // sentence with tag, remote and dot in into
+            "yyy", "zz.z"
+        };
+
         private RevisionGraphRevision _artificialCommitNode;
         private RevisionGraphRevision _realCommitNode;
+        private RevisionGraphRevision _mergeCommitNode;
+        private RevisionGraphRevision _undetectedMergeCommitNode;
+        private RevisionGraphRevision _innerCommitNode;
         private ILaneNodeLocator _laneNodeLocator;
         private LaneInfoProvider _infoProvider;
 
@@ -43,17 +117,61 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
                     Body = "fix: bugs\r\n\r\nall bugs fixed"
                 }
             };
+            var mergeCommitObjectId = ObjectId.Parse("b48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _mergeCommitNode = new RevisionGraphRevision(mergeCommitObjectId, 0)
+            {
+                GitRevision = new GitCommands.GitRevision(mergeCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "merge remote tracking branch upstream/branch",
+                    Body = "merge commit's subject here will not be parsed\r\n\r\nmerge commit's body might list details and/or conflicts...",
+                    HasMultiLineMessage = true
+                }
+            };
+            var undetectedMergeCommitObjectId = ObjectId.Parse("c48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _undetectedMergeCommitNode = new RevisionGraphRevision(undetectedMergeCommitObjectId, 0)
+            {
+                GitRevision = new GitCommands.GitRevision(undetectedMergeCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "special merge",
+                    Body = "merge commit's subject here will not be parsed\r\n\r\nmerge commit's body might list details and/or conflicts...",
+                    HasMultiLineMessage = true
+                }
+            };
+            var innerCommitObjectId = ObjectId.Parse("d48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _innerCommitNode = new RevisionGraphRevision(innerCommitObjectId, 0)
+            {
+                GitRevision = new GitCommands.GitRevision(innerCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "fix: further bugs",
+                    Body = "fix: further bugs"
+                }
+            };
             _laneNodeLocator = Substitute.For<ILaneNodeLocator>();
             _infoProvider = new LaneInfoProvider(_laneNodeLocator);
         }
 
-        private void GetLaneInfo_should_display(RevisionGraphRevision node, string prefix = "", string suffix = "")
+        private void GetLaneInfo_should_display(RevisionGraphRevision node,
+            string branch = null, string mergedWith = null,
+            string prefix = "", string suffix = "")
         {
             _infoProvider.GetLaneInfo(0, 0).Should()
-                .Be(string.Format("{0}{1}{2}{2}{3}{4}",
+                .Be(string.Format(branch == null ? "{0}{1}{2}{2}{6}{7}"
+                                                 : "{0}{1}{2}\n{3}: {4}{5}{2}{6}{7}",
                     prefix,
                     node.GitRevision.Guid,
                     Environment.NewLine,
+                    Strings.Branch,
+                    branch,
+                    mergedWith == null ? "" : string.Format(LaneInfoProvider.TestAccessor.MergedWithText.Text, mergedWith),
                     node.GitRevision.Body,
                     suffix));
         }
@@ -123,6 +241,213 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
 
             GetLaneInfo_should_display(_realCommitNode, suffix: _realCommitNode.GitRevision.Subject + Strings.BodyNotLoaded);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_branch_and_source_from_merge_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_mergeCommitNode, isAtNode: false));
+
+            for (int index = 0; index < MergeSubjectsWithDecoding.Count; index += 3)
+            {
+                string subject = MergeSubjectsWithDecoding[index + 0];
+                string mergedWith = MergeSubjectsWithDecoding[index + 1];
+                string into = MergeSubjectsWithDecoding[index + 2];
+                _mergeCommitNode.GitRevision.Subject = subject;
+
+                GetLaneInfo_should_display(_mergeCommitNode, into, mergedWith);
+            }
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_only_the_branch_from_next_merge_node()
+        {
+            int maxScoreIsIgnored;
+            _mergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            for (int index = 0; index < MergeSubjectsWithDecoding.Count; index += 3)
+            {
+                string subject = MergeSubjectsWithDecoding[index + 0];
+                string mergedWith = MergeSubjectsWithDecoding[index + 1];
+                string into = MergeSubjectsWithDecoding[index + 2];
+                _mergeCommitNode.GitRevision.Subject = subject;
+
+                GetLaneInfo_should_display(_realCommitNode, into);
+            }
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_only_the_branch_from_detected_merge_node_in_a_tree()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // merge
+            // |     \
+            // inner  (omitted)
+            // |
+            // undetected merge
+            // |               \
+            // real             (omitted)
+            int maxScoreIsIgnored;
+            _mergeCommitNode.AddParent(_innerCommitNode, out maxScoreIsIgnored);
+            _innerCommitNode.AddParent(_undetectedMergeCommitNode, out maxScoreIsIgnored);
+            _undetectedMergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.GitRevision.Subject = subject;
+
+            GetLaneInfo_should_display(_realCommitNode, into);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_only_the_branch_from_inner_node_in_a_tree()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // merge
+            // |    \
+            // inner (omitted)
+            // |
+            // real
+            int maxScoreIsIgnored;
+            _mergeCommitNode.AddParent(_innerCommitNode, out maxScoreIsIgnored);
+            _innerCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _realCommitNode.GitRevision.Refs = new GitRef[] { new GitRef(null, null, GitRefName.RefsTagsPrefix + "tag_shall_be_ignored") };
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            Check(new GitRef(null, null, GitRefName.RefsHeadsPrefix + "local_branch"));
+            Check(new GitRef(null, null, GitRefName.RefsRemotesPrefix + "remote_branch", "origin"));
+            Check(new GitRef(null, null, GitRefName.RefsStashPrefix + "@0"));
+
+            return;
+
+            void Check(GitRef gitRef)
+            {
+                _innerCommitNode.GitRevision.Refs = new GitRef[] { gitRef };
+
+                GetLaneInfo_should_display(_realCommitNode, gitRef.Name);
+            }
+        }
+
+        [Test]
+        public void GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef__at_junction_node()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // merge
+            // |    \
+            // real  (omitted)
+            int maxScoreIsIgnored;
+            _mergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+
+            GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef();
+        }
+
+        [Test]
+        public void GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef__at_inner_node()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // artificial
+            // |
+            // merge
+            // |    \
+            // real  (omitted or maybe even missing)
+            int maxScoreIsIgnored;
+            _artificialCommitNode.AddParent(_mergeCommitNode, out maxScoreIsIgnored);
+            _mergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+
+            GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef();
+        }
+
+        private void GetLaneInfo_should_prefer_the_branch_from_merge_to_a_GitRef()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.GitRevision.Subject = subject;
+
+            var gitRef = new GitRef(null, null, GitRefName.RefsHeadsPrefix + "local_branch");
+            _mergeCommitNode.GitRevision.Refs = new GitRef[] { gitRef };
+
+            GetLaneInfo_should_display(_realCommitNode, into);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_the_merged_branch()
+        {
+            // test tree
+            //
+            // merge
+            // |    \
+            // inner real
+            int maxScoreIsIgnored;
+            _mergeCommitNode.AddParent(_innerCommitNode, out maxScoreIsIgnored);
+            _mergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.GitRevision.Subject = subject;
+
+            GetLaneInfo_should_display(_realCommitNode, branch: mergedWith);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_not_display_a_branch_if_none_to_detect()
+        {
+            // synthetic test tree
+            //
+            // artificial
+            // |
+            // undetected merge
+            // |   \
+            // |    inner
+            // |   /
+            // real
+            int maxScoreIsIgnored;
+            _artificialCommitNode.AddParent(_undetectedMergeCommitNode, out maxScoreIsIgnored);
+            _undetectedMergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _undetectedMergeCommitNode.AddParent(_innerCommitNode, out maxScoreIsIgnored);
+            _innerCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            GetLaneInfo_should_display(_realCommitNode);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_not_display_a_branch_if_none_at_first_children()
+        {
+            // synthetic test tree which does not need the right junction of merges
+            //
+            // artificial
+            // |  merge
+            // |  |     \
+            // |  inner  (omitted)
+            // | /
+            // undetected merge
+            // |               \
+            // real             (omitted)
+            int maxScoreIsIgnored;
+            _artificialCommitNode.AddParent(_undetectedMergeCommitNode, out maxScoreIsIgnored);
+            _undetectedMergeCommitNode.AddParent(_realCommitNode, out maxScoreIsIgnored);
+            _mergeCommitNode.AddParent(_innerCommitNode, out maxScoreIsIgnored);
+            _innerCommitNode.AddParent(_undetectedMergeCommitNode, out maxScoreIsIgnored);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            string subject = MergeSubjectsWithDecoding[0];
+            string mergedWith = MergeSubjectsWithDecoding[1];
+            string into = MergeSubjectsWithDecoding[2];
+            _mergeCommitNode.GitRevision.Subject = subject;
+
+            GetLaneInfo_should_display(_realCommitNode);
         }
     }
 }


### PR DESCRIPTION
Fixes #5125.
Fixes #4450.
Supersedes #5436 (adapted to new Revision Graph model).

#### Changes proposed in this pull request:
- Show nearest branch in tooltip of Revision Graph

#### Screenshots before and after (if PR changes UI):
- before
![grafik](https://user-images.githubusercontent.com/36601201/47819035-98315d80-dd59-11e8-917f-8a514a7607c9.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/47819083-b6975900-dd59-11e8-9cde-bedf8f9187c3.png)
![grafik](https://user-images.githubusercontent.com/36601201/47819201-1a218680-dd5a-11e8-8064-2ee2de62cc6e.png)

#### What did I do to test the code and ensure quality:
- Add NUnit tests

#### Has been tested on (remove any that don't apply):
- Git Extensions 3.00.rc2
- 15258628f2415e635a998f32489bb44b9759b258 
- Git 2.19.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI X:100,00% Y:100,00%