### PR TITLE
AutoCompleteWord git-status must not lock git

### DIFF
--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -30,7 +30,10 @@ namespace GitUI.AutoCompletion
 
             var autoCompleteWords = new HashSet<string>();
 
-            foreach (var file in _module.GetAllChangedFiles())
+            var cmd = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.Default, noLocks: true);
+            var output = _module.RunGitCmd(cmd);
+            var changedFiles = GitCommandHelpers.GetStatusChangedFilesFromString(_module, output);
+            foreach (var file in changedFiles)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Part of #6076

## Proposed changes
AutoComplete (in at least FormCommit) uses git-status to get changed files for suggestions. This call must not lock the git-status call to get differences or any manipulations to the index (stage, unstage, refresh, commit).
Git-status can take several seconds for big repos.

## Test methodology <!-- How did you ensure quality? -->
Git Command Log, add stacktrace
Open FormCommit, close
Verify that one of the calls (normally the second) to git-status:
```
git --no-optional-locks status --porcelain=2 -z --untracked-files --ignore-submodules=none
```

contains
```
vid GitUI.AutoCompletion.CommitAutoCompleteProvider.<GetAutoCompleteWordsAsync>d__3.MoveNext()
```

## Test environment(s) 