### PR TITLE
Pub/sub for the left panel

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -92,7 +92,8 @@ namespace GitUI.BranchTreePanel
         {
             RegisterClick(mnubtnCollapseAll, () => treeMain.CollapseAll());
             RegisterClick(mnubtnExpandAll, () => treeMain.ExpandAll());
-            RegisterClick(mnubtnReload, () => ThreadHelper.JoinableTaskFactory.RunAsync(() => ReloadAsync()).FileAndForget());
+
+            RegisterClick(mnubtnReload, () => RefreshTree());
 
             treeMain.NodeMouseClick += OnNodeMouseClick;
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -265,10 +265,14 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode()
+            protected override void PostFillTreeViewNode(bool firstTime)
             {
-                TreeViewNode.Text = $@"{Strings.Branches} ({Nodes.Count})";
+                if (firstTime)
+                {
+                    TreeViewNode.Expand();
+                }
 
+                TreeViewNode.Text = $@"{Strings.Branches} ({Nodes.Count})";
                 var activeBranch = Nodes.DepthEnumerator<LocalBranchNode>().FirstOrDefault(b => b.IsActive);
                 TreeViewNode.TreeView.SelectedNode = activeBranch?.TreeViewNode;
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -187,7 +187,7 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        private class BranchTree : Tree
+        private sealed class BranchTree : Tree
         {
             private readonly IAheadBehindDataProvider _aheadBehindDataProvider;
 
@@ -195,10 +195,14 @@ namespace GitUI.BranchTreePanel
                 : base(treeNode, uiCommands)
             {
                 _aheadBehindDataProvider = aheadBehindDataProvider;
-                uiCommands.UICommandsChanged += delegate { TreeViewNode.TreeView.SelectedNode = null; };
             }
 
-            protected override async Task LoadNodesAsync(CancellationToken token)
+            public override void RefreshTree()
+            {
+                ReloadNodes(LoadNodesAsync);
+            }
+
+            private async Task LoadNodesAsync(CancellationToken token)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
@@ -261,17 +265,12 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void FillTreeViewNode()
+            protected override void PostFillTreeViewNode()
             {
-                base.FillTreeViewNode();
-
                 TreeViewNode.Text = $@"{Strings.Branches} ({Nodes.Count})";
 
                 var activeBranch = Nodes.DepthEnumerator<LocalBranchNode>().FirstOrDefault(b => b.IsActive);
-                if (activeBranch == null)
-                {
-                    TreeViewNode.TreeView.SelectedNode = null;
-                }
+                TreeViewNode.TreeView.SelectedNode = activeBranch?.TreeViewNode;
             }
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -25,11 +25,14 @@ namespace GitUI.BranchTreePanel
             public RemoteBranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands)
                 : base(treeNode, uiCommands)
             {
-                // TODO unsubscribe this event as needed
-                uiCommands.UICommandsChanged += delegate { TreeViewNode.TreeView.SelectedNode = null; };
             }
 
-            protected override async Task LoadNodesAsync(CancellationToken token)
+            public override void RefreshTree()
+            {
+                ReloadNodes(LoadNodesAsync);
+            }
+
+            private async Task LoadNodesAsync(CancellationToken token)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
@@ -114,9 +117,8 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void FillTreeViewNode()
+            protected override void PostFillTreeViewNode()
             {
-                base.FillTreeViewNode();
                 TreeViewNode.Expand();
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -117,9 +117,12 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode()
+            protected override void PostFillTreeViewNode(bool firstTime)
             {
-                TreeViewNode.Expand();
+                if (firstTime)
+                {
+                    TreeViewNode.Expand();
+                }
             }
 
             internal void PopupManageRemotesForm(string remoteName)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -64,25 +64,19 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        private class TagTree : Tree
+        private sealed class TagTree : Tree
         {
             public TagTree(TreeNode treeNode, IGitUICommandsSource uiCommands)
                 : base(treeNode, uiCommands)
             {
-                uiCommands.UICommandsChanged += OnUICommandsChanged;
             }
 
-            private void OnUICommandsChanged(object sender, GitUICommandsChangedEventArgs e)
+            public override void RefreshTree()
             {
-                if (TreeViewNode?.TreeView == null)
-                {
-                    return;
-                }
-
-                TreeViewNode.TreeView.SelectedNode = null;
+                ReloadNodes(LoadNodesAsync);
             }
 
-            protected override async Task LoadNodesAsync(CancellationToken token)
+            private async Task LoadNodesAsync(CancellationToken token)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
@@ -105,12 +99,9 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void FillTreeViewNode()
+            protected override void PostFillTreeViewNode()
             {
-                base.FillTreeViewNode();
-
                 TreeViewNode.Text = $@"{Strings.Tags} ({Nodes.Count})";
-
                 TreeViewNode.Collapse();
             }
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -99,10 +99,14 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
-            protected override void PostFillTreeViewNode()
+            protected override void PostFillTreeViewNode(bool firstTime)
             {
+                if (firstTime)
+                {
+                    TreeViewNode.Collapse();
+                }
+
                 TreeViewNode.Text = $@"{Strings.Tags} ({Nodes.Count})";
-                TreeViewNode.Collapse();
             }
         }
     }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -107,12 +108,35 @@ namespace GitUI.BranchTreePanel
             protected readonly Nodes Nodes;
             private readonly IGitUICommandsSource _uiCommandsSource;
 
+            private readonly CancellationTokenSequence _reloadCancellationTokenSequence = new CancellationTokenSequence();
+
             protected Tree(TreeNode treeNode, IGitUICommandsSource uiCommands)
             {
                 Nodes = new Nodes(this);
                 _uiCommandsSource = uiCommands;
                 TreeViewNode = treeNode;
+
+                uiCommands.UICommandsChanged += (a, e) =>
+                {
+                    if (TreeViewNode?.TreeView != null)
+                    {
+                        TreeViewNode.TreeView.SelectedNode = null;
+                    }
+
+                    e.OldCommands.PostRepositoryChanged -= UICommands_PostRepositoryChanged;
+                    uiCommands.UICommands.PostRepositoryChanged += UICommands_PostRepositoryChanged;
+                };
+
+                uiCommands.UICommands.PostRepositoryChanged += UICommands_PostRepositoryChanged;
             }
+
+            private void UICommands_PostRepositoryChanged(object sender, GitUIPluginInterfaces.GitUIEventArgs e)
+            {
+                // Run on UI thread
+                TreeViewNode.TreeView.InvokeAsync(RefreshTree).FileAndForget();
+            }
+
+            public abstract void RefreshTree();
 
             public TreeNode TreeViewNode { get; }
             public GitUICommands UICommands => _uiCommandsSource.UICommands;
@@ -124,45 +148,88 @@ namespace GitUI.BranchTreePanel
             public bool IgnoreSelectionChangedEvent { get; set; }
             protected GitModule Module => UICommands.Module;
 
-            public async Task ReloadAsync(CancellationToken token)
+            // Invoke from child class to reload nodes for the current Tree. Clears Nodes, invokes
+            // input async function that should populate Nodes, then fills the tree view with its contents,
+            // making sure to disable/enable the control.
+            protected void ReloadNodes(Func<CancellationToken, Task> loadNodesTask)
             {
-                await TreeViewNode.TreeView.SwitchToMainThreadAsync(token);
-                ClearNodes();
+                ThreadHelper.ThrowIfNotOnUIThread();
 
-                await LoadNodesAsync(token).ConfigureAwait(false);
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    try
+                    {
+                        var token = _reloadCancellationTokenSequence.Next();
 
-                await TreeViewNode.TreeView.SwitchToMainThreadAsync(token);
-                TreeViewNode.TreeView.BeginUpdate();
-                try
-                {
-                    FillTreeViewNode();
-                    if (TreeViewNode.TreeView.SelectedNode != null)
-                    {
-                        TreeViewNode.TreeView.SelectedNode.EnsureVisible();
+                        TreeViewNode.TreeView.BeginUpdate();
+                        TreeViewNode.TreeView.Enabled = false;
+                        IgnoreSelectionChangedEvent = true;
+                        Nodes.Clear();
+
+                        await loadNodesTask(token);
+
+                        token.ThrowIfCancellationRequested();
+                        await TreeViewNode.TreeView.SwitchToMainThreadAsync();
+
+                        FillTreeViewNode();
                     }
-                    else if (TreeViewNode.TreeView.Nodes.Count > 0)
+                    finally
                     {
-                        TreeViewNode.TreeView.Nodes[0].EnsureVisible();
+                        IgnoreSelectionChangedEvent = false;
+                        TreeViewNode.TreeView.Enabled = true;
+                        TreeViewNode.TreeView.EndUpdate();
+                        ExpandPathToSelectedNode();
                     }
-                }
-                finally
-                {
-                    TreeViewNode.TreeView.EndUpdate();
-                }
+                }).FileAndForget();
             }
 
-            protected abstract Task LoadNodesAsync(CancellationToken token);
-
-            protected virtual void ClearNodes()
+            private void FillTreeViewNode()
             {
-                Nodes.Clear();
-            }
+                ThreadHelper.ThrowIfNotOnUIThread();
 
-            protected virtual void FillTreeViewNode()
-            {
                 var expandedNodesState = TreeViewNode.GetExpandedNodesState();
                 Nodes.FillTreeViewNode(TreeViewNode);
+                PostFillTreeViewNode();
                 TreeViewNode.RestoreExpandedNodesState(expandedNodesState);
+            }
+
+            // Called after the TreeView has been populated from Nodes. A good place to update properties
+            // of the TreeViewNode, such as it's name (TreeViewNode.Text), Expand/Collapse state, and
+            // to set selected node (TreeViewNode.TreeView.SelectedNode).
+            protected virtual void PostFillTreeViewNode()
+            {
+            }
+
+            private void ExpandPathToSelectedNode()
+            {
+                TreeNode selectedNode = null;
+                if (TreeViewNode.TreeView.SelectedNode != null)
+                {
+                    selectedNode = TreeViewNode.TreeView.SelectedNode;
+                }
+                else if (TreeViewNode.TreeView.Nodes.Count > 0)
+                {
+                    selectedNode = TreeViewNode.TreeView.Nodes[0];
+                }
+
+                if (selectedNode == null)
+                {
+                    return;
+                }
+
+                SetSelectedNode(selectedNode);
+                return;
+
+                void SetSelectedNode(TreeNode node)
+                {
+                    TreeViewNode.TreeView.SelectedNode = node;
+                    TreeViewNode.TreeView.SelectedNode.EnsureVisible();
+
+                    // EnsureVisible leads to horizontal scrolling in some cases. We make sure to force horizontal
+                    // scroll back to 0. Note that we use SendMessage rather than SetScrollPos as the former works
+                    // outside of Begin/EndUpdate.
+                    NativeMethods.SendMessageInt((IntPtr)TreeViewNode.TreeView.Handle, NativeMethods.WM_HSCROLL, (IntPtr)NativeMethods.SB_LEFT, IntPtr.Zero);
+                }
             }
         }
 
