### PR TITLE
Fix 5197 highlight by author

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1142,6 +1142,12 @@ namespace GitCommands
             set => SetColor("othertagcolor", value);
         }
 
+        public static Color AuthoredRevisionsHighlightColor
+        {
+            get => GetColor("authoredhighlightcolor", Color.LightYellow);
+            set => SetColor("authoredhighlightcolor", value);
+        }
+
         public static Color TagColor
         {
             get => GetColor("tagcolor", Color.DarkBlue);
@@ -1236,6 +1242,12 @@ namespace GitCommands
         {
             get => GetBool("stripedbranchchange", true);
             set => SetBool("stripedbranchchange", value);
+        }
+
+        public static bool HighlightAuthoredRevisions
+        {
+            get { return GetBool("highlightauthoredrevisions", true); }
+            set { SetBool("highlightauthoredrevisions", value); }
         }
 
         public static string LastFormatPatchDir

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -31,6 +31,9 @@
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
             this.gbRevisionGraph = new System.Windows.Forms.GroupBox();
             this.tlpnlRevisionGraph = new System.Windows.Forms.TableLayoutPanel();
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel = new System.Windows.Forms.Label();
+            this.lblColorHighlightAuthored = new System.Windows.Forms.Label();
+            this.chkHighlightAuthored = new System.Windows.Forms.CheckBox();
             this.MulticolorBranches = new System.Windows.Forms.CheckBox();
             this._NO_TRANSLATE_ColorRemoteBranchLabel = new System.Windows.Forms.Label();
             this.lblColorBranchRemote = new System.Windows.Forms.Label();
@@ -80,7 +83,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tlpnlMain.Size = new System.Drawing.Size(985, 598);
+            tlpnlMain.Size = new System.Drawing.Size(1394, 836);
             tlpnlMain.TabIndex = 0;
             // 
             // gbRevisionGraph
@@ -92,7 +95,7 @@
             this.gbRevisionGraph.Location = new System.Drawing.Point(3, 3);
             this.gbRevisionGraph.Name = "gbRevisionGraph";
             this.gbRevisionGraph.Padding = new System.Windows.Forms.Padding(8);
-            this.gbRevisionGraph.Size = new System.Drawing.Size(979, 286);
+            this.gbRevisionGraph.Size = new System.Drawing.Size(1388, 262);
             this.gbRevisionGraph.TabIndex = 0;
             this.gbRevisionGraph.TabStop = false;
             this.gbRevisionGraph.Text = "Revision graph";
@@ -105,24 +108,27 @@
             this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorHighlightAuthoredLabel, 1, 7);
+            this.tlpnlRevisionGraph.Controls.Add(this.lblColorHighlightAuthored, 0, 7);
+            this.tlpnlRevisionGraph.Controls.Add(this.chkHighlightAuthored, 0, 6);
             this.tlpnlRevisionGraph.Controls.Add(this.MulticolorBranches, 0, 0);
-            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorRemoteBranchLabel, 1, 9);
-            this.tlpnlRevisionGraph.Controls.Add(this.lblColorBranchRemote, 0, 9);
-            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorOtherLabel, 1, 10);
-            this.tlpnlRevisionGraph.Controls.Add(this.lblColorLabel, 0, 10);
+            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorRemoteBranchLabel, 1, 10);
+            this.tlpnlRevisionGraph.Controls.Add(this.lblColorBranchRemote, 0, 10);
+            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorOtherLabel, 1, 11);
+            this.tlpnlRevisionGraph.Controls.Add(this.lblColorLabel, 0, 11);
             this.tlpnlRevisionGraph.Controls.Add(this.chkDrawAlternateBackColor, 0, 2);
             this.tlpnlRevisionGraph.Controls.Add(this.DrawNonRelativesTextGray, 0, 5);
             this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorGraphLabel, 1, 0);
             this.tlpnlRevisionGraph.Controls.Add(this.DrawNonRelativesGray, 0, 4);
             this.tlpnlRevisionGraph.Controls.Add(this.StripedBanchChange, 0, 1);
-            this.tlpnlRevisionGraph.Controls.Add(this.lblColorBranchLocal, 0, 8);
-            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorBranchLabel, 1, 8);
-            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorTagLabel, 1, 7);
-            this.tlpnlRevisionGraph.Controls.Add(this.lblColorTag, 0, 7);
+            this.tlpnlRevisionGraph.Controls.Add(this.lblColorBranchLocal, 0, 9);
+            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorBranchLabel, 1, 9);
+            this.tlpnlRevisionGraph.Controls.Add(this._NO_TRANSLATE_ColorTagLabel, 1, 8);
+            this.tlpnlRevisionGraph.Controls.Add(this.lblColorTag, 0, 8);
             this.tlpnlRevisionGraph.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlRevisionGraph.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlRevisionGraph.Location = new System.Drawing.Point(8, 21);
             this.tlpnlRevisionGraph.Name = "tlpnlRevisionGraph";
