### PR TITLE
Differentiate rename between identical and modified

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -916,7 +916,12 @@ namespace GitUI
 
                 if (gitItemStatus.IsRenamed)
                 {
-                    return 3;
+                    if (gitItemStatus.RenameCopyPercentage == "100")
+                    {
+                        return 3; // Rename icon
+                    }
+
+                    return 2; // Modified icon
                 }
 
                 if (gitItemStatus.IsCopied)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5744

Changes proposed in this pull request:
- Renamed files with identical content keep the current icon, "Aa".
- Renamed and modified files get the modified icon(pen).
 
Screenshots before and after (if PR changes UI):
- Both LICENSE and README are renamed
- Only README is modified

Before:
![image](https://user-images.githubusercontent.com/505330/48337483-52cb3500-e663-11e8-8580-98c47d4c3937.png)


After:
![image](https://user-images.githubusercontent.com/505330/48337476-4e9f1780-e663-11e8-9295-80a58121ab65.png)


What did I do to test the code and ensure quality:
- Commit a 25MB large text document
- Changed one character.
- Made sure this small change still generated a non 100 similarity, it was 99

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
