### PR TITLE
Update Git recommended version to 2.20.1

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -21,7 +21,7 @@ namespace GitCommands
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
 
         public static readonly GitVersion LastSupportedVersion = v2_11_0;
-        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.19.1");
+        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.20.1");
 
         private static GitVersion _current;
 


### PR DESCRIPTION
Fixes #6038

## Proposed changes
Update the recommended Git version 2.19.1 -> 2.20.1

2.21 just released (not git-for-windows yet), not many changes there

## Test methodology <!-- How did you ensure quality? -->
Usage of Git since release 21 days ago (and 2.10 before that).
No major changes in 2.20

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.20.1