### PR TITLE
Help text for Edit .gitignore not wrapped

### DIFF
--- a/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.Designer.cs
@@ -193,7 +193,6 @@
             this.label1.Size = new System.Drawing.Size(270, 383);
             this.label1.TabIndex = 4;
             this.label1.Text = resources.GetString("label1.Text");
-            this.label1.WordWrap = false;
             // 
             // flowLayoutPanel1
             // 


### PR DESCRIPTION
Changes proposed in this pull request:
- Help text is not wrapped

Removing WordWrap sets the default to true, as for similar controls.

Screenshots before and after (if PR changes UI):
- before
![image](https://user-images.githubusercontent.com/6248932/50056729-b4018f00-0160-11e9-96bd-c11ef01188fc.png)

- after
![image](https://user-images.githubusercontent.com/6248932/50056737-d1365d80-0160-11e9-89b1-ece85f938209.png)


What did I do to test the code and ensure quality:
- Open the form

Has been tested on (remove any that don't apply):
