### PR TITLE
Add context menu item "Copy link" to Commit Info

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
 
 namespace GitUI.CommitInfo
 {
@@ -35,6 +37,7 @@ namespace GitUI.CommitInfo
             this.pnlCommitMessage = new System.Windows.Forms.Panel();
             this.rtbxCommitMessage = new System.Windows.Forms.RichTextBox();
             this.commitInfoContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.copyLinkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyCommitInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.showContainedInBranchesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -108,6 +111,7 @@ namespace GitUI.CommitInfo
             // commitInfoContextMenuStrip
             // 
             this.commitInfoContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyLinkToolStripMenuItem,
             this.copyCommitInfoToolStripMenuItem,
             this.toolStripSeparator1,
             this.showContainedInBranchesToolStripMenuItem,
@@ -120,12 +124,20 @@ namespace GitUI.CommitInfo
             this.addNoteToolStripMenuItem});
             this.commitInfoContextMenuStrip.Name = "commitInfoContextMenuStrip";
             this.commitInfoContextMenuStrip.Size = new System.Drawing.Size(454, 192);
+            this.commitInfoContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.commitInfoContextMenuStrip_Opening);
+            // 
+            // copyLinkStripMenuItem
+            // 
+            this.copyLinkToolStripMenuItem.Name = "copyLinkStripMenuItem";
+            this.copyLinkToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
+            this.copyLinkToolStripMenuItem.Text = "Copy link";
+            this.copyLinkToolStripMenuItem.Click += new System.EventHandler(this.copyLinkToolStripMenuItem_Click);
             // 
             // copyCommitInfoToolStripMenuItem
             // 
             this.copyCommitInfoToolStripMenuItem.Name = "copyCommitInfoToolStripMenuItem";
             this.copyCommitInfoToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
-            this.copyCommitInfoToolStripMenuItem.Text = "Copy commit info";
+            this.copyCommitInfoToolStripMenuItem.Text = "&Copy commit info";
             this.copyCommitInfoToolStripMenuItem.Click += new System.EventHandler(this.copyCommitInfoToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
@@ -184,7 +196,7 @@ namespace GitUI.CommitInfo
             // 
             this.addNoteToolStripMenuItem.Name = "addNoteToolStripMenuItem";
             this.addNoteToolStripMenuItem.Size = new System.Drawing.Size(453, 22);
-            this.addNoteToolStripMenuItem.Text = "Add notes";
+            this.addNoteToolStripMenuItem.Text = "Add &notes";
             this.addNoteToolStripMenuItem.Click += new System.EventHandler(this.addNoteToolStripMenuItem_Click);
             // 
             // commitInfoHeader
@@ -242,6 +254,7 @@ namespace GitUI.CommitInfo
 
         private System.Windows.Forms.RichTextBox RevisionInfo;
         private System.Windows.Forms.ContextMenuStrip commitInfoContextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem copyLinkToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showContainedInBranchesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showContainedInTagsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyCommitInfoToolStripMenuItem;

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -44,14 +44,15 @@ namespace GitUI.CommitInfo
             }
         }
 
-        private readonly TranslationString _containedInBranches = new TranslationString("Contained in branches:");
-        private readonly TranslationString _containedInNoBranch = new TranslationString("Contained in no branch");
-        private readonly TranslationString _containedInTags = new TranslationString("Contained in tags:");
-        private readonly TranslationString _containedInNoTag = new TranslationString("Contained in no tag");
-        private readonly TranslationString _trsLinksRelatedToRevision = new TranslationString("Related links:");
-        private readonly TranslationString _derivesFromTag = new TranslationString("Derives from tag:");
-        private readonly TranslationString _derivesFromNoTag = new TranslationString("Derives from no tag");
-        private readonly TranslationString _plusCommits = new TranslationString("commits");
+        private static readonly TranslationString _copyLink = new TranslationString("Copy &link ({0})");
+        private static readonly TranslationString _containedInBranches = new TranslationString("Contained in branches:");
+        private static readonly TranslationString _containedInNoBranch = new TranslationString("Contained in no branch");
+        private static readonly TranslationString _containedInTags = new TranslationString("Contained in tags:");
+        private static readonly TranslationString _containedInNoTag = new TranslationString("Contained in no tag");
+        private static readonly TranslationString _trsLinksRelatedToRevision = new TranslationString("Related links:");
+        private static readonly TranslationString _derivesFromTag = new TranslationString("Derives from tag:");
+        private static readonly TranslationString _derivesFromNoTag = new TranslationString("Derives from no tag");
+        private static readonly TranslationString _plusCommits = new TranslationString("commits");
 
         private const int MaximumDisplayedRefs = 20;
         private readonly ILinkFactory _linkFactory = new LinkFactory();
