### PR TITLE
Fixed issue that 'Show first parent' only works when 'Current branch only' is also enabled

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -164,25 +164,31 @@ namespace GitCommands
                     $"--pretty=format:\"{fullFormat}\"",
                     { AppSettings.ShowReflogReferences, "--reflog" },
                     {
-                        refFilterOptions.HasFlag(RefFilterOptions.All),
-                        "--all",
+                        refFilterOptions.HasFlag(RefFilterOptions.FirstParent),
+                        "--first-parent",
                         new ArgumentBuilder
                         {
                             {
-                                refFilterOptions.HasFlag(RefFilterOptions.Branches) &&
-                                !branchFilter.IsNullOrWhiteSpace() &&
-                                branchFilter.IndexOfAny(new[] { '?', '*', '[' }) != -1,
-                                "--branches=" + branchFilter
+                                refFilterOptions.HasFlag(RefFilterOptions.All),
+                                "--all",
+                                new ArgumentBuilder
+                                {
+                                    {
+                                        refFilterOptions.HasFlag(RefFilterOptions.Branches) &&
+                                        !branchFilter.IsNullOrWhiteSpace() &&
+                                        branchFilter.IndexOfAny(new[] { '?', '*', '[' }) != -1,
+                                        "--branches=" + branchFilter
+                                    },
+                                    { refFilterOptions.HasFlag(RefFilterOptions.Remotes), "--remotes" },
+                                    { refFilterOptions.HasFlag(RefFilterOptions.Tags), "--tags" },
+                                }.ToString()
                             },
-                            { refFilterOptions.HasFlag(RefFilterOptions.Remotes), "--remotes" },
-                            { refFilterOptions.HasFlag(RefFilterOptions.Tags), "--tags" },
+                            { refFilterOptions.HasFlag(RefFilterOptions.Boundary), "--boundary" },
+                            { refFilterOptions.HasFlag(RefFilterOptions.ShowGitNotes), "--not --glob=notes --not" },
+                            { refFilterOptions.HasFlag(RefFilterOptions.NoMerges), "--no-merges" },
+                            { refFilterOptions.HasFlag(RefFilterOptions.SimplifyByDecoration), "--simplify-by-decoration" }
                         }.ToString()
                     },
