### PR TITLE
Exception if no current checkout when selecting current revision

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2644,7 +2644,13 @@ namespace GitUI
                 case Commands.ShowFilteredBranches: ShowFilteredBranches(); break;
                 case Commands.ShowRemoteBranches: ToggleShowRemoteBranches(); break;
                 case Commands.ShowFirstParent: ShowFirstParent(); break;
-                case Commands.SelectCurrentRevision: SetSelectedRevision(new GitRevision(CurrentCheckout)); break;
+                case Commands.SelectCurrentRevision:
+                    if (CurrentCheckout != null)
+                    {
+                        SetSelectedRevision(new GitRevision(CurrentCheckout));
+                    }
+
+                    break;
                 case Commands.GoToCommit: MenuCommands.GotoCommitExecute(); break;
                 case Commands.GoToParent: goToParentToolStripMenuItem_Click(); break;
                 case Commands.GoToMergeBaseCommit: goToMergeBaseCommitToolStripMenuItem_Click(null, null); break;


### PR DESCRIPTION
Seen in #5873

## Proposed changes
If navigating to current revision (Ctrl-Shift-C) and there is no current revision, GE will fail with an exception

## Test methodology
Manual

Create a new orphan branch, then Ctrl-Shift-C

## Test environment(s) 