### PR TITLE
Split the reordering and rebuilding of the graph.

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -278,7 +278,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                             Brush brush;
 
-                            if (revisionGraphRevision.Parent.EndSegments.Count > 1)
+                            if (revisionGraphRevision.Parent.Children.Count > 1)
                             {
                                 brush = GetBrushForRevision(revisionGraphRevision.Child, revisionGraphRevision.Child.IsRelative);
                             }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -14,16 +14,26 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         private ConcurrentDictionary<ObjectId, RevisionGraphRevision> _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
         private ConcurrentBag<RevisionGraphRevision> _nodes = new ConcurrentBag<RevisionGraphRevision>();
 
-        // The maxscore is used to keep a chronological order during graph buiding. It is cheaper than doing _nodes.Max(n => n.Score)
-        private int _maxScore = 0;
+        /// <summary>
+        /// The max score is used to keep a chronological order during the graph building.
+        /// It is cheaper than doing <c>_nodes.Max(n => n.Score)</c>.
+        /// </summary>
+        private int _maxScore;
 
-        // The nodecache is an ordered list with the nodes. This is used to be able to draw commits before the graph is completed.
-        private List<RevisionGraphRevision> _orderedNodesCache = null;
+        /// <summary>
+        /// The node cache is an ordered list with the nodes.
+        /// This is used so we can draw commits before the graph building is complete.
+        /// </summary>
+        /// <remarks>This cache is very cheap to build.</remarks>
+        private List<RevisionGraphRevision> _orderedNodesCache;
         private bool _reorder = true;
         private int _orderedUntilScore = -1;
 
-        // The orderedrowcache contains the rows with the segments stored in lanes.
-        private List<RevisionGraphRow> _orderedRowCache = null;
+        /// <summary>
+        /// The ordered row cache contains rows with segments stored in lanes.
+        /// </summary>
+        /// <remarks>This cache is very expensive to build.</remarks>
+        private List<RevisionGraphRow> _orderedRowCache;
         private bool _rebuild = true;
         private int _buildUntilScore = -1;
 
@@ -51,14 +61,20 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             return _orderedRowCache.Count;
         }
 
