### PR TITLE
Prevent treeview scrolling during reload

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -176,13 +176,20 @@ namespace GitUI.BranchTreePanel
                     if (selectedNode != null)
                     {
                         treeMain.SelectedNode = selectedNode;
-                        treeMain.SelectedNode.EnsureVisible();
+                        ExpandPathToSelectedNode();
                     }
 
                     _rootNodes.ForEach(t => t.IgnoreSelectionChangedEvent = false);
                 }
 
                 treeMain.EndUpdate();
+            }
+
+            void ExpandPathToSelectedNode()
+            {
+                treeMain.Scrollable = false; // disable scrolling, so the next call does not horizontally (nor vertically) scroll
+                treeMain.SelectedNode.EnsureVisible();
+                treeMain.Scrollable = true;
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5907 

Changes proposed in this pull request:
Disable treeview scrolling during refresh when EnsureVisible is called by setting treeview as not scrollable. This is kind of a hack, but I found this as only way to prevent horizontal scrolling without using P/Invoke.
 
Screenshots before and after (if PR changes UI):
-before 
![image](https://user-images.githubusercontent.com/33052757/49997663-7818cf00-ff92-11e8-9aea-3c153db770c0.png)
-after
![image](https://user-images.githubusercontent.com/33052757/49997710-98488e00-ff92-11e8-8e34-3064effe619b.png)

Has been tested on (remove any that don't apply):
- Windows 10
