### PR TITLE
WIP Make sure posix paths are quoted when needed

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -136,7 +136,7 @@ namespace GitCommands
                 return false;
             }
 
-            posixPath = "/" + directoryInfo.FullName.ToPosixPath().Remove(1, 1);
+            posixPath = ("/" + directoryInfo.FullName.ToPosixPath().Remove(1, 1)).QuoteIfContainsWhiteSpace();
             return true;
         }
 

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -11,6 +11,7 @@ namespace System
     {
         private static readonly char[] _newLine = { '\n' };
         private static readonly char[] _space = { ' ' };
+        private static readonly char[] _whiteSpaceChars = { ' ', '\r', '\n', '\t' };
 
         // NOTE ordinal string comparison is the default as most string comparison in GE is against static ASCII output from git.exe
 
@@ -208,6 +209,38 @@ namespace System
         public static string QuoteNE([CanBeNull] this string s)
         {
             return s.IsNullOrEmpty() ? s : s.Quote();
+        }
+
+        /// <summary>
+        /// Quotes this string if it contains whitespace
+        /// </summary>
+        [Pure]
+        [ContractAnnotation("s:null=>null")]
+        public static string QuoteIfContainsWhiteSpace([CanBeNull] this string s)
+        {
+            return s.IsNullOrEmpty() ? s : NeedsEscaping() ? s.Quote() : s;
+            bool NeedsEscaping()
+            {
+                if (string.IsNullOrWhiteSpace(s))
+                {
+                    // Quote empty or white space strings
+                    return true;
+                }
+
+                if (s.IndexOfAny(_whiteSpaceChars) == -1)
+                {
+                    // Doesn't contain any white space
+                    return false;
+                }
+
+                if (s.Length > 1 && s[0] == '"' && s[s.Length - 1] == '"')
+                {
+                    // String is already quoted
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4097

Changes proposed in this pull request:
- Quotes posix  paths where needed
- Add a copy of what Drew did for stringbuilder for strings.  Add a Quote method that quotes when there is whitespace
 
Screenshots before and after (if PR changes UI):


What did I do to test the code and ensure quality:
- Tested console
    1. Created a repo in a folder with spaces 
    2. Opened GE repo and went to console
    3. Switched Repo to spaces repo
    4. Clicked in console and verified cd command was quoted

- Ran tests


Has been tested on (remove any that don't apply):