### PR TITLE
Issue 3320 - Plugin registration phase

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -690,6 +690,7 @@ namespace GitUI.CommandsDialogs
             }
 
             UpdatePluginMenu(Module.IsValidGitWorkingDir());
+            PluginRegistry.ArePluginsRegistered = true;
         }
 
         private void UnregisterPlugins()
@@ -698,6 +699,8 @@ namespace GitUI.CommandsDialogs
             {
                 plugin.Unregister(UICommands);
             }
+
+            PluginRegistry.ArePluginsRegistered = false;
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -163,16 +163,11 @@ namespace GitUI.CommandsDialogs
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
-
-                try
-                {
-                    PluginRegistry.Initialize();
-                }
-                finally
+                await PluginRegistry.InitializeAsync(async () =>
                 {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     RegisterPlugins();
-                }
+                });
             }).FileAndForget();
 
             _filterRevisionsHelper = new FilterRevisionsHelper(toolStripRevisionFilterTextBox, toolStripRevisionFilterDropDownButton, RevisionGrid, toolStripRevisionFilterLabel, ShowFirstParent, form: this);
@@ -690,7 +685,6 @@ namespace GitUI.CommandsDialogs
             }
 
             UpdatePluginMenu(Module.IsValidGitWorkingDir());
-            PluginRegistry.ArePluginsRegistered = true;
         }
 
         private void UnregisterPlugins()
@@ -699,8 +693,6 @@ namespace GitUI.CommandsDialogs
             {
                 plugin.Unregister(UICommands);
             }
-
-            PluginRegistry.ArePluginsRegistered = false;
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -163,11 +163,9 @@ namespace GitUI.CommandsDialogs
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
-                await PluginRegistry.InitializeAsync(async () =>
-                {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    RegisterPlugins();
-                });
+                PluginRegistry.Initialize();
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                RegisterPlugins();
             }).FileAndForget();
 
             _filterRevisionsHelper = new FilterRevisionsHelper(toolStripRevisionFilterTextBox, toolStripRevisionFilterDropDownButton, RevisionGrid, toolStripRevisionFilterLabel, ShowFirstParent, form: this);
@@ -518,7 +516,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnClosed(EventArgs e)
         {
-            UnregisterPlugins();
+            PluginRegistry.Unregister(UICommands);
             base.OnClosed(e);
         }
 
@@ -670,10 +668,10 @@ namespace GitUI.CommandsDialogs
 
                     pluginsToolStripMenuItem.DropDownItems.Insert(pluginsToolStripMenuItem.DropDownItems.Count - 2, item);
                 }
-
-                // Allow the plugin to perform any self-registration actions
-                plugin.Register(UICommands);
             }
+
+            // Allow the plugin to perform any self-registration actions
+            PluginRegistry.Register(UICommands);
 
             UICommands.RaisePostRegisterPlugin(this);
 
@@ -685,14 +683,6 @@ namespace GitUI.CommandsDialogs
             }
 
             UpdatePluginMenu(Module.IsValidGitWorkingDir());
-        }
-
-        private void UnregisterPlugins()
-        {
-            foreach (var plugin in PluginRegistry.Plugins)
-            {
-                plugin.Unregister(UICommands);
-            }
         }
 
         /// <summary>
@@ -1896,7 +1886,7 @@ namespace GitUI.CommandsDialogs
         {
             var module = e.GitModule;
             HideVariableMainMenuItems();
-            UnregisterPlugins();
+            PluginRegistry.Unregister(UICommands);
             RevisionGrid.InvalidateCount();
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
             _submoduleStatusProvider.Init();

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -13,6 +13,8 @@ namespace GitUI
 
         public static List<IRepositoryHostPlugin> GitHosters { get; } = new List<IRepositoryHostPlugin>();
 
+        public static bool ArePluginsRegistered { get; set; }
+
         public static void Initialize()
         {
             lock (Plugins)

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands.Utils;
 using GitUI;
@@ -49,7 +50,8 @@ namespace TranslationApp
             }
 
             // required for translation
-            PluginRegistry.Initialize();
+            ThreadHelper.JoinableTaskFactory.Run(() => PluginRegistry.InitializeAsync(() => Task.CompletedTask));
+
             string[] args = Environment.GetCommandLineArgs();
             if (args.Length == 1)
             {

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -50,7 +50,7 @@ namespace TranslationApp
             }
 
             // required for translation
-            ThreadHelper.JoinableTaskFactory.Run(() => PluginRegistry.InitializeAsync(() => Task.CompletedTask));
+            ThreadHelper.JoinableTaskFactory.Run(() => PluginRegistry.Initialize());
 
             string[] args = Environment.GetCommandLineArgs();
             if (args.Length == 1)

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -50,7 +50,7 @@ namespace TranslationApp
             }
 
             // required for translation
-            ThreadHelper.JoinableTaskFactory.Run(() => PluginRegistry.Initialize());
+            PluginRegistry.Initialize();
 
             string[] args = Environment.GetCommandLineArgs();
             if (args.Length == 1)


### PR DESCRIPTION
This is WIP on #3320.
I need plugins to be registered even when GitExtensions are started with arguments to start other dialog than browse.

If this approach is ok, I will extend this PR also for other dialogs.

Yet I'm considering moving original plugin registration from FormBrowse into GitUICommands and let only menu items binding there. Thoughts?