### PR TITLE
CommitInfo message events did not trigger

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -101,6 +101,9 @@ namespace GitUI.CommitInfo
             this.rtbxCommitMessage.Size = new System.Drawing.Size(440, 20);
             this.rtbxCommitMessage.TabIndex = 1;
             this.rtbxCommitMessage.Text = "";
+            this.rtbxCommitMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
+            this.rtbxCommitMessage.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
+            this.rtbxCommitMessage.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 
             // commitInfoContextMenuStrip
             // 


### PR DESCRIPTION
Affected:
 * Clicking links
 * Copying text was not in plain text but RichTextBox_KeyDown
 * Mouse key navigation (back/forward) did not register

Fixes #5904

## Proposed changes
- Adding the RichBoxText delegates missing when the box was split in two late in 3.0

## Test methodology <!-- How did you ensure quality? -->
- Manual 

## Test environment(s)