### PR TITLE
Fix loading of some plugins that failed

### DIFF
--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.TeamFoundation.Build.Client" Version="11.0.60610.1" />
     <PackageReference Include="Microsoft.TeamFoundation.Client-final" Version="12.0.21005.1" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.112.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\CommonAssemblyInfo.cs">


### PR DESCRIPTION
due to a bad version of "Newtonsoft.Json"


PS: the binding redirect was already there
Fixes https://github.com/gitextensions/gitextensions/issues/6140#issuecomment-456101158


## Proposed changes

Other projects use v10.0.3 and a dependency of "TfsInterop.Vs2015" use
a v8 that could end up in the output directory.
So the plugins fails to load because can find "Newtonsoft.Json" in v10


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When building locally (and perhaps on AppVeyor ?), sometimes, the plugins requiring "Newtonsoft.Json" as dependency failed to load

### After

The plugins could load.

