### PR TITLE
Issue 4885 - Integration of PluginManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ libgit2sharp
 Setup/GitExtensions/
 Setup/GitExtensions-Portable-*.zip
 Setup/tools/tx.exe
+Plugins/GitExtensions.PluginManager/*
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/Setup/Download-PluginManager.ps1
+++ b/Setup/Download-PluginManager.ps1
@@ -1,0 +1,53 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True, Position=1)]
+    [string] $ExtractRootPath
+)
+
+Set-Location $PSScriptRoot
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$Releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/maraf/GitExtensions.PluginManager/releases'
+
+$Assets = $Releases[0].assets;
+foreach ($Asset in $Assets)
+{
+    if ($Asset.name.StartsWith('GitExtensions.PluginManager'))
+    {
+        $AssetToDownload = $Asset;
+        break;
+    }
+}
+
+if (!($null -eq $AssetToDownload))
+{
+    $AssetUrl = $AssetToDownload.browser_download_url;
+
+    $DownloadName = [System.IO.Path]::GetFileName($AssetToDownload.name);
+    $DownloadFilePath = [System.IO.Path]::Combine($ExtractRootPath, $DownloadName);
+    $ExtractPath = [System.IO.Path]::Combine($ExtractRootPath, 'Output');
+
+    if (!(Test-Path $DownloadFilePath))
+    {
+        if (!(Test-Path $ExtractRootPath))
+        {
+            New-Item -ItemType directory -Path $ExtractRootPath | Out-Null;
+        }
+
+        if (!(Test-Path $ExtractPath))
+        {
+            New-Item -ItemType directory -Path $ExtractPath | Out-Null;
+        }
+
+        Write-Host ('Downloading "' + $DownloadName + '".');
+
+        Invoke-WebRequest -Uri $AssetUrl -OutFile $DownloadFilePath;
+        Expand-Archive $DownloadFilePath -DestinationPath $ExtractPath -Force
+    }
+    else 
+    {
+        Write-Host ('Download "' + $DownloadName + '" already exists.');
+    }
+}
+
+Pop-Location

--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -61,6 +61,8 @@ IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\GitExtensions\bin\%Configuration%\System.Runtime.InteropServices.RuntimeInformation.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 
+xcopy /y /e ..\Plugins\GitExtensions.PluginManager\Output GitExtensions\Plugins\
+IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\Plugins\AutoCompileSubmodules\bin\%Configuration%\AutoCompileSubmodules.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\Plugins\BackgroundFetch\bin\%Configuration%\BackgroundFetch.dll GitExtensions\Plugins\

--- a/Setup/PluginManager.wxs
+++ b/Setup/PluginManager.wxs
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <DirectoryRef Id="PluginsDir">
+            <Component Id="cmp94CDDBC4517C64BBE29AA495BEE71701" Guid="*">
+                <File Id="fil5A1F49842E462A71257B235C341A47D0" KeyPath="yes" Source="$(var.PluginManagerSourceDir)\GitExtensions.PluginManager.dll" />
+            </Component>
+            <Component Id="cmp758E70D5170854A7E3D58759118F411C" Guid="*">
+                <File Id="fil9418D15B38CB04ACA6359D68FD3B4233" KeyPath="yes" Source="$(var.PluginManagerSourceDir)\Neptuo.dll" />
+            </Component>
+            <Component Id="cmp6967EC4BBF939736C385BD7E9C14455A" Guid="*">
+                <File Id="fil49B3175A42B30F52F7E81802DCED4B52" KeyPath="yes" Source="$(var.PluginManagerSourceDir)\NuGet.config" />
+            </Component>
+            <Directory Id="dir24D4204D9E00AE581312FB73FE758C22" Name="PackageManager">
+                <Component Id="cmp9D8F26B567E391E660CC6A35ACB5D94C" Guid="*">
+                    <File Id="fil04BF9952F70979845606C493533B8068" KeyPath="yes" Source="$(var.PluginManagerSourceDir)\PackageManager\PackageManager.UI.exe" />
+                </Component>
+            </Directory>
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <ComponentGroup Id="PluginMananger">
+            <ComponentRef Id="cmp94CDDBC4517C64BBE29AA495BEE71701" />
+            <ComponentRef Id="cmp758E70D5170854A7E3D58759118F411C" />
+            <ComponentRef Id="cmp6967EC4BBF939736C385BD7E9C14455A" />
+            <ComponentRef Id="cmp9D8F26B567E391E660CC6A35ACB5D94C" />
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/Setup/Prepare-Release.ps1
+++ b/Setup/Prepare-Release.ps1
@@ -124,6 +124,54 @@ function Update-Contributors {
     }
 }
 
+function Download-PluginManager([string] $ExtractRootPath)
+{
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $Releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/maraf/GitExtensions.PluginManager/releases'
+
+    $Assets = $Releases[0].assets;
+    foreach ($Asset in $Assets)
+    {
+        if ($Asset.name.StartsWith('GitExtensions.PluginManager'))
+        {
+            $AssetToDownload = $Asset;
+            break;
+        }
+    }
+
+    if (!($AssetToDownload -eq $null))
+    {
+        $AssetUrl = $AssetToDownload.browser_download_url;
+        $Version = $AssetToDownload.tag_name;
+    
+        $DownloadName = [System.IO.Path]::GetFileName($AssetToDownload.name);
+        $DownloadFilePath = [System.IO.Path]::Combine($ExtractRootPath, $DownloadName);
+        $ExtractPath = [System.IO.Path]::Combine($ExtractRootPath, 'Output');
+
+        if (!(Test-Path $DownloadFilePath))
+        {
+            if (!(Test-Path $ExtractRootPath))
+            {
+                New-Item -ItemType directory -Path $ExtractRootPath | Out-Null;
+            }
+
+            if (!(Test-Path $ExtractPath))
+            {
+                New-Item -ItemType directory -Path $ExtractPath | Out-Null;
+            }
+
+            Write-Host ('Downloading "' + $DownloadName + '".');
+
+            Invoke-WebRequest -Uri $AssetUrl -OutFile $DownloadFilePath;
+            Expand-Archive $DownloadFilePath -DestinationPath $ExtractPath -Force
+        }
+        else 
+        {
+            Write-Host ('Download "' + $DownloadName + '" already exists.');
+        }
+    }
+}
+
 
 pushd $PSScriptRoot
 
@@ -147,6 +195,11 @@ try {
     Write-Host Generate the changelog
     Write-Host ----------------------------------------------------------------------
     Generate-Changelog -milestones $milestoneNumbers
+
+    Write-Host ----------------------------------------------------------------------
+    Write-Host Download PluginManager
+    Write-Host ----------------------------------------------------------------------
+    Download-PluginManager -ExtractRootPath '..\Plugins\GitExtensions.PluginManager'
 
     Write-Host ----------------------------------------------------------------------
     Write-Host Compile and package

--- a/Setup/Prepare-Release.ps1
+++ b/Setup/Prepare-Release.ps1
@@ -124,55 +124,6 @@ function Update-Contributors {
     }
 }
 
-function Download-PluginManager([string] $ExtractRootPath)
-{
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    $Releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/maraf/GitExtensions.PluginManager/releases'
-
-    $Assets = $Releases[0].assets;
-    foreach ($Asset in $Assets)
-    {
-        if ($Asset.name.StartsWith('GitExtensions.PluginManager'))
-        {
-            $AssetToDownload = $Asset;
-            break;
-        }
-    }
-
-    if (!($AssetToDownload -eq $null))
-    {
-        $AssetUrl = $AssetToDownload.browser_download_url;
-        $Version = $AssetToDownload.tag_name;
-    
-        $DownloadName = [System.IO.Path]::GetFileName($AssetToDownload.name);
-        $DownloadFilePath = [System.IO.Path]::Combine($ExtractRootPath, $DownloadName);
-        $ExtractPath = [System.IO.Path]::Combine($ExtractRootPath, 'Output');
-
-        if (!(Test-Path $DownloadFilePath))
-        {
-            if (!(Test-Path $ExtractRootPath))
-            {
-                New-Item -ItemType directory -Path $ExtractRootPath | Out-Null;
-            }
-
-            if (!(Test-Path $ExtractPath))
-            {
-                New-Item -ItemType directory -Path $ExtractPath | Out-Null;
-            }
-
-            Write-Host ('Downloading "' + $DownloadName + '".');
-
-            Invoke-WebRequest -Uri $AssetUrl -OutFile $DownloadFilePath;
-            Expand-Archive $DownloadFilePath -DestinationPath $ExtractPath -Force
-        }
-        else 
-        {
-            Write-Host ('Download "' + $DownloadName + '" already exists.');
-        }
-    }
-}
-
-
 pushd $PSScriptRoot
 
 try {
@@ -199,7 +150,7 @@ try {
     Write-Host ----------------------------------------------------------------------
     Write-Host Download PluginManager
     Write-Host ----------------------------------------------------------------------
-    Download-PluginManager -ExtractRootPath '..\Plugins\GitExtensions.PluginManager'
+    .\Download-PluginManager.ps1 -ExtractRootPath '..\Plugins\GitExtensions.PluginManager'
 
     Write-Host ----------------------------------------------------------------------
     Write-Host Compile and package

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -692,6 +692,7 @@
           <ComponentRef Id="NString.dll" />
           <ComponentRef Id="System.Collections.Immutable.dll" />
         </Feature>
+        <ComponentGroupRef Id="PluginMananger" />
       </Feature>
       <Feature Id="GitExtensions.desktop" Title="Desktop shortcut" Level="1">
         <ComponentRef Id="GitExtensions.desktop" />

--- a/Setup/Setup.wixproj
+++ b/Setup/Setup.wixproj
@@ -96,4 +96,7 @@
   <Target Name="HeatPluginMananger" BeforeTargets="BeforeBuild">
     <HeatDirectory Directory="..\Plugins\GitExtensions.PluginManager\Output" OutputFile="PluginManager.wxs" ComponentGroupName="PluginMananger" DirectoryRefId="PluginsDir" PreprocessorVariable="var.PluginManagerSourceDir" AutogenerateGuids="true" ToolPath="$(WixToolPath)" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" />
   </Target>
+  <Target Name="DownloadPluginMananger" BeforeTargets="HeatPluginMananger">
+    <Exec Command="powershell.exe .\Download-PluginManager.ps1 -ExtractRootPath '..\Plugins\GitExtensions.PluginManager'" />
+  </Target>
 </Project>

--- a/Setup/Setup.wixproj
+++ b/Setup/Setup.wixproj
@@ -24,7 +24,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <SuppressIces>ICE61;ICE80;ICE91;ICE38</SuppressIces>
-    <DefineConstants>Version=$(Version);NumericVersion=$(NumericVersion)</DefineConstants>
+    <DefineConstants>Version=$(Version);NumericVersion=$(NumericVersion);PluginManagerSourceDir=..\Plugins\GitExtensions.PluginManager\Output</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -40,6 +40,7 @@
     <DefineConstants>Version=$(Version);NumericVersion=$(NumericVersion)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="PluginManager.wxs" />
     <Compile Include="Product.wxs" />
     <Compile Include="UI\CancelDlg.wxs" />
     <Compile Include="UI\CustomizeDlg.wxs" />
@@ -91,5 +92,8 @@
     <Exec Command="
 	call BuildGitExtNative.cmd $(Configuration) build">
     </Exec>
+  </Target>
+  <Target Name="HeatPluginMananger" BeforeTargets="BeforeBuild">
+    <HeatDirectory Directory="..\Plugins\GitExtensions.PluginManager\Output" OutputFile="PluginManager.wxs" ComponentGroupName="PluginMananger" DirectoryRefId="PluginsDir" PreprocessorVariable="var.PluginManagerSourceDir" AutogenerateGuids="true" ToolPath="$(WixToolPath)" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" />
   </Target>
 </Project>


### PR DESCRIPTION
This pull integrates download and inclusion of a latest PluginManager from its releases in GitHub repository.

Downloaded content is stored in Plugins\GitExtensions.PluginManager and is excluded from git.
New download is executed only when a new PluginManager release is found.
HeatDirectory build task is used for integration into Setup.wixproj.