### PR TITLE
Restore green Commit icon in Task Bar Jump List

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -182,6 +182,16 @@ namespace GitUI.CommandsDialogs
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
             revisionDiff.Bind(RevisionGrid, fileTree);
 
+            var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
+            _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
+            _windowsJumpListManager = new WindowsJumpListManager(repositoryDescriptionProvider);
+            _windowsJumpListManager.CreateJumpList(
+                Handle,
+                new WindowsThumbnailToolbarButtons(
+                    new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
+                    new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
+                    new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
+
             InitCountArtificial(out _gitStatusMonitor);
 
             if (!EnvUtils.RunningOnWindows())
@@ -229,10 +239,6 @@ namespace GitUI.CommandsDialogs
             _controller = new FormBrowseController(new GitGpgController(() => Module));
             _commitDataManager = new CommitDataManager(() => Module);
             _submoduleStatusProvider = new SubmoduleStatusProvider();
-
-            var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
-            _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
-            _windowsJumpListManager = new WindowsJumpListManager(repositoryDescriptionProvider);
 
             FillBuildReport(); // Ensure correct page visibility
             RevisionGrid.ShowBuildServerInfo = true;
@@ -475,13 +481,6 @@ namespace GitUI.CommandsDialogs
                 base.OnLoad(e);
                 return;
             }
-
-            _windowsJumpListManager.CreateJumpList(
-                Handle,
-                new WindowsThumbnailToolbarButtons(
-                    new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
-                    new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
-                    new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
 
             RevisionGrid.Load();
             _filterBranchHelper.InitToolStripBranchFilter();


### PR DESCRIPTION
Fix a regression of #6020

## Proposed changes

- create the Task Bar Jump List in the constructor already in order to the use initial Commit icon there

## Screenshots

### Before
![grafik](https://user-images.githubusercontent.com/36601201/51203048-7418fd80-1900-11e9-9f29-3190ba438d4b.png)

### After
![grafik](https://user-images.githubusercontent.com/36601201/51203071-809d5600-1900-11e9-8459-3b1e36978af1.png)

## Test methodology
- manual testing

## Test environment(s)
- Git Extensions 3.01.00.0
- Build 5a313988bf4ab8e0c37bdf1f2c658c9469e1e257
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)
![grafik](https://user-images.githubusercontent.com/36601201/51203229-d7a32b00-1900-11e9-8a89-3f89d86c803b.png)