### PR TITLE
Add try catch around method to guess system encoding.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -292,31 +292,39 @@ namespace GitCommands
             {
                 if (_systemEncoding == null)
                 {
-                    // check whether GitExtensions works with standard msysgit or msysgit-unicode
-
-                    // invoke a git command that returns an invalid argument in its response, and
-                    // check if a unicode-only character is reported back. If so assume msysgit-unicode
-
-                    // git config --get with a malformed key (no section) returns:
-                    // "error: key does not contain a section: <key>"
-                    const string controlStr = "ą"; // "a caudata"
-                    var arguments = new GitArgumentBuilder("config")
+                    try
                     {
-                        "--get",
-                        controlStr
-                    };
+                        // check whether GitExtensions works with standard msysgit or msysgit-unicode
 
-                    string s = new GitModule("").RunGitCmd(arguments, Encoding.UTF8);
-                    if (s != null && s.IndexOf(controlStr) != -1)
-                    {
-                        _systemEncoding = new UTF8Encoding(false);
+                        // invoke a git command that returns an invalid argument in its response, and
+                        // check if a unicode-only character is reported back. If so assume msysgit-unicode
+
+                        // git config --get with a malformed key (no section) returns:
+                        // "error: key does not contain a section: <key>"
+                        const string controlStr = "ą"; // "a caudata"
+                        var arguments = new GitArgumentBuilder("config")
+                        {
+                            "--get",
+                            controlStr
+                        };
+
+                        string s = new GitModule("").RunGitCmd(arguments, Encoding.UTF8);
+                        if (s != null && s.IndexOf(controlStr) != -1)
+                        {
+                            _systemEncoding = new UTF8Encoding(false);
+                        }
+                        else
+                        {
+                            _systemEncoding = Encoding.Default;
+                        }
+
+                        Debug.WriteLine("System encoding: " + _systemEncoding.EncodingName);
                     }
-                    else
+                    catch (Exception)
                     {
-                        _systemEncoding = Encoding.Default;
+                        // Ignore exception. If the git location itself is not configured correctly yet, we could never execute it.
+                        return Encoding.Default;
                     }
-
-                    Debug.WriteLine("System encoding: " + _systemEncoding.EncodingName);
                 }
 
                 return _systemEncoding;


### PR DESCRIPTION
It crashes when trying to detect git.exe, causing this code to fail.

I got a new laptop. I wanted to install gitextensions, and I failed because of this. Needed to debug to fix this. This is not acceptable for new users.

Changes proposed in this pull request:
- Do not crash during auto-resolve git command. Not the best solution, but did not want to refactor gitmodule close before the release.
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- Git Extensions 3.00.rc2
- Build 7931098b5468ff0bae5abed2767f47c11435c921 (Dirty)
- Git 2.19.2.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3221.0
- DPI 120dpi (125% scaling)
