### PR TITLE
Prevent duplicate fixup!/squash! prefix

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -405,10 +405,10 @@ namespace GitUI.CommandsDialogs
             switch (_commitKind)
             {
                 case CommitKind.Fixup:
-                    message = $"fixup! {_editedCommit.Subject}";
+                    message = TryAddPrefix("fixup!", _editedCommit.Subject);
                     break;
                 case CommitKind.Squash:
-                    message = $"squash! {_editedCommit.Subject}";
+                    message = TryAddPrefix("squash!", _editedCommit.Subject);
                     break;
                 default:
                     message = Module.GetMergeMessage();
@@ -434,6 +434,11 @@ namespace GitUI.CommandsDialogs
             base.OnShown(e);
 
             return;
+
+            string TryAddPrefix(string prefix, string suffix)
+            {
+                return suffix.StartsWith(prefix) ? suffix : $"{prefix} {suffix}";
+            }
 
             void AssignCommitMessageFromTemplate()
             {


### PR DESCRIPTION
### Changes proposed in this pull request:
- Don't duplicate prefixes

When creating a fixup or squash commit on top of an existing `fixup!` or `squash!` commit, you could end up with doubled prefixes.

Git performs a stable reordering of commits during autosquash, so there's no need to double these prefixes.
 
### What did I do to test the code and ensure quality:
- Manual testing

### Has been tested on:
- Windows 10
