### PR TITLE
Do not crash if git.exe is not found

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -47,6 +47,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PSTaskDialog">
+      <HintPath>..\Bin\PSTaskDialog.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/GitExtensions/app.manifest
+++ b/GitExtensions/app.manifest
@@ -32,6 +32,14 @@
     </application>
   </compatibility>
 
+  <dependency>
+    <dependentAssembly>
+        <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" 
+                          version="6.0.0.0" processorArchitecture="*"
+                          publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+
   <asmv3:application>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
       <dpiAware>true</dpiAware>

--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -13,7 +13,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public sealed class CommonLogic : Translate
     {
-        private readonly TranslationString _cantReadRegistry =
+        private static readonly TranslationString _cantReadRegistry =
             new TranslationString("GitExtensions has insufficient permissions to check the registry.");
 
         private readonly TranslationString _selectFile =
@@ -88,7 +88,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 StringComparison.CurrentCultureIgnoreCase);
         }
 
-        public string GetRegistryValue(RegistryKey root, string subkey, string key)
+        public static string GetRegistryValue(RegistryKey root, string subkey, string key)
         {
             string value = null;
             try

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -25,6 +25,9 @@ namespace ResourceManager
             }
         }
 
+        public static string FindGitExecutable => _instance.Value._findGitExecutable.Text;
+        public static string InstallGitInstructions => _instance.Value._installGitInstructions.Text;
+        public static string GitExecutableNotFound => _instance.Value._gitExecutableNotFoundText.Text;
         public static string Date => _instance.Value._dateText.Text;
         public static string Author => GetAuthor(1);
         public static string AuthorDate => GetAuthorDate(1);
@@ -44,25 +47,29 @@ namespace ResourceManager
 
         public static string BodyNotLoaded => _instance.Value._bodyNotLoaded.Text;
 
-        private readonly TranslationString _dateText       = new TranslationString("Date");
-        private readonly TranslationString _authorText     = new TranslationString("{0:Author|Authors}");
+        private readonly TranslationString _dateText = new TranslationString("Date");
+        private readonly TranslationString _authorText = new TranslationString("{0:Author|Authors}");
+        private readonly TranslationString _installGitInstructions = new TranslationString("Install git...");
+        private readonly TranslationString _findGitExecutable = new TranslationString("Find git...");
+        private readonly TranslationString _gitExecutableNotFoundText =
+            new TranslationString("The Git executable could not be located on your system.");
         private readonly TranslationString _authorDateText = new TranslationString("{0:Author date|Author dates}");
-        private readonly TranslationString _committerText  = new TranslationString("Committer");
+        private readonly TranslationString _committerText = new TranslationString("Committer");
         private readonly TranslationString _commitDateText = new TranslationString("{0:Commit date|Commits dates}");
         private readonly TranslationString _commitHashText = new TranslationString("{0:Commit hash|Commits hashes}");
-        private readonly TranslationString _messageText    = new TranslationString("{0:Message|Messages}");
-        private readonly TranslationString _workspaceText  = new TranslationString("Working directory");
-        private readonly TranslationString _indexText      = new TranslationString("Commit index");
+        private readonly TranslationString _messageText = new TranslationString("{0:Message|Messages}");
+        private readonly TranslationString _workspaceText = new TranslationString("Working directory");
+        private readonly TranslationString _indexText = new TranslationString("Commit index");
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
         private readonly TranslationString _branchText     = new TranslationString("Branch");
-        private readonly TranslationString _branchesText   = new TranslationString("Branches");
-        private readonly TranslationString _remotesText    = new TranslationString("Remotes");
-        private readonly TranslationString _tagsText       = new TranslationString("Tags");
+        private readonly TranslationString _branchesText = new TranslationString("Branches");
+        private readonly TranslationString _remotesText = new TranslationString("Remotes");
+        private readonly TranslationString _tagsText = new TranslationString("Tags");
         private readonly TranslationString _bodyNotLoaded  = new TranslationString("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
 
-        private readonly TranslationString _parentsText    = new TranslationString("{0:Parent|Parents}");
-        private readonly TranslationString _childrenText   = new TranslationString("{0:Child|Children}");
+        private readonly TranslationString _parentsText = new TranslationString("{0:Parent|Parents}");
+        private readonly TranslationString _childrenText = new TranslationString("{0:Child|Children}");
 
         public static string GetParents(int value)
         {
@@ -137,10 +144,10 @@ namespace ResourceManager
 
         private readonly TranslationString _secondsAgo = new TranslationString("{0} {1:second|seconds} ago");
         private readonly TranslationString _minutesAgo = new TranslationString("{0} {1:minute|minutes} ago");
-        private readonly TranslationString _hoursAgo   = new TranslationString("{0} {1:hour|hours} ago");
-        private readonly TranslationString _daysAgo    = new TranslationString("{0} {1:day|days} ago");
-        private readonly TranslationString _weeksAgo   = new TranslationString("{0} {1:week|weeks} ago");
-        private readonly TranslationString _monthsAgo  = new TranslationString("{0} {1:month|months} ago");
-        private readonly TranslationString _yearsAgo   = new TranslationString("{0} {1:year|years} ago");
+        private readonly TranslationString _hoursAgo = new TranslationString("{0} {1:hour|hours} ago");
+        private readonly TranslationString _daysAgo = new TranslationString("{0} {1:day|days} ago");
+        private readonly TranslationString _weeksAgo = new TranslationString("{0} {1:week|weeks} ago");
+        private readonly TranslationString _monthsAgo = new TranslationString("{0} {1:month|months} ago");
+        private readonly TranslationString _yearsAgo = new TranslationString("{0} {1:year|years} ago");
     }
 }

--- a/UnitTests/GitCommandsTests/MockExecutable.cs
+++ b/UnitTests/GitCommandsTests/MockExecutable.cs
@@ -57,6 +57,11 @@ namespace GitCommandsTests
                 });
         }
 
+        public bool Exists()
+        {
+            return true;
+        }
+
         public void Verify()
         {
             Assert.IsEmpty(_outputStackByArguments, "All staged output should have been consumed.");


### PR DESCRIPTION
Fixes #5562

The settings dialog has a lot of logic to find git.exe or git.cmd. It even has a download link and an option to manually select the proper path. This code is never reached. A lot of refactoring is done that makes almost all code depend on git.exe to be set to the correct path. I did not change this existing code. Didn't remove or cleanup anything. Not sure how to handle this, but for now I wanted a solution for the 3.00 release.

I looked at the PR @RussKie did earlier and could not get this to work properly. The code is not tested on hidpi settings.

Changes proposed in this pull request:
- Do not crash when git.exe is not found
- Try to locate git.exe (this is also done in the settings dialog, but this code is never reached)
- Offer a download link and manual locate button
 
Screenshots before and after (if PR changes UI):
Before:
![image](https://user-images.githubusercontent.com/38675/48370710-60f87000-e6ba-11e8-86c8-0bb1366a9fa9.png)

After:
![image](https://user-images.githubusercontent.com/38675/48370690-54741780-e6ba-11e8-9eff-1571e135051b.png)

What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19.1
- Windows 10
