### PR TITLE
Revision Links: Detect GH issues without #

### DIFF
--- a/GitExtensions.settings
+++ b/GitExtensions.settings
@@ -120,7 +120,7 @@
       &lt;RevisionPart&gt;LocalBranches&lt;/RevisionPart&gt;
       &lt;RevisionPart&gt;RemoteBranches&lt;/RevisionPart&gt;
     &lt;/SearchInParts&gt;
-    &lt;SearchPattern&gt;(?i)(?&amp;lt;!pull request |pr[ _]?)#\d+&lt;/SearchPattern&gt;
+    &lt;SearchPattern&gt;(?i)(?&amp;lt;!pull request |pr[ _]?)(#|(((feat(ure)?)|fix)[/_-]))\d+&lt;/SearchPattern&gt;
     &lt;UseOnlyFirstRemote&gt;false&lt;/UseOnlyFirstRemote&gt;
   &lt;/GitExtLinkDef&gt;
   &lt;GitExtLinkDef&gt;


### PR DESCRIPTION
Changes proposed in this pull request:
- detect GH issues without `#`, especially in branch names, e.g.
  - feature/98765
  - feat-98765
  - fix/98765
  - fix_98765
 
Screenshots before and after (if PR changes UI):
- before:
![grafik](https://user-images.githubusercontent.com/36601201/48810772-1b2b4f80-ed2b-11e8-96b0-06eef4247f1f.png)
- after:
![grafik](https://user-images.githubusercontent.com/36601201/48810743-0484f880-ed2b-11e8-9033-bad67134d7d1.png)

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.rc2
- Build 876903cf464aebd11d09a01a9849ea87043d4803
- Git 2.19.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)