@@ -182,7 +249,7 @@ namespace GitUI.BranchTreePanel
             private TreeNode _treeViewNode;
             public TreeNode TreeViewNode
             {
-                protected get => _treeViewNode;
+                get => _treeViewNode;
                 set
                 {
                     _treeViewNode = value;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -836,8 +836,6 @@ namespace GitUI.CommandsDialogs
 
                 if (validBrowseDir)
                 {
-                    ReloadRepoObjectsTree();
-
                     _windowsJumpListManager.AddToRecent(Module.WorkingDir);
 
                     // add Navigate and View menu
@@ -935,16 +933,6 @@ namespace GitUI.CommandsDialogs
 
                 RevisionGrid.IndexWatcher.Reset();
             }
-        }
-
-        private void ReloadRepoObjectsTree()
-        {
-            if (MainSplitContainer.Panel1Collapsed)
-            {
-                return;
-            }
-
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => repoObjectsTree.ReloadAsync()).FileAndForget();
         }
 
         private void OnActivate()
@@ -1332,6 +1320,7 @@ namespace GitUI.CommandsDialogs
         {
             RefreshRevisions();
             RefreshStatus();
+            repoObjectsTree.RefreshTree();
         }
 
         private void RefreshDashboardToolStripMenuItemClick(object sender, EventArgs e)