-            this.tlpnlRevisionGraph.RowCount = 12;
+            this.tlpnlRevisionGraph.RowCount = 13;
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -135,8 +141,48 @@
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlRevisionGraph.Size = new System.Drawing.Size(963, 256);
+            this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlRevisionGraph.Size = new System.Drawing.Size(1372, 233);
             this.tlpnlRevisionGraph.TabIndex = 0;
+            // 
+            // _NO_TRANSLATE_ColorHighlightAuthoredLabel
+            // 
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.AutoSize = true;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.BackColor = System.Drawing.Color.Red;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Cursor = System.Windows.Forms.Cursors.Hand;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Enabled = false;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Location = new System.Drawing.Point(176, 138);
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Name = "_NO_TRANSLATE_ColorHighlightAuthoredLabel";
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Size = new System.Drawing.Size(27, 19);
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.TabIndex = 8;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Text = "Red";
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Click += new System.EventHandler(this.ColorLabel_Click);
+            // 
+            // lblColorHighlightAuthored
+            // 
+            this.lblColorHighlightAuthored.AutoSize = true;
+            this.lblColorHighlightAuthored.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblColorHighlightAuthored.Enabled = false;
+            this.lblColorHighlightAuthored.Location = new System.Drawing.Point(3, 141);
+            this.lblColorHighlightAuthored.Margin = new System.Windows.Forms.Padding(3);
+            this.lblColorHighlightAuthored.Name = "lblColorHighlightAuthored";
+            this.lblColorHighlightAuthored.Size = new System.Drawing.Size(167, 13);
+            this.lblColorHighlightAuthored.TabIndex = 7;
+            this.lblColorHighlightAuthored.Text = "Color authored revisions";
+            // 
+            // chkHighlightAuthored
+            // 
+            this.chkHighlightAuthored.AutoSize = true;
+            this.chkHighlightAuthored.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkHighlightAuthored.Location = new System.Drawing.Point(3, 118);
+            this.chkHighlightAuthored.Name = "chkHighlightAuthored";
+            this.chkHighlightAuthored.Size = new System.Drawing.Size(167, 17);
+            this.chkHighlightAuthored.TabIndex = 6;
+            this.chkHighlightAuthored.Text = "Highlight authored revisions";
+            this.chkHighlightAuthored.UseVisualStyleBackColor = true;
+            this.chkHighlightAuthored.CheckedChanged += new System.EventHandler(this.chkHighlightAuthored_CheckedChanged);
             // 
             // MulticolorBranches
             // 
@@ -144,7 +190,7 @@
             this.MulticolorBranches.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MulticolorBranches.Location = new System.Drawing.Point(3, 3);
             this.MulticolorBranches.Name = "MulticolorBranches";
-            this.MulticolorBranches.Size = new System.Drawing.Size(172, 17);
+            this.MulticolorBranches.Size = new System.Drawing.Size(167, 17);
             this.MulticolorBranches.TabIndex = 0;
             this.MulticolorBranches.Text = "Multicolor branches";
             this.MulticolorBranches.UseVisualStyleBackColor = true;
@@ -156,10 +202,10 @@
             this._NO_TRANSLATE_ColorRemoteBranchLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(181, 199);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(176, 195);
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Name = "_NO_TRANSLATE_ColorRemoteBranchLabel";
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(26, 19);
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 13;
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(27, 19);
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 14;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorRemoteBranchLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -168,11 +214,11 @@
             // 
             this.lblColorBranchRemote.AutoSize = true;
             this.lblColorBranchRemote.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblColorBranchRemote.Location = new System.Drawing.Point(3, 202);
+            this.lblColorBranchRemote.Location = new System.Drawing.Point(3, 198);
             this.lblColorBranchRemote.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorBranchRemote.Name = "lblColorBranchRemote";
-            this.lblColorBranchRemote.Size = new System.Drawing.Size(172, 13);
-            this.lblColorBranchRemote.TabIndex = 12;
+            this.lblColorBranchRemote.Size = new System.Drawing.Size(167, 13);
+            this.lblColorBranchRemote.TabIndex = 13;
             this.lblColorBranchRemote.Text = "Color remote branch";
             // 
             // _NO_TRANSLATE_ColorOtherLabel
