### PR TITLE
Fix CodeCov coverage - exclude unit test files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,13 +71,14 @@ test_script:
         -filter:"+[*]* -[FluentAssertions*]* -[SmartFormat*]* -[nunit*]*" `
         -excludebyattribute:*.ExcludeFromCodeCoverage* `
         -excludebyfile:*\*Designer.cs `
-        -output:"OpenCover.GitExtensions.xml" `
+        -excludedirs:UnitTests\ `
+        -output:"OpenCover.GitExtensions.ProdOnly.xml" `
         -target:"nunit3-console.exe" `
         -targetargs:"$testAssemblies"
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
     $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
     $codecov = "packages\Codecov.$codecov_version\tools\codecov.exe"
-    &$codecov -f ".\OpenCover.GitExtensions.xml"
+    &$codecov -f ".\OpenCover.GitExtensions.ProdOnly.xml" --flag production
 
 
 # here we are going to override common configuration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,14 +71,14 @@ test_script:
         -filter:"+[*]* -[FluentAssertions*]* -[SmartFormat*]* -[nunit*]*" `
         -excludebyattribute:*.ExcludeFromCodeCoverage* `
         -excludebyfile:*\*Designer.cs `
-        -excludedirs:UnitTests\ `
-        -output:"OpenCover.GitExtensions.ProdOnly.xml" `
+        -output:"OpenCover.GitExtensions.xml" `
         -target:"nunit3-console.exe" `
         -targetargs:"$testAssemblies"
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
     $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
     $codecov = "packages\Codecov.$codecov_version\tools\codecov.exe"
-    &$codecov -f ".\OpenCover.GitExtensions.ProdOnly.xml" --flag production
+    &$codecov -f ".\OpenCover.GitExtensions.xml" --flag production
+    &$codecov -f ".\OpenCover.GitExtensions.xml" --flag tests
 
 
 # here we are going to override common configuration

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
       default: false
 
 comment:
-  layout: "diff"
+  layout: "diff,flags"
 
 flags:
   production:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,16 @@ coverage:
 
 comment:
   layout: "diff"
+
+flags:
+  production:
+    paths:
+      - GitCommands/
+      - GitExtUtils/
+      - GitUI/
+      - NetSpell.SpellChecker/
+      - Plugins/
+      - ResourceManager/
+  tests:
+    paths:
+      - UnitTests/


### PR DESCRIPTION
Fixes Unit test coverage calculated by CodeCov. It excludes `/UnitTests/` sources recursively.

**Before**: https://codecov.io/gh/gitextensions/gitextensions (44.61% overall)

**Now**: https://codecov.io/gh/wachulski/gitextensions/tree/06a679fa84b0adc4a48ab763e5b7af2d6a4a206f (34.05% overall)