### PR TITLE
Plugin GitStatistics: Added calculation of comment lines for assembler files

### DIFF
--- a/Plugins/Statistics/GitStatistics/CodeFile.cs
+++ b/Plugins/Statistics/GitStatistics/CodeFile.cs
@@ -98,6 +98,13 @@ namespace GitStatistics
                 {
                     commentLineCount++;
                 }
+                else if ((extension.Equals(".asm", StringComparison.OrdinalIgnoreCase) ||
+                          extension.Equals(".s", StringComparison.OrdinalIgnoreCase) ||
+                          extension.Equals(".inc", StringComparison.OrdinalIgnoreCase)) &&
+                          line.StartsWith(";"))
+                {
+                    commentLineCount++;
+                }
 
                 if (!skipResetFlag)
                 {


### PR DESCRIPTION
Changes proposed in this pull request:
-  Adds assembly style comments calculation in files with extensions .asm, .s and .inc.

What did I do to test the code and ensure quality:
-  Change is small and follows the rest of the code. Built and tested manually on my repository to make sure it works.
