### PR TITLE
Use high DPI mouse cursors

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -59,6 +59,7 @@
     <Compile Include="GitUI\ControlThreadingExtensions.cs" />
     <Compile Include="GitUI\ControlUtil.cs" />
     <Compile Include="GitUI\DpiUtil.cs" />
+    <Compile Include="GitUI\HighDpiMouseCursors.cs" />
     <Compile Include="GitUI\ListViewExtensions.cs" />
     <Compile Include="GitUI\TableLayoutPanelExtensions.cs" />
     <Compile Include="GitUI\ThreadHelper.cs" />

--- a/GitExtUtils/GitUI/HighDpiMouseCursors.cs
+++ b/GitExtUtils/GitUI/HighDpiMouseCursors.cs
@@ -27,14 +27,15 @@ namespace GitExtUtils.GitUI
             void SetCursor(string fieldName, IDC idc)
             {
                 var field = typeof(Cursors).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
-                field?.SetValue(null, new Cursor(LoadCursor(IntPtr.Zero, idc)));
+                field?.SetValue(null, new Cursor(NativeMethods.LoadCursor(IntPtr.Zero, idc)));
             }
         }
 
-#pragma warning disable SA1305 // parameter should not use Hungarian notation
-        [DllImport("user32.dll")]
-        private static extern IntPtr LoadCursor(IntPtr hInstance, IDC lpCursorName);
-#pragma warning restore SA1305 // parameter should not use Hungarian notation
+        private static class NativeMethods
+        {
+            [DllImport("user32.dll")]
+            public static extern IntPtr LoadCursor(IntPtr hInstance, IDC lpCursorName);
+        }
 
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/GitExtUtils/GitUI/HighDpiMouseCursors.cs
+++ b/GitExtUtils/GitUI/HighDpiMouseCursors.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace GitExtUtils.GitUI
+{
+    internal static class HighDpiMouseCursors
+    {
+        /// <summary>
+        /// Replaces some .NET Framework 96-dpi .cur file mouse cursors with system cursors.
+        /// </summary>
+        public static void Enable()
+        {
+            try
+            {
+                SetCursor("hand", IDC.HAND);
+                SetCursor("hSplit", IDC.SIZENS);
+                SetCursor("vSplit", IDC.SIZEWE);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            void SetCursor(string fieldName, IDC idc)
+            {
+                var field = typeof(Cursors).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
+                field?.SetValue(null, new Cursor(LoadCursor(IntPtr.Zero, idc)));
+            }
+        }
+
+#pragma warning disable SA1305 // parameter should not use Hungarian notation
+        [DllImport("user32.dll")]
+        private static extern IntPtr LoadCursor(IntPtr hInstance, IDC lpCursorName);
+#pragma warning restore SA1305 // parameter should not use Hungarian notation
+
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        [SuppressMessage("ReSharper", "UnusedMember.Local")]
+        private enum IDC
+        {
+            ARROW = 32512,
+            IBEAM = 32513,
+            WAIT = 32514,
+            CROSS = 32515,
+            UPARROW = 32516,
+            SIZE = 32640,
+            ICON = 32641,
+            SIZENWSE = 32642,
+            SIZENESW = 32643,
+            SIZEWE = 32644,
+            SIZENS = 32645,
+            SIZEALL = 32646,
+            NO = 32648,
+            HAND = 32649,
+            APPSTARTING = 32650,
+            HELP = 32651
+        }
+    }
+}

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 using GitUI;
 using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
@@ -24,6 +25,8 @@ namespace GitExtensions
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            HighDpiMouseCursors.Enable();
 
             try
             {


### PR DESCRIPTION
Relates to #4775.

## Proposed changes

- Replace some 96-dpi .cur files provided by the framework with high-DPI system cursors

Full disclaimer: this uses private reflection, which is generally a no-no, but in doing so it catches any exception and continues with no negative effects that I can see.

An equivalent change is being made to dotnet/winforms, but until we move to .NET Core we are stuck with this approach.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/350947/51382852-c8de9300-1b0f-11e9-879d-13c36b7e7821.png)

![image](https://user-images.githubusercontent.com/350947/51382881-ddbb2680-1b0f-11e9-91b4-78c894f371c8.png)


### After

![image](https://user-images.githubusercontent.com/350947/51382928-f297ba00-1b0f-11e9-9bb5-ae4c8203e73a.png)

![image](https://user-images.githubusercontent.com/350947/51382938-fcb9b880-1b0f-11e9-90b0-39a8bce72feb.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10
- UI Scaling: 150%
