### PR TITLE
Added guard for EnsureScoreIsAbove.

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -64,16 +64,20 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             int maxScore = Score;
 
+            var processed = new HashSet<RevisionGraphRevision>();
+
             var stack = new Stack<RevisionGraphRevision>();
             stack.Push(this);
+            processed.Add(this);
             while (stack.Count > 0)
             {
                 var revision = stack.Pop();
 
-                foreach (var parent in revision.Parents.Where(r => r.Score < maxScore + 1))
+                foreach (var parent in revision.Parents.Where(r => r.Score < maxScore + 1 && !processed.Contains(r)))
                 {
                     parent.Score = maxScore + 1;
                     maxScore = parent.Score;
+                    processed.Add(parent);
                     stack.Push(parent);
                 }
             }


### PR DESCRIPTION
Fixes endless loop in the linux repo. The method is not entered very often, so it should hurt performance. 

Changes proposed in this pull request:
- Added guard for EnsureScoreIsAbove. It happens that the same revision has multiple Children. This could cause an endless loop. Happens in the linux repo
 
What did I do to test the code and ensure quality:
- Manual testing

Has been tested on (remove any that don't apply):
- GIT 2.19.2
- Windows 10
