### PR TITLE
Fix AE: Can not add a section that already exists: -remote

### DIFF
--- a/GitCommands/Remotes/GitRemoteManager.cs
+++ b/GitCommands/Remotes/GitRemoteManager.cs
@@ -31,6 +31,20 @@ namespace GitCommands.Remotes
         string RemoveRemote(GitRemote remote);
 
         /// <summary>
+        /// Returns true if input remote exists and is enabled.
+        /// </summary>
+        /// <param name="remoteName">Name of remote to check.</param>
+        /// <returns>True if input remote exists and is enabled.</returns>
+        bool EnabledRemoteExists(string remoteName);
+
+        /// <summary>
+        /// Returns true if input remote exists and is disabled.
+        /// </summary>
+        /// <param name="remoteName">Name of remote to check.</param>
+        /// <returns>True if input remote exists and is disabled.</returns>
+        bool DisabledRemoteExists(string remoteName);
+
+        /// <summary>
         ///   Saves the remote details by creating a new or updating an existing remote entry in .git/config file.
         /// </summary>
         /// <param name="remote">An existing remote instance or <see langword="null"/> if creating a new entry.</param>
@@ -240,6 +254,26 @@ namespace GitCommands.Remotes
         }
 
         /// <summary>
+        /// Returns true if input remote exists and is enabled.
+        /// </summary>
+        /// <param name="remoteName">Name of remote to check.</param>
+        /// <returns>True if input remote exists and is enabled.</returns>
+        public bool EnabledRemoteExists(string remoteName)
+        {
+            return GetEnabledRemoteNames().FirstOrDefault(r => r == remoteName) != null;
+        }
+
+        /// <summary>
+        /// Returns true if input remote exists and is disabled.
+        /// </summary>
+        /// <param name="remoteName">Name of remote to check.</param>
+        /// <returns>True if input remote exists and is disabled.</returns>
+        public bool DisabledRemoteExists(string remoteName)
+        {
+            return GetDisabledRemoteNames().FirstOrDefault(r => r == remoteName) != null;
+        }
+
+        /// <summary>
         ///   Saves the remote details by creating a new or updating an existing remote entry in .git/config file.
         /// </summary>
         /// <param name="remote">An existing remote instance or <see langword="null"/> if creating a new entry.</param>
@@ -275,6 +309,13 @@ namespace GitCommands.Remotes
             if (creatingNew)
             {
                 output = module.AddRemote(remoteName, remoteUrl);
+
+                // If output was returned, something went wrong
+                if (!string.IsNullOrWhiteSpace(output))
+                {
+                    return new GitRemoteSaveResult(output, false);
+                }
+
                 updateRemoteRequired = true;
             }
             else

--- a/GitCommands/Remotes/GitRemoteManager.cs
+++ b/GitCommands/Remotes/GitRemoteManager.cs
@@ -341,8 +341,22 @@ namespace GitCommands.Remotes
                 module.LocalConfigFile.RemoveConfigSection($"{sectionName}.{remoteName}");
             }
 
+            var newSectionName = (disabled ? DisabledSectionPrefix : "") + SectionRemote;
+
+            // ensure that the section with the same name doesn't already exist
+            // use case:
+            // - a user has added a remote,
+            // - then deactivated the remote via GE
+            // - then added a remote with the same name from a command line or via UI
+            // - then attempted to deactivate the new remote
+            var dupSection = sections.FirstOrDefault(s => s.SectionName == newSectionName && s.SubSection == remoteName);
+            if (dupSection != null)
+            {
+                module.LocalConfigFile.RemoveConfigSection($"{newSectionName}.{remoteName}");
+            }
+
             // rename the remote
-            section.SectionName = (disabled ? DisabledSectionPrefix : "") + SectionRemote;
+            section.SectionName = newSectionName;
 
             module.LocalConfigFile.AddConfigSection(section);
             module.LocalConfigFile.Save();

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -82,6 +82,12 @@ Inactive remote is completely invisible to git.");
 
         private readonly TranslationString _lvgDisabledHeader =
             new TranslationString("Inactive");
+
+        private readonly TranslationString _enabledRemoteAlreadyExists =
+            new TranslationString("An active remote named \"{0}\" already exists.");
+
+        private readonly TranslationString _disabledRemoteAlreadyExists =
+            new TranslationString("An inactive remote named \"{0}\" already exists.");
         #endregion
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
@@ -360,6 +366,18 @@ Inactive remote is completely invisible to git.");
                     checkBoxSepPushUrl.Checked = false;
                 }
 
