### PR TITLE
fix FileStatusList layout after replacing Dock.Fill by Anchor

### DIFF
--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -91,6 +91,7 @@
             this.FilterComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.FilterComboBox.FormattingEnabled = true;
             this.FilterComboBox.Location = new System.Drawing.Point(0, 0);
+            this.FilterComboBox.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
             this.FilterComboBox.Name = "FilterComboBox";
             this.FilterComboBox.Size = new System.Drawing.Size(682, 21);
             this.FilterComboBox.TabIndex = 0;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -150,9 +150,30 @@ namespace GitUI
             get { return _filterVisible; }
             set
             {
+                if (value == _filterVisible)
+                {
+                    return;
+                }
+
                 _filterVisible = value;
-                FilterComboBox.Visible = _filterVisible;
-                FilterWatermarkLabel.Visible = _filterVisible;
+                FilterVisibleInternal = value;
+            }
+        }
+
+        private bool FilterVisibleInternal
+        {
+            set
+            {
+                FilterComboBox.Visible = value;
+                FilterWatermarkLabel.Visible = value;
+
+                int top = value
+                    ? FileStatusListView.Margin.Top + FilterComboBox.Bottom + FilterComboBox.Margin.Bottom
+                    : FileStatusListView.Margin.Top;
+
+                int height = ClientRectangle.Height - FileStatusListView.Margin.Bottom - top;
+
+                FileStatusListView.SetBounds(0, top, 0, height, BoundsSpecified.Y | BoundsSpecified.Height);
             }
         }
 
@@ -973,10 +994,7 @@ namespace GitUI
         private void HandleVisibility_NoFilesLabel_FilterComboBox(bool filesPresent)
         {
             NoFiles.Visible = !filesPresent;
-            if (_filterVisible)
-            {
-                FilterComboBox.Visible = filesPresent;
-            }
+            FilterVisibleInternal = FilterVisible && filesPresent;
         }
 
         // Event handlers


### PR DESCRIPTION
Fixes #6149

## Proposed changes

Manually update `ListView.Top` to emulate `Dock.Fill` with present `Dock.Top` siblings.

## Test methodology

- visually inspected Diff tab in `FormBrowse`'s bottom panel to make sure `ListView` is still correctly laid out below the filter.
- visually inspected commit form to make sure `ListView` takes all available height when filter is invisible.


## Test environment(s)

- Windows 7 SP1