### PR TITLE
Fix #6144, it should treat none as default.

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -127,11 +127,13 @@ namespace GitUI.CommandsDialogs
             _branch = Module.GetSelectedBranch();
             BindRemotesDropDown(defaultRemote);
 
+            if (pullAction == AppSettings.PullAction.None)
+            {
+                pullAction = AppSettings.DefaultPullAction;
+            }
+
             switch (pullAction)
             {
-                case AppSettings.PullAction.None:
-                    // Treat None as Fetch
-                    goto case AppSettings.PullAction.Fetch;
                 case AppSettings.PullAction.Merge:
                     Merge.Checked = true;
                     Prune.Enabled = true;

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -151,8 +151,8 @@ namespace GitUI.CommandsDialogs
                     break;
                 case AppSettings.PullAction.FetchPruneAll:
                     Fetch.Checked = true;
-                    _NO_TRANSLATE_Remotes.Text = AllRemotes;
                     Prune.Checked = true;
+                    _NO_TRANSLATE_Remotes.Text = AllRemotes;
                     break;
                 case AppSettings.PullAction.Default:
                     Debug.Assert(false, "pullAction is not a valid action");
@@ -980,6 +980,26 @@ namespace GitUI.CommandsDialogs
             {
                 Branches.Text = localBranch.Text;
             }
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FormPull _form;
+
+            public TestAccessor(FormPull form)
+            {
+                _form = form;
+            }
+
+            public RadioButton Merge => _form.Merge;
+            public RadioButton Rebase => _form.Rebase;
+            public RadioButton Fetch => _form.Fetch;
+            public CheckBox AutoStash => _form.AutoStash;
+            public CheckBox Prune => _form.Prune;
+            public ComboBox Remotes => _form._NO_TRANSLATE_Remotes;
+            public TextBox LocalBranch => _form.localBranch;
         }
     }
 }

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormPullTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormPullTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GitCommands;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs.CommitDialog
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormPullTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _commands;
+        private AppSettings.PullAction _originalDefaultPullAction;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalDefaultPullAction = AppSettings.DefaultPullAction;
+
+            if (_referenceRepository == null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AppSettings.DefaultPullAction = _originalDefaultPullAction;
+            _commands = null;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, true)]
+        [TestCase(AppSettings.PullAction.Rebase, false, false, true, false, false, false)]
+        [TestCase(AppSettings.PullAction.Fetch, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchAll, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, true, false, true)]
+        public void Should_correctly_setup_for_defined_pull_action(AppSettings.PullAction pullAction,
+            bool mergeChecked, bool pruneChecked, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneEnabled)
+        {
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.Merge.Checked.Should().Be(mergeChecked);
+                    accessor.Prune.Checked.Should().Be(pruneChecked);
+                    accessor.Rebase.Checked.Should().Be(rebaseChecked);
+                    accessor.Fetch.Checked.Should().Be(fetchChecked);
+                    accessor.AutoStash.Checked.Should().Be(autoStashChecked);
+                    accessor.Prune.Enabled.Should().Be(pruneEnabled);
+                    accessor.Remotes.Text.Should().Be("[ All ]");
+                },
+                null, null, pullAction);
+        }
+
+        [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, true)]
+        [TestCase(AppSettings.PullAction.Rebase, false, false, true, false, false, false)]
+        [TestCase(AppSettings.PullAction.Fetch, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchAll, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, true, false, true)]
+        public void Should_use_user_DefaultPullAction_pull_action_None(AppSettings.PullAction pullAction,
+            bool mergeChecked, bool pruneChecked, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneEnabled)
+        {
+            AppSettings.DefaultPullAction = pullAction;
+
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.Merge.Checked.Should().Be(mergeChecked);
+                    accessor.Prune.Checked.Should().Be(pruneChecked);
+                    accessor.Rebase.Checked.Should().Be(rebaseChecked);
+                    accessor.Fetch.Checked.Should().Be(fetchChecked);
+                    accessor.AutoStash.Checked.Should().Be(autoStashChecked);
+                    accessor.Prune.Enabled.Should().Be(pruneEnabled);
+                    accessor.Remotes.Text.Should().Be("[ All ]");
+                },
+                null, null, AppSettings.PullAction.None);
+        }
+
+        private void RunFormTest(Action<FormPull> testDriver, string remoteBranch, string remote, AppSettings.PullAction pullAction)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                },
+                remoteBranch, remote, pullAction);
+        }
+
+        private void RunFormTest(Func<FormPull, Task> testDriverAsync, string remoteBranch, string remote, AppSettings.PullAction pullAction)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    // False because we haven't performed any actions
+                    Assert.False(_commands.StartPullDialog(owner: null, remoteBranch: remoteBranch, remote: remote, pullAction: pullAction));
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Avatars\AvatarTestBase.cs" />
     <Compile Include="Avatars\BackupAvatarProviderTests.cs" />
     <Compile Include="CancellationTokenSequenceTests.cs" />
+    <Compile Include="CommandsDialogs\CommitDialog\FormPullTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormInitTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormCommitTests.cs" />
     <Compile Include="CommandsDialogs\ReferenceRepository.cs" />


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6144


## Proposed changes

- It should treat `AppSettings.PullAction.None` as `AppSettings.DefaultPullAction` instead of `AppSettings.PullAction.Fetch`.
Reason: https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L1716
https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L1736-L1757
When there's args for pull passed in the command, the default pull action is changed.
https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L1732
https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L493

But it opens the window with `pullAction` parameter default value to `AppSettings.PullAction.None`. So it should treat `AppSettings.PullAction.None` as `AppSettings.DefaultPullAction` instead of `AppSettings.PullAction.Fetch`. Or the settings changing is useless.