### PR TITLE
Fix possible ArgumentException on startup

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -290,7 +290,10 @@ namespace GitUI.CommandsDialogs
                 Brush lastBrush = null;
 
                 gitStatusMonitor = new GitStatusMonitor(this);
-                DeActivateGitStatusMonitor();
+                if (!NeedsGitStatusMonitor())
+                {
+                    gitStatusMonitor.Active = false;
+                }
 
                 gitStatusMonitor.GitStatusMonitorStateChanged += (s, e) =>
                 {
@@ -561,9 +564,9 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void DeActivateGitStatusMonitor()
+        private bool NeedsGitStatusMonitor()
         {
-            _gitStatusMonitor.Active = AppSettings.ShowGitStatusInBrowseToolbar || (AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowWorkingDirChanges);
+            return AppSettings.ShowGitStatusInBrowseToolbar || (AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowWorkingDirChanges);
         }
 
         private void UICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
@@ -1445,7 +1448,7 @@ namespace GitUI.CommandsDialogs
 
             _dashboard?.RefreshContent();
 
-            DeActivateGitStatusMonitor();
+            _gitStatusMonitor.Active = NeedsGitStatusMonitor();
         }
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
bug fix for PR #6020

## Proposed changes

- do not enter the GitStatusMonitor's state Running in the constructor -- as before PR #6020 -- to avoid an ArgumentException which was thrown under some conditions (reported in [#6005](https://github.com/gitextensions/gitextensions/pull/6005#issuecomment-452557155))

## Test methodology

- manual testing, thanks to @vbjay

## Test environment(s)

- Git Extensions 3.01.00.0
- Build 5da362915f3b82abfbf18c67fbc32c5ffd6ccb21
- Git 2.20.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)