### PR TITLE
Display ahead and behind information in the push button

### DIFF
--- a/GitCommands/Git/AheadBehindData.cs
+++ b/GitCommands/Git/AheadBehindData.cs
@@ -1,0 +1,16 @@
+﻿namespace GitCommands.Git
+{
+    public struct AheadBehindData
+    {
+        public string Branch { get; set; }
+        public string AheadCount { get; set; }
+        public string BehindCount { get; set; }
+
+        public string ToDisplay()
+        {
+            return (!string.IsNullOrEmpty(AheadCount) ? AheadCount + "↑" : string.Empty)
+                   + (!string.IsNullOrEmpty(AheadCount) && !string.IsNullOrEmpty(BehindCount) ? " " : string.Empty)
+                   + (!string.IsNullOrEmpty(BehindCount) ? BehindCount + "↓" : string.Empty);
+        }
+    }
+}

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using GitUIPluginInterfaces;
+using JetBrains.Annotations;
+
+namespace GitCommands.Git
+{
+    public interface IAheadBehindDataProvider
+    {
+        IDictionary<string, AheadBehindData> GetData(string branchName = "");
+    }
+
+    public class AheadBehindDataProvider : IAheadBehindDataProvider
+    {
+        private readonly Func<IExecutable> _getGitExecutable;
+
+        // TODO handle [gone] status to show that remote branch no longer exists
+        private readonly Regex _aheadBehindRegEx =
+            new Regex(@"^(\[(ahead (?<ahead_p>\d+))?(, )?(behind (?<behind_p>\d+))?\])?::(\[(ahead (?<ahead_u>\d+))?(, )?(behind (?<behind_u>\d+))?\])?::(?<branch>.*)$",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+        public AheadBehindDataProvider(Func<IExecutable> getGitExecutable)
+        {
+            _getGitExecutable = getGitExecutable;
+        }
+
+        public IDictionary<string, AheadBehindData> GetData(string branchName = "")
+        {
+            return GetData(null, branchName);
+        }
+
+        // This method is required to facilitate unit tests
+        private IDictionary<string, AheadBehindData> GetData(Encoding encoding, string branchName = "")
+        {
+            if (branchName == null)
+            {
+                throw new ArgumentException(nameof(branchName));
+            }
+
+            if (branchName == "(no branch)")
+            {
+                return null;
+            }
+
+            var aheadBehindGitCommand = new GitArgumentBuilder("for-each-ref")
+            {
+                "--format=\"%(push:track)::%(upstream:track)::%(refname:short)\"",
+                "refs/heads/" + branchName
+            };
+
+            var result = GetGitExecutable().GetOutput(aheadBehindGitCommand, outputEncoding: encoding);
+            if (string.IsNullOrEmpty(result))
+            {
+                return null;
+            }
+
+            var matches = _aheadBehindRegEx.Matches(result);
+            if (matches.Count < 1 || (matches.Count == 1 && (!matches[0].Groups["branch"].Success ||
+                                                             !(matches[0].Groups["ahead_p"].Success || matches[0].Groups["ahead_u"].Success ||
+                                                               matches[0].Groups["behind_p"].Success || matches[0].Groups["behind_u"].Success))))
+            {
+                return null;
+            }
+
+            var aheadBehindForBranchesData = new Dictionary<string, AheadBehindData>();
+            foreach (Match match in matches)
+            {
+                aheadBehindForBranchesData.Add(match.Groups["branch"].Value,
+                    new AheadBehindData
+                    {
+                        // The information is displayed in the push button, so the push info  is preferred (may differ from upstream)
+                        Branch = match.Groups["branch"].Value,
+                        AheadCount = match.Groups["ahead_p"].Success ? match.Groups["ahead_p"].Value : match.Groups["ahead_u"].Value,
+                        BehindCount = match.Groups["behind_p"].Success ? match.Groups["behind_p"].Value : match.Groups["behind_u"].Value
+                    });
+            }
+
+            return aheadBehindForBranchesData;
+        }
+
+        [NotNull]
+        private IExecutable GetGitExecutable()
+        {
+            var executable = _getGitExecutable();
+
+            if (executable == null)
+            {
+                throw new ArgumentException($"Require a valid instance of {nameof(IExecutable)}");
+            }
+
+            return executable;
+        }
+
+        internal TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
+
+        public readonly struct TestAccessor
+        {
+            private readonly AheadBehindDataProvider _provider;
+
+            public TestAccessor(AheadBehindDataProvider provider)
+            {
+                _provider = provider;
+            }
+
+            public IDictionary<string, AheadBehindData> GetData(Encoding encoding, string branchName) => _provider.GetData(encoding, branchName);
+        }
+    }
+}

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -16,7 +16,7 @@ namespace GitCommands
     public static class ExecutableExtensions
     {
         private static readonly Regex _ansiCodePattern = new Regex(@"\u001B[\u0040-\u005F].*?[\u0040-\u007E]", RegexOptions.Compiled);
-        private static readonly Encoding _defaultOutputEncoding = GitModule.SystemEncoding;
+        private static readonly Lazy<Encoding> _defaultOutputEncoding = new Lazy<Encoding>(() => GitModule.SystemEncoding, false);
 
         /// <summary>
         /// Launches a process for the executable and returns its output.
@@ -68,7 +68,7 @@ namespace GitCommands
         {
             if (outputEncoding == null)
             {
-                outputEncoding = _defaultOutputEncoding;
+                outputEncoding = _defaultOutputEncoding.Value;
             }
 
             if (cache != null && cache.TryGet(arguments, out var output, out var error))
@@ -187,7 +187,7 @@ namespace GitCommands
 
             if (outputEncoding == null)
             {
-                outputEncoding = _defaultOutputEncoding;
+                outputEncoding = _defaultOutputEncoding.Value;
             }
 
             using (var process = executable.Start(arguments, createWindow: false, redirectInput: input != null, redirectOutput: true, outputEncoding))
@@ -270,7 +270,7 @@ namespace GitCommands
         {
             if (outputEncoding == null)
             {
-                outputEncoding = _defaultOutputEncoding;
+                outputEncoding = _defaultOutputEncoding.Value;
             }
 
             using (var process = executable.Start(arguments, createWindow: false, redirectInput: writeInput != null, redirectOutput: true, outputEncoding))

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -184,6 +184,12 @@ namespace GitCommands
         public string WorkingDir { get; }
 
         /// <summary>
+        /// Gets the access to the current git executable associated with this module.
+        /// </summary>
+        [NotNull]
+        public IExecutable GitExecutable => _gitExecutable;
+
+        /// <summary>
         /// Gets the location of .git directory for the current working folder.
         /// </summary>
         [NotNull]

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -12,6 +12,7 @@ namespace GitCommands
         private static readonly GitVersion v1_8_4 = new GitVersion("1.8.4");
         private static readonly GitVersion v1_8_5 = new GitVersion("1.8.5");
         private static readonly GitVersion v2_0_1 = new GitVersion("2.0.1");
+        private static readonly GitVersion v2_5_0 = new GitVersion("2.5.0");
         private static readonly GitVersion v2_5_1 = new GitVersion("2.5.1");
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
@@ -108,6 +109,8 @@ namespace GitCommands
         public bool SupportPushForceWithLease => this >= v1_8_5;
 
         public bool RaceConditionWhenGitStatusIsUpdatingIndex => this < v2_0_1;
+
+        public bool SupportAheadBehindData => this >= v2_5_0;
 
         public bool SupportWorktree => this >= v2_5_1;
 

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -85,6 +85,8 @@
     <Compile Include="FileHelper.cs" />
     <Compile Include="FullPathResolver.cs" />
     <Compile Include="GitRevisionInfoProvider.cs" />
+    <Compile Include="Git\AheadBehindData.cs" />
+    <Compile Include="Git\AheadBehindDataProvider.cs" />
     <Compile Include="Git\ExecutableExtensions.cs" />
     <Compile Include="Git\GitDescribeProvider.cs" />
     <Compile Include="Git\DetachedHeadParser.cs" />
@@ -96,8 +98,6 @@
     <Compile Include="Git\Executable.cs" />
     <Compile Include="Git\GitRevisionTester.cs" />
     <Compile Include="Git\GitRefName.cs" />
-    <Compile Include="Git\IExecutable.cs" />
-    <Compile Include="Git\IProcess.cs" />
     <Compile Include="Git\Tag\GitCreateTagArgs.cs" />
     <Compile Include="Git\Tag\GitCreateTagCmd.cs" />
     <Compile Include="Git\GitDeleteRemoteBranchesCmd.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -894,6 +894,12 @@ namespace GitCommands
             set => SetBool("showstashcount", value);
         }
 
+        public static bool ShowAheadBehindData
+        {
+            get => GetBool("showaheadbehinddata", true);
+            set => SetBool("showaheadbehinddata", value);
+        }
+
         public static bool ShowSubmoduleStatus
         {
             get => GetBool("showsubmodulestatus", false);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -25,6 +25,7 @@ namespace GitUI.BranchTreePanel
             protected string Name { get; set; }
 
             private string ParentPath { get; }
+            protected string AheadBehind { get; set; }
 
             /// <summary>Full path of the branch. <example>"issues/issue1344"</example></summary>
             public string FullPath => ParentPath.Combine(PathSeparator.ToString(), Name);
@@ -51,6 +52,12 @@ namespace GitUI.BranchTreePanel
                 var dirs = fullPath.Split(PathSeparator);
                 Name = dirs[dirs.Length - 1];
                 ParentPath = dirs.Take(dirs.Length - 1).Join(PathSeparator.ToString());
+            }
+
+            public void UpdateAheadBehind(string aheadBehindData)
+            {
+                AheadBehind = aheadBehindData;
+                TreeViewNode.Text = DisplayText();
             }
 
             [CanBeNull]
@@ -82,7 +89,7 @@ namespace GitUI.BranchTreePanel
 
             public override string DisplayText()
             {
-                return Name;
+                return string.IsNullOrEmpty(AheadBehind) ? Name : $"{Name} ({AheadBehind})";
             }
 
             protected void SelectRevision()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
@@ -45,6 +46,8 @@ namespace GitUI.BranchTreePanel
             InitializeComplete();
 
             RegisterContextActions();
+
+            InitializeAheadBehindProvider();
 
             treeMain.ShowNodeToolTips = true;
             treeMain.HideSelection = false;
@@ -168,6 +171,7 @@ namespace GitUI.BranchTreePanel
                 // We ConfigureAwait(true) so that we're back on the UI thread when tasks are complete
                 await Task.WhenAll(tasks).ConfigureAwait(true);
                 ThreadHelper.AssertOnUIThread();
+                DisplayAheadBehindInformationForBranches();
             }
             finally
             {
@@ -424,6 +428,52 @@ namespace GitUI.BranchTreePanel
             // Don't use e.Node, when folding/unfolding a node,
             // e.Node won't be the one you double clicked, but a child node instead
             Node.OnNode<Node>(treeMain.SelectedNode, node => node.OnDoubleClick());
+        }
+
+        private AheadBehindDataProvider _aheadBehindDataProvider;
+        private void DisplayAheadBehindInformationForBranches()
+        {
+            if (_rootNodes.Count == 0 || _aheadBehindDataProvider == null || !AppSettings.ShowAheadBehindData)
+            {
+                return;
+            }
+
+            var aheadBehindData = _aheadBehindDataProvider.GetData();
+            if (aheadBehindData == null)
+            {
+                // no tracking information
+                return;
+            }
+
+            treeMain.LabelEdit = true;
+            TreeNodeCollection nodes = _rootNodes[0].TreeViewNode.Nodes;
+            foreach (TreeNode n in nodes)
+            {
+                UpdateAheadBehindDataOnbranches(n, aheadBehindData);
+            }
+
+            treeMain.LabelEdit = false;
+        }
+
+        private void UpdateAheadBehindDataOnbranches(TreeNode treeNode, IDictionary<string, AheadBehindData> aheadBehindData)
+        {
+            var branchNode = treeNode.Tag as LocalBranchNode;
+            if (branchNode != null && aheadBehindData.ContainsKey(branchNode.FullPath))
+            {
+                branchNode.UpdateAheadBehind(aheadBehindData[branchNode.FullPath].ToDisplay());
+            }
+
+            foreach (TreeNode tn in treeNode.Nodes)
+            {
+                UpdateAheadBehindDataOnbranches(tn, aheadBehindData);
+            }
+        }
+
+        public void InitializeAheadBehindProvider()
+        {
+            _aheadBehindDataProvider = GitVersion.Current.SupportAheadBehindData
+                ? new AheadBehindDataProvider(() => Module.GitExecutable)
+                : null;
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
             this.fetchAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fetchPruneAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setDefaultPullButtonActionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripButtonPush = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButtonPush = new GitUI.CommandsDialogs.ToolStripPushButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripFileExplorer = new System.Windows.Forms.ToolStripButton();
             this.GitBash = new System.Windows.Forms.ToolStripButton();
@@ -1808,7 +1808,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripButton RefreshButton;
         private ToolStripSeparator toolStripSeparator5;
         private ToolStripTextBox toolStripRevisionFilterTextBox;
-        private ToolStripButton toolStripButtonPush;
+        private ToolStripPushButton toolStripButtonPush;
         private ToolStripLabel toolStripRevisionFilterLabel;
         private ToolStripSplitButton toolStripSplitStash;
         private ToolStripMenuItem stashChangesToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -503,6 +503,9 @@ namespace GitUI.CommandsDialogs
             UpdateSubmodulesStructure();
             UpdateStashCount();
 
+            toolStripButtonPush.Initialize(new AheadBehindDataProvider(() => Module.GitExecutable), GitVersion.Current.SupportAheadBehindData);
+            toolStripButtonPush.DisplayAheadBehindInformation(Module.GetSelectedBranch());
+
             base.OnLoad(e);
         }
 
@@ -592,6 +595,8 @@ namespace GitUI.CommandsDialogs
                 RevisionGrid.ForceRefreshRevisions();
                 InternalInitialize(true);
             }
+
+            toolStripButtonPush.DisplayAheadBehindInformation(Module.GetSelectedBranch());
         }
 
         #region IBrowseRepo

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1917,6 +1917,7 @@ namespace GitUI.CommandsDialogs
             UICommands = new GitUICommands(module);
             if (Module.IsValidGitWorkingDir())
             {
+                repoObjectsTree.InitializeAheadBehindProvider();
                 var path = Module.WorkingDir;
                 ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
                 AppSettings.RecentWorkingDir = path;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -31,6 +31,7 @@
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
             this.groupBoxPerformance = new System.Windows.Forms.GroupBox();
             this.tlpnlPerformance = new System.Windows.Forms.TableLayoutPanel();
+            this.chkShowAheadBehindDataInBrowseWindow = new System.Windows.Forms.CheckBox();
             this.chkCheckForUncommittedChangesInCheckoutBranch = new System.Windows.Forms.CheckBox();
             this.chkShowGitStatusInToolbar = new System.Windows.Forms.CheckBox();
             this.chkShowGitStatusForArtificialCommits = new System.Windows.Forms.CheckBox();
@@ -91,7 +92,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tlpnlMain.Size = new System.Drawing.Size(2132, 1438);
+            tlpnlMain.Size = new System.Drawing.Size(1438, 846);
             tlpnlMain.TabIndex = 0;
             // 
             // groupBoxPerformance
@@ -102,7 +103,7 @@
             this.groupBoxPerformance.Location = new System.Drawing.Point(3, 3);
             this.groupBoxPerformance.Name = "groupBoxPerformance";
             this.groupBoxPerformance.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxPerformance.Size = new System.Drawing.Size(2126, 195);
+            this.groupBoxPerformance.Size = new System.Drawing.Size(1432, 239);
             this.groupBoxPerformance.TabIndex = 0;
             this.groupBoxPerformance.TabStop = false;
             this.groupBoxPerformance.Text = "Performance";
@@ -114,19 +115,20 @@
             this.tlpnlPerformance.ColumnCount = 2;
             this.tlpnlPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 6);
