### PR TITLE
VS2019 initial support

### DIFF
--- a/GitExtensionsVSIX/source.extension.vsixmanifest
+++ b/GitExtensionsVSIX/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
     </Metadata>
 
     <Installation>
-        <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
 
     <Dependencies>
@@ -25,6 +25,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Allow installation of VSIX in VS2019.
https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/