### PR TITLE
Fix Ctrl+C not copying object ID in revision grid

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -576,6 +576,14 @@ namespace GitUI.UserControls.RevisionGrid
                     }
 
                     break;
+                case Keys.Control | Keys.C:
+                    var selectedRevisions = SelectedObjectIds;
+                    if (selectedRevisions != null && selectedRevisions.Count != 0)
+                    {
+                        Clipboard.SetText(string.Join(Environment.NewLine, selectedRevisions));
+                    }
+
+                    break;
                 default:
                     base.OnKeyDown(e);
                     break;


### PR DESCRIPTION
Fixes #5735, following #5736.

Changes proposed in this pull request:
- Ctrl+C in the revision grid copies selected commit SHA-s hash(es) to the clipboard
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.a1
- bddad48ac0a418272e62a90ed59923168cfd23ed  (Dirty)
- Git 2.19.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3190.0
- DPI X:150.00% Y:150.00%
