### PR TITLE
Fixed issue that Dashboard is not shown when it should. Loading indicator keeps spinning

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -129,7 +129,7 @@ namespace GitExtensions
 
             if (args.Length <= 1)
             {
-                commands.StartBrowseDialog(startWithDashboard: !AppSettings.StartWithRecentWorkingDir);
+                commands.StartBrowseDialog();
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -442,6 +442,7 @@ namespace GitUI.CommandsDialogs
             if (_startWithDashboard || !Module.IsValidGitWorkingDir())
             {
                 base.OnLoad(e);
+                ShowDashboard();
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -96,7 +96,6 @@ namespace GitUI.CommandsDialogs
         private readonly IAppTitleGenerator _appTitleGenerator;
         private readonly WindowsJumpListManager _windowsJumpListManager;
         private readonly SubmoduleStatusProvider _submoduleStatusProvider;
-        private readonly bool _startWithDashboard;
 
         [CanBeNull] private BuildReportTabPageExtension _buildReportTabPageExtension;
         private ConEmuControl _terminal;
@@ -126,11 +125,9 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
         }
 
-        public FormBrowse([NotNull] GitUICommands commands, string filter, ObjectId selectCommit = null, bool startWithDashboard = false)
+        public FormBrowse([NotNull] GitUICommands commands, string filter, ObjectId selectCommit = null)
             : base(commands)
         {
-            _startWithDashboard = startWithDashboard;
-
             InitializeComponent();
 
             commandsToolStripMenuItem.DropDownOpening += CommandsToolStripMenuItem_DropDownOpening;
@@ -439,10 +436,9 @@ namespace GitUI.CommandsDialogs
             LayoutRevisionInfo();
             InternalInitialize(false);
 
-            if (_startWithDashboard || !Module.IsValidGitWorkingDir())
+            if (!Module.IsValidGitWorkingDir())
             {
                 base.OnLoad(e);
-                ShowDashboard();
                 return;
             }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1060,9 +1060,9 @@ namespace GitUI
             return StartSettingsDialog(owner, CommandsDialogs.SettingsDialog.Pages.GitConfigSettingsPage.GetPageReference());
         }
 
-        public bool StartBrowseDialog(IWin32Window owner = null, string filter = "", ObjectId selectedCommit = null, bool startWithDashboard = false)
+        public bool StartBrowseDialog(IWin32Window owner = null, string filter = "", ObjectId selectedCommit = null)
         {
-            var form = new FormBrowse(this, filter, selectedCommit, startWithDashboard);
+            var form = new FormBrowse(this, filter, selectedCommit);
 
             if (Application.MessageLoop)
             {


### PR DESCRIPTION
Fixes #5629 

Fixes issue that was posted on Gitter. Its a minor issue, but easy to fix.

Description:
> I don't have time to open an issue, but I noticed that at current upstream/master (b4a57cf503d846553ae1b5106618b6004a1735b5), if you try to run GitExtensions.exe out of the Debug or Release folder (without passing a "browse") arg, it starts up and there's an infinite spinner in the repo graph control. If you hit F5, it refreshes and works. Quick debugging, I noticed that when this happens, we never enter the "if (keepRunning || _backgroundEvent.WaitOne(200))" branch in RevisionDataGridView.BackgroundThreadEntry.
> In fact, easy repro, just remove the "browse "E:\DATA\code\active\gitextensions\GitExtensions.."" Command line arguments in the Debug settings for GitExtensions in Visual Studio, and F5 to build and run.
> I'll try to open an issue when I get the chance.
> Unless someone else can do it.

Its easy to reproduce as described in the description.

Changes proposed in this pull request:
- If Git Extensions opens without 'browse', it expects the dashboard to be opened. Ensure the dashboard is opened.
- Before, it only opened the dashboard if the current directory is not a valid git repository. Because it was not opened with 'browse', it also didn't load the revisions. Leaving the spinner the spin, forever.
- Its safe to call the method ShowDashboard(); twice, it has a guard.
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
