### PR TITLE
Hide depreciated lfs-clone option

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -16,6 +16,7 @@ namespace GitCommands
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
         private static readonly GitVersion v2_11_0 = new GitVersion("2.11.0");
+        private static readonly GitVersion v2_15_0 = new GitVersion("2.15.0");
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
 
         public static readonly GitVersion LastSupportedVersion = v2_11_0;
@@ -115,6 +116,8 @@ namespace GitCommands
         public bool SupportMergeUnrelatedHistory => this >= v2_9_0;
 
         public bool SupportStatusPorcelainV2 => this >= v2_11_0;
+
+        public bool DepreciatedLfsClone => this >= v2_15_0;
 
         public bool SupportNoOptionalLocks => this >= v2_15_2;
 

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -170,8 +170,9 @@ namespace GitUI.CommandsDialogs
 
             FromTextUpdate(null, null);
 
+            cbLfs.Visible = !GitVersion.Current.DepreciatedLfsClone;
             cbLfs.Enabled = Module.HasLfsSupport();
-            if (!cbLfs.Enabled)
+            if (!cbLfs.Enabled || !cbLfs.Visible)
             {
                 cbLfs.Checked = false;
             }


### PR DESCRIPTION
Fixes #5905 
Closes #5972

## Proposed changes
- Hide lfs-clone if the option is depreciated
Also solves layout in i.e. Russian

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/6248932/50730291-27883200-114a-11e9-9afa-73eed3023db5.png)

### After
![image](https://user-images.githubusercontent.com/6248932/50730296-4981b480-114a-11e9-945c-8ca4d1e61ebe.png)

![image](https://user-images.githubusercontent.com/6248932/50730303-661dec80-114a-11e9-8fcc-84c83c162c05.png)

## Test methodology <!-- How did you ensure quality? -->

- Open dialog and check that the correct option appears


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.20.1