### PR TITLE
Fix empty commit detail and exception when reseting to a remote branch, complaining about the Commit Date < min UTC DateTime

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -186,7 +186,7 @@ namespace GitUI.BranchTreePanel
                 }
                 else
                 {
-                    using (var form = new FormResetCurrentBranch(UICommands, new GitRevision(objectId)))
+                    using (var form = new FormResetCurrentBranch(UICommands, Module.GetRevision(objectId)))
                     {
                         form.ShowDialog(TreeViewNode.TreeView);
                     }


### PR DESCRIPTION
Fixes #5984

## Proposed changes

Fix empty commit detail and exception when reseting to a remote branch, complaining about the Commit Date < min UTC DateTime

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/596334/50390088-896d9280-076d-11e9-8b09-2f27fcdd74e9.png)

### After

![image](https://user-images.githubusercontent.com/596334/50390244-c044a800-076f-11e9-8c50-b8dd414a7b4d.png)

## Test methodology

- Tried to reset to the remote branch, the information now shows correctly

## Test environment(s)

- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17763.0