### PR TITLE
Fix ArgumentException on collapsed file list items,

### DIFF
--- a/GitExtUtils/GitUI/ListViewExtensions.cs
+++ b/GitExtUtils/GitUI/ListViewExtensions.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 using GitCommands;
 
@@ -57,5 +59,17 @@ namespace GitUI
 
             return listView.SelectedItems[listView.SelectedItems.Count - 1];
         }
+
+        /// <summary>
+        /// A workaround for <see cref="ListViewItem.Bounds"/> which throws <see cref="ArgumentException"/>
+        /// on item from a collapsed <see cref="ListViewGroup"/>
+        /// </summary>
+        public static Rectangle BoundsOrEmpty(this ListViewItem item) =>
+            (Rectangle)_getItemRectOrEmptyMethod.Value.Invoke(item.ListView, new object[] { item.Index });
+
+        private static readonly Lazy<MethodInfo> _getItemRectOrEmptyMethod =
+            new Lazy<MethodInfo>(() => typeof(ListView).GetMethod(
+                "GetItemRectOrEmpty",
+                BindingFlags.Instance | BindingFlags.NonPublic));
     }
 }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -949,7 +949,7 @@ namespace GitUI
             var minWidth = FileStatusListView.ClientSize.Width;
 
             var contentWidth = FileStatusListView.Items()
-                .Where(item => item.Bounds.IntersectsWith(FileStatusListView.ClientRectangle))
+                .Where(item => item.BoundsOrEmpty().IntersectsWith(FileStatusListView.ClientRectangle))
                 .Select(item =>
                 {
                     var (_, _, textStart, textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);


### PR DESCRIPTION
Fixes #5683
Alternative for PR #5802

Changes proposed in this pull request:
`ListViewItem.BoundsOrEmpty()` extension method to workaround `ArgumentException` when calling `ListViewItem.Bounds` on an item from a collapsed `ListViewGroup`
 
What did I do to test the code and ensure quality:
- Manually tested on Windows 7:
  - select any commit in Revision grid, wait until `FileStatusList` populates the data
  - collapse the top group in `FileStatusList`
  - change `FileStatusList` width using splitter