### PR TITLE
Fix incorrect v-position for parent centered windows

### DIFF
--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -13,10 +14,9 @@ namespace GitUI
     /// <remarks>Includes support for font, hotkey, icon, translation, and position restore.</remarks>
     public class GitExtensionsForm : GitExtensionsFormBase
     {
-        private readonly WindowPositionManager _windowPositionManager = new WindowPositionManager();
-
+        private IWindowPositionManager _windowPositionManager = new WindowPositionManager();
+        private Func<IReadOnlyList<Rectangle>> _getScreensWorkingArea = () => Screen.AllScreens.Select(screen => screen.WorkingArea).ToArray();
         private bool _needsPositionRestore;
-        private bool _windowCentred;
 
         /// <summary>Creates a new <see cref="GitExtensionsForm"/> without position restore.</summary>
         public GitExtensionsForm()
@@ -89,10 +89,9 @@ namespace GitUI
 
             if (WindowState == FormWindowState.Minimized)
             {
+                // TODO: do we still need to assert when restored it is shown on the correct monitor?
                 return;
             }
-
-            _windowCentred = StartPosition == FormStartPosition.CenterParent;
 
             var position = _windowPositionManager.LoadPosition(this);
             if (position == null)
@@ -102,7 +101,8 @@ namespace GitUI
 
             _needsPositionRestore = false;
 
-            if (!Screen.AllScreens.Any(screen => screen.WorkingArea.IntersectsWith(position.Rect)))
+            var workingArea = _getScreensWorkingArea();
+            if (!workingArea.Any(screen => screen.IntersectsWith(position.Rect)))
             {
                 if (position.State == FormWindowState.Maximized)
                 {
@@ -114,6 +114,7 @@ namespace GitUI
 
             SuspendLayout();
 
+            var windowCentred = StartPosition == FormStartPosition.CenterParent;
             StartPosition = FormStartPosition.Manual;
 
             if (FormBorderStyle == FormBorderStyle.Sizable ||
@@ -122,11 +123,11 @@ namespace GitUI
                 Size = DpiUtil.Scale(position.Rect.Size, originalDpi: position.DeviceDpi);
             }
 
-            if (Owner == null || !_windowCentred)
+            if (Owner == null || !windowCentred)
             {
                 var location = DpiUtil.Scale(position.Rect.Location, originalDpi: position.DeviceDpi);
 
-                if (WindowPositionManager.FindWindowScreen(location, Screen.AllScreens.Select(screen => screen.WorkingArea)) is Rectangle rect)
+                if (WindowPositionManager.FindWindowScreen(location, workingArea) is Rectangle rect)
                 {
                     location.Y = rect.Y;
                 }
@@ -147,6 +148,31 @@ namespace GitUI
             }
 
             ResumeLayout();
+        }
+
+        // This is a base class for many forms, which have own GetTestAccessor() methods. This has to be unique
+        internal GitExtensionsFormTestAccessor GetGitExtensionsFormTestAccessor() => new GitExtensionsFormTestAccessor(this);
+
+        internal readonly struct GitExtensionsFormTestAccessor
+        {
+            private readonly GitExtensionsForm _form;
+
+            public GitExtensionsFormTestAccessor(GitExtensionsForm form)
+            {
+                _form = form;
+            }
+
+            public IWindowPositionManager WindowPositionManager
+            {
+                get => _form._windowPositionManager;
+                set => _form._windowPositionManager = value;
+            }
+
+            public Func<IReadOnlyList<Rectangle>> GetScreensWorkingArea
+            {
+                get => _form._getScreensWorkingArea;
+                set => _form._getScreensWorkingArea = value;
+            }
         }
     }
 }

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -139,7 +139,7 @@ namespace GitUI
                 // Calculate location for modal form with parent
                 Location = new Point(
                     Owner.Left + (Owner.Width / 2) - (Width / 2),
-                    Math.Max(0, Owner.Top + (Owner.Height / 2) - (Height / 2)));
+                    Owner.Top + (Owner.Height / 2) - (Height / 2));
             }
 
             if (WindowState != position.State)

