### PR TITLE
Fix clone dialog doesn't pick up destination

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -84,6 +84,11 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
+                if (!string.IsNullOrEmpty(_url) && Directory.Exists(_url))
+                {
+                    _NO_TRANSLATE_To.Text = _url;
+                }
+
                 // Try to be more helpful to the user.
                 // Use the clipboard text as a potential source URL.
                 try


### PR DESCRIPTION
Fixes #5590

Changes proposed in this pull request:
- use the clone command's argument as destination folder unless it describes a repo
 
Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Windows 7