### PR TITLE
Git Notes not displayed in Commit info

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1138,6 +1138,7 @@ namespace GitCommands
                 MessageEncoding = lines[9]
             };
 
+            revision.HasNotes = !shortFormat;
             if (shortFormat)
             {
                 revision.Subject = ReEncodeCommitMessage(lines[10], revision.MessageEncoding);

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -87,6 +87,7 @@ namespace GitCommands
         [CanBeNull]
         public string Body { get; set; }
         public bool HasMultiLineMessage { get; set; }
+        public bool HasNotes { get; set; }
 
         // UTF-8 when is null or empty
         public string MessageEncoding { get; set; }

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -104,7 +104,9 @@ namespace GitCommands
 
             var arguments = BuildArguments(refFilterOptions, branchFilter, revisionFilter, pathFilter);
 
+#if TRACE
             var sw = Stopwatch.StartNew();
+#endif
 
             // This property is relatively expensive to call for every revision, so
             // cache it for the duration of the loop.
@@ -148,7 +150,9 @@ namespace GitCommands
                     }
                 }
 
+#if TRACE
                 Trace.WriteLine($"**** [{nameof(RevisionReader)}] Emitted {revisionCount} revisions in {sw.Elapsed.TotalMilliseconds:#,##0.#} ms. bufferSize={buffer.Length} poolCount={stringPool.Count}");
+#endif
             }
 
             if (!token.IsCancellationRequested)
@@ -426,7 +430,8 @@ namespace GitCommands
                 MessageEncoding = encodingName,
                 Subject = subject,
                 Body = body,
-                HasMultiLineMessage = !ReferenceEquals(subject, body)
+                HasMultiLineMessage = !ReferenceEquals(subject, body),
+                HasNotes = false
             };
 
             return true;

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -630,6 +630,8 @@ namespace GitUI.CommitInfo
         private void addNoteToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Module.EditNotes(_revision.ObjectId);
+            _revision.HasNotes = false;
+            _revision.Body = null;
             ReloadCommitInfo();
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -208,10 +208,11 @@ namespace GitUI.CommitInfo
             {
                 var data = _commitDataManager.CreateFromRevision(_revision, _children);
 
-                if (_revision != null && _revision.Body == null)
+                if (_revision != null && (_revision.Body == null || (AppSettings.ShowGitNotes && !_revision.HasNotes)))
                 {
                     _commitDataManager.UpdateBody(data, out _);
                     _revision.Body = data.Body;
+                    _revision.HasNotes = true;
                 }
 
                 var commitMessage = _commitDataBodyRenderer.Render(data, showRevisionsAsLinks: CommandClickedEvent != null);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -941,7 +941,8 @@ namespace GitUI
                         CommitDate = DateTime.MaxValue,
                         CommitterEmail = userEmail,
                         Subject = Strings.Workspace,
-                        ParentIds = new[] { ObjectId.IndexId }
+                        ParentIds = new[] { ObjectId.IndexId },
+                        HasNotes = true
                     };
                     _gridView.Add(workTreeRev);
 
@@ -955,7 +956,8 @@ namespace GitUI
                         CommitDate = DateTime.MaxValue,
                         CommitterEmail = userEmail,
                         Subject = Strings.Index,
-                        ParentIds = new[] { filteredCurrentCheckout }
+                        ParentIds = new[] { filteredCurrentCheckout },
+                        HasNotes = true
                     };
                     _gridView.Add(indexRev);
 


### PR DESCRIPTION
Fixes #5653

## Proposed changes
GE supports adding Git Notes in the commit info view, shown as a part of 

In 2.x GE always fetched CommitInfo separately for each commit.
In 3.0 the full commit message is saved for commits newer than 6 months and information if multiline existed is stored with each commit. Git Notes is not fetched at this stage.
Git Notes were therefore just shown for multiline messages older than six months.

This PR will fetch the Git Notes if not done already for each commit similar to 2.x.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/6248932/50577557-c3ecc480-0e2a-11e9-93a3-99ee99091bb6.png)

![image](https://user-images.githubusercontent.com/6248932/50577569-f1397280-0e2a-11e9-897c-645ed878cee5.png)

### After
![image](https://user-images.githubusercontent.com/6248932/50577581-16c67c00-0e2b-11e9-8e45-4c7fe1c92dc6.png)

## Test methodology <!-- How did you ensure quality? -->
Manual

## Test environment(s) 