@@ -181,10 +227,10 @@
             this._NO_TRANSLATE_ColorOtherLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorOtherLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorOtherLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(181, 218);
+            this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(176, 214);
             this._NO_TRANSLATE_ColorOtherLabel.Name = "_NO_TRANSLATE_ColorOtherLabel";
-            this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(26, 19);
-            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 15;
+            this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(27, 19);
+            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 16;
             this._NO_TRANSLATE_ColorOtherLabel.Text = "Red";
             this._NO_TRANSLATE_ColorOtherLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorOtherLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -193,11 +239,11 @@
             // 
             this.lblColorLabel.AutoSize = true;
             this.lblColorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblColorLabel.Location = new System.Drawing.Point(3, 221);
+            this.lblColorLabel.Location = new System.Drawing.Point(3, 217);
             this.lblColorLabel.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorLabel.Name = "lblColorLabel";
-            this.lblColorLabel.Size = new System.Drawing.Size(172, 13);
-            this.lblColorLabel.TabIndex = 14;
+            this.lblColorLabel.Size = new System.Drawing.Size(167, 13);
+            this.lblColorLabel.TabIndex = 15;
             this.lblColorLabel.Text = "Color other label";
             // 
             // chkDrawAlternateBackColor
@@ -206,7 +252,7 @@
             this.chkDrawAlternateBackColor.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkDrawAlternateBackColor.Location = new System.Drawing.Point(3, 49);
             this.chkDrawAlternateBackColor.Name = "chkDrawAlternateBackColor";
-            this.chkDrawAlternateBackColor.Size = new System.Drawing.Size(172, 17);
+            this.chkDrawAlternateBackColor.Size = new System.Drawing.Size(167, 17);
             this.chkDrawAlternateBackColor.TabIndex = 3;
             this.chkDrawAlternateBackColor.Text = "Draw alternate background";
             this.chkDrawAlternateBackColor.UseVisualStyleBackColor = true;
@@ -215,10 +261,10 @@
             // 
             this.DrawNonRelativesTextGray.AutoSize = true;
             this.DrawNonRelativesTextGray.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(3, 118);
+            this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(3, 95);
             this.DrawNonRelativesTextGray.Name = "DrawNonRelativesTextGray";
-            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(172, 17);
-            this.DrawNonRelativesTextGray.TabIndex = 6;
+            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(167, 17);
+            this.DrawNonRelativesTextGray.TabIndex = 5;
             this.DrawNonRelativesTextGray.Text = "Draw non relatives text gray";
             this.DrawNonRelativesTextGray.UseVisualStyleBackColor = true;
             // 
@@ -228,9 +274,9 @@
             this._NO_TRANSLATE_ColorGraphLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorGraphLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorGraphLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorGraphLabel.Location = new System.Drawing.Point(181, 0);
+            this._NO_TRANSLATE_ColorGraphLabel.Location = new System.Drawing.Point(176, 0);
             this._NO_TRANSLATE_ColorGraphLabel.Name = "_NO_TRANSLATE_ColorGraphLabel";
-            this._NO_TRANSLATE_ColorGraphLabel.Size = new System.Drawing.Size(26, 23);
+            this._NO_TRANSLATE_ColorGraphLabel.Size = new System.Drawing.Size(27, 23);
             this._NO_TRANSLATE_ColorGraphLabel.TabIndex = 1;
             this._NO_TRANSLATE_ColorGraphLabel.Text = "Red";
             this._NO_TRANSLATE_ColorGraphLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -240,10 +286,10 @@
             // 
             this.DrawNonRelativesGray.AutoSize = true;
             this.DrawNonRelativesGray.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DrawNonRelativesGray.Location = new System.Drawing.Point(3, 95);
+            this.DrawNonRelativesGray.Location = new System.Drawing.Point(3, 72);
             this.DrawNonRelativesGray.Name = "DrawNonRelativesGray";
-            this.DrawNonRelativesGray.Size = new System.Drawing.Size(172, 17);
-            this.DrawNonRelativesGray.TabIndex = 5;
+            this.DrawNonRelativesGray.Size = new System.Drawing.Size(167, 17);
+            this.DrawNonRelativesGray.TabIndex = 4;
             this.DrawNonRelativesGray.Text = "Draw non relatives graph gray";
             this.DrawNonRelativesGray.UseVisualStyleBackColor = true;
             // 
