### PR TITLE
Browse: Delay status updates when opening/refreshing repos

### DIFF
--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -8,7 +8,6 @@ using JetBrains.Annotations;
 
 namespace GitCommands.Logging
 {
-    // TODO capture process working directory
     // TODO capture number of input bytes
     // TODO capture number of standard output bytes
     // TODO capture number of standard error bytes
@@ -85,18 +84,16 @@ namespace GitCommands.Logging
                     fileName = "git";
                 }
 
-                var pid = ProcessId == null ? "     " : $"{ProcessId,5}";
-                var exit = ExitCode == null ? "  " : $"{ExitCode,2}";
+                var pid = ProcessId == null ? "" : $"{ProcessId}";
+                var exit = ExitCode == null ? "" : $"{ExitCode}";
 
-                return $"{StartedAt:HH:mm:ss.fff} {duration,7} {pid} {(IsOnMainThread ? "UI" : "  ")} {exit} {fileName} {Arguments}";
+                return $"{StartedAt:HH:mm:ss.fff} {duration,7} {pid,5} {(IsOnMainThread ? "UI" : "  ")} {exit,2} {fileName} {Arguments}";
             }
         }
 
         public string FullLine(string sep)
         {
-            var duration = Duration == null
-                ? "running"
-                : $"{((TimeSpan)Duration).TotalMilliseconds:0}ms";
+            var duration = Duration == null ? "" : $"{((TimeSpan)Duration).TotalMilliseconds:0}";
 
             var fileName = FileName;
 
@@ -105,12 +102,12 @@ namespace GitCommands.Logging
                 fileName = "git";
             }
 
-            var pid = ProcessId == null ? "     " : $"{ProcessId}";
-            var exit = ExitCode == null ? "  " : $"{ExitCode}";
+            var pid = ProcessId == null ? "" : $"{ProcessId}";
+            var exit = ExitCode == null ? "" : $"{ExitCode}";
             var callStack = CallStack == null ? "" : $"{Environment.NewLine}{CallStack}";
 
             return
-                $"{StartedAt:HH:mm:ss.fff}{sep}{duration}{sep}{pid}{sep}{(IsOnMainThread ? "UI" : "")}{sep}{exit}{sep}{fileName}{sep}{Arguments}{sep}{WorkingDir}{callStack}";
+                $"{StartedAt:O}{sep}{duration}{sep}{pid}{sep}{(IsOnMainThread ? "UI" : "")}{sep}{exit}{sep}{fileName}{sep}{Arguments}{sep}{WorkingDir}{callStack}";
         }
 
         public string Detail

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -75,7 +75,7 @@ namespace GitCommands.Logging
             {
                 var duration = Duration == null
                     ? "running"
-                    : $"{((TimeSpan)Duration).TotalMilliseconds:0}ms";
+                    : $"{((TimeSpan)Duration).TotalMilliseconds:0,0} ms";
 
                 var fileName = FileName;
 
@@ -87,7 +87,7 @@ namespace GitCommands.Logging
                 var pid = ProcessId == null ? "" : $"{ProcessId}";
                 var exit = ExitCode == null ? "" : $"{ExitCode}";
 
-                return $"{StartedAt:HH:mm:ss.fff} {duration,7} {pid,5} {(IsOnMainThread ? "UI" : "  ")} {exit,2} {fileName} {Arguments}";
+                return $"{StartedAt:HH:mm:ss.fff} {duration,9} {pid,5} {(IsOnMainThread ? "UI" : "  ")} {exit,2} {fileName} {Arguments}";
             }
         }
 

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -60,6 +60,8 @@ namespace GitCommands.Submodules
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 // First task: Gather list of submodules on a background thread.
+                // Add a short delay to prio log first
+                await Task.Delay(100, cancelToken);
 
                 // Don't access Module directly because it's not thread-safe.  Use a thread-local version:
                 var threadModule = new GitModule(workingDirectory);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1014,6 +1014,8 @@ namespace GitUI.CommandsDialogs
                 {
                     ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
+                        // Add a delay to not interfere with GUI updates when switching repository
+                        await Task.Delay(500);
                         await TaskScheduler.Default;
 
                         var result = Module.GetStashes().Count;


### PR DESCRIPTION
Part of #5733

Changes proposed in this pull request:
- Command logging tweaks
Part of logging other info, currently cut from the PR but helping me to analyze

- Delay commit-count initiation when switching repo (from 0-100ms to 200-300ms)
- Delay stash-count initiation from directly to 500 ms
- Delay calculating submodule structure from directly to 100 ms
Delays are introduced to at least start the GUI related before the background jobs. They could (at least the stash count) be started after GUI is updated.

Moved the following to #5756 
~~- Removed dynamic calculation of submodule status. (Temporary hack, commenting out).
This requires a large number of git commands, delaying other commands. This should not cause the GUI to hang, there is likely some resource conflict too. (Discussions in the PR.)
If this solves the problem, the change will be to make this configurable.~~
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
