### PR TITLE
fix: FormCommit default button

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -398,8 +398,6 @@ namespace GitUI.CommandsDialogs
                 Initialize();
             }
 
-            AcceptButton = Commit;
-
             string message;
 
             switch (_commitKind)
@@ -1860,7 +1858,6 @@ namespace GitUI.CommandsDialogs
 
                 Commit.Enabled = true;
                 Amend.Enabled = true;
-                AcceptButton = Commit;
             }
 
             if (AppSettings.RevisionGraphShowWorkingDirChanges)


### PR DESCRIPTION
Undo default button setting in FormCommit.

Reverting changes introduced in
* 4449536319ee86c8ceb159a61abba0c87c6274ce
* a688346a21bd0ba9f22d0294c3547703e5a2ea20

Closes #5644