+                if (_remoteManager.EnabledRemoteExists(remote))
+                {
+                    MessageBox.Show(this, string.Format(_enabledRemoteAlreadyExists.Text, remote), _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    return;
+                }
+
+                if (_remoteManager.DisabledRemoteExists(remote))
+                {
+                    MessageBox.Show(this, string.Format(_disabledRemoteAlreadyExists.Text, remote), _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    return;
+                }
+
                 // update all other remote properties
                 var result = _remoteManager.SaveRemote(_selectedRemote,
                                                        remote,
@@ -369,7 +387,8 @@ Inactive remote is completely invisible to git.");
 
                 if (!string.IsNullOrEmpty(result.UserMessage))
                 {
-                    MessageBox.Show(this, result.UserMessage, _gitMessage.Text);
+                    MessageBox.Show(this, result.UserMessage, _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                    return;
                 }
                 else
                 {

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -159,6 +159,7 @@ Inactive remote is completely invisible to git.");
                     group.Items[0].Selected = true;
                 }
 
+                Remotes.FocusedItem = Remotes.SelectedItems[0];
                 Remotes.Select();
             }
             else
@@ -235,6 +236,11 @@ Inactive remote is completely invisible to git.");
                 finally
                 {
                     Remotes.EndUpdate();
+                    if (Remotes.SelectedIndices.Count > 0)
+                    {
+                        Remotes.EnsureVisible(Remotes.SelectedIndices[0]);
+                    }
+
                     Url.EndUpdate();
                     comboBoxPushUrl.EndUpdate();
                 }

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -329,8 +329,8 @@ Inactive remote is completely invisible to git.");
 
             _selectedRemote.Disabled = !_selectedRemote.Disabled;
             _remoteManager.ToggleRemoteState(_selectedRemote.Name, _selectedRemote.Disabled);
-            BindBtnToggleState(_selectedRemote.Disabled);
-            BindRemotes(_selectedRemote.Name);
+
+            Initialize(_selectedRemote.Name);
         }
 
         private void SaveClick(object sender, EventArgs e)

--- a/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
@@ -70,21 +70,24 @@ namespace GitCommandsTests
             content.Should().NotBeEmpty();
         }
 
-        [Test]
-        public void LoadGitCommitTemplate_real_filesystem()
+        public class IntegrationTests
         {
-            using (var helper = new GitModuleTestHelper())
+            [Test]
+            public void LoadGitCommitTemplate_real_filesystem()
             {
-                var manager = new CommitTemplateManager(helper.Module);
+                using (var helper = new GitModuleTestHelper())
+                {
+                    var manager = new CommitTemplateManager(helper.Module);
 
-                const string content = "line1\r\nline2\rline3\nline4";
+                    const string content = "line1\r\nline2\rline3\nline4";
 
-                helper.Module.SetSetting("commit.template", "template.txt");
-                helper.CreateRepoFile("template.txt", content);
+                    helper.Module.SetSetting("commit.template", "template.txt");
+                    helper.CreateRepoFile("template.txt", content);
 
-                var body = manager.LoadGitCommitTemplate();
+                    var body = manager.LoadGitCommitTemplate();
 
-                body.Should().Be(content);
+                    body.Should().Be(content);
+                }
             }
         }
     }

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CommonTestUtils;
 using FluentAssertions;
 using GitCommands.Config;
 using GitCommands.Remotes;
@@ -408,6 +409,41 @@ namespace GitCommandsTests.Remote
             var enabledRemotesNoBranches = _controller.GetEnabledRemoteNamesWithoutBranches();
             Assert.AreEqual(1, enabledRemotesNoBranches.Count);
             Assert.AreEqual(enabledRemoteNameNoBranches, enabledRemotesNoBranches[0]);
