### PR TITLE
Close the Stash Manager on Esc keypress

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -32,6 +32,7 @@ namespace GitUI.CommandsDialogs
         private FormStash()
         {
             InitializeComponent();
+            CompleteTheInitialization();
         }
 
         public FormStash(GitUICommands commands)
@@ -39,8 +40,58 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             View.ExtraDiffArgumentsChanged += delegate { StashedSelectedIndexChanged(null, null); };
+            CompleteTheInitialization();
+        }
+
+        private void CompleteTheInitialization()
+        {
+            KeyPreview = true;
+            View.EscapePressed += () => DialogResult = DialogResult.Cancel;
             splitContainer1.SplitterDistance = DpiUtil.Scale(280);
             InitializeComplete();
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape && e.Modifiers == Keys.None)
+            {
+                var focusedControl = this.FindFocusedControl();
+                var comboBox = focusedControl as ComboBox;
+                if (comboBox != null && comboBox.DroppedDown)
+                {
+                    comboBox.DroppedDown = false;
+                }
+                else
+                {
+                    var textBox = focusedControl as TextBoxBase;
+                    if (textBox != null && textBox.SelectionLength > 0)
+                    {
+                        textBox.SelectionLength = 0;
+                    }
+                    else
+                    {
+                        DialogResult = DialogResult.Cancel;
+                    }
+                }
+
+                // do not let the modal form react itself on this preview of the Escape key press
+                e.SuppressKeyPress = true;
+                e.Handled = true;
+            }
+
+            base.OnKeyDown(e);
+        }
+
+        protected override void OnKeyUp(KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape && e.Modifiers == Keys.None)
+            {
+                // do not let the modal form react itself on this preview of the Escape key press
+                e.SuppressKeyPress = true;
+                e.Handled = true;
+            }
+
+            base.OnKeyUp(e);
         }
 
         private void FormStashFormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
Fixes #5958

## Proposed changes
- close the dialog on Escape keypress unless some text is selected or a combobox is dropped down
- do the DPI scaling in the default constructor, too

It does not work without KeyPreview = true. Though the modal Form must not react on Escape itself. It would close it too early. That's why ComboBoxes must be handled manually. (It was no fun to find a working solution.)

## Screenshots
N/A

## Test methodology
- manual testing

## Test environment(s)
- Git Extensions 3.01.00.0
- Build 136697dee2cd176894ebf0f2a09835608aa950fc
- Git 2.20.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)