### PR TITLE
WIP: POC for removing useless curves in revision graph

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -11,6 +11,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         int GetLaneCount();
         IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
         int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
+        void MoveLaneRightToStraigten(RevisionGraphSegment revisionGraphRevision);
     }
 
     // The RevisionGraphRow contains an ordered list of Segments that crosses the row or connects to the revision in the row.
@@ -29,13 +30,18 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public IReadOnlyList<RevisionGraphSegment> Segments { get; private set; }
 
         // This dictonary contains a cached list of all segments and the lane index the segment is in for this row.
-        private IReadOnlyDictionary<RevisionGraphSegment, int> _segmentLanes;
+        private IDictionary<RevisionGraphSegment, int> _segmentLanes;
 
         // The cached lanecount
         private int _laneCount;
 
         // The cached revisionlane
         private int _revisionLane;
+
+        public void MoveLaneRightToStraigten(RevisionGraphSegment revisionGraphRevision)
+        {
+            _segmentLanes[revisionGraphRevision] = _segmentLanes[revisionGraphRevision] + 1;
+        }
 
         // The row contains ordered segments. This method sorts the segments per lane.
         // Segments that cross this row (start above and end below) get there own private lane.

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -13,7 +13,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
         int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
         bool Straightened { get; set; }
-        void MoveLaneRightToStraighten(RevisionGraphSegment revisionGraphRevision, int indexToMove);
+        void MoveLaneRightToStraighten(RevisionGraphSegment revisionGraphRevision, int indexToMove, bool moveOthers);
     }
 
     // The RevisionGraphRow contains an ordered list of Segments that crosses the row or connects to the revision in the row.
@@ -42,17 +42,17 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public bool Straightened { get; set; }
 
-        public void MoveLaneRightToStraighten(RevisionGraphSegment revisionGraphRevision, int indexToMove)
+        public void MoveLaneRightToStraighten(RevisionGraphSegment revisionGraphRevision, int indexToMove, bool moveOthers)
         {
             foreach (var segmentLane in _segmentLanes.ToArray())
             {
-                if (segmentLane.Value >= indexToMove)
+                if (segmentLane.Value == indexToMove || (moveOthers && segmentLane.Value >= indexToMove))
                 {
                     _segmentLanes[segmentLane.Key] = _segmentLanes[segmentLane.Key] + 1;
                 }
             }
 
-            if (_revisionLane >= indexToMove)
+            if (_revisionLane == indexToMove || (moveOthers && _revisionLane >= indexToMove))
             {
                 _revisionLane++;
             }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
@@ -11,7 +12,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         int GetLaneCount();
         IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
         int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
-        void MoveLaneRightToStraigten(RevisionGraphSegment revisionGraphRevision);
+        bool Straightened { get; set; }
+        void MoveLaneRightToStraighten(RevisionGraphSegment revisionGraphRevision, int indexToMove);
     }
 
     // The RevisionGraphRow contains an ordered list of Segments that crosses the row or connects to the revision in the row.
@@ -38,9 +40,22 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         // The cached revisionlane
         private int _revisionLane;
 
-        public void MoveLaneRightToStraigten(RevisionGraphSegment revisionGraphRevision)
+        public bool Straightened { get; set; }
+
+        public void MoveLaneRightToStraighten(RevisionGraphSegment revisionGraphRevision, int indexToMove)
         {
-            _segmentLanes[revisionGraphRevision] = _segmentLanes[revisionGraphRevision] + 1;
+            foreach (var segmentLane in _segmentLanes.ToArray())
+            {
+                if (segmentLane.Value >= indexToMove)
+                {
+                    _segmentLanes[segmentLane.Key] = _segmentLanes[segmentLane.Key] + 1;
+                }
+            }
+
+            if (_revisionLane >= indexToMove)
+            {
+                _revisionLane++;
+            }
         }
 
         // The row contains ordered segments. This method sorts the segments per lane.


### PR DESCRIPTION
Fixes #5782 

Changes proposed in this pull request:
- Example implementation for reducing useless curves at nearly 0 performance cost

First commit, remove the not-needed curves:
![image](https://user-images.githubusercontent.com/38675/48565243-6642fe00-e8f8-11e8-9034-6748378fe136.png) 

Second commit, make the lines more smooth:
![image](https://user-images.githubusercontent.com/38675/48638935-53046100-e9d2-11e8-9948-e51c5226d48b.png)


What did I do to test the code and ensure quality:
- Scrolling through the log

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10