+            this.tlpnlPerformance.Controls.Add(this.chkShowAheadBehindDataInBrowseWindow, 0, 6);
+            this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 7);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusInToolbar, 0, 0);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusForArtificialCommits, 0, 1);
             this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 5);
             this.tlpnlPerformance.Controls.Add(this.chkShowSubmoduleStatusInBrowse, 0, 2);
             this.tlpnlPerformance.Controls.Add(this.chkUseFastChecks, 0, 4);
             this.tlpnlPerformance.Controls.Add(this.chkShowCurrentChangesInRevisionGraph, 0, 3);
-            this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 7);
-            this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 7);
+            this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 8);
+            this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 8);
             this.tlpnlPerformance.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tlpnlPerformance.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlPerformance.Location = new System.Drawing.Point(8, 21);
             this.tlpnlPerformance.Name = "tlpnlPerformance";
-            this.tlpnlPerformance.RowCount = 6;
+            this.tlpnlPerformance.RowCount = 9;
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -135,17 +137,29 @@
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
-            this.tlpnlPerformance.Size = new System.Drawing.Size(2110, 165);
+            this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlPerformance.Size = new System.Drawing.Size(1416, 210);
             this.tlpnlPerformance.TabIndex = 0;
+            // 
+            // chkShowAheadBehindDataInBrowseWindow
+            // 
+            this.chkShowAheadBehindDataInBrowseWindow.AutoSize = true;
+            this.chkShowAheadBehindDataInBrowseWindow.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkShowAheadBehindDataInBrowseWindow.Location = new System.Drawing.Point(3, 141);
+            this.chkShowAheadBehindDataInBrowseWindow.Name = "chkShowAheadBehindDataInBrowseWindow";
+            this.chkShowAheadBehindDataInBrowseWindow.Size = new System.Drawing.Size(347, 17);
+            this.chkShowAheadBehindDataInBrowseWindow.TabIndex = 10;
+            this.chkShowAheadBehindDataInBrowseWindow.Text = "Show ahead and behind information on status bar in browse window";
+            this.chkShowAheadBehindDataInBrowseWindow.UseVisualStyleBackColor = true;
             // 
             // chkCheckForUncommittedChangesInCheckoutBranch
             // 
             this.chkCheckForUncommittedChangesInCheckoutBranch.AutoSize = true;
             this.chkCheckForUncommittedChangesInCheckoutBranch.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkCheckForUncommittedChangesInCheckoutBranch.Location = new System.Drawing.Point(3, 141);
