### PR TITLE
#5658 Update node cache to fix quick search

### DIFF
--- a/GitCommands/Git/GitRevisionTester.cs
+++ b/GitCommands/Git/GitRevisionTester.cs
@@ -106,7 +106,7 @@ namespace GitCommands.Git
                 return true;
             }
 
-            return revision.Author?.StartsWith(criteria, StringComparison.CurrentCultureIgnoreCase) == true ||
+            return revision.Author?.IndexOf(criteria, StringComparison.CurrentCultureIgnoreCase) >= 0 ||
                    revision.Subject?.IndexOf(criteria, StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -371,6 +371,7 @@ namespace GitUI.UserControls.RevisionGrid
         [CanBeNull]
         public GitRevision GetRevision(int rowIndex)
         {
+            _revisionGraph.CacheTo(rowIndex, /*no update of _orderedRowCache necessary*/ -1);
             return _revisionGraph.GetNodeForRow(rowIndex)?.GitRevision;
         }
 


### PR DESCRIPTION
Fixes #5658

Changes proposed in this pull request:
- update the node cache to ensure that the quick search *gets* the revisions
- match the quick search string anywhere in the `revision.Author`
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.a1
- 9ba3f7c
- Git 2.18.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0