### PR TITLE
Fix tab order of Add Submodule form

### DIFF
--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.Designer.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.Designer.cs
@@ -45,7 +45,7 @@
             this.Add.Location = new System.Drawing.Point(378, 96);
             this.Add.Name = "Add";
             this.Add.Size = new System.Drawing.Size(102, 25);
-            this.Add.TabIndex = 7;
+            this.Add.TabIndex = 8;
             this.Add.Text = "Add";
             this.Add.UseVisualStyleBackColor = true;
             this.Add.Click += new System.EventHandler(this.AddClick);
@@ -56,7 +56,7 @@
             this.Browse.Location = new System.Drawing.Point(378, 12);
             this.Browse.Name = "Browse";
             this.Browse.Size = new System.Drawing.Size(102, 25);
-            this.Browse.TabIndex = 6;
+            this.Browse.TabIndex = 2;
             this.Browse.Text = "Browse";
             this.Browse.UseVisualStyleBackColor = true;
             this.Browse.Click += new System.EventHandler(this.BrowseClick);
@@ -71,7 +71,7 @@
             this.Directory.Location = new System.Drawing.Point(144, 14);
             this.Directory.Name = "Directory";
             this.Directory.Size = new System.Drawing.Size(228, 23);
-            this.Directory.TabIndex = 5;
+            this.Directory.TabIndex = 1;
             this.Directory.SelectedIndexChanged += new System.EventHandler(this.DirectorySelectedIndexChanged);
             this.Directory.TextUpdate += new System.EventHandler(this.DirectoryTextUpdate);
             // 
@@ -81,7 +81,7 @@
             this.label1.Location = new System.Drawing.Point(5, 17);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(108, 15);
-            this.label1.TabIndex = 4;
+            this.label1.TabIndex = 0;
             this.label1.Text = "Path to submodule";
             // 
             // label2
@@ -90,7 +90,7 @@
             this.label2.Location = new System.Drawing.Point(5, 44);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(62, 15);
-            this.label2.TabIndex = 8;
+            this.label2.TabIndex = 3;
             this.label2.Text = "Local path";
             // 
             // LocalPath
@@ -100,7 +100,7 @@
             this.LocalPath.Location = new System.Drawing.Point(144, 41);
             this.LocalPath.Name = "LocalPath";
             this.LocalPath.Size = new System.Drawing.Size(228, 23);
-            this.LocalPath.TabIndex = 9;
+            this.LocalPath.TabIndex = 4;
             // 
             // label3
             // 
@@ -108,7 +108,7 @@
             this.label3.Location = new System.Drawing.Point(5, 71);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(44, 15);
-            this.label3.TabIndex = 10;
+            this.label3.TabIndex = 5;
             this.label3.Text = "Branch";
             // 
             // Branch
@@ -119,7 +119,7 @@
             this.Branch.Location = new System.Drawing.Point(144, 68);
             this.Branch.Name = "Branch";
             this.Branch.Size = new System.Drawing.Size(228, 23);
-            this.Branch.TabIndex = 11;
+            this.Branch.TabIndex = 6;
             this.Branch.DropDown += new System.EventHandler(this.BranchDropDown);
             // 
             // chkForce
@@ -128,7 +128,7 @@
             this.chkForce.Location = new System.Drawing.Point(8, 100);
             this.chkForce.Name = "chkForce";
             this.chkForce.Size = new System.Drawing.Size(55, 19);
-            this.chkForce.TabIndex = 12;
+            this.chkForce.TabIndex = 7;
             this.chkForce.Text = "Force";
             this.chkForce.UseVisualStyleBackColor = true;
             // 


### PR DESCRIPTION
Fixes tab order of Add Submodule form

* I think from left to right, from top to bottom should be the standard tab order

## Screenshots

### Before

![old](https://user-images.githubusercontent.com/748505/50528344-1312bc80-0aee-11e9-802c-efa49974ea22.png)

### After

![new](https://user-images.githubusercontent.com/748505/50528348-19a13400-0aee-11e9-837b-4c390cb19c24.png)
