### PR TITLE
Use stack instead of recursion in MakeRelative

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -83,6 +83,12 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return;
             }
 
+            if (!Parents.Any())
+            {
+                IsRelative = true;
+                return;
+            }
+
             var stack = new Stack<RevisionGraphRevision>();
             stack.Push(this);
 

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -83,11 +83,19 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return;
             }
 
-            IsRelative = true;
+            var stack = new Stack<RevisionGraphRevision>();
+            stack.Push(this);
 
-            foreach (RevisionGraphRevision parent in Parents)
+            while (stack.Count > 0)
             {
-                parent.MakeRelative();
+                var revision = stack.Pop();
+
+                revision.IsRelative = true;
+
+                foreach (var parent in revision.Parents.Where(r => !r.IsRelative))
+                {
+                    stack.Push(parent);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4971.

Changes proposed in this pull request:
Method `RevisionGraphRevision.MakeRelative` now uses a stack of revisions instead of being recursive.
 
What did I do to test the code and ensure quality:
Manually tried highlighting the current branch on large-ish repositories. Works instantly.

Has been tested on (remove any that don't apply):
- Git 2.19.2.windows.1
- Microsoft Windows NT 10.0.17134.0
