### PR TITLE
Avoid blocking UI via WebClient.OpenReadTaskAsync

### DIFF
--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -104,6 +104,8 @@ namespace GitUI
 
             if (!token.IsCancellationRequested)
             {
+                await this.SwitchToMainThreadAsync();
+
                 RefreshImage(image);
             }
         }

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -73,6 +73,9 @@ namespace Gource
                     GitWorkingDir = WorkingDir.Text;
 
                     RunRealCmdDetached(GourcePath.Text, arguments);
+
+                    await this.SwitchToMainThreadAsync();
+
                     Close();
                 });
         }


### PR DESCRIPTION
Fixes #5859.
Follows and replaces #5868.

### Changes
- `WebClient.OpenReadTaskAsync` can block synchronously, so move calls to thread pool
- Limit number of concurrent downloads to prevent thread pool exhaustion.
 
### Testing method
- Manual testing, and the UI does seem more responsive during scrolling after clearing the avatar cache.

### Tested on
- Windows 10
