### PR TITLE
Fix ArgumentException on collapsed file list items

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -949,7 +949,7 @@ namespace GitUI
             var minWidth = FileStatusListView.ClientSize.Width;
 
             var contentWidth = FileStatusListView.Items()
-                .Where(item => item.Bounds.IntersectsWith(FileStatusListView.ClientRectangle))
+                .Where(item => /*not collapsed*/ item.Position.Y > 0 && item.Bounds.IntersectsWith(FileStatusListView.ClientRectangle))
                 .Select(item =>
                 {
                     var (_, _, textStart, textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);


### PR DESCRIPTION
Fixes #5683

Changes proposed in this pull request:
- do not measure the width of file list items which are hidden because they belong to a collapsed group
 
Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Windows 7