### PR TITLE
fix OverflowException on mousewheel with negative Cursor.Y

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -63,6 +63,7 @@
     <Compile Include="GitUI\TableLayoutPanelExtensions.cs" />
     <Compile Include="GitUI\ThreadHelper.cs" />
     <Compile Include="GitUI\UIExtensions.cs" />
+    <Compile Include="GitUI\Win32ApiUtil.cs" />
     <Compile Include="Linq\LinqExtensions.cs" />
     <Compile Include="MruCache.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/GitExtUtils/GitUI/Win32ApiUtil.cs
+++ b/GitExtUtils/GitUI/Win32ApiUtil.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace GitUI
+{
+    public static class Win32ApiUtil
+    {
+        /// <summary>
+        /// Convert <see cref="Message.LParam"/> to <see cref="Point"/>
+        /// </summary>
+        public static Point ToPoint(this IntPtr lparam) =>
+            new Point(unchecked((int)lparam.ToInt64()));
+    }
+}

--- a/GitUI/MouseWheelRedirector.cs
+++ b/GitUI/MouseWheelRedirector.cs
@@ -45,8 +45,7 @@ namespace GitUI
             }
 
             // WM_MOUSEWHEEL, find the control at screen position m.LParam
-            var pos = new Point(m.LParam.ToInt32());
-            IntPtr hwnd = NativeMethods.WindowFromPoint(pos);
+            IntPtr hwnd = NativeMethods.WindowFromPoint(m.LParam.ToPoint());
             if (hwnd == IntPtr.Zero)
             {
                 return false;

--- a/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
+++ b/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
@@ -56,8 +56,13 @@
     <Compile Include="MruCacheTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TableLayoutPanelExtensionsTests.cs" />
+    <Compile Include="Win32ApiTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Externals\ICSharpCode.TextEditor\Project\ICSharpCode.TextEditor.csproj">
+      <Project>{2d18be89-d210-49eb-a9dd-2246fbb3df6d}</Project>
+      <Name>ICSharpCode.TextEditor</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
       <Project>{0F1F1168-A4B2-4FA2-B17B-735140D17F39}</Project>
       <Name>GitExtUtils</Name>

--- a/UnitTests/GitExtUtils/Win32ApiTests.cs
+++ b/UnitTests/GitExtUtils/Win32ApiTests.cs
@@ -1,0 +1,37 @@
+using System;
+using GitUI;
+using NUnit.Framework;
+
+namespace GitExtUtilsTests
+{
+    [TestFixture]
+    public class Win32ApiTests
+    {
+        [Test]
+        public void LParam_to_Point_restores_original_point(
+            [Values(short.MinValue, -1, 0, 1, short.MaxValue)] short x,
+            [Values(short.MinValue, -1, 0, 1, short.MaxValue)] short y)
+        {
+            var point = ToLParam(x, y).ToPoint();
+
+            Assert.That(point.X, Is.EqualTo(x));
+            Assert.That(point.Y, Is.EqualTo(y));
+        }
+
+        [Test]
+        public void LParam_to_point_in_ICSharpCode_restores_original_point(
+            [Values(short.MinValue, -1, 0, 1, short.MaxValue)] short x,
+            [Values(short.MinValue, -1, 0, 1, short.MaxValue)] short y)
+        {
+            var point = ICSharpCode.TextEditor.Util.Win32Util.ToPoint(ToLParam(x, y));
+
+            Assert.That(point.X, Is.EqualTo(x));
+            Assert.That(point.Y, Is.EqualTo(y));
+        }
+
+        private static IntPtr ToLParam(short x, short y) =>
+            new IntPtr(
+                ((long)x & 0x00000000_0000FFFF) |
+                (((long)y & 0x00000000_0000FFFF) << 16));
+    }
+}


### PR DESCRIPTION
Fixes #5621

Changes proposed in this pull request:

Convert `LParam` to `Point` in a more robust way, which supports negative `y` coordinate.

Use the new approach in `ICSharpCode.TextEditor` project as well for consistency.

What did I do to test the code and ensure quality:

- Added UnitTests verifying the correctness of both `ToPoint` extension method copies, one for all `gitextensions` projects, another one for `ICShaprCode.TextEditor` project.
- Tested scrolling by mouse wheel, especially near control boundaries.