### PR TITLE
Include Microsoft.VisualStudio.Composition.dll in setup package

### DIFF
--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -58,6 +58,8 @@ xcopy /y ..\GitExtensions\bin\%Configuration%\PSTaskDialog.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\GitExtensions\bin\%Configuration%\ResourceManager.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
+xcopy /y ..\GitExtensions\bin\%Configuration%\Microsoft.VisualStudio.Composition.dll GitExtensions\
+IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\GitExtensions\bin\%Configuration%\Microsoft.VisualStudio.Threading.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y ..\GitExtensions\bin\%Configuration%\Microsoft.VisualStudio.Validation.dll GitExtensions\

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -98,6 +98,9 @@
       <Component Id="RestSharp.dll" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\RestSharp.dll" />
       </Component>
+      <Component Id="Microsoft.VisualStudio.Composition.dll" Guid="*">
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\Microsoft.VisualStudio.Composition.dll" />
+      </Component>
       <Component Id="Microsoft.VisualStudio.Threading.dll" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\Microsoft.VisualStudio.Threading.dll" />
       </Component>
@@ -607,6 +610,7 @@
       <ComponentRef Id="English.Plugins.xlf" />
       <ComponentRef Id="Git.hub.dll" />
       <ComponentRef Id="RestSharp.dll" />
+      <ComponentRef Id="Microsoft.VisualStudio.Composition.dll" />
       <ComponentRef Id="Microsoft.VisualStudio.Threading.dll" />
       <ComponentRef Id="Microsoft.VisualStudio.Validation.dll" />
       <ComponentRef Id="System.Runtime.InteropServices.RuntimeInformation.dll" />


### PR DESCRIPTION
## Proposed changes
- Microsoft.VisualStudio.Composition.dll was recently included in Plugin.Interfaces project but hasn't been included in setup package thus producing an exception upon app start.

## Test methodology

- Installed custom built setup to make sure the crash does not happen any more
- Verified this dll is included in portable version zip