@@ -253,7 +299,7 @@
             this.StripedBanchChange.Dock = System.Windows.Forms.DockStyle.Fill;
             this.StripedBanchChange.Location = new System.Drawing.Point(3, 26);
             this.StripedBanchChange.Name = "StripedBanchChange";
-            this.StripedBanchChange.Size = new System.Drawing.Size(172, 17);
+            this.StripedBanchChange.Size = new System.Drawing.Size(167, 17);
             this.StripedBanchChange.TabIndex = 2;
             this.StripedBanchChange.Text = "Striped branch change";
             this.StripedBanchChange.UseVisualStyleBackColor = true;
@@ -262,11 +308,11 @@
             // 
             this.lblColorBranchLocal.AutoSize = true;
             this.lblColorBranchLocal.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblColorBranchLocal.Location = new System.Drawing.Point(3, 183);
+            this.lblColorBranchLocal.Location = new System.Drawing.Point(3, 179);
             this.lblColorBranchLocal.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorBranchLocal.Name = "lblColorBranchLocal";
-            this.lblColorBranchLocal.Size = new System.Drawing.Size(172, 13);
-            this.lblColorBranchLocal.TabIndex = 10;
+            this.lblColorBranchLocal.Size = new System.Drawing.Size(167, 13);
+            this.lblColorBranchLocal.TabIndex = 11;
             this.lblColorBranchLocal.Text = "Color branch";
             // 
             // _NO_TRANSLATE_ColorBranchLabel
@@ -275,10 +321,10 @@
             this._NO_TRANSLATE_ColorBranchLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorBranchLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorBranchLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(181, 180);
+            this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(176, 176);
             this._NO_TRANSLATE_ColorBranchLabel.Name = "_NO_TRANSLATE_ColorBranchLabel";
-            this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(26, 19);
-            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 11;
+            this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(27, 19);
+            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 12;
             this._NO_TRANSLATE_ColorBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorBranchLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -289,10 +335,10 @@
             this._NO_TRANSLATE_ColorTagLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorTagLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorTagLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(181, 161);
+            this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(176, 157);
             this._NO_TRANSLATE_ColorTagLabel.Name = "_NO_TRANSLATE_ColorTagLabel";
-            this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(26, 19);
-            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 9;
+            this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(27, 19);
+            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 10;
             this._NO_TRANSLATE_ColorTagLabel.Text = "Red";
             this._NO_TRANSLATE_ColorTagLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorTagLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -301,11 +347,11 @@
             // 
             this.lblColorTag.AutoSize = true;
             this.lblColorTag.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblColorTag.Location = new System.Drawing.Point(3, 164);
+            this.lblColorTag.Location = new System.Drawing.Point(3, 160);
             this.lblColorTag.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorTag.Name = "lblColorTag";
-            this.lblColorTag.Size = new System.Drawing.Size(172, 13);
-            this.lblColorTag.TabIndex = 8;
+            this.lblColorTag.Size = new System.Drawing.Size(167, 13);
+            this.lblColorTag.TabIndex = 9;
             this.lblColorTag.Text = "Color tag";
             // 
             // gbDiffView
@@ -314,10 +360,10 @@
             this.gbDiffView.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gbDiffView.Controls.Add(this.tlpnlDiffView);
             this.gbDiffView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbDiffView.Location = new System.Drawing.Point(3, 295);
+            this.gbDiffView.Location = new System.Drawing.Point(3, 271);
             this.gbDiffView.Name = "gbDiffView";
             this.gbDiffView.Padding = new System.Windows.Forms.Padding(8);
-            this.gbDiffView.Size = new System.Drawing.Size(979, 125);
+            this.gbDiffView.Size = new System.Drawing.Size(1388, 124);
             this.gbDiffView.TabIndex = 1;
             this.gbDiffView.TabStop = false;
             this.gbDiffView.Text = "Difference view";
@@ -341,7 +387,7 @@
             this.tlpnlDiffView.Controls.Add(this.lblColorLineAdded, 0, 1);
             this.tlpnlDiffView.Controls.Add(this._NO_TRANSLATE_ColorAddedLineLabel, 1, 1);
             this.tlpnlDiffView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlDiffView.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlDiffView.Location = new System.Drawing.Point(8, 21);
             this.tlpnlDiffView.Name = "tlpnlDiffView";
             this.tlpnlDiffView.RowCount = 5;
             this.tlpnlDiffView.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -349,7 +395,7 @@
             this.tlpnlDiffView.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlDiffView.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlDiffView.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlDiffView.Size = new System.Drawing.Size(963, 95);
