### PR TITLE
#5981 superproject-refs for 3.0

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -865,6 +865,8 @@ namespace GitUI
                     await TaskScheduler.Default;
                     return GetSuperprojectCheckout(ShowRemoteRef, capturedModule);
                 });
+                _superprojectCurrentCheckout.Task.ContinueWith((task) => Refresh(),
+                    TaskScheduler.FromCurrentSynchronizationContext());
 
                 ResetNavigationHistory();
             }


### PR DESCRIPTION
Refresh revision grid when superproject branch/tag is completed

(cherry picked from commit 1c1359cfd29c841c3bf278224877b529bc7c6da9)

see #5981
