### PR TITLE
GitExtensionsDoc for 3.00

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1731,7 +1731,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                Process.Start("http://git-extensions-documentation.readthedocs.org/en/release-3.00/");
+                Process.Start("http://git-extensions-documentation.readthedocs.org/en/master/");
             }
             catch (Win32Exception)
             {

--- a/Setup/set_version_to.py
+++ b/Setup/set_version_to.py
@@ -19,79 +19,98 @@ if __name__ == '__main__':
         parser.print_help()
         exit(1)
 
+    m = re.match("(\d+\.\d+)", args.version)
+    if m:
+        short_version = m.group(1)
+    else:
+        parser.print_help()
+        exit(1)
+
+    verData = ["0"] * 4
+    verSplitted = args.version.split('.')
+    for i in range(len(verSplitted)):
+        verData[i] = verSplitted[i]
+
     if not args.text:
       args.text = args.version
     
+    filename = "..\GitUI\CommandsDialogs\FormBrowse.cs"
+    pattern = re.compile(r'(git-extensions-documentation.readthedocs.org/en)(/\w+)', re.IGNORECASE)
+    commonAssemblyInfo = open(filename, "r").readlines()
+    o = ""
+    for i in commonAssemblyInfo:
+        o += pattern.sub(r"\1/release-%s" % (short_version), i)
+    outfile = open(filename, "w")
+    outfile.writelines(o)
+
     filenames = [ "..\CommonAssemblyInfo.cs", "..\CommonAssemblyInfoExternals.cs" ]
     for filename in filenames:
         commonAssemblyInfo = open(filename, "r").readlines()
-        for i in range(len(commonAssemblyInfo)):
-            line = commonAssemblyInfo[i]
+        o = ""
+        for i in commonAssemblyInfo:
+            line = i
             if line.find("[assembly: Assembly") != -1:
                 if line.find("AssemblyVersion(") != -1 or line.find("AssemblyFileVersion(") != -1:
                     data = line.split('"')
                     data[1] = args.version
-                    commonAssemblyInfo[i] = '"'.join(data)
-                if line.find("AssemblyInformationalVersion(") != -1:
+                    line = '"'.join(data)
+                elif line.find("AssemblyInformationalVersion(") != -1:
                     data = line.split('"')
                     data[1] = args.text
-                    commonAssemblyInfo[i] = '"'.join(data)
+                    line = '"'.join(data)
+            o += line
         outfile = open(filename, "w")
-        outfile.writelines(commonAssemblyInfo)
+        outfile.writelines(o)
     
     filename = "..\GitExtensionsShellEx\GitExtensionsShellEx.rc"
     gitExtensionsShellEx = open(filename, "r").readlines()
-    verData = ["0"] * 4
-    verSplitted = args.version.split('.')
-    for i in range(len(verSplitted)):
-        verData[i] = verSplitted[i]
-    for i in range(len(gitExtensionsShellEx)):
-        line = gitExtensionsShellEx[i]
+    o = ""
+    for i in gitExtensionsShellEx:
+        line = i
         if line.find("FILEVERSION") != -1:
             data = line.split(' ')
             data[2] = ','.join(verData) + '\n'
-            gitExtensionsShellEx[i] = ' '.join(data)
+            line = ' '.join(data)
         elif line.find("PRODUCTVERSION") != -1:
             data = line.split(' ')
             data[2] = ','.join(verData) + '\n'
-            gitExtensionsShellEx[i] = ' '.join(data)
+            line = ' '.join(data)
         elif line.find('"FileVersion"') != -1:
             data = line.split(', ', 1)
             data[1] = '"' + '.'.join(verSplitted) + '"\n'
-            gitExtensionsShellEx[i] = ', '.join(data)
+            line = ', '.join(data)
         elif line.find('"ProductVersion"') != -1:
             data = line.split(', ', 1)
             data[1] = '"' + args.text + '"\n'
-            gitExtensionsShellEx[i] = ', '.join(data)
+            line = ', '.join(data)
+        o += line
     outfile = open(filename, "w")
-    outfile.writelines(gitExtensionsShellEx)
+    outfile.writelines(o)
     
     filename = "..\GitExtSshAskPass\SshAskPass.rc2"
     gitExtSshAskPass = open(filename, "r").readlines()
-    verData = ["0"] * 4
-    verSplitted = args.version.split('.')
-    for i in range(len(verSplitted)):
-        verData[i] = verSplitted[i]
-    for i in range(len(gitExtSshAskPass)):
-        line = gitExtSshAskPass[i]
+    o = ""
+    for i in gitExtSshAskPass:
+        line = i
         if line.find("FILEVERSION") != -1:
             data = line.split(' ')
             data[2] = ','.join(verData) + '\n'
-            gitExtSshAskPass[i] = ' '.join(data)
+            line = ' '.join(data)
         elif line.find("PRODUCTVERSION") != -1:
             data = line.split(' ')
             data[2] = ','.join(verData) + '\n'
-            gitExtSshAskPass[i] = ' '.join(data)
+            line = ' '.join(data)
         elif line.find('"FileVersion"') != -1:
             data = line.split(', ', 1)
             data[1] = '"' + '.'.join(verSplitted) + '"\n'
-            gitExtSshAskPass[i] = ', '.join(data)
+            line = ', '.join(data)
         elif line.find('"ProductVersion"') != -1:
             data = line.split(', ', 1)
             data[1] = '"' + args.text + '"\n'
-            gitExtSshAskPass[i] = ', '.join(data)
+            line = ', '.join(data)
+        o += line
     outfile = open(filename, "w")
-    outfile.writelines(gitExtSshAskPass)
+    outfile.writelines(o)
 
     for i in range(1, len(verSplitted)):
         if len(verSplitted[i]) == 1:
@@ -99,40 +118,45 @@ if __name__ == '__main__':
     
     filename = "MakeInstallers.cmd"
     makeInstallers = open(filename, "r").readlines()
-    for i in range(len(makeInstallers)):
-        line = makeInstallers[i]
+    o = ""
+    for i in makeInstallers:
+        line = i
         if line.find("set numericVersion=") == 0:
             data = line.split('=')
             data[1] = '.'.join(verSplitted) + '\n'
-            makeInstallers[i] = '='.join(data)
-        if line.find("set version=") == 0:
+            line = '='.join(data)
+        elif line.find("set version=") == 0:
             data = line.split('=')
             data[1] = args.text + '\n'
-            makeInstallers[i] = '='.join(data)
+            line= '='.join(data)
+        o += line
     outfile = open(filename, "w")
-    outfile.writelines(makeInstallers)
+    outfile.writelines(o)
     
     filename = "..\GitExtensionsDoc\source\conf.py"
     docoConf = open(filename, "r").readlines()
-    for i in range(len(docoConf)):
-        line = docoConf[i]
+    o = ""
+    for i in docoConf:
+        line = i
         if line.find("release = ") != -1:
             data = line.split(' = ')
             data[1] = '.'.join(verSplitted)
-            docoConf[i] = " = '".join(data) + "'\n"
-        if line.find("version = ") != -1:
+            line = " = '".join(data) + "'\n"
+        elif line.find("version = ") != -1:
             data = line.split(' = ')
             data[1] = args.text
-            docoConf[i] = " = '".join(data) + "'\n"
+            line = " = '".join(data) + "'\n"
+        o += line
     outfile = open(filename, "w")
-    outfile.writelines(docoConf)
+    outfile.writelines(o)
     
     filename = "..\GitExtensionsVSIX\source.extension.vsixmanifest"
     vsixManifest = open(filename, "r").readlines()
-    for i in range(len(vsixManifest)):
-        line = vsixManifest[i]
+    o = ""
+    for i in vsixManifest:
+        line = i
         if line.find("<Identity Publisher=\"GitExt Team\" Version=") != -1:
             line = re.sub("<Identity Publisher=\"GitExt Team\" Version=\"[0-9\.]+", "<Identity Publisher=\"GitExt Team\" Version=\"" + '.'.join(verSplitted), line)
-            vsixManifest[i] = line
+        o += line
     outfile = open(filename, "w")
-    outfile.writelines(vsixManifest)    
+    outfile.writelines(o)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ build_script:
     Write-Output "Platform: $env:IdeVersion"
     # for release branches mark the repo as clean
     if (!$env:APPVEYOR_PULL_REQUEST_TITLE -and $env:APPVEYOR_REPO_BRANCH.StartsWith("release/")) {
+        & git update-index --skip-worktree GitUI\CommandsDialogs\FormBrowse.cs
         & git update-index --skip-worktree CommonAssemblyInfo.cs
         & git update-index --skip-worktree CommonAssemblyInfoExternals.cs
         & git update-index --skip-worktree GitExtSshAskPass/SshAskPass.rc2


### PR DESCRIPTION
Point to 'master' for the doc subrepo

For the doc link in the app (FormBrowse), point to 'master' build of the doc repo
Update set_version_to.py to set the doc version link in FormBrowse, so it is not forgotten

Note: When merging release branches or running set_version_to.py on master, the explicit 'master' pointer will be lost.
This should not be critical

Closes #5693 

Screenshots before and after (if PR changes UI):
- n/a

What did I do to test the code and ensure quality:
- no code changes

Has been tested on (remove any that don't apply):