+            this.tlpnlDiffView.Size = new System.Drawing.Size(1372, 95);
             this.tlpnlDiffView.TabIndex = 0;
             // 
             // lblColorLineRemoved
@@ -359,7 +405,7 @@
             this.lblColorLineRemoved.Location = new System.Drawing.Point(3, 3);
             this.lblColorLineRemoved.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorLineRemoved.Name = "lblColorLineRemoved";
-            this.lblColorLineRemoved.Size = new System.Drawing.Size(153, 13);
+            this.lblColorLineRemoved.Size = new System.Drawing.Size(150, 13);
             this.lblColorLineRemoved.TabIndex = 0;
             this.lblColorLineRemoved.Text = "Color removed line";
             // 
@@ -370,7 +416,7 @@
             this.lblColorSection.Location = new System.Drawing.Point(3, 79);
             this.lblColorSection.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorSection.Name = "lblColorSection";
-            this.lblColorSection.Size = new System.Drawing.Size(153, 13);
+            this.lblColorSection.Size = new System.Drawing.Size(150, 13);
             this.lblColorSection.TabIndex = 8;
             this.lblColorSection.Text = "Color section";
             // 
@@ -380,9 +426,9 @@
             this._NO_TRANSLATE_ColorSectionLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorSectionLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorSectionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorSectionLabel.Location = new System.Drawing.Point(162, 76);
+            this._NO_TRANSLATE_ColorSectionLabel.Location = new System.Drawing.Point(159, 76);
             this._NO_TRANSLATE_ColorSectionLabel.Name = "_NO_TRANSLATE_ColorSectionLabel";
-            this._NO_TRANSLATE_ColorSectionLabel.Size = new System.Drawing.Size(26, 19);
+            this._NO_TRANSLATE_ColorSectionLabel.Size = new System.Drawing.Size(27, 19);
             this._NO_TRANSLATE_ColorSectionLabel.TabIndex = 9;
             this._NO_TRANSLATE_ColorSectionLabel.Text = "Red";
             this._NO_TRANSLATE_ColorSectionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -394,9 +440,9 @@
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Location = new System.Drawing.Point(162, 57);
+            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Location = new System.Drawing.Point(159, 57);
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Name = "_NO_TRANSLATE_ColorAddedLineDiffLabel";
-            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Size = new System.Drawing.Size(26, 19);
+            this._NO_TRANSLATE_ColorAddedLineDiffLabel.Size = new System.Drawing.Size(27, 19);
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.TabIndex = 7;
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.Text = "Red";
             this._NO_TRANSLATE_ColorAddedLineDiffLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -409,7 +455,7 @@
             this.lblColorHilghlightLineAdded.Location = new System.Drawing.Point(3, 60);
             this.lblColorHilghlightLineAdded.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorHilghlightLineAdded.Name = "lblColorHilghlightLineAdded";
-            this.lblColorHilghlightLineAdded.Size = new System.Drawing.Size(153, 13);
+            this.lblColorHilghlightLineAdded.Size = new System.Drawing.Size(150, 13);
             this.lblColorHilghlightLineAdded.TabIndex = 6;
             this.lblColorHilghlightLineAdded.Text = "Color added line highlighting";
             // 
@@ -419,9 +465,9 @@
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Location = new System.Drawing.Point(162, 38);
+            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Location = new System.Drawing.Point(159, 38);
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Name = "_NO_TRANSLATE_ColorRemovedLineDiffLabel";
-            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Size = new System.Drawing.Size(26, 19);
+            this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Size = new System.Drawing.Size(27, 19);
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.TabIndex = 5;
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.Text = "Red";
             this._NO_TRANSLATE_ColorRemovedLineDiffLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -434,7 +480,7 @@
             this.lblColorHilghlightLineRemoved.Location = new System.Drawing.Point(3, 41);
             this.lblColorHilghlightLineRemoved.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorHilghlightLineRemoved.Name = "lblColorHilghlightLineRemoved";
-            this.lblColorHilghlightLineRemoved.Size = new System.Drawing.Size(153, 13);
+            this.lblColorHilghlightLineRemoved.Size = new System.Drawing.Size(150, 13);
             this.lblColorHilghlightLineRemoved.TabIndex = 4;
             this.lblColorHilghlightLineRemoved.Text = "Color removed line highlighting";
             // 
@@ -444,9 +490,9 @@
             this._NO_TRANSLATE_ColorRemovedLine.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorRemovedLine.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorRemovedLine.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorRemovedLine.Location = new System.Drawing.Point(162, 0);
