### PR TITLE
Fix copying RichTextBox text and restore context menu for CommitInfoHeader

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -122,6 +122,8 @@ namespace GitUI.CommitInfo
                     .Throttle(TimeSpan.FromMilliseconds(100))
                     .ObserveOn(MainThreadScheduler.Instance)
                     .Subscribe(_ => handler(_.EventArgs));
+
+            commitInfoHeader.SetContextMenuStrip(commitInfoContextMenuStrip);
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -51,6 +51,11 @@ namespace GitUI.CommitInfo
                 .Subscribe(_ => rtbRevisionHeader_ContentsResized(_.EventArgs));
         }
 
+        public void SetContextMenuStrip(ContextMenuStrip contextMenuStrip)
+        {
+            rtbRevisionHeader.ContextMenuStrip = contextMenuStrip;
+        }
+
         public void ShowCommitInfo(GitRevision revision, IReadOnlyList<ObjectId> children)
         {
             this.InvokeAsync(() =>

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1109,7 +1109,6 @@ namespace GitUI.Editor.RichTextBoxExtension
                 return string.Empty;
             }
 
-            ////rtb.HideSelection = true;
             IntPtr oldMask = rtb.BeginUpdate();
 
             int nStart = rtb.SelectionStart;
@@ -1136,15 +1135,12 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
             finally
             {
-                //--------------------------
                 // finish, restore
                 rtb.SelectionStart = nStart;
                 rtb.SelectionLength = nEnd;
 
                 rtb.EndUpdate(oldMask);
-                rtb.HideSelection = false;
-
-                //--------------------------
+                rtb.Invalidate();
             }
 
             return text.ToString();


### PR DESCRIPTION
Fixes #6045

## Proposed changes

- restore symmetry, i.e. do not touch `rtb.HideSelection` at all
- invalidate RichTextBox after `EndUpdate`
- assign context menu to CommitInfoHeader, too

## Screenshots

### After

![grafik](https://user-images.githubusercontent.com/36601201/50799609-00ae3500-12dd-11e9-96b0-a20f5f55db65.png)

## Test methodology

- manual testing

## Test environment

- Git Extensions 3.01.00.0
- Build 4d1f476ec202a5a2ee08ce4a96b5bb3daf83a05f
- Git 2.20.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)