### PR TITLE
clean arguments in FormCommit

### DIFF
--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -179,6 +179,31 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Adds the git argument syntax for members of the <see cref="CleanMode"/> enum.
+        /// </summary>
+        /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
+        /// <param name="mode">The enum member to add to the builder.</param>
+        public static void Add(this ArgumentBuilder builder, CleanMode mode)
+        {
+            builder.Add(GetArgument());
+
+            string GetArgument()
+            {
+                switch (mode)
+                {
+                    case CleanMode.OnlyNonIgnored:
+                        return "";
+                    case CleanMode.OnlyIgnored:
+                        return "-X";
+                    case CleanMode.All:
+                        return "-x";
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(mode), (int)mode, typeof(CleanMode));
+                }
+            }
+        }
+
+        /// <summary>
         /// Adds the git argument syntax for members of the <see cref="GitBisectOption"/> enum.
         /// </summary>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -54,6 +54,19 @@ namespace GitCommands
         All = 5
     }
 
+    /// <summary>Mode for 'git clean'</summary>
+    public enum CleanMode
+    {
+        /// <summary>Only untracked files not in .gitignore, the default. Git clean without either -x or -X option.</summary>
+        OnlyNonIgnored = 1,
+
+        /// <summary>Only files included in any ignore list (.gitignore, $GIT_DIR/info/exclude). Git clean with -X option.</summary>
+        OnlyIgnored = 2,
+
+        /// <summary>All files not tracked by Git. Git clean with  -x option.</summary>
+        All = 3
+    }
+
     public static class GitCommandHelpers
     {
         #region SSH / Plink
@@ -428,15 +441,20 @@ namespace GitCommands
             };
         }
 
-        public static ArgumentString CleanUpCmd(bool dryRun, bool directories, bool nonIgnored, bool ignored, string paths = null)
+        /// <summary>
+        /// Arguments for git-clean
+        /// </summary>
+        /// <param name="mode">The cleanup mode what to delete</param>
+        /// <param name="dryRun">Only show what would be deleted</param>
+        /// <param name="directories">Delete untracked directories too</param>
+        /// <param name="paths">Limit to specific paths</param>
+        public static ArgumentString CleanCmd(CleanMode mode, bool dryRun, bool directories, string paths = null)
         {
             return new GitArgumentBuilder("clean")
             {
+                mode,
                 { directories, "-d" },
-                { !nonIgnored && !ignored, "-x" },
-                { ignored, "-X" },
-                { dryRun, "--dry-run" },
-                { !dryRun, "-f" },
+                { dryRun, "--dry-run", "-f" },
                 paths
             };
         }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -579,10 +579,10 @@ namespace GitCommands
 
         #endregion
 
-        public ExecutionResult Clean(bool dryRun, bool directories = false, bool nonIgnored = false, bool ignored = false, string paths = null)
+        public ExecutionResult Clean(CleanMode mode, bool dryRun = false, bool directories = false, string paths = null)
         {
             return _gitExecutable.Execute(
-                GitCommandHelpers.CleanUpCmd(dryRun, directories, nonIgnored, ignored, paths));
+                GitCommandHelpers.CleanCmd(mode, dryRun, directories, paths));
         }
 
         public bool EditNotes(ObjectId commitId)

--- a/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
@@ -32,7 +32,7 @@
             this.Cleanup = new System.Windows.Forms.Button();
             this.Cancel = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.RemoveIngnored = new System.Windows.Forms.RadioButton();
+            this.RemoveIgnored = new System.Windows.Forms.RadioButton();
             this.RemoveNonIgnored = new System.Windows.Forms.RadioButton();
             this.RemoveAll = new System.Windows.Forms.RadioButton();
             this.RemoveDirectories = new System.Windows.Forms.CheckBox();
@@ -86,7 +86,7 @@
             //
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.Controls.Add(this.RemoveIngnored);
+            this.groupBox1.Controls.Add(this.RemoveIgnored);
             this.groupBox1.Controls.Add(this.RemoveNonIgnored);
             this.groupBox1.Controls.Add(this.RemoveAll);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
@@ -96,15 +96,15 @@
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Remove untracked files from working directory";
             //
-            // RemoveIngnored
+            // RemoveIgnored
             //
-            this.RemoveIngnored.AutoSize = true;
-            this.RemoveIngnored.Location = new System.Drawing.Point(7, 67);
-            this.RemoveIngnored.Name = "RemoveIngnored";
-            this.RemoveIngnored.Size = new System.Drawing.Size(218, 19);
-            this.RemoveIngnored.TabIndex = 2;
-            this.RemoveIngnored.Text = "Remove only ignored untracked files";
-            this.RemoveIngnored.UseVisualStyleBackColor = true;
+            this.RemoveIgnored.AutoSize = true;
+            this.RemoveIgnored.Location = new System.Drawing.Point(7, 67);
+            this.RemoveIgnored.Name = "RemoveIgnored";
+            this.RemoveIgnored.Size = new System.Drawing.Size(218, 19);
+            this.RemoveIgnored.TabIndex = 2;
+            this.RemoveIgnored.Text = "Remove only ignored untracked files";
+            this.RemoveIgnored.UseVisualStyleBackColor = true;
             //
             // RemoveNonIgnored
             //
