### PR TITLE
Fix incorrect resolution of {cDefaultRemotePathFromUrl} script variable

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -376,6 +376,7 @@
     </Compile>
     <Compile Include="Hotkey\KeysExtensions.cs" />
     <Compile Include="Script\PowerShellHelper.cs" />
+    <Compile Include="Script\ScriptOptionsParser.cs" />
     <Compile Include="Script\ScriptRunner.cs" />
     <Compile Include="AutoCompletion\AutoCompleteWord.cs" />
     <Compile Include="Script\FormFilePrompt.cs">

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -1,0 +1,487 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Config;
+using GitUI.HelperDialogs;
+using GitUIPluginInterfaces;
+using JetBrains.Annotations;
+
+namespace GitUI.Script
+{
+    public sealed class ScriptOptionsParser
+    {
+        public static readonly IReadOnlyList<string> Options = new[]
+        {
+            "{sHashes}",
+            "{sTag}",
+            "{sBranch}",
+            "{sLocalBranch}",
+            "{sRemoteBranch}",
+            "{sRemote}",
+            "{sRemoteUrl}",
+            "{sRemotePathFromUrl}",
+            "{sHash}",
+            "{sMessage}",
+            "{sAuthor}",
+            "{sCommitter}",
+            "{sAuthorDate}",
+            "{sCommitDate}",
+            "{cTag}",
+            "{cBranch}",
+            "{cLocalBranch}",
+            "{cRemoteBranch}",
+            "{cHash}",
+            "{cMessage}",
+            "{cAuthor}",
+            "{cCommitter}",
+            "{cAuthorDate}",
+            "{cCommitDate}",
+            "{cDefaultRemote}",
+            "{cDefaultRemoteUrl}",
+            "{cDefaultRemotePathFromUrl}",
+            "{UserInput}",
+            "{UserFiles}",
+            "{WorkingDir}"
+        };
+
+        public static (string argument, bool abort) Parse(string argument, IGitModule module, IWin32Window owner, RevisionGridControl revisionGrid)
+        {
+            GitRevision selectedRevision = null;
+            GitRevision currentRevision = null;
+
+            IReadOnlyList<GitRevision> allSelectedRevisions = Array.Empty<GitRevision>();
+            var selectedLocalBranches = new List<IGitRef>();
+            var selectedRemoteBranches = new List<IGitRef>();
+            var selectedRemotes = new List<string>();
+            var selectedBranches = new List<IGitRef>();
+            var selectedTags = new List<IGitRef>();
+            var currentLocalBranches = new List<IGitRef>();
+            var currentRemoteBranches = new List<IGitRef>();
+            var currentRemote = "";
+            var currentBranches = new List<IGitRef>();
+            var currentTags = new List<IGitRef>();
+
+            foreach (string option in Options)
+            {
+                if (string.IsNullOrEmpty(argument) || !argument.Contains(option))
+                {
+                    continue;
+                }
+
+                if (option.StartsWith("{c") && currentRevision == null)
+                {
+                    currentRevision = GetCurrentRevision(module, revisionGrid, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches, currentRevision);
+
+                    if (currentLocalBranches.Count == 1)
+                    {
+                        currentRemote = module.GetSetting(string.Format(SettingKeyString.BranchRemote, currentLocalBranches[0].Name));
+                    }
+                    else
+                    {
+                        currentRemote = module.GetCurrentRemote();
+                        if (string.IsNullOrEmpty(currentRemote))
+                        {
+                            currentRemote = module.GetSetting(string.Format(SettingKeyString.BranchRemote,
+                                AskToSpecify(currentLocalBranches, "Current Revision Branch")));
+                        }
+                    }
+                }
+                else if (option.StartsWith("{s") && selectedRevision == null && revisionGrid != null)
+                {
+                    allSelectedRevisions = revisionGrid.GetSelectedRevisions();
+                    selectedRevision = CalculateSelectedRevision(revisionGrid, selectedRemoteBranches, selectedRemotes, selectedLocalBranches, selectedBranches, selectedTags);
+                }
+
+                argument = ParseScriptArguments(argument, option, owner, module, allSelectedRevisions, selectedTags, selectedBranches, selectedLocalBranches, selectedRemoteBranches, selectedRemotes, selectedRevision, currentTags, currentBranches, currentLocalBranches, currentRemoteBranches, currentRevision, currentRemote);
+                if (argument == null)
+                {
+                    return (argument: null, abort: true);
+                }
+            }
+
+            return (argument, abort: false);
+        }
+
+        private static string AskToSpecify(IEnumerable<IGitRef> options, string title)
+        {
+            using (var f = new FormRunScriptSpecify(options, title))
+            {
+                f.ShowDialog();
+                return f.Ret;
+            }
+        }
+
+        private static string AskToSpecify(IEnumerable<string> options, string title)
+        {
+            using (var f = new FormRunScriptSpecify(options, title))
+            {
+                f.ShowDialog();
+                return f.Ret;
+            }
+        }
+
+        private static GitRevision CalculateSelectedRevision(RevisionGridControl revisionGrid, List<IGitRef> selectedRemoteBranches,
+            List<string> selectedRemotes, List<IGitRef> selectedLocalBranches,
+            List<IGitRef> selectedBranches, List<IGitRef> selectedTags)
+        {
+            GitRevision selectedRevision = revisionGrid.LatestSelectedRevision;
+            foreach (var head in selectedRevision.Refs)
+            {
+                if (head.IsTag)
+                {
+                    selectedTags.Add(head);
+                }
+                else if (head.IsHead || head.IsRemote)
+                {
+                    selectedBranches.Add(head);
+                    if (head.IsRemote)
+                    {
+                        selectedRemoteBranches.Add(head);
+                        if (!selectedRemotes.Contains(head.Remote))
+                        {
+                            selectedRemotes.Add(head.Remote);
+                        }
+                    }
+                    else
+                    {
+                        selectedLocalBranches.Add(head);
+                    }
+                }
+            }
+
+            return selectedRevision;
+        }
+
+        [CanBeNull]
+        private static GitRevision GetCurrentRevision(
+            IGitModule module, [CanBeNull] RevisionGridControl revisionGrid, List<IGitRef> currentTags, List<IGitRef> currentLocalBranches,
+            List<IGitRef> currentRemoteBranches, List<IGitRef> currentBranches, [CanBeNull] GitRevision currentRevision)
+        {
+            if (currentRevision == null)
+            {
+                IEnumerable<IGitRef> refs;
+
+                if (revisionGrid == null)
+                {
+                    var currentRevisionGuid = module.GetCurrentCheckout();
+                    refs = module.GetRefs(true, true).Where(gitRef => gitRef.ObjectId == currentRevisionGuid).ToList();
+                }
+                else
+                {
+                    currentRevision = revisionGrid.GetCurrentRevision();
+                    refs = currentRevision.Refs;
+                }
+
+                foreach (var gitRef in refs)
+                {
+                    if (gitRef.IsTag)
+                    {
+                        currentTags.Add(gitRef);
+                    }
+                    else if (gitRef.IsHead || gitRef.IsRemote)
+                    {
+                        currentBranches.Add(gitRef);
+                        if (gitRef.IsRemote)
+                        {
+                            currentRemoteBranches.Add(gitRef);
+                        }
+                        else
+                        {
+                            currentLocalBranches.Add(gitRef);
+                        }
+                    }
+                }
+            }
+
+            return currentRevision;
+        }
+
+        private static string GetRemotePath(string url)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+                Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
+            {
+                return uri.LocalPath.SubstringUntilLast('.');
+            }
+
+            return "";
+        }
+
+        private static string ParseScriptArguments(string argument, string option, IWin32Window owner, IGitModule module, IReadOnlyList<GitRevision> allSelectedRevisions, in IList<IGitRef> selectedTags, in IList<IGitRef> selectedBranches, in IList<IGitRef> selectedLocalBranches, in IList<IGitRef> selectedRemoteBranches, in IList<string> selectedRemotes, GitRevision selectedRevision, in IList<IGitRef> currentTags, in IList<IGitRef> currentBranches, in IList<IGitRef> currentLocalBranches, in IList<IGitRef> currentRemoteBranches, GitRevision currentRevision, string currentRemote)
+        {
+            string remote;
+            string url;
+            switch (option)
+            {
+                case "{sHashes}":
+                    argument = argument.Replace(option,
+                        string.Join(" ", allSelectedRevisions.Select(revision => revision.Guid).ToArray()));
+                    break;
+
+                case "{sTag}":
+                    if (selectedTags.Count == 1)
+                    {
+                        argument = argument.Replace(option, selectedTags[0].Name);
+                    }
+                    else if (selectedTags.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(selectedTags, "Selected Revision Tag"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{sBranch}":
+                    if (selectedBranches.Count == 1)
+                    {
+                        argument = argument.Replace(option, selectedBranches[0].Name);
+                    }
+                    else if (selectedBranches.Count != 0)
+                    {
+                        argument = argument.Replace(option,
+                            AskToSpecify(selectedBranches, "Selected Revision Branch"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{sLocalBranch}":
+                    if (selectedLocalBranches.Count == 1)
+                    {
+                        argument = argument.Replace(option, selectedLocalBranches[0].Name);
+                    }
+                    else if (selectedLocalBranches.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(selectedLocalBranches, "Selected Revision Local Branch"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{sRemoteBranch}":
+                    if (selectedRemoteBranches.Count == 1)
+                    {
+                        argument = argument.Replace(option, selectedRemoteBranches[0].Name);
+                    }
+                    else if (selectedRemoteBranches.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(selectedRemoteBranches, "Selected Revision Remote Branch"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{sRemote}":
+                    if (selectedRemotes.Count == 0)
+                    {
+                        argument = argument.Replace(option, "");
+                        break;
+                    }
+
+                    remote = selectedRemotes.Count == 1
+                        ? selectedRemotes[0]
+                        : AskToSpecify(selectedRemotes, "Selected Revision Remote");
+
+                    argument = argument.Replace(option, remote);
+                    break;
+                case "{sRemoteUrl}":
+                    if (selectedRemotes.Count == 0)
+                    {
+                        argument = argument.Replace(option, "");
+                        break;
+                    }
+
+                    remote = selectedRemotes.Count == 1
+                        ? selectedRemotes[0]
+                        : AskToSpecify(selectedRemotes, "Selected Revision Remote");
+
+                    url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
+                    argument = argument.Replace(option, url);
+                    break;
+                case "{sRemotePathFromUrl}":
+                    if (selectedRemotes.Count == 0)
+                    {
+                        argument = argument.Replace(option, "");
+                        break;
+                    }
+
+                    remote = selectedRemotes.Count == 1
+                        ? selectedRemotes[0]
+                        : AskToSpecify(selectedRemotes, "Selected Revision Remote");
+
+                    url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
+                    argument = argument.Replace(option, GetRemotePath(url));
+                    break;
+                case "{sHash}":
+                    argument = argument.Replace(option, selectedRevision.Guid);
+                    break;
+                case "{sMessage}":
+                    argument = argument.Replace(option, selectedRevision.Subject);
+                    break;
+                case "{sAuthor}":
+                    argument = argument.Replace(option, selectedRevision.Author);
+                    break;
+                case "{sCommitter}":
+                    argument = argument.Replace(option, selectedRevision.Committer);
+                    break;
+                case "{sAuthorDate}":
+                    argument = argument.Replace(option, selectedRevision.AuthorDate.ToString());
+                    break;
+                case "{sCommitDate}":
+                    argument = argument.Replace(option, selectedRevision.CommitDate.ToString());
+                    break;
+                case "{cTag}":
+                    if (currentTags.Count == 1)
+                    {
+                        argument = argument.Replace(option, currentTags[0].Name);
+                    }
+                    else if (currentTags.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(currentTags, "Current Revision Tag"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{cBranch}":
+                    if (currentBranches.Count == 1)
+                    {
+                        argument = argument.Replace(option, currentBranches[0].Name);
+                    }
+                    else if (currentBranches.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(currentBranches, "Current Revision Branch"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{cLocalBranch}":
+                    if (currentLocalBranches.Count == 1)
+                    {
+                        argument = argument.Replace(option, currentLocalBranches[0].Name);
+                    }
+                    else if (currentLocalBranches.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(currentLocalBranches, "Current Revision Local Branch"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{cRemoteBranch}":
+                    if (currentRemoteBranches.Count == 1)
+                    {
+                        argument = argument.Replace(option, currentRemoteBranches[0].Name);
+                    }
+                    else if (currentRemoteBranches.Count != 0)
+                    {
+                        argument = argument.Replace(option, AskToSpecify(currentRemoteBranches, "Current Revision Remote Branch"));
+                    }
+                    else
+                    {
+                        argument = argument.Replace(option, "");
+                    }
+
+                    break;
+                case "{cHash}":
+                    argument = argument.Replace(option, currentRevision.Guid);
+                    break;
+                case "{cMessage}":
+                    argument = argument.Replace(option, currentRevision.Subject);
+                    break;
+                case "{cAuthor}":
+                    argument = argument.Replace(option, currentRevision.Author);
+                    break;
+                case "{cCommitter}":
+                    argument = argument.Replace(option, currentRevision.Committer);
+                    break;
+                case "{cAuthorDate}":
+                    argument = argument.Replace(option, currentRevision.AuthorDate.ToString());
+                    break;
+                case "{cCommitDate}":
+                    argument = argument.Replace(option, currentRevision.CommitDate.ToString());
+                    break;
+                case "{cDefaultRemote}":
+                    if (string.IsNullOrEmpty(currentRemote))
+                    {
+                        argument = argument.Replace(option, "");
+                        break;
+                    }
+
+                    argument = argument.Replace(option, currentRemote);
+                    break;
+                case "{cDefaultRemoteUrl}":
+                    if (string.IsNullOrEmpty(currentRemote))
+                    {
+                        argument = argument.Replace(option, "");
+                        break;
+                    }
+
+                    url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
+                    argument = argument.Replace(option, url);
+                    break;
+                case "{cDefaultRemotePathFromUrl}":
+                    if (string.IsNullOrEmpty(currentRemote))
+                    {
+                        argument = argument.Replace(option, "");
+                        break;
+                    }
+
+                    url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
+                    argument = argument.Replace(option, GetRemotePath(url));
+                    break;
+                case "{UserInput}":
+                    using (var prompt = new SimplePrompt())
+                    {
+                        prompt.ShowDialog();
+                        argument = argument.Replace(option, prompt.UserInput);
+                    }
+
+                    break;
+                case "{UserFiles}":
+                    using (FormFilePrompt prompt = new FormFilePrompt())
+                    {
+                        if (prompt.ShowDialog(owner) != DialogResult.OK)
+                        {
+                            // abort parsing as the user chose to abort
+                            return null;
+                        }
+
+                        argument = argument.Replace(option, prompt.FileInput);
+                        break;
+                    }
+
+                case "{WorkingDir}":
+                    argument = argument.Replace(option, module.WorkingDir);
+                    break;
+            }
+
+            return argument;
+        }
+
+        internal static TestAccessor GetTestAccessor() => new TestAccessor();
+
+        public readonly struct TestAccessor
+        {
+            public string ParseScriptArguments(string argument, string option, IWin32Window owner, IGitModule module, IReadOnlyList<GitRevision> allSelectedRevisions, List<IGitRef> selectedTags, List<IGitRef> selectedBranches, List<IGitRef> selectedLocalBranches, List<IGitRef> selectedRemoteBranches, List<string> selectedRemotes, GitRevision selectedRevision, List<IGitRef> currentTags, List<IGitRef> currentBranches, List<IGitRef> currentLocalBranches, List<IGitRef> currentRemoteBranches, GitRevision currentRevision, string currentRemote) =>
+                ScriptOptionsParser.ParseScriptArguments(argument, option, owner, module, allSelectedRevisions, selectedTags, selectedBranches, selectedLocalBranches, selectedRemoteBranches, selectedRemotes, selectedRevision, currentTags, currentBranches, currentLocalBranches, currentRemoteBranches, currentRevision, currentRemote);
+        }
+    }
+}

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -84,7 +84,7 @@ namespace GitUI.Script
             if (Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
                 Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
             {
-                return uri.LocalPath.SubstringAfterLast('.');
+                return uri.LocalPath.SubstringUntilLast('.');
             }
 
             return "";

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -4,10 +4,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
-using GitCommands.Config;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
-using JetBrains.Annotations;
 
 namespace GitUI.Script
 {
@@ -53,7 +51,7 @@ namespace GitUI.Script
             }
 
             string argument = script.Arguments;
-            foreach (string option in _options)
+            foreach (string option in ScriptOptionsParser.Options)
             {
                 if (string.IsNullOrEmpty(argument) || !argument.Contains(option))
                 {
@@ -79,17 +77,6 @@ namespace GitUI.Script
             return RunScript(owner, module, script, revisionGrid);
         }
 
-        private static string GetRemotePath(string url)
-        {
-            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
-                Uri.TryCreate("ssh://" + url.Replace(":", "/"), UriKind.Absolute, out uri))
-            {
-                return uri.LocalPath.SubstringUntilLast('.');
-            }
-
-            return "";
-        }
-
         private static bool RunScript(IWin32Window owner, GitModule module, ScriptInfo scriptInfo, RevisionGridControl revisionGrid)
         {
             if (scriptInfo.AskConfirmation && MessageBox.Show(owner, $"Do you want to execute '{scriptInfo.Name}'?", "Script", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
@@ -98,326 +85,13 @@ namespace GitUI.Script
             }
 
             string originalCommand = scriptInfo.Command;
-            string argument = scriptInfo.Arguments;
-
-            string command = OverrideCommandWhenNecessary(originalCommand);
-            IReadOnlyList<GitRevision> allSelectedRevisions = Array.Empty<GitRevision>();
-
-            GitRevision selectedRevision = null;
-            GitRevision currentRevision = null;
-
-            var selectedLocalBranches = new List<IGitRef>();
-            var selectedRemoteBranches = new List<IGitRef>();
-            var selectedRemotes = new List<string>();
-            var selectedBranches = new List<IGitRef>();
-            var selectedTags = new List<IGitRef>();
-            var currentLocalBranches = new List<IGitRef>();
-            var currentRemoteBranches = new List<IGitRef>();
-            var currentRemote = "";
-            var currentBranches = new List<IGitRef>();
-            var currentTags = new List<IGitRef>();
-
-            foreach (string option in _options)
+            (string argument, bool abort) = ScriptOptionsParser.Parse(scriptInfo.Arguments, module, owner, revisionGrid);
+            if (abort)
             {
-                if (string.IsNullOrEmpty(argument) || !argument.Contains(option))
-                {
-                    continue;
-                }
-
-                if (option.StartsWith("{c") && currentRevision == null)
-                {
-                    currentRevision = GetCurrentRevision(module, revisionGrid, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches, currentRevision);
-
-                    if (currentLocalBranches.Count == 1)
-                    {
-                        currentRemote = module.GetSetting(string.Format(SettingKeyString.BranchRemote, currentLocalBranches[0].Name));
-                    }
-                    else
-                    {
-                        currentRemote = module.GetCurrentRemote();
-                        if (string.IsNullOrEmpty(currentRemote))
-                        {
-                            currentRemote = module.GetSetting(string.Format(SettingKeyString.BranchRemote,
-                                AskToSpecify(currentLocalBranches, "Current Revision Branch")));
-                        }
-                    }
-                }
-                else if (option.StartsWith("{s") && selectedRevision == null && revisionGrid != null)
-                {
-                    allSelectedRevisions = revisionGrid.GetSelectedRevisions();
-                    selectedRevision = CalculateSelectedRevision(revisionGrid, selectedRemoteBranches, selectedRemotes, selectedLocalBranches, selectedBranches, selectedTags);
-                }
-
-                string remote;
-                string url;
-                switch (option)
-                {
-                    case "{sHashes}":
-                        argument = argument.Replace(option,
-                            string.Join(" ", allSelectedRevisions.Select(revision => revision.Guid).ToArray()));
-                        break;
-                    case "{sTag}":
-                        if (selectedTags.Count == 1)
-                        {
-                            argument = argument.Replace(option, selectedTags[0].Name);
-                        }
-                        else if (selectedTags.Count != 0)
-                        {
-                            argument = argument.Replace(option, AskToSpecify(selectedTags, "Selected Revision Tag"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{sBranch}":
-                        if (selectedBranches.Count == 1)
-                        {
-                            argument = argument.Replace(option, selectedBranches[0].Name);
-                        }
-                        else if (selectedBranches.Count != 0)
-                        {
-                            argument = argument.Replace(option,
-                                                        AskToSpecify(selectedBranches, "Selected Revision Branch"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{sLocalBranch}":
-                        if (selectedLocalBranches.Count == 1)
-                        {
-                            argument = argument.Replace(option, selectedLocalBranches[0].Name);
-                        }
-                        else if (selectedLocalBranches.Count != 0)
-                        {
-                            argument = argument.Replace(option,
-                                                        AskToSpecify(selectedLocalBranches,
-                                                                     "Selected Revision Local Branch"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{sRemoteBranch}":
-                        if (selectedRemoteBranches.Count == 1)
-                        {
-                            argument = argument.Replace(option, selectedRemoteBranches[0].Name);
-                        }
-                        else if (selectedRemoteBranches.Count != 0)
-                        {
-                            argument = argument.Replace(option,
-                                                        AskToSpecify(selectedRemoteBranches,
-                                                                     "Selected Revision Remote Branch"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{sRemote}":
-                        if (selectedRemotes.Count == 0)
-                        {
-                            argument = argument.Replace(option, "");
-                            break;
-                        }
-
-                        remote = selectedRemotes.Count == 1
-                            ? selectedRemotes[0]
-                            : AskToSpecify(selectedRemotes, "Selected Revision Remote");
-
-                        argument = argument.Replace(option, remote);
-                        break;
-                    case "{sRemoteUrl}":
-                        if (selectedRemotes.Count == 0)
-                        {
-                            argument = argument.Replace(option, "");
-                            break;
-                        }
-
-                        remote = selectedRemotes.Count == 1
-                            ? selectedRemotes[0]
-                            : AskToSpecify(selectedRemotes, "Selected Revision Remote");
-
-                        url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
-                        argument = argument.Replace(option, url);
-                        break;
-                    case "{sRemotePathFromUrl}":
-                        if (selectedRemotes.Count == 0)
-                        {
-                            argument = argument.Replace(option, "");
-                            break;
-                        }
-
-                        remote = selectedRemotes.Count == 1
-                            ? selectedRemotes[0]
-                            : AskToSpecify(selectedRemotes, "Selected Revision Remote");
-
-                        url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
-                        argument = argument.Replace(option, GetRemotePath(url));
-                        break;
-                    case "{sHash}":
-                        argument = argument.Replace(option, selectedRevision.Guid);
-                        break;
-                    case "{sMessage}":
-                        argument = argument.Replace(option, selectedRevision.Subject);
-                        break;
-                    case "{sAuthor}":
-                        argument = argument.Replace(option, selectedRevision.Author);
-                        break;
-                    case "{sCommitter}":
-                        argument = argument.Replace(option, selectedRevision.Committer);
-                        break;
-                    case "{sAuthorDate}":
-                        argument = argument.Replace(option, selectedRevision.AuthorDate.ToString());
-                        break;
-                    case "{sCommitDate}":
-                        argument = argument.Replace(option, selectedRevision.CommitDate.ToString());
-                        break;
-                    case "{cTag}":
-                        if (currentTags.Count == 1)
-                        {
-                            argument = argument.Replace(option, currentTags[0].Name);
-                        }
-                        else if (currentTags.Count != 0)
-                        {
-                            argument = argument.Replace(option, AskToSpecify(currentTags, "Current Revision Tag"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{cBranch}":
-                        if (currentBranches.Count == 1)
-                        {
-                            argument = argument.Replace(option, currentBranches[0].Name);
-                        }
-                        else if (currentBranches.Count != 0)
-                        {
-                            argument = argument.Replace(option,
-                                                        AskToSpecify(currentBranches, "Current Revision Branch"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{cLocalBranch}":
-                        if (currentLocalBranches.Count == 1)
-                        {
-                            argument = argument.Replace(option, currentLocalBranches[0].Name);
-                        }
-                        else if (currentLocalBranches.Count != 0)
-                        {
-                            argument = argument.Replace(option,
-                                                        AskToSpecify(currentLocalBranches,
-                                                                     "Current Revision Local Branch"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{cRemoteBranch}":
-                        if (currentRemoteBranches.Count == 1)
-                        {
-                            argument = argument.Replace(option, currentRemoteBranches[0].Name);
-                        }
-                        else if (currentRemoteBranches.Count != 0)
-                        {
-                            argument = argument.Replace(option,
-                                                        AskToSpecify(currentRemoteBranches,
-                                                                     "Current Revision Remote Branch"));
-                        }
-                        else
-                        {
-                            argument = argument.Replace(option, "");
-                        }
-
-                        break;
-                    case "{cHash}":
-                        argument = argument.Replace(option, currentRevision.Guid);
-                        break;
-                    case "{cMessage}":
-                        argument = argument.Replace(option, currentRevision.Subject);
-                        break;
-                    case "{cAuthor}":
-                        argument = argument.Replace(option, currentRevision.Author);
-                        break;
-                    case "{cCommitter}":
-                        argument = argument.Replace(option, currentRevision.Committer);
-                        break;
-                    case "{cAuthorDate}":
-                        argument = argument.Replace(option, currentRevision.AuthorDate.ToString());
-                        break;
-                    case "{cCommitDate}":
-                        argument = argument.Replace(option, currentRevision.CommitDate.ToString());
-                        break;
-                    case "{cDefaultRemote}":
-                        if (string.IsNullOrEmpty(currentRemote))
-                        {
-                            argument = argument.Replace(option, "");
-                            break;
-                        }
-
-                        argument = argument.Replace(option, currentRemote);
-                        break;
-                    case "{cDefaultRemoteUrl}":
-                        if (string.IsNullOrEmpty(currentRemote))
-                        {
-                            argument = argument.Replace(option, "");
-                            break;
-                        }
-
-                        url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
-                        argument = argument.Replace(option, url);
-                        break;
-                    case "{cDefaultRemotePathFromUrl}":
-                        if (string.IsNullOrEmpty(currentRemote))
-                        {
-                            argument = argument.Replace(option, "");
-                            break;
-                        }
-
-                        url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
-                        argument = argument.Replace(option, GetRemotePath(url));
-                        break;
-                    case "{UserInput}":
-                        using (var prompt = new SimplePrompt())
-                        {
-                            prompt.ShowDialog();
-                            argument = argument.Replace(option, prompt.UserInput);
-                        }
-
-                        break;
-                    case "{UserFiles}":
-                        using (FormFilePrompt prompt = new FormFilePrompt())
-                        {
-                            if (prompt.ShowDialog(owner) != DialogResult.OK)
-                            {
-                                return false;
-                            }
-
-                            argument = argument.Replace(option, prompt.FileInput);
-                            break;
-                        }
-
-                    case "{WorkingDir}":
-                        argument = argument.Replace(option, module.WorkingDir);
-                        break;
-                }
+                return false;
             }
 
+            string command = OverrideCommandWhenNecessary(originalCommand);
             command = ExpandCommandVariables(command, module);
 
             if (scriptInfo.IsPowerShell)
@@ -481,116 +155,6 @@ namespace GitUI.Script
             return originalCommand.Replace("{WorkingDir}", module.WorkingDir);
         }
 
-        private static GitRevision CalculateSelectedRevision(RevisionGridControl revisionGrid, List<IGitRef> selectedRemoteBranches,
-                                                             List<string> selectedRemotes, List<IGitRef> selectedLocalBranches,
-                                                             List<IGitRef> selectedBranches, List<IGitRef> selectedTags)
-        {
-            GitRevision selectedRevision = revisionGrid.LatestSelectedRevision;
-            foreach (var head in selectedRevision.Refs)
-            {
-                if (head.IsTag)
-                {
-                    selectedTags.Add(head);
-                }
-                else if (head.IsHead || head.IsRemote)
-                {
-                    selectedBranches.Add(head);
-                    if (head.IsRemote)
-                    {
-                        selectedRemoteBranches.Add(head);
-                        if (!selectedRemotes.Contains(head.Remote))
-                        {
-                            selectedRemotes.Add(head.Remote);
-                        }
-                    }
-                    else
-                    {
-                        selectedLocalBranches.Add(head);
-                    }
-                }
-            }
-
-            return selectedRevision;
-        }
-
-        [CanBeNull]
-        private static GitRevision GetCurrentRevision(
-            GitModule module, [CanBeNull] RevisionGridControl revisionGrid, List<IGitRef> currentTags, List<IGitRef> currentLocalBranches,
-            List<IGitRef> currentRemoteBranches, List<IGitRef> currentBranches, [CanBeNull] GitRevision currentRevision)
-        {
-            if (currentRevision == null)
-            {
-                IEnumerable<IGitRef> refs;
-
-                if (revisionGrid == null)
-                {
-                    var currentRevisionGuid = module.GetCurrentCheckout();
-                    refs = module.GetRefs(true, true).Where(gitRef => gitRef.ObjectId == currentRevisionGuid).ToList();
-                }
-                else
-                {
-                    currentRevision = revisionGrid.GetCurrentRevision();
-                    refs = currentRevision.Refs;
-                }
-
-                foreach (var gitRef in refs)
-                {
-                    if (gitRef.IsTag)
-                    {
-                        currentTags.Add(gitRef);
-                    }
-                    else if (gitRef.IsHead || gitRef.IsRemote)
-                    {
-                        currentBranches.Add(gitRef);
-                        if (gitRef.IsRemote)
-                        {
-                            currentRemoteBranches.Add(gitRef);
-                        }
-                        else
-                        {
-                            currentLocalBranches.Add(gitRef);
-                        }
-                    }
-                }
-            }
-
-            return currentRevision;
-        }
-
-        private static readonly IReadOnlyList<string> _options = new[]
-        {
-            "{sHashes}",
-            "{sTag}",
-            "{sBranch}",
-            "{sLocalBranch}",
-            "{sRemoteBranch}",
-            "{sRemote}",
-            "{sRemoteUrl}",
-            "{sRemotePathFromUrl}",
-            "{sHash}",
-            "{sMessage}",
-            "{sAuthor}",
-            "{sCommitter}",
-            "{sAuthorDate}",
-            "{sCommitDate}",
-            "{cTag}",
-            "{cBranch}",
-            "{cLocalBranch}",
-            "{cRemoteBranch}",
-            "{cHash}",
-            "{cMessage}",
-            "{cAuthor}",
-            "{cCommitter}",
-            "{cAuthorDate}",
-            "{cCommitDate}",
-            "{cDefaultRemote}",
-            "{cDefaultRemoteUrl}",
-            "{cDefaultRemotePathFromUrl}",
-            "{UserInput}",
-            "{UserFiles}",
-            "{WorkingDir}"
-        };
-
         private const string PluginPrefix = "plugin:";
         private const string NavigateToPrefix = "navigateTo:";
 
@@ -627,15 +191,6 @@ namespace GitUI.Script
         }
 
         private static string AskToSpecify(IEnumerable<IGitRef> options, string title)
-        {
-            using (var f = new FormRunScriptSpecify(options, title))
-            {
-                f.ShowDialog();
-                return f.Ret;
-            }
-        }
-
-        private static string AskToSpecify(IEnumerable<string> options, string title)
         {
             using (var f = new FormRunScriptSpecify(options, title))
             {

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -105,6 +105,13 @@ namespace GitUIPluginInterfaces
         /// <returns>Registered remotes.</returns>
         IReadOnlyList<string> GetRemoteNames();
 
+        /// <summary>
+        /// Gets the commit ID of the currently checked out commit.
+        /// If the repo is bare or has no commits, <c>null</c> is returned.
+        /// </summary>
+        [CanBeNull]
+        ObjectId GetCurrentCheckout();
+
         /// <summary>Gets the remote of the current branch; or "" if no remote is configured.</summary>
         string GetCurrentRemote();
 

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Helpers\DiffKindRevisionTests.cs" />
     <Compile Include="ControlUtilTests.cs" />
     <Compile Include="LinqExtensionsTests.cs" />
+    <Compile Include="Script\ScriptOptionsParserTests.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractorTests.cs" />
     <Compile Include="SplitterManagerTest.cs" />
     <Compile Include="StringBuilderExtensionsTests.cs" />
@@ -92,7 +93,7 @@
     <Compile Include="UserControls\RevisionGrid\GitRefListsForRevisionTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\LaneNodeLocatorTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProviderTests.cs" />
-    <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphMultiThreadingTests.cs" />	
+    <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphMultiThreadingTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphTests.cs" />
     <Compile Include="UserManual\SingleHtmlUserManualFixture.cs" />
     <Compile Include="UserManual\StandardHtmlUserManualFixture.cs" />

--- a/UnitTests/GitUITests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUITests/Script/ScriptOptionsParserTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using GitCommands.Config;
+using GitUI.Script;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.Script
+{
+    [TestFixture]
+    public class ScriptOptionsParserTests
+    {
+        private IGitModule _module;
+
+        [SetUp]
+        public void Setup()
+        {
+            _module = Substitute.For<IGitModule>();
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_cDefaultRemotePathFromUrl_currentRemote_unset()
+        {
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments("{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", "{cDefaultRemotePathFromUrl}", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+
+            result.Should().Be("{openUrl} https://gitlab.com/tree/{sBranch}");
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_cDefaultRemotePathFromUrl_currentRemote_set()
+        {
+            var currentRemote = "myRemote";
+            _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote)).Returns("https://gitlab.com/gitlabhq/gitlabhq.git");
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments("{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", "{cDefaultRemotePathFromUrl}", null, _module, null, null, null, null, null, null, null, null, null, null, null, null, currentRemote);
+
+            result.Should().Be("{openUrl} https://gitlab.com/gitlabhq/gitlabhq/tree/{sBranch}");
+        }
+    }
+}


### PR DESCRIPTION
`{cDefaultRemotePathFromUrl}` script variable now resolves correctly.

Fixes #5932

Also added tests for script options parser
* Extract script options parser into a separate class
* Extract the actual option reslution into a separate method
* Add tests confirming the correct resolution of `{cDefaultRemotePathFromUrl}` script option

NB: I will cherrypick only the first commit on to v3.0.1 branch.