### PR TITLE
Avoid automatic quotes on FileFilter value.

### DIFF
--- a/GitUI/UserControls/RevisionGridClasses/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGridClasses/FormRevisionFilter.cs
@@ -97,7 +97,7 @@ namespace GitUI.RevisionGridClasses
         {
             var filter = "";
             if (FileFilterCheck.Checked)
-                filter += string.Format(" \"{0}\"", FileFilter.Text.ToPosixPath());
+                filter += string.Format(" {0}", FileFilter.Text.ToPosixPath());
             return filter;
         }
 


### PR DESCRIPTION
This allows to specify several files/directories as filter values.
If someone has spaces in the path/file names, then the quotes must be already added in the filter dialog.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes  #5623 

Changes proposed in this pull request:
- Removed automatic quotes around the filter value entered in the dialog.
- Makes it possible to specify not only one, but several different directories/files in the filter dialog.
 
What did I do to test the code and ensure quality:
Manual tests.
E.g. specify the following value ' "*TortoiseSVN License.txt*" "*Traditional Chin*.gif" ' in filter dialog.

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 7
