### PR TITLE
Clear "dirty" flag for release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ packages/
 GitExtensions.*.sln.VisualState.xml
 GitExtensions.settings.backup
 /Setup/*.zip
+/Setup/Changelog.md
 *.received.*


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5698

Changes proposed in this pull request:
- Commit version changes

 
Screenshots before and after (if PR changes UI):

What did I do to test the code and ensure quality:
- ran ```.\Prepare-Release.ps1 -oldVersion 2.51.05 -newVersion 3.0.0 -milestones '49' -CommitChanges```
- extracted zip and ran program.  Noticed dirty was not visible 

Has been tested on (remove any that don't apply):

