### PR TITLE
Update View menu items when toggled

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1814,12 +1814,14 @@ namespace GitUI
         internal void ToggleShowAuthorDate()
         {
             AppSettings.ShowAuthorDate = !AppSettings.ShowAuthorDate;
+            MenuCommands.TriggerMenuChanged();
             Refresh();
         }
 
         internal void ToggleShowRemoteBranches()
         {
             AppSettings.ShowRemoteBranches = !AppSettings.ShowRemoteBranches;
+            MenuCommands.TriggerMenuChanged();
             _gridView.Invalidate();
         }
 
@@ -1885,6 +1887,7 @@ namespace GitUI
         internal void ToggleShowRelativeDate(EventArgs e)
         {
             AppSettings.RelativeDate = !AppSettings.RelativeDate;
+            MenuCommands.TriggerMenuChanged();
             Refresh();
         }
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -54,3 +54,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/01/23, amaiorano, Antonio Maiorano, amaiorano@gmail.com
 2019/01/23, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
 2019/01/24, KindDragon, Arkadii Shapkin, arkady.shapkin@gmail.com
+2019/01/24, DCFerg, Dan Ferguson, dferguson.gh@gmail.com


### PR DESCRIPTION
"Show relative date", "Show author date", and "Show remote branches"
in the View menu are now correctly checked or unchecked when they are
toggled.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6086


## Proposed changes

Add MenuCommands.TriggerMenuChanged() call to procedures ToggleShowAuthorDate, ToggleShowRemoteBranches, and ToggleShowRelativeDate.


## Test methodology <!-- How did you ensure quality? -->

- Observe that the View menu status for options "Show remote branches", "Show author date",  and "Show relative date" have toggled after clicking them and then returning to the View menu. 
- Confirm that the displayed status of the View menu option matches the current display in the main view (e.g., if "Show relative date" is checked, relative dates are being shown.)


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.00.00.4433
- Build fca7cf228b481ee8c1b779cf7b882ccdfbdcd1bc
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3260.0
- DPI 96dpi (no scaling)