+            this.chkCheckForUncommittedChangesInCheckoutBranch.Location = new System.Drawing.Point(3, 164);
             this.chkCheckForUncommittedChangesInCheckoutBranch.Name = "chkCheckForUncommittedChangesInCheckoutBranch";
-            this.chkCheckForUncommittedChangesInCheckoutBranch.Size = new System.Drawing.Size(324, 17);
+            this.chkCheckForUncommittedChangesInCheckoutBranch.Size = new System.Drawing.Size(347, 17);
             this.chkCheckForUncommittedChangesInCheckoutBranch.TabIndex = 6;
             this.chkCheckForUncommittedChangesInCheckoutBranch.Text = "Check for uncommitted changes in checkout branch dialog";
             this.chkCheckForUncommittedChangesInCheckoutBranch.UseVisualStyleBackColor = true;
@@ -157,7 +171,7 @@
             this.chkShowGitStatusInToolbar.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowGitStatusInToolbar.Location = new System.Drawing.Point(3, 3);
             this.chkShowGitStatusInToolbar.Name = "chkShowGitStatusInToolbar";
-            this.chkShowGitStatusInToolbar.Size = new System.Drawing.Size(2104, 17);
+            this.chkShowGitStatusInToolbar.Size = new System.Drawing.Size(1410, 17);
             this.chkShowGitStatusInToolbar.TabIndex = 0;
             this.chkShowGitStatusInToolbar.Text = "Show number of changed files on commit button";
             this.chkShowGitStatusInToolbar.UseVisualStyleBackColor = true;
@@ -170,7 +184,7 @@
             this.chkShowGitStatusForArtificialCommits.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowGitStatusForArtificialCommits.Location = new System.Drawing.Point(3, 26);
             this.chkShowGitStatusForArtificialCommits.Name = "chkShowGitStatusForArtificialCommits";
