### PR TITLE
Update build version 2.99.90 -> 3.01.00.0

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("GitExtensions")]
 [assembly: AssemblyProduct("GitExtensions")]
-[assembly: AssemblyCopyright("Copyright © 2008-2018 GitExtensions Team")]
+[assembly: AssemblyCopyright("Copyright ? 2008-2018 GitExtensions Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,9 +20,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("3.00.00.4433")]
-[assembly: AssemblyFileVersion("3.00.00.4433")]
-[assembly: AssemblyInformationalVersion("3.00.00.4433")]
+[assembly: AssemblyVersion("3.01.00.0")]
+[assembly: AssemblyFileVersion("3.01.00.0")]
+[assembly: AssemblyInformationalVersion("3.01.00.0")]
 
 // Disable CLS compliance. See https://github.com/gitextensions/gitextensions/issues/4710
 [assembly: CLSCompliant(isCompliant: false)]

--- a/CommonAssemblyInfoExternals.cs
+++ b/CommonAssemblyInfoExternals.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -13,9 +13,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("3.00.00.4433")]
-[assembly: AssemblyFileVersion("3.00.00.4433")]
-[assembly: AssemblyInformationalVersion("3.00.00.4433")]
+[assembly: AssemblyVersion("3.01.00.0")]
+[assembly: AssemblyFileVersion("3.01.00.0")]
+[assembly: AssemblyInformationalVersion("3.01.00.0")]
 
 // Disable CLS compliance. See https://github.com/gitextensions/gitextensions/issues/4710
 [assembly: CLSCompliant(isCompliant: false)]

--- a/GitExtSshAskPass/SshAskPass.rc2
+++ b/GitExtSshAskPass/SshAskPass.rc2
@@ -13,8 +13,8 @@
 // Version
 //
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,00,00,4433
- PRODUCTVERSION 3,00,00,4433
+ FILEVERSION 3,01,00,0
+ PRODUCTVERSION 3,01,00,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -29,12 +29,12 @@ BEGIN
     BEGIN
         BLOCK "040904B0"
         BEGIN
-            VALUE "FileVersion", "3.00.00.4433"
+            VALUE "FileVersion", "3.01.00.0"
             VALUE "FileDescription", "Interactively ask for SSH password"
             VALUE "InternalName", "GitExtensions"
             VALUE "LegalCopyright", "Copyright 2013-2018"
             VALUE "OriginalFilename", "GitExtSshAskPass.exe"
-            VALUE "ProductVersion", "3.00.00.4433"
+            VALUE "ProductVersion", "3.01.00.0"
             VALUE "ProductName", "GitExtensions"
         END
     END

--- a/GitExtensionsShellEx/GitExtensionsShellEx.rc
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.rc
@@ -51,8 +51,8 @@ IDI_ICONPATCHAPPLY          ICON    "Resources\\IconPatchApply.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 3,00,00,4433
- PRODUCTVERSION 3,00,00,4433
+ FILEVERSION 3,01,00,0
+ PRODUCTVERSION 3,01,00,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "040904B0"
         BEGIN
             VALUE "FileDescription", "Shell extensions for Windows Explorer"
-            VALUE "FileVersion", "3.00.00.4433"
+            VALUE "FileVersion", "3.01.00.0"
             VALUE "InternalName", "GitExtensions"
             VALUE "LegalCopyright", "Copyright 2008-2018"
             VALUE "OriginalFilename", "GitExtensionsShellEx.dll"
             VALUE "ProductName", "GitExtensions"
-            VALUE "ProductVersion", "3.00.00.4433"
+            VALUE "ProductVersion", "3.01.00.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/GitExtensionsVSIX/source.extension.vsixmanifest
+++ b/GitExtensionsVSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Publisher="GitExt Team" Version="3.00.00.4433" Language="en-US" Id="GitExtensions..550013F4-337C-4750-8967-DDEEEC2EB497" />
+        <Identity Publisher="GitExt Team" Version="3.01.00.0" Language="en-US" Id="GitExtensions..550013F4-337C-4750-8967-DDEEEC2EB497" />
         <DisplayName>GitExtensions</DisplayName>
         <Description xml:space="preserve" >Git Extensions is a graphical user interface for Git that allows you to control Git without using the command-line</Description>
         <MoreInfo>https://gitextensions.github.io/</MoreInfo>

--- a/Setup/MakeInstallers.cmd
+++ b/Setup/MakeInstallers.cmd
@@ -4,8 +4,8 @@ rem
 rem Update this version number with every release
 rem
 setlocal
-set version=3.00.00.4433
-set numericVersion=3.00.00.4433
+set version=3.01.00.0
+set numericVersion=3.01.00.0
 if not "%APPVEYOR_BUILD_VERSION%"=="" (
     set version=%APPVEYOR_BUILD_VERSION%
     set numericVersion=%APPVEYOR_BUILD_VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.00.00.{build}
+version: 3.01.00.{build}
 
 os: Visual Studio 2017
 


### PR DESCRIPTION

Changes proposed in this pull request:
- Clarify that master is used for next feature release (critical issues off the release/3.00 branch). Set version higher than in release
 
Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- n/a 

Has been tested on (remove any that don't apply):