@@ -585,6 +586,27 @@ namespace GitUI.CommitInfo
 
                 return WebUtility.HtmlEncode(_containedInNoTag.Text);
             }
+        }
+
+        private void commitInfoContextMenuStrip_Opening(object sender, CancelEventArgs e)
+        {
+            var rtb = (sender as ContextMenuStrip)?.SourceControl as RichTextBox;
+            if (rtb == null)
+            {
+                copyLinkToolStripMenuItem.Visible = false;
+                return;
+            }
+
+            int charIndex = rtb.GetCharIndexFromPosition(rtb.PointToClient(MousePosition));
+            string link = rtb.GetLink(charIndex);
+            copyLinkToolStripMenuItem.Visible = link != null;
+            copyLinkToolStripMenuItem.Text = string.Format(_copyLink.Text, link);
+            copyLinkToolStripMenuItem.Tag = link;
+        }
+
+        private void copyLinkToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ClipboardUtil.TrySetText(copyLinkToolStripMenuItem.Tag as string);
         }
 
         private void showContainedInBranchesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/UnitTests/GitUITests/Editor/RichTextBoxXhtmlSupportExtensionTests.cs
+++ b/UnitTests/GitUITests/Editor/RichTextBoxXhtmlSupportExtensionTests.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Net;
+using System.Text;
+using System.Windows.Forms;
+using FluentAssertions;
+using GitUI.Editor.RichTextBoxExtension;
+using NUnit.Framework;
+using ResourceManager;
+
+namespace GitUITests.Editor
+{
+    [TestFixture]
+    public class RichTextBoxXhtmlSupportExtensionTests
+    {
+        private const string _defaultLinkText = "link";
+        private const string _defaultLinkUri = "https://uri.org";
+        private const string _defaultPrefix = "pre ";
+        private const string _defaultSuffix = " suf";
+
+        private RichTextBox _rtb;
+        private ILinkFactory _linkFactory;
+
+        [SetUp]
+        public void Setup()
+        {
+            _rtb = new RichTextBox();
+            _linkFactory = new LinkFactory();
+        }
+
+        private void SetupLink(string prefix, string linkText, string uri, string suffix)
+        {
+            var text = new StringBuilder();
+
+            if (prefix != null)
+            {
+                text.Append(prefix);
+            }
+
+            if (uri != null)
+            {
+                if (linkText == null)
+                {
+                    text.Append(WebUtility.HtmlEncode(uri));
+                }
+                else
+                {
+                    text.Append(_linkFactory.CreateLink(linkText, uri));
+                }
+            }
+
+            if (suffix != null)
+            {
+                text.Append(suffix);
+            }
+
+            _rtb.SetXHTMLText(text.ToString());
+        }
+
+        private void SetupDefaultLink()
+        {
+            SetupLink(_defaultPrefix, _defaultLinkText, _defaultLinkUri, _defaultSuffix);
+        }
+
+        [Test]
+        public void GetLink_should_return_null_if_index_is_invalid()
+        {
+            SetupLink(prefix: "", linkText: null, uri: null, suffix: "");
+            _rtb.GetLink(-1).Should().BeNull();
+            _rtb.GetLink(0).Should().BeNull();
+
+            SetupDefaultLink();
+            _rtb.GetLink(-1).Should().BeNull();
+            _rtb.GetLink(_rtb.Text.Length).Should().BeNull();
+        }
+
+        [Test]
+        public void GetLink_should_return_null_if_left_of_link()
+        {
+            SetupDefaultLink();
+            for (int index = 0; index < _defaultPrefix.Length; ++index)
+            {
+                _rtb.GetLink(index).Should().BeNull();
+            }
+        }
+
+        [Test]
+        public void GetLink_should_return_null_if_right_of_link()
+        {
+            SetupDefaultLink();
+            for (int index = _defaultPrefix.Length + _defaultLinkText.Length; index < _rtb.Text.Length; ++index)
+            {
+                _rtb.GetLink(index).Should().BeNull();
+            }
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_at_link()
+        {
+            SetupDefaultLink();
+            for (int index = _defaultPrefix.Length; index < _defaultPrefix.Length + _defaultLinkText.Length; ++index)
+            {
+                _rtb.GetLink(index).Should().Be(_defaultLinkUri);
+            }
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_begins_with_link()
+        {
+            SetupLink(prefix: null, _defaultLinkText, _defaultLinkUri, _defaultSuffix);
+            _rtb.GetLink(0).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_link_at_line_begin()
+        {
+            SetupLink(_defaultPrefix + "\n", _defaultLinkText, _defaultLinkUri, _defaultSuffix);
+            _rtb.GetLink(_defaultPrefix.Length + 1).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_ends_with_link()
+        {
+            SetupLink(_defaultPrefix, _defaultLinkText, _defaultLinkUri, suffix: null);
+            _rtb.GetLink(_defaultPrefix.Length).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_link_at_line_end()
+        {
+            SetupLink(_defaultPrefix, _defaultLinkText, _defaultLinkUri, "\n" + _defaultSuffix);
+            _rtb.GetLink(_defaultPrefix.Length).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_comma_after_link()
+        {
+            SetupLink(_defaultPrefix, _defaultLinkText, _defaultLinkUri, "," + _defaultSuffix);
+            _rtb.GetLink(_defaultPrefix.Length).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_without_link_text()
+        {
+            SetupLink(_defaultPrefix, null, _defaultLinkUri, _defaultSuffix);
+            _rtb.GetLink(_defaultPrefix.Length).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_ends_with_link_without_link_text()
+        {
+            SetupLink(_defaultPrefix, null, _defaultLinkUri, suffix: null);
+            _rtb.GetLink(_defaultPrefix.Length).Should().Be(_defaultLinkUri);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ControlThreadingExtensionsTests.cs" />
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />
     <Compile Include="Editor\FileViewerTextTests.cs" />
+    <Compile Include="Editor\RichTextBoxXhtmlSupportExtensionTests.cs" />
     <Compile Include="FindFilePredicateProviderTest.cs" />
     <Compile Include="GitExtensionsFormTests.cs" />
     <Compile Include="Helpers\DiffKindRevisionTests.cs" />


### PR DESCRIPTION
Fixes #6088

## Proposed changes

- add a context menu item `Copy link` to the Commit Info which copies the link under the mouse to the Clipboard
- add shortcuts to other menu items which trigger actions
- remove the unused function and its overload `RichTextBoxXhtmlSupportExtension.AddLink()`

## Screenshots

### Before

![grafik](https://user-images.githubusercontent.com/36601201/50998299-465e3e00-1527-11e9-882b-80e966713c31.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/50998197-04cd9300-1527-11e9-9c3a-064627af0e08.png)![grafik](https://user-images.githubusercontent.com/36601201/50999962-fafa5e80-152b-11e9-9290-4db90580f5d6.png)

## Test methodology

- manual testing
- NUnit test for `RichTextBoxXhtmlSupportExtension.GetLink()`

## Test environment

- Git Extensions 3.01.00.0
- Build 6c16ec5a9a04632859ec2d1f882f36eb9bce5959
- Git 2.20.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)