### PR TITLE
use --no-optional-locks for submodule status and stash list

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -456,17 +456,17 @@ namespace GitCommands
         }
 
         [CanBeNull]
-        public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string fileName, string oldFileName, bool staged)
+        public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string fileName, string oldFileName, bool staged, bool noLocks = false)
         {
-            Patch patch = module.GetCurrentChanges(fileName, oldFileName, staged, "", module.FilesEncoding);
+            Patch patch = module.GetCurrentChanges(fileName, oldFileName, staged, "", module.FilesEncoding, noLocks: noLocks);
             string text = patch != null ? patch.Text : "";
             return ParseSubmoduleStatus(text, module, fileName);
         }
 
         [CanBeNull]
-        public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string submodule)
+        public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string submodule, bool noLocks = false)
         {
-            return GetCurrentSubmoduleChanges(module, submodule, submodule, false);
+            return GetCurrentSubmoduleChanges(module, submodule, submodule, false, noLocks: noLocks);
         }
 
         [CanBeNull]

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -168,7 +168,7 @@ namespace GitCommands.Submodules
                 await TaskScheduler.Default;
                 cancelToken.ThrowIfCancellationRequested();
 
-                var submoduleStatus = GitCommandHelpers.GetCurrentSubmoduleChanges(supermodule, submoduleName);
+                var submoduleStatus = GitCommandHelpers.GetCurrentSubmoduleChanges(supermodule, submoduleName, noLocks: true);
                 if (submoduleStatus != null && submoduleStatus.Commit != submoduleStatus.OldCommit)
                 {
                     submoduleStatus.CheckSubmoduleStatus(submoduleStatus.GetSubmodule(supermodule));

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -197,7 +197,7 @@ namespace GitUI.BranchTreePanel
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
-                var branchNames = Module.GetRefs(false).Select(b => b.Name);
+                var branchNames = Module.GetRefs(tags: false, branches: true, noLocks: true).Select(b => b.Name);
                 FillBranchTree(branchNames, token);
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -30,7 +30,7 @@ namespace GitUI.BranchTreePanel
                 token.ThrowIfCancellationRequested();
                 var nodes = new Dictionary<string, BaseBranchNode>();
 
-                var branches = Module.GetRefs()
+                var branches = Module.GetRefs(tags: true, branches: true, noLocks: true)
                     .Where(branch => branch.IsRemote && !branch.IsTag)
                     .OrderBy(branch => branch.Name)
                     .Select(branch => branch.Name);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2047,7 +2047,7 @@ namespace GitUI.CommandsDialogs
                     // Make sure there are never more than a 100 branches added to the menu
                     // GitExtensions will hang when the drop down is too large...
                     return Module
-                        .GetRefs(tags: false)
+                        .GetRefs(tags: false, branches: true, noLocks: true)
                         .Select(b => b.Name)
                         .Take(100);
                 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1035,7 +1035,7 @@ namespace GitUI.CommandsDialogs
                     await Task.Delay(500);
                     await TaskScheduler.Default;
 
-                    var result = Module.GetStashes().Count;
+                    var result = Module.GetStashes(noLocks: true).Count;
 
                     await this.SwitchToMainThreadAsync();
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -868,7 +868,7 @@ namespace GitUI
                 _superprojectCurrentCheckout = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await TaskScheduler.Default;
-                    return GetSuperprojectCheckout(ShowRemoteRef, capturedModule);
+                    return GetSuperprojectCheckout(ShowRemoteRef, capturedModule, noLocks: true);
                 });
                 _superprojectCurrentCheckout.Task.ContinueWith((task) => Refresh(),
                     TaskScheduler.FromCurrentSynchronizationContext());
@@ -1024,7 +1024,7 @@ namespace GitUI
         }
 
         [CanBeNull]
-        private static SuperProjectInfo GetSuperprojectCheckout(Func<IGitRef, bool> showRemoteRef, GitModule gitModule)
+        private static SuperProjectInfo GetSuperprojectCheckout(Func<IGitRef, bool> showRemoteRef, GitModule gitModule, bool noLocks = false)
         {
             if (gitModule.SuperprojectModule == null)
             {
@@ -1046,7 +1046,7 @@ namespace GitUI
                 spi.CurrentBranch = commit;
             }
 
-            var refs = gitModule.SuperprojectModule.GetSubmoduleItemsForEachRef(gitModule.SubmodulePath, showRemoteRef);
+            var refs = gitModule.SuperprojectModule.GetSubmoduleItemsForEachRef(gitModule.SubmodulePath, showRemoteRef, noLocks: noLocks);
 
             if (refs != null)
             {

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using GitCommands;
 using GitUIPluginInterfaces;
+using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace GitCommandsTests
@@ -502,6 +503,39 @@ namespace GitCommandsTests
                     helper.Dispose();
                 }
             }
+        }
+
+        [TestCase(false, @"stash list")]
+        [TestCase(true, @"--no-optional-locks stash list")]
+        public void GetStashesCmd(bool noLocks, string expected)
+        {
+            Assert.AreEqual(expected, _gitModule.GetStashesCmd(noLocks).ToString());
+        }
+
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", null, false)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color extra -- ""new""", "new", "old", false, "extra", null, false)]
+        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", null, true)]
+        public void GetCurrentChangesCmd(string expected, string fileName, [CanBeNull] string oldFileName, bool staged,
+            string extraDiffArguments, Encoding encoding, bool noLocks)
+        {
+            Assert.AreEqual(expected, _gitModule.GetCurrentChangesCmd(fileName, oldFileName, staged,
+                extraDiffArguments, encoding, noLocks).ToString());
+        }
+
+        [TestCase(@"for-each-ref --sort=-committerdate --format=""%(objectname) %(refname)"" refs/heads/", false)]
+        [TestCase(@"--no-optional-locks for-each-ref --sort=-committerdate --format=""%(objectname) %(refname)"" refs/heads/", true)]
+        public void GetSortedRefsCommand(string expected, bool noLocks)
+        {
+            Assert.AreEqual(expected, _gitModule.GetSortedRefsCommand(noLocks).ToString());
+        }
+
+        [TestCase(@"show-ref --dereference", true, true, false)]
+        [TestCase(@"show-ref --tags", true, false, false)]
+        [TestCase(@"for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", false, true, false)]
+        [TestCase(@"--no-optional-locks for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", false, true, true)]
+        public void GetRefsCmd(string expected, bool tags, bool branches, bool noLocks)
+        {
+            Assert.AreEqual(expected, _gitModule.GetRefsCmd(tags, branches, noLocks).ToString());
         }
     }
 }


### PR DESCRIPTION
Part of #5769

## Proposed changes

Run some Git commands with less importance with --no-optional-locks, to avoid they lock out commands important for interactivity.
This includes:
- Sub submodule status (in submodule menu)
- stash count (in Browse)
- superproject tag/branch info (in revision grid)
- branch menu dropdown
- side panel dropdown

When "--no-optional-locks" was added, only git-status was improved, but further commands could be improved eventually.
The intention with the change is to decrease "random" lockups, it is not expected that noticeable changes are seen also if i.e. git-diff has been implemented.

## Test methodology <!-- How did you ensure quality? -->
Manual for functionality (no changes)
Added command output format tests

## Test environment(s) <!-- Remove any that don't apply -->
