### PR TITLE
Fix 6075 update gh issues link

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -235,13 +235,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void GitHubItem_Click(object sender, EventArgs e)
         {
-            Process.Start(@"http://github.com/gitextensions/gitextensions");
+            Process.Start(@"https://github.com/gitextensions/gitextensions");
         }
 
         private static void IssuesItem_Click(object sender, EventArgs e)
         {
             UserEnvironmentInformation.CopyInformation();
-            Process.Start(@"http://github.com/gitextensions/gitextensions/issues");
+            Process.Start(@"https://github.com/gitextensions/gitextensions/issues");
         }
 
         private void openItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2738,7 +2738,7 @@ namespace GitUI.CommandsDialogs
         private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UserEnvironmentInformation.CopyInformation();
-            Process.Start(@"https://github.com/gitextensions/gitextensions/issues/new");
+            Process.Start(@"https://github.com/gitextensions/gitextensions/issues");
         }
 
         private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Plugins/Gerrit/FormGitReview.cs
+++ b/Plugins/Gerrit/FormGitReview.cs
@@ -155,7 +155,7 @@ namespace Gerrit
 
         private void lnkGitReviewPatterns_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"http://github.com/openstack-infra/git-review#git-review");
+            Process.Start(@"https://github.com/openstack-infra/git-review#git-review");
         }
     }
 }

--- a/Plugins/Gerrit/FormPluginInformation.cs
+++ b/Plugins/Gerrit/FormPluginInformation.cs
@@ -24,7 +24,7 @@ namespace Gerrit
 
         private void _NO_TRANSLATE_TargetLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"http://github.com/openstack-infra/git-review#git-review");
+            Process.Start(@"https://github.com/openstack-infra/git-review#git-review");
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Closes #6075


## Proposed changes

- Direct users to GH issues page where they can click "New Issue" button.
This is necessary to simplify our management of issue and feature templates that are no provided via a new link such as: `https://github.com/gitextensions/gitextensions/issues/new/choose`
