### PR TITLE
fix: Commit info context menu is scrambled

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -102,7 +102,6 @@
             // 
             // commitInfoContextMenuStrip
             // 
-            this.commitInfoContextMenuStrip.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.commitInfoContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyCommitInfoToolStripMenuItem,
             this.toolStripSeparator1,


### PR DESCRIPTION
Fixes #5657
 
Screenshots before and after (if PR changes UI):
- before:
![image](https://user-images.githubusercontent.com/6248932/47755378-4a0b5400-dc9e-11e8-9630-3ede2076446c.png)

- after:
![image](https://user-images.githubusercontent.com/4403806/47767287-0b6dac00-dd27-11e8-9286-885bb27f93d9.png)