@@ -229,7 +229,7 @@
         private System.Windows.Forms.Button Cleanup;
         private System.Windows.Forms.Button Cancel;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.RadioButton RemoveIngnored;
+        private System.Windows.Forms.RadioButton RemoveIgnored;
         private System.Windows.Forms.RadioButton RemoveNonIgnored;
         private System.Windows.Forms.RadioButton RemoveAll;
         private System.Windows.Forms.CheckBox RemoveDirectories;

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
 
         private void Preview_Click(object sender, EventArgs e)
         {
-            var cleanUpCmd = GitCommandHelpers.CleanUpCmd(true, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
+            var cleanUpCmd = GitCommandHelpers.CleanCmd(GetCleanMode(), dryRun: true, directories: RemoveDirectories.Checked, paths: GetPathArgumentFromGui());
             string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
             PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
         }
@@ -54,10 +54,30 @@ namespace GitUI.CommandsDialogs
         {
             if (MessageBox.Show(this, _reallyCleanupQuestion.Text, _reallyCleanupQuestionCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
-                var cleanUpCmd = GitCommandHelpers.CleanUpCmd(false, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
+                var cleanUpCmd = GitCommandHelpers.CleanCmd(GetCleanMode(), dryRun: false, directories: RemoveDirectories.Checked, paths: GetPathArgumentFromGui());
                 string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
                 PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
             }
+        }
+
+        private CleanMode GetCleanMode()
+        {
+            if (RemoveAll.Checked)
+            {
+                return CleanMode.All;
+            }
+
+            if (RemoveNonIgnored.Checked)
+            {
+                return CleanMode.OnlyNonIgnored;
+            }
+
+            if (RemoveIgnored.Checked)
+            {
+                return CleanMode.OnlyIgnored;
+            }
+
+            throw new NotSupportedException($"Unknown value for {nameof(CleanMode)}.");
         }
 
         [CanBeNull]

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
 
         private void Preview_Click(object sender, EventArgs e)
         {
-            var cleanUpCmd = GitCommandHelpers.CleanUpCmd(true, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIngnored.Checked, GetPathArgumentFromGui());
+            var cleanUpCmd = GitCommandHelpers.CleanUpCmd(true, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
             string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
             PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
         }
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs
         {
             if (MessageBox.Show(this, _reallyCleanupQuestion.Text, _reallyCleanupQuestionCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
-                var cleanUpCmd = GitCommandHelpers.CleanUpCmd(false, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIngnored.Checked, GetPathArgumentFromGui());
+                var cleanUpCmd = GitCommandHelpers.CleanUpCmd(false, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
                 string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
                 PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
             }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -638,7 +638,7 @@ namespace GitUI
 
                 if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    Module.Clean(dryRun: false, directories: true);
+                    Module.Clean(CleanMode.OnlyNonIgnored, directories: true);
                 }
 
                 return true;

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -591,26 +591,24 @@ namespace GitCommandsTests.Git
         public void CleanUpCmd()
         {
             Assert.AreEqual(
-                "clean -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: true, ignored: false).Arguments);
-            Assert.AreEqual(
                 "clean --dry-run",
-                GitCommandHelpers.CleanUpCmd(dryRun: true, directories: false, nonIgnored: true, ignored: false).Arguments);
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: true, directories: false).Arguments);
+            Assert.AreEqual(
+                "clean -f",
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: false).Arguments);
             Assert.AreEqual(
                 "clean -d -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: true, nonIgnored: true, ignored: false).Arguments);
-            Assert.AreEqual(
-                "clean -x -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: false, ignored: false).Arguments);
-            Assert.AreEqual(
-                "clean -X -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: true, ignored: true).Arguments);
-            Assert.AreEqual(
-                "clean -X -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: false, ignored: true).Arguments);
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: true).Arguments);
             Assert.AreEqual(
                 "clean -f paths",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: true, ignored: false, "paths").Arguments);
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: false, "paths").Arguments);
+
+            Assert.AreEqual(
+                "clean -x -f",
+                GitCommandHelpers.CleanCmd(CleanMode.All, dryRun: false, directories: false).Arguments);
+            Assert.AreEqual(
+                "clean -X -f",
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyIgnored, dryRun: false, directories: false).Arguments);
         }
 
         [Test]


### PR DESCRIPTION
Fixes #5849 

## Proposed changes
- Cleanup arguments to CleanUpCmd, nonIgnored was reverse
- FormCommit can optionally delete new untracked files. That option previouly deleted the ignored files too. The original intention was not that, changed in ArgumentBuilder() rewrite in 3.0.
- Exception for the meaningless clean command without nonignored and ignored.

## Test methodology <!-- How did you ensure quality? -->
- Updated tests
- Manual in FormClean and FormCommit

## Test environment(s) <!-- Remove any that don't apply -->
- GIT 2.20.1