### PR TITLE
Fix sorting of commit templates.

### DIFF
--- a/GitCommands/CommitTemplateManager.cs
+++ b/GitCommands/CommitTemplateManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -43,11 +42,11 @@ namespace GitCommands
 
     public sealed class CommitTemplateManager : ICommitTemplateManager
     {
-        private class RegisteredCommitTemplateItem
+        private struct RegisteredCommitTemplateItem
         {
-            public string Name { get; }
+            public readonly string Name;
 
-            public Func<string> Text { get; }
+            public readonly Func<string> Text;
 
             public RegisteredCommitTemplateItem(string name, Func<string> text)
             {
@@ -82,7 +81,7 @@ namespace GitCommands
             {
                 lock (RegisteredTemplatesStorage)
                 {
-                    return RegisteredTemplatesStorage.Select(item => new CommitTemplateItem(item.Name, item.Text()));
+                    return RegisteredTemplatesStorage.Select(item => new CommitTemplateItem(item.Name, item.Text())).AsReadOnlyList();
                 }
             }
         }

--- a/GitCommands/CommitTemplateManager.cs
+++ b/GitCommands/CommitTemplateManager.cs
@@ -43,7 +43,20 @@ namespace GitCommands
 
     public sealed class CommitTemplateManager : ICommitTemplateManager
     {
-        private static readonly ConcurrentDictionary<string, Func<string>> RegisteredTemplatesDic = new ConcurrentDictionary<string, Func<string>>();
+        private class RegisteredCommitTemplateItem
+        {
+            public string Name { get; }
+
+            public Func<string> Text { get; }
+
+            public RegisteredCommitTemplateItem(string name, Func<string> text)
+            {
+                Name = name;
+                Text = text;
+            }
+        }
+
+        private static readonly List<RegisteredCommitTemplateItem> RegisteredTemplatesStorage = new List<RegisteredCommitTemplateItem>();
         private readonly IFileSystem _fileSystem;
         private readonly IGitModule _module;
         private readonly IFullPathResolver _fullPathResolver;
@@ -63,7 +76,16 @@ namespace GitCommands
         /// <summary>
         /// Gets the collection of all currently registered commit templates provided by plugins.
         /// </summary>
-        public IEnumerable<CommitTemplateItem> RegisteredTemplates => RegisteredTemplatesDic.Select(item => new CommitTemplateItem(item.Key, item.Value()));
+        public IEnumerable<CommitTemplateItem> RegisteredTemplates
+        {
+            get
+            {
+                lock (RegisteredTemplatesStorage)
+                {
+                    return RegisteredTemplatesStorage.Select(item => new CommitTemplateItem(item.Name, item.Text()));
+                }
+            }
+        }
 
         /// <summary>
         /// Loads commit template from the file specified in .git/config
@@ -100,7 +122,13 @@ namespace GitCommands
         /// <param name="templateText">The body of the template.</param>
         public void Register(string templateName, Func<string> templateText)
         {
-            RegisteredTemplatesDic.TryAdd(templateName, templateText);
+            lock (RegisteredTemplatesStorage)
+            {
+                if (RegisteredTemplatesStorage.All(item => item.Name != templateName))
+                {
+                    RegisteredTemplatesStorage.Add(new RegisteredCommitTemplateItem(templateName, templateText));
+                }
+            }
         }
 
         /// <summary>
@@ -109,7 +137,10 @@ namespace GitCommands
         /// <param name="templateName">The name of the template.</param>
         public void Unregister(string templateName)
         {
-            RegisteredTemplatesDic.TryRemove(templateName, out _);
+            lock (RegisteredTemplatesStorage)
+            {
+                RegisteredTemplatesStorage.RemoveAll(item => item.Name == templateName);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- Jira commit templates may be ordered by JQL and this sorting have to be saved on UI. ConcurrentDictionary is not ordered class and must not be used to store ordered data.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Incorrect sorting (have to be ordered by updateDate)
![image](https://user-images.githubusercontent.com/27559075/51732802-dad4ae80-2098-11e9-869b-34d6160e7c1e.png)

### After

Sorting fixed

![image](https://user-images.githubusercontent.com/27559075/51733663-723b0100-209b-11e9-8b90-abfb20696bf6.png)

## Test methodology <!-- How did you ensure quality? -->

- Setup Jira plugin with sorting
- Open commit form and template popup
- Templates are ordered
- Close commit form
- Open commit form again and check templates


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
