### PR TITLE
Show remote branch in status bar in commit dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -905,12 +905,18 @@ namespace GitUI.CommandsDialogs
             await TaskScheduler.Default;
 
             var currentBranchName = Module.GetSelectedBranch();
-
-            var currentBranch = Module.GetRefs(false, true).FirstOrDefault(r => r.LocalName == Module.GetSelectedBranch());
-            var pushTo = $" -> {currentBranch.TrackingRemote}/{currentBranch.MergeWith}";
+            var currentBranch = Module.GetRefs(false, true).FirstOrDefault(r => r.LocalName == currentBranchName);
+            string pushTo;
             if (string.IsNullOrEmpty(currentBranch.TrackingRemote) || string.IsNullOrEmpty(currentBranch.MergeWith))
             {
-                pushTo = " (No remote branch configured)";
+                pushTo = new TranslationString(" -> (No remote branch configured)").Text;
+            }
+            else
+            {
+                var pushToTranslation = new TranslationString(" -> {0}/{1}");
+                pushTo = string.Format(pushToTranslation.Text,
+                                      currentBranch.TrackingRemote,
+                                      currentBranch.MergeWith);
             }
 
             await this.SwitchToMainThreadAsync();

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -136,6 +136,9 @@ namespace GitUI.CommandsDialogs
             + Environment.NewLine + "Use this feature when a file is big and never change."
             + Environment.NewLine + "Git will never check if the file has changed that will improve status check performance.");
         private readonly TranslationString _stopTrackingFail = new TranslationString("Fail to stop tracking the file '{0}'.");
+
+        private readonly TranslationString _statusBarBranchWithRemote = new TranslationString("{0} -> {1}/{2}");
+        private readonly TranslationString _statusBarBranchWithoutRemote = new TranslationString("{0} -> (No remote branch configured)");
         #endregion
 
         private event Action OnStageAreaLoaded;
@@ -906,17 +909,15 @@ namespace GitUI.CommandsDialogs
 
             var currentBranchName = Module.GetSelectedBranch();
             var currentBranch = Module.GetRefs(false, true).FirstOrDefault(r => r.LocalName == currentBranchName);
-            string pushTo;
+            string statusBarBranchText;
             if (string.IsNullOrEmpty(currentBranch.TrackingRemote) || string.IsNullOrEmpty(currentBranch.MergeWith))
             {
-                pushTo = new TranslationString(" -> (No remote branch configured)").Text;
+                statusBarBranchText = string.Format(_statusBarBranchWithoutRemote.Text, currentBranchName);
             }
             else
             {
-                var pushToTranslation = new TranslationString(" -> {0}/{1}");
-                pushTo = string.Format(pushToTranslation.Text,
-                                      currentBranch.TrackingRemote,
-                                      currentBranch.MergeWith);
+                statusBarBranchText = string.Format(_statusBarBranchWithRemote.Text, currentBranchName,
+                    currentBranch.TrackingRemote, currentBranch.MergeWith);
             }
 
             await this.SwitchToMainThreadAsync();
@@ -925,7 +926,7 @@ namespace GitUI.CommandsDialogs
             {
                 UICommands.StartRemotesDialog(this, null, currentBranchName);
             };
-            branchNameLabel.Text = currentBranchName + pushTo;
+            branchNameLabel.Text = statusBarBranchText;
             Text = string.Format(_formTitle.Text, currentBranchName, PathUtil.GetDisplayPath(Module.WorkingDir));
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -906,9 +906,20 @@ namespace GitUI.CommandsDialogs
 
             var currentBranchName = Module.GetSelectedBranch();
 
+            var currentBranch = Module.GetRefs(false, true).FirstOrDefault(r => r.LocalName == Module.GetSelectedBranch());
+            var pushTo = $" -> {currentBranch.TrackingRemote}/{currentBranch.MergeWith}";
+            if (string.IsNullOrEmpty(currentBranch.TrackingRemote) || string.IsNullOrEmpty(currentBranch.MergeWith))
+            {
+                pushTo = " (No remote branch configured)";
+            }
+
             await this.SwitchToMainThreadAsync();
 
-            branchNameLabel.Text = currentBranchName;
+            branchNameLabel.Click += (object sender, EventArgs e) =>
+            {
+                UICommands.StartRemotesDialog(this, null, currentBranchName);
+            };
+            branchNameLabel.Text = currentBranchName + pushTo;
             Text = string.Format(_formTitle.Text, currentBranchName, PathUtil.GetDisplayPath(Module.WorkingDir));
         }
 

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -210,13 +210,13 @@ Inactive remote is completely invisible to git.");
             InitialiseTabBehaviors(preselectLocal);
             if (preselectLocal != null)
             {
-                ActivateTabBehaviors();
+                ActivateTabDefaultPullBehavior();
             }
         }
 
-        private void ActivateTabBehaviors()
+        private void ActivateTabDefaultPullBehavior()
         {
-                tabControl1.SelectedTab = tabPage2;
+            tabControl1.SelectedTab = tabPage2;
         }
 
         private void InitialiseTabRemotes(string preselectRemote = null)
@@ -273,7 +273,7 @@ Inactive remote is completely invisible to git.");
             RemoteBranches.ClearSelection();
             RemoteBranches.SelectionChanged += RemoteBranchesSelectionChanged;
             var preselectLocalRow = RemoteBranches.Rows.Cast<DataGridViewRow>().
-                FirstOrDefault(r => r.DataBoundItem is GitRef gitRef ? gitRef.LocalName == preselectLocal : false);
+                FirstOrDefault(r => r.DataBoundItem is IGitRef gitRef ? gitRef.LocalName == preselectLocal : false);
             if (preselectLocalRow != null)
             {
                 preselectLocalRow.Selected = true;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -924,13 +924,15 @@ namespace GitUI
         }
 
         /// <param name="preselectRemote">makes the FormRemotes initially select the given remote</param>
-        public bool StartRemotesDialog(IWin32Window owner, string preselectRemote = null)
+        /// <param name="preselectLocal">makes the FormRemotes initially show tab "Default push behavior" and select the given local</param>
+        public bool StartRemotesDialog(IWin32Window owner, string preselectRemote = null, string preselectLocal = null)
         {
             bool Action()
             {
                 using (var form = new FormRemotes(this))
                 {
                     form.PreselectRemoteOnLoad = preselectRemote;
+                    form.PreselectLocalOnLoad = preselectLocal;
                     form.ShowDialog(owner);
                 }
 


### PR DESCRIPTION
Fixes issue #6118. Replaces PR https://github.com/gitextensions/gitextensions/pull/6128

## Proposed changes

- Added remote branch to status bar item branchNameLabel
- Added click event to open "Default pull behavior" for current branch- 

## Screenshots

Status bar:
![image](https://user-images.githubusercontent.com/2737900/51586667-7110a500-1ede-11e9-9325-b12a05bb745e.png)
![image](https://user-images.githubusercontent.com/2737900/51586689-82f24800-1ede-11e9-80b4-5993d1f3681a.png)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 4a5573077e83a20c25cb7c777619b6670c24a98b
- Git 2.19.2.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3260.0
- DPI 96dpi (no scaling)

