### PR TITLE
Refresh revision grid when superproject branch/tag is completed

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -869,6 +869,8 @@ namespace GitUI
                     await TaskScheduler.Default;
                     return GetSuperprojectCheckout(ShowRemoteRef, capturedModule);
                 });
+                _superprojectCurrentCheckout.Task.ContinueWith((task) => Refresh(),
+                    TaskScheduler.FromCurrentSynchronizationContext());
 
                 ResetNavigationHistory();
             }


### PR DESCRIPTION
Regression, implemented as in 2.51

Fixes #5874


## Proposed changes
Refresh grid when information about superproject is completed.
In 3.0 explicit refresh (e.g. selecting a revision) is required


## Screenshots

### Before
![image](https://user-images.githubusercontent.com/6248932/50384050-19a0ce80-06bf-11e9-8394-4563de8a280a.png)

### After
![image](https://user-images.githubusercontent.com/6248932/50384055-3210e900-06bf-11e9-946e-4c77d84bace8.png)


## Test methodology <!-- How did you ensure quality? -->
Manual test.
Select a subrepo and notice that the superproject branches appear after some time (without explicit UI interaction.)

## Test environment(s) 