### PR TITLE
Copy commit message when copy commit info is used

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -591,7 +591,7 @@ namespace GitUI.CommitInfo
 
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var commitInfo = $"{commitInfoHeader.GetPlainText()}{Environment.NewLine}{RevisionInfo.GetPlainText()}";
+            var commitInfo = $"{commitInfoHeader.GetPlainText()}{Environment.NewLine}{Environment.NewLine}{rtbxCommitMessage.GetPlainText()}{Environment.NewLine}{RevisionInfo.GetPlainText()}";
             Clipboard.SetText(commitInfo);
         }
 


### PR DESCRIPTION
Fixes #5707

Changes proposed in this pull request:
- Include the commit message when copy commitinfo in commitinfo panel
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
