### PR TITLE
WIP Add a code of conduct to the project

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at gitextensions@outlook.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,8 @@ Specifically:
 
 When filing a pull request, you should be prepared to answer questions about your changes
 and to perform additional work on the changes in response to review feedback.
+
+## Conduct
+
+Please review our [code of conduct](CODE_OF_CONDUCT.md).
+

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ title="More information in the wiki"><img src="https://ds0k0en9abmn1.cloudfront.
   </tr>
 </table>
 
+# Conduct
+
+Project maintainers pledge to foster an open and welcoming environment, and ask contributors to do the same.
+
+For more information see our [code of conduct](CODE_OF_CONDUCT.md).
+
 
 # Shoutouts
 


### PR DESCRIPTION
Git Extensions grows every day thanks to its dedicated maintainers and amazing community. With ten years of development to reflect upon, and a major release in the last month, it's an exciting time for everyone on the project. Git Extensions is as alive as ever!

Software development, as a field, could do well to increase representation. A big part of that is assuring newcomers to the project that thier contributions will be considered fairly and equally, and that interactions will adhere to certain values and standards.

The _Contributor Covenant_ is a widely used code of conduct (over 40,000 open source projects including the Linux kernel, Kubernetes, Rails, Swift) that spells out some common sense standards for the behaviour of maintainers and contributors.

This PR proposes the document unchanged (other than the addition of an email address), with references from `README.md` and `CONTRIBUTING.md`.

---

Merging this PR should only happen with agreement from all maintainers. Please tick your name if you agree to adhere to these values yourself and to enforce such values within the community.

- [ ] @gerhardol 
- [ ] @jbialobr 
- [ ] @KindDragon 
- [ ] @RussKie 
- [ ] @spdr870 
- [x] @drewnoakes 

We also welcome discussion from the community

Further reading:

- https://opensource.guide/code-of-conduct/
- https://www.contributor-covenant.org/