-        // Build the revision graph. There are two caches that are build in this method.
-        // cache 1: an ordered list of the revisions. This is very cheap to build. (_orderedNodesCache)
-        // cache 2: an ordered list of all prepared graphrows. This is expensive to build. (_orderedRowCache)
-        // untillRow: the row that needs to be displayed. This ensures the orded revisions are available untill this index.
-        // graphUntillRow: the graph can be build per x rows. This defines the row index that the graph will be cached until.
-        public void CacheTo(int untillRow, int graphUntillRow)
+        /// <summary>
+        /// Builds the revision graph cache. There are two caches that are build in this method.
+        /// <para>Cache 1: an ordered list of the revisions. This is very cheap to build. (_orderedNodesCache).</para>
+        /// <para>Cache 2: an ordered list of all prepared graph rows. This is expensive to build. (_orderedRowCache)</para>
+        /// </summary>
+        /// <param name="currentRowIndex">
+        /// The row that needs to be displayed. This ensures the ordered revisions are available up to this index.
+        /// </param>
+        /// <param name="lastToCacheRowIndex">
+        /// The graph can be build per x rows. This defines the last row index that the graph will build cache to.
+        /// </param>
+        public void CacheTo(int currentRowIndex, int lastToCacheRowIndex)
         {
-            if (_orderedNodesCache == null || _reorder || _orderedNodesCache.Count < untillRow)
+            if (_orderedNodesCache == null || _reorder || _orderedNodesCache.Count < currentRowIndex)
             {
                 _orderedNodesCache = _nodes.OrderBy(n => n.Score).ToList();
                 if (_orderedNodesCache.Count > 0)
@@ -71,63 +87,65 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             if (_orderedRowCache == null || _rebuild)
             {
-                _orderedRowCache = new List<RevisionGraphRow>(untillRow);
+                _orderedRowCache = new List<RevisionGraphRow>(currentRowIndex);
                 _rebuild = false;
             }
 
             int nextIndex = _orderedRowCache.Count;
-            if (nextIndex <= graphUntillRow)
+            if (nextIndex > lastToCacheRowIndex)
             {
-                int cacheCount = _orderedNodesCache.Count;
-                while (nextIndex <= graphUntillRow && cacheCount > nextIndex)
+                return;
+            }
+
+            int cacheCount = _orderedNodesCache.Count;
+            while (nextIndex <= lastToCacheRowIndex && cacheCount > nextIndex)
+            {
+                bool startSegmentsAdded = false;
+
+                RevisionGraphRevision revision = _orderedNodesCache[nextIndex];
+
+                // The list containing the segments is created later. We can set the correct capacity then, to prevent resizing
+                List<RevisionGraphSegment> segments;
+
+                if (nextIndex > 0)
                 {
-                    bool startSegmentsAdded = false;
+                    // Copy lanes from last row
+                    RevisionGraphRow previousRevisionGraphRow = _orderedRowCache[nextIndex - 1];
 
-                    RevisionGraphRevision revision = _orderedNodesCache[nextIndex];
+                    // Create segments list with te correct capacity
+                    segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revision.StartSegments.Count);
 
-                    // The list containing the segments is created later. We can set the correct capacity then, to prevent resizing
-                    List<RevisionGraphSegment> segments;
-
-                    if (nextIndex > 0)
+                    // Loop through all segments that do not end in this row
+                    foreach (var segment in previousRevisionGraphRow.Segments.Where(s => s.Parent != previousRevisionGraphRow.Revision))
                     {
-                        // Copy lanes from last row
-                        RevisionGraphRow previousRevisionGraphRow = _orderedRowCache[nextIndex - 1];
+                        segments.Add(segment);
 
-                        // Create segments list with te correct capacity
-                        segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revision.StartSegments.Count);
-
-                        // Loop through all segments that do not end in this row
-                        foreach (var segment in previousRevisionGraphRow.Segments.Where(s => s.Parent != previousRevisionGraphRow.Revision))
+                        // This segments continues in the next row. Copy all other segments that start from this revision to this lane.
+                        if (revision == segment.Parent && !startSegmentsAdded)
                         {
-                            segments.Add(segment);
-
-                            // This segments continues in the next row. Copy all other segments that start from this revision to this lane.
-                            if (revision == segment.Parent && !startSegmentsAdded)
-                            {
-                                startSegmentsAdded = true;
-                                segments.AddRange(revision.StartSegments);
-                            }
+                            startSegmentsAdded = true;
+                            segments.AddRange(revision.StartSegments);
                         }
                     }
-                    else
-                    {
-                        // Create segments list with te correct capacity
-                        segments = new List<RevisionGraphSegment>(revision.StartSegments.Count);
-                    }
-
-                    if (!startSegmentsAdded)
-                    {
-                        // Add new segments started by this revision to the end
-                        segments.AddRange(revision.StartSegments);
-                    }
-
-                    _orderedRowCache.Add(new RevisionGraphRow(revision, segments));
-                    _buildUntilScore = revision.Score;
-                    nextIndex++;
+                }
+                else
+                {
+                    // Create segments list with te correct capacity
+                    segments = new List<RevisionGraphSegment>(revision.StartSegments.Count);
                 }
 
-                Updated?.Invoke();
+                if (!startSegmentsAdded)
+                {
+                    // Add new segments started by this revision to the end
+                    segments.AddRange(revision.StartSegments);
+                }
+
+                _orderedRowCache.Add(new RevisionGraphRow(revision, segments));
+                _buildUntilScore = revision.Score;
+                nextIndex++;
             }
+
+            Updated?.Invoke();
         }
 
         public bool IsRowRelative(int row)
@@ -204,36 +222,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
         }
 
-        // This method will validate the topo order in brute force.
-        // Only used for unit testing.
-        public bool ValidateTopoOrder()
-        {
-            int currentIndex = 0;
-            foreach (var node in _orderedNodesCache)
-            {
-                foreach (var parent in node.Parents)
-                {
-                    if (!TryGetRowIndex(parent.Objectid, out int parentIndex) || parentIndex < currentIndex)
-                    {
-                        return false;
-                    }
-                }
-
-                foreach (var child in node.Children)
-                {
-                    if (!TryGetRowIndex(child.Objectid, out int childIndex) || childIndex > currentIndex)
-                    {
-                        return false;
-                    }
-                }
-
-                currentIndex++;
-            }
-
-            return true;
-        }
-
-        // Add a single revision from the git log.
+        /// <summary>
+        /// Add a single revision from the git log.
+        /// </summary>
         public void Add(GitRevision revision, RevisionNodeFlags types)
         {
             if (!_nodeByObjectId.TryGetValue(revision.ObjectId, out RevisionGraphRevision revisionGraphRevision))
@@ -241,45 +232,41 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 // This revision is added from the log, but not seen before. This is probably a root node (new branch) OR the revisions
                 // are not in topo order. If this the case, we deal with it later.
                 revisionGraphRevision = new RevisionGraphRevision(revision.ObjectId, ++_maxScore);
-                revisionGraphRevision.ApplyFlags(types);
                 revisionGraphRevision.LaneColor = revisionGraphRevision.IsCheckedOut ? 0 : _maxScore;
 
-                revisionGraphRevision.GitRevision = revision;
                 _nodeByObjectId.TryAdd(revision.ObjectId, revisionGraphRevision);
-                _nodes.Add(revisionGraphRevision);
             }
             else
             {
-                // This revision was added as a parent before. Probably only the objectid is known. Set all the other properties.
-                revisionGraphRevision.GitRevision = revision;
-                revisionGraphRevision.ApplyFlags(types);
-
-                // Since this revision was added earlier, but is now found in the log. Increase the score to the current maxScore
-                // to keep the order ok.
+                // This revision was added earlier, but is now found in the log.
+                // Increase the score to the current maxScore to keep the order in tact.
                 revisionGraphRevision.EnsureScoreIsAbove(++_maxScore);
-                _nodes.Add(revisionGraphRevision);
             }
