### PR TITLE
Browse: Inconsistent behavior for Refresh button and F5/Repository-menu

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1281,10 +1281,16 @@ namespace GitUI.CommandsDialogs
             UICommands.StartPushDialog(this, pushOnShow: ModifierKeys.HasFlag(Keys.Shift));
         }
 
-        private void RefreshToolStripMenuItemClick(object sender, EventArgs e)
+        private void RefreshStatus()
         {
+            _gitStatusMonitor?.RequestRefresh();
             _submoduleStatusUpdateNeeded = true;
             _stashCountUpdateNeeded = true;
+        }
+
+        private void RefreshToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            RefreshStatus();
             RefreshRevisions();
         }
 
@@ -1420,7 +1426,7 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshButtonClick(object sender, EventArgs e)
         {
-            _gitStatusMonitor?.RequestRefresh();
+            RefreshStatus();
             RefreshRevisions();
         }
 


### PR DESCRIPTION
Two separate implementations of the behavior

Changes proposed in this pull request:
- Consistent behavior. Both refreshed the revisions/graph
 - Button refreshed commit count
 - F5/Menu refreshed submodule status and stash count
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual test

Has been tested on (remove any that don't apply):
