### PR TITLE
Submodule reset: Delete new files

### DIFF
--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -204,6 +204,33 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Adds the git argument syntax for members of the <see cref="ResetMode"/> enum.
+        /// </summary>
+        /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
+        /// <param name="mode">The enum member to add to the builder.</param>
+        public static void Add(this ArgumentBuilder builder, ResetMode mode)
+        {
+            builder.Add(GetArgument());
+
+            string GetArgument()
+            {
+                switch (mode)
+                {
+                    case ResetMode.ResetIndex:
+                        return "";
+                    case ResetMode.Soft:
+                        return "--soft";
+                    case ResetMode.Mixed:
+                        return "--mixed";
+                    case ResetMode.Hard:
+                        return "--hard";
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(mode), (int)mode, typeof(ResetMode));
+                }
+            }
+        }
+
+        /// <summary>
         /// Adds the git argument syntax for members of the <see cref="GitBisectOption"/> enum.
         /// </summary>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>

--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -179,6 +179,31 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Adds the git argument syntax for members of the <see cref="CleanMode"/> enum.
+        /// </summary>
+        /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
+        /// <param name="mode">The enum member to add to the builder.</param>
+        public static void Add(this ArgumentBuilder builder, CleanMode mode)
+        {
+            builder.Add(GetArgument());
+
+            string GetArgument()
+            {
+                switch (mode)
+                {
+                    case CleanMode.OnlyNonIgnored:
+                        return "";
+                    case CleanMode.OnlyIgnored:
+                        return "-X";
+                    case CleanMode.All:
+                        return "-x";
+                    default:
+                        throw new InvalidEnumArgumentException(nameof(mode), (int)mode, typeof(CleanMode));
+                }
+            }
+        }
+
+        /// <summary>
         /// Adds the git argument syntax for members of the <see cref="GitBisectOption"/> enum.
         /// </summary>
         /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -18,40 +18,40 @@ namespace GitCommands
     public enum UntrackedFilesMode
     {
         /// <summary>Default is <see cref="All"/>; when <see cref="UntrackedFilesMode"/> is NOT used, 'git status' uses <see cref="Normal"/>.</summary>
-        Default = 1,
+        Default = 0,
 
         /// <summary>Show no untracked files.</summary>
-        No = 2,
+        No,
 
         /// <summary>Shows untracked files and directories.</summary>
-        Normal = 3,
+        Normal,
 
         /// <summary>Shows untracked files and directories, and individual files in untracked directories.</summary>
-        All = 4
+        All
     }
 
     /// <summary>Specifies whether to ignore changes to submodules when looking for changes (e.g. via 'git status').</summary>
     public enum IgnoreSubmodulesMode
     {
         /// <summary>Default is <see cref="All"/> (hides all changes to submodules).</summary>
-        Default = 1,
+        Default = 0,
 
         /// <summary>Consider a submodule modified when it either:
         ///  contains untracked or modified files,
         ///  or its HEAD differs from the commit recorded in the superproject.</summary>
-        None = 2,
+        None,
 
         /// <summary>Submodules NOT considered dirty when they only contain <i>untracked</i> content
         ///  (but they are still scanned for modified content).</summary>
-        Untracked = 3,
+        Untracked,
 
         /// <summary>Ignores all changes to the work tree of submodules,
         ///  only changes to the <i>commits</i> stored in the superproject are shown.</summary>
-        Dirty = 4,
+        Dirty,
 
         /// <summary>Hides all changes to submodules
         ///  (and suppresses the output of submodule summaries when the config option status.submodulesummary is set).</summary>
-        All = 5
+        All
     }
 
     /// <summary>Mode for 'git clean'</summary>

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -54,6 +54,19 @@ namespace GitCommands
         All = 5
     }
 
+    /// <summary>Mode for 'git clean'</summary>
+    public enum CleanMode
+    {
+        /// <summary>Only untracked files not in .gitignore, the default. Git clean without either -x or -X option.</summary>
+        OnlyNonIgnored = 1,
+
+        /// <summary>Only files included in any ignore list (.gitignore, $GIT_DIR/info/exclude). Git clean with -X option.</summary>
+        OnlyIgnored = 2,
+
+        /// <summary>All files not tracked by Git. Git clean with  -x option.</summary>
+        All = 3
+    }
+
     public static class GitCommandHelpers
     {
         #region SSH / Plink
@@ -434,15 +447,20 @@ namespace GitCommands
             };
         }
 
