### PR TITLE
Fix #6144, it should treat none as default.

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -127,11 +127,13 @@ namespace GitUI.CommandsDialogs
             _branch = Module.GetSelectedBranch();
             BindRemotesDropDown(defaultRemote);
 
+            if (pullAction == AppSettings.PullAction.None)
+            {
+                pullAction = AppSettings.DefaultPullAction;
+            }
+
             switch (pullAction)
             {
-                case AppSettings.PullAction.None:
-                    // Treat None as Fetch
-                    goto case AppSettings.PullAction.Fetch;
                 case AppSettings.PullAction.Merge:
                     Merge.Checked = true;
                     Prune.Enabled = true;

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -1001,6 +1001,10 @@ namespace GitUI.CommandsDialogs
             public RadioButton Merge => _form.Merge;
             public RadioButton Rebase => _form.Rebase;
             public RadioButton Fetch => _form.Fetch;
+            public CheckBox AutoStash => _form.AutoStash;
+            public CheckBox Prune => _form.Prune;
+            public ComboBox Remotes => _form._NO_TRANSLATE_Remotes;
+            public TextBox LocalBranch => _form.localBranch;
         }
     }
 }

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormPullTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormPullTests.cs
@@ -102,6 +102,56 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 //// select an action different from None/fetch
                 AppSettings.PullAction.Merge);
         }
+        
+        [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, true)]
+        [TestCase(AppSettings.PullAction.Rebase, false, false, true, false, false, false)]
+        [TestCase(AppSettings.PullAction.Fetch, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchAll, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, true, false, true)]
+        public void Should_correctly_setup_for_defined_pull_action(AppSettings.PullAction pullAction,
+            bool mergeChecked, bool pruneChecked, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneEnabled)
+        {
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.Merge.Checked.Should().Be(mergeChecked);
+                    accessor.Prune.Checked.Should().Be(pruneChecked);
+                    accessor.Rebase.Checked.Should().Be(rebaseChecked);
+                    accessor.Fetch.Checked.Should().Be(fetchChecked);
+                    accessor.AutoStash.Checked.Should().Be(autoStashChecked);
+                    accessor.Prune.Enabled.Should().Be(pruneEnabled);
+                    accessor.Remotes.Text.Should().Be("[ All ]");
+                },
+                null, null, pullAction);
+        }
+
+        [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, true)]
+        [TestCase(AppSettings.PullAction.Rebase, false, false, true, false, false, false)]
+        [TestCase(AppSettings.PullAction.Fetch, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchAll, false, false, false, true, false, true)]
+        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, true, false, true)]
+        public void Should_use_user_DefaultPullAction_pull_action_None(AppSettings.PullAction pullAction,
+            bool mergeChecked, bool pruneChecked, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneEnabled)
+        {
+            AppSettings.DefaultPullAction = pullAction;
+
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.Merge.Checked.Should().Be(mergeChecked);
+                    accessor.Prune.Checked.Should().Be(pruneChecked);
+                    accessor.Rebase.Checked.Should().Be(rebaseChecked);
+                    accessor.Fetch.Checked.Should().Be(fetchChecked);
+                    accessor.AutoStash.Checked.Should().Be(autoStashChecked);
+                    accessor.Prune.Enabled.Should().Be(pruneEnabled);
+                    accessor.Remotes.Text.Should().Be("[ All ]");
+                },
+                null, null, AppSettings.PullAction.None);
+        }
 
         private void RunFormTest(Action<FormPull> testDriver, string remoteBranch, string remote, AppSettings.PullAction pullAction)
         {

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormPullTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormPullTests.cs
@@ -102,7 +102,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 //// select an action different from None/fetch
                 AppSettings.PullAction.Merge);
         }
-        
+
         [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, true)]
         [TestCase(AppSettings.PullAction.Rebase, false, false, true, false, false, false)]
         [TestCase(AppSettings.PullAction.Fetch, false, false, false, true, false, true)]

--- a/contributors.txt
+++ b/contributors.txt
@@ -55,6 +55,7 @@ YYYY/MM/DD, github id, Full name, email
 2019/01/23, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
 2019/01/24, KindDragon, Arkadii Shapkin, arkady.shapkin@gmail.com
 2019/01/24, jbialobr, Janusz Białobrzewski, jbialobr@o2.pl
+2019/01/24, SetoKaiba, Jie Situ, 61304189@qq.com
 2019/01/24, mstv, Michael Seibt, mstv@gmx.net
 2019/01/24, DCFerg, Dan Ferguson, dferguson.gh@gmail.com
 2019/01/24, NikolayXHD, Nikolai Idalgo Dias, hidalgo1984@list.ru


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6144


## Proposed changes

- It should treat `AppSettings.PullAction.None` as `AppSettings.DefaultPullAction` instead of `AppSettings.PullAction.Fetch`.
Reason: https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L1716
https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L1736-L1757
When there's args for pull passed in the command, the default pull action is changed.
https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L1732
https://github.com/gitextensions/gitextensions/blob/1be9b2a4c1a84d33ae011705b9b1076465696ee3/GitUI/GitUICommands.cs#L493

But it opens the window with `pullAction` parameter default value to `AppSettings.PullAction.None`. So it should treat `AppSettings.PullAction.None` as `AppSettings.DefaultPullAction` instead of `AppSettings.PullAction.Fetch`. Or the settings changing is useless.