### PR TITLE
Limits RevisionsSplitContainer.SplitterDistance to a min of 0

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3012,7 +3012,7 @@ namespace GitUI.CommandsDialogs
                 if (commitInfoPosition == CommitInfoPosition.RightwardFromList)
                 {
                     RevisionsSplitContainer.FixedPanel = FixedPanel.Panel2;
-                    RevisionsSplitContainer.SplitterDistance = RevisionsSplitContainer.Width - width;
+                    RevisionsSplitContainer.SplitterDistance = Math.Max(0, RevisionsSplitContainer.Width - width);
                     RevisionInfo.Parent = RevisionsSplitContainer.Panel2;
                     RevisionGrid.Parent = RevisionsSplitContainer.Panel1;
                 }


### PR DESCRIPTION
A splitter distance below 0 is invalid and throws, and this operation is capable of resulting in less than 0.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5806 

Changes proposed in this pull request:
- Math.Max on setting splitter distance to ensure it is not invalidly below 0.
 

What did I do to test the code and ensure quality:
- Ran it. Looking at the test project it seemed this kind of thing is not tested for. I would be happy to add tests if you can point me in the right direction. 

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 8.1