@@ -2973,7 +2962,6 @@ namespace GitUI.CommandsDialogs
         private void toggleBranchTreePanel_Click(object sender, EventArgs e)
         {
             MainSplitContainer.Panel1Collapsed = !MainSplitContainer.Panel1Collapsed;
-            ReloadRepoObjectsTree();
             RefreshLayoutToggleButtonStates();
         }
 


### PR DESCRIPTION
This is work based off the conversations from this other PR: https://github.com/gitextensions/gitextensions/pull/5617

Changes proposed in this pull request:

Rework RepoObjectsTree (ROT) so that instead of being "push" updated from FormBrowse via ROT.ReloadAsync, the Tree nodes (Branches, Remotes, and Tags) now "pull" for changes via UICommands.PostRepositoryChanged (i.e. "pubsub").

This refactor will allow for the Submodules tree work proposed in the other [PR](https://github.com/gitextensions/gitextensions/pull/5617) to be done more easily. In fact, I have a local commit on top of these changes for this, and it works very well now.
 
Screenshots before and after (if PR changes UI):
- No screenshots as it behaves pretty much like before. Unfortunately, because each Tree node is responsible for updating itself independently, there's a bit more refresh glitchiness, but I tried to minimize it (see Tree.ReloadNodes).


What did I do to test the code and ensure quality:

This change removes the "push" update from FormBrowse, so I identified the places that used to perform this push, and made sure to address them, and test them. Namely:

* Refresh (from button or menu): Refresh is used for when user does stuff in shell outside of GE, so we do care about this. This works by calling ROT.RefreshTree which acts as though the repo has changed.
* FormReflog: Now uses GitUICommands instead of creating its own FormCreateBranch so that PostRepositoryChanged will get called.
* Undo last commit: Nothing to do since undoing a commit shouldn't affect Branches/Remotes/Tags. (Note that with Submodules, we might revert a commit that affects submodule status, so maybe call SubmoduleProvider.Upate after? Or for now, just let user refresh until SubmoduleProvider can do its own polling for changes in the background?).
* FormBrowse.RegisterPlugins: Nothing to do since ROT is not affected by plugins.

Apart from that, I tested:
* Switching repos
* Create/delete branches
* Using FormReflog to create branches
* Refreshing (both refresh button and "Reload" ROT context action) after making modifications outside the repo. Note that the "Reload" action should probably be removed since Refresh does the trick, and actually, if you create a branch outside of GE, then reload ROT, it will show the branch but FormBrowse will not, so probably better to just drop ROT.Reload and stick to Refresh only.

Has been tested on (remove any that don't apply):
- GIT 2.19.1.windows.1
- Windows 10
