### PR TITLE
Tweak presentation of DPI info on the "About" form

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("GitExtensions")]
 [assembly: AssemblyProduct("GitExtensions")]
-[assembly: AssemblyCopyright("Copyright © 2008-2018 GitExt Team")]
+[assembly: AssemblyCopyright("Copyright © 2008-2018 GitExtensions Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/GitUI/CommandsDialogs/EnvironmentInfo.Designer.cs
+++ b/GitUI/CommandsDialogs/EnvironmentInfo.Designer.cs
@@ -50,8 +50,9 @@
             tableLayoutPanel1.Controls.Add(this.copyButton, 1, 0);
             tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             tableLayoutPanel1.Location = new System.Drawing.Point(0, 4);
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
-            tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
+            tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(0, 8, 0, 8);
             tableLayoutPanel1.RowCount = 1;
             tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tableLayoutPanel1.Size = new System.Drawing.Size(165, 68);
@@ -62,6 +63,7 @@
             this.environmentIssueInfo.AutoSize = true;
             this.environmentIssueInfo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.environmentIssueInfo.Location = new System.Drawing.Point(11, 8);
+            this.environmentIssueInfo.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.environmentIssueInfo.Name = "environmentIssueInfo";
             this.environmentIssueInfo.Size = new System.Drawing.Size(112, 52);
             this.environmentIssueInfo.TabIndex = 0;
@@ -72,6 +74,7 @@
             this.copyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.copyButton.Image = global::GitUI.Properties.Images.CopyToClipboard;
             this.copyButton.Location = new System.Drawing.Point(129, 11);
+            this.copyButton.Margin = new System.Windows.Forms.Padding(0);
             this.copyButton.Name = "copyButton";
             this.copyButton.Size = new System.Drawing.Size(25, 26);
             this.copyButton.TabIndex = 1;
@@ -83,6 +86,7 @@
             lblSeparatorBottom.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             lblSeparatorBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
             lblSeparatorBottom.Location = new System.Drawing.Point(0, 72);
+            lblSeparatorBottom.Margin = new System.Windows.Forms.Padding(0);
             lblSeparatorBottom.Name = "lblSeparatorBottom";
             lblSeparatorBottom.Size = new System.Drawing.Size(165, 2);
             lblSeparatorBottom.TabIndex = 1;
@@ -92,6 +96,7 @@
             lblSeparatorTop.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             lblSeparatorTop.Dock = System.Windows.Forms.DockStyle.Top;
             lblSeparatorTop.Location = new System.Drawing.Point(0, 4);
+            lblSeparatorTop.Margin = new System.Windows.Forms.Padding(0);
             lblSeparatorTop.Name = "lblSeparatorTop";
             lblSeparatorTop.Size = new System.Drawing.Size(165, 2);
             lblSeparatorTop.TabIndex = 0;
@@ -105,8 +110,9 @@
             this.Controls.Add(lblSeparatorTop);
             this.Controls.Add(tableLayoutPanel1);
             this.Controls.Add(lblSeparatorBottom);
+            this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "EnvironmentInfo";
-            this.Padding = new System.Windows.Forms.Padding(0, 4, 0, 4);
+            this.Padding = new System.Windows.Forms.Padding(0);
             this.Size = new System.Drawing.Size(165, 78);
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
@@ -116,6 +122,7 @@
         }
 
         #endregion
+
         private System.Windows.Forms.Button copyButton;
         private System.Windows.Forms.Label environmentIssueInfo;
     }

--- a/GitUI/CommandsDialogs/EnvironmentInfo.cs
+++ b/GitUI/CommandsDialogs/EnvironmentInfo.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs
 
             InitializeComponent();
 
-            environmentIssueInfo.Text = UserEnvironmentInformation.GetInformation().Replace("-", "");
+            environmentIssueInfo.Text = UserEnvironmentInformation.GetInformation().Replace("- ", "");
         }
 
         public ToolTip ToolTip { get; set; }

--- a/GitUI/CommandsDialogs/FormAbout.Designer.cs
+++ b/GitUI/CommandsDialogs/FormAbout.Designer.cs
@@ -172,7 +172,7 @@
             this.environmentInfo.Dock = System.Windows.Forms.DockStyle.Fill;
             this.environmentInfo.Location = new System.Drawing.Point(15, 108);
             this.environmentInfo.Name = "environmentInfo";
