### PR TITLE
Copy SHA via Ctrl+C broken

### DIFF
--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -32,7 +32,7 @@ namespace GitUI.UserControls.RevisionGrid
             _revisionFunc = revisionFunc;
         }
 
-        private void AddItem(string displayText, Func<GitRevision, string> extractRevisionText, Image image, char? hotkey, Keys shortcutKeys = Keys.None)
+        private void AddItem(string displayText, Func<GitRevision, string> extractRevisionText, Image image, char? hotkey)
         {
             var textToCopy = ExtractRevisionTexts(extractRevisionText);
             if (textToCopy == null)
@@ -41,10 +41,10 @@ namespace GitUI.UserControls.RevisionGrid
             }
 
             displayText += ":   " + textToCopy.Select(t => t.SubstringUntil('\n')).Join(", ").ShortenTo(40);
-            AddItem(displayText, textToCopy.Join("\n"), image, hotkey, shortcutKeys);
+            AddItem(displayText, textToCopy.Join("\n"), image, hotkey);
         }
 
-        private void AddItem([NotNull] string displayText, [NotNull] string textToCopy, Image image, char? hotkey, Keys shortcutKeys = Keys.None)
+        private void AddItem([NotNull] string displayText, [NotNull] string textToCopy, Image image, char? hotkey)
         {
             if (hotkey.HasValue)
             {
@@ -62,7 +62,6 @@ namespace GitUI.UserControls.RevisionGrid
             var item = new ToolStripMenuItem
             {
                 Text = displayText,
-                ShortcutKeys = shortcutKeys,
                 ShowShortcutKeys = true,
                 Image = image
             };
@@ -153,7 +152,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             // Add other items
             int count = revisions.Count();
-            AddItem(Strings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C', Keys.Control | Keys.C);
+            AddItem(Strings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C');
             AddItem(Strings.GetMessage(count), r => r.Body ?? r.Subject, Images.Message, 'M');
             AddItem(Strings.GetAuthor(count), r => $"{r.Author} <{r.AuthorEmail}>", Images.Author, 'A');
 

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
@@ -64,25 +64,6 @@ namespace GitUITests.UserControls.RevisionGrid
         }
 
         [Test]
-        public void Should_show_add_required_shortcuts()
-        {
-            var revisions = new[] { new GitRevision(ObjectId.Random()) };
-            _copyContextMenuItem.SetRevisionFunc(() => revisions);
-
-            _copyContextMenuItem.ShowDropDown();
-
-            _copyContextMenuItem.DropDownItems.Count.Should().Be(4);
-
-            var withShortCuts = _copyContextMenuItem.DropDownItems.OfType<ToolStripMenuItem>()
-                                            .Where(mi => mi.ShortcutKeys != Keys.None)
-                                            .ToArray();
-            withShortCuts.Length.Should().Be(1);
-
-            withShortCuts[0].Text.Should().StartWith(AddHotKey(Strings.GetCommitHash(1), 'C'));
-            withShortCuts[0].ShortcutKeys.Should().Be(Keys.Control | Keys.C);
-        }
-
-        [Test]
         public void Should_show_info_if_commit_has_defined_branches()
         {
             var revision = new GitRevision(ObjectId.Random());


### PR DESCRIPTION
Fixes #5735

Changes proposed in this pull request:
- Remove the hotkey ctrl-c from the context menu. It breaks more then it fixes.
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
