### PR TITLE
Copy selected diff text to commit message

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1003,6 +1003,11 @@ namespace GitUI.Editor
             }
         }
 
+        public string GetSelectedText()
+        {
+            return internalFileViewer.GetSelectedText();
+        }
+
         public int GetSelectionPosition()
         {
             return internalFileViewer.GetSelectionPosition();

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -241,6 +241,7 @@ namespace GitUI.Hotkey
             {
                 new HotkeySettings(
                     FormCommit.HotkeySettingsName,
+                    Hk(FormCommit.Command.AddSelectionToCommitMessage, Keys.C),
                     Hk(FormCommit.Command.AddToGitIgnore, Keys.None),
                     Hk(FormCommit.Command.DeleteSelectedFiles, Keys.Delete),
                     Hk(FormCommit.Command.EditFile, EditFileHotkey),

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using GitUI;
 using GitUI.CommandsDialogs;
+using ICSharpCode.TextEditor;
 using NUnit.Framework;
 
 namespace GitUITests.CommandsDialogs.CommitDialog
@@ -98,6 +101,78 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             });
         }
 
+        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
+        public void AddSelectionToCommitMessage_shall_be_ignored_unless_diff_is_focused(
+            string message,
+            int selectionStart,
+            int selectionLength,
+            string expectedMessage,
+            int expectedSelectionStart)
+        {
+            TestAddSelectionToCommitMessage(focusSelectedDiff: false, CommitMessageTestData.SelectedText,
+                message, selectionStart, selectionLength,
+                expectedResult: false, expectedMessage: message, expectedSelectionStart: selectionStart);
+        }
+
+        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
+        public void AddSelectionToCommitMessage_shall_be_ignored_if_no_difftext_is_selected(
+            string message,
+            int selectionStart,
+            int selectionLength,
+            string expectedMessage,
+            int expectedSelectionStart)
+        {
+            TestAddSelectionToCommitMessage(focusSelectedDiff: true, selectedText: "",
+                message, selectionStart, selectionLength,
+                expectedResult: false, expectedMessage: message, expectedSelectionStart: selectionStart);
+        }
+
+        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
+        public void AddSelectionToCommitMessage_shall_modify_the_commit_message(
+            string message,
+            int selectionStart,
+            int selectionLength,
+            string expectedMessage,
+            int expectedSelectionStart)
+        {
+            TestAddSelectionToCommitMessage(focusSelectedDiff: true, CommitMessageTestData.SelectedText,
+                message, selectionStart, selectionLength,
+                expectedResult: true, expectedMessage, expectedSelectionStart);
+        }
+
+        private void TestAddSelectionToCommitMessage(
+            bool focusSelectedDiff,
+            string selectedText,
+            string message,
+            int selectionStart,
+            int selectionLength,
+            bool expectedResult,
+            string expectedMessage,
+            int expectedSelectionStart)
+        {
+            RunFormTest(form =>
+            {
+                var ta = form.GetTestAccessor();
+
+                var selectedDiff = ta.SelectedDiff.GetTestAccessor().FileViewerInternal;
+                selectedDiff.SetText(selectedText, openWithDifftool: null);
+                selectedDiff.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(
+                    new TextLocation(0, 0), new TextLocation(selectedText.Length, 0));
+                if (focusSelectedDiff)
+                {
+                    selectedDiff.Focus();
+                }
+
+                ta.Message.Text = message;
+                ta.Message.SelectionStart = selectionStart;
+                ta.Message.SelectionLength = selectionLength;
+                ta.ExecuteCommand(FormCommit.Command.AddSelectionToCommitMessage).Should().Be(expectedResult);
+                ta.Message.Text.Should().Be(expectedMessage);
+                ta.Message.SelectionStart.Should().Be(expectedSelectionStart);
+                ta.Message.SelectionLength.Should().Be(expectedResult ? 0 : selectionLength);
+            });
+        }
+
         private void RunFormTest(Action<FormCommit> testDriver, CommitKind commitKind = CommitKind.Normal)
         {
             RunFormTest(
@@ -133,6 +208,27 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                     }
                 },
                 testDriverAsync);
+        }
+    }
+
+    public class CommitMessageTestData
+    {
+        internal const string SelectedText = "selection";
+        private const string SelectedTextWithNewLine = SelectedText + "\n";
+
+        public static IEnumerable TestCases
+        {
+            get
+            {
+                yield return new TestCaseData("", 0, 0, SelectedTextWithNewLine, 0 + SelectedTextWithNewLine.Length);
+                yield return new TestCaseData("msg", 0, 0, SelectedTextWithNewLine + "msg", 0 + SelectedTextWithNewLine.Length);
+                yield return new TestCaseData("msg", 1, 0, "m" + SelectedTextWithNewLine + "sg", 1 + SelectedTextWithNewLine.Length);
+                yield return new TestCaseData("msg", 2, 0, "ms" + SelectedTextWithNewLine + "g", 2 + SelectedTextWithNewLine.Length);
+                yield return new TestCaseData("msg", 3, 0, "msg" + SelectedTextWithNewLine, 3 + SelectedTextWithNewLine.Length);
+                yield return new TestCaseData("msg", 0, 1, "" + SelectedText + "sg", 0 + SelectedText.Length);
+                yield return new TestCaseData("msg", 1, 1, "m" + SelectedText + "g", 1 + SelectedText.Length);
+                yield return new TestCaseData("msg", 2, 1, "ms" + SelectedText, 2 + SelectedText.Length);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #6115

## Proposed changes

- add a context menu item to the Commit dialog's FileViewer in order to
copy the selected text directly to the current position of the commit message (without using the clipboard).
- add the hotkey `C` for this function which is only available when the FileViewer has the focus

## Screenshots

### Before

![grafik](https://user-images.githubusercontent.com/36601201/51208800-ee507e80-190e-11e9-9dee-90b975bcea26.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/51348378-e0cbfd80-1aa2-11e9-8112-f174cc07f318.png)

## Test methodology

- added NUnit tests for the function `AddSelectionToCommitMessage()`

## Test environment(s)

- Git Extensions 3.01.00.0
- Build 7c93bcc80237e9fde6bf5f87267a06a8606bd21b
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)