### PR TITLE
Select the default branch when creating Github pull request

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -133,7 +133,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     {
                         await TaskScheduler.Default;
 
-                        var branches = remote.GetHostedRepository().GetBranches();
+                        IHostedRepository hostedRepository = remote.GetHostedRepository();
+                        var branches = hostedRepository.GetBranches();
 
                         await this.SwitchToMainThreadAsync();
 
@@ -142,7 +143,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         var selectItem = 0;
                         for (var i = 0; i < branches.Count; i++)
                         {
-                            if (branches[i].Name == _currentBranch)
+                            if (branches[i].Name == hostedRepository.GetDefaultBranch())
                             {
                                 selectItem = i;
                             }

--- a/Plugins/GitHub3/GitHubRepo.cs
+++ b/Plugins/GitHub3/GitHubRepo.cs
@@ -98,6 +98,11 @@ namespace GitHub3
                 .ToList();
         }
 
+        public string GetDefaultBranch()
+        {
+            return _repo.GetDefaultBranch();
+        }
+
         public IHostedRepository Fork()
         {
             return new GitHubRepo(_repo.CreateFork());

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
@@ -31,6 +31,12 @@ namespace GitUIPluginInterfaces.RepositoryHosts
         IReadOnlyList<IHostedBranch> GetBranches();
 
         /// <summary>
+        /// Returns the default branch of the repository.
+        /// </summary>
+        /// <returns>The default branch of the repository.</returns>
+        string GetDefaultBranch();
+
+        /// <summary>
         /// Forks the repo owned by somebody else to "my" repos.
         /// </summary>
         /// <returns>The new repo, owned by me.</returns>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5109

Changes proposed in this pull request:
- Added default branch to a repository, fetched from GitHub API (see [PR in submodule](https://github.com/gitextensions/Git.hub/pull/10))
- Selecting the default branch when creating Github pull request.
 
What did I do to test the code and ensure quality:
- Run with different repositories with different default branch to make sure it works properly. 

Has been tested on (remove any that don't apply):
- GIT 2.11 and above
- Windows 7 and above
