### PR TITLE
Show the output produced in ProcessExited event handlers.

### DIFF
--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -160,8 +160,9 @@ namespace GitUI.UserControls
 
                             _exitcode = _process.ExitCode;
                             _process = null;
-                            _outputThrottle?.Stop(flush: true);
+                            _outputThrottle?.FlushOutput();
                             FireProcessExited();
+                            _outputThrottle?.Stop(flush: true);
                         }).FileAndForget();
                 };
 
@@ -227,7 +228,7 @@ namespace GitUI.UserControls
                 }
             }
 
-            private void FlushOutput()
+            public void FlushOutput()
             {
                 lock (_textToAdd)
                 {

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -39,12 +39,12 @@ namespace GitUI.UserControls
             void AppendMessage(string text)
             {
                 Debug.Assert(text != null, "text != null");
-                Debug.Assert(!InvokeRequired, "!InvokeRequired");
-
                 if (IsDisposed)
                 {
                     return;
                 }
+
+                Debug.Assert(!InvokeRequired, "!InvokeRequired");
 
                 _editbox.Visible = true;
                 _editbox.Text += text;


### PR DESCRIPTION
Changes proposed in this pull request:
- Flush after the process exited but keep throttling until ProcessExited is handled.
