### PR TITLE
Correct version number format changes

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("GitExtensions")]
 [assembly: AssemblyProduct("GitExtensions")]
-[assembly: AssemblyCopyright("Copyright ? 2008-2018 GitExtensions Team")]
+[assembly: AssemblyCopyright("Copyright © 2008-2018 GitExtensions Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CommonAssemblyInfoExternals.cs
+++ b/CommonAssemblyInfoExternals.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/GitExtensionsVSIX/source.extension.vsixmanifest
+++ b/GitExtensionsVSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Publisher="GitExt Team" Version="3.01.00.0" Language="en-US" Id="GitExtensions..550013F4-337C-4750-8967-DDEEEC2EB497" />
+        <Identity Publisher="GitExt Team" Version="3.01.00.00" Language="en-US" Id="GitExtensions..550013F4-337C-4750-8967-DDEEEC2EB497" />
         <DisplayName>GitExtensions</DisplayName>
         <Description xml:space="preserve" >Git Extensions is a graphical user interface for Git that allows you to control Git without using the command-line</Description>
         <MoreInfo>https://gitextensions.github.io/</MoreInfo>

--- a/Setup/MakeInstallers.cmd
+++ b/Setup/MakeInstallers.cmd
@@ -5,7 +5,7 @@ rem Update this version number with every release
 rem
 setlocal
 set version=3.01.00.0
-set numericVersion=3.01.00.0
+set numericVersion=3.01.00.00
 if not "%APPVEYOR_BUILD_VERSION%"=="" (
     set version=%APPVEYOR_BUILD_VERSION%
     set numericVersion=%APPVEYOR_BUILD_VERSION%


### PR DESCRIPTION
fixup for #5881  ca8cda58f070c300ff0c082d881e2d53dc246e76

Changes proposed in this pull request:
- Changes was done with editor which removed file format
 
Has been tested on (remove any that don't apply):