### PR TITLE
Links pointing to GE 2.51 documentation

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -71,7 +71,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void linkGitRevParse_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html#_specifying_revisions");
+            Process.Start(@"https://git-scm.com/docs/git-rev-parse#_specifying_revisions");
         }
 
         private void LoadTagsAsync()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1729,7 +1729,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                Process.Start("http://git-extensions-documentation.readthedocs.org/en/release-2.51/");
+                Process.Start("http://git-extensions-documentation.readthedocs.org/en/release-3.00/");
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
Part of #5693

Changes proposed in this pull request:
- Fix link to old git-rev-parse documentation 
- Link documentation to 3.00

Note: release/3.00 must be created in GitExtensionsDoc by someone with privileges too.
(only one change compared to 2.51 documentation so far, update tracked in #5693)
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- manual

Has been tested on (remove any that don't apply):
