### PR TITLE
Improve clipboard set-text operations

### DIFF
--- a/GitExtUtils/ClipboardUtil.cs
+++ b/GitExtUtils/ClipboardUtil.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using JetBrains.Annotations;
+
+namespace GitExtUtils
+{
+    public static class ClipboardUtil
+    {
+        public static bool TrySetText([NotNull] string text)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            try
+            {
+                // Setting clipboard data can fail, as applications can lock the clipboard.
+                // Such failures surface as ExternalException.
+                // Here we use an approach that retries to set the data periodically as required,
+                // and throws if it's unable to do so after a given number of attempts.
+                //
+                // See https://github.com/gitextensions/gitextensions/issues/4542
+
+                Clipboard.SetDataObject(
+                    text,
+                    copy: true, // keep the data on the clipboard, even after GitExtensions exits
+                    retryTimes: 5,
+                    retryDelay: 100);
+
+                return true;
+            }
+            catch (ExternalException)
+            {
+                // The clipboard is being used by another process
+                return false;
+            }
+        }
+    }
+}

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -50,6 +50,7 @@
     <Compile Include="ArgumentString.cs" />
     <Compile Include="ArrayExtensions.cs" />
     <Compile Include="BinarySearch.cs" />
+    <Compile Include="ClipboardUtil.cs" />
     <Compile Include="GitArgumentBuilder.cs" />
     <Compile Include="GitUI\CancellationTokenSequence.cs" />
     <Compile Include="GitUI\ComboBoxExtensions.cs" />

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -17,6 +17,7 @@ using GitCommands.Gpg;
 using GitCommands.Submodules;
 using GitCommands.UserRepositoryHistory;
 using GitCommands.Utils;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
@@ -1961,7 +1962,7 @@ namespace GitUI.CommandsDialogs
                 fileNames.Append(Path.Combine(module.WorkingDir, item.Name).ToNativePath());
             }
 
-            Clipboard.SetText(fileNames.ToString());
+            ClipboardUtil.TrySetText(fileNames.ToString());
         }
 
         private void deleteIndexLockToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -16,6 +16,7 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.Patches;
 using GitCommands.Utils;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.AutoCompletion;
 using GitUI.CommandsDialogs.CommitDialog;
@@ -2426,7 +2427,7 @@ namespace GitUI.CommandsDialogs
                 fileNames.Append(_fullPathResolver.Resolve(item.Name).ToNativePath());
             }
 
-            Clipboard.SetText(fileNames.ToString());
+            ClipboardUtil.TrySetText(fileNames.ToString());
         }
 
         private void OpenFilesWithDiffTool(IEnumerable<GitItemStatus> items, string firstRevision, string secondRevision)

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -148,7 +149,7 @@ namespace GitUI.CommandsDialogs
 
         private void copySha1ToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Clipboard.SetText(GetShaOfRefLine().ToString());
+            ClipboardUtil.TrySetText(GetShaOfRefLine().ToString());
         }
 
         private void linkCurrentBranch_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands.Git.Tag;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -388,7 +389,7 @@ namespace GitUI.CommandsDialogs
             if (Warnings != null && Warnings.SelectedRows.Count != 0 && Warnings.SelectedRows[0].DataBoundItem != null)
             {
                 var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
-                Clipboard.SetText(lostObject.ObjectId.ToString());
+                ClipboardUtil.TrySetText(lostObject.ObjectId.ToString());
             }
         }
 
@@ -397,7 +398,7 @@ namespace GitUI.CommandsDialogs
             if (Warnings != null && Warnings.SelectedRows.Count != 0 && Warnings.SelectedRows[0].DataBoundItem != null)
             {
                 var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
-                Clipboard.SetText(lostObject.Parent?.ToString());
+                ClipboardUtil.TrySetText(lostObject.Parent?.ToString());
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Hotkey;
@@ -447,7 +448,7 @@ See the changes in the commit form.");
             if (tvGitTree.SelectedNode?.Tag is GitItem gitItem)
             {
                 var fileName = _fullPathResolver.Resolve(gitItem.FileName);
-                Clipboard.SetText(fileName.ToNativePath());
+                ClipboardUtil.TrySetText(fileName.ToNativePath());
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -13,6 +13,7 @@ using GitCommands;
 using GitCommands.ExternalLinks;
 using GitCommands.Git;
 using GitCommands.Remotes;
+using GitExtUtils;
 using GitUI.CommandsDialogs;
 using GitUI.Editor.RichTextBoxExtension;
 using GitUI.Hotkey;
@@ -593,7 +594,7 @@ namespace GitUI.CommitInfo
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var commitInfo = $"{commitInfoHeader.GetPlainText()}{Environment.NewLine}{Environment.NewLine}{rtbxCommitMessage.GetPlainText()}{Environment.NewLine}{RevisionInfo.GetPlainText()}";
-            Clipboard.SetText(commitInfo);
+            ClipboardUtil.TrySetText(commitInfo);
         }
 
         private void showContainedInBranchesRemoteToolStripMenuItem_Click(object sender, EventArgs e)
@@ -697,7 +698,7 @@ namespace GitUI.CommitInfo
             }
 
             // Override RichTextBox Ctrl-c handling to copy plain text
