### PR TITLE
only update submodule status at changes

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -117,10 +117,10 @@
             this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 6);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusInToolbar, 0, 0);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusForArtificialCommits, 0, 1);
-            this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 4);
-            this.tlpnlPerformance.Controls.Add(this.chkShowSubmoduleStatusInBrowse, 0, 5);
-            this.tlpnlPerformance.Controls.Add(this.chkUseFastChecks, 0, 3);
-            this.tlpnlPerformance.Controls.Add(this.chkShowCurrentChangesInRevisionGraph, 0, 2);
+            this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 5);
+            this.tlpnlPerformance.Controls.Add(this.chkShowSubmoduleStatusInBrowse, 0, 2);
+            this.tlpnlPerformance.Controls.Add(this.chkUseFastChecks, 0, 4);
+            this.tlpnlPerformance.Controls.Add(this.chkShowCurrentChangesInRevisionGraph, 0, 3);
             this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 7);
             this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 7);
             this.tlpnlPerformance.Dock = System.Windows.Forms.DockStyle.Top;
@@ -161,6 +161,7 @@
             this.chkShowGitStatusInToolbar.TabIndex = 0;
             this.chkShowGitStatusInToolbar.Text = "Show number of changed files on commit button (restart required)";
             this.chkShowGitStatusInToolbar.UseVisualStyleBackColor = true;
+            this.chkShowGitStatusInToolbar.CheckedChanged += new System.EventHandler(this.ShowGitStatus_CheckedChanged);
             // 
             // chkShowGitStatusForArtificialCommits
             // 
@@ -173,15 +174,16 @@
             this.chkShowGitStatusForArtificialCommits.TabIndex = 1;
             this.chkShowGitStatusForArtificialCommits.Text = "Show number of changed files for artificial commits (restart required)";
             this.chkShowGitStatusForArtificialCommits.UseVisualStyleBackColor = true;
+            this.chkShowGitStatusForArtificialCommits.CheckedChanged += new System.EventHandler(this.ShowGitStatus_CheckedChanged);
             // 
             // chkShowStashCountInBrowseWindow
             // 
             this.chkShowStashCountInBrowseWindow.AutoSize = true;
             this.chkShowStashCountInBrowseWindow.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkShowStashCountInBrowseWindow.Location = new System.Drawing.Point(3, 95);
+            this.chkShowStashCountInBrowseWindow.Location = new System.Drawing.Point(3, 118);
             this.chkShowStashCountInBrowseWindow.Name = "chkShowStashCountInBrowseWindow";
             this.chkShowStashCountInBrowseWindow.Size = new System.Drawing.Size(324, 17);
-            this.chkShowStashCountInBrowseWindow.TabIndex = 4;
+            this.chkShowStashCountInBrowseWindow.TabIndex = 5;
             this.chkShowStashCountInBrowseWindow.Text = "Show stash count on status bar in browse window";
             this.chkShowStashCountInBrowseWindow.UseVisualStyleBackColor = true;
             // 
@@ -189,10 +191,10 @@
             // 
             this.chkShowSubmoduleStatusInBrowse.AutoSize = true;
             this.chkShowSubmoduleStatusInBrowse.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkShowSubmoduleStatusInBrowse.Location = new System.Drawing.Point(3, 118);
+            this.chkShowSubmoduleStatusInBrowse.Location = new System.Drawing.Point(3, 49);
             this.chkShowSubmoduleStatusInBrowse.Name = "chkShowSubmoduleStatusInBrowse";
             this.chkShowSubmoduleStatusInBrowse.Size = new System.Drawing.Size(324, 17);
-            this.chkShowSubmoduleStatusInBrowse.TabIndex = 5;
+            this.chkShowSubmoduleStatusInBrowse.TabIndex = 2;
             this.chkShowSubmoduleStatusInBrowse.Text = "Show submodule status in browse menu";
             this.chkShowSubmoduleStatusInBrowse.UseVisualStyleBackColor = true;
             // 
@@ -200,10 +202,10 @@
             // 
             this.chkUseFastChecks.AutoSize = true;
             this.chkUseFastChecks.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkUseFastChecks.Location = new System.Drawing.Point(3, 72);
+            this.chkUseFastChecks.Location = new System.Drawing.Point(3, 95);
             this.chkUseFastChecks.Name = "chkUseFastChecks";
             this.chkUseFastChecks.Size = new System.Drawing.Size(324, 17);
-            this.chkUseFastChecks.TabIndex = 3;
+            this.chkUseFastChecks.TabIndex = 4;
             this.chkUseFastChecks.Text = "Use FileSystemWatcher to check if index is changed";
             this.chkUseFastChecks.UseVisualStyleBackColor = true;
             // 
