### PR TITLE
#5642 fix performance issue when selecting large diff

### DIFF
--- a/GitExtUtils/BinarySearch.cs
+++ b/GitExtUtils/BinarySearch.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace GitCommands
+{
+    public static class BinarySearch
+    {
+        /// <summary>
+        /// Find first integer between min and (min + count - 1) where "predicate" returns true.
+        /// </summary>
+        /// <remarks>
+        /// Assumes "predicate" is a non-decreasing function, i.e.
+        /// if predicate(i) == true then predicate(i + n) == true for any positive n.
+        /// </remarks>
+        public static int Find(int min, int count, Func<int, bool> predicate)
+        {
+            if (count == 0)
+            {
+                return -1;
+            }
+
+            if (predicate(min))
+            {
+                return min;
+            }
+
+            if (count == 1)
+            {
+                return -1;
+            }
+
+            int halfCount = count / 2;
+            int middle = min + halfCount;
+            int searchRightHalfResult = Find(middle, count - halfCount, predicate);
+
+            if (searchRightHalfResult > middle)
+            {
+                return searchRightHalfResult;
+            }
+
+            if (searchRightHalfResult == -1)
+            {
+                return -1;
+            }
+
+            // searchRightHalfResult == middle
+
+            int newLeft = min + 1;
+            int searchLeftResult = Find(newLeft, middle - newLeft, predicate);
+
+            if (searchLeftResult == -1)
+            {
+                return middle;
+            }
+
+            return searchLeftResult;
+        }
+    }
+}

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ArgumentBuilder.cs" />
     <Compile Include="ArgumentString.cs" />
     <Compile Include="ArrayExtensions.cs" />
+    <Compile Include="BinarySearch.cs" />
     <Compile Include="GitArgumentBuilder.cs" />
     <Compile Include="GitUI\CancellationTokenSequence.cs" />
     <Compile Include="GitUI\ComboBoxExtensions.cs" />

--- a/GitExtUtils/GitUI/ListViewExtensions.cs
+++ b/GitExtUtils/GitUI/ListViewExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
@@ -21,6 +22,16 @@ namespace GitUI
 
         public static T Tag<T>(this ListViewGroup grp) =>
             (T)grp.Tag;
+
+        public static Image Image(this ListViewItem item)
+        {
+            if (item.ImageList == null || item.ImageIndex == -1)
+            {
+                return null;
+            }
+
+            return item.ImageList.Images[item.ImageIndex];
+        }
 
         public static IEnumerable<T> ItemTags<T>(this ListView listView) =>
             listView.Items().Select(Tag<T>);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -39,6 +40,11 @@ namespace GitUI
         private IReadOnlyList<(GitRevision revision, IReadOnlyList<GitItemStatus> statuses)> _itemsWithParent = Array.Empty<(GitRevision, IReadOnlyList<GitItemStatus>)>();
         [CanBeNull] private IDisposable _selectedIndexChangeSubscription;
 
+        /// <summary>
+        /// flag to prevent recursion ClientSizeChanged -> UpdateColumnWidth -> ScrollBar visibility changed -> ClientSizeChanged
+        /// </summary>
+        private bool _updatingColumnWidth;
+
         public event EventHandler SelectedIndexChanged;
         public event EventHandler DataSourceChanged;
 
@@ -59,6 +65,7 @@ namespace GitUI
             FileStatusListView.SmallImageList = CreateImageList();
             FileStatusListView.LargeImageList = CreateImageList();
             FileStatusListView.AllowCollapseGroups = true;
+            FileStatusListView.Scroll += FileStatusListView_Scroll;
 
             HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: true);
             Controls.SetChildIndex(NoFiles, 0);
@@ -358,6 +365,20 @@ namespace GitUI
             }
         }
 
+        private static (Image Image, string Text, int TextStart, int TextWidth, int TextMaxWidth) FormatListViewItem(ListViewItem item, PathFormatter formatter, int itemWidth)
+        {
+            var gitItemStatus = item.Tag<GitItemStatus>();
+            var image = item.Image();
+            int itemLeft = item.Position.X;
+
+            var textStart = itemLeft + (image?.Width ?? 0);
+            var textMaxWidth = itemWidth - textStart;
+            var (text, textWidth) = formatter.FormatTextForDrawing(textMaxWidth, gitItemStatus.Name, gitItemStatus.OldName);
+            text = AppendItemSubmoduleStatus(text, gitItemStatus);
+
+            return (image, text, textStart, textWidth, textMaxWidth);
+        }
+
         public int GetNextIndex(bool searchBackward, bool loop)
         {
             int curIdx = SelectedIndex;
@@ -491,31 +512,6 @@ namespace GitUI
 
                 return -1;
             }