+
+            // This revision may have been added as a parent before. Probably only the ObjectId is known. Set all the other properties.
+            revisionGraphRevision.GitRevision = revision;
+            revisionGraphRevision.ApplyFlags(types);
+            _nodes.Add(revisionGraphRevision);
 
             // No build the revisions parent/child structure. The parents need to added here. The child structure is kept in synch in
             // the RevisionGraphRevision class.
-            foreach (ObjectId parentObjectId in revision.ParentIds)
+            if (revision.ParentIds != null)
             {
-                if (!_nodeByObjectId.TryGetValue(parentObjectId, out RevisionGraphRevision parentRevisionGraphRevision))
+                foreach (ObjectId parentObjectId in revision.ParentIds)
                 {
-                    // This parent is not loaded before. Create a new (partial) revision. We will complete the info in the revision
-                    // when this revision is loaded from the log.
-                    parentRevisionGraphRevision = new RevisionGraphRevision(parentObjectId, ++_maxScore);
-                    _nodeByObjectId.TryAdd(parentObjectId, parentRevisionGraphRevision);
-
-                    // Store the newly created segment (connection between 2 revisions)
-                    revisionGraphRevision.AddParent(parentRevisionGraphRevision, out int newMaxScore);
-                    _maxScore = Math.Max(_maxScore, newMaxScore);
-                }
-                else
-                {
-                    // This revision is already loaded, add the existing revision to the parents list of new revision.
-                    // If the current score is lower, cache is invalid. The new score will (probably) be higher.
-                    ResetCacheIfNeeded(parentRevisionGraphRevision);
+                    if (!_nodeByObjectId.TryGetValue(parentObjectId, out RevisionGraphRevision parentRevisionGraphRevision))
+                    {
+                        // This parent is not loaded before. Create a new (partial) revision. We will complete the info in the revision
+                        // when this revision is loaded from the log.
+                        parentRevisionGraphRevision = new RevisionGraphRevision(parentObjectId, ++_maxScore);
+                        _nodeByObjectId.TryAdd(parentObjectId, parentRevisionGraphRevision);
+                    }
+                    else
+                    {
+                        // This revision is already loaded, add the existing revision to the parents list of new revision.
+                        // If the current score is lower, cache is invalid. The new score will (probably) be higher.
+                        MarkCacheAsInvalidIfNeeded(parentRevisionGraphRevision);
+                    }
 
                     // Store the newly created segment (connection between 2 revisions)
                     revisionGraphRevision.AddParent(parentRevisionGraphRevision, out int newMaxScore);
@@ -287,10 +274,10 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 }
             }
 
-            ResetCacheIfNeeded(revisionGraphRevision);
+            MarkCacheAsInvalidIfNeeded(revisionGraphRevision);
         }
 
-        private void ResetCacheIfNeeded(RevisionGraphRevision revisionGraphRevision)
+        private void MarkCacheAsInvalidIfNeeded(RevisionGraphRevision revisionGraphRevision)
         {
             if (revisionGraphRevision.Score <= _orderedUntilScore)
             {
@@ -300,6 +287,47 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             if (revisionGraphRevision.Score <= _buildUntilScore)
             {
                 _rebuild = true;
+            }
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly RevisionGraph _revisionGraph;
+
+            public TestAccessor(RevisionGraph revisionGraph)
+            {
+                _revisionGraph = revisionGraph;
+            }
+
+            // This method will validate the topo order in brute force.
+            // Only used for unit testing.
+            public bool ValidateTopoOrder()
+            {
+                int currentIndex = 0;
+                foreach (var node in _revisionGraph._orderedNodesCache)
+                {
+                    foreach (var parent in node.Parents)
+                    {
+                        if (!_revisionGraph.TryGetRowIndex(parent.Objectid, out int parentIndex) || parentIndex < currentIndex)
+                        {
+                            return false;
+                        }
+                    }
+
+                    foreach (var child in node.Children)
+                    {
+                        if (!_revisionGraph.TryGetRowIndex(child.Objectid, out int childIndex) || childIndex > currentIndex)
+                        {
+                            return false;
+                        }
+                    }
+
+                    currentIndex++;
+                }
+
+                return true;
             }
         }
     }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -37,9 +37,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public bool HasRef { get; set; }
         public bool IsCheckedOut { get; set; }
 
