### PR TITLE
Include missing assembly in portable build

### DIFF
--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -58,6 +58,8 @@ xcopy /y ..\GitExtensions\bin\%Configuration%\Microsoft.VisualStudio.Threading.d
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\GitExtensions\bin\%Configuration%\Microsoft.VisualStudio.Validation.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
+xcopy /y ..\GitExtensions\bin\%Configuration%\System.Runtime.InteropServices.RuntimeInformation.dll GitExtensions\
+IF ERRORLEVEL 1 EXIT /B 1
 
 xcopy /y ..\Plugins\AutoCompileSubmodules\bin\%Configuration%\AutoCompileSubmodules.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5750 

Changes proposed in this pull request:
- Added missing file to portable build script 
 
Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
- Build portable and make sure file was in zip

Has been tested on (remove any that don't apply):
