### PR TITLE
Link Translations to wiki page

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -230,7 +230,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void TranslateItem_Click(object sender, EventArgs e)
         {
-            Process.Start("https://www.transifex.com/git-extensions/git-extensions/translate/");
+            Process.Start("https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private static void GitHubItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1912,7 +1912,7 @@ namespace GitUI.CommandsDialogs
 
         private void TranslateToolStripMenuItemClick(object sender, EventArgs e)
         {
-            Process.Start("https://www.transifex.com/git-extensions/git-extensions/translate/");
+            Process.Start("https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private void FileExplorerToolStripMenuItemClick(object sender, EventArgs e)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ For more details please refer to [versions comparison](https://github.com/gitext
   </tr>
   <tr>
     <td>Translations</td>
-    <td><a target="_blank" style="text-decoration:none; color:black; font-size:66%" href="https://www.transifex.com/projects/p/git-extensions"
-title="See more information on Transifex.com"><img src="https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png" ></a></td>
+    <td><a target="_blank" style="text-decoration:none; color:black; font-size:66%" href="https://github.com/gitextensions/gitextensions/wiki/Translations"
+title="More information in the wiki"><img src="https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png" ></a></td>
   </tr>
 </table>
 
@@ -75,8 +75,8 @@ The code is in maintenance mode with no significant active development planned. 
   </tr>
   <tr>
     <td>Translations</td>
-    <td colspan=2><a target="_blank" style="text-decoration:none; color:black; font-size:66%" href="https://www.transifex.com/projects/p/git-extensions"
-title="See more information on Transifex.com"><img src="https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png" ></a></td>
+    <td colspan=2><a target="_blank" style="text-decoration:none; color:black; font-size:66%" href="https://github.com/gitextensions/gitextensions/wiki/Translations"
+title="More information in the wiki"><img src="https://ds0k0en9abmn1.cloudfront.net/static/charts/images/tx-logo-micro.646b0065fce6.png" ></a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fixes #5766

Changes proposed in this pull request:
- Link translations to a new wiki page

The wiki page itself should be refined, more or less just a placeholder right now
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- Manual test, code search

Has been tested on (remove any that don't apply):
- Windows 10
