### PR TITLE
Fix crash when open project setting in Jira commit hint plugin

### DIFF
--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -46,7 +46,7 @@ namespace GitUIPluginInterfaces
                     : Setting[settings];
 
                 control.Text = control.Multiline
-                    ? settingVal.Replace("\n", Environment.NewLine)
+                    ? settingVal?.Replace("\n", Environment.NewLine)
                     : settingVal;
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5842 Crash when open Jira commit hint settings 

Changes proposed in this pull request:
- Only fix crash when open project setting in Jira commit hint plugin

Screenshots before and after (if PR changes UI):
Before:
![1](https://user-images.githubusercontent.com/5438647/49367521-60715900-f6fd-11e8-8f15-1e2ace16beb9.png)

After:
![2](https://user-images.githubusercontent.com/5438647/49367533-67986700-f6fd-11e8-973f-a76447105596.png)

What did I do to test the code and ensure quality:
Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19
- Windows 10 x64
