### PR TITLE
Fix Pull dialog is suppressed when "Fetch and Prune all" is the default action

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2390,8 +2390,9 @@ namespace GitUI.CommandsDialogs
 
         private void DoPull(AppSettings.PullAction pullAction, bool isSilent)
         {
-            // Special case for FetchPruneAll to make sure user confirms the action
-            if (pullAction == AppSettings.PullAction.FetchPruneAll)
+            // Special case for FetchPruneAll to make sure user confirms the action.
+            // Notice, if action is not silent, we just show a regular Pull dialog without any confirmations.
+            if (isSilent && pullAction == AppSettings.PullAction.FetchPruneAll)
             {
                 bool isActionConfirmed = AppSettings.DontConfirmFetchAndPruneAll
                                          || MessageBox.Show(
@@ -2399,12 +2400,11 @@ namespace GitUI.CommandsDialogs
                                              _pullFetchPruneAllConfirmation.Text,
                                              _pullFetchPruneAll.Text,
                                              MessageBoxButtons.YesNo) == DialogResult.Yes;
-                if (isActionConfirmed)
-                {
-                    UICommands.StartPullDialogAndPullImmediately(this, pullAction: AppSettings.PullAction.FetchPruneAll);
-                }
 
-                return;
+                if (!isActionConfirmed)
+                {
+                    return;
+                }
             }
 
             if (isSilent)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5879

Changes proposed in this pull request:
- Fix Pull Dialog is suppressed when the "Fetch and Prune all" is the default action.
 
Screenshots before and after (if PR changes UI):
**BEFORE:**
![pullfix_before](https://user-images.githubusercontent.com/1074182/50100486-4f5e3700-0229-11e9-8d0e-e5b53d6d9d8d.gif)

**AFTER:**
![pullfix_after](https://user-images.githubusercontent.com/1074182/50100624-9a784a00-0229-11e9-95c7-0870001124bb.gif)

What did I do to test the code and ensure quality:
- Run manual local testing

Has been tested on (remove any that don't apply):
- Windows 10