@@ -211,10 +213,10 @@
             // 
             this.chkShowCurrentChangesInRevisionGraph.AutoSize = true;
             this.chkShowCurrentChangesInRevisionGraph.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkShowCurrentChangesInRevisionGraph.Location = new System.Drawing.Point(3, 49);
+            this.chkShowCurrentChangesInRevisionGraph.Location = new System.Drawing.Point(3, 72);
             this.chkShowCurrentChangesInRevisionGraph.Name = "chkShowCurrentChangesInRevisionGraph";
             this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(324, 17);
-            this.chkShowCurrentChangesInRevisionGraph.TabIndex = 2;
+            this.chkShowCurrentChangesInRevisionGraph.TabIndex = 3;
             this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes as an artificial commit";
             this.chkShowCurrentChangesInRevisionGraph.UseVisualStyleBackColor = true;
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -42,6 +42,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             tlpnlEmailSettings.AdjustWidthToSize(0, lblCommitsLimit, lblDefaultCloneDestination);
         }
 
+        private void SetSubmoduleStatus()
+        {
+            chkShowSubmoduleStatusInBrowse.Enabled = chkShowGitStatusInToolbar.Checked || chkShowGitStatusForArtificialCommits.Checked;
+            chkShowSubmoduleStatusInBrowse.Checked = chkShowSubmoduleStatusInBrowse.Enabled && chkShowSubmoduleStatusInBrowse.Checked;
+        }
+
         protected override void SettingsToPage()
         {
             chkCheckForUncommittedChangesInCheckoutBranch.Checked = AppSettings.CheckForUncommittedChangesInCheckoutBranch;
@@ -52,9 +58,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkStashUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInAutoStash;
             chkShowCurrentChangesInRevisionGraph.Checked = AppSettings.RevisionGraphShowWorkingDirChanges;
             chkShowStashCountInBrowseWindow.Checked = AppSettings.ShowStashCount;
-            chkShowSubmoduleStatusInBrowse.Checked = AppSettings.ShowSubmoduleStatus;
             chkShowGitStatusInToolbar.Checked = AppSettings.ShowGitStatusInBrowseToolbar;
             chkShowGitStatusForArtificialCommits.Checked = AppSettings.ShowGitStatusForArtificialCommits;
+            chkShowSubmoduleStatusInBrowse.Checked = AppSettings.ShowSubmoduleStatus;
             SmtpServer.Text = AppSettings.SmtpServer;
             SmtpServerPort.Text = AppSettings.SmtpPort.ToString();
             chkUseSSL.Checked = AppSettings.SmtpUseSsl;
@@ -64,6 +70,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkUseFastChecks.Checked = AppSettings.UseFastChecks;
             cbDefaultCloneDestination.Text = AppSettings.DefaultCloneDestinationPath;
             chkFollowRenamesInFileHistoryExact.Checked = AppSettings.FollowRenamesInFileHistoryExactOnly;
+            SetSubmoduleStatus();
         }
 
         protected override void PageToSettings()
@@ -90,6 +97,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RevisionGraphShowWorkingDirChanges = chkShowCurrentChangesInRevisionGraph.Checked;
             AppSettings.ShowStashCount = chkShowStashCountInBrowseWindow.Checked;
             AppSettings.ShowSubmoduleStatus = chkShowSubmoduleStatusInBrowse.Checked;
+
             AppSettings.DefaultCloneDestinationPath = cbDefaultCloneDestination.Text;
             AppSettings.FollowRenamesInFileHistoryExactOnly = chkFollowRenamesInFileHistoryExact.Checked;
         }
@@ -139,6 +147,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 cbDefaultCloneDestination.Text = userSelectedPath;
             }
+        }
+
+        private void ShowGitStatus_CheckedChanged(object sender, System.EventArgs e)
+        {
+            SetSubmoduleStatus();
         }
     }
 }


### PR DESCRIPTION
This is a follow up to #5747 after discussions with @amaiorano 
This is part 1 of #5769 - should maybe be considered for 3.0

This is based on #5747 minus last commit, submitted for @amaiorano to give feedback

Changes proposed in this pull request:

SubmoduleStatus: Update only when commit-count reports changes to submodules

Update submodule status at changes directly (async)
when changes detected, do not wait for dropdown or form reactivation
Submodule status setting is now dependent on the status updates

There are two special cases:
 * If submodule status changes to None, the status must be cleared
 * Changes are only triggered on submodule changes, supermodule changes are not detected, If a module has supermodules, the status is always calculated when opening the module (but not triggered if there are changes in the supermodules.
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
- Windows 7/10