### PR TITLE
Force commit info to clear on module change

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1876,6 +1876,7 @@ namespace GitUI.CommandsDialogs
 #endif
 
                 HideDashboard();
+                RevisionInfo.SetRevisionWithChildren(null, Array.Empty<ObjectId>());
                 UICommands.RepoChangedNotifier.Notify();
                 RevisionGrid.IndexWatcher.Reset();
                 RegisterPlugins();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5624 

Changes proposed in this pull request:
- Force CommitInfo to clear on module change.
 
Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
- Opened GE Repo.
- Created a new repo by using start menu in GE.
- Verified the commit info from GE did not show in the new repo.

Has been tested on (remove any that don't apply):