-            this.chkShowGitStatusForArtificialCommits.Size = new System.Drawing.Size(2104, 17);
+            this.chkShowGitStatusForArtificialCommits.Size = new System.Drawing.Size(1410, 17);
             this.chkShowGitStatusForArtificialCommits.TabIndex = 1;
             this.chkShowGitStatusForArtificialCommits.Text = "Show number of changed files for artificial commits";
             this.chkShowGitStatusForArtificialCommits.UseVisualStyleBackColor = true;
@@ -182,7 +196,7 @@
             this.chkShowStashCountInBrowseWindow.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowStashCountInBrowseWindow.Location = new System.Drawing.Point(3, 118);
             this.chkShowStashCountInBrowseWindow.Name = "chkShowStashCountInBrowseWindow";
-            this.chkShowStashCountInBrowseWindow.Size = new System.Drawing.Size(324, 17);
+            this.chkShowStashCountInBrowseWindow.Size = new System.Drawing.Size(347, 17);
             this.chkShowStashCountInBrowseWindow.TabIndex = 5;
             this.chkShowStashCountInBrowseWindow.Text = "Show stash count on status bar in browse window";
             this.chkShowStashCountInBrowseWindow.UseVisualStyleBackColor = true;
@@ -193,7 +207,7 @@
             this.chkShowSubmoduleStatusInBrowse.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowSubmoduleStatusInBrowse.Location = new System.Drawing.Point(3, 49);
             this.chkShowSubmoduleStatusInBrowse.Name = "chkShowSubmoduleStatusInBrowse";
-            this.chkShowSubmoduleStatusInBrowse.Size = new System.Drawing.Size(324, 17);
+            this.chkShowSubmoduleStatusInBrowse.Size = new System.Drawing.Size(347, 17);
             this.chkShowSubmoduleStatusInBrowse.TabIndex = 2;
             this.chkShowSubmoduleStatusInBrowse.Text = "Show submodule status in browse menu";
             this.chkShowSubmoduleStatusInBrowse.UseVisualStyleBackColor = true;
@@ -204,7 +218,7 @@
             this.chkUseFastChecks.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkUseFastChecks.Location = new System.Drawing.Point(3, 95);
             this.chkUseFastChecks.Name = "chkUseFastChecks";
-            this.chkUseFastChecks.Size = new System.Drawing.Size(324, 17);
+            this.chkUseFastChecks.Size = new System.Drawing.Size(347, 17);
             this.chkUseFastChecks.TabIndex = 4;
             this.chkUseFastChecks.Text = "Use FileSystemWatcher to check if index is changed";
             this.chkUseFastChecks.UseVisualStyleBackColor = true;
@@ -215,7 +229,7 @@
             this.chkShowCurrentChangesInRevisionGraph.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowCurrentChangesInRevisionGraph.Location = new System.Drawing.Point(3, 72);
             this.chkShowCurrentChangesInRevisionGraph.Name = "chkShowCurrentChangesInRevisionGraph";
-            this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(324, 17);
+            this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(347, 17);
             this.chkShowCurrentChangesInRevisionGraph.TabIndex = 3;
             this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes as an artificial commit";
             this.chkShowCurrentChangesInRevisionGraph.UseVisualStyleBackColor = true;
@@ -224,9 +238,9 @@
             // 
             this.lblCommitsLimit.AutoSize = true;
             this.lblCommitsLimit.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblCommitsLimit.Location = new System.Drawing.Point(3, 161);
+            this.lblCommitsLimit.Location = new System.Drawing.Point(3, 184);
             this.lblCommitsLimit.Name = "lblCommitsLimit";
-            this.lblCommitsLimit.Size = new System.Drawing.Size(324, 27);
+            this.lblCommitsLimit.Size = new System.Drawing.Size(347, 26);
             this.lblCommitsLimit.TabIndex = 7;
             this.lblCommitsLimit.Text = "Limit number of commits that will be loaded at startup";
             this.lblCommitsLimit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -238,14 +252,14 @@
             0,
             0,
             0});
-            this._NO_TRANSLATE_MaxCommits.Location = new System.Drawing.Point(333, 164);
+            this._NO_TRANSLATE_MaxCommits.Location = new System.Drawing.Point(356, 187);
             this._NO_TRANSLATE_MaxCommits.Maximum = new decimal(new int[] {
             1000000,
             0,
             0,
             0});
             this._NO_TRANSLATE_MaxCommits.Name = "_NO_TRANSLATE_MaxCommits";
-            this._NO_TRANSLATE_MaxCommits.Size = new System.Drawing.Size(85, 21);
+            this._NO_TRANSLATE_MaxCommits.Size = new System.Drawing.Size(85, 20);
             this._NO_TRANSLATE_MaxCommits.TabIndex = 8;
             this._NO_TRANSLATE_MaxCommits.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this._NO_TRANSLATE_MaxCommits.ThousandsSeparator = true;
@@ -260,10 +274,10 @@
             this.groupBoxEmailSettings.AutoSize = true;
             this.groupBoxEmailSettings.Controls.Add(this.tlpnlEmailSettings);
             this.groupBoxEmailSettings.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxEmailSettings.Location = new System.Drawing.Point(3, 434);
+            this.groupBoxEmailSettings.Location = new System.Drawing.Point(3, 476);
             this.groupBoxEmailSettings.Name = "groupBoxEmailSettings";
             this.groupBoxEmailSettings.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxEmailSettings.Size = new System.Drawing.Size(2126, 107);
+            this.groupBoxEmailSettings.Size = new System.Drawing.Size(1432, 104);
             this.groupBoxEmailSettings.TabIndex = 2;
             this.groupBoxEmailSettings.TabStop = false;
             this.groupBoxEmailSettings.Text = "Email settings for sending patches";
@@ -281,29 +295,29 @@
             this.tlpnlEmailSettings.Controls.Add(this.SmtpServerPort, 2, 1);
             this.tlpnlEmailSettings.Controls.Add(this.lblSmtpServerName, 0, 0);
             this.tlpnlEmailSettings.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tlpnlEmailSettings.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlEmailSettings.Location = new System.Drawing.Point(8, 21);
             this.tlpnlEmailSettings.Name = "tlpnlEmailSettings";
             this.tlpnlEmailSettings.RowCount = 3;
             this.tlpnlEmailSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlEmailSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlEmailSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlEmailSettings.Size = new System.Drawing.Size(2110, 77);
+            this.tlpnlEmailSettings.Size = new System.Drawing.Size(1416, 75);
             this.tlpnlEmailSettings.TabIndex = 0;
             // 
             // SmtpServer
             // 
-            this.SmtpServer.Location = new System.Drawing.Point(115, 3);
+            this.SmtpServer.Location = new System.Drawing.Point(117, 3);
             this.SmtpServer.Name = "SmtpServer";
-            this.SmtpServer.Size = new System.Drawing.Size(179, 21);
+            this.SmtpServer.Size = new System.Drawing.Size(179, 20);
             this.SmtpServer.TabIndex = 0;
             // 
             // lblSmtpServerPort
             // 
             this.lblSmtpServerPort.AutoSize = true;
             this.lblSmtpServerPort.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblSmtpServerPort.Location = new System.Drawing.Point(3, 27);