-                    { refFilterOptions.HasFlag(RefFilterOptions.Boundary), "--boundary" },
-                    { refFilterOptions.HasFlag(RefFilterOptions.ShowGitNotes), "--not --glob=notes --not" },
-                    { refFilterOptions.HasFlag(RefFilterOptions.NoMerges), "--no-merges" },
-                    { refFilterOptions.HasFlag(RefFilterOptions.FirstParent), "--first-parent" },
-                    { refFilterOptions.HasFlag(RefFilterOptions.SimplifyByDecoration), "--simplify-by-decoration" },
                     revisionFilter,
                     "--",
                     pathFilter

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -166,12 +166,12 @@ namespace GitCommands
             {
                 "-z",
                 $"--pretty=format:\"{FullFormat}\"",
-                { AppSettings.ShowReflogReferences, "--reflog" },
                 {
                     refFilterOptions.HasFlag(RefFilterOptions.FirstParent),
                     "--first-parent",
                     new ArgumentBuilder
                     {
+                        { AppSettings.ShowReflogReferences, "--reflog" },
                         {
                             refFilterOptions.HasFlag(RefFilterOptions.All),
                             "--all",

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -179,8 +179,7 @@ namespace GitCommands
                             {
                                 {
                                     refFilterOptions.HasFlag(RefFilterOptions.Branches) &&
-                                    !branchFilter.IsNullOrWhiteSpace() &&
-                                    branchFilter.IndexOfAny(new[] { '?', '*', '[' }) != -1,
+                                    !branchFilter.IsNullOrWhiteSpace() && branchFilter.IndexOfAny(new[] { '?', '*', '[' }) != -1,
                                     "--branches=" + branchFilter
                                 },
                                 { refFilterOptions.HasFlag(RefFilterOptions.Remotes), "--remotes" },

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -462,17 +462,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                                  .DefaultIfEmpty()
                                  .Max();
 
-            // When 'git log --first-parent' filtration is enabled and when only current
-            // branch needed to be rendered (and this filter actually works),
-            // it is much more readable to limit max lanes to 1.
-            int maxLanes =
-                (AppSettings.ShowFirstParent &&
-                 AppSettings.ShowCurrentBranchOnly &&
-                 AppSettings.BranchFilterEnabled)
-                    ? 1
-                    : MaxLanes;
-
-            laneCount = Math.Min(laneCount, maxLanes);
+            laneCount = Math.Min(laneCount, MaxLanes);
             var columnWidth = (LaneWidth * laneCount) + ColumnLeftMargin;
             if (columnWidth > minimumWidth)
             {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -201,6 +201,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     // Store the newly created segment (connection between 2 revisions)
                     revisionGraphRevision.AddParent(parentRevisionGraphRevision, out int newMaxScore);
                     _maxScore = Math.Max(_maxScore, newMaxScore);
+
+                    if (types.HasFlag(RevisionNodeFlags.OnlyFirstParent))
+                    {
+                        break;
+                    }
                 }
             }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -21,7 +21,8 @@ namespace GitUI.UserControls.RevisionGrid
     {
         None = 0,
         CheckedOut = 1,
-        HasRef = 2
+        HasRef = 2,
+        OnlyFirstParent = 4
     }
 
     public sealed class RevisionDataGridView : DataGridView

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -907,6 +907,11 @@ namespace GitUI
                     flags |= RevisionNodeFlags.HasRef;
                 }
 
+                if (_refFilterOptions.HasFlag(RefFilterOptions.FirstParent))
+                {
+                    flags |= RevisionNodeFlags.OnlyFirstParent;
+                }
+
                 _gridView.Add(revision, flags);
 
                 return;

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Git\GitDescribeProviderTests.cs" />
     <Compile Include="Git\GitRefNameTests.cs" />
     <Compile Include="PlinkTests.cs" />
+    <Compile Include="RevisionReaderTests.cs" />
     <Compile Include="StreamExtensionsTests.cs" />
     <Compile Include="MockExecutable.cs" />
     <Compile Include="RepoNameExtractorTest.cs" />

--- a/UnitTests/GitCommandsTests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommandsTests/RevisionReaderTests.cs
@@ -16,10 +16,23 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void BuildArguments_should_do_something()
+        public void BuildArguments_should_appy_first_parent_correct()
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(/* args */);
-            args.ToString().Should().Be(".....");
+            RefFilterOptions refFilterOptions = RefFilterOptions.FirstParent;
+
+            string arguments = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(refFilterOptions, string.Empty, string.Empty, string.Empty).ToString();
+
+            // Check arguments that I expect
+            Assert.IsTrue(arguments.Contains("--first-parent"));
+
+            // Check for combinations that cannot be used together
+            Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--all")); // first-parent contradicts --all (it does work together, but makes no sense)
+            Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--reflog")); // first-parent works with reflog, but breaks the graph. Also, it doesn't make sense
+            Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--no-merges"));
+            Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--boundary")); // Having this and --first-parent gives strange result.
+            Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--not --glob=notes --not")); // Not sure why, but first-parent is not compatible with this
+            Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--simplify-by-decoration")); // first-parent is more restrictive, it should win
+            Assert.IsFalse(arguments.Contains("--all") && arguments.Contains("--branches")); // Show all branches and filter them, doesn't make sense
         }
     }
 }

