### PR TITLE
Fix "Delete all" context action on branch folder in left panel

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -145,10 +145,7 @@ namespace GitUI.BranchTreePanel
 
             public void Delete()
             {
-                UICommands.StartDeleteBranchDialog(ParentWindow(), new[]
-                {
-                    FullPath
-                });
+                UICommands.StartDeleteBranchDialog(ParentWindow(), FullPath);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs
 
             if (_defaultBranches != null)
             {
-                Branches.SetSelectedText(_defaultBranches.Join(", "));
+                Branches.SetSelectedText(_defaultBranches.Join(" "));
             }
         }
 


### PR DESCRIPTION
FormDeleteBranch expects a space-separated list of branches, not comma-separated.
Also opportunistically modified call to UICommands.StartDeleteBranchDialog to use overload that takes a single branch.

Fixes #6068


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/6893883/50948858-143ed480-1472-11e9-95fa-4be52785922d.png)

### After

![image](https://user-images.githubusercontent.com/6893883/50948920-510acb80-1472-11e9-98ec-f522123b1a43.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Made sure Delete All, then Delete and Select multiple branches functionality in FormDeleteBranch work as expected.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10
