### PR TITLE
Add missing test assemblies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ build_script:
 # to run your custom scripts instead of automatic tests
 test_script:
 - ps: |
-    $testAssemblies = (Get-ChildItem -Path UnitTests\*\bin\Release\ -Filter '*Tests.dll' -Recurse -Exclude 'ApprovalTests.dll').FullName
+    $testAssemblies = (Get-ChildItem -Path UnitTests -Filter '*Tests.dll' -Recurse -Exclude 'ApprovalTests.dll').FullName | Where-Object { $_.Contains('\bin\Release') }
     $packageConfig = [xml](Get-Content .nuget\packages.config)
     $opencover_version = $packageConfig.SelectSingleNode('/packages/package[@id="OpenCover"]').version
     $opencover_console = "packages\OpenCover.$opencover_version\tools\OpenCover.Console.exe"


### PR DESCRIPTION
The original script was searching for test assemblies located at a depth of one level under UnitTests folder.
Plugin-related tests are located at two levels deep and thus weren't picked up by the build pipeline.