--- a/GitUI/WindowPositionManager.cs
+++ b/GitUI/WindowPositionManager.cs
@@ -8,7 +8,24 @@ using JetBrains.Annotations;
 
 namespace GitUI
 {
-    internal sealed class WindowPositionManager
+    internal interface IWindowPositionManager
+    {
+        /// <summary>
+        /// Retrieves a persisted position for the given <paramref name="form"/>.
+        /// </summary>
+        /// <param name="form">The form to look the position for.</param>
+        /// <returns>The form's persisted position; otherwise <see langword="null"/>.</returns>
+        WindowPosition LoadPosition(Form form);
+
+        /// <summary>
+        ///   Save the position of a form to the user settings. Hides the window
+        ///   as a side-effect.
+        /// </summary>
+        /// <param name="form">The form to save the position for.</param>
+        void SavePosition(Form form);
+    }
+
+    internal sealed class WindowPositionManager : IWindowPositionManager
     {
         private static WindowPositionList _windowPositionList;
 

--- a/UnitTests/GitUITests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUITests/GitExtensionsFormTests.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Drawing;
+using System.Threading;
+using System.Windows.Forms;
+using FluentAssertions;
+using GitUI;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public class GitExtensionsFormTests
+    {
+        private IWindowPositionManager _windowPositionManager;
+
+        [SetUp]
+        public void Setup()
+        {
+            _windowPositionManager = Substitute.For<IWindowPositionManager>();
+        }
+
+        [Test]
+        public void RestorePosition_should_not_restore_position_if_not_required()
+        {
+            var form = new MockForm(false)
+            {
+                Location = new Point(-100, -100),
+                Size = new Size(500, 500)
+            };
+
+            var test = form.GetGitExtensionsFormTestAccessor();
+            test.GetScreensWorkingArea = () => throw new InvalidOperationException();
+
+            form.InvokeRestorePosition();
+
+            form.Location.Should().Be(new Point(-100, -100));
+            form.Size.Should().Be(new Size(500, 500));
+        }
+
+        [Test]
+        public void RestorePosition_should_not_restore_position_if_minimised()
+        {
+            var form = new MockForm(false)
+            {
+                Location = new Point(-100, -100),
+                Size = new Size(500, 500),
+                WindowState = FormWindowState.Minimized
+            };
+
+            var test = form.GetGitExtensionsFormTestAccessor();
+            test.GetScreensWorkingArea = () => throw new InvalidOperationException();
+
+            form.InvokeRestorePosition();
+
+            form.Location.Should().Be(new Point(-100, -100));
+            form.Size.Should().Be(new Size(500, 500));
+            form.WindowState.Should().Be(FormWindowState.Minimized);
+        }
+
+        [Test]
+        public void RestorePosition_should_not_restore_position_if_not_persisted()
+        {
+            var form = new MockForm(true)
+            {
+                Location = new Point(-100, -100),
+                Size = new Size(500, 500)
+            };
+
+            var test = form.GetGitExtensionsFormTestAccessor();
+            test.GetScreensWorkingArea = () => throw new InvalidOperationException();
+            test.WindowPositionManager = _windowPositionManager;
+
+            _windowPositionManager.LoadPosition(form).Returns(x => null);
+
+            form.InvokeRestorePosition();
+
+            form.Location.Should().Be(new Point(-100, -100));
+            form.Size.Should().Be(new Size(500, 500));
+        }
+
+        [TestCase(FormBorderStyle.Fixed3D)]
+        [TestCase(FormBorderStyle.FixedDialog)]
+        [TestCase(FormBorderStyle.FixedSingle)]
+        [TestCase(FormBorderStyle.FixedToolWindow)]
+        [TestCase(FormBorderStyle.None)]
+        public void RestorePosition_should_not_scale_fixed_window_if_different_dpi(FormBorderStyle borderStyle)
+        {
+            var form = new MockForm(true)
+            {
+                Location = new Point(-100, -100),
+                Size = new Size(300, 300),
+                FormBorderStyle = borderStyle
+            };
+
+            var screens = new[]
+            {
+                new Rectangle(-1920, 0, 1920, 1080),
+                new Rectangle(1920, 0, 1920, 1080),
+                new Rectangle(0, 0, 1920, 1080)
+            };
+
+            var test = form.GetGitExtensionsFormTestAccessor();
+            test.GetScreensWorkingArea = () => screens;
+            test.WindowPositionManager = _windowPositionManager;
+
+            _windowPositionManager.LoadPosition(form).Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), 96, FormWindowState.Normal, "bla"));
+
+            form.InvokeRestorePosition();
+
+            form.Size.Should().Be(new Size(300, 300));
+        }
+
+        [TestCase(96, 500, 500)]
+        [TestCase(120, 400, 400)]
+        [TestCase(144, 333, 333)]
+        [TestCase(192, 250, 250)]
+        public void RestorePosition_should_scale_sizable_window_if_different_dpi(int savedDpi, int expectedWidthAt96dpi, int expectedHeightAt96dpi)
+        {
+            var form = new MockForm(true)
+            {
+                Location = new Point(-100, -100),
+                Size = new Size(300, 300),
+            };
+
+            var screens = new[]
+            {
+                new Rectangle(-1920, 0, 1920, 1080),
+                new Rectangle(1920, 0, 1920, 1080),
+                new Rectangle(0, 0, 1920, 1080)
+            };
+
+            var test = form.GetGitExtensionsFormTestAccessor();
+            test.GetScreensWorkingArea = () => screens;
+            test.WindowPositionManager = _windowPositionManager;
+
+            _windowPositionManager.LoadPosition(form).Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), savedDpi, FormWindowState.Normal, "bla"));
+
+            form.InvokeRestorePosition();
+
+            form.Size.Should().Be(new Size(expectedHeightAt96dpi, expectedHeightAt96dpi));
+        }
+
+        [Test]
+        public void RestorePosition_should_position_window_with_Owner_set_and_CenterParent()
+        {
+            var owner = new Form
+            {
+                Location = new Point(-1000, 100),
+                Size = new Size(800, 600)
+            };
+            var form = new MockForm(true)
+            {
+                Owner = owner,
+                StartPosition = FormStartPosition.CenterParent
+            };
+            var screens = new[]
+            {
+                new Rectangle(-1920, 0, 1920, 1080),
+                new Rectangle(1920, 0, 1920, 1080),
+                new Rectangle(0, 0, 1920, 1080)
+            };
+
+            var test = form.GetGitExtensionsFormTestAccessor();
+            test.GetScreensWorkingArea = () => screens;
+            test.WindowPositionManager = _windowPositionManager;
+            _windowPositionManager.LoadPosition(form).Returns(x => new WindowPosition(new Rectangle(100, 100, 300, 200), 96, FormWindowState.Normal, "bla"));
+
+            form.InvokeRestorePosition();
+
+            form.Location.Should().Be(new Point(/* -1000 + (800 - 300)/2 */-750, /* 100 + (600-200)/2 */300));
+        }
+
+        private class MockForm : GitExtensionsForm
+        {
+            public MockForm(bool enablePositionRestore)
+                : base(enablePositionRestore)
+            {
+            }
+
+            public void InvokeRestorePosition()
+            {
+                RestorePosition();
+            }
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUITests/GitExtensionsFormTests.cs
@@ -142,12 +142,14 @@ namespace GitUITests
             form.Size.Should().Be(new Size(expectedHeightAt96dpi, expectedHeightAt96dpi));
         }
 