+            this._NO_TRANSLATE_ColorRemovedLine.Location = new System.Drawing.Point(159, 0);
             this._NO_TRANSLATE_ColorRemovedLine.Name = "_NO_TRANSLATE_ColorRemovedLine";
-            this._NO_TRANSLATE_ColorRemovedLine.Size = new System.Drawing.Size(26, 19);
+            this._NO_TRANSLATE_ColorRemovedLine.Size = new System.Drawing.Size(27, 19);
             this._NO_TRANSLATE_ColorRemovedLine.TabIndex = 1;
             this._NO_TRANSLATE_ColorRemovedLine.Text = "Red";
             this._NO_TRANSLATE_ColorRemovedLine.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -459,7 +505,7 @@
             this.lblColorLineAdded.Location = new System.Drawing.Point(3, 22);
             this.lblColorLineAdded.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorLineAdded.Name = "lblColorLineAdded";
-            this.lblColorLineAdded.Size = new System.Drawing.Size(153, 13);
+            this.lblColorLineAdded.Size = new System.Drawing.Size(150, 13);
             this.lblColorLineAdded.TabIndex = 2;
             this.lblColorLineAdded.Text = "Color added line";
             // 
@@ -469,9 +515,9 @@
             this._NO_TRANSLATE_ColorAddedLineLabel.BackColor = System.Drawing.Color.Red;
             this._NO_TRANSLATE_ColorAddedLineLabel.Cursor = System.Windows.Forms.Cursors.Hand;
             this._NO_TRANSLATE_ColorAddedLineLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_ColorAddedLineLabel.Location = new System.Drawing.Point(162, 19);
+            this._NO_TRANSLATE_ColorAddedLineLabel.Location = new System.Drawing.Point(159, 19);
             this._NO_TRANSLATE_ColorAddedLineLabel.Name = "_NO_TRANSLATE_ColorAddedLineLabel";
-            this._NO_TRANSLATE_ColorAddedLineLabel.Size = new System.Drawing.Size(26, 19);
+            this._NO_TRANSLATE_ColorAddedLineLabel.Size = new System.Drawing.Size(27, 19);
             this._NO_TRANSLATE_ColorAddedLineLabel.TabIndex = 3;
             this._NO_TRANSLATE_ColorAddedLineLabel.Text = "Red";
             this._NO_TRANSLATE_ColorAddedLineLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -483,9 +529,8 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(tlpnlMain);
             this.Name = "ColorsSettingsPage";
-            this.Text = "Colors";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1001, 614);
+            this.Size = new System.Drawing.Size(1410, 852);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbRevisionGraph.ResumeLayout(false);
@@ -530,5 +575,8 @@
         private System.Windows.Forms.CheckBox chkDrawAlternateBackColor;
         private System.Windows.Forms.TableLayoutPanel tlpnlRevisionGraph;
         private System.Windows.Forms.TableLayoutPanel tlpnlDiffView;
+        private System.Windows.Forms.Label lblColorHighlightAuthored;
+        private System.Windows.Forms.CheckBox chkHighlightAuthored;
+        private System.Windows.Forms.Label _NO_TRANSLATE_ColorHighlightAuthoredLabel;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
@@ -43,7 +44,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             DrawNonRelativesGray.Checked = AppSettings.RevisionGraphDrawNonRelativesGray;
             DrawNonRelativesTextGray.Checked = AppSettings.RevisionGraphDrawNonRelativesTextGray;
             StripedBanchChange.Checked = AppSettings.StripedBranchChange;
+            chkHighlightAuthored.Checked = AppSettings.HighlightAuthoredRevisions;
 
+            _NO_TRANSLATE_ColorHighlightAuthoredLabel.BackColor = AppSettings.HighlightAuthoredRevisions ? AppSettings.AuthoredRevisionsHighlightColor : Color.LightYellow;
+            _NO_TRANSLATE_ColorHighlightAuthoredLabel.Text = AppSettings.AuthoredRevisionsHighlightColor.Name;
+            _NO_TRANSLATE_ColorHighlightAuthoredLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorHighlightAuthoredLabel.BackColor);
             _NO_TRANSLATE_ColorGraphLabel.BackColor = AppSettings.GraphColor;
             _NO_TRANSLATE_ColorGraphLabel.Text = AppSettings.GraphColor.Name;
             _NO_TRANSLATE_ColorGraphLabel.ForeColor = ColorHelper.GetForeColorForBackColor(_NO_TRANSLATE_ColorGraphLabel.BackColor);
