### PR TITLE
Update links to application dependencies wiki page

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -306,7 +306,7 @@ namespace GitExtensions
 
                 case 1:
                     {
-                        Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Git");
+                        Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
                         return false;
                     }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -86,7 +86,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void downloadGitForWindows_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Git");
+            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
         }
 
         private void ChangeHomeButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

I've renamed and updated the wiki page to talk about the application's dependencies - https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies.
The code is updated to reflect the change.