### PR TITLE
Solved column size problem in FileStatusList

### DIFF
--- a/GitUI/UserControls/ExListView.cs
+++ b/GitUI/UserControls/ExListView.cs
@@ -391,7 +391,7 @@ namespace GitUI.UserControls
                         break;
 
                     case NativeMethods.WM_MOUSEWHEEL:
-                        type = HighWord(msg.WParam.ToInt32()) > 0
+                        type = HighWord(msg.WParam.ToInt64()) > 0
                             ? ScrollEventType.SmallDecrement
                             : ScrollEventType.SmallIncrement;
                         break;

--- a/GitUI/UserControls/ExListView.cs
+++ b/GitUI/UserControls/ExListView.cs
@@ -373,11 +373,10 @@ namespace GitUI.UserControls
                     break;
 
                 default:
+                    HandleScroll(m);
                     base.WndProc(ref m);
                     break;
             }
-
-            HandleScroll(m);
 
             void HandleScroll(Message msg)
             {
@@ -387,12 +386,14 @@ namespace GitUI.UserControls
                 switch (msg.Msg)
                 {
                     case NativeMethods.WM_VSCROLL:
-                        type = (ScrollEventType)(msg.WParam.ToInt32() & 0xffff);
-                        newValue = msg.WParam.ToInt32() & 0x0000ffff;
+                        type = (ScrollEventType)LowWord(msg.WParam.ToInt64());
+                        newValue = HighWord(msg.WParam.ToInt64());
                         break;
 
                     case NativeMethods.WM_MOUSEWHEEL:
-                        type = ScrollEventType.EndScroll;
+                        type = HighWord(msg.WParam.ToInt32()) > 0
+                            ? ScrollEventType.SmallDecrement
+                            : ScrollEventType.SmallIncrement;
                         break;
 
                     case NativeMethods.WM_KEYDOWN:
@@ -428,6 +429,12 @@ namespace GitUI.UserControls
 
                 newValue = newValue ?? NativeMethods.GetScrollPos(Handle, NativeMethods.SB_VERT);
                 Scroll?.Invoke(this, new ScrollEventArgs(type, newValue.Value));
+
+                short LowWord(long number) =>
+                    unchecked((short)(number & 0x0000ffff));
+
+                short HighWord(long number) =>
+                    unchecked((short)(number >> 16));
             }
 
             void HandleAddedGroup(Message msg)

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -40,10 +40,12 @@
             // 
             // FileStatusListView
             // 
+            this.FileStatusListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.FileStatusListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.FileStatusListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader});
-            this.FileStatusListView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.FileStatusListView.FullRowSelect = true;
             this.FileStatusListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
             this.FileStatusListView.HideSelection = false;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -40,10 +40,7 @@ namespace GitUI
         private IReadOnlyList<(GitRevision revision, IReadOnlyList<GitItemStatus> statuses)> _itemsWithParent = Array.Empty<(GitRevision, IReadOnlyList<GitItemStatus>)>();
         [CanBeNull] private IDisposable _selectedIndexChangeSubscription;
 
-        /// <summary>
-        /// flag to prevent recursion ClientSizeChanged -> UpdateColumnWidth -> ScrollBar visibility changed -> ClientSizeChanged
-        /// </summary>
-        private bool _handlingClientSizeChange;
+        private bool _updatingColumnWidth;
 
         public event EventHandler SelectedIndexChanged;
         public event EventHandler DataSourceChanged;
@@ -943,45 +940,34 @@ namespace GitUI
             }
         }
 
-        private void UpdateColumnWidth(Action onComplete = null)
+        private void UpdateColumnWidth()
         {
-            var pathFormatter = new PathFormatter(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
-            var minWidth = FileStatusListView.ClientSize.Width;
-
-            var contentWidth = FileStatusListView.Items()
-                .Where(item => item.BoundsOrEmpty().IntersectsWith(FileStatusListView.ClientRectangle))
-                .Select(item =>
-                {
-                    var (_, _, textStart, textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);
-                    return textStart + textWidth;
-                })
-                .DefaultIfEmpty(minWidth)
-                .Max();
-
-            int width = Math.Max(minWidth, contentWidth);
-
-            if (width == columnHeader.Width)
+            // prevent infinite recursions such as
+            // ClientSizeChanged -> UpdateColumnWidth -> ScrollBar visibility changed -> ClientSizeChanged
+            if (!_updatingColumnWidth)
             {
-                onComplete?.Invoke();
-                return;
+                _updatingColumnWidth = true;
+                columnHeader.Width = GetWidth();
+                _updatingColumnWidth = false;
             }
 
-            FileStatusListView.BeginUpdate();
-            columnHeader.Width = width;
-
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            int GetWidth()
             {
-                // by postponing ListView redraw we workaround the bug
-                // that renders ListView unusable if column Width is set within any
-                // event handler like SizeChanged, ClientSizeChanged, Layout and etc.
-                // https://github.com/gitextensions/gitextensions/issues/5437
-                await Task.Delay(TimeSpan.FromMilliseconds(10));
+                var pathFormatter = new PathFormatter(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
+                var controlWidth = FileStatusListView.ClientSize.Width;
 
-                await this.SwitchToMainThreadAsync();
-                FileStatusListView.EndUpdate();
+                var contentWidth = FileStatusListView.Items()
+                    .Where(item => item.BoundsOrEmpty().IntersectsWith(FileStatusListView.ClientRectangle))
+                    .Select(item =>
+                    {
+                        (_, _, int textStart, int textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);
+                        return textStart + textWidth;
+                    })
+                    .DefaultIfEmpty(controlWidth)
+                    .Max();
 
-                onComplete?.Invoke();
-            }).FileAndForget();
+                return Math.Max(contentWidth, controlWidth);
+            }
         }
 
         private void HandleVisibility_NoFilesLabel_FilterComboBox(bool filesPresent)
@@ -1002,11 +988,7 @@ namespace GitUI
                 return;
             }
 
-            if (!_handlingClientSizeChange)
-            {
-                _handlingClientSizeChange = true;
-                UpdateColumnWidth(onComplete: () => _handlingClientSizeChange = false);
-            }
+            UpdateColumnWidth();
         }
 
         private void FileStatusListView_ContextMenu_Opening(object sender, CancelEventArgs e)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -983,11 +983,6 @@ namespace GitUI
 
         private void FileStatusListView_ClientSizeChanged(object sender, EventArgs e)
         {
-            if (!IsHandleCreated || !FileStatusListView.IsHandleCreated || !FileStatusListView.Created || DesignMode)
-            {
-                return;
-            }
-
             UpdateColumnWidth();
         }
 


### PR DESCRIPTION
Fixes #5917

## Proposed changes

Turns out the problem was caused by setting `Dock.Fill` to `ListView` control.
After figuring that out there is no need in hack with resizing column after a small delay.

## Test methodology

Manual

## Test environment(s)

Windows 7 SP1