--- a/UnitTests/GitCommandsTests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommandsTests/RevisionReaderTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public sealed class RevisionReaderTests
+    {
+        private RevisionReader _revisionReader;
+
+        [SetUp]
+        public void Setup()
+        {
+            _revisionReader = new RevisionReader();
+        }
+
+        [Test]
+        public void BuildArguments_should_do_something()
+        {
+            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(/* args */);
+            args.ToString().Should().Be(".....");
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommandsTests/RevisionReaderTests.cs
@@ -7,12 +7,20 @@ namespace GitCommandsTests
     [TestFixture]
     public sealed class RevisionReaderTests
     {
+        private bool _showReflogReferences;
         private RevisionReader _revisionReader;
 
         [SetUp]
         public void Setup()
         {
+            _showReflogReferences = AppSettings.ShowReflogReferences;
             _revisionReader = new RevisionReader();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AppSettings.ShowReflogReferences = _showReflogReferences;
         }
 
         [Test]
@@ -33,6 +41,68 @@ namespace GitCommandsTests
             Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--not --glob=notes --not")); // Not sure why, but first-parent is not compatible with this
             Assert.IsFalse(arguments.Contains("--first-parent") && arguments.Contains("--simplify-by-decoration")); // first-parent is more restrictive, it should win
             Assert.IsFalse(arguments.Contains("--all") && arguments.Contains("--branches")); // Show all branches and filter them, doesn't make sense
+        }
+
+        [Test]
+        public void BuildArguments_should_be_NUL_terminated()
+        {
+            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(RefFilterOptions.All, "", "", "");
+
+            args.ToString().Should().Contain(" log -z ");
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void BuildArguments_should_add_reflog_if_requested(bool reflog)
+        {
+            AppSettings.ShowReflogReferences = reflog;
+
+            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(RefFilterOptions.All, "", "", "");
+
+            if (reflog)
+            {
+                args.ToString().Should().Contain(" --reflog ");
+            }
+            else
+            {
+                args.ToString().Should().NotContain(" --reflog ");
+            }
+        }
+
+        /* first 'parent first' */
+        [TestCase(RefFilterOptions.FirstParent, " --first-parent ", null)]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.NoMerges, " --first-parent ", null)]
+        [TestCase(RefFilterOptions.All, null, " --first-parent ")]
+        /* if not 'first parent', then 'all' */
+        [TestCase(RefFilterOptions.FirstParent, null, " --all ")]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.All, null, " --all ")]
+        [TestCase(RefFilterOptions.All, " --all ", null)]
+        [TestCase(RefFilterOptions.Branches | RefFilterOptions.All, " --all ", null)]
+        /* if not 'first parent' and not 'all' - selected branches, if requested */
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Remotes, " --first-parent ", " --branches=")]
+        [TestCase(RefFilterOptions.All | RefFilterOptions.Remotes, " --all ", " --branches=")]
+        [TestCase(RefFilterOptions.Branches, " --branches=", null)]
+        /* if not 'first parent' and not 'all' - *ALL* remotes, if requested */
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Remotes, " --first-parent ", " --remotes ")]
+        [TestCase(RefFilterOptions.All | RefFilterOptions.Remotes, " --all ", " --remotes ")]
+        [TestCase(RefFilterOptions.Remotes, " --remotes ", null)]
+        /* if not 'first parent' and not 'all' - *ALL* tags, if requested */
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Tags, " --first-parent ", " --tags ")]
+        [TestCase(RefFilterOptions.All | RefFilterOptions.Tags, " --all ", " --tags ")]
+        [TestCase(RefFilterOptions.Tags, " --tags ", null)]
+        public void BuildArguments_check_parameters(RefFilterOptions refFilterOptions, string expectedToContain, string notExpectedToContain)
+        {
+            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(refFilterOptions, "my_*", "my_revision", "my_path");
+
+            if (expectedToContain != null)
+            {
+                args.ToString().Should().Contain(expectedToContain);
+            }
+
+            if (notExpectedToContain != null)
+            {
+                args.ToString().Should().NotContain(notExpectedToContain);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes issue posted on gitter:
`Hey all, there's something that I've often wondered about GE. When "Show first parents" is enabled, it only seems to do what I want when "Show current branch only" (Ctrl+Shift+U) is used. Otherwise, it seems to present an odd looking graph (to me) that isn't very useful.`

Seems that 'Show first parent' only works when 'Current branch only' is also enabled. This is not user friendly.

Changes proposed in this pull request:
- Make 'Show first parent' always work. Especially since the button is very prominent in the toolbar.
- Make the rendering work. It showed a strange narrow line with broken branches.
- Make the rendering not crash. The broken lines where actually branches that never stopt. Meaning: 
100.000 revisions = 100.000 lanes wide at the bottom = not responding app.
Even when the lanes where not all visible, it stopped responding.
- The code is not as clean as it should. It was kinda hacky before, and it is still a bit hacky.
- Deleted a hack that RevisionGraphColumnProvider needed to know that --first-parent was enabled.
- Suggestions/Help for better solutions are welcome. It is late and wanted a solution with minimal impact on performance and regression.

Screenshots before and after (if PR changes UI):
- Before the fix, with only 'show first parent' enabled
![image](https://user-images.githubusercontent.com/38675/48227550-ee7a4e00-e3a2-11e8-8583-57d72b9139b5.png)
- Before the fix, with both 'show first parent' and 'current branch only' enabled
![image](https://user-images.githubusercontent.com/38675/48227570-f639f280-e3a2-11e8-8b45-d93fe4b4c82e.png)
- After the fix, with only 'show first parent' enabled
![image](https://user-images.githubusercontent.com/38675/48227612-11a4fd80-e3a3-11e8-8baf-5fec457cfe51.png)

What did I do to test the code and ensure quality:
- Manual testing
- Staring at code

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