-        // The score is used to order the revisions in topo-order. The initial score will be assigned when the revision is loaded
-        // from the commit log (the result of git.exe). The score will be adjusted if required when this revision is added as a parent
-        // to a revision with a higher score.
+        /// <summary>
+        /// The score is used to order the revisions in topo-order. The initial score will be assigned when a revision is loaded
+        /// from the commit log (the result of git.exe). The score will be adjusted, if required, when this revision is added as a parent
+        /// to a revision with a higher score.
+        /// </summary>
         public int Score { get; private set; }
 
         public int LaneColor { get; set; }
@@ -68,9 +70,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public ObjectId Objectid { get; set; }
 
-        public ConcurrentBag<RevisionGraphRevision> Parents { get; private set; }
-        public ConcurrentBag<RevisionGraphRevision> Children { get; private set; }
-        public SynchronizedCollection<RevisionGraphSegment> StartSegments { get; private set; }
+        public ConcurrentBag<RevisionGraphRevision> Parents { get; }
+        public ConcurrentBag<RevisionGraphRevision> Children { get; }
+        public SynchronizedCollection<RevisionGraphSegment> StartSegments { get; }
 
         // Mark this commit, and all its parents, as relative. Used for branch highlighting.
         // By default, the current checkout will be marked relative.

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -20,7 +20,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Parents = new ConcurrentBag<RevisionGraphRevision>();
             Children = new ConcurrentBag<RevisionGraphRevision>();
             StartSegments = new SynchronizedCollection<RevisionGraphSegment>();
-            EndSegments = new ConcurrentBag<RevisionGraphSegment>();
 
             Score = guessScore;
 
@@ -72,7 +71,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public ConcurrentBag<RevisionGraphRevision> Parents { get; private set; }
         public ConcurrentBag<RevisionGraphRevision> Children { get; private set; }
         public SynchronizedCollection<RevisionGraphSegment> StartSegments { get; private set; }
-        public ConcurrentBag<RevisionGraphSegment> EndSegments { get; private set; }
 
         // Mark this commit, and all its parents, as relative. Used for branch highlighting.
         // By default, the current checkout will be marked relative.
@@ -117,7 +115,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             maxScore = parent.EnsureScoreIsAbove(Score);
 
             RevisionGraphSegment revisionGraphSegment = new RevisionGraphSegment(parent, this);
-            parent.EndSegments.Add(revisionGraphSegment);
             StartSegments.Add(revisionGraphSegment);
 
             return revisionGraphSegment;

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
-using FluentAssertions;
 using GitCommands;
 using GitUI.UserControls.RevisionGrid;
 using GitUI.UserControls.RevisionGrid.Graph;
 using GitUIPluginInterfaces;
 using NUnit.Framework;
-using ResourceManager;
 
 namespace GitUITests.UserControls.RevisionGrid
 {
@@ -85,7 +81,7 @@ namespace GitUITests.UserControls.RevisionGrid
         public void ShouldReorderInTopoOrder()
         {
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
-            Assert.IsTrue(_revisionGraph.ValidateTopoOrder());
+            Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
 
             GitRevision commit1 = new GitRevision(ObjectId.Random());
 
@@ -96,12 +92,12 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.Add(commit2, RevisionNodeFlags.None); // This commit is now dangling
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
-            Assert.IsTrue(_revisionGraph.ValidateTopoOrder());
+            Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
 
             _revisionGraph.Add(commit1, RevisionNodeFlags.None); // Add the connecting commit
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
-            Assert.IsTrue(_revisionGraph.ValidateTopoOrder());
+            Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
 
             // Add a new head
             GitRevision newHead = new GitRevision(ObjectId.Random());
@@ -109,7 +105,7 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.Add(newHead, RevisionNodeFlags.None); // Add commit that has the current top node as parent.
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count); // Call to cache fix the order
-            Assert.IsTrue(_revisionGraph.ValidateTopoOrder());
+            Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
         }
 
         private static IEnumerable<GitRevision> Revisions


### PR DESCRIPTION
Rebuilding the graph is expensive, and is usually not needed. Minor fix. I did not refactor the cache to minimize impact of this PR.

Fixes #5658

Changes proposed in this pull request:
- Split the reordering and rebuilding of the graph. (reordering is fast, rebuilding is slow)
- Because the graph rows are rebuild less often, this results in better performance while the revisions are still being loaded. There was some flickering I wanted to solve.
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