-        }
-
-        private static (Image Image, string Text) GetDisplayElements(ListViewItem item, PathFormatter formatter, int itemWidth)
-        {
-            var gitItemStatus = item.Tag<GitItemStatus>();
-
-            Image image = null;
-            if (item.ImageList != null && item.ImageIndex != -1)
-            {
-                image = item.ImageList.Images[item.ImageIndex];
-            }
-
-            var (_, textWidth) = GetHorizontalTextRange(item, image, itemWidth);
-            var text = formatter.FormatTextForDrawing(textWidth, gitItemStatus.Name, gitItemStatus.OldName);
-            text = AppendItemSubmoduleStatus(text, gitItemStatus);
-
-            return (image, text);
-        }
-
-        private static (int TextStartX, int TextWidth) GetHorizontalTextRange(ListViewItem item, Image image, int itemWidth)
-        {
-            var textStartX = item.Position.X + (image?.Width ?? 0);
-            var textWidth = itemWidth - textStartX;
-
-            return (textStartX, textWidth);
         }
 
         public void SelectAll()
@@ -778,9 +774,6 @@ namespace GitUI
             FileStatusListView.Groups.Clear();
             FileStatusListView.Items.Clear();
 
-            var truncateMethod = AppSettings.TruncatePathMethod;
-            var fileNameOnlyMode = truncateMethod == TruncatePathMethod.FileNameOnly;
-
             var list = new List<ListViewItem>();
             foreach (var (revision, statuses) in GitItemStatusesWithParents)
             {
@@ -809,7 +802,7 @@ namespace GitUI
 
                 foreach (var item in statuses)
                 {
-                    if (!(_filter?.IsMatch(item.Name) ?? true))
+                    if (!IsFilterMatch(item))
                     {
                         continue;
                     }
@@ -840,19 +833,6 @@ namespace GitUI
                     }
 
                     listItem.Tag = item;
-
-                    var (image, text) = GetDisplayElements(listItem, pathFormatter, FileStatusListView.ClientSize.Width);
-                    if (image == default && text == default)
-                    {
-                        continue;
-                    }
-
-                    if (fileNameOnlyMode && !(_filter?.IsMatch(text) ?? true))
-                    {
-                        continue;
-                    }
-
-                    listItem.Text = text;
                     list.Add(listItem);
                 }
             }
@@ -962,13 +942,40 @@ namespace GitUI
 
         private void UpdateColumnWidth()
         {
-            FileStatusListView.BeginUpdate();
-            columnHeader.AutoResize(ColumnHeaderAutoResizeStyle.ColumnContent);
-            var minWidth = FileStatusListView.ClientSize.Width;
-            if (columnHeader.Width < minWidth)
+            if (_updatingColumnWidth)
             {
-                columnHeader.Width = minWidth;
+                return;
             }
+
+            var pathFormatter = new PathFormatter(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
+            var minWidth = FileStatusListView.ClientSize.Width;
+
+            var contentWidth = FileStatusListView.Items()
+                .Where(item => item.Bounds.IntersectsWith(FileStatusListView.ClientRectangle))
+                .Select(item =>
+                {
+                    var (_, _, textStart, textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);
+                    return textStart + textWidth;
+                })
+                .DefaultIfEmpty(minWidth)
+                .Max();
+
+            int width = Math.Max(minWidth, contentWidth);
+
+            if (width == columnHeader.Width)
+            {
+                return;
+            }
+
+            if (_updatingColumnWidth)
+            {
+                return;
+            }
+
+            _updatingColumnWidth = true;
+
+            FileStatusListView.BeginUpdate();
+            columnHeader.Width = width;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -980,6 +987,8 @@ namespace GitUI
 
                 await this.SwitchToMainThreadAsync();
                 FileStatusListView.EndUpdate();
+
+                _updatingColumnWidth = false;
             }).FileAndForget();
         }
 