-            Clipboard.SetText(rtb.GetSelectionPlainText());
+            ClipboardUtil.TrySetText(rtb.GetSelectionPlainText());
             e.Handled = true;
         }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitUI.Editor.RichTextBoxExtension;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
@@ -109,7 +110,7 @@ namespace GitUI.CommitInfo
             }
 
             // Override RichTextBox Ctrl-c handling to copy plain text
-            Clipboard.SetText(rtb.GetSelectionPlainText());
+            ClipboardUtil.TrySetText(rtb.GetSelectionPlainText());
             e.Handled = true;
         }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Patches;
 using GitCommands.Settings;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
@@ -960,7 +961,7 @@ namespace GitUI.Editor
                 }
             }
 
-            Clipboard.SetText(DoAutoCRLF(code));
+            ClipboardUtil.TrySetText(DoAutoCRLF(code));
 
             return;
 
@@ -990,7 +991,7 @@ namespace GitUI.Editor
 
             if (!string.IsNullOrEmpty(selectedText))
             {
-                Clipboard.SetText(selectedText);
+                ClipboardUtil.TrySetText(selectedText);
                 return;
             }
 
@@ -998,7 +999,7 @@ namespace GitUI.Editor
 
             if (!text.IsNullOrEmpty())
             {
-                Clipboard.SetText(text);
+                ClipboardUtil.TrySetText(text);
             }
         }
 
@@ -1286,7 +1287,7 @@ namespace GitUI.Editor
                 code = string.Join("\n", lines);
             }
 
-            Clipboard.SetText(DoAutoCRLF(code));
+            ClipboardUtil.TrySetText(DoAutoCRLF(code));
         }
 
         private string DoAutoCRLF(string text)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitUI.CommitInfo;
 using GitUI.Editor;
 using GitUI.HelperDialogs;
@@ -366,7 +367,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            Clipboard.SetText(commit.Summary);
+            ClipboardUtil.TrySetText(commit.Summary);
         }
 
         private void blamePreviousRevisionToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitUI.Properties;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -68,7 +69,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             item.Click += delegate
             {
-                Clipboard.SetText(textToCopy);
+                ClipboardUtil.TrySetText(textToCopy);
             };
 
             DropDownItems.Add(item);

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.UserControls.RevisionGrid.Columns;
 using GitUI.UserControls.RevisionGrid.Graph;
@@ -580,7 +581,7 @@ namespace GitUI.UserControls.RevisionGrid
                     var selectedRevisions = SelectedObjectIds;
                     if (selectedRevisions != null && selectedRevisions.Count != 0)
                     {
-                        Clipboard.SetText(string.Join(Environment.NewLine, selectedRevisions));
+                        ClipboardUtil.TrySetText(string.Join(Environment.NewLine, selectedRevisions));
                     }
 
                     break;

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 
 namespace GitUI
@@ -13,7 +13,7 @@ namespace GitUI
         private static bool _dirty;
         private static string _sha;
 
-        public static void CopyInformation() => Clipboard.SetText(GetInformation());
+        public static void CopyInformation() => ClipboardUtil.TrySetText(GetInformation());
 
         public static string GetInformation()
         {

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitExtUtils;
 using GitUI;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
@@ -390,7 +391,7 @@ namespace Bitbucket
                 if (e.Button == MouseButtons.Right)
                 {
                     // Just copy the text
-                    Clipboard.SetText(link);
+                    ClipboardUtil.TrySetText(link);
                 }
                 else
                 {

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
+using GitExtUtils;
 using GitUIPluginInterfaces;
 using ResourceManager;
 
@@ -92,19 +93,19 @@ namespace ReleaseNotesGenerator
 
         private void buttonCopyOrigOutput_Click(object sender, EventArgs e)
         {
-            Clipboard.SetText(textBoxResult.Text);
+            ClipboardUtil.TrySetText(textBoxResult.Text);
         }
 
         private void buttonCopyAsPlainText_Click(object sender, EventArgs e)
         {
             string result = CreateTextTable(_lastGeneratedLogLines, true, true);
-            Clipboard.SetText(result);
+            ClipboardUtil.TrySetText(result);
         }
 
         private void buttonCopyAsTextTableSpace_Click(object sender, EventArgs e)
         {
             string result = CreateTextTable(_lastGeneratedLogLines, true, false);
-            Clipboard.SetText(result);
+            ClipboardUtil.TrySetText(result);
         }
 
         private void buttonCopyAsHtml_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #4542

Changes proposed in this pull request:
- Applications can lock the clipboard, in which case `Clipboard.SetText` throws. This commit introduces `ClipboardUtil.TrySetText` which uses retry-with-wait logic in an attempt to recover from problems. If retrying N times doesn't work, it returns false rather than throwing.
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on:
- Windows 10

---

@RussKie previously asked if I could make this injectable/testable. It'd be easy to create an `IClipboardOperations` interface, but it's not clear how to make it accessible other than via a replaceable singleton. I'm open to suggestions, though anything adventurous would probably be a better fit for after 3.0.