### PR TITLE
Avoid adding newline at the end of formatted output

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1122,7 +1122,7 @@ namespace GitCommands
             var args = new GitArgumentBuilder("log")
             {
                 "-n1",
-                $"--format={format}",
+                $"--pretty=format:{format}",
                 objectId
             };
 


### PR DESCRIPTION
Fixes #5804

## Proposed changes
FormFileHistory and FormCommitDiff Displayed "Notes:" also when there were none due to a newline being added to the git-log output.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/50791651-c33cae00-12c2-11e9-8c0b-51bcc2233e50.png)

### After

![image](https://user-images.githubusercontent.com/6248932/50791735-0139d200-12c3-11e9-899e-edf82d604274.png)

## Test methodology <!-- How did you ensure quality? -->
Manual

Double-click in the revision graph or check file history

## Test environment(s)