+        }
+
+        public class IntegrationTests
+        {
+            [Test]
+            public void ToggleRemoteState_should_not_fail_if_activate_repeatedly()
+            {
+                using (var helper = new GitModuleTestHelper())
+                {
+                    var manager = new GitRemoteManager(() => helper.Module);
+
+                    const string remoteName = "active";
+                    helper.Module.AddRemote(remoteName, "http://localhost/remote/repo.git");
+                    manager.ToggleRemoteState(remoteName, true);
+
+                    helper.Module.AddRemote(remoteName, "http://localhost/remote/repo.git");
+                    manager.ToggleRemoteState(remoteName, false);
+                }
+            }
+
+            [Test]
+            public void ToggleRemoteState_should_not_fail_if_deactivate_repeatedly()
+            {
+                using (var helper = new GitModuleTestHelper())
+                {
+                    var manager = new GitRemoteManager(() => helper.Module);
+
+                    const string remoteName = "active";
+                    helper.Module.AddRemote(remoteName, "http://localhost/remote/repo.git");
+                    manager.ToggleRemoteState(remoteName, true);
+
+                    helper.Module.AddRemote(remoteName, "http://localhost/remote/repo.git");
+                    manager.ToggleRemoteState(remoteName, true);
+                }
+            }
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -126,7 +126,7 @@ namespace GitCommandsTests.Remote
         {
             const string remoteName = "a";
             const string remoteUrl = "b";
-            const string output = "yes!";
+            const string output = "";
             _module.AddRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
             var result = _controller.SaveRemote(null, remoteName, remoteUrl, null, null);
@@ -143,7 +143,7 @@ namespace GitCommandsTests.Remote
             const string remoteUrl = "b";
             const string remotePushUrl = "c";
             const string remotePuttySshKey = "";
-            const string output = "yes!";
+            const string output = "";
             _module.AddRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
             var result = _controller.SaveRemote(null, remoteName, remoteUrl, remotePushUrl, remotePuttySshKey);

--- a/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitRemoteManagerTests.cs
@@ -411,6 +411,36 @@ namespace GitCommandsTests.Remote
             Assert.AreEqual(enabledRemoteNameNoBranches, enabledRemotesNoBranches[0]);
         }
 
+        [Test]
+        public void EnabledRemoteExists_returns_true_for_enabled_remotes_only()
+        {
+            string enabledRemoteName = "enabledRemote";
+            string disabledRemoteName = "disabledRemote";
+
+            _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
+
+            var sections = new List<IConfigSection> { new ConfigSection($"{GitRemoteManager.DisabledSectionPrefix}{GitRemoteManager.SectionRemote}.{disabledRemoteName}", true) };
+            _configFile.GetConfigSections().Returns(x => sections);
+
+            Assert.IsTrue(_controller.EnabledRemoteExists(enabledRemoteName));
+            Assert.IsFalse(_controller.EnabledRemoteExists(disabledRemoteName));
+        }
+
+        [Test]
+        public void DisabledRemoteExists_returns_true_for_disabled_remotes_only()
+        {
+            string enabledRemoteName = "enabledRemote";
+            string disabledRemoteName = "disabledRemote";
+
+            _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
+
+            var sections = new List<IConfigSection> { new ConfigSection($"{GitRemoteManager.DisabledSectionPrefix}{GitRemoteManager.SectionRemote}.{disabledRemoteName}", true) };
+            _configFile.GetConfigSections().Returns(x => sections);
+
+            Assert.IsTrue(_controller.DisabledRemoteExists(disabledRemoteName));
+            Assert.IsFalse(_controller.DisabledRemoteExists(enabledRemoteName));
+        }
+
         public class IntegrationTests
         {
             [Test]


### PR DESCRIPTION
Discovered while adding UI tests in #6100

Use case:
- a user has added a remote
- then deactivated the remote via GE
- then added a remote with the same name from a command line or via UI
- then attempted to deactivate the new remote

Application then crash with:

    System.ArgumentException : Can not add a section that already exists: -remote
       at GitCommands.Config.ConfigFile.AddConfigSection(IConfigSection configSection) in C:\Development\gitextensions\GitCommands\Config\ConfigFile.cs:line 253
       at GitCommands.Settings.ConfigFileSettingsCache.<>c__DisplayClass9_0.<AddConfigSection>b__0() in C:\Development\gitextensions\GitCommands\Settings\ConfigFileSettingsCache.cs:line 79
       at GitCommands.SettingsCache.<>c__DisplayClass3_0.<LockedAction>b__0() in C:\Development\gitextensions\GitCommands\Settings\SettingsCache.cs:line 26
       at GitCommands.SettingsCache.LockedAction[T](Func`1 action) in C:\Development\gitextensions\GitCommands\Settings\SettingsCache.cs:line 35
       at GitCommands.SettingsCache.LockedAction(Action action) in C:\Development\gitextensions\GitCommands\Settings\SettingsCache.cs:line 24
       at GitCommands.Settings.ConfigFileSettingsCache.AddConfigSection(IConfigSection configSection) in C:\Development\gitextensions\GitCommands\Settings\ConfigFileSettingsCache.cs:line 76
       at GitCommands.Settings.ConfigFileSettings.AddConfigSection(IConfigSection configSection) in C:\Development\gitextensions\GitCommands\Settings\ConfigFileSettings.cs:line 113
       at GitCommands.Remotes.GitRemoteManager.ToggleRemoteState(String remoteName, Boolean disabled) in C:\Development\gitextensions\GitCommands\Remotes\GitRemoteManager.cs:line 341
       at GitCommandsTests.Remote.GitRemoteManagerTests.IntegrationTests.ToggleRemoteState_should_not_fail_if_deactivate_repeatedly() in C:\Development\gitextensions\UnitTests\GitCommandsTests\Remote\GitRemoteManagerTests.cs:line 368