### PR TITLE
Reenable vertical ruler

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1069,7 +1069,7 @@ namespace GitCommands
 
         public static int DiffVerticalRulerPosition
         {
-            get => GetInt("diffverticalrulerposition", 80);
+            get => GetInt("diffverticalrulerposition", 0);
             set => SetInt("diffverticalrulerposition", value);
         }
 

--- a/GitUI/Editor/FileViewerInternal.Designer.cs
+++ b/GitUI/Editor/FileViewerInternal.Designer.cs
@@ -40,7 +40,6 @@
             this.TextEditor.Name = "TextEditor";
             this.TextEditor.Size = new System.Drawing.Size(757, 519);
             this.TextEditor.TabIndex = 3;
-            this.TextEditor.ShowVRuler = false;
             // 
             // FileViewerInternal
             // 


### PR DESCRIPTION
This reenables the vertical ruler introduced in #4095 (2.51) by @freza-tm, disabled in #5087 (3.00) 3871f6bcaebe4289cee3541eacf59a5544c9f9a1 by @drewnoakes 
#5927 proposed to remove the dead code as 2.51 (also in the documentation).
This PR changes the defaults to 0 instead, so it is not visible by default.

Changes proposed in this pull request:
- Reenable the vertical ruler with default 0
 
Screenshots before and after (if PR changes UI):
If enabled
![image](https://user-images.githubusercontent.com/6248932/50059813-eb396580-018b-11e9-80b6-dc9823773c5f.png)

What did I do to test the code and ensure quality:
- Manual test

Has been tested on (remove any that don't apply):