-        public static ArgumentString CleanUpCmd(bool dryRun, bool directories, bool nonIgnored, bool ignored, string paths = null)
+        /// <summary>
+        /// Arguments for git-clean
+        /// </summary>
+        /// <param name="mode">The cleanup mode what to delete</param>
+        /// <param name="dryRun">Only show what would be deleted</param>
+        /// <param name="directories">Delete untracked directories too</param>
+        /// <param name="paths">Limit to specific paths</param>
+        public static ArgumentString CleanCmd(CleanMode mode, bool dryRun, bool directories, string paths = null)
         {
             return new GitArgumentBuilder("clean")
             {
+                mode,
                 { directories, "-d" },
-                { !nonIgnored && !ignored, "-x" },
-                { ignored, "-X" },
-                { dryRun, "--dry-run" },
-                { !dryRun, "-f" },
+                { dryRun, "--dry-run", "-f" },
                 paths
             };
         }

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -58,13 +58,31 @@ namespace GitCommands
     public enum CleanMode
     {
         /// <summary>Only untracked files not in .gitignore, the default. Git clean without either -x or -X option.</summary>
-        OnlyNonIgnored = 1,
+        OnlyNonIgnored = 0,
 
         /// <summary>Only files included in any ignore list (.gitignore, $GIT_DIR/info/exclude). Git clean with -X option.</summary>
-        OnlyIgnored = 2,
+        OnlyIgnored,
 
         /// <summary>All files not tracked by Git. Git clean with  -x option.</summary>
-        All = 3
+        All
+    }
+
+    /// <summary>Arguments to 'git reset'.</summary>
+    public enum ResetMode
+    {
+        /// <summary>(no option)</summary>
+        ResetIndex = 0,
+
+        /// <summary>--soft</summary>
+        Soft,
+
+        /// <summary>--mixed</summary>
+        Mixed,
+
+        /// <summary>--hard</summary>
+        Hard
+
+        // All options are not implemented, like --merge, --keep, --patch
     }
 
     public static class GitCommandHelpers
@@ -179,30 +197,26 @@ namespace GitCommands
             };
         }
 
-        public static ArgumentString ResetSoftCmd(string commit)
+        /// <summary>
+        /// The Git command line for reset
+        /// </summary>
+        /// <param name="mode">Reset mode</param>
+        /// <param name="commit">Optional commit-ish (for reset-index this is tree-ish and mandatory)</param>
+        /// <param name="file">Optional file to reset</param>
+        /// <returns>Argument string</returns>
+        public static ArgumentString ResetCmd(ResetMode mode, string commit = null, string file = null)
         {
-            return new GitArgumentBuilder("reset")
+            if (mode == ResetMode.ResetIndex && commit.IsNullOrWhiteSpace())
             {
-                "--soft",
-                commit.QuoteNE()
-            };
-        }
+                throw new ArgumentException("reset to index requires a tree-ish parameter");
+            }
 
-        public static ArgumentString ResetMixedCmd(string commit)
-        {
             return new GitArgumentBuilder("reset")
             {
-                "--mixed",
-                commit.QuoteNE()
-            };
-        }
-
-        public static ArgumentString ResetHardCmd(string commit)
-        {
-            return new GitArgumentBuilder("reset")
-            {
-                "--hard",
-                commit.QuoteNE()
+                mode,
+                commit.QuoteNE(),
+                "--",
+                file?.ToPosixPath().QuoteNE()
             };
         }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -579,10 +579,10 @@ namespace GitCommands
 
         #endregion
 
-        public ExecutionResult Clean(bool dryRun, bool directories = false, bool nonIgnored = false, bool ignored = false, string paths = null)
+        public ExecutionResult Clean(CleanMode mode, bool dryRun = false, bool directories = false, string paths = null)
         {
             return _gitExecutable.Execute(
-                GitCommandHelpers.CleanUpCmd(dryRun, directories, nonIgnored, ignored, paths));
+                GitCommandHelpers.CleanCmd(mode, dryRun, directories, paths));
         }
 
         public bool EditNotes(ObjectId commitId)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1471,42 +1471,9 @@ namespace GitCommands
             return _gitExecutable.GetOutput(args);
         }
 
