### PR TITLE
Implement F3 to open difftool for .png

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1111,13 +1111,14 @@ namespace GitUI.CommandsDialogs
 
         private async Task SetSelectedDiffAsync(GitItemStatus item, bool staged)
         {
+            Action openWithDiffTool = () => (staged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick();
             if (item.Name.EndsWith(".png"))
             {
-                await SelectedDiff.ViewFileAsync(item.Name);
+                await SelectedDiff.ViewFileAsync(item.Name, openWithDiffTool);
             }
             else if (item.IsTracked)
             {
-                SelectedDiff.ViewCurrentChanges(item, staged, () => (staged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick());
+                SelectedDiff.ViewCurrentChanges(item, staged, openWithDiffTool);
             }
             else
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -343,7 +343,7 @@ namespace GitUI.Editor
             };
         }
 
-        public Task ViewFileAsync(string fileName)
+        public Task ViewFileAsync(string fileName, [CanBeNull] Action openWithDifftool = null)
         {
             return ShowOrDeferAsync(
                 fileName,
@@ -352,7 +352,7 @@ namespace GitUI.Editor
                     getImage: GetImage,
                     getFileText: GetFileText,
                     getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), ""),
-                    openWithDifftool: null /* not implemented */));
+                    openWithDifftool));
 
             Image GetImage()
             {
@@ -770,7 +770,7 @@ namespace GitUI.Editor
                                 }
 
                                 PictureBox.Image = image == null ? null : DpiUtil.Scale(image);
-                                internalFileViewer.SetText("", () => { });
+                                internalFileViewer.SetText("", openWithDifftool);
                             });
             }
 


### PR DESCRIPTION
addendum to PR #4848 for issue #4500

Changes proposed in this pull request:
- Commit Dialog: handle the hotkey F3 for image file (.png), too
 
Screenshots before and after (if PR changes UI):
- before *and* after
![grafik](https://user-images.githubusercontent.com/36601201/49345853-d25c8a80-f68a-11e8-9289-adf15ed512cb.png)

What did I do to test the code and ensure quality:
- manual testing

Has been tested on (remove any that don't apply):
- Git 2.19.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0