@@ -85,6 +90,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RevisionGraphDrawNonRelativesGray = DrawNonRelativesGray.Checked;
             AppSettings.RevisionGraphDrawNonRelativesTextGray = DrawNonRelativesTextGray.Checked;
             AppSettings.StripedBranchChange = StripedBanchChange.Checked;
+            AppSettings.HighlightAuthoredRevisions = chkHighlightAuthored.Checked;
+            AppSettings.AuthoredRevisionsHighlightColor = chkHighlightAuthored.Checked ? _NO_TRANSLATE_ColorHighlightAuthoredLabel.BackColor : Color.LightYellow;
 
             AppSettings.GraphColor = _NO_TRANSLATE_ColorGraphLabel.BackColor;
             AppSettings.TagColor = _NO_TRANSLATE_ColorTagLabel.BackColor;
@@ -124,6 +131,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 label.Text = colorDialog.Color.Name;
                 label.ForeColor = ColorHelper.GetForeColorForBackColor(label.BackColor);
             }
+        }
+
+        private void chkHighlightAuthored_CheckedChanged(object sender, EventArgs e)
+        {
+            lblColorHighlightAuthored.Enabled = chkHighlightAuthored.Checked;
+            _NO_TRANSLATE_ColorHighlightAuthoredLabel.Enabled = chkHighlightAuthored.Checked;
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
+++ b/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GitCommands;
 using GitCommands.Config;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.UserControls
@@ -14,7 +15,7 @@ namespace GitUI.UserControls
 
         /// <returns><c>true</c> if the UI should be refreshed in response to this change.</returns>
         [MustUseReturnValue]
-        public bool ProcessRevisionSelectionChange(GitModule currentModule, IReadOnlyCollection<GitRevision> selectedRevisions)
+        public bool ProcessRevisionSelectionChange(IGitModule currentModule, IReadOnlyCollection<GitRevision> selectedRevisions)
         {
             if (selectedRevisions.Count > 1)
             {
@@ -24,7 +25,6 @@ namespace GitUI.UserControls
             var revision = selectedRevisions.FirstOrDefault();
 
             var changed = !string.Equals(revision?.AuthorEmail, AuthorEmailToHighlight, StringComparison.OrdinalIgnoreCase);
-
             if (changed)
             {
                 AuthorEmailToHighlight = revision != null
@@ -38,6 +38,11 @@ namespace GitUI.UserControls
 
         public bool IsHighlighted([CanBeNull] GitRevision revision)
         {
+            if (string.IsNullOrWhiteSpace(revision?.AuthorEmail))
+            {
+                return false;
+            }
+
             return string.Equals(revision?.AuthorEmail, AuthorEmailToHighlight, StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
+++ b/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
@@ -43,7 +43,7 @@ namespace GitUI.UserControls
                 return false;
             }
 
-            return string.Equals(revision?.AuthorEmail, AuthorEmailToHighlight, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(revision.AuthorEmail, AuthorEmailToHighlight, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -247,9 +247,9 @@ namespace GitUI.UserControls.RevisionGrid
                 return SystemBrushes.Highlight;
             }
 
-            if (revision != null && !revision.IsArtificial && AuthorHighlighting.IsHighlighted(revision))
+            if (AppSettings.HighlightAuthoredRevisions && revision != null && !revision.IsArtificial && AuthorHighlighting.IsHighlighted(revision))
             {
-                return Brushes.LightYellow;
+                return new SolidBrush(AppSettings.AuthoredRevisionsHighlightColor);
             }
 
             if (rowIndex % 2 == 0 && AppSettings.RevisionGraphDrawAlternateBackColor)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -185,6 +185,7 @@ namespace GitUI
             HotkeysEnabled = true;
 
             _gridView.ShowCellToolTips = false;
+            _gridView.AuthorHighlighting = _authorHighlighting;
 
             _gridView.KeyPress += (_, e) => _quickSearchProvider.OnKeyPress(e);
             _gridView.KeyUp += OnGridViewKeyUp;
@@ -994,9 +995,12 @@ namespace GitUI
                     ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
                         await this.SwitchToMainThreadAsync();
+
                         SetPage(_gridView);
                         _isRefreshingRevisions = false;
                         CheckAndRepairInitialRevision();
+                        HighlightRevisionsByAuthor(GetSelectedRevisions());
+
                         if (ShowBuildServerInfo)
                         {
                             await _buildServerWatcher.LaunchBuildServerInfoFetchOperationAsync();
@@ -1188,6 +1192,11 @@ namespace GitUI
             compareWithCurrentBranchToolStripMenuItem.Enabled = Module.GetSelectedBranch(setDefaultIfEmpty: false).IsNotNullOrWhitespace();
             compareSelectedCommitsMenuItem.Enabled = firstSelectedRevision != null && secondSelectedRevision != null;
 
+            HighlightRevisionsByAuthor(selectedRevisions);
+        }
+
+        private void HighlightRevisionsByAuthor(in IReadOnlyList<GitRevision> selectedRevisions)
+        {
             if (Parent != null &&
                 !_gridView.UpdatingVisibleRows &&
                 _authorHighlighting.ProcessRevisionSelectionChange(Module, selectedRevisions))

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -81,7 +81,7 @@
     <Compile Include="ThreadHelperTests.cs" />
     <Compile Include="TranslationTest.cs" />
     <Compile Include="UITest.cs" />
-    <Compile Include="UserControls\AuthorRevisionHighlightingFixture.cs" />
+    <Compile Include="UserControls\AuthorRevisionHighlightingTests.cs" />
     <Compile Include="UserControls\ConsoleEmulatorOutputControlFixture.cs" />
     <Compile Include="Editor\Diff\DiffLineNumAnalyzerTests.cs" />
     <Compile Include="Editor\Diff\LinePrefixHelperFixture.cs" />

--- a/UnitTests/GitUITests/UserControls/AuthorRevisionHighlightingTests.cs
+++ b/UnitTests/GitUITests/UserControls/AuthorRevisionHighlightingTests.cs
@@ -153,6 +153,40 @@ namespace GitUITests.UserControls
             sut.AuthorEmailToHighlight.Should().Be(ExpectedAuthorEmail2);
         }
 
+        [Test]
+        public void IsHighlighted_should_return_false_if_revision_is_null()
+        {
+            var sut = new AuthorRevisionHighlighting();
+
+            sut.IsHighlighted(null).Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("\t")]
+        public void IsHighlighted_should_return_false_if_revision_AuthorEmail_is_null_or_whitespace(string authorEmail)
+        {
+            var sut = new AuthorRevisionHighlighting();
+
+            sut.IsHighlighted(new GitRevision(ObjectId.Random()) { AuthorEmail = authorEmail }).Should().BeFalse();
+        }
+
+        [TestCase("a@a.aaa", "a@a.aaa", true)]
+        [TestCase("A@A.aaa", "a@a.aaa", true)]
+        [TestCase("b@A.aaa", "a@a.aaa", false)]
+        [TestCase("a@a.aaa", null, false)]
+        [TestCase("a@a.aaa", "", false)]
+        [TestCase("a@a.aaa", "\t", false)]
+        public void IsHighlighted_should_return_true_if_revision_AuthorEmail_matches_AuthorEmailToHighlight(string authorEmail, string highlightEmail, bool expected)
+        {
+            var currentModule = NewModule();
+            var sut = new AuthorRevisionHighlighting();
+            sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(highlightEmail) });
+            sut.AuthorEmailToHighlight.Should().Be(highlightEmail);
+
+            sut.IsHighlighted(new GitRevision(ObjectId.Random()) { AuthorEmail = authorEmail }).Should().Be(expected);
+        }
+
         private static GitModule NewModule()
         {
             return new GitModule(Path.GetTempPath());

--- a/UnitTests/GitUITests/UserControls/AuthorRevisionHighlightingTests.cs
+++ b/UnitTests/GitUITests/UserControls/AuthorRevisionHighlightingTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace GitUITests.UserControls
 {
     [TestFixture]
-    internal class AuthorRevisionHighlightingFixture
+    internal class AuthorRevisionHighlightingTests
     {
         private const string ExpectedAuthorEmail1 = "doe1@example.org";
         private const string ExpectedAuthorEmail2 = "doe2@example.org";


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Closes #5197

## Proposed changes

- Restore highlighting by author changed/removed as part of #5087. Currently instead of highlighting the whole commit row, only author's name is rendered in bold.
- Restore configuration
- Add highlight colour configuration
- Add tests


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/4403806/50391029-c39d5b00-0792-11e9-822b-24dd07542088.png)

### After
![image](https://user-images.githubusercontent.com/4403806/50391050-1840d600-0793-11e9-9903-927be4a1d0a4.png)

![image](https://user-images.githubusercontent.com/4403806/50466134-cea0f700-09ef-11e9-8245-c82c184aa3b7.png)


## Test methodology <!-- How did you ensure quality? -->

- manual
- added few unit tests


NB: I don't think it should have a significant effect on performance, however I haven't test it. 