### PR TITLE
Use native methods instead of recursion for resolving correct path casing

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.RegularExpressions;
 using GitCommands.Utils;
 using JetBrains.Annotations;
@@ -17,12 +14,6 @@ namespace GitCommands
 
         public static readonly char PosixDirectorySeparatorChar = '/';
         public static readonly char NativeDirectorySeparatorChar = Path.DirectorySeparatorChar;
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        internal static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        internal static extern int GetLongPathName(string lpszShortPath, StringBuilder lpszLongPath, int cchBuffer);
 
         /// <summary>Replaces native path separator with posix path separator.</summary>
         [NotNull]
@@ -254,50 +245,6 @@ namespace GitCommands
             }
 
             return path;
-        }
-
-        /// <summary>
-        /// Gets the exact case used on the file system for an existing file or directory.
-        /// </summary>
-        /// <param name="path">A relative or absolute path.</param>
-        /// <param name="exactPath">The full path using the correct case if the path exists.  Otherwise, null.</param>
-        /// <returns>True if the exact path was found.  False otherwise.</returns>
-        /// <remarks>
-        /// This supports drive-lettered paths and UNC paths, but a UNC root
-        /// will be returned in lowercase (e.g., \\server\share).
-        /// </remarks>
-        [ContractAnnotation("=>false,exactPath:null")]
-        [ContractAnnotation("=>true,exactPath:notnull")]
-        [ContractAnnotation("path:null=>false,exactPath:null")]
-        public static bool TryGetExactPath(string path, out string exactPath)
-        {
-            if (!File.Exists(path) && !Directory.Exists(path))
-            {
-                exactPath = null;
-                return false;
-            }
-
-            // The section below contains native windows (kernel32) calls
-            // and breaks on Linux. Only use it on Windows. Casing is only
-            // a Windows problem anyway.
-            if (EnvUtils.RunningOnWindows())
-            {
-                // grab the 8.3 file path
-                var shortPath = new StringBuilder(4096);
-                if (GetShortPathName(path, shortPath, shortPath.Capacity) > 0)
-                {
-                    // use 8.3 file path to get properly cased full file path
-                    var longPath = new StringBuilder(4096);
-                    if (GetLongPathName(shortPath.ToString(), longPath, longPath.Capacity) > 0)
-                    {
-                        exactPath = longPath.ToString();
-                        return true;
-                    }
-                }
-            }
-
-            exactPath = path;
-            return true;
         }
 
         [CanBeNull]

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands;
-using GitCommands.Utils;
 using GitExtUtils.GitUI;
 using GitUI.Properties;
 using JetBrains.Annotations;
@@ -27,6 +26,7 @@ namespace GitUI.CommandsDialogs
         private readonly FilterBranchHelper _filterBranchHelper;
         private readonly FormBrowseMenus _formBrowseMenus;
         private readonly IFullPathResolver _fullPathResolver;
+        private readonly FormFileHistoryController _controller = new FormFileHistoryController();
 
         private BuildReportTabPageExtension _buildReportTabPageExtension;
 
@@ -198,7 +198,7 @@ namespace GitUI.CommandsDialogs
                 // we will need this later to look up proper casing for the file
                 var fullFilePath = _fullPathResolver.Resolve(fileName);
 
-                if (PathUtil.TryGetExactPath(fullFilePath, out fileName))
+                if (_controller.TryGetExactPath(fullFilePath, out fileName))
                 {
                     fileName = fileName.Substring(Module.WorkingDir.Length);
                 }

