### PR TITLE
Cleanup selection code

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -213,50 +213,6 @@ namespace GitUI.UserControls.RevisionGrid
 
                 return data;
             }
-            set
-            {
-                if (value != null &&
-                    SelectedRows.Count == value.Count &&
-                    SelectedObjectIds?.SequenceEqual(value) == true)
-                {
-                    return;
-                }
-
-                if (value == null)
-                {
-                    // Setting CurrentCell to null internally calls ClearSelection
-                    CurrentCell = null;
-                    return;
-                }
-
-                DataGridViewCell currentCell = null;
-
-                foreach (var guid in value)
-                {
-                    if (TryGetRevisionIndex(guid) is int index &&
-                        index >= 0 &&
-                        index < Rows.Count)
-                    {
-                        Rows[index].Selected = true;
-
-                        if (currentCell == null)
-                        {
-                            // Set the current cell to the first item. We use cell
-                            // 1 because cell 0 could be hidden if they've chosen to
-                            // not see the graph
-                            currentCell = Rows[index].Cells[1];
-                        }
-                    }
-                }
-
-                // Only clear selection if we have a current cell
-                if (currentCell != null)
-                {
-                    ClearSelection();
-                }
-
-                CurrentCell = currentCell;
-            }
         }
 
         internal void AddColumn(ColumnProvider columnProvider)

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -288,5 +288,15 @@ namespace GitCommandsTests.Git
             Assert.False(ObjectId.Parse("0123456789012345678901234567890123456789").Equals(" 0123456789012345678901234567890123456789 "));
             Assert.False(ObjectId.Parse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Equals("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
         }
+
+        [Test]
+        public void Equals_using_operator()
+        {
+            string objectIdString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+            Assert.IsTrue(ObjectId.Parse(objectIdString) == ObjectId.Parse(objectIdString));
+            Assert.IsFalse(ObjectId.Parse(objectIdString) != ObjectId.Parse(objectIdString));
+            Assert.IsFalse(ObjectId.Parse(objectIdString) == ObjectId.Random());
+            Assert.IsTrue(ObjectId.Parse(objectIdString) != ObjectId.Random());
+        }
     }
 }


### PR DESCRIPTION
I wanted to work on #5353. Couldn't simulate it. The current code for choosing what rows to select in the revision grid, after a refresh/commit/initial loading/etc is too complex. I attempted to clean up unused code and simplified the current code a little.

Changes proposed in this pull request:
- Simplify selection code and cleanup
- Added a unit test to test == operator on ObjectId. And it works.
 
Screenshots before and after (if PR changes UI):
- No UI changes

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
