### PR TITLE
fix: Pull dialog options from shell extensions

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1729,7 +1729,7 @@ namespace GitUI
             }
             else
             {
-                StartPullDialog(remoteBranch: remoteBranch);
+                StartPullDialog(remoteBranch: remoteBranch, pullAction: AppSettings.PullAction.Merge);
             }
         }
 


### PR DESCRIPTION


Fixes #6144


## Proposed changes

- Pull dialog options now correctly pre-selects options when "Pull" option is invoked from Windows Explorer shell extension.

I haven't bisected it, but it is plausible we regressed as far back as afc7fa0984068d617b3e95dcb3c0fa5e57392e40.


## Test methodology <!-- How did you ensure quality? -->

- I ran the app from VS with debugger command line args: `pull "C:\Development\gitextensions"` and observed "Pull" dialog with "Merge" option preselected


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
