### PR TITLE
Jira Commit Hint plugin can't load

### DIFF
--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -105,6 +105,8 @@ xcopy /y ..\Plugins\JiraCommitHintPlugin\bin\%Configuration%\JiraCommitHintPlugi
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\Plugins\JiraCommitHintPlugin\bin\%Configuration%\NString.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
+xcopy /y ..\Plugins\JiraCommitHintPlugin\bin\%Configuration%\System.Collections.Immutable.dll GitExtensions\Plugins\
+IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\Plugins\ProxySwitcher\bin\%Configuration%\ProxySwitcher.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\Plugins\ReleaseNotesGenerator\bin\%Configuration%\ReleaseNotesGenerator.dll GitExtensions\Plugins\


### PR DESCRIPTION
Fixes #5500

Changes proposed in this pull request:
- add missing assembly to the portable build

What did I do to test the code and ensure quality:
- verified the portable archive contains the necessary assembly
- opened the settings without observing the exception