+            this.lblSmtpServerPort.Location = new System.Drawing.Point(3, 26);
             this.lblSmtpServerPort.Name = "lblSmtpServerPort";
-            this.lblSmtpServerPort.Size = new System.Drawing.Size(106, 27);
+            this.lblSmtpServerPort.Size = new System.Drawing.Size(108, 26);
             this.lblSmtpServerPort.TabIndex = 1;
             this.lblSmtpServerPort.Text = "Port";
             this.lblSmtpServerPort.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -312,9 +326,9 @@
             // 
             this.chkUseSSL.AutoSize = true;
             this.chkUseSSL.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkUseSSL.Location = new System.Drawing.Point(3, 57);
+            this.chkUseSSL.Location = new System.Drawing.Point(3, 55);
             this.chkUseSSL.Name = "chkUseSSL";
-            this.chkUseSSL.Size = new System.Drawing.Size(106, 17);
+            this.chkUseSSL.Size = new System.Drawing.Size(108, 17);
             this.chkUseSSL.TabIndex = 3;
             this.chkUseSSL.Text = "Use SSL/TLS";
             this.chkUseSSL.UseVisualStyleBackColor = true;
@@ -322,9 +336,9 @@
             // 
             // SmtpServerPort
             // 
-            this.SmtpServerPort.Location = new System.Drawing.Point(115, 30);
+            this.SmtpServerPort.Location = new System.Drawing.Point(117, 29);
             this.SmtpServerPort.Name = "SmtpServerPort";
-            this.SmtpServerPort.Size = new System.Drawing.Size(49, 21);
+            this.SmtpServerPort.Size = new System.Drawing.Size(49, 20);
             this.SmtpServerPort.TabIndex = 2;
             this.SmtpServerPort.Text = "587";
             // 
@@ -332,10 +346,10 @@
             // 
             this.lblSmtpServerName.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblSmtpServerName.AutoSize = true;
-            this.lblSmtpServerName.Location = new System.Drawing.Point(3, 7);
+            this.lblSmtpServerName.Location = new System.Drawing.Point(3, 6);
             this.lblSmtpServerName.Name = "lblSmtpServerName";
             this.lblSmtpServerName.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.lblSmtpServerName.Size = new System.Drawing.Size(106, 13);
+            this.lblSmtpServerName.Size = new System.Drawing.Size(108, 13);
             this.lblSmtpServerName.TabIndex = 0;
             this.lblSmtpServerName.Text = "SMTP server name";
             this.lblSmtpServerName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -345,10 +359,10 @@
             this.groupBoxBehaviour.AutoSize = true;
             this.groupBoxBehaviour.Controls.Add(this.tlpnlBehaviour);
             this.groupBoxBehaviour.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxBehaviour.Location = new System.Drawing.Point(3, 204);
+            this.groupBoxBehaviour.Location = new System.Drawing.Point(3, 248);
             this.groupBoxBehaviour.Name = "groupBoxBehaviour";
             this.groupBoxBehaviour.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxBehaviour.Size = new System.Drawing.Size(2126, 224);
+            this.groupBoxBehaviour.Size = new System.Drawing.Size(1432, 222);
             this.groupBoxBehaviour.TabIndex = 1;
             this.groupBoxBehaviour.TabStop = false;
             this.groupBoxBehaviour.Text = "Behaviour";
@@ -374,7 +388,7 @@
             this.tlpnlBehaviour.Controls.Add(this.chkStartWithRecentWorkingDir, 0, 5);
             this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistory, 0, 4);
             this.tlpnlBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tlpnlBehaviour.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlBehaviour.Location = new System.Drawing.Point(8, 21);
             this.tlpnlBehaviour.Name = "tlpnlBehaviour";
             this.tlpnlBehaviour.RowCount = 8;
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -385,7 +399,7 @@
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlBehaviour.Size = new System.Drawing.Size(2110, 194);
+            this.tlpnlBehaviour.Size = new System.Drawing.Size(1416, 193);
             this.tlpnlBehaviour.TabIndex = 0;
             // 
             // chkFollowRenamesInFileHistoryExact
@@ -394,7 +408,7 @@
             this.chkFollowRenamesInFileHistoryExact.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkFollowRenamesInFileHistoryExact.Location = new System.Drawing.Point(273, 95);
             this.chkFollowRenamesInFileHistoryExact.Name = "chkFollowRenamesInFileHistoryExact";
-            this.chkFollowRenamesInFileHistoryExact.Size = new System.Drawing.Size(1776, 17);
+            this.chkFollowRenamesInFileHistoryExact.Size = new System.Drawing.Size(1082, 17);
             this.chkFollowRenamesInFileHistoryExact.TabIndex = 5;
             this.chkFollowRenamesInFileHistoryExact.Text = "Follow exact renames and copies only";
             this.chkFollowRenamesInFileHistoryExact.UseVisualStyleBackColor = true;
@@ -418,7 +432,7 @@
             0,
             0});
             this.RevisionGridQuickSearchTimeout.Name = "RevisionGridQuickSearchTimeout";
-            this.RevisionGridQuickSearchTimeout.Size = new System.Drawing.Size(85, 21);
+            this.RevisionGridQuickSearchTimeout.Size = new System.Drawing.Size(85, 20);
             this.RevisionGridQuickSearchTimeout.TabIndex = 12;
             this.RevisionGridQuickSearchTimeout.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.RevisionGridQuickSearchTimeout.ThousandsSeparator = true;
@@ -432,7 +446,7 @@
             // 
             this.btnDefaultDestinationBrowse.AutoSize = true;
             this.btnDefaultDestinationBrowse.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.btnDefaultDestinationBrowse.Location = new System.Drawing.Point(2055, 141);
+            this.btnDefaultDestinationBrowse.Location = new System.Drawing.Point(1361, 141);
             this.btnDefaultDestinationBrowse.Name = "btnDefaultDestinationBrowse";
             this.btnDefaultDestinationBrowse.Size = new System.Drawing.Size(52, 23);
             this.btnDefaultDestinationBrowse.TabIndex = 10;
@@ -446,7 +460,7 @@
             this.lblQuickSearchTimeout.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblQuickSearchTimeout.Location = new System.Drawing.Point(3, 167);
             this.lblQuickSearchTimeout.Name = "lblQuickSearchTimeout";
-            this.lblQuickSearchTimeout.Size = new System.Drawing.Size(264, 27);
+            this.lblQuickSearchTimeout.Size = new System.Drawing.Size(264, 26);
             this.lblQuickSearchTimeout.TabIndex = 11;
             this.lblQuickSearchTimeout.Text = "Revision grid quick search timeout [ms]";
             this.lblQuickSearchTimeout.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -470,7 +484,7 @@
             this.cbDefaultCloneDestination.FormattingEnabled = true;
             this.cbDefaultCloneDestination.Location = new System.Drawing.Point(273, 141);
             this.cbDefaultCloneDestination.Name = "cbDefaultCloneDestination";
