### PR TITLE
Fix RemoteObjectTree branch folder nodes sometimes becoming bold

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -109,10 +109,7 @@ namespace GitUI.BranchTreePanel
             {
                 base.ApplyStyle();
                 TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.BranchDocument);
-                if (IsActive)
-                {
-                    TreeViewNode.NodeFont = new Font(AppSettings.Font, FontStyle.Bold);
-                }
+                SetNodeFont(IsActive ? FontStyle.Bold : FontStyle.Regular);
             }
 
             public override bool Equals(object obj)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -218,8 +219,37 @@ namespace GitUI.BranchTreePanel
                 return ToString();
             }
 
+            protected void SetNodeFont(FontStyle style)
+            {
+                if (style == FontStyle.Regular)
+                {
+                    // For regular, set to null to use the NativeTreeView font
+                    if (TreeViewNode.NodeFont != null)
+                    {
+                        TreeViewNode.NodeFont.Dispose();
+                        TreeViewNode.NodeFont = null;
+                    }
+                }
+                else
+                {
+                    // If current font doesn't have the input style, get rid of it
+                    if (TreeViewNode.NodeFont != null && !TreeViewNode.NodeFont.Style.HasFlag(style))
+                    {
+                        TreeViewNode.NodeFont.Dispose();
+                        TreeViewNode.NodeFont = null;
+                    }
+
+                    // If non-null, our font is already valid, otherwise create a new one
+                    if (TreeViewNode.NodeFont == null)
+                    {
+                        TreeViewNode.NodeFont = new Font(AppSettings.Font, style);
+                    }
+                }
+            }
+
             protected virtual void ApplyStyle()
             {
+                SetNodeFont(FontStyle.Regular);
             }
 
             internal virtual void OnSelected()


### PR DESCRIPTION
Fixes RemoteObjectTree sometimes resulting in font bolding for branch path nodes upon switching repo. 

Screenshots before and after (if PR changes UI):

This is what can happen:
![image](https://user-images.githubusercontent.com/6893883/47948292-e9318500-df04-11e8-8dc9-e464b762c871.png)

Note that "amaiorano" should not be bolded. This happened because the previous repo's 2 root nodes had the second node bolded, not the first; upon switching to this repo, it recycled the 2nd node for the branch path "amaiorano", but left it bold. This happened because the font reset for all nodes was removed as an optimization in cd68a511068cd2c0095793d27b2f4c50efb955a6. This change brings it back, but in an optimal way.

What did I do to test the code and ensure quality:
- Tested opening different repos, and in particular the one that caused this problem to show up.

Has been tested on (remove any that don't apply):
- Windows 10
