### PR TITLE
Remove unused setting for DiffViewer vertical ruler

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1067,12 +1067,6 @@ namespace GitCommands
             set => SetBool("showdiffforallparents", value);
         }
 
-        public static int DiffVerticalRulerPosition
-        {
-            get => GetInt("diffverticalrulerposition", 80);
-            set => SetInt("diffverticalrulerposition", value);
-        }
-
         public static string RecentWorkingDir
         {
             get => GetString("RecentWorkingDir", null);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -37,11 +37,8 @@
             this.chkRememberShowEntireFilePreference = new System.Windows.Forms.CheckBox();
             this.chkRememberNumberOfContextLines = new System.Windows.Forms.CheckBox();
             this.chkOmitUninterestingDiff = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.VerticalRulerPosition = new System.Windows.Forms.NumericUpDown();
             this.tooltip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanelForDiffViewer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.VerticalRulerPosition)).BeginInit();
             this.SuspendLayout();
             // 
             // tableLayoutPanelForDiffViewer
@@ -57,8 +54,6 @@
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkRememberShowEntireFilePreference, 0, 2);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkRememberNumberOfContextLines, 0, 3);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkOmitUninterestingDiff, 0, 4);
-            this.tableLayoutPanelForDiffViewer.Controls.Add(this.label1, 0, 7);
-            this.tableLayoutPanelForDiffViewer.Controls.Add(this.VerticalRulerPosition, 1, 7);
             this.tableLayoutPanelForDiffViewer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanelForDiffViewer.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanelForDiffViewer.Name = "tableLayoutPanelForDiffViewer";
@@ -145,33 +140,6 @@
             this.chkOmitUninterestingDiff.Text = "Omit uninteresting changes from combined diff";
             this.chkOmitUninterestingDiff.UseVisualStyleBackColor = true;
             // 
-            // label1
-            // 
-            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 168);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(144, 13);
-            this.label1.TabIndex = 12;
-            this.label1.Text = "Vertical ruler position [chars]";
-            // 
-            // VerticalRulerPosition
-            // 
-            this.VerticalRulerPosition.Location = new System.Drawing.Point(305, 164);
-            this.VerticalRulerPosition.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.VerticalRulerPosition.Name = "VerticalRulerPosition";
-            this.VerticalRulerPosition.Size = new System.Drawing.Size(120, 21);
-            this.VerticalRulerPosition.TabIndex = 11;
-            this.VerticalRulerPosition.Value = new decimal(new int[] {
-            80,
-            0,
-            0,
-            0});
-            // 
             // tooltip
             // 
             this.tooltip.AutoPopDelay = 30000;
@@ -186,7 +154,6 @@
             this.Size = new System.Drawing.Size(1132, 821);
             this.tableLayoutPanelForDiffViewer.ResumeLayout(false);
             this.tableLayoutPanelForDiffViewer.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.VerticalRulerPosition)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -203,7 +170,5 @@
         private System.Windows.Forms.ToolTip tooltip;
         private System.Windows.Forms.CheckBox chkOpenSubmoduleDiffInSeparateWindow;
         private System.Windows.Forms.CheckBox chkShowDiffForAllParents;
-        private System.Windows.Forms.NumericUpDown VerticalRulerPosition;
-        private System.Windows.Forms.Label label1;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -20,7 +20,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkRememberNumberOfContextLines.Checked = AppSettings.RememberNumberOfContextLines;
             chkOpenSubmoduleDiffInSeparateWindow.Checked = AppSettings.OpenSubmoduleDiffInSeparateWindow;
             chkShowDiffForAllParents.Checked = AppSettings.ShowDiffForAllParents;
-            VerticalRulerPosition.Value = AppSettings.DiffVerticalRulerPosition;
         }
 
         protected override void PageToSettings()
@@ -32,7 +31,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RememberNumberOfContextLines = chkRememberNumberOfContextLines.Checked;
             AppSettings.OpenSubmoduleDiffInSeparateWindow = chkOpenSubmoduleDiffInSeparateWindow.Checked;
             AppSettings.ShowDiffForAllParents = chkShowDiffForAllParents.Checked;
-            AppSettings.DiffVerticalRulerPosition = (int)VerticalRulerPosition.Value;
         }
 
         public static SettingsPageReference GetPageReference()

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -238,23 +238,7 @@ namespace GitUI.Editor
 
         private void OnUICommandsChanged(object sender, [CanBeNull] GitUICommandsChangedEventArgs e)
         {
-            if (e?.OldCommands != null)
-            {
-                e.OldCommands.PostSettings -= UICommands_PostSettings;
-            }
-
-            var commandSource = sender as IGitUICommandsSource;
-            if (commandSource?.UICommands != null)
-            {
-                commandSource.UICommands.PostSettings += UICommands_PostSettings;
-            }
-
             Encoding = null;
-        }
-
-        private void UICommands_PostSettings(object sender, GitUIPostActionEventArgs e)
-        {
-            internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition;
         }
 
         protected override void OnRuntimeLoad()
@@ -1386,11 +1370,6 @@ namespace GitUI.Editor
                 UICommandsSourceSet -= OnUICommandsSourceSet;
                 _async.Dispose();
                 components?.Dispose();
-
-                if (TryGetUICommands(out var uiCommands))
-                {
-                    uiCommands.PostSettings -= UICommands_PostSettings;
-                }
             }
 
             base.Dispose(disposing);

--- a/GitUI/Editor/FileViewerInternal.Designer.cs
+++ b/GitUI/Editor/FileViewerInternal.Designer.cs
@@ -40,7 +40,6 @@
             this.TextEditor.Name = "TextEditor";
             this.TextEditor.Size = new System.Drawing.Size(757, 519);
             this.TextEditor.TabIndex = 3;
-            this.TextEditor.ShowVRuler = false;
             // 
             // FileViewerInternal
             // 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -62,8 +62,6 @@ namespace GitUI.Editor
             TextEditor.ActiveTextAreaControl.TextEditorProperties.EnableFolding = false;
 
             _lineNumbersControl = new DiffViewerLineNumberControl(TextEditor.ActiveTextAreaControl.TextArea);
-
-            VRulerPosition = AppSettings.DiffVerticalRulerPosition;
         }
 
         public new Font Font
@@ -248,6 +246,7 @@ namespace GitUI.Editor
             set => TextEditor.ShowTabs = value;
         }
 
+        // Unused
         public int VRulerPosition
         {
             get => TextEditor.VRulerRow;


### PR DESCRIPTION
Settings lists a setting for "vertical ruler" that is not used.
(The ruler would show when exceeding 80 characters.)
I have not found if it ever has been used.
The documentation for 'latest' has set this as unused.

Changes proposed in this pull request:
- Remove the code for the vertical ruler
 
Screenshots before and after (if PR changes UI):
- 
![image](https://user-images.githubusercontent.com/6248932/50058075-a6a1d000-0173-11e9-8141-b349126be957.png)

-
![image](https://user-images.githubusercontent.com/6248932/50058082-bf11ea80-0173-11e9-91df-76935fa2a7a9.png)


What did I do to test the code and ensure quality:
- Manual tests

Has been tested on (remove any that don't apply):
