### PR TITLE
Git Version check was removed from settings

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -472,6 +472,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
                 IEnumerable<Func<bool>> CheckFuncs()
                 {
+                    yield return CheckGitCmdValid;
                     yield return CheckGlobalUserSettingsValid;
                     yield return CheckEditorTool;
                     yield return CheckMergeTool;


### PR DESCRIPTION
Fixes #5695

Changes proposed in this pull request:
- Restore Git version check in settings
 
Screenshots before and after (if PR changes UI):
- ![image](https://user-images.githubusercontent.com/6248932/47969260-36ccff80-e075-11e8-9f5b-83cf6c19b67c.png)

- 
![image](https://user-images.githubusercontent.com/6248932/47970673-19a22c00-e089-11e8-861b-c71af06aad6e.png)

- 
![image](https://user-images.githubusercontent.com/6248932/47970689-50784200-e089-11e8-9703-5c169f0ba586.png)


What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- GIT 2.19.1
- Windows 10
