### PR TITLE
Use stack instead of recursion in EnsureScoreIsAbove

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -57,10 +57,25 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             Score = minimalScore;
 
-            int maxScore = Score;
-            foreach (RevisionGraphRevision parent in Parents)
+            if (!Parents.Any())
             {
-                maxScore = Math.Max(parent.EnsureScoreIsAbove(Score + 1), maxScore);
+                return Score;
+            }
+
+            int maxScore = Score;
+
+            var stack = new Stack<RevisionGraphRevision>();
+            stack.Push(this);
+            while (stack.Count > 0)
+            {
+                var revision = stack.Pop();
+
+                foreach (var parent in revision.Parents.Where(r => r.Score < maxScore + 1))
+                {
+                    parent.Score = maxScore + 1;
+                    maxScore = parent.Score;
+                    stack.Push(parent);
+                }
             }
 
             return maxScore;


### PR DESCRIPTION
Fixes #5853

Changes proposed in this pull request:
- Avoid recursion to fix stackoverflow
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19.1
- Windows 10
