### PR TITLE
Fix side panel sometimes ending up with duplicate sets of remotes whe…

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -288,10 +288,13 @@ namespace GitUI.BranchTreePanel
                 _gitRemoteManager.ToggleRemoteState(Name, disabled: false);
                 if (fetch)
                 {
+                    // DoFetch invokes UICommands.RepoChangedNotifier.Notify
                     DoFetch();
                 }
-
-                UICommands.RepoChangedNotifier.Notify();
+                else
+                {
+                    UICommands.RepoChangedNotifier.Notify();
+                }
             }
 
             public void Disable()


### PR DESCRIPTION
…n "Activate & fetch" selected on an inactive remote

Problem is that the "fetch" operation would invoke UICommands.RepoChangedNotifier.Notify(), then this same function would get invoked yet again right after. This second call would sometimes cancel the first, which would cancel the repopulation of nodes in the TreeView.

Fixes #6106


## Proposed changes

- Don't call UICommands.RepoChangedNotifier.Notify() twice in a row from the side panel as this might cancel the tree view update

## Test methodology <!-- How did you ensure quality? -->

- Manual testing. This was easier to reproduce without a debugger attached (timing), and when activating a repo with many branches (e.g. gerhardol's fork)


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10

