### PR TITLE
fix filter branch filter

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -165,6 +165,7 @@ namespace GitCommands
             return new GitArgumentBuilder("log")
             {
                 "-z",
+                branchFilter,
                 $"--pretty=format:\"{FullFormat}\"",
                 {
                     refFilterOptions.HasFlag(RefFilterOptions.FirstParent),


### PR DESCRIPTION
by adding the name of the branch in the `git log` command arguments
that was accidentally removed during the refactoring to use ArgumentBuilder

fix #5278

Original code (notice the `{2}`):
https://github.com/gitextensions/gitextensions/blob/cd45f12f6356ae4127b962a91b8d6fc45885a32f/GitCommands/RevisionGraph.cs#L195

PS: @RussKie  with the release to come, I don't know if this fix should be done in master or release/3.00