### PR TITLE
Fix broken custom stash message

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -314,16 +314,22 @@ namespace GitCommands
 
         public static ArgumentString StashSaveCmd(bool untracked, bool keepIndex, string message, IReadOnlyList<string> selectedFiles)
         {
-            var isPartialStash = selectedFiles != null && selectedFiles.Any();
+            if (selectedFiles == null)
+            {
+                selectedFiles = Array.Empty<string>();
+            }
+
+            var isPartialStash = selectedFiles.Any();
 
             return new GitArgumentBuilder("stash")
             {
                 { isPartialStash, "push", "save" },
                 { untracked && GitVersion.Current.StashUntrackedFilesSupported, "-u" },
                 { keepIndex, "--keep-index" },
-                message.QuoteNE(),
+                { isPartialStash && !string.IsNullOrWhiteSpace(message), "-m" },
+                { !string.IsNullOrWhiteSpace(message), message.Quote() },
                 { isPartialStash, "--" },
-                { isPartialStash, selectedFiles }
+                { isPartialStash, string.Join(" ", selectedFiles.Where(path => !string.IsNullOrWhiteSpace(path)).Select(path => path.QuoteNE())) }
             };
         }
 

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -525,8 +525,54 @@ namespace GitCommandsTests.Git
                 GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, "message", null).Arguments);
 
             Assert.AreEqual(
-                "stash push -- a b",
+                "stash push -- \"a\" \"b\"",
                 GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, null, new[] { "a", "b" }).Arguments);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\t")]
+        public void StashSaveCmd_should_not_add_empty_message_full_stash(string theMessage)
+        {
+            Assert.AreEqual(
+               "stash save",
+               GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, theMessage, Array.Empty<string>()).Arguments);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\t")]
+        public void StashPushCmd_should_not_add_empty_message_partial_stash(string theMessage)
+        {
+            Assert.AreEqual(
+               "stash push -- \"a\" \"b\"",
+               GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, theMessage, new[] { "a", "b" }).Arguments);
+        }
+
+        [Test]
+        public void StashSaveCmd_should_add_message_if_provided_full_stash()
+        {
+            Assert.AreEqual(
+               "stash save \"test message\"",
+               GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, "test message", Array.Empty<string>()).Arguments);
+        }
+
+        [Test]
+        public void StashPushCmd_should_add_message_if_provided_partial_stash()
+        {
+            Assert.AreEqual(
+               "stash push -m \"test message\" -- \"a\" \"b\"",
+               GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, "test message", new[] { "a", "b" }).Arguments);
+        }
+
+        [Test]
+        public void StashPushCmd_should_not_add_null_or_empty_filenames()
+        {
+            Assert.AreEqual(
+               "stash push -- \"a\"",
+               GitCommandHelpers.StashSaveCmd(untracked: false, keepIndex: false, null, new[] { null, "", "a" }).Arguments);
         }
 
         [Test]


### PR DESCRIPTION
fix custom stash message broken

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6016 


## Proposed changes

- code kindly provided by Jay Asbury, user vbjay


### Before

stash custom message broken

### After

not broken, and added a check for empty message

## Test methodology <!-- How did you ensure quality? -->

- I didn't write any tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.00.00.4433
- Build fca7cf228b481ee8c1b779cf7b882ccdfbdcd1bc
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.15063.0
- .NET Framework 4.7.3260.0
- DPI 96dpi (no scaling)