--- a/GitUI/CommandsDialogs/FormFileHistoryController.cs
+++ b/GitUI/CommandsDialogs/FormFileHistoryController.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Text;
+using GitCommands.Utils;
+using JetBrains.Annotations;
+
+namespace GitUI.CommandsDialogs
+{
+    public sealed class FormFileHistoryController
+    {
+        /// <summary>
+        /// Gets the exact case used on the file system for an existing file or directory.
+        /// </summary>
+        /// <param name="path">A relative or absolute path.</param>
+        /// <param name="exactPath">The full path using the correct case if the path exists.  Otherwise, null.</param>
+        /// <returns>True if the exact path was found.  False otherwise.</returns>
+        /// <remarks>
+        /// This supports drive-lettered paths and UNC paths, but a UNC root
+        /// will be returned in lowercase (e.g., \\server\share).
+        /// </remarks>
+        [ContractAnnotation("=>false,exactPath:null")]
+        [ContractAnnotation("=>true,exactPath:notnull")]
+        [ContractAnnotation("path:null=>false,exactPath:null")]
+        public bool TryGetExactPath(string path, out string exactPath)
+        {
+            if (!File.Exists(path) && !Directory.Exists(path))
+            {
+                exactPath = null;
+                return false;
+            }
+
+            // The section below contains native windows (kernel32) calls
+            // and breaks on Linux. Only use it on Windows. Casing is only
+            // a Windows problem anyway.
+            if (EnvUtils.RunningOnWindows())
+            {
+                // grab the 8.3 file path
+                var shortPath = new StringBuilder(4096);
+                if (NativeMethods.GetShortPathName(path, shortPath, shortPath.Capacity) > 0)
+                {
+                    // use 8.3 file path to get properly cased full file path
+                    var longPath = new StringBuilder(4096);
+                    if (NativeMethods.GetLongPathName(shortPath.ToString(), longPath, longPath.Capacity) > 0)
+                    {
+                        exactPath = longPath.ToString();
+                        return true;
+                    }
+                }
+            }
+
+            exactPath = path;
+            return true;
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -146,6 +146,7 @@
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommand.cs" />
     <Compile Include="CommandsDialogs\BrowseDialog\MenuCommandsBase.cs" />
     <Compile Include="CommandsDialogs\FormBrowseController.cs" />
+    <Compile Include="CommandsDialogs\FormFileHistoryController.cs" />
     <Compile Include="CommandsDialogs\FullBleedTabControl.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -93,6 +93,12 @@ namespace GitUI
         internal static extern bool ShowCaretAPI(
             IntPtr hwnd);
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern int GetLongPathName(string lpszShortPath, StringBuilder lpszLongPath, int cchBuffer);
+
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
         internal static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
 

--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -93,12 +93,6 @@ namespace GitUI
         internal static extern bool ShowCaretAPI(
             IntPtr hwnd);
 
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        internal static extern uint GetShortPathName(string lpszLongPath, StringBuilder lpszShortPath, int cchBuffer);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        internal static extern int GetLongPathName(string lpszShortPath, StringBuilder lpszLongPath, int cchBuffer);
-
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
         internal static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
 

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -232,14 +232,8 @@ namespace GitCommandsTests.Helpers
                 @"C:\Program Files (x86)",
                 @"Does not exist",
                 @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32",
-                @"..",
                 "",
                 " "
-            };
-
-            var expectedExactPaths = new Dictionary<string, string>()
-            {
-                { @"..", Path.GetDirectoryName(Environment.CurrentDirectory) },
             };
 
             foreach (var path in paths)
@@ -252,8 +246,7 @@ namespace GitCommandsTests.Helpers
 
                 if (actual)
                 {
-                    var expectedPath = expectedExactPaths.TryGetValue(path, out string expectedExactPath) ? expectedExactPath : path;
-                    Assert.AreEqual(expectedPath.ToLower(), exactPath.ToLower());
+                    Assert.AreEqual(path.ToLower(), exactPath.ToLower());
                 }
                 else
                 {

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using NUnit.Framework;
@@ -215,62 +214,6 @@ namespace GitCommandsTests.Helpers
 
             Assert.AreEqual(@"~\SomePath", PathUtil.GetDisplayPath(Path.Combine(home, "SomePath")));
             Assert.AreEqual("c:\\SomePath", PathUtil.GetDisplayPath("c:\\SomePath"));
-        }
-
-        [Test]
-        public void TryGetExactPathName()
-        {
-            // TODO: needs rework/refactor
-
-            var paths = new[]
-            {
-                @"C:\Users\Public\desktop.ini",
-                @"C:\pagefile.sys",
-                @"C:\Windows\System32\cmd.exe",
-                @"C:\Users\Default\NTUSER.DAT",
-                @"C:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies",
-                @"C:\Program Files (x86)",
-                @"Does not exist",
-                @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32",
-                "",
-                " "
-            };
-
-            foreach (var path in paths)
-            {
-                var lowercasePath = path.ToLower();
-                var expected = File.Exists(lowercasePath) || Directory.Exists(lowercasePath);
-                var actual = PathUtil.TryGetExactPath(lowercasePath, out string exactPath);
-
-                Assert.AreEqual(expected, actual);
-
-                if (actual)
-                {
-                    Assert.AreEqual(path.ToLower(), exactPath.ToLower());
-                }
-                else
-                {
-                    Assert.IsNull(exactPath);
-                }
-            }
-        }
-
-        [TestCase("Folder1\\file1.txt", true, true)]
-        [TestCase("FOLDER1\\file1.txt", true, false)]
-        [TestCase("fOLDER1\\file1.txt", true, false)]
-        [TestCase("Folder2\\file1.txt", false, false)]
-        public void TryGetExactPathName_should_check_if_path_matches_case(string relativePath, bool isResolved, bool doesMatch)
-        {
-            using (var repo = new GitModuleTestHelper())
-            {
-                // Create a file
-                var notUsed = repo.CreateFile(Path.Combine(repo.TemporaryPath, "Folder1"), "file1.txt", "bla");
-
-                var expected = Path.Combine(repo.TemporaryPath, relativePath);
-
-                Assert.AreEqual(isResolved, PathUtil.TryGetExactPath(expected, out string exactPath));
-                Assert.AreEqual(doesMatch, exactPath == expected);
-            }
         }
 
         [Test]

--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using CommonTestUtils;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs
+{
+    [TestFixture]
+    public sealed class FormFileHistoryControllerTests
+    {
+        private FormFileHistoryController _controller;
+
+        [SetUp]
+        public void Setup()
+        {
+            _controller = new FormFileHistoryController();
+        }
+
+        [Test]
+        public void TryGetExactPathName()
+        {
+            // TODO: needs rework/refactor
+
+            var paths = new[]
+            {
+                @"C:\Users\Public\desktop.ini",
+                @"C:\pagefile.sys",
+                @"C:\Windows\System32\cmd.exe",
+                @"C:\Users\Default\NTUSER.DAT",
+                @"C:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies",
+                @"C:\Program Files (x86)",
+                @"Does not exist",
+                @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32",
+                "",
+                " "
+            };
+
+            foreach (var path in paths)
+            {
+                var lowercasePath = path.ToLower();
+                var expected = File.Exists(lowercasePath) || Directory.Exists(lowercasePath);
+                var actual = _controller.TryGetExactPath(lowercasePath, out string exactPath);
+
+                Assert.AreEqual(expected, actual);
+
+                if (actual)
+                {
+                    Assert.AreEqual(path.ToLower(), exactPath.ToLower());
+                }
+                else
+                {
+                    Assert.IsNull(exactPath);
+                }
+            }
+        }
+
+        [TestCase("Folder1\\file1.txt", true, true)]
+        [TestCase("FOLDER1\\file1.txt", true, false)]
+        [TestCase("fOLDER1\\file1.txt", true, false)]
+        [TestCase("Folder2\\file1.txt", false, false)]
+        public void TryGetExactPathName_should_check_if_path_matches_case(string relativePath, bool isResolved, bool doesMatch)
+        {
+            using (var repo = new GitModuleTestHelper())
+            {
+                // Create a file
+                var notUsed = repo.CreateFile(Path.Combine(repo.TemporaryPath, "Folder1"), "file1.txt", "bla");
+
+                var expected = Path.Combine(repo.TemporaryPath, relativePath);
+
+                Assert.AreEqual(isResolved, _controller.TryGetExactPath(expected, out string exactPath));
+                Assert.AreEqual(doesMatch, exactPath == expected);
+            }
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="CancellationTokenSequenceTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormInitTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormCommitTests.cs" />
+    <Compile Include="CommandsDialogs\FormFileHistoryControllerTests.cs" />
     <Compile Include="CommandsDialogs\ReferenceRepository.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffContextMenuControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />


### PR DESCRIPTION
Fixes #5963

## Proposed changes
- Use native methods (from FileHistory code) to find proper casing for path.
- The method is not used for recentrepositories. This PR only merges the 2 existing methods for resolving path casing.

## Test methodology

- Unit tests
- No manual testing done

## Test environment(s)

- Git Extensions 3.00.00.4429
- Build c15bad2784fbfc0261427b371fda07348acc52c5
- Git 2.19.2.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3221.0
- DPI 120dpi (125% scaling)
