### PR TITLE
EditNetSpell: Double click marks the whole word (including underscores)

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -209,6 +209,7 @@ namespace GitUI.SpellChecker
             _customUnderlines = new SpellCheckEditControl(TextBox);
             TextBox.SelectionChanged += TextBox_SelectionChanged;
             TextBox.TextChanged += TextBoxTextChanged;
+            TextBox.DoubleClick += TextBox_DoubleClick;
 
             EnabledChanged += EditNetSpellEnabledChanged;
 
@@ -704,6 +705,13 @@ namespace GitUI.SpellChecker
 
             var handler = SelectionChanged;
             handler?.Invoke(sender, e);
+        }
+
+        private void TextBox_DoubleClick(object sender, EventArgs e)
+        {
+            int charIndexAtMousePosition = TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
+            (int start, int length) = _wordAtCursorExtractor.GetWordBounds(TextBox.Text, charIndexAtMousePosition);
+            TextBox.Select(start, length);
         }
 
         private void ShowWatermark()

--- a/GitUI/SpellChecker/SpellCheckerHelper.cs
+++ b/GitUI/SpellChecker/SpellCheckerHelper.cs
@@ -4,7 +4,7 @@
     {
         public static bool IsSeparator(this char c)
         {
-            return !char.IsLetterOrDigit(c);
+            return !char.IsLetterOrDigit(c) && c != '_';
         }
     }
 }

--- a/UnitTests/GitUITests/SpellChecker/WordAtCursorExtractorTests.cs
+++ b/UnitTests/GitUITests/SpellChecker/WordAtCursorExtractorTests.cs
@@ -20,13 +20,103 @@ namespace GitUITests.SpellChecker
         [TestCase("Add,git", ExpectedResult = "git")]
         [TestCase("Add (.git", ExpectedResult = ".git")]
         [TestCase("Introduce Tes", ExpectedResult = "Tes")]
-        [TestCase("Add).git", ExpectedResult = "git")]
+        [TestCase("Add).git", ExpectedResult = "git")] // test strings with a closing round bracket confuse the testcase parser a little
         [TestCase("[Add].git", ExpectedResult = "git")]
         [TestCase("Introduce .babeljs]", ExpectedResult = "")]
         [TestCase("func().otherFun", ExpectedResult = "otherFun")]
