### PR TITLE
Feature/6094

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -223,9 +223,15 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// </summary>
         private bool CheckRowCacheIsDirty(IList<RevisionGraphRow> orderedRowCache, IList<RevisionGraphRevision> orderedNodesCache)
         {
-            int indexToCompare = orderedRowCache.Count - 1;
+            // We need bounds checking on orderedNodesCache. It should be always larger then the rowcache,
+            // but another thread could clear the orderedNodesCache while another is building orderedRowCache.
+            // This is not a problem, since all methods use local instances of those caches. We do need to invalidate.
+            if (orderedRowCache.Count > orderedNodesCache.Count)
+            {
+                return true;
+            }
 
-            // We do not need bounds checking on orderedNodesCache. It is always larger then the rowcache.
+            int indexToCompare = orderedRowCache.Count - 1;
             return orderedRowCache[indexToCompare].Revision != orderedNodesCache[indexToCompare];
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6094

## Proposed changes

- Added bounds checking to orderedNodesCache.
- It is possible (it happens..) that one thread is building the orderedRowCache and another is clearing orderedNodesCache. We should do bounds checking to validate this.
- Mark rowcache as dirty if it is larger then the orderedNodesCache

## Test methodology <!-- How did you ensure quality? -->

- Compiling

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.00.00.4429
- Build c15bad2784fbfc0261427b371fda07348acc52c5
- Git 2.19.2.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3221.0
- DPI 120dpi (125% scaling)