-        // TODO use an enum to set the reset kind (soft / mixed / hard)
-
-        public void ResetSoft(string commit, string file = null)
+        public void Reset(ResetMode mode, string file = null)
         {
-            _gitExecutable.RunCommand(
-                new GitArgumentBuilder("reset")
-            {
-                "--soft",
-                commit.QuoteNE(),
-                "--",
-                file.QuoteNE()
-            });
-        }
-
-        public void ResetMixed(string commit, string file = null)
-        {
-            _gitExecutable.RunCommand(
-                new GitArgumentBuilder("reset")
-            {
-                "--mixed",
-                commit.QuoteNE(),
-                "--",
-                file.QuoteNE()
-            });
-        }
-
-        public void ResetHard(string commit, string file = null)
-        {
-            _gitExecutable.RunCommand(
-                new GitArgumentBuilder("reset")
-            {
-                "--hard",
-                commit.QuoteNE(),
-                "--",
-                file.QuoteNE()
-            });
+            _gitExecutable.RunCommand(GitCommandHelpers.ResetCmd(mode, null, file));
         }
 
         public string ResetFile(string file)
@@ -2795,12 +2762,7 @@ namespace GitCommands
 
         public void UnstageFileToRemove(string file)
         {
-            var args = new GitArgumentBuilder("reset")
-            {
-                "HEAD",
-                "--",
-                file.ToPosixPath().QuoteNE()
-            };
+            var args = GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, "HEAD", file);
             _gitExecutable.RunCommand(args);
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3091,11 +3091,7 @@ namespace GitUI.CommandsDialogs
         {
             if (AppSettings.DontConfirmUndoLastCommit || MessageBox.Show(this, _undoLastCommitText.Text, _undoLastCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
-                var args = new GitArgumentBuilder("reset")
-                {
-                    "--soft",
-                    "HEAD~1"
-                };
+                var args = GitCommandHelpers.ResetCmd(ResetMode.Soft, "HEAD~1");
                 Module.RunGitCmd(args);
                 RefreshRevisions();
             }

--- a/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
@@ -32,7 +32,7 @@
             this.Cleanup = new System.Windows.Forms.Button();
             this.Cancel = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.RemoveIngnored = new System.Windows.Forms.RadioButton();
+            this.RemoveIgnored = new System.Windows.Forms.RadioButton();
             this.RemoveNonIgnored = new System.Windows.Forms.RadioButton();
             this.RemoveAll = new System.Windows.Forms.RadioButton();
             this.RemoveDirectories = new System.Windows.Forms.CheckBox();
@@ -86,7 +86,7 @@
             //
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.Controls.Add(this.RemoveIngnored);
+            this.groupBox1.Controls.Add(this.RemoveIgnored);
             this.groupBox1.Controls.Add(this.RemoveNonIgnored);
             this.groupBox1.Controls.Add(this.RemoveAll);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
@@ -96,15 +96,15 @@
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Remove untracked files from working directory";
             //
-            // RemoveIngnored
+            // RemoveIgnored
             //
-            this.RemoveIngnored.AutoSize = true;
-            this.RemoveIngnored.Location = new System.Drawing.Point(7, 67);
-            this.RemoveIngnored.Name = "RemoveIngnored";
-            this.RemoveIngnored.Size = new System.Drawing.Size(218, 19);
-            this.RemoveIngnored.TabIndex = 2;
-            this.RemoveIngnored.Text = "Remove only ignored untracked files";
-            this.RemoveIngnored.UseVisualStyleBackColor = true;
+            this.RemoveIgnored.AutoSize = true;
+            this.RemoveIgnored.Location = new System.Drawing.Point(7, 67);
+            this.RemoveIgnored.Name = "RemoveIgnored";
+            this.RemoveIgnored.Size = new System.Drawing.Size(218, 19);
+            this.RemoveIgnored.TabIndex = 2;
+            this.RemoveIgnored.Text = "Remove only ignored untracked files";
+            this.RemoveIgnored.UseVisualStyleBackColor = true;
             //
             // RemoveNonIgnored
             //
@@ -229,7 +229,7 @@
         private System.Windows.Forms.Button Cleanup;
         private System.Windows.Forms.Button Cancel;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.RadioButton RemoveIngnored;
+        private System.Windows.Forms.RadioButton RemoveIgnored;
         private System.Windows.Forms.RadioButton RemoveNonIgnored;
         private System.Windows.Forms.RadioButton RemoveAll;
         private System.Windows.Forms.CheckBox RemoveDirectories;

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
 
         private void Preview_Click(object sender, EventArgs e)
         {
-            var cleanUpCmd = GitCommandHelpers.CleanUpCmd(true, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
+            var cleanUpCmd = GitCommandHelpers.CleanCmd(GetCleanMode(), dryRun: true, directories: RemoveDirectories.Checked, paths: GetPathArgumentFromGui());
             string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
             PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
         }
@@ -54,10 +54,30 @@ namespace GitUI.CommandsDialogs
         {
             if (MessageBox.Show(this, _reallyCleanupQuestion.Text, _reallyCleanupQuestionCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
-                var cleanUpCmd = GitCommandHelpers.CleanUpCmd(false, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
+                var cleanUpCmd = GitCommandHelpers.CleanCmd(GetCleanMode(), dryRun: false, directories: RemoveDirectories.Checked, paths: GetPathArgumentFromGui());
                 string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
                 PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
             }
+        }
+
+        private CleanMode GetCleanMode()
+        {
+            if (RemoveAll.Checked)
+            {
+                return CleanMode.All;
+            }
+
+            if (RemoveNonIgnored.Checked)
+            {
+                return CleanMode.OnlyNonIgnored;
+            }
+
+            if (RemoveIgnored.Checked)
+            {
+                return CleanMode.OnlyIgnored;
+            }
+
+            throw new NotSupportedException($"Unknown value for {nameof(CleanMode)}.");
         }
 
         [CanBeNull]

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
 
         private void Preview_Click(object sender, EventArgs e)
         {
-            var cleanUpCmd = GitCommandHelpers.CleanUpCmd(true, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIngnored.Checked, GetPathArgumentFromGui());
+            var cleanUpCmd = GitCommandHelpers.CleanUpCmd(true, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
             string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
             PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
         }
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs
         {
             if (MessageBox.Show(this, _reallyCleanupQuestion.Text, _reallyCleanupQuestionCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
-                var cleanUpCmd = GitCommandHelpers.CleanUpCmd(false, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIngnored.Checked, GetPathArgumentFromGui());
+                var cleanUpCmd = GitCommandHelpers.CleanUpCmd(false, RemoveDirectories.Checked, RemoveNonIgnored.Checked, RemoveIgnored.Checked, GetPathArgumentFromGui());
                 string cmdOutput = FormProcess.ReadDialog(this, cleanUpCmd);
                 PreviewOutput.Text = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1451,7 +1451,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                Module.ResetMixed("HEAD");
+                Module.Reset(ResetMode.Mixed);
             }
 
             Initialize();
@@ -2888,7 +2888,7 @@ namespace GitUI.CommandsDialogs
                 GitModule module = Module.GetSubmodule(item.Name);
 
                 // Reset all changes.
-                module.ResetHard("");
+                module.Reset(ResetMode.Hard);
 
                 // Also delete new files, if requested.
                 if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2893,28 +2893,7 @@ namespace GitUI.CommandsDialogs
                 // Also delete new files, if requested.
                 if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    var submoduleUnstagedFiles = module.GetWorkTreeFiles();
-                    foreach (var file in submoduleUnstagedFiles.Where(file => file.IsNew))
-                    {
-                        try
-                        {
-                            string path = _fullPathResolver.Resolve(file.Name);
-                            if (File.Exists(path))
-                            {
-                                File.Delete(path);
-                            }
-                            else
-                            {
-                                Directory.Delete(path, true);
-                            }
-                        }
-                        catch (IOException)
-                        {
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                        }
-                    }
+                    module.Clean(CleanMode.OnlyNonIgnored, directories: true);
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -633,7 +633,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (ShowAbortMessage())
                 {
-                    Module.ResetHard("");
+                    Module.Reset(ResetMode.Hard);
                     Close();
                 }
             }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -817,28 +817,7 @@ namespace GitUI.CommandsDialogs
                 // Also delete new files, if requested.
                 if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    var workTreeFiles = module.GetWorkTreeFiles();
-                    foreach (var file in workTreeFiles.Where(file => file.IsNew))
-                    {
-                        try
-                        {
-                            string path = _fullPathResolver.Resolve(file.Name);
-                            if (File.Exists(path))
-                            {
-                                File.Delete(path);
-                            }
-                            else
-                            {
-                                Directory.Delete(path, true);
-                            }
-                        }
-                        catch (IOException)
-                        {
-                        }
-                        catch (UnauthorizedAccessException)
-                        {
-                        }
-                    }
+                    module.Clean(CleanMode.OnlyNonIgnored, directories: true);
                 }
             }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -812,7 +812,7 @@ namespace GitUI.CommandsDialogs
                 GitModule module = Module.GetSubmodule(name);
 
                 // Reset all changes.
-                module.ResetHard("");
+                module.Reset(ResetMode.Hard);
 
                 // Also delete new files, if requested.
                 if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -638,7 +638,7 @@ namespace GitUI
 
                 if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
-                    Module.Clean(dryRun: false, directories: true);
+                    Module.Clean(CleanMode.OnlyNonIgnored, directories: true);
                 }
 
                 return true;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -633,7 +633,7 @@ namespace GitUI
                 else
                 {
                     // Reset all changes.
-                    Module.ResetHard("");
+                    Module.Reset(ResetMode.Hard);
                 }
 
                 if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -63,18 +63,18 @@ namespace GitUI.HelperDialogs
         {
             if (Soft.Checked)
             {
-                FormProcess.ShowDialog(this, GitCommandHelpers.ResetSoftCmd(Revision.Guid));
+                FormProcess.ShowDialog(this, GitCommandHelpers.ResetCmd(ResetMode.Soft, Revision.Guid));
             }
             else if (Mixed.Checked)
             {
-                FormProcess.ShowDialog(this, GitCommandHelpers.ResetMixedCmd(Revision.Guid));
+                FormProcess.ShowDialog(this, GitCommandHelpers.ResetCmd(ResetMode.Mixed, Revision.Guid));
             }
             else if (Hard.Checked)
             {
                 if (MessageBox.Show(this, _resetHardWarning.Text, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
                 {
                     var currentCheckout = Module.GetCurrentCheckout();
-                    if (FormProcess.ShowDialog(this, GitCommandHelpers.ResetHardCmd(Revision.Guid)))
+                    if (FormProcess.ShowDialog(this, GitCommandHelpers.ResetCmd(ResetMode.Hard, Revision.Guid)))
                     {
                         if (currentCheckout != Revision.ObjectId)
                         {

--- a/Plugins/Gerrit/FormGerritDownload.cs
+++ b/Plugins/Gerrit/FormGerritDownload.cs
@@ -119,7 +119,7 @@ namespace Gerrit
 
                         var resetCommand = UICommands.CreateRemoteCommand();
 
-                        resetCommand.CommandText = GitCommandHelpers.ResetHardCmd("FETCH_HEAD");
+                        resetCommand.CommandText = GitCommandHelpers.ResetCmd(ResetMode.Hard, "FETCH_HEAD");
 
                         if (!RunCommand(resetCommand, change))
                         {

--- a/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
 using GitUIPluginInterfaces;
@@ -252,6 +254,71 @@ namespace GitCommandsTests
                 id
             };
             Assert.AreEqual(args.ToString(), "");
+        }
+
+        [Test]
+        public void Add_ForcePushOptions_ensure_all_switches_are_handled()
+        {
+            foreach (int mode in Enum.GetValues(typeof(ForcePushOptions)))
+            {
+                // unimplemented switches will result in InvalidEnumArgumentException
+                var args = new ArgumentBuilder
+                {
+                    (ForcePushOptions)mode
+                };
+            }
+        }
+
+        [Test]
+        public void Add_GitBisectOption_ensure_all_switches_are_handled()
+        {
+            foreach (int mode in Enum.GetValues(typeof(GitBisectOption)))
+            {
+                // unimplemented switches will result in InvalidEnumArgumentException
+                var args = new ArgumentBuilder
+                {
+                    (GitBisectOption)mode
+                };
+            }
+        }
+
+        [Test]
+        public void Add_IgnoreSubmodulesMode_ensure_all_switches_are_handled()
+        {
+            foreach (int mode in Enum.GetValues(typeof(IgnoreSubmodulesMode)))
+            {
+                // unimplemented switches will result in InvalidEnumArgumentException
+                var args = new ArgumentBuilder
+                {
+                    (IgnoreSubmodulesMode)mode
+                };
+            }
+        }
+
+        [Test]
+        public void Add_CleanMode_ensure_all_switches_are_handled()
+        {
+            foreach (int mode in Enum.GetValues(typeof(CleanMode)))
+            {
+                // unimplemented switches will result in InvalidEnumArgumentException
+                var args = new ArgumentBuilder
+                {
+                    (CleanMode)mode
+                };
+            }
+        }
+
+        [Test]
+        public void Add_ResetMode_ensure_all_switches_are_handled()
+        {
+            foreach (int mode in Enum.GetValues(typeof(ResetMode)))
+            {
+                // unimplemented switches will result in InvalidEnumArgumentException
+                var args = new ArgumentBuilder
+                {
+                    (ResetMode)mode
+                };
+            }
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -637,26 +637,24 @@ namespace GitCommandsTests.Git
         public void CleanUpCmd()
         {
             Assert.AreEqual(
-                "clean -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: true, ignored: false).Arguments);
-            Assert.AreEqual(
                 "clean --dry-run",
-                GitCommandHelpers.CleanUpCmd(dryRun: true, directories: false, nonIgnored: true, ignored: false).Arguments);
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: true, directories: false).Arguments);
+            Assert.AreEqual(
+                "clean -f",
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: false).Arguments);
             Assert.AreEqual(
                 "clean -d -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: true, nonIgnored: true, ignored: false).Arguments);
-            Assert.AreEqual(
-                "clean -x -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: false, ignored: false).Arguments);
-            Assert.AreEqual(
-                "clean -X -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: true, ignored: true).Arguments);
-            Assert.AreEqual(
-                "clean -X -f",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: false, ignored: true).Arguments);
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: true).Arguments);
             Assert.AreEqual(
                 "clean -f paths",
-                GitCommandHelpers.CleanUpCmd(dryRun: false, directories: false, nonIgnored: true, ignored: false, "paths").Arguments);
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: false, "paths").Arguments);
+
+            Assert.AreEqual(
+                "clean -x -f",
+                GitCommandHelpers.CleanCmd(CleanMode.All, dryRun: false, directories: false).Arguments);
+            Assert.AreEqual(
+                "clean -X -f",
+                GitCommandHelpers.CleanCmd(CleanMode.OnlyIgnored, dryRun: false, directories: false).Arguments);
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -633,48 +633,33 @@ namespace GitCommandsTests.Git
                 () => GitCommandHelpers.RebaseCmd("branch", false, false, false, false, from: "from", onto: null));
         }
 
-        [Test]
-        public void CleanCmd()
+        [TestCase("clean --dry-run", CleanMode.OnlyNonIgnored, true, false)]
+        [TestCase("clean -f", CleanMode.OnlyNonIgnored, false, false)]
+        [TestCase("clean -d -f", CleanMode.OnlyNonIgnored, false, true)]
+        [TestCase("clean -f paths", CleanMode.OnlyNonIgnored, false, false, "paths")]
+        [TestCase("clean -x -f", CleanMode.All, false, false)]
+        [TestCase("clean -X -f", CleanMode.OnlyIgnored, false, false)]
+        public void CleanCmd(string expected, CleanMode mode, bool dryRun, bool directories, string paths = null)
         {
-            Assert.AreEqual(
-                "clean --dry-run",
-                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: true, directories: false).Arguments);
-            Assert.AreEqual(
-                "clean -f",
-                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: false).Arguments);
-            Assert.AreEqual(
-                "clean -d -f",
-                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: true).Arguments);
-            Assert.AreEqual(
-                "clean -f paths",
-                GitCommandHelpers.CleanCmd(CleanMode.OnlyNonIgnored, dryRun: false, directories: false, "paths").Arguments);
-
-            Assert.AreEqual(
-                "clean -x -f",
-                GitCommandHelpers.CleanCmd(CleanMode.All, dryRun: false, directories: false).Arguments);
-            Assert.AreEqual(
-                "clean -X -f",
-                GitCommandHelpers.CleanCmd(CleanMode.OnlyIgnored, dryRun: false, directories: false).Arguments);
+            Assert.AreEqual(expected,
+                GitCommandHelpers.CleanCmd(mode, dryRun, directories, paths).Arguments);
         }
 
         [Test]
-        public void ResetCmd()
+        public void ResetCmd_index_requires_treeish()
         {
             Assert.Throws<ArgumentException>(
                 () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, file: "file.txt"));
-            Assert.AreEqual(
-                @"reset ""tree-ish"" -- ""file.txt""",
-                GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, commit: "tree-ish", file: "file.txt").Arguments);
+        }
 
-            Assert.AreEqual(
-                @"reset --soft --",
-                GitCommandHelpers.ResetCmd(ResetMode.Soft).Arguments);
-            Assert.AreEqual(
-                @"reset --mixed --",
-                GitCommandHelpers.ResetCmd(ResetMode.Mixed).Arguments);
-            Assert.AreEqual(
-                @"reset --hard --",
-                GitCommandHelpers.ResetCmd(ResetMode.Hard).Arguments);
+        [TestCase(@"reset ""tree-ish"" -- ""file.txt""", ResetMode.ResetIndex, "tree-ish", "file.txt")]
+        [TestCase(@"reset --soft --", ResetMode.Soft)]
+        [TestCase(@"reset --mixed --", ResetMode.Mixed)]
+        [TestCase(@"reset --hard --", ResetMode.Hard)]
+        public void ResetCmd(string expected, ResetMode mode, string commit = null, string file = null)
+        {
+            Assert.AreEqual(expected,
+                GitCommandHelpers.ResetCmd(mode, commit, file).Arguments);
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -634,7 +634,7 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void CleanUpCmd()
+        public void CleanCmd()
         {
             Assert.AreEqual(
                 "clean --dry-run",
@@ -655,6 +655,26 @@ namespace GitCommandsTests.Git
             Assert.AreEqual(
                 "clean -X -f",
                 GitCommandHelpers.CleanCmd(CleanMode.OnlyIgnored, dryRun: false, directories: false).Arguments);
+        }
+
+        [Test]
+        public void ResetCmd()
+        {
+            Assert.Throws<ArgumentException>(
+                () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, file: "file.txt"));
+            Assert.AreEqual(
+                @"reset ""tree-ish"" -- ""file.txt""",
+                GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, commit: "tree-ish", file: "file.txt").Arguments);
+
+            Assert.AreEqual(
+                @"reset --soft --",
+                GitCommandHelpers.ResetCmd(ResetMode.Soft).Arguments);
+            Assert.AreEqual(
+                @"reset --mixed --",
+                GitCommandHelpers.ResetCmd(ResetMode.Mixed).Arguments);
+            Assert.AreEqual(
+                @"reset --hard --",
+                GitCommandHelpers.ResetCmd(ResetMode.Hard).Arguments);
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -633,33 +633,43 @@ namespace GitCommandsTests.Git
                 () => GitCommandHelpers.RebaseCmd("branch", false, false, false, false, from: "from", onto: null));
         }
 
