### PR TITLE
Avoid automatic quotes on FileFilter value.

### DIFF
--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -119,7 +119,7 @@ namespace GitUI.UserControls.RevisionGrid
         {
             if (FileFilterCheck.Checked)
             {
-                return FileFilter.Text.ToPosixPath().Quote();
+                return FileFilter.Text.ToPosixPath();
             }
 
             return "";


### PR DESCRIPTION
This allows to specify several files/directories as filter values.
If someone has spaces in the path/file names, then the quotes must be already added in the filter dialog.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5623 

Changes proposed in this pull request:
- Removed automatic quotes around the filter value entered in the dialog.
- Makes it possible to specify not only one, but several different directories/files in the filter dialog.
 
What did I do to test the code and ensure quality:
- Manual tests.
- E.g. specify the following value ' "*TortoiseSVN License.txt" "*Traditional Chin*.gif" ' in filter dialog.

Has been tested on (remove any that don't apply):
- GIT 2.18
- Windows 10