### PR TITLE
Fixes 5880: Reorder nodes correct

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using GitCommands;
 using GitUIPluginInterfaces;
@@ -64,20 +65,19 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             int maxScore = Score;
 
-            var processed = new HashSet<RevisionGraphRevision>();
-
             var stack = new Stack<RevisionGraphRevision>();
             stack.Push(this);
-            processed.Add(this);
             while (stack.Count > 0)
             {
                 var revision = stack.Pop();
 
-                foreach (var parent in revision.Parents.Where(r => r.Score < maxScore + 1 && !processed.Contains(r)))
+                foreach (var parent in revision.Parents.Where(r => r.Score <= revision.Score))
                 {
-                    parent.Score = maxScore + 1;
-                    maxScore = parent.Score;
-                    processed.Add(parent);
+                    parent.Score = revision.Score + 1;
+
+                    Debug.Assert(parent.Score > revision.Score, "Reorder score failed.");
+
+                    maxScore = Math.Max(parent.Score, maxScore);
                     stack.Push(parent);
                 }
             }

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -78,7 +78,10 @@ namespace GitUITests.UserControls.RevisionGrid
                 GitRevision revision = new GitRevision(ObjectId.Random());
                 if (randomRevisions.Count > 1)
                 {
-                    revision.ParentIds = new ObjectId[] { randomRevisions[_random.Next(randomRevisions.Count - 1)].ObjectId };
+                    var randomRevision1 = randomRevisions[_random.Next(randomRevisions.Count - 1)];
+                    var randomRevision2 = randomRevisions[_random.Next(randomRevisions.Count - 1)];
+
+                    revision.ParentIds = new ObjectId[] { randomRevision1.ObjectId, randomRevision2.ObjectId };
                 }
 
                 _revisionGraph.Add(revision, RevisionNodeFlags.None);
@@ -86,7 +89,7 @@ namespace GitUITests.UserControls.RevisionGrid
                 randomRevisions.Add(revision);
             }
 
-            Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
+            Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder(), "Revisions not reordered to topo order");
         }
 
         private void BuildCache()


### PR DESCRIPTION
Fixes #5880

Changes proposed in this pull request:
- Make EnsureScoreIsAbove method not rely on order of execution
- Do not solely rely on maxscore, since it drivers the score up fast, overflowing int32
 
What did I do to test the code and ensure quality:
- Extended existing unit test
- No manual testing done

Has been tested on (remove any that don't apply):
- GIT 2.19.1
- Windows 10
