### PR TITLE
Handle Esc in all FileViewers of FormFileHistory to close the window

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -56,6 +56,11 @@ namespace GitUI.CommandsDialogs
             _commitDataManager = new CommitDataManager(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
 
+            CommitDiff.EscapePressed += Close;
+            View.EscapePressed += Close;
+            Diff.EscapePressed += Close;
+            Blame.EscapePressed += Close;
+
             copyToClipboardToolStripMenuItem.SetRevisionFunc(() => FileChanges.GetSelectedRevisions());
 
             InitializeComplete();

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -18,6 +18,11 @@ namespace GitUI.Blame
     {
         public event EventHandler<CommandEventArgs> CommandClick;
 
+        /// <summary>
+        /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
+        /// </summary>
+        public event Action EscapePressed;
+
         private readonly AsyncLoader _blameLoader = new AsyncLoader();
 
         [CanBeNull] private GitBlameLine _lastBlameLine;
@@ -46,12 +51,14 @@ namespace GitUI.Blame
             BlameCommitter.MouseLeave += BlameCommitter_MouseLeave;
             BlameCommitter.SelectedLineChanged += SelectedLineChanged;
             BlameCommitter.RequestDiffView += ActiveTextAreaControlDoubleClick;
+            BlameCommitter.EscapePressed += () => EscapePressed?.Invoke();
 
             BlameFile.IsReadOnly = true;
             BlameFile.ScrollPosChanged += BlameFile_ScrollPosChanged;
             BlameFile.SelectedLineChanged += SelectedLineChanged;
             BlameFile.RequestDiffView += ActiveTextAreaControlDoubleClick;
             BlameFile.MouseMove += BlameFile_MouseMove;
+            BlameFile.EscapePressed += () => EscapePressed?.Invoke();
 
             CommitInfo.CommandClicked += commitInfo_CommandClicked;
         }

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -10,11 +10,17 @@ namespace GitUI.UserControls
 {
     public partial class CommitDiff : GitModuleControl
     {
+        /// <summary>
+        /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
+        /// </summary>
+        public event Action EscapePressed;
+
         public CommitDiff()
         {
             InitializeComponent();
             InitializeComplete();
 
+            DiffText.EscapePressed += () => EscapePressed?.Invoke();
             DiffText.ExtraDiffArgumentsChanged += DiffText_ExtraDiffArgumentsChanged;
             DiffFiles.Focus();
             DiffFiles.SetDiffs();


### PR DESCRIPTION
Fixes #5957

## Proposed changes
- handle Esc in all FileViewers of FormFileHistory, too, to close the window
- add event EscapePressed to BlameControl and CommitDiff
- avoid NRE in ICSharpCode.TextEditor on close

## Screenshots
N/A

## Test methodology
- manual testing

## Test environment(s)
- Git Extensions 3.01.00.0
- Build b78af86a6d0fbe08ec677308ca35a8fbf986ebd5
- Git 2.20.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)