### PR TITLE
fix: Saving command log to file broken

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 {
                     File.WriteAllLines(
                         fileDialog.FileName,
-                        CommandLog.Commands.Select(cle => cle.ToString()));
+                        CommandLog.Commands.Select(cle => cle.ColumnLine));
                 }
             }
         }


### PR DESCRIPTION
Fixes #5633 

File now looks similar to the following:
```
19:47:37.078    85ms 13124 UI  1 git config --get ą
19:47:37.200    42ms 11044 UI  0 git --version
19:47:37.932   311ms  9568     0 git for-each-ref --sort=-committerdate refs/heads/ --format="%(objectname) %(refname)"
19:47:38.449   107ms 17280     0 git ls-files -z --unmerged
19:47:39.201    56ms 10884 UI  0 git rev-parse HEAD
19:47:39.335   185ms   932 UI  0 git rev-parse --git-common-dir
19:47:39.559    79ms 13824 UI  0 git rev-parse HEAD
19:47:39.657   458ms  6064 UI  0 git show-ref --dereference
19:47:40.276   263ms 14244     0 git for-each-ref --sort=-committerdate refs/heads/ --format="%(objectname) %(refname)"
19:47:40.335  1456ms 12420       git -c log.showSignature=false log -z --pretty=format:"%H%T%P%n%at%n%ct%n%e%n%aN%n%aE%n%cN%n%cE%n%s%n%n%b" --all --boundary --not --glob=notes --not --max-count=100000 --
19:47:40.553   153ms  3132     0 git ls-files -z --unmerged
19:47:40.581   124ms 10552     0 git rev-parse --git-common-dir
19:47:40.724   128ms 16104     0 git rev-parse --git-common-dir
19:47:41.332    95ms 16536     0 git rev-parse --git-common-dir
19:47:41.794    73ms 16968     0 git rev-parse --git-common-dir
19:47:42.332    95ms 12284     0 git rev-parse --git-common-dir
19:47:43.338   672ms 16264     0 git --no-optional-locks status --porcelain=2 -z --untracked-files --ignore-submodules=none
19:47:44.425   272ms 13208     0 git -c diff.submodule=short -c diff.noprefix=false diff --no-color -- "Externals/NBug"
19:47:44.425   277ms 14776     0 git -c diff.submodule=short -c diff.noprefix=false diff --no-color -- "GitExtensionsDoc"
19:47:44.426   366ms 16960     0 git -c diff.submodule=short -c diff.noprefix=false diff --no-color -- "Externals/ICSharpCode.TextEditor"
19:47:44.444   297ms  8944     0 git -c diff.submodule=short -c diff.noprefix=false diff --no-color -- "Externals/conemu-inside"
19:47:44.450   306ms  9896     0 git -c diff.submodule=short -c diff.noprefix=false diff --no-color -- "Externals/Git.hub"
19:47:48.040   194ms 13756     0 git for-each-ref --sort=-committerdate --sort=-taggerdate --format="%(refname)" refs/
19:47:48.131   130ms 16100     0 git branch --contains fbe214361292acd8edc924b5b88acb53433e9c3a
19:47:48.243   386ms  5032     0 git tag --contains fbe214361292acd8edc924b5b88acb53433e9c3a
19:47:48.250   379ms 15352     0 git describe --tags --first-parent --abbrev=40 fbe214361292acd8edc924b5b88acb53433e9c3a
19:47:49.097   167ms  2476     0 git branch --contains fbe214361292acd8edc924b5b88acb53433e9c3a
19:47:49.097   251ms  7548     0 git tag --contains fbe214361292acd8edc924b5b88acb53433e9c3a
19:47:49.100   133ms  7228     0 git describe --tags --first-parent --abbrev=40 fbe214361292acd8edc924b5b88acb53433e9c3a
19:47:49.190    99ms  8628     0 git remote
19:47:49.232   156ms 13112     0 git remote
```