-            this.environmentInfo.Padding = new System.Windows.Forms.Padding(0, 4, 0, 4);
+            this.environmentInfo.Padding = new System.Windows.Forms.Padding(0, 12, 0, 4);
             this.environmentInfo.Size = new System.Drawing.Size(414, 101);
             this.environmentInfo.TabIndex = 5;
             this.environmentInfo.ToolTip = this.toolTip;

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
             environmentInfo.SetCopyButtonTooltip(_copyTooltip.Text);
 
             // Click handlers
-            _NO_TRANSLATE_labelProductName.LinkClicked += (s, e) => { Process.Start(@"http://github.com/gitextensions/gitextensions"); };
+            _NO_TRANSLATE_labelProductName.LinkClicked += (s, e) => { Process.Start(@"https://github.com/gitextensions/gitextensions"); };
             _NO_TRANSLATE_ThanksTo.LinkClicked += delegate { ShowContributorsForm(); };
             pictureDonate.Click += delegate { Process.Start(FormDonate.DonationUrl); };
             linkLabelIcons.LinkClicked += delegate { Process.Start("http://p.yusukekamiyamane.com/"); };

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
             environmentInfo.SetCopyButtonTooltip(_copyTooltip.Text);
 
             // Click handlers
-            _NO_TRANSLATE_labelProductName.LinkClicked += (s, e) => { Process.Start(@"https://github.com/gitextensions/gitextensions"); };
+            _NO_TRANSLATE_labelProductName.LinkClicked += delegate { Process.Start("https://github.com/gitextensions/gitextensions"); };
             _NO_TRANSLATE_ThanksTo.LinkClicked += delegate { ShowContributorsForm(); };
             pictureDonate.Click += delegate { Process.Start(FormDonate.DonationUrl); };
             linkLabelIcons.LinkClicked += delegate { Process.Start("http://p.yusukekamiyamane.com/"); };

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -36,7 +36,7 @@ namespace GitUI
             StringBuilder sb = new StringBuilder();
 
             sb.Append($"- Git Extensions {AppSettings.ProductVersion}{Environment.NewLine}");
-            sb.Append($"- {_sha} {(_dirty ? " (Dirty)" : "")}{Environment.NewLine}");
+            sb.Append($"- {_sha}{(_dirty ? " (Dirty)" : "")}{Environment.NewLine}");
             sb.Append($"- Git {gitVer}{Environment.NewLine}");
             sb.Append($"- {Environment.OSVersion}{Environment.NewLine}");
             sb.Append($"- {RuntimeInformation.FrameworkDescription}{Environment.NewLine}");

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -7,7 +7,7 @@ using GitExtUtils.GitUI;
 
 namespace GitUI
 {
-    public sealed class UserEnvironmentInformation
+    public static class UserEnvironmentInformation
     {
         private static bool _alreadySet;
         private static bool _dirty;

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -36,7 +36,7 @@ namespace GitUI
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine($"- Git Extensions {AppSettings.ProductVersion}");
-            sb.AppendLine($"- {_sha}{(_dirty ? " (Dirty)" : "")}");
+            sb.AppendLine($"- Build {_sha.Substring(0, 9)}{(_dirty ? " (Dirty)" : "")}");
             sb.AppendLine($"- Git {gitVer}");
             sb.AppendLine($"- {Environment.OSVersion}");
             sb.AppendLine($"- {RuntimeInformation.FrameworkDescription}");

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -40,7 +40,7 @@ namespace GitUI
             sb.AppendLine($"- Git {gitVer}");
             sb.AppendLine($"- {Environment.OSVersion}");
             sb.AppendLine($"- {RuntimeInformation.FrameworkDescription}");
-            sb.AppendLine($"- DPI X:{DpiUtil.ScaleX:P} Y:{DpiUtil.ScaleY:P}");
+            sb.AppendLine($"- DPI {DpiUtil.DpiX}dpi ({(DpiUtil.ScaleX == 1 ? "no" : $"{Math.Round(DpiUtil.ScaleX * 100)}%")} scaling)");
 
             return sb.ToString();
         }

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -35,12 +35,13 @@ namespace GitUI
             // Build and open FormAbout design to make sure info still looks good if you change this code.
             StringBuilder sb = new StringBuilder();
 
-            sb.Append($"- Git Extensions {AppSettings.ProductVersion}{Environment.NewLine}");
-            sb.Append($"- {_sha}{(_dirty ? " (Dirty)" : "")}{Environment.NewLine}");
-            sb.Append($"- Git {gitVer}{Environment.NewLine}");
-            sb.Append($"- {Environment.OSVersion}{Environment.NewLine}");
-            sb.Append($"- {RuntimeInformation.FrameworkDescription}{Environment.NewLine}");
-            sb.Append($"- DPI X:{DpiUtil.ScaleX:P} Y:{DpiUtil.ScaleY:P}");
+            sb.AppendLine($"- Git Extensions {AppSettings.ProductVersion}");
+            sb.AppendLine($"- {_sha}{(_dirty ? " (Dirty)" : "")}");
+            sb.AppendLine($"- Git {gitVer}");
+            sb.AppendLine($"- {Environment.OSVersion}");
+            sb.AppendLine($"- {RuntimeInformation.FrameworkDescription}");
+            sb.AppendLine($"- DPI X:{DpiUtil.ScaleX:P} Y:{DpiUtil.ScaleY:P}");
+
             return sb.ToString();
         }
 

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -41,6 +41,7 @@ namespace GitUI
             sb.AppendLine($"- {Environment.OSVersion}");
             sb.AppendLine($"- {RuntimeInformation.FrameworkDescription}");
             sb.AppendLine($"- DPI {DpiUtil.DpiX}dpi ({(DpiUtil.ScaleX == 1 ? "no" : $"{Math.Round(DpiUtil.ScaleX * 100)}%")} scaling)");
