### PR TITLE
Browse: Sort the Plugin list in alphabetic order

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -618,8 +618,10 @@ namespace GitUI.CommandsDialogs
         private void RegisterPlugins()
         {
             var existingPluginMenus = pluginsToolStripMenuItem.DropDownItems.OfType<ToolStripMenuItem>().ToLookup(c => c.Tag);
+            var pluginEntries = PluginRegistry.Plugins
+                .OrderBy(entry => entry.Name, StringComparer.CurrentCultureIgnoreCase);
 
-            foreach (var plugin in PluginRegistry.Plugins)
+            foreach (var plugin in pluginEntries)
             {
                 // Add the plugin to the Plugins menu, if not already added
                 if (!existingPluginMenus.Contains(plugin))

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -52,7 +52,8 @@ namespace JiraCommitHintPlugin
 
         public JiraCommitHintPlugin()
         {
-            Description = description;
+            SetNameAndDescription(description);
+            Translate();
             Icon = Resources.IconJira;
         }
 


### PR DESCRIPTION
Changes proposed in this pull request:
Plugins were sorted in Settings (in 3.0) but not in the Plugins menu.
Jira plugin was not init correctly (name was not set).
 
Screenshots before and after (if PR changes UI):
- before
 ![image](https://user-images.githubusercontent.com/6248932/50057394-2165ed80-016a-11e9-81ee-5d699573dc2d.png)
- after
![image](https://user-images.githubusercontent.com/6248932/50057495-5fafdc80-016b-11e9-9224-2557e2b078b2.png)

What did I do to test the code and ensure quality:
- Manual test

Has been tested on (remove any that don't apply):
