### PR TITLE
Show correct tooltips for graph lanes

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -391,6 +391,8 @@
     <Compile Include="UserControls\GitItemStatusWithParent.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
     <Compile Include="UserControls\ListViewGroupHitInfo.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProvider.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneNodeLocator.cs" />
     <Compile Include="UserControls\RevisionGrid\Columns\RevisionGraphColumnProvider.cs" />
     <Compile Include="UserControls\RevisionGrid\Columns\MultilineIndicator.cs" />
     <Compile Include="UserControls\HslColor.cs" />

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -294,8 +294,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             {
                 var s = new StringBuilder();
 
-                s.Append(revision.Body?.TrimEnd()
-                    ?? revision.Subject + "\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
+                s.Append(revision.Body?.TrimEnd() ?? revision.Subject + Strings.BodyNotLoaded);
 
                 if (revision.Refs.Count != 0)
                 {

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using JetBrains.Annotations;
+using ResourceManager;
+
+namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    internal sealed class LaneInfoProvider
+    {
+        private static readonly TranslationString NoInfoText = new TranslationString("Sorry, this commit seems to be not loaded.");
+        private readonly ILaneNodeLocator _nodeLocator;
+
+        public LaneInfoProvider(ILaneNodeLocator nodeLocator)
+        {
+            _nodeLocator = nodeLocator;
+        }
+
+        public string GetLaneInfo(int rowIndex, int lane)
+        {
+            (var node, bool isAtNode) = _nodeLocator.FindPrevNode(rowIndex, lane);
+            if (node == null)
+            {
+                return string.Empty;
+            }
+
+            if (node.GitRevision == null)
+            {
+                return NoInfoText.Text;
+            }
+
+            var laneInfoText = new StringBuilder();
+            if (!node.GitRevision.IsArtificial)
+            {
+                if (isAtNode)
+                {
+                    laneInfoText.Append("* ");
+                }
+
+                laneInfoText.AppendLine(node.GitRevision.Guid);
+                laneInfoText.AppendLine();
+            }
+
+            if (node.GitRevision.Body != null)
+            {
+                laneInfoText.Append(node.GitRevision.Body.TrimEnd());
+            }
+            else
+            {
+                laneInfoText.Append(node.GitRevision.Subject);
+                if (node.GitRevision.HasMultiLineMessage)
+                {
+                    laneInfoText.Append(Strings.BodyNotLoaded);
+                }
+            }
+
+            return laneInfoText.ToString();
+        }
+
+        internal readonly struct TestAccessor
+        {
+            internal static TranslationString NoInfoText => LaneInfoProvider.NoInfoText;
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneNodeLocator.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneNodeLocator.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+
+namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    internal interface ILaneNodeLocator
+    {
+        (RevisionGraphRevision, bool isAtNode) FindPrevNode(int rowIndex, int lane);
+    }
+
+    internal sealed class LaneNodeLocator : ILaneNodeLocator
+    {
+        private readonly IRevisionGraphRowProvider _revisionGraphRowProvider;
+
+        public static readonly (RevisionGraphRevision, bool) NotFoundResult = (null, false);
+
+        public LaneNodeLocator(IRevisionGraphRowProvider revisionGraphRowProvider)
+        {
+            _revisionGraphRowProvider = revisionGraphRowProvider;
+        }
+
+        public (RevisionGraphRevision, bool isAtNode) FindPrevNode(int rowIndex, int lane)
+        {
+            if (rowIndex < 0 || lane < 0)
+            {
+                // as unlikely as it may be...
+                // don't throw, just pretend we couldn't find it
+                return NotFoundResult;
+            }
+
+            IRevisionGraphRow row = _revisionGraphRowProvider.GetSegmentsForRow(rowIndex);
+            if (row == null)
+            {
+                return NotFoundResult;
+            }
+
+            if (row.GetCurrentRevisionLane() == lane)
+            {
+                return (row.Revision, isAtNode: true);
+            }
+
+            var segmentsForLane = row.GetSegmentsForIndex(lane);
+            if (segmentsForLane.Count() > 0)
+            {
+                var firstParent = segmentsForLane.First().Parent;
+#if DEBUG
+                if (segmentsForLane.Any(segment => segment.Parent != firstParent))
+                {
+                    throw new Exception(string.Format("All segments for a lane should have the same parent.\n"
+                                                      + "Not fulfilled for rowIndex {0} lane {1} with {2} segments.",
+                                                      rowIndex, lane, segmentsForLane.Count()));
+                }
+#endif
+                return (firstParent, isAtNode: false);
+            }
+
+            return NotFoundResult;
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -8,8 +8,13 @@ using JetBrains.Annotations;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
+    internal interface IRevisionGraphRowProvider
+    {
+        IRevisionGraphRow GetSegmentsForRow(int row);
+    }
+
     // The RevisionGraph contains all the basic structures needed to render the graph.
-    public class RevisionGraph
+    public class RevisionGraph : IRevisionGraphRowProvider
     {
         // Some unordered collections with raw data
         private ConcurrentDictionary<ObjectId, RevisionGraphRevision> _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
@@ -123,7 +128,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             return localOrderedNodesCache.ElementAt(row);
         }
 
-        public RevisionGraphRow GetSegmentsForRow(int row)
+        public IRevisionGraphRow GetSegmentsForRow(int row)
         {
             // Use a local variable, because the cached list can be reset
             var localOrderedRowCache = _orderedRowCache;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -8,9 +8,9 @@ using GitUIPluginInterfaces;
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
     // This class represents a revision, or node.
-    //     *  <- revision
+    //     *  <- child revision
     //     |
-    //     *  <- revision
+    //     *  <- parent revision
     public class RevisionGraphRevision
     {
         public RevisionGraphRevision(ObjectId objectId, int guessScore)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -3,11 +3,21 @@ using System.Collections.Generic;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
+    public interface IRevisionGraphRow
+    {
+        RevisionGraphRevision Revision { get; }
+        IReadOnlyList<RevisionGraphSegment> Segments { get; }
+        int GetCurrentRevisionLane();
+        int GetLaneCount();
+        IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
+        int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
+    }
+
     // The RevisionGraphRow contains an ordered list of Segments that crosses the row or connects to the revision in the row.
     // The segments can be returned in the order how it is stored.
     // Segments are not the same as lanes.A crossing segment is a lane, but multiple segments can connect to the revision.
     // Therefor, a single lane can have multiple segments.
-    public class RevisionGraphRow
+    public class RevisionGraphRow : IRevisionGraphRow
     {
         public RevisionGraphRow(RevisionGraphRevision revision, IReadOnlyList<RevisionGraphSegment> segments)
         {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -1,20 +1,20 @@
 ﻿namespace GitUI.UserControls.RevisionGrid.Graph
 {
     // This class represents the connection between 2 revisions.
-    //     *
-    //     |   <- segment connects two commits
-    //     *
+    //     *    <- Child
+    //     |    <- segment connects two commits
+    //     *    <- Parent
     // A segment can span multiple rows when rendered as a graph.
     // Example: This graph has 6 segements.
-    //     *
-    //   / | \
+    //     *    <- Child
+    //   / | \  <- Child.StartSegments ("start" although they are merged here)
     //  |  *  |
     //  |  |  |
     //  |  *  |
     //   \ |  |
     //     *  |
     //     | /
-    //     *
+    //     *    <- Parent
     public class RevisionGraphSegment
     {
         public RevisionGraphSegment(RevisionGraphRevision parent, RevisionGraphRevision child)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
@@ -56,6 +56,15 @@ namespace GitUI
                         provider.TryGetToolTip(e, revision, out var toolTip) &&
                         !string.IsNullOrWhiteSpace(toolTip))
                     {
+                        int lineCount = 0;
+                        for (int pos = 0; pos < toolTip.Length; ++pos)
+                        {
+                            if (toolTip[pos] == '\n' && ++lineCount == 30)
+                            {
+                                return toolTip.Substring(0, pos + 1) + "...";
+                            }
+                        }
+
                         return toolTip;
                     }
 

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -37,9 +37,12 @@ namespace ResourceManager
         public static string LoadingData => _instance.Value._loadingDataText.Text;
         public static string UninterestingDiffOmitted => _instance.Value._uninterestingDiffOmitted.Text;
 
+        public static string Branch => _instance.Value._branchText.Text;
         public static string Branches => _instance.Value._branchesText.Text;
         public static string Remotes => _instance.Value._remotesText.Text;
         public static string Tags => _instance.Value._tagsText.Text;
+
+        public static string BodyNotLoaded => _instance.Value._bodyNotLoaded.Text;
 
         private readonly TranslationString _dateText       = new TranslationString("Date");
         private readonly TranslationString _authorText     = new TranslationString("{0:Author|Authors}");
@@ -52,9 +55,11 @@ namespace ResourceManager
         private readonly TranslationString _indexText      = new TranslationString("Commit index");
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
+        private readonly TranslationString _branchText     = new TranslationString("Branch");
         private readonly TranslationString _branchesText   = new TranslationString("Branches");
         private readonly TranslationString _remotesText    = new TranslationString("Remotes");
         private readonly TranslationString _tagsText       = new TranslationString("Tags");
+        private readonly TranslationString _bodyNotLoaded  = new TranslationString("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
 
         private readonly TranslationString _parentsText    = new TranslationString("{0:Parent|Parents}");
         private readonly TranslationString _childrenText   = new TranslationString("{0:Child|Children}");

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -90,7 +90,9 @@
     <Compile Include="UserControls\RepoStateVisualiserTests.cs" />
     <Compile Include="UserControls\RevisionGrid\CopyContextMenuItemTests.cs" />
     <Compile Include="UserControls\RevisionGrid\GitRefListsForRevisionTests.cs" />
-    <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphMultiThreadingTests.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneNodeLocatorTests.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProviderTests.cs" />
+    <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphMultiThreadingTests.cs" />	
     <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphTests.cs" />
     <Compile Include="UserManual\SingleHtmlUserManualFixture.cs" />
     <Compile Include="UserManual\StandardHtmlUserManualFixture.cs" />

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GitCommands;
+using GitUI.UserControls.RevisionGrid.Graph;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+using ResourceManager;
+
+namespace GitUITests.UserControls.RevisionGrid.Graph
+{
+    [TestFixture]
+    public class LaneInfoProviderTests
+    {
+        private RevisionGraphRevision _artificialCommitNode;
+        private RevisionGraphRevision _realCommitNode;
+        private ILaneNodeLocator _laneNodeLocator;
+        private LaneInfoProvider _infoProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _artificialCommitNode = new RevisionGraphRevision(ObjectId.WorkTreeId, 0)
+            {
+                GitRevision = new GitCommands.GitRevision(ObjectId.WorkTreeId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Body = "WIP: fixing bugs"
+                }
+            };
+            var realCommitObjectId = ObjectId.Parse("a48da1aba59a65b2a7f0df7e3512817caf16819f");
+            _realCommitNode = new RevisionGraphRevision(realCommitObjectId, 0)
+            {
+                GitRevision = new GitCommands.GitRevision(realCommitObjectId)
+                {
+                    Author = "John Doe",
+                    AuthorDate = DateTime.Parse("2010-03-24 13:37:12"),
+                    AuthorEmail = "j.doe@some.email.dotcom",
+                    Subject = "fix: bugs",
+                    Body = "fix: bugs\r\n\r\nall bugs fixed"
+                }
+            };
+            _laneNodeLocator = Substitute.For<ILaneNodeLocator>();
+            _infoProvider = new LaneInfoProvider(_laneNodeLocator);
+        }
+
+        private void GetLaneInfo_should_display(RevisionGraphRevision node, string prefix = "", string suffix = "")
+        {
+            _infoProvider.GetLaneInfo(0, 0).Should()
+                .Be(string.Format("{0}{1}{2}{2}{3}{4}",
+                    prefix,
+                    node.GitRevision.Guid,
+                    Environment.NewLine,
+                    node.GitRevision.Body,
+                    suffix));
+        }
+
+        [Test]
+        public void GetLaneInfo_should_return_empty_if_node_null()
+        {
+            _infoProvider.GetLaneInfo(0, 0).Should().BeEmpty();
+        }
+
+        [Test]
+        public void GetLaneInfo_should_return_no_info_if_node_revision_null()
+        {
+            var nodeWithoutRevision = new RevisionGraphRevision(ObjectId.WorkTreeId, 0);
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (nodeWithoutRevision, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0).Should().Be(LaneInfoProvider.TestAccessor.NoInfoText.Text);
+        }
+
+        [Test]
+        public void GetLaneInfo_for_non_artificial_commit_should_contain_guid_and_mark_if_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: true));
+
+            GetLaneInfo_should_display(_realCommitNode, prefix: "* ");
+        }
+
+        [Test]
+        public void GetLaneInfo_for_non_artificial_commit_should_contain_guid_and_no_mark_if_not_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            GetLaneInfo_should_display(_realCommitNode);
+        }
+
+        [Test]
+        public void GetLaneInfo_for_artificial_commit_should_not_add_guid_and_mark_if_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_artificialCommitNode, isAtNode: true));
+
+            _infoProvider.GetLaneInfo(0, 0).Should().Be(_artificialCommitNode.GitRevision.Body);
+        }
+
+        [Test]
+        public void GetLaneInfo_for_artificial_commit_should_not_add_guid_and_mark_if_not_at_node()
+        {
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_artificialCommitNode, isAtNode: false));
+
+            _infoProvider.GetLaneInfo(0, 0).Should().Be(_artificialCommitNode.GitRevision.Body);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_the_subject_if_singleline_body_null()
+        {
+            _realCommitNode.GitRevision.Body = null;
+            _realCommitNode.GitRevision.HasMultiLineMessage = false;
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            GetLaneInfo_should_display(_realCommitNode, suffix: _realCommitNode.GitRevision.Subject);
+        }
+
+        [Test]
+        public void GetLaneInfo_should_display_the_subject_and_hint_if_multiline_body_null()
+        {
+            _realCommitNode.GitRevision.Body = null;
+            _realCommitNode.GitRevision.HasMultiLineMessage = true;
+            _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
+
+            GetLaneInfo_should_display(_realCommitNode, suffix: _realCommitNode.GitRevision.Subject + Strings.BodyNotLoaded);
+        }
+    }
+}

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GitUI.UserControls.RevisionGrid.Graph;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls.RevisionGrid.Graph
+{
+    [TestFixture]
+    public class LaneNodeLocatorTests
+    {
+        private IRevisionGraphRowProvider _revisionGraphRowProvider;
+        private LaneNodeLocator _laneNodeLocator;
+
+        [SetUp]
+        public void Setup()
+        {
+            _revisionGraphRowProvider = Substitute.For<IRevisionGraphRowProvider>();
+            _laneNodeLocator = new LaneNodeLocator(_revisionGraphRowProvider);
+        }
+
+        private RevisionGraphRevision SetupLaneRow(int row, int lane, int laneCount, int nodeLane = -1, RevisionGraphSegment firstSegment = null)
+        {
+            var node = new RevisionGraphRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
+            var revisionGraphRow = Substitute.For<IRevisionGraphRow>();
+
+            var segments = new List<RevisionGraphSegment>();
+            if (firstSegment != null)
+            {
+                segments.Add(firstSegment);
+            }
+
+            if (lane < laneCount)
+            {
+                revisionGraphRow.GetSegmentsForIndex(lane).Returns(segments);
+            }
+
+            revisionGraphRow.GetCurrentRevisionLane().Returns(nodeLane);
+            if (lane == nodeLane)
+            {
+                revisionGraphRow.Revision.Returns(node);
+            }
+            else
+            {
+                segments.Add(new RevisionGraphSegment(node, null));
+            }
+
+            _revisionGraphRowProvider.GetSegmentsForRow(row).Returns(x => revisionGraphRow);
+            return node;
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_lane_negative()
+        {
+            _laneNodeLocator.FindPrevNode(0, -1).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_rowIndex_negative()
+        {
+            _laneNodeLocator.FindPrevNode(-1, 0).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_model_does_not_have_row()
+        {
+            const int row = 100;
+            _revisionGraphRowProvider.GetSegmentsForRow(row).Returns(x => null);
+            _laneNodeLocator.FindPrevNode(row, 0).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_rowIndex_exceeds_model_row_count()
+        {
+            // It is not up to FindPrevNode() to check this, because:
+            // The model does not provide a property "Count". Tough it returns null in this case.
+            FindPrevNode_should_return_null_if_model_does_not_have_row();
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_node_if_it_is_at_the_node_lane_although_lane_count_is_0()
+        {
+            const int row = 100;
+            const int lane = 0;
+            var node = SetupLaneRow(row, lane, laneCount: 0, nodeLane: lane);
+
+            // row.GetCurrentRevisionLane() == lane
+            _laneNodeLocator.FindPrevNode(row, lane).Should().Be((node, true));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_lane_exceeds_lane_count_and_lane_is_not_the_node_lane()
+        {
+            const int row = 100;
+            const int lane = 10;
+            SetupLaneRow(row, lane, laneCount: lane);
+
+            // lane >= _revisionGraphRowProvider.GetSegmentsForRow(rowIndex).Count
+            _laneNodeLocator.FindPrevNode(row, lane).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_null_if_there_is_no_lane_info()
+        {
+            const int row = 100;
+            const int lane = 3;
+            SetupLaneRow(row, lane, laneCount: lane + 1);
+            _revisionGraphRowProvider.GetSegmentsForRow(row).GetSegmentsForIndex(lane).Returns(x => new List<RevisionGraphSegment>());
+
+            // segmentsForLane.Count() <= 0
+            _laneNodeLocator.FindPrevNode(row, lane).Should().Be((null, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_parent_node_of_the_single_segment()
+        {
+            const int row = 100;
+            const int lane = 3;
+            var laneNode = SetupLaneRow(row, lane, laneCount: lane + 1);
+
+            // innermost "return"
+            _laneNodeLocator.FindPrevNode(row, lane).Should().Be((laneNode, false));
+        }
+
+        [Test]
+        public void FindPrevNode_should_return_the_parent_node_of_the_first_segment_and_throw_in_debug_build()
+        {
+            const int row = 100;
+            const int lane = 3;
+            var parentNode = new RevisionGraphRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
+            var childNode = new RevisionGraphRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
+            var segment = new RevisionGraphSegment(parentNode, childNode);
+            var laneNode = SetupLaneRow(row, lane, laneCount: lane + 1, firstSegment: segment);
+
+#if !DEBUG
+            // innermost "return" in RELEASE build
+            _laneNodeLocator.FindPrevNode(row, lane).Should().Be((parentNode, false));
+#else
+            try
+            {
+                // Exception before innermost "return" in DEBUG build
+                _laneNodeLocator.FindPrevNode(row, lane).Should().Be((parentNode, false));
+                throw new AssertionException("The debug build should throw an exception!");
+            }
+            catch (Exception x)
+            {
+                x.Message.Should().Be(string.Format("All segments for a lane should have the same parent.\n"
+                                                    + "Not fulfilled for rowIndex {0} lane {1} with {2} segments.",
+                                                    row, lane, 2));
+            }
+#endif
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Factor out LaneInfoProvider and LaneNodeLocator
- Extract new interfaces IRevisionGraphRowProvider and IRevisionGraphRow
- Solve regression in LaneNodeLocator
- Show the hash for every lane, prepend "*" for the node's lane
- Make hint on not yet loaded Body translatable
- Limit tooltips to 30 lines
- Add tests
 
Screenshots before and after (if PR changes UI):
- tooltip at an head node: before
![grafik](https://user-images.githubusercontent.com/36601201/48306798-27035e80-e540-11e8-9435-6d3c079c5fa7.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/48306825-a5600080-e540-11e8-8cb4-e5b16362caf5.png)

- hash: before
![grafik](https://user-images.githubusercontent.com/36601201/48307089-08a06180-e546-11e8-8c0b-6091c9ea9907.png)
![grafik](https://user-images.githubusercontent.com/36601201/48307093-135af680-e546-11e8-8000-95c506368f9c.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/48307100-266dc680-e546-11e8-930c-3d18ff843db3.png)
![grafik](https://user-images.githubusercontent.com/36601201/48307102-2f5e9800-e546-11e8-9513-e0fd913afabc.png)

- not loaded body: before
![grafik](https://user-images.githubusercontent.com/36601201/48307047-0093f200-e545-11e8-8e8c-3a7fa970b53a.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/48307045-f40f9980-e544-11e8-94c0-4d3b0a5503cb.png)

- parent not loaded: before
no tooltip
- after
![grafik](https://user-images.githubusercontent.com/36601201/48307145-130f2b00-e547-11e8-9f15-a096e9e26103.png)

- long body: before
![grafik](https://user-images.githubusercontent.com/36601201/48306975-79924a00-e543-11e8-9adb-69395d1146b4.png)
- after
![grafik](https://user-images.githubusercontent.com/36601201/48306984-b0686000-e543-11e8-8117-0c590b74bd29.png)

What did I do to test the code and ensure quality:
- added tests
- manual test with the Linux repo

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.a1
- 4cce7856c2d5341ca8e4d0b21f4141ebdf115efe 
- Git 2.19.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0