### PR TITLE
fix Win32ApiTests against x86 platform

### DIFF
--- a/UnitTests/GitExtUtils/Win32ApiTests.cs
+++ b/UnitTests/GitExtUtils/Win32ApiTests.cs
@@ -31,7 +31,7 @@ namespace GitExtUtilsTests
 
         private static IntPtr ToLParam(short x, short y) =>
             new IntPtr(
-                ((long)x & 0x00000000_0000FFFF) |
-                (((long)y & 0x00000000_0000FFFF) << 16));
+                x & 0x0000_FFFF |
+                (y & 0x0000_FFFF) << 16);
     }
 }

--- a/contributors.txt
+++ b/contributors.txt
@@ -54,3 +54,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/01/23, amaiorano, Antonio Maiorano, amaiorano@gmail.com
 2019/01/23, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
 2019/01/24, KindDragon, Arkadii Shapkin, arkady.shapkin@gmail.com
+2019/01/24, NikolayXHD, Nikolai Idalgo Dias, hidalgo1984@list.ru


### PR DESCRIPTION
Fix faling Win32ApiTests tests when run against x86 platform, issue was discovered
and reported https://github.com/gitextensions/gitextensions/pull/6111#issuecomment-456175161 by @vbjay 

## Test environment(s)

- Windows 7 SP1

Win32Api tests were successfully run against x86 and x64 platforms