-        [TestCase("clean --dry-run", CleanMode.OnlyNonIgnored, true, false)]
-        [TestCase("clean -f", CleanMode.OnlyNonIgnored, false, false)]
-        [TestCase("clean -d -f", CleanMode.OnlyNonIgnored, false, true)]
-        [TestCase("clean -f paths", CleanMode.OnlyNonIgnored, false, false, "paths")]
-        [TestCase("clean -x -f", CleanMode.All, false, false)]
-        [TestCase("clean -X -f", CleanMode.OnlyIgnored, false, false)]
-        public void CleanCmd(string expected, CleanMode mode, bool dryRun, bool directories, string paths = null)
+        [TestCase(CleanMode.OnlyNonIgnored, true, false, null, "clean --dry-run")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, null, "clean -f")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, true, null, "clean -d -f")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, "paths", "clean -f paths")]
+        [TestCase(CleanMode.OnlyIgnored, false, false, null, "clean -X -f")]
+        [TestCase(CleanMode.All, false, false, null, "clean -x -f")]
+        public void CleanCmd(CleanMode mode, bool dryRun, bool directories, string paths, string expected)
         {
-            Assert.AreEqual(expected,
-                GitCommandHelpers.CleanCmd(mode, dryRun, directories, paths).Arguments);
+            Assert.AreEqual(expected, GitCommandHelpers.CleanCmd(mode, dryRun, directories, paths).Arguments);
         }
 
