### PR TITLE
Introduce option to disable build result tab #6063

### DIFF
--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -113,12 +113,14 @@ namespace GitCommands.Settings
     {
         public readonly StringSetting Type;
         public readonly BoolNullableSetting EnableIntegration;
+        public readonly BoolNullableSetting ShowBuildResultPage;
 
         public BuildServer(RepoDistSettings container)
             : base(container, "BuildServer")
         {
             Type = new StringSetting("Type", this, null);
             EnableIntegration = new BoolNullableSetting("EnableIntegration", this, defaultValue: false);
+            ShowBuildResultPage = new BoolNullableSetting("ShowBuildResultPage", this, defaultValue: true);
         }
 
         public SettingsPath TypeSettings => new SettingsPath(this, Type.ValueOrDefault);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1279,7 +1279,7 @@ namespace GitUI.CommandsDialogs
 
             if (_buildReportTabPageExtension == null)
             {
-                _buildReportTabPageExtension = new BuildReportTabPageExtension(CommitInfoTabControl, _buildReportTabCaption.Text);
+                _buildReportTabPageExtension = new BuildReportTabPageExtension(() => Module, CommitInfoTabControl, _buildReportTabCaption.Text);
             }
 
             // Note: FillBuildReport will check if tab is visible and revision is OK

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -395,7 +395,7 @@ namespace GitUI.CommandsDialogs
 
             if (_buildReportTabPageExtension == null)
             {
-                _buildReportTabPageExtension = new BuildReportTabPageExtension(tabControl1, _buildReportTabCaption.Text);
+                _buildReportTabPageExtension = new BuildReportTabPageExtension(() => Module, tabControl1, _buildReportTabCaption.Text);
             }
 
             _buildReportTabPageExtension.FillBuildReport(selectedRevisions.Count == 1 ? revision : null);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
@@ -23,6 +23,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.checkBoxEnableBuildServerIntegration = new System.Windows.Forms.CheckBox();
             this.labelBuildServerSettingsInfo = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.checkBoxShowBuildResultPage = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -31,11 +32,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.buildServerSettingsPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.SetColumnSpan(this.buildServerSettingsPanel, 2);
             this.buildServerSettingsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.buildServerSettingsPanel.Location = new System.Drawing.Point(0, 99);
+            this.buildServerSettingsPanel.Location = new System.Drawing.Point(0, 120);
             this.buildServerSettingsPanel.Margin = new System.Windows.Forms.Padding(0, 10, 3, 2);
             this.buildServerSettingsPanel.MinimumSize = new System.Drawing.Size(343, 197);
             this.buildServerSettingsPanel.Name = "buildServerSettingsPanel";
-            this.buildServerSettingsPanel.Size = new System.Drawing.Size(531, 420);
+            this.buildServerSettingsPanel.Size = new System.Drawing.Size(1549, 197);
             this.buildServerSettingsPanel.TabIndex = 5;
             // 
             // BuildServerType
@@ -44,10 +45,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.BuildServerType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.BuildServerType.Enabled = false;
             this.BuildServerType.FormattingEnabled = true;
-            this.BuildServerType.Location = new System.Drawing.Point(97, 66);
+            this.BuildServerType.Location = new System.Drawing.Point(94, 87);
             this.BuildServerType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.BuildServerType.Name = "BuildServerType";
-            this.BuildServerType.Size = new System.Drawing.Size(434, 21);
+            this.BuildServerType.Size = new System.Drawing.Size(1455, 21);
             this.BuildServerType.TabIndex = 4;
             this.BuildServerType.SelectedIndexChanged += new System.EventHandler(this.BuildServerType_SelectedIndexChanged);
             // 
@@ -55,9 +56,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             // 
             this.labelBuildServerType.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.labelBuildServerType.AutoSize = true;
-            this.labelBuildServerType.Location = new System.Drawing.Point(3, 70);
+            this.labelBuildServerType.Location = new System.Drawing.Point(3, 91);
             this.labelBuildServerType.Name = "labelBuildServerType";
-            this.labelBuildServerType.Size = new System.Drawing.Size(88, 13);
+            this.labelBuildServerType.Size = new System.Drawing.Size(85, 13);
             this.labelBuildServerType.TabIndex = 3;
             this.labelBuildServerType.Text = "Build server type";
             // 
@@ -69,7 +70,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.checkBoxEnableBuildServerIntegration.Location = new System.Drawing.Point(3, 45);
             this.checkBoxEnableBuildServerIntegration.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.checkBoxEnableBuildServerIntegration.Name = "checkBoxEnableBuildServerIntegration";
-            this.checkBoxEnableBuildServerIntegration.Size = new System.Drawing.Size(172, 17);
+            this.checkBoxEnableBuildServerIntegration.Size = new System.Drawing.Size(168, 17);
             this.checkBoxEnableBuildServerIntegration.TabIndex = 1;
             this.checkBoxEnableBuildServerIntegration.Text = "Enable build server integration";
             this.checkBoxEnableBuildServerIntegration.ThreeState = true;
@@ -82,7 +83,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.labelBuildServerSettingsInfo.Location = new System.Drawing.Point(3, 0);
             this.labelBuildServerSettingsInfo.Margin = new System.Windows.Forms.Padding(3, 0, 3, 30);
             this.labelBuildServerSettingsInfo.Name = "labelBuildServerSettingsInfo";
-            this.labelBuildServerSettingsInfo.Size = new System.Drawing.Size(507, 13);
+            this.labelBuildServerSettingsInfo.Size = new System.Drawing.Size(488, 13);
             this.labelBuildServerSettingsInfo.TabIndex = 0;
             this.labelBuildServerSettingsInfo.Text = "Git Extensions can integrate with build servers to supply per-commit Continuous I" +
     "ntegration information.";
@@ -96,6 +97,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.labelBuildServerSettingsInfo, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.checkBoxEnableBuildServerIntegration, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.checkBoxShowBuildResultPage, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.labelBuildServerType, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.buildServerSettingsPanel, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.BuildServerType, 1, 2);
@@ -107,9 +109,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(534, 706);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1552, 894);
             this.tableLayoutPanel1.TabIndex = 6;
