### PR TITLE
Retrieve worktrees for the current module.

### DIFF
--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void Initialize()
         {
-            var lines = new Executable("git").GetOutput("worktree list --porcelain").Split('\n').GetEnumerator();
+            var lines = Module.RunGitCmd("worktree list --porcelain").Split('\n').GetEnumerator();
 
             _worktrees = new List<WorkTree>();
             WorkTree currentWorktree = null;


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/gitextensions/gitextensions/commit/c9b4e25536c8031ba761ba1d8a8c85d8157310bb

`new Executable("git")` executes git command with the GE working directory. The git command should be executed with the current repo directory. I think that Executable should always require passing to it a workingDir. It has to be verified if the mentioned commit did not introduce more regressions like this.