-        [Test]
-        public void ResetCmd_index_requires_treeish()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("\t")]
+        public void ResetCmd_should_throw_if_ResetIndex_and_hash_is_null_or_empty(string hash)
         {
             Assert.Throws<ArgumentException>(
-                () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, file: "file.txt"));
+                () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, commit: hash, file: "file.txt"));
         }
 
-        [TestCase(@"reset ""tree-ish"" -- ""file.txt""", ResetMode.ResetIndex, "tree-ish", "file.txt")]
-        [TestCase(@"reset --soft --", ResetMode.Soft)]
-        [TestCase(@"reset --mixed --", ResetMode.Mixed)]
-        [TestCase(@"reset --hard --", ResetMode.Hard)]
-        public void ResetCmd(string expected, ResetMode mode, string commit = null, string file = null)
+        [TestCase(ResetMode.ResetIndex, "tree-ish", null, @"reset ""tree-ish"" --")]
+        [TestCase(ResetMode.ResetIndex, "tree-ish", "file.txt", @"reset ""tree-ish"" -- ""file.txt""")]
+        [TestCase(ResetMode.Soft, null, null, @"reset --soft --")]
+        [TestCase(ResetMode.Mixed, null, null, @"reset --mixed --")]
+        [TestCase(ResetMode.Hard, null, null, @"reset --hard --")]
+        [TestCase(ResetMode.Soft, "tree-ish", null, @"reset --soft ""tree-ish"" --")]
+        [TestCase(ResetMode.Mixed, "tree-ish", null, @"reset --mixed ""tree-ish"" --")]
+        [TestCase(ResetMode.Hard, "tree-ish", null, @"reset --hard ""tree-ish"" --")]
+        [TestCase(ResetMode.Soft, null, "file.txt", @"reset --soft -- ""file.txt""")]
+        [TestCase(ResetMode.Mixed, null, "file.txt", @"reset --mixed -- ""file.txt""")]
+        [TestCase(ResetMode.Hard, null, "file.txt", @"reset --hard -- ""file.txt""")]
+        [TestCase(ResetMode.Soft, "tree-ish", "file.txt", @"reset --soft ""tree-ish"" -- ""file.txt""")]
+        [TestCase(ResetMode.Mixed, "tree-ish", "file.txt", @"reset --mixed ""tree-ish"" -- ""file.txt""")]
+        [TestCase(ResetMode.Hard, "tree-ish", "file.txt", @"reset --hard ""tree-ish"" -- ""file.txt""")]
+        public void ResetCmd(ResetMode mode, string commit, string file, string expected)
         {
-            Assert.AreEqual(expected,
-                GitCommandHelpers.ResetCmd(mode, commit, file).Arguments);
+            Assert.AreEqual(expected, GitCommandHelpers.ResetCmd(mode, commit, file).Arguments);
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -389,15 +389,13 @@ namespace GitCommandsTests
             }
         }
 
