### PR TITLE
NullException comparing when no HEAD

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2782,7 +2782,7 @@ namespace GitCommands
         }
 
         /// <summary>Dirty but fast. This sometimes fails.</summary>
-        public static string GetSelectedBranchFast([CanBeNull] string repositoryPath)
+        public static string GetSelectedBranchFast([CanBeNull] string repositoryPath, bool setDefaultIfEmpty = true)
         {
             if (string.IsNullOrEmpty(repositoryPath))
             {
@@ -2804,7 +2804,7 @@ namespace GitCommands
 
             if (!headFileContents.StartsWith("ref: "))
             {
-                return DetachedHeadParser.DetachedBranch;
+                return setDefaultIfEmpty ? DetachedHeadParser.DetachedBranch : string.Empty;
             }
 
             const string prefix = "ref: refs/heads/";
@@ -2817,10 +2817,14 @@ namespace GitCommands
             return headFileContents.Substring(prefix.Length).TrimEnd();
         }
 
-        /// <summary>Gets the current branch; or "(no branch)" if HEAD is detached.</summary>
-        public string GetSelectedBranch(string repositoryPath)
+        /// <summary>
+        /// Gets the current branch
+        /// </summary>
+        /// <param name="setDefaultIfEmpty">Return "(no branch)" if detached</param>
+        /// <returns>Current branchname</returns>
+        public string GetSelectedBranch(bool setDefaultIfEmpty)
         {
-            string head = GetSelectedBranchFast(repositoryPath);
+            string head = GetSelectedBranchFast(WorkingDir, setDefaultIfEmpty);
 
             if (!string.IsNullOrEmpty(head))
             {
@@ -2832,12 +2836,12 @@ namespace GitCommands
 
             return result.ExitCode == 0
                 ? result.StandardOutput
-                : DetachedHeadParser.DetachedBranch;
+                : setDefaultIfEmpty ? DetachedHeadParser.DetachedBranch : string.Empty;
         }
 
         public string GetSelectedBranch()
         {
-            return GetSelectedBranch(WorkingDir);
+            return GetSelectedBranch(true);
         }
 
         public bool IsDetachedHead()

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
@@ -50,7 +51,7 @@ namespace GitUI.CommandsDialogs
         {
             _isDirtyDir = UICommands.Module.IsDirtyDir();
             _currentBranch = UICommands.Module.GetSelectedBranch();
-            _isBranchCheckedOut = _currentBranch != "(no branch)";
+            _isBranchCheckedOut = _currentBranch != DetachedHeadParser.DetachedBranch;
             linkCurrentBranch.Text = "current branch (" + _currentBranch + ")";
             linkCurrentBranch.Visible = _isBranchCheckedOut;
             _lastHitRowIndex = 0;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1180,7 +1180,7 @@ namespace GitUI
             }
 
             compareToWorkingDirectoryMenuItem.Enabled = firstSelectedRevision != null && firstSelectedRevision.ObjectId != ObjectId.WorkTreeId;
-            compareWithCurrentBranchToolStripMenuItem.Enabled = Module.GetSelectedBranch().IsNotNullOrWhitespace();
+            compareWithCurrentBranchToolStripMenuItem.Enabled = Module.GetSelectedBranch(setDefaultIfEmpty: false).IsNotNullOrWhitespace();
             compareSelectedCommitsMenuItem.Enabled = firstSelectedRevision != null && secondSelectedRevision != null;
 
             if (Parent != null &&
@@ -2338,7 +2338,7 @@ namespace GitUI
 
         private void CompareWithCurrentBranchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var headBranch = Module.GetSelectedBranch();
+            var headBranch = Module.GetSelectedBranch(setDefaultIfEmpty: false);
             if (headBranch.IsNullOrWhiteSpace())
             {
                 MessageBox.Show(this, "No branch is currently selected");


### PR DESCRIPTION
Fixes #5812

Changes proposed in this pull request:
- Avoid exception when comparing
 
Screenshots before and after (if PR changes UI):

- 
![image](https://user-images.githubusercontent.com/6248932/49046723-57502b80-f1d5-11e8-9133-6bd0116199ac.png)

-
- 
![image](https://user-images.githubusercontent.com/6248932/49046781-8ebed800-f1d5-11e8-9524-eb80d4cfb31e.png)


What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