+        [TestCase("func().other_fun", ExpectedResult = "other_fun")]
+        [TestCase("obj._field", ExpectedResult = "_field")]
+        [TestCase("func(type init_", ExpectedResult = "init_")]
         public string ExtractsMeaningfulWord(string text)
         {
             return _wordAtCursorExtractor.Extract(text, text.Length - 1);
+        }
+
+        [TestCase("", -2, -1, 0, ExpectedResult = true)]
+        [TestCase("", -1, -1, 0, ExpectedResult = true)]
+        [TestCase("", 0, -1, 0, ExpectedResult = true)]
+        [TestCase("", 1, -1, 0, ExpectedResult = true)]
+        [TestCase("_obj.f", -2, -1, 0, ExpectedResult = true)]
+        [TestCase("_obj.f", -1, -1, 0, ExpectedResult = true)]
+        [TestCase("_obj.f", 0, 0, 4, ExpectedResult = true)]
+        [TestCase("_obj.f", 1, 0, 4, ExpectedResult = true)]
+        [TestCase("_obj.f", 2, 0, 4, ExpectedResult = true)]
+        [TestCase("_obj.f", 3, 0, 4, ExpectedResult = true)]
+        [TestCase("_obj.f", 4, 4, 1, ExpectedResult = true)]
+        [TestCase("_obj.f", 5, 5, 1, ExpectedResult = true)]
+        [TestCase("_obj.f", 6, 5, 1, ExpectedResult = true)]
+        [TestCase("_obj.f", 7, 5, 1, ExpectedResult = true)]
+        [TestCase("0  3", 0, 0, 1, ExpectedResult = true)]
+        [TestCase("0  2", 1, 1, 1, ExpectedResult = true)]
+        [TestCase("0  2", 2, 2, 1, ExpectedResult = true)]
+        [TestCase("0  2", 3, 3, 1, ExpectedResult = true)]
+        public bool Test_GetWordBounds(string text, int index, int expectedStart, int expectedLength)
+        {
+            (int start, int length) = _wordAtCursorExtractor.GetWordBounds(text, index);
+            return start == expectedStart && length == expectedLength;
+        }
+
+        [TestCase("", -2, ExpectedResult = -1)]
+        [TestCase("", -1, ExpectedResult = -1)]
+        [TestCase("", 0, ExpectedResult = -1)]
+        [TestCase("", 1, ExpectedResult = -1)]
+        [TestCase("012", -2, ExpectedResult = -1)]
+        [TestCase("012", -1, ExpectedResult = -1)]
+        [TestCase("012", 0, ExpectedResult = 0)]
+        [TestCase("012", 1, ExpectedResult = 0)]
+        [TestCase("012", 2, ExpectedResult = 0)]
+        [TestCase("012", 3, ExpectedResult = 0)]
+        [TestCase("012", 4, ExpectedResult = 0)]
+        [TestCase("01A34", 5, ExpectedResult = 0)]
+        [TestCase("01a34", 5, ExpectedResult = 0)]
+        [TestCase("01_34", 5, ExpectedResult = 0)]
+        [TestCase("01 34", 5, ExpectedResult = 3)]
+        [TestCase("01.34", 5, ExpectedResult = 3)]
+        [TestCase("01 .4", 5, ExpectedResult = 3)]
+        [TestCase("01..4", 5, ExpectedResult = 3)]
+        [TestCase("01).4", 5, ExpectedResult = 4)]
+        [TestCase("01].4", 5, ExpectedResult = 4)]
+        [TestCase("012.4", 5, ExpectedResult = 4)]
+        [TestCase("012.4", 4, ExpectedResult = 4)]
+        [TestCase("012.4", 3, ExpectedResult = 4)] // The result is right from the initial index!
+        [TestCase("012/4", 3, ExpectedResult = 4)] // ditto
+        [TestCase("012.4", 2, ExpectedResult = 0)]
+        [TestCase("012.4", 1, ExpectedResult = 0)]
+        [TestCase("012.4", 0, ExpectedResult = 0)]
+        public int Test_FindStartOfWord(string text, int index)
+        {
+            return _wordAtCursorExtractor.FindStartOfWord(text, index);
+        }
+
+        [TestCase("", -2, ExpectedResult = -1)]
+        [TestCase("", -1, ExpectedResult = -1)]
+        [TestCase("", 0, ExpectedResult = 0)]
+        [TestCase("", 1, ExpectedResult = 0)]
+        [TestCase("012", -2, ExpectedResult = -1)]
+        [TestCase("012", -1, ExpectedResult = -1)]
+        [TestCase("012", 0, ExpectedResult = 3)]
+        [TestCase("012", 1, ExpectedResult = 3)]
+        [TestCase("012", 2, ExpectedResult = 3)]
+        [TestCase("012", 3, ExpectedResult = 3)]
+        [TestCase("012", 4, ExpectedResult = 3)]
+        [TestCase("01A34", 0, ExpectedResult = 5)]
+        [TestCase("01a34", 0, ExpectedResult = 5)]
+        [TestCase("01_34", 0, ExpectedResult = 5)]
+        [TestCase("01 34", 0, ExpectedResult = 2)]
+        [TestCase("01/34", 0, ExpectedResult = 2)]
+        [TestCase("01/34", 1, ExpectedResult = 2)]
+        [TestCase("01/34", 2, ExpectedResult = 2)]
+        [TestCase("01/34", 3, ExpectedResult = 5)]
+        [TestCase("01/34", 4, ExpectedResult = 5)]
+        [TestCase("/12", 0, ExpectedResult = 0)]
+        [TestCase("/12", 1, ExpectedResult = 3)]
+        [TestCase("01/", 0, ExpectedResult = 2)]
+        [TestCase("01/", 1, ExpectedResult = 2)]
+        [TestCase("01/", 2, ExpectedResult = 2)]
+        [TestCase("01/", 3, ExpectedResult = 3)]
+        public int Test_FindEndOfWord(string text, int index)
+        {
+            return _wordAtCursorExtractor.FindEndOfWord(text, index);
         }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- `EditNetSpell`, which is used e.g. for entering the commit message, marks the whole word (including underscores) on double click.
 
Screenshots before and after (if PR changes UI):
- before/after:
![grafik](https://user-images.githubusercontent.com/36601201/48159907-ce7d5880-e2d6-11e8-81b9-53c52469d406.png)   ![grafik](https://user-images.githubusercontent.com/36601201/48160129-56636280-e2d7-11e8-957c-f6ccac02ca04.png)
![grafik](https://user-images.githubusercontent.com/36601201/48160028-18fed500-e2d7-11e8-88d6-dcbfa548c50f.png)   ![grafik](https://user-images.githubusercontent.com/36601201/48160164-6ed37d00-e2d7-11e8-9ac2-4ebb8c441ef3.png)
![grafik](https://user-images.githubusercontent.com/36601201/48160067-2c11a500-e2d7-11e8-9dd5-a299449b1049.png)   ![grafik](https://user-images.githubusercontent.com/36601201/48160203-83177a00-e2d7-11e8-89e2-fe61d5c03db5.png)
![grafik](https://user-images.githubusercontent.com/36601201/48160096-421f6580-e2d7-11e8-8dc4-cbd1a19756a4.png)   ![grafik](https://user-images.githubusercontent.com/36601201/48160225-91659600-e2d7-11e8-949d-51f03843fcc1.png)

What did I do to test the code and ensure quality:
- added test cases

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.a1
- 9fe58242d44ca3d312dd9a76ec5164b897ed073d 
- Git 2.19.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0