### PR TITLE
Make GitExtensions project authority of GIT info

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -87,6 +87,13 @@
   <ItemGroup>
     <EmbeddedResource Include="AutoCompleteRegexes.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="GitInfo">
+      <Version>2.0.18</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AddPluginBinaries" AfterTargets="ResolveProjectReferences">
     <ItemGroup>

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -54,6 +54,9 @@ namespace GitExtensions
                 }
             }
 
+            // This is done here so these values can be used in the GitGui project but this project is the authority of the values.
+            UserEnvironmentInformation.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty);
+
             // NOTE we perform the rest of the application's startup in another method to defer
             // the JIT processing more types than required to configure NBug.
             // In this way, there's more chance we can handle startup exceptions correctly.

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -58,11 +58,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitInfo">
-      <Version>2.0.18</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft-WindowsAPICodePack-Core">
       <Version>1.1.3.3</Version>
     </PackageReference>

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -8,13 +8,19 @@ namespace GitUI
 {
     public sealed class UserEnvironmentInformation
     {
-        public static void CopyInformation()
-        {
-            Clipboard.SetText(GetInformation());
-        }
+        private static bool _alreadySet;
+        private static bool _dirty;
+        private static string _sha;
+
+        public static void CopyInformation() => Clipboard.SetText(GetInformation());
 
         public static string GetInformation()
         {
+            if (!_alreadySet)
+            {
+                throw new InvalidOperationException($"{nameof(Initialise)} must be called first");
+            }
+
             string gitVer;
             try
             {
@@ -27,12 +33,24 @@ namespace GitUI
 
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendFormat("- Git Extensions {0}{1}", AppSettings.ProductVersion, Environment.NewLine);
-            sb.AppendFormat("- {0} {1}{2}", ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty ? " (Dirty)" : "", Environment.NewLine);
-            sb.AppendFormat("- Git {0}{1}", gitVer, Environment.NewLine);
-            sb.AppendFormat("- {0}{1}", Environment.OSVersion, Environment.NewLine);
-            sb.AppendFormat("- {0}", RuntimeInformation.FrameworkDescription);
+            sb.Append($"- Git Extensions {AppSettings.ProductVersion}{Environment.NewLine}");
+            sb.Append($"- {_sha} {(_dirty ? " (Dirty)" : "")}{Environment.NewLine}");
+            sb.Append($"- Git {gitVer}{Environment.NewLine}");
+            sb.Append($"- {Environment.OSVersion}{Environment.NewLine}");
+            sb.Append($"- {RuntimeInformation.FrameworkDescription}");
             return sb.ToString();
+        }
+
+        public static void Initialise(string sha, bool isDirty)
+        {
+            if (_alreadySet)
+            {
+                return;
+            }
+
+            _alreadySet = true;
+            _sha = sha;
+            _dirty = isDirty;
         }
     }
 }

--- a/UnitTests/GitUITests/TranslationTest.cs
+++ b/UnitTests/GitUITests/TranslationTest.cs
@@ -28,6 +28,7 @@ namespace GitUITests
         [Apartment(ApartmentState.STA)]
         public void CreateInstanceOfClass()
         {
+            UserEnvironmentInformation.Initialise("", false);
             var translatableTypes = TranslationUtil.GetTranslatableTypes();
 
             var problems = new List<(string typeName, Exception exception)>();


### PR DESCRIPTION
Prevents environment data from getting stale by a commit but GitGUI not being rebuilt

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes Issue noted in https://github.com/gitextensions/gitextensions/pull/5640#issuecomment-434284350

Changes proposed in this pull request:
- Make GitExtensions project authority of Git info.  Any time  GitExtensions is built git info is recalculated.  
 
Screenshots before and after (if PR changes UI):


What did I do to test the code and ensure quality:
- Ran project and made sure info was still current. 

Has been tested on (remove any that don't apply):
