### PR TITLE
Fixed null reference when hovering over lane in graph

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -505,7 +505,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     if (segmentsForLane.Count() == 1)
                     {
                         // Crossing lange
-                        laneInfoText.Append(segmentsForLane.First().Parent.GitRevision.Body ?? segmentsForLane.First().Parent.GitRevision.Subject);
+                        laneInfoText.Append(segmentsForLane.First().Parent.GitRevision?.Body ?? segmentsForLane.First().Parent.GitRevision?.Subject);
                     }
                     else
                     if (segmentsForLane.Count() > 1)
@@ -515,7 +515,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                         {
                             laneInfoText.AppendLine(row.Revision.Objectid.ToString());
                             laneInfoText.AppendLine();
-                            laneInfoText.Append(row.Revision.GitRevision.Body ?? row.Revision.GitRevision.Subject);
+                            laneInfoText.Append(row.Revision.GitRevision?.Body ?? row.Revision.GitRevision?.Subject);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes null reference when hovering over a lane that continues beyond the limit of the graph. For example, see the screenprint below. The linux repo has over 600.000 commits. Its limited by default on 100.000 commits. Go to the last commit and hover over the lanes in the graph. A null reference is thrown. The application doesn't crash, the exception is eaten somewhere. Still, its better to prevent.

![image](https://user-images.githubusercontent.com/38675/48152290-c1a33980-e2c3-11e8-85cf-03a3cfd932be.png)


Changes proposed in this pull request:
- Added null check
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
