### PR TITLE
Fix ROT selected node ensuring visible without collapsing other nodes…

### DIFF
--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -65,6 +65,8 @@ namespace GitUI
 
         internal const int WM_USER = 0x0400;
         internal const int EM_FORMATRANGE = WM_USER + 57;
+        internal const int WM_HSCROLL = 276;
+        internal const int SB_LEFT = 6;
 
         // from vsstyle.h
         internal const int TEXT_MAININSTRUCTION = 1;


### PR DESCRIPTION
… in tree

[Recent fix](https://github.com/gitextensions/gitextensions/commit/ef1b946a40cabd121d42eeb133b33863d56e273b) set Scrollable to false to avoid horizontal scroll, but setting this property has the side effect of collapsing all nodes in the tree. The solution provided in this change has the same net effect, without messing up the expanded/collapsed state of the tree at this point.

## Proposed changes

I'm not sure if anyone saw [my post on the merged PR here](https://github.com/gitextensions/gitextensions/pull/5910#issuecomment-450247964), but as I explain there, the fix has the unwanted side effect of collapsing the entire tree, and only expanding it to the selected node. The fix I put in place here gives us exactly what we want: it maintains the expanded/collapsed state of the tree, while scrolling the selected node into view, but keeping horizontal scroll at 0.

I spent a lot of time on this, testing different approaches. Many people recommend using SetScrollPos (e.g. [here](https://stackoverflow.com/questions/25352834/c-sharp-treeview-ensurevisible-how-else-can-i-scroll)), but as described on [CodeProject here](https://www.codeproject.com/Articles/10023/TreeView-without-right-scrolling), using SendMessage is better because it can be done outside of Begin/EndUpdate.

I also opportunistically made a small change to avoid having to wait for the UI thread explicitly by using ConfigureAwait(true).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Without my change, you can see that everything is collapsed except "master" node and its parent "Branches":

![image](https://user-images.githubusercontent.com/6893883/50543652-fe94f980-0bab-11e9-91b4-8aa14bb525b7.png)

### After

With my change, we maintain the expanded/collapsed state that the ROT established:

![image](https://user-images.githubusercontent.com/6893883/50543587-867a0400-0baa-11e9-877c-d71517fca4d0.png)

This is very important, since each root node -- Branches, Remotes, and Tags -- are responsible for setting their own expanded state. For example, Remotes expands itself, while Tags collapses itself. Furthermore, my Submodules ROT work also needs to control its node expansion state.

Now some screenshots that show that it still brings the selected node into view, while keeping the horizontal scroll flush to the left:

I have a repo with lots and lots of branches, and I purposely scroll away from the selected branch both vertically and horizontally:

![image](https://user-images.githubusercontent.com/6893883/50543608-17e97600-0bab-11e9-8e55-55aeaddd8a5e.png)

And after hitting F5 to refresh:

![image](https://user-images.githubusercontent.com/6893883/50543611-233ca180-0bab-11e9-846c-c8d5b55fdba1.png)


## Test methodology <!-- How did you ensure quality? -->

- Tested with different repos, especially one with many branches, and tested refresh with scroll positions at different places.
- Tested switching between repos, in particular between those with very few branches so that there's no scrolling, and with repos that have large number of branches with both vertical and horizontal scroll.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT git version 2.19.1.windows.1
- Windows 10
