### PR TITLE
WIP 5678: Really removed horizontal scrollbar, instead of making it invisble

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -298,11 +298,6 @@ namespace GitUI.Editor
             return toolStripItem;
         }
 
-        public void EnableScrollBars(bool enable)
-        {
-            internalFileViewer.EnableScrollBars(enable);
-        }
-
         public void SetVisibilityDiffContextMenu(bool visible, bool isStagingDiff)
         {
             _currentViewIsPatch = visible;

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -191,13 +191,6 @@ namespace GitUI.Editor
             return 0;
         }
 
-        public void EnableScrollBars(bool enable)
-        {
-            TextEditor.ActiveTextAreaControl.VScrollBar.Width = 0;
-            TextEditor.ActiveTextAreaControl.VScrollBar.Visible = enable;
-            TextEditor.ActiveTextAreaControl.TextArea.Dock = DockStyle.Fill;
-        }
-
         public void AddPatchHighlighting()
         {
             _diffHighlightService.AddPatchHighlighting(TextEditor.Document);

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -28,7 +28,6 @@ namespace GitUI.Editor
         event KeyEventHandler KeyUp;
         event EventHandler DoubleClick;
 
-        void EnableScrollBars(bool enable);
         void Find();
         Task FindNextAsync(bool searchForwardOrOpenWithDifftool);
 

--- a/GitUI/UserControls/BlameControl.Designer.cs
+++ b/GitUI/UserControls/BlameControl.Designer.cs
@@ -88,8 +88,9 @@
             // 
             // BlameCommitter
             // 
+            this.BlameCommitter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
             this.BlameCommitter.ContextMenuStrip = this.contextMenu;
-            this.BlameCommitter.Dock = System.Windows.Forms.DockStyle.Fill;
             this.BlameCommitter.IsReadOnly = false;
             this.BlameCommitter.Location = new System.Drawing.Point(0, 0);
             this.BlameCommitter.Margin = new System.Windows.Forms.Padding(0);

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitUI.CommitInfo;
 using GitUI.Editor;
 using GitUI.HelperDialogs;
@@ -38,13 +39,13 @@ namespace GitUI.Blame
             InitializeComplete();
 
             BlameCommitter.IsReadOnly = true;
-            BlameCommitter.EnableScrollBars(false);
             BlameCommitter.ShowLineNumbers = false;
             BlameCommitter.ScrollPosChanged += BlameCommitter_ScrollPosChanged;
             BlameCommitter.MouseMove += BlameCommitter_MouseMove;
             BlameCommitter.MouseLeave += BlameCommitter_MouseLeave;
             BlameCommitter.SelectedLineChanged += SelectedLineChanged;
             BlameCommitter.RequestDiffView += ActiveTextAreaControlDoubleClick;
+            BlameCommitter.Width = DpiUtil.Scale(2000);
 
             BlameFile.IsReadOnly = true;
             BlameFile.ScrollPosChanged += BlameFile_ScrollPosChanged;


### PR DESCRIPTION
Fixes #5678

Changes proposed in this pull request:
- The horizontalscrollbar in the blame view was there and active. Only made invisible by a hack.
- Applied another hack, by making the committer panel wider, so no horizontal scrollbar is there
- The code is not really good. But this hack is better then the old one. This doesn't rely on the internals of the ICSharpCode control.
- Before, scrolling horizontal was possible. Either by using mouse buttons, or by selecting the text. This broke the control. Now scrolling horizontal is not possible. Scrolling is impossible because the control is really wide now. This is not visible, it is clipped by its parent.
 
Screenshots before and after (if PR changes UI):
- No UI changes, only a bug fix

What did I do to test the code and ensure quality:
- Manual testing
- Testing on 200% scaling

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