@@ -999,16 +1008,6 @@ namespace GitUI
             if (!FileStatusListView.IsHandleCreated)
             {
                 return;
-            }
-
-            var formatter = new PathFormatter(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
-            foreach (ListViewItem item in FileStatusListView.Items)
-            {
-                var (_, text) = GetDisplayElements(item, formatter, FileStatusListView.ClientSize.Width);
-
-                // let FileStatusListView know the actual displayed text
-                // in order to properly display horizontal scroll
-                item.Text = text;
             }
 
             UpdateColumnWidth();
@@ -1059,37 +1058,35 @@ namespace GitUI
             var item = e.Item;
             var formatter = new PathFormatter(e.Graphics, FileStatusListView.Font);
 
-            var (image, text) = GetDisplayElements(item, formatter, item.Bounds.Width);
-            if (image == default && text == default)
-            {
-                return;
-            }
+            var (image, text, textStartX, _, textMaxWidth) = FormatListViewItem(item, formatter, item.Bounds.Width);
 
             if (image != null)
             {
                 e.Graphics.DrawImageUnscaled(image, item.Position.X, item.Position.Y);
             }
 
-            var slashIndex = text.LastIndexOf('/');
-
-            var (textStartX, textWidth) = GetHorizontalTextRange(item, image, item.Bounds.Width);
-            var textRect = new Rectangle(textStartX, item.Bounds.Top, textWidth, item.Bounds.Height);
-
-            if (slashIndex == -1 || slashIndex >= text.Length - 1)
+            if (!string.IsNullOrEmpty(text))
             {
-                formatter.DrawString(text, textRect, SystemColors.ControlText);
-                return;
+                var slashIndex = text.LastIndexOf('/');
+
+                var textRect = new Rectangle(textStartX, item.Bounds.Top, textMaxWidth, item.Bounds.Height);
+
+                if (slashIndex == -1 || slashIndex >= text.Length - 1)
+                {
+                    formatter.DrawString(text, textRect, SystemColors.ControlText);
+                    return;
+                }
+
+                var prefix = text.Substring(0, slashIndex + 1);
+                var tail = text.Substring(slashIndex + 1);
+
+                var prefixSize = formatter.MeasureString(prefix);
+
+                DrawString(textRect, prefix, SystemColors.GrayText);
+
+                textRect.Offset(prefixSize.Width, 0);
+                DrawString(textRect, tail, SystemColors.ControlText);
             }
-
-            var prefix = text.Substring(0, slashIndex + 1);
-            var tail = text.Substring(slashIndex + 1);
-
-            var prefixSize = formatter.MeasureString(prefix);
-
-            DrawString(textRect, prefix, SystemColors.GrayText);
-
-            textRect.Offset(prefixSize.Width, 0);
-            DrawString(textRect, tail, SystemColors.ControlText);
 
             void DrawString(Rectangle rect, string s, Color color)
             {
@@ -1267,6 +1264,16 @@ namespace GitUI
             SelectedIndexChanged?.Invoke(this, EventArgs.Empty);
         }
 
+        private void FileStatusListView_Scroll(object sender, ScrollEventArgs e)
+        {
+            if (e.Type == ScrollEventType.ThumbTrack)
+            {
+                return;
+            }
+
+            UpdateColumnWidth();
+        }
+
         #region Filtering
 
         private string _toolTipText = "";
@@ -1285,8 +1292,32 @@ namespace GitUI
             _filter = string.IsNullOrEmpty(value)
                 ? null
                 : new Regex(value, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            UpdateFileStatusListView(true);
+            UpdateFileStatusListView(updateCausedByFilter: true);
             return FileStatusListView.Items.Count;
+        }
+
+        private bool IsFilterMatch(GitItemStatus item)
+        {
+            if (_filter == null)
+            {
+                return true;
+            }
+
+            string name = item.Name.TrimEnd(PathUtil.PosixDirectorySeparatorChar);
+            string oldName = item.OldName;
+
+            if (AppSettings.TruncatePathMethod == TruncatePathMethod.FileNameOnly)
+            {
+                name = Path.GetFileName(name);
+                oldName = Path.GetFileName(oldName);
+            }
+
+            if (_filter.IsMatch(name))
+            {
+                return true;
+            }
+
+            return oldName != null && _filter.IsMatch(oldName);
         }
 
         private void InitialiseFiltering()

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1010,6 +1010,13 @@ namespace GitUI
                 return;
             }
 
+            if (!FileStatusListView.Created)
+            {
+                // The parent form gets closed, it destroys children controls.
+                // While processing WmDestroy ExListView.OnClientSize change fires
+                return;
+            }
+
             UpdateColumnWidth();
         }
 


### PR DESCRIPTION
Fixes #5642

Changes proposed in this pull request:
- `FileStatusList` does not use `ColumnHeaderAutoResizeStyle.ColumnContent`
anymore, instead column width is determined by visible content only and
is updated on vertical scroll

- Path formatter uses binary search to choose how many characters to
truncate from path

What did I do to test the code and ensure quality:
- Tested on Windows 7
- Observed acceptable performance with linux repository with all `Truncate long filenames` settings