### PR TITLE
Diff window exception when adding a submodule without history

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -140,7 +140,7 @@ namespace GitCommands
             var treeGuid = ObjectId.Parse(lines[1]);
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
-            var parentGuids = lines[2].Split(' ').Select(id => ObjectId.Parse(id)).ToList();
+            var parentGuids = lines[2].Split(' ').Where(id => id.IsNotNullOrWhitespace()).Select(id => ObjectId.Parse(id)).ToList();
             var author = module.ReEncodeStringFromLossless(lines[3]);
             var authorDate = DateTimeUtils.ParseUnixTime(lines[4]);
             var committer = module.ReEncodeStringFromLossless(lines[5]);


### PR DESCRIPTION
Fixes #5873

## Proposed changes
Add a check for parsing information for submodules in Diff (Commit or RevisionDiff)
Check if parent is not null or empty before parsing.
Parent will be null if a submodule is new and the submodule has no history

## Test methodology <!-- How did you ensure quality? -->
See test case in the issue

## Test environment(s) 
- GIT 2.20.1
