### PR TITLE
Apply AppSettings.CommitFont to rtbxCommitMessage

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -101,10 +101,11 @@ namespace GitUI.CommitInfo
             _gitRevisionExternalLinksParser = new GitRevisionExternalLinksParser(_effectiveLinkDefinitionsProvider, _externalLinkRevisionParser);
             _gitDescribeProvider = new GitDescribeProvider(() => Module);
 
-            RevisionInfo.Font = AppSettings.Font;
             var color = SystemColors.Window.MakeColorDarker(0.04);
             pnlCommitMessage.BackColor = color;
             rtbxCommitMessage.BackColor = color;
+            rtbxCommitMessage.Font = AppSettings.CommitFont;
+            RevisionInfo.Font = AppSettings.Font;
 
             Hotkeys = HotkeySettingsManager.LoadHotkeys(FormBrowse.HotkeySettingsName);
             addNoteToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys((int)FormBrowse.Command.AddNotes).ToShortcutKeyDisplayString();


### PR DESCRIPTION
Changes proposed in this pull request:
- Apply the `AppSettings.CommitFont` to `CommitInfo.rtbxCommitMessage`
Using a monospace font is quite useful for detailed commit messages in the Subversion style.
 
Screenshots before and after (if PR changes UI):
- before
![grafik](https://user-images.githubusercontent.com/36601201/48026139-8d097380-e145-11e8-95de-d581c8fe5352.png)
- after with the default font
![grafik](https://user-images.githubusercontent.com/36601201/48026400-423c2b80-e146-11e8-976a-89eac0dd4d80.png)
- after with a monospace font
![grafik](https://user-images.githubusercontent.com/36601201/48026249-d48fff80-e145-11e8-9abe-b6fc17a7aa92.png)

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.a1
- 6d5a3c66a4fc89bc41d101a1d453dbed6d7a22ab  (Dirty)
- Git 2.19.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0