### PR TITLE
Fix for issue "Delete dialog appears when pressing ctrl+alt+del on latest commit of a branch" with id 5636

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -216,7 +216,7 @@ namespace GitUI.Editor
                     }
                     else
                     {
-                        encodingToolStripComboBox.SelectedIndex = 0;
+                        encodingToolStripComboBox.SelectedIndex = -1;
                     }
                 }).FileAndForget();
             }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -216,7 +216,7 @@ namespace GitUI.Editor
                     }
                     else
                     {
-                        encodingToolStripComboBox.SelectedIndex = -1;
+                        encodingToolStripComboBox.SelectedIndex = 0;
                     }
                 }).FileAndForget();
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1241,13 +1241,13 @@ namespace GitUI
             {
                 return;
             }
-			
-			// Check modifier detail if pressed.
-			
-			if (e.Modifiers == Keys.None)
+
+            // Check modifier detail if pressed.
+
+            if (e.Modifiers == Keys.None)
             {
-				return;
-			}
+                return;
+            }
 
             switch (e.KeyCode)
             {
@@ -1262,7 +1262,6 @@ namespace GitUI
 
                 case Keys.Delete:
                     {
-                        
                         InitiateRefAction(
                             new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch()),
                             gitRef =>

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1255,7 +1255,11 @@ namespace GitUI
 
                 case Keys.Delete:
                     {
-                        InitiateRefAction(
+                        // Check modifier detail if pressed.
+
+                        if (e.Modifiers == Keys.None)
+                        {
+                            InitiateRefAction(
                             new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch()),
                             gitRef =>
                             {
@@ -1273,6 +1277,8 @@ namespace GitUI
                                 }
                             },
                             FormQuickGitRefSelector.Action.Delete);
+                        }
+
                         break;
                     }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1241,6 +1241,13 @@ namespace GitUI
             {
                 return;
             }
+			
+			// Check modifier detail if pressed.
+			
+			if (e.Modifiers == Keys.None)
+            {
+				return;
+			}
 
             switch (e.KeyCode)
             {
@@ -1255,11 +1262,8 @@ namespace GitUI
 
                 case Keys.Delete:
                     {
-                        // Check modifier detail if pressed.
-
-                        if (e.Modifiers == Keys.None)
-                        {
-                            InitiateRefAction(
+                        
+                        InitiateRefAction(
                             new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch()),
                             gitRef =>
                             {
@@ -1277,7 +1281,6 @@ namespace GitUI
                                 }
                             },
                             FormQuickGitRefSelector.Action.Delete);
-                        }
 
                         break;
                     }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1242,8 +1242,6 @@ namespace GitUI
                 return;
             }
 
-            // Check modifier detail if pressed.
-
             if (e.Modifiers == Keys.None)
             {
                 return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1242,7 +1242,7 @@ namespace GitUI
                 return;
             }
 
-            if (e.Modifiers == Keys.None)
+            if (e.Modifiers != Keys.None)
             {
                 return;
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5636

Changes proposed in this pull request:
- On clicking ctrl+alt+del , modifiers ctrl+alt were ignored and it was treated as if del key was fixed. With this fix if modifiers are present then del key is ignored.

 
Screenshots before and after (if PR changes UI):
- None


What did I do to test the code and ensure quality:
- Manual testing of the change.


Has been tested on (remove any that don't apply):
- GIT 2.11 and above: 2.18
- Windows 7 and above : windows 10.
