### PR TITLE
Fix RepoObjectsTree (left panel) remaining blank when ReloadAsync is …

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -167,18 +167,21 @@ namespace GitUI.BranchTreePanel
             }
             finally
             {
-                await this.SwitchToMainThreadAsync(token);
-                Enabled = true;
-
-                var selectedNode = treeMain.AllNodes().FirstOrDefault(n =>
-                    _rootNodes.Any(rn => $"{rn.TreeViewNode.FullPath}{treeMain.PathSeparator}{currentBranch}" == n.FullPath));
-                if (selectedNode != null)
+                await this.SwitchToMainThreadAsync();
+                if (!token.IsCancellationRequested)
                 {
-                    treeMain.SelectedNode = selectedNode;
-                    treeMain.SelectedNode.EnsureVisible();
+                    Enabled = true;
+                    var selectedNode = treeMain.AllNodes().FirstOrDefault(n =>
+                        _rootNodes.Any(rn => $"{rn.TreeViewNode.FullPath}{treeMain.PathSeparator}{currentBranch}" == n.FullPath));
+                    if (selectedNode != null)
+                    {
+                        treeMain.SelectedNode = selectedNode;
+                        treeMain.SelectedNode.EnsureVisible();
+                    }
+
+                    _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                 }
 
-                _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                 treeMain.EndUpdate();
             }
         }


### PR DESCRIPTION
…cancelled (e.g. by spamming refresh)

Problem is that if during ReloadAsync, a System.OperationCanceledException is thrown due to cancellation, we cannot use token anymore in the finally block to switch to main thread. Doing so causes another exception to be thrown, and we never end up executing the code below, which includes "treeMain.EndUpdate()" required to restore rendering of the tree view.

Fixes #5778 