+            sb.AppendLine($"- Primary screen resolution {Screen.PrimaryScreen.Bounds.Width} x {Screen.PrimaryScreen.Bounds.Height}");
 
             return sb.ToString();
         }

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -36,7 +36,7 @@ namespace GitUI
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine($"- Git Extensions {AppSettings.ProductVersion}");
-            sb.AppendLine($"- Build {_sha.Substring(0, 9)}{(_dirty ? " (Dirty)" : "")}");
+            sb.AppendLine($"- Build {_sha}{(_dirty ? " (Dirty)" : "")}");
             sb.AppendLine($"- Git {gitVer}");
             sb.AppendLine($"- {Environment.OSVersion}");
             sb.AppendLine($"- {RuntimeInformation.FrameworkDescription}");

--- a/UnitTests/GitUITests/TranslationTest.cs
+++ b/UnitTests/GitUITests/TranslationTest.cs
@@ -28,7 +28,8 @@ namespace GitUITests
         [Apartment(ApartmentState.STA)]
         public void CreateInstanceOfClass()
         {
-            UserEnvironmentInformation.Initialise("", false);
+            UserEnvironmentInformation.Initialise("0123456789012345678901234567890123456789", isDirty: false);
+
             var translatableTypes = TranslationUtil.GetTranslatableTypes();
 
             var problems = new List<(string typeName, Exception exception)>();


### PR DESCRIPTION
Follows https://github.com/gitextensions/gitextensions/pull/5737#pullrequestreview-173691187

## Changes

- Tweak environment info output
 
## Screenshots

### Before

![image](https://user-images.githubusercontent.com/350947/48402430-879ec100-e723-11e8-9065-7c165ee3c24d.png)

```text
- Git Extensions 3.00.rc2
- Build 22c1cfd7e (Dirty)
- Git 2.19.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3190.0
- DPI 144dpi (150% scaling)
```

### After

![image](https://user-images.githubusercontent.com/350947/48402232-05ae9800-e723-11e8-81b3-4cb3746859b7.png)

```text
- Git Extensions 3.00.rc2
- 5b18fe38e0c12c3ca8b85bb16d2f576
- Git 2.19.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3190.0
- DPI 144dpi (150% scaling)
```

## Quality

- Manual testing

Has been tested on:
- GIT 2.19.1
- Windows 10
