### PR TITLE
Fix scrolling index in PatchGrid for one skipped patch

### DIFF
--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -43,7 +43,8 @@ namespace GitUI
             if (patchFiles.Any())
             {
                 int rowsInView = Patches.DisplayedRowCount(false);
-                Patches.FirstDisplayedScrollingRowIndex = Math.Max(0, patchFiles.TakeWhile(pf => !pf.IsNext).Count() - (rowsInView / 2));
+                int currentPatchFileIndex = patchFiles.TakeWhile(pf => !pf.IsNext).Count() - 1;
+                Patches.FirstDisplayedScrollingRowIndex = Math.Max(0, currentPatchFileIndex - (rowsInView / 2));
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #
#5959

## Proposed changes

- Use 0-based index for FirstDisplayedScrollingRowIndex instead of 1-based in accordance with the [specification](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.datagridview.firstdisplayedscrollingrowindex?view=netframework-4.6.1).

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->