-            this.cbDefaultCloneDestination.Size = new System.Drawing.Size(1776, 21);
+            this.cbDefaultCloneDestination.Size = new System.Drawing.Size(1082, 21);
             this.cbDefaultCloneDestination.TabIndex = 9;
             // 
             // chkShowGitCommandLine
@@ -547,7 +561,7 @@
             this.Controls.Add(tlpnlMain);
             this.Name = "GeneralSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(2148, 1454);
+            this.Size = new System.Drawing.Size(1454, 862);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.groupBoxPerformance.ResumeLayout(false);
@@ -603,5 +617,6 @@
         private System.Windows.Forms.TableLayoutPanel tlpnlBehaviour;
         private System.Windows.Forms.TableLayoutPanel tlpnlEmailSettings;
         private System.Windows.Forms.CheckBox chkFollowRenamesInFileHistoryExact;
+        private System.Windows.Forms.CheckBox chkShowAheadBehindDataInBrowseWindow;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -58,6 +58,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkStashUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInAutoStash;
             chkShowCurrentChangesInRevisionGraph.Checked = AppSettings.RevisionGraphShowWorkingDirChanges;
             chkShowStashCountInBrowseWindow.Checked = AppSettings.ShowStashCount;
+            chkShowAheadBehindDataInBrowseWindow.Checked = AppSettings.ShowAheadBehindData;
             chkShowGitStatusInToolbar.Checked = AppSettings.ShowGitStatusInBrowseToolbar;
             chkShowGitStatusForArtificialCommits.Checked = AppSettings.ShowGitStatusForArtificialCommits;
             chkShowSubmoduleStatusInBrowse.Checked = AppSettings.ShowSubmoduleStatus;
@@ -96,6 +97,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RevisionGridQuickSearchTimeout = (int)RevisionGridQuickSearchTimeout.Value;
             AppSettings.RevisionGraphShowWorkingDirChanges = chkShowCurrentChangesInRevisionGraph.Checked;
             AppSettings.ShowStashCount = chkShowStashCountInBrowseWindow.Checked;