-        [Test]
-        public void RestorePosition_should_position_window_with_Owner_set_and_CenterParent()
+        [TestCase(-1000, 100, /* -1000 + (800 - 300)/2 */ -750, /* 100 + (600-200)/2 */300)]
+        [TestCase(0, 0, /* 0 + (800 - 300)/2 */ 250, /* 0 + (600-200)/2 */200)]
+        [TestCase(1000, -400, /* 1000 + (800 - 300)/2 */ 1250, /* -400 + (600-200)/2 */ -200)]
+        public void RestorePosition_should_position_window_with_Owner_set_and_CenterParent(int ownerFormTop, int ownerFormLeft, int expectFormTop, int expectedFormLeft)
         {
             var owner = new Form
             {
-                Location = new Point(-1000, 100),
+                Location = new Point(ownerFormTop, ownerFormLeft),
                 Size = new Size(800, 600)
             };
             var form = new MockForm(true)
@@ -169,7 +171,7 @@ namespace GitUITests
 
             form.InvokeRestorePosition();
 
-            form.Location.Should().Be(new Point(/* -1000 + (800 - 300)/2 */-750, /* 100 + (600-200)/2 */300));
+            form.Location.Should().Be(new Point(expectFormTop, expectedFormLeft));
         }
 
         private class MockForm : GitExtensionsForm

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />
     <Compile Include="Editor\FileViewerTextTests.cs" />
     <Compile Include="FindFilePredicateProviderTest.cs" />
+    <Compile Include="GitExtensionsFormTests.cs" />
     <Compile Include="Helpers\DiffKindRevisionTests.cs" />
     <Compile Include="ControlUtilTests.cs" />
     <Compile Include="LinqExtensionsTests.cs" />


### PR DESCRIPTION
Changes proposed in this pull request:
- If a user had a secondary monitor above the primary monitor, the main windows was opened on the secondary monitor, windows that persist their locations would get opened on the primary monitor.
The fix places new windows at the center of their parent.

What did I do to test the code and ensure quality:
- refactored the code so it can be tested
- added tests
- fixed the code
