### PR TITLE
Fix crash when open file with ".settings" extension

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2390,8 +2390,16 @@ namespace GitUI.CommandsDialogs
             }
 
             var fileName = list.SelectedItem.Name;
+            var path = _fullPathResolver.Resolve(fileName).ToNativePath();
 
-            Process.Start(_fullPathResolver.Resolve(fileName).ToNativePath());
+            try
+            {
+                Process.Start(path);
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                OsShellUtil.OpenAs(path);
+            }
         }
 
         private void OpenWithToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5840 Crash when try open GitExtensions.settings

Changes proposed in this pull request:
- Handle the exception and force "open with" dialog when can't open file with command "open"
 
Screenshots before and after (if PR changes UI):
 ![shot_181203_121615](https://user-images.githubusercontent.com/5438647/49364385-4a5f9a80-f6f5-11e8-9475-011777e6ccc3.png)

![shot_181203_121907](https://user-images.githubusercontent.com/5438647/49364574-ac200480-f6f5-11e8-896e-d7bfbef5ebd8.png)

What did I do to test the code and ensure quality:
Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10

