### PR TITLE
Fix GetSubmodulesLocalPaths(recursive: true) not actually recursing d…

### DIFF
--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -25,6 +25,10 @@ namespace CommonTestUtils
             module.Init(bare: false, shared: false);
             Module = module;
 
+            // Don't assume global user/email
+            Module.RunGitCmd(@"config user.name ""author""");
+            Module.RunGitCmd(@"config user.email ""<author@mail.com>""");
+
             return;
 
             string GetTemporaryPath()

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -114,10 +114,29 @@ namespace CommonTestUtils
                 // Directory.Delete seems to intermittently fail, so delete the files first before deleting folders
                 foreach (var file in Directory.GetFiles(TemporaryPath, "*", SearchOption.AllDirectories))
                 {
+                    if (File.GetAttributes(file).HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        continue;
+                    }
+
+                    File.SetAttributes(file, FileAttributes.Normal);
                     File.Delete(file);
                 }
 
-                Directory.Delete(TemporaryPath, true);
+                // Delete tends to fail on the first try, so give it a few tries as a best effort.
+                // By this point, all files have been deleted anyway, so this is mainly about removing
+                // empty directories.
+                for (int tries = 0; tries < 10; ++tries)
+                {
+                    try
+                    {
+                        Directory.Delete(TemporaryPath, true);
+                        break;
+                    }
+                    catch
+                    {
+                    }
+                }
             }
             catch
             {

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using GitCommands;
@@ -451,6 +452,61 @@ namespace GitCommandsTests
 
             Assert.AreEqual("Please enter a name.", _gitModule.AddRemote("", path));
             Assert.AreEqual("Please enter a name.", _gitModule.AddRemote(null, path));
+        }
+
+        [Test]
+        public void GetSubmodulesLocalPaths()
+        {
+            var moduleTestHelpers = new List<CommonTestUtils.GitModuleTestHelper>();
+            try
+            {
+                const int numModules = 4;
+
+                for (int i = 0; i < numModules; ++i)
+                {
+                    moduleTestHelpers.Add(new CommonTestUtils.GitModuleTestHelper($"repo{i}"));
+                }
+
+                foreach (var helper in moduleTestHelpers)
+                {
+                    // TODO: move to GitModuleTestHelper constructor (can't assume all users have global user.name/email configured)
+                    helper.Module.RunGitCmd(@"config user.name ""author""");
+                    helper.Module.RunGitCmd(@"config user.email ""<author@mail.com>""");
+
+                    // Submodules require at least one commit
+                    helper.Module.RunGitCmd(@"commit --allow-empty -m ""Initial commit""");
+                }
+
+                for (int i = numModules - 1; i > 0; --i)
+                {
+                    var parent = moduleTestHelpers[i - 1];
+                    var child = moduleTestHelpers[i];
+
+                    // Add child as submodule of parent
+                    parent.Module.RunGitCmd(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true));
+
+                    parent.Module.RunGitCmd(@"commit -am ""Add submodule""");
+                }
+
+                // Init all modules of root
+                var root = moduleTestHelpers[0];
+                root.Module.RunGitCmd(@"submodule update --init --recursive");
+
+                var paths = root.Module.GetSubmodulesLocalPaths(recursive: true);
+                Assert.AreEqual(paths.Count, 3);
+                Assert.AreEqual(paths, new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" });
+
+                paths = root.Module.GetSubmodulesLocalPaths(recursive: false);
+                Assert.AreEqual(paths.Count, 1);
+                Assert.AreEqual(paths, new string[] { "repo1" });
+            }
+            finally
+            {
+                foreach (var helper in moduleTestHelpers)
+                {
+                    helper.Dispose();
+                }
+            }
         }
     }
 }

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -469,10 +469,6 @@ namespace GitCommandsTests
 
                 foreach (var helper in moduleTestHelpers)
                 {
-                    // TODO: move to GitModuleTestHelper constructor (can't assume all users have global user.name/email configured)
-                    helper.Module.RunGitCmd(@"config user.name ""author""");
-                    helper.Module.RunGitCmd(@"config user.email ""<author@mail.com>""");
-
                     // Submodules require at least one commit
                     helper.Module.RunGitCmd(@"commit --allow-empty -m ""Initial commit""");
                 }
@@ -484,7 +480,6 @@ namespace GitCommandsTests
 
                     // Add child as submodule of parent
                     parent.Module.RunGitCmd(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true));
-
                     parent.Module.RunGitCmd(@"commit -am ""Add submodule""");
                 }
 

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -488,12 +488,12 @@ namespace GitCommandsTests
                 root.Module.RunGitCmd(@"submodule update --init --recursive");
 
                 var paths = root.Module.GetSubmodulesLocalPaths(recursive: true);
-                Assert.AreEqual(paths.Count, 3);
-                Assert.AreEqual(paths, new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" });
+                Assert.AreEqual(3, paths.Count);
+                Assert.AreEqual(new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" }, paths);
 
                 paths = root.Module.GetSubmodulesLocalPaths(recursive: false);
-                Assert.AreEqual(paths.Count, 1);
-                Assert.AreEqual(paths, new string[] { "repo1" });
+                Assert.AreEqual(1, paths.Count);
+                Assert.AreEqual(new string[] { "repo1" }, paths);
             }
             finally
             {


### PR DESCRIPTION
…eeper than one level

Fixes the fact that submodules were not actually being parsed recursively deeper than one level, and therefore not displayed properly in the Submodules menu.

Screenshots before and after (if PR changes UI):

As a test, I added GitExtensions as a submodule to GitExtensions under NBug. Without my change, when you open the top-level repo and expand the Submodules menu, you see:

![image](https://user-images.githubusercontent.com/6893883/47959699-0166da00-dfc1-11e8-98d2-e65c1daa2107.png)

Here we see ```Externals/NBug/gitextensions2```, but none of its submodules. With this change, we actually see everything:

![image](https://user-images.githubusercontent.com/6893883/47959700-16436d80-dfc1-11e8-8ae5-9fdd049c0963.png)

Note that I found this problem while working towards https://github.com/gitextensions/gitextensions/pull/5617. As a sneak peak, with this fix, the submodules ROT for this repo looks like this:

![image](https://user-images.githubusercontent.com/6893883/47959734-f06a9880-dfc1-11e8-83db-7b0d0f7de546.png)


What did I do to test the code and ensure quality:
- Tested a few different repos, and especially the one I crafted with submodules with a depth of 3.

Has been tested on (remove any that don't apply):
- GIT 2.19.1.windows.1
- Windows 10

Extra note:

Another thing I want to mention is that I think most places where we call GitModule.GetSubmodulesLocalPaths, we probably don't mean to recurse, but we do, such as in:
* GitModule.GetTreeFiles
* ImpactLoader.GetTasks
* IndexLockManager.UnlockIndex
* GitCommandHelpers.GetAllChangedFilesFromString_v1
* FormPull.PullChanges

Since this code change fixes recursion, this could impact performance for deeply nested submodule hierarchies. I think we should consider making the "recursive" parameter false by default, or force us to pass it in all the time to make it evident. In any case, this would be another change.

