### PR TITLE
Make FormReflog use UICommands when displaying FormCreateBranch

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2955,11 +2955,9 @@ namespace GitUI.CommandsDialogs
 
         private void toolStripMenuItemReflog_Click(object sender, EventArgs e)
         {
-            var formReflog = new FormReflog(UICommands);
-            formReflog.ShowDialog();
-            if (formReflog.ShouldRefresh)
+            using (var formReflog = new FormReflog(UICommands))
             {
-                RefreshRevisions();
+                formReflog.ShowDialog();
             }
         }
 


### PR DESCRIPTION
With this, we can remove the ShouldRefresh-related code since interested parties already subscribe to the UICommands_PostRepositoryChanged event, including FormBrowse itself for the revision graph, and the left panel.

## Proposed changes

This change basically improves the code around FormReflog, making it use UICommands like most other places. Apart from clean up, this not only updates the revision grid when we create or reset a branch from FormReflog, but it also updates the left panel,  which is originally why I made this change.

## Screenshots <!-- Remove this section if PR does not change UI -->

No screenshot as there is no UI difference, but there is a UX difference: prior, when creating/resetting a branch from FormReflog, the revision grid would only get updated on closing the dialog. Now, the revision grid (and left panel, and anything else that might register on the UICommands_PostRepositoryChanged event) gets updated immediately while FormReflog is still up.

## Test methodology <!-- How did you ensure quality? -->

- Basic manual testing


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10