+            // 
+            // checkBoxShowBuildResultPage
+            // 
+            this.checkBoxShowBuildResultPage.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.checkBoxShowBuildResultPage, 2);
+            this.checkBoxShowBuildResultPage.Enabled = false;
+            this.checkBoxShowBuildResultPage.Location = new System.Drawing.Point(3, 66);
+            this.checkBoxShowBuildResultPage.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.checkBoxShowBuildResultPage.Name = "checkBoxShowBuildResultPage";
+            this.checkBoxShowBuildResultPage.Size = new System.Drawing.Size(133, 17);
+            this.checkBoxShowBuildResultPage.TabIndex = 2;
+            this.checkBoxShowBuildResultPage.Text = "Show build result page";
+            this.checkBoxShowBuildResultPage.ThreeState = true;
+            this.checkBoxShowBuildResultPage.UseVisualStyleBackColor = true;
             // 
             // BuildServerIntegrationSettingsPage
             // 
@@ -118,7 +135,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.MinimumSize = new System.Drawing.Size(454, 286);
             this.Name = "BuildServerIntegrationSettingsPage";
-            this.Size = new System.Drawing.Size(534, 706);
+            this.Size = new System.Drawing.Size(1552, 894);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
@@ -134,5 +151,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private System.Windows.Forms.CheckBox checkBoxEnableBuildServerIntegration;
         private System.Windows.Forms.Label labelBuildServerSettingsInfo;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.CheckBox checkBoxShowBuildResultPage;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -46,6 +46,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     await this.SwitchToMainThreadAsync();
 
                     checkBoxEnableBuildServerIntegration.Enabled = true;
+                    checkBoxShowBuildResultPage.Enabled = true;
                     BuildServerType.Enabled = true;
 
                     BuildServerType.DataSource = new[] { _noneItem.Text }.Concat(buildServerTypes).ToArray();
@@ -65,6 +66,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     await this.SwitchToMainThreadAsync();
 
                     checkBoxEnableBuildServerIntegration.SetNullableChecked(CurrentSettings.BuildServer.EnableIntegration.Value);
+                    checkBoxShowBuildResultPage.SetNullableChecked(CurrentSettings.BuildServer.ShowBuildResultPage.Value);
 
                     BuildServerType.SelectedItem = CurrentSettings.BuildServer.Type.Value ?? _noneItem.Text;
                 });
@@ -73,6 +75,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             CurrentSettings.BuildServer.EnableIntegration.Value = checkBoxEnableBuildServerIntegration.GetNullableChecked();
+            CurrentSettings.BuildServer.ShowBuildResultPage.Value = checkBoxShowBuildResultPage.GetNullableChecked();
 
             var selectedBuildServerType = GetSelectedBuildServerType();
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -61,3 +61,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/01/24, NikolayXHD, Nikolai Idalgo Dias, hidalgo1984@list.ru
 2019/01/24, mast-eu, Martin Steinisch, martin.steinisch@gmail.com
 2019/01/24, pmiossec, Philippe Miossec, pmiossec@gmail.com
+2019/01/24, IEVin, Ivan Vinogradov, i.e.vin@ya.ru


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6063 Introduce option to disable build result tab

## Proposed changes
- In Tools/Options/Build server integration add new option "Show build result page". By default this option enabled. If you disable this option the build results tab will not be loaded. These changes affect the main window and the history window.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![2](https://user-images.githubusercontent.com/5438647/50832749-30525100-1360-11e9-880d-6fea18a5a684.png)
![3](https://user-images.githubusercontent.com/5438647/50832835-7a3b3700-1360-11e9-97f1-af2c484168ae.png)
<!-- TODO -->

### After
![6](https://user-images.githubusercontent.com/5438647/50832996-f170cb00-1360-11e9-9fb8-f1a484bad03f.png)
![5](https://user-images.githubusercontent.com/5438647/50832934-bff7ff80-1360-11e9-9666-671e51e49e3c.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

-  Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.20.1 <!-- Add version 2.11 or above -->
- Windows 10 x64 <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->
