### PR TITLE
QuickPull should behave the same as the default toolbar does.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2170,7 +2170,7 @@ namespace GitUI.CommandsDialogs
                 case Command.FindFileInSelectedCommit: FindFileInSelectedCommit(); break;
                 case Command.CheckoutBranch: CheckoutBranchToolStripMenuItemClick(null, null); break;
                 case Command.QuickFetch: QuickFetch(); break;
-                case Command.QuickPull: UICommands.StartPullDialogAndPullImmediately(this); break;
+                case Command.QuickPull: ToolStripButtonPullClick(null, null); break;
                 case Command.QuickPush: UICommands.StartPushDialog(this, true); break;
                 case Command.CloseRepository: CloseToolStripMenuItemClick(null, null); break;
                 case Command.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;


### PR DESCRIPTION
Changes proposed in this pull request:
- QuickPull shortcut action should behave the same way as the toolbar button. 


What did I do to test the code and ensure quality:
- Look at surrounding code. 

Has been tested on (remove any that don't apply):
- GIT 2.20
- Windows 10