+            AppSettings.ShowAheadBehindData = chkShowAheadBehindDataInBrowseWindow.Checked;
             AppSettings.ShowSubmoduleStatus = chkShowSubmoduleStatusInBrowse.Checked;
 
             AppSettings.DefaultCloneDestinationPath = cbDefaultCloneDestination.Text;

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Git;
+using GitUI.Properties;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs
+{
+    public class ToolStripPushButton : ToolStripButton
+    {
+        private readonly TranslationString _push = new TranslationString("Push");
+
+        private readonly TranslationString _aheadCommitsToPush =
+            new TranslationString("{0} new commit(s) will be pushed");
+
+        private readonly TranslationString _behindCommitsTointegrateOrForcePush =
+            new TranslationString("{0} commit(s) should be integrated (or will be lost if force pushed)");
+
+        private IAheadBehindDataProvider _aheadBehindDataProvider;
+        private bool _supportsAheadBehindData;
+
+        public void Initialize(IAheadBehindDataProvider aheadBehindDataProvider, bool supportsAheadBehindData)
+        {
+            _aheadBehindDataProvider = aheadBehindDataProvider;
+            _supportsAheadBehindData = supportsAheadBehindData;
+            ResetToDefaultState();
+        }
+
+        public void DisplayAheadBehindInformation(string branchName)
+        {
+            if (!_supportsAheadBehindData || !AppSettings.ShowAheadBehindData)
+            {
+                return;
+            }
+
+            ResetToDefaultState();
+
+            var aheadBehindData = _aheadBehindDataProvider.GetData(branchName);
+            if (aheadBehindData == null || aheadBehindData.Count < 1 || !aheadBehindData.ContainsKey(branchName))
+            {
+                return;
+            }
+
+            var data = aheadBehindData[branchName];
+
+            if (AppSettings.ShowAheadBehindData)
+            {
+                Text = data.ToDisplay();
+                DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
+            }
+
+            ToolTipText = GetToolTipText(data);
+
+            if (!string.IsNullOrEmpty(data.BehindCount))
+            {
+                Image = Images.Unstage;
+            }
+        }
+
+        private void ResetToDefaultState()
+        {
+            DisplayStyle = ToolStripItemDisplayStyle.Image;
+            Image = Images.Push;
+            ToolTipText = _push.Text;
+        }
+
+        private string GetToolTipText(AheadBehindData data)
+        {
+            string tooltip = null;
+            if (!string.IsNullOrEmpty(data.AheadCount))
+            {
+                tooltip = string.Format(_aheadCommitsToPush.Text, data.AheadCount);
+            }
+
+            if (!string.IsNullOrEmpty(data.BehindCount))
+            {
+                if (!string.IsNullOrEmpty(tooltip))
+                {
+                    tooltip += Environment.NewLine;
+                }
+
+                tooltip += string.Format(_behindCommitsTointegrateOrForcePush.Text, data.BehindCount);
+            }
+
+            return tooltip;
+        }
+
+        internal TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
+
+        public readonly struct TestAccessor
+        {
+            private readonly ToolStripPushButton _button;
+
+            public TestAccessor(ToolStripPushButton button)
+            {
+                _button = button;
+            }
+
+            public string GetToolTipText(AheadBehindData data) => _button.GetToolTipText(data);
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -288,6 +288,9 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\ToolStripPushButton.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="CommitInfo\CommitInfoHeader.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -75,6 +75,7 @@
     <Compile Include="IBrowseRepo.cs" />
     <Compile Include="IConfigFileSettings.cs" />
     <Compile Include="IConfigSection.cs" />
+    <Compile Include="IExecutable.cs" />
     <Compile Include="IGitCommand.cs" />
     <Compile Include="IGitItem.cs" />
     <Compile Include="IGitPluginForRepository.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="IGitRef.cs" />
     <Compile Include="IGitRemoteCommand.cs" />
     <Compile Include="ILockableNotifier.cs" />
+    <Compile Include="IProcess.cs" />
     <Compile Include="ISettingsValueGetter.cs" />
     <Compile Include="ObjectId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -1,8 +1,8 @@
 using System.Text;
-using GitUIPluginInterfaces;
+using GitCommands;
 using JetBrains.Annotations;
 
-namespace GitCommands
+namespace GitUIPluginInterfaces
 {
     /// <summary>
     /// Defines an executable that can be launched to create processes.
@@ -14,7 +14,7 @@ namespace GitCommands
         /// </summary>
         /// <remarks>
         /// This is a low level means of starting a process. Most code will want to use one of the extension methods
-        /// provided by <see cref="ExecutableExtensions"/>.
+        /// provided by <c>ExecutableExtensions</c>.
         /// </remarks>
         /// <param name="arguments">Any command line arguments to be passed to the executable when it is started.</param>
         /// <param name="createWindow">Whether to create a window for the process or not.</param>

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -60,6 +60,11 @@ namespace GitUIPluginInterfaces
         string WorkingDir { get; }
 
         /// <summary>
+        /// Gets the access to the current git executable associated with this module.
+        /// </summary>
+        IExecutable GitExecutable { get; }
+
+        /// <summary>
         /// Gets the location of .git directory for the current working folder.
         /// </summary>
         string WorkingDirGitDir { get; }

--- a/Plugins/GitUIPluginInterfaces/IProcess.cs
+++ b/Plugins/GitUIPluginInterfaces/IProcess.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace GitCommands
+namespace GitUIPluginInterfaces
 {
     /// <summary>
     /// Defines a process instance.

--- a/UnitTests/GitCommandsTests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Git/AheadBehindDataProviderTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Git;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public class AheadBehindDataProviderTests
+    {
+        private MemoryStream _standardOutputStream;
+        private MemoryStream _standardErrorStream;
+        private StreamReader _outputStreamReader;
+        private StreamReader _errorStreamReader;
+        private IProcess _process;
+        private IExecutable _executable;
+        private AheadBehindDataProvider _provider;
+
+        [SetUp]
+        public void Setup()
+        {
+            _standardOutputStream = new MemoryStream();
+            _standardErrorStream = new MemoryStream();
+            _outputStreamReader = new StreamReader(_standardOutputStream);
+            _errorStreamReader = new StreamReader(_standardErrorStream);
+
+            _process = Substitute.For<IProcess>();
+            _process.StandardOutput.Returns(x => _outputStreamReader);
+            _process.StandardError.Returns(x => _errorStreamReader);
+
+            _executable = Substitute.For<IExecutable>();
+            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>()).Returns(x => _process);
+
+            _provider = new AheadBehindDataProvider(() => _executable);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _standardOutputStream?.Dispose();
+            _standardErrorStream?.Dispose();
+            _outputStreamReader?.Dispose();
+            _errorStreamReader?.Dispose();
+        }
+
+        [TestCase(null)]
+        public void GetData_should_throw_if_branch_null(string branchName)
+        {
+            ((Action)(() => _provider.GetTestAccessor().GetData(Encoding.UTF8, branchName))).Should().Throw<ArgumentException>();
+        }
+
+        [Test]
+        public void GetData_should_return_null_if_detached_head()
+        {
+            _provider.GetTestAccessor().GetData(Encoding.UTF8, "(no branch)").Should().BeNull();
+        }
+
+        [Test]
+        public void GetData_should_return_null_if_git_output_empty()
+        {
+            _provider.GetTestAccessor().GetData(Encoding.UTF8, "**").Should().BeNull();
+        }
+
+        [TestCase("::::my-branch")]
+        [TestCase("::[gone]::branch-with-no-more-remote")]
+        [TestCase("::::")]
+        public void GetData_should_return_null_if_git_output_has_no_data(string result)
+        {
+            SetResultOfGitCommand(result);
+
+            _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch").Should().BeNull();
+        }
+
+        [Test]
+        public void GetData_should_return_empty_result_if_unable_match_branch()
+        {
+            SetResultOfGitCommand("results!");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "**");
+
+            data.Should().BeNull();
+        }
+
+        [Test]
+        public void GetData_should_return_ahead_for_a_branch()
+        {
+            SetResultOfGitCommand("::[ahead 10]::my-branch");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be("10");
+            aheadBehindData.BehindCount.Should().Be(string.Empty);
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("10↑");
+        }
+
+        [Test]
+        public void GetData_should_return_behind_for_a_branch()
+        {
+            SetResultOfGitCommand("::[behind 2]::my-branch");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be(string.Empty);
+            aheadBehindData.BehindCount.Should().Be("2");
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("2↓");
+        }
+
+        [Test]
+        public void GetData_should_return_ahead_and_behind_for_a_branch()
+        {
+            SetResultOfGitCommand("::[ahead 99, behind 3]::my-branch");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be("99");
+            aheadBehindData.BehindCount.Should().Be("3");
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("99↑ 3↓");
+        }
+
+        [Test]
+        public void GetData_should_return_ahead_and_behind_for_all_branches()
+        {
+            SetResultOfGitCommand("::branch-not-changed\n"
+                    + "::[gone]::branch-with-no-more-remote\n"
+                    + "::[ahead 99, behind 3]::ahead-behind-branch\n"
+                    + "::[ahead 3]::ahead-branch\n"
+                    + "::[behind 4]::behind-branch");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "*");
+
+            data.Should().HaveCount(3);
+            data.Should().BeEquivalentTo(
+                new Dictionary<string, AheadBehindData>
+                {
+                    { "ahead-behind-branch", new AheadBehindData { AheadCount = "99", BehindCount = "3", Branch = "ahead-behind-branch" } },
+                    { "ahead-branch", new AheadBehindData { AheadCount = "3", BehindCount = string.Empty, Branch = "ahead-branch" } },
+                    { "behind-branch", new AheadBehindData { AheadCount = string.Empty, BehindCount = "4", Branch = "behind-branch" } },
+                });
+        }
+
+        private void SetResultOfGitCommand(string result)
+        {
+            var writer = new StreamWriter(_standardOutputStream);
+            writer.Write(result);
+            writer.Flush();
+            _standardOutputStream.Position = 0;
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="ExternalLinks\ExternalLinksStorageIntegrationTests.cs" />
     <Compile Include="FileAssociatedIconProviderTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
+    <Compile Include="Git\AheadBehindDataProviderTests.cs" />
     <Compile Include="Git\ExecutableExtensionsTests.cs" />
     <Compile Include="Git\GitDescribeProviderTests.cs" />
     <Compile Include="Git\GitRefNameTests.cs" />

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProviderTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphMultiThreadingTests.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\RevisionGraphTests.cs" />
+    <Compile Include="UserControls\ToolStripPushButtonTests.cs" />
     <Compile Include="UserManual\SingleHtmlUserManualFixture.cs" />
     <Compile Include="UserManual\StandardHtmlUserManualFixture.cs" />
     <Compile Include="WindowPositionManagerTests.cs" />

--- a/UnitTests/GitUITests/UserControls/ToolStripPushButtonTests.cs
+++ b/UnitTests/GitUITests/UserControls/ToolStripPushButtonTests.cs
@@ -1,0 +1,164 @@
+﻿using System.Collections.Generic;
+using System.Windows.Forms;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Git;
+using GitUI.CommandsDialogs;
+using GitUI.Properties;
+using JetBrains.Annotations;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls
+{
+    [TestFixture]
+    public class ToolStripPushButtonTests
+    {
+        private static readonly int PushImageHashCode = Images.Push.RawFormat.GetHashCode();
+        private bool _originalShowAheadBehindData;
+        private IAheadBehindDataProvider _aheadBehindDataProvider;
+        private ToolStripPushButton _sut;
+
+        [SetUp]
+        public void Setup()
+        {
+            _originalShowAheadBehindData = AppSettings.ShowAheadBehindData;
+            AppSettings.ShowAheadBehindData = true;
+
+            _aheadBehindDataProvider = Substitute.For<IAheadBehindDataProvider>();
+
+            _sut = new ToolStripPushButton();
+            _sut.Initialize(_aheadBehindDataProvider, true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AppSettings.ShowAheadBehindData = _originalShowAheadBehindData;
+        }
+
+        [Test]
+        public void DisplayAheadBehindInformation_should_not_display_anything_if_does_not_support_ahead_behind()
+        {
+            _sut.Initialize(_aheadBehindDataProvider, false);
+
+            _sut.DisplayAheadBehindInformation("any-branchName");
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
+            _sut.ToolTipText.Should().Be("Push");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(PushImageHashCode);
+        }
+
+        [TestCaseSource(nameof(GetInvalidAheadBehindData))]
+        public void DisplayAheadBehindInformation_should_display_default_text_image_if_ahead_behind_data_null(IDictionary<string, AheadBehindData> data)
+        {
+            var branchName = "who_cares";
+            _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
+            _sut.ToolTipText.Should().Be("Push");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(PushImageHashCode);
+        }
+
+        private static IEnumerable<TestCaseData> GetInvalidAheadBehindData
+        {
+            [UsedImplicitly]
+            get
+            {
+                int index = 0;
+                yield return new TestCaseData(null)
+                    .SetName($"{++index}. AheadBehindData is null");
+
+                yield return new TestCaseData(new Dictionary<string, AheadBehindData>())
+                    .SetName($"{++index}. AheadBehindData is empty");
+
+                yield return new TestCaseData(new Dictionary<string, AheadBehindData> { { "some_branch", new AheadBehindData() } })
+                    .SetName($"{++index}. AheadBehindData doesn't contain desired branch");
+            }
+        }
+
+        [Test]
+        public void DisplayAheadBehindInformation_should_display_normal_state_when_no_data_returned()
+        {
+            var branchName = "(no branch) or any-branch";
+            _aheadBehindDataProvider.GetData(branchName).Returns(x => null);
+
+            _sut.DisplayAheadBehindInformation(branchName);
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
+            _sut.ToolTipText.Should().Be("Push");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(PushImageHashCode);
+        }
+
+        [Test]
+        public void DisplayAheadBehindInformation_should_display_normal_state_when_in_ahead_state()
+        {
+            var branchName = "my-branch";
+            var data = new Dictionary<string, AheadBehindData>
+            {
+                { branchName, new AheadBehindData { AheadCount = "9", BehindCount = string.Empty, Branch = branchName } }
+            };
+            _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
+
+            _sut.DisplayAheadBehindInformation(branchName);
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
+            _sut.ToolTipText.Should().Contain("9 new commit(s) will be pushed");
+            _sut.ToolTipText.Should().NotContain("commit(s) should be integrated");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(PushImageHashCode);
+        }
+
+        [Test]
+        public void DisplayAheadBehindInformation_should_display_warning_state_when_in_behind_state()
+        {
+            var branchName = "my-branch";
+            var data = new Dictionary<string, AheadBehindData>
+            {
+                { branchName, new AheadBehindData { AheadCount = string.Empty, BehindCount = "2", Branch = branchName } }
+            };
+            _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
+
+            _sut.DisplayAheadBehindInformation(branchName);
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
+            _sut.ToolTipText.Should().NotContain("new commit(s) will be pushed");
+            _sut.ToolTipText.Should().Contain("2 commit(s) should be integrated");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(Images.Unstage.RawFormat.GetHashCode());
+        }
+
+        [Test]
+        public void DisplayAheadBehindInformation_should_display_warning_state_when_in_ahead_and_behind_state()
+        {
+            var branchName = "my-branch";
+            var data = new Dictionary<string, AheadBehindData>
+            {
+                { branchName, new AheadBehindData { AheadCount = "99", BehindCount = "3", Branch = branchName } }
+            };
+            _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
+
+            _sut.DisplayAheadBehindInformation(branchName);
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
+            _sut.ToolTipText.Should().Contain("99 new commit(s) will be pushed");
+            _sut.ToolTipText.Should().Contain("3 commit(s) should be integrated");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(Images.Unstage.RawFormat.GetHashCode());
+        }
+
+        [Test]
+        public void DisplayAheadBehindInformation_should_display_nothing_when_disabled()
+        {
+            AppSettings.ShowAheadBehindData = false;
+
+            var branchName = "my-branch";
+
+            _sut.DisplayAheadBehindInformation(branchName);
+
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
+            _sut.ToolTipText.Should().NotContain("99 new commit(s) will be pushed");
+            _sut.ToolTipText.Should().NotContain("3 commit(s) should be integrated");
+            _sut.Image.RawFormat.GetHashCode().Should().Be(Images.Unstage.RawFormat.GetHashCode());
+
+            _aheadBehindDataProvider.DidNotReceive().GetData(Arg.Any<string>());
+        }
+    }
+}


### PR DESCRIPTION
when the current branch is tracking a remote one.

## Proposed changes

* Display the count of unpushed commits and not integrated commit in the '2↑ 5↓' format
* Update the tooltip of the "push" button to explain the numbers
* Change the color of the "push" button if commits need to be integrated (or force pushed)

This change was made to improve understanding by the user of what Git will do when it will push.
It's a special ask by a git/gitextensions newcomer that liked the Visual Studio way to present data (because he don't really used eanough git to understand the git graph displayed in GitExtensions)

Requires Git >=2.5 (there is a control).

## Screenshots

### Before
A normal push button:

![image](https://user-images.githubusercontent.com/460196/50453501-482ddc00-0941-11e9-8b88-71666a6f406b.png)

### After
When there is something to push:

![image](https://user-images.githubusercontent.com/460196/50453777-5aa91500-0943-11e9-8ae7-e367b0f8406f.png)


When the branch is behind (not up to date):

![image](https://user-images.githubusercontent.com/460196/50453703-d0f94780-0942-11e9-94d1-96d70e840ae9.png)


When the branch is ahead and also behind commits (that required an integration --rebase or merge-- or a force push):

![image](https://user-images.githubusercontent.com/460196/50453750-27ff1c80-0943-11e9-87f1-769d23ff7c42.png)

The setting to disable the text in the "push" button for thoose that don't like button that resize themself, like the commit one (but that don't disable the tooltip and the color change in the button):

![image](https://user-images.githubusercontent.com/460196/50453804-7f04f180-0943-11e9-85e0-5c8a51c86e5f.png)

PS: I reused the "unstage" icon but I would prefer a new color (orange?) but I'm not a gimp expert. I will have a look later... (Or if someone could help).

## Test methodology

- manual tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.20
- Windows 10
