### PR TITLE
Replace ConcurrentBag in RevisionGraph

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -80,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>
     </PackageReference>

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
@@ -280,8 +278,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                             Brush brush;
 
-                            if (revisionGraphRevision.Parent.Children.Count > 1)
+                            if (!revisionGraphRevision.Parent.Children.IsEmpty
+                                && !revisionGraphRevision.Parent.Children.Pop().IsEmpty)
                             {
+                                // revisionGraphRevision.Parent.Children has more than one element
                                 brush = GetBrushForRevision(revisionGraphRevision.Child, revisionGraphRevision.Child.IsRelative);
                             }
                             else

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using GitCommands;
 using GitUIPluginInterfaces;
@@ -18,7 +19,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     {
         // Some unordered collections with raw data
         private ConcurrentDictionary<ObjectId, RevisionGraphRevision> _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
-        private ConcurrentBag<RevisionGraphRevision> _nodes = new ConcurrentBag<RevisionGraphRevision>();
+        private ImmutableList<RevisionGraphRevision> _nodes = ImmutableList<RevisionGraphRevision>.Empty;
 
         /// <summary>
         /// The max score is used to keep a chronological order during the graph building.
@@ -48,7 +49,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             _maxScore = 0;
             _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
-            _nodes = new ConcurrentBag<RevisionGraphRevision>();
+            _nodes = ImmutableList<RevisionGraphRevision>.Empty;
             _orderedNodesCache = null;
             _orderedRowCache = null;
         }
@@ -212,7 +213,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             // Ensure all parents are loaded before adding it to the _nodes list. This is important for ordering.
-            _nodes.Add(revisionGraphRevision);
+            ImmutableInterlocked.Update(ref _nodes, list => list.Add(revisionGraphRevision));
         }
 
         /// <summary>
@@ -313,7 +314,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             _reorder = false;
 
             // Use a local variable, because the cached list can be reset
-            var localOrderedNodesCache = _nodes.OrderBy(n => n.Score).ToList();
+            var localOrderedNodesCache = _nodes.ToList();
+            localOrderedNodesCache.Sort((x, y) => x.Score.CompareTo(y.Score));
             _orderedNodesCache = localOrderedNodesCache;
             if (localOrderedNodesCache.Count > 0)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -549,7 +549,9 @@ namespace GitUI.UserControls.RevisionGrid
             // With lock, loading the commit info slows down terribly.
             if (_revisionGraph.TryGetNode(objectId, out var node))
             {
-                return node.Children.Select(d => d.GitRevision.ObjectId).ToList();
+                var children = node.Children.Select(d => d.GitRevision.ObjectId).ToList();
+                children.Reverse();
+                return children;
             }
 
             return Array.Empty<ObjectId>();


### PR DESCRIPTION
Concurrent collections are optimized for a small number of collections with a large number of accessors. The collections are often large, so higher fixed collection overhead is acceptable to improve performance at scale.

The RevisionGraph has a different pattern: a large number of small collections with read operations dominating. The concurrent collections are replaced with immutable collections chosen to optimize the primary use cases.