### PR TITLE
Text when no common ancestors assumed 2 commits

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -59,7 +59,7 @@ namespace GitUI
         private readonly TranslationString _rebaseBranchInteractive = new TranslationString("Rebase branch interactively.");
         private readonly TranslationString _areYouSureRebase = new TranslationString("Are you sure you want to rebase? This action will rewrite commit history.");
         private readonly TranslationString _dontShowAgain = new TranslationString("Don't show me this message again.");
-        private readonly TranslationString _noMergeBaseCommit = new TranslationString("There is no merge base commit between these 2 commits.");
+        private readonly TranslationString _noMergeBaseCommit = new TranslationString("There is no common ancestor for the selected commits.");
 
         private readonly FormRevisionFilter _revisionFilter = new FormRevisionFilter();
         private readonly NavigationHistory _navigationHistory = new NavigationHistory();


### PR DESCRIPTION
Changes proposed in this pull request:
- Text for no common ancestors
Follow up to #5638 
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/47963186-d31ce500-e028-11e8-8f78-7015564c03c9.png)


- 
![image](https://user-images.githubusercontent.com/6248932/47963288-322f2980-e02a-11e8-868e-08f266dbb18a.png)



What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
