### PR TITLE
Increase contrast of blue branch and selected row

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -10,7 +10,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         internal static readonly IReadOnlyList<Color> PresetGraphColors = new[]
 {
             Color.FromArgb(240, 36, 117),
-            Color.FromArgb(52, 152, 219),
+            Color.FromArgb(120, 180, 255), // light blue
             Color.FromArgb(46, 204, 113),
             Color.FromArgb(142, 68, 173),
             Color.FromArgb(231, 76, 60),


### PR DESCRIPTION
Changes proposed in this pull request:
- increase the contrast between the blue branch graph lanes and the selected revision row
 
Screenshots before and after (if PR changes UI):
- before
![grafik](https://user-images.githubusercontent.com/36601201/47957962-21969900-dfc1-11e8-95f4-82d8aac359bc.png)
- intermediate replaced commit
![grafik](https://user-images.githubusercontent.com/36601201/47958003-d466f700-dfc1-11e8-99ac-0566719545c9.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/47963576-512fba80-e02e-11e8-9ac1-48f5cd874c2b.png)

What did I do to test the code and ensure quality:
- just run GE

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.a1
- 4f3829a 
- Git 2.18.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
