### PR TITLE
Corrected git log command.

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2268,7 +2268,7 @@ namespace GitUI.CommandsDialogs
                     var module = new GitModule(_fullPathResolver.Resolve(name.EnsureTrailingPathSeparator()));
                     args = new GitArgumentBuilder("log")
                     {
-                        "--pretty = format:\"    %m %h - %s\"",
+                        "--pretty=format:\"    %m %h - %s\"",
                         "--no-merges",
                         $"{from}...{to}"
                     };


### PR DESCRIPTION
With spaces around the '=' it resulted with the git error:
fatal: ambiguous argument '=': unknown revision or path not in the working tree.