-        [TestCase(null, null, "reset --hard --")]
-        [TestCase("HEAD", null, "reset --hard \"HEAD\" --")]
-        [TestCase("HEAD", "file.txt", "reset --hard \"HEAD\" -- \"file.txt\"")]
-        [TestCase(null, "file.txt", "reset --hard -- \"file.txt\"")]
-        public void ResetHard_calls_correct_command_and_parses_response(string commit, string file, string args)
+        [TestCase(null, "reset --hard --")]
+        [TestCase("file.txt", "reset --hard -- \"file.txt\"")]
+        public void Reset_with_Hard_should_issue_correct_command_and_parse_response(string file, string args)
         {
             using (_executable.StageCommand(args))
             {
-                _gitModule.ResetHard(commit, file);
+                _gitModule.Reset(ResetMode.Hard, file);
             }
         }
 


### PR DESCRIPTION
Fixes #5937
closes #5849

This includes #6001 (require the changes there, the discussions were mixed up anyway)

## Proposed changes
- Refactor Reset arguments, use mode instead of separate arguments 
- Resolve #5937 by using git-reset instead of internal handling (similar change in FormCommit in 2012 or so).

## Test methodology 
- Simplified usage and tests for the refactoring 
- Manual tests for delete

## Test environment(s) 
- GIT 2.20.1