### PR TITLE
Fix non-readonly commit message

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -96,6 +96,7 @@ namespace GitUI.CommitInfo
             this.rtbxCommitMessage.Location = new System.Drawing.Point(8, 8);
             this.rtbxCommitMessage.Margin = new System.Windows.Forms.Padding(8);
             this.rtbxCommitMessage.Name = "rtbxCommitMessage";
+            this.rtbxCommitMessage.ReadOnly = true;
             this.rtbxCommitMessage.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
             this.rtbxCommitMessage.Size = new System.Drawing.Size(440, 20);
             this.rtbxCommitMessage.TabIndex = 1;


### PR DESCRIPTION
Fixes  #5870

Changes proposed in this pull request:
- Set `rtbxCommitMessage.ReadOnly` to `true`
 
Screenshots before and after (if PR changes UI):

No visual change.

What did I do to test the code and ensure quality:
- Manually tested the commit info tab in the main view.
- Manually tested the commit message in the diff window.

Has been tested on (remove any that don't apply):
- Windows 1809


I separated this into two commits. The real change happens in the second one.
