### PR TITLE
Make portable build use portable config

### DIFF
--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -1,4 +1,8 @@
 @echo off
+REM Run Prepare-Release.ps1 instead to make a portable build.  This script is called by that script
+REM To make a portable build run either of these commands and then this script
+REM .\Set-Portable.ps1 -IsPortable
+REM .\Set-Portable.ps Debug -IsPortable
 
 cd /d "%~p0"
 

--- a/Setup/Prepare-Release.ps1
+++ b/Setup/Prepare-Release.ps1
@@ -152,11 +152,20 @@ try {
     Write-Host Compile and package
     Write-Host ----------------------------------------------------------------------
     # preparing the build artifacts
-	python set_version_to.py -v $newVersion -t $newVersion-beta1
-	
+    python set_version_to.py -v $newVersion -t $newVersion-beta1
+
     $env:SKIP_PAUSE=1
     .\BuildInstallers.cmd
-	.\MakePortableArchive.cmd Release $newVersion-beta1
+
+    # Set IsPortable in config to true
+    .\Set-Portable.ps1 -IsPortable
+    Write-Host ----------------------------------------------------------------------
+    Write-Host Make Portable Archive
+    Write-Host -------------------------------------------------------------------
+    .\MakePortableArchive.cmd Release $newVersion-beta1
+    
+    # Restore IsPortable in config
+    .\Set-Portable.ps1
 
     Write-Host ----------------------------------------------------------------------
     Write-Host Package PDBs

--- a/Setup/Set-Portable.ps1
+++ b/Setup/Set-Portable.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$false, Position=1)]
+    [string] $Configuration="Release",
+    [switch] $IsPortable = $false
+)
+
+Write-Host ----------------------------------------------------------------------
+Write-Host "Alter Config IsPortable:$IsPortable"
+Write-Host ----------------------------------------------------------------------
+#$pth = [System.IO.Path]::Combine($PSScriptRoot,"..\GitExtensions\bin\Release\GitExtensions.exe.config")
+$pth = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot,"..\GitExtensions\bin\$Configuration\GitExtensions.exe.config"))
+Write-Host $pth
+if($pth){
+    $doc= [xml](Get-Content $pth)
+    $port=$doc.configuration.applicationSettings.'GitCommands.Properties.Settings'.setting|? {$_.name -eq 'IsPortable'}
+    if($port){
+        Write-Host "IsPortable was  $($port.value)"
+        $port.value=$IsPortable.ToString()
+        $doc.Save($pth)
+        Write-Host "IsPortable is $($port.value)"
+    }
+    else {
+        Write-Error -Message "Cannot find IsPortable setting in $pth"
+    }
+}
+else {
+    Write-Error -Message "Cannot find config file.  Did you run '.\build'?"
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,11 @@ after_test:
 - ps: |
     & Setup\BuildInstallers.cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    & Setup\Set-Portable.ps1 -IsPortable
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
     & Setup\MakePortableArchive.cmd Release $env:APPVEYOR_BUILD_VERSION
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    & Setup\Set-Portable.ps1
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 artifacts:


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5758

Changes proposed in this pull request:
- Make Portable Build store IsPortable: True in GitExtensions.exe.config

Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
- Ran Prepare-Release and opened zip

Has been tested on (remove any that don't apply):
