### PR TITLE
Fix/search text box width

### DIFF
--- a/GitUI/CommandsDialogs/SearchControl.Designer.cs
+++ b/GitUI/CommandsDialogs/SearchControl.Designer.cs
@@ -63,8 +63,7 @@
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.txtSearchBox, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.listBoxSearchResult, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;

--- a/GitUI/CommandsDialogs/SearchControl.cs
+++ b/GitUI/CommandsDialogs/SearchControl.cs
@@ -97,7 +97,6 @@ namespace GitUI.CommandsDialogs
             listBoxSearchResult.Width = width;
             listBoxSearchResult.Height = Math.Min(800, listBoxSearchResult.Font.Height * (listBoxSearchResult.Items.Count + 1));
 
-            Width = listBoxSearchResult.Width;
             _onSizeChanged(new Size(width + Margin.Right + Margin.Left,
                 listBoxSearchResult.Height + txtSearchBox.Height));
             var txtBoxOnScreen = PointToScreen(txtSearchBox.Location + new Size(0, txtSearchBox.Height));

--- a/GitUI/CommandsDialogs/SearchControl.cs
+++ b/GitUI/CommandsDialogs/SearchControl.cs
@@ -83,6 +83,14 @@ namespace GitUI.CommandsDialogs
 
             listBoxSearchResult.Visible = true;
 
+            var txtBoxOnScreen = PointToScreen(txtSearchBox.Location + new Size(0, txtSearchBox.Height));
+            if (ParentForm != null && !ParentForm.Controls.Contains(listBoxSearchResult))
+            {
+                ParentForm.Controls.Add(listBoxSearchResult);
+                var listBoxLocationOnScreen = txtBoxOnScreen;
+                listBoxSearchResult.Location = ParentForm.PointToClient(listBoxLocationOnScreen);
+            }
+
             int width = 300;
 
             using (Graphics g = listBoxSearchResult.CreateGraphics())
@@ -99,14 +107,6 @@ namespace GitUI.CommandsDialogs
 
             _onSizeChanged(new Size(width + Margin.Right + Margin.Left,
                 listBoxSearchResult.Height + txtSearchBox.Height));
-            var txtBoxOnScreen = PointToScreen(txtSearchBox.Location + new Size(0, txtSearchBox.Height));
-
-            if (ParentForm != null && !ParentForm.Controls.Contains(listBoxSearchResult))
-            {
-                ParentForm.Controls.Add(listBoxSearchResult);
-                var listBoxLocationOnScreen = txtBoxOnScreen;
-                listBoxSearchResult.Location = ParentForm.PointToClient(listBoxLocationOnScreen);
-            }
 
             listBoxSearchResult.BringToFront();
         }


### PR DESCRIPTION
Fixes #5866 

Changes proposed in this pull request:
- In `SearchControl`: Move "`listBoxSearchResult` detaching" before measuring the width
  - This enables setting `listBoxSearchResult.Width` freely (also when the `SearchControl` children are layouted).
- Fix the "minimum width" issue when `SearchControl` is used within the `RepoObjectsTree` by using **100 % column width** in `SearchControl.tableLayoutPanel1`
 
Screenshots before and after (if PR changes UI):


![image](https://user-images.githubusercontent.com/388796/49675383-b8012300-fa75-11e8-9df6-d1d5307da007.png)


What did I do to test the code and ensure quality:
- I've tested the text box + the drop down in
  - The branches panel
  - The "Diff" tab in the bottom panel
  - The "File Tree" tab in the bottom panel

