### PR TITLE
Fixes 5353: scrolling issue caused by refreshing the objecttree

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -161,6 +161,7 @@ namespace GitUI.BranchTreePanel
             try
             {
                 treeMain.BeginUpdate();
+                _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = true);
                 var tasks = _rootNodes.Select(r => r.ReloadAsync(token)).ToArray();
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
@@ -173,12 +174,11 @@ namespace GitUI.BranchTreePanel
                     _rootNodes.Any(rn => $"{rn.TreeViewNode.FullPath}{treeMain.PathSeparator}{currentBranch}" == n.FullPath));
                 if (selectedNode != null)
                 {
-                    _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = true);
                     treeMain.SelectedNode = selectedNode;
-                    _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                     treeMain.SelectedNode.EnsureVisible();
                 }
 
+                _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                 treeMain.EndUpdate();
             }
         }


### PR DESCRIPTION
Fixes #5353 
Fixes #5726 

Changes proposed in this pull request:
- Extend the section where selectionchanged events are ignored
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
