### PR TITLE
Added check if branch filter is enabled before applying simplify filter

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -780,7 +780,7 @@ namespace GitUI
                     _refFilterOptions |= RefFilterOptions.FirstParent;
                 }
 
-                if (AppSettings.ShowSimplifyByDecoration)
+                if (AppSettings.ShowSimplifyByDecoration && AppSettings.BranchFilterEnabled)
                 {
                     _refFilterOptions |= RefFilterOptions.SimplifyByDecoration;
                 }


### PR DESCRIPTION
Fixes #4642
Follow up of #5663

Changes proposed in this pull request:
- Add missing check if branch filter is enabled
 
What did I do to test the code and ensure quality:
- As I use Linux, I can't compile Version 3.0x ...

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Linux 4.18