### PR TITLE
WIP: Simplify "Go to commit" form

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.Designer.cs
@@ -19,22 +19,23 @@
             this.textboxCommitExpression = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.linkGitRevParse = new System.Windows.Forms.LinkLabel();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.label2 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.comboBoxTags = new System.Windows.Forms.ComboBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.comboBoxBranches = new System.Windows.Forms.ComboBox();
+            this.linkGitRevParse = new System.Windows.Forms.LinkLabel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // goButton
             // 
             this.goButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.goButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.goButton.Location = new System.Drawing.Point(521, 10);
+            this.goButton.Enabled = false;
+            this.goButton.Location = new System.Drawing.Point(366, 29);
             this.goButton.Name = "goButton";
-            this.goButton.Size = new System.Drawing.Size(75, 28);
+            this.goButton.Size = new System.Drawing.Size(115, 24);
             this.goButton.TabIndex = 3;
             this.goButton.Text = "Go";
             this.goButton.UseVisualStyleBackColor = true;
@@ -42,132 +43,123 @@
             // 
             // textboxCommitExpression
             // 
-            this.textboxCommitExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textboxCommitExpression.Location = new System.Drawing.Point(155, 13);
+            this.textboxCommitExpression.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textboxCommitExpression.Location = new System.Drawing.Point(106, 3);
             this.textboxCommitExpression.Name = "textboxCommitExpression";
-            this.textboxCommitExpression.Size = new System.Drawing.Size(360, 23);
+            this.textboxCommitExpression.Size = new System.Drawing.Size(375, 20);
             this.textboxCommitExpression.TabIndex = 0;
             this.textboxCommitExpression.TextChanged += new System.EventHandler(this.commitExpression_TextChanged);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 17);
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(3, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(112, 15);
+            this.label1.Size = new System.Drawing.Size(97, 26);
             this.label1.TabIndex = 2;
             this.label1.Text = "Commit expression:";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // groupBox1
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.Controls.Add(this.linkGitRevParse);
-            this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Location = new System.Drawing.Point(45, 43);
+            this.groupBox1.AutoSize = true;
+            this.groupBox1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.SetColumnSpan(this.groupBox1, 2);
+            this.groupBox1.Controls.Add(this.tableLayoutPanel2);
+            this.groupBox1.Location = new System.Drawing.Point(3, 59);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(470, 141);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(16);
+            this.groupBox1.Size = new System.Drawing.Size(478, 131);
             this.groupBox1.TabIndex = 4;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Help";
             // 
-            // linkGitRevParse
+            // tableLayoutPanel2
             // 
-            this.linkGitRevParse.AutoSize = true;
-            this.linkGitRevParse.Location = new System.Drawing.Point(19, 112);
-            this.linkGitRevParse.Name = "linkGitRevParse";
-            this.linkGitRevParse.Size = new System.Drawing.Size(126, 15);
-            this.linkGitRevParse.TabIndex = 0;
-            this.linkGitRevParse.TabStop = true;
-            this.linkGitRevParse.Text = "More see git-rev-parse";
-            this.linkGitRevParse.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkGitRevParse_LinkClicked);
+            this.tableLayoutPanel2.AutoSize = true;
+            this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel2.ColumnCount = 1;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.linkGitRevParse, 0, 2);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(16, 29);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 3;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 8F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(446, 86);
+            this.tableLayoutPanel2.TabIndex = 1;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(19, 22);
+            this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label2.Location = new System.Drawing.Point(3, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(413, 75);
+            this.label2.Size = new System.Drawing.Size(440, 65);
             this.label2.TabIndex = 0;
             this.label2.Text = "Commit expression examples:\r\n- complete commit hash: e. g.: 8eab51fcb9c4538eb74c4" +
     "dcd4c31ffd693ad25c9\r\n- partial commit hash (if unique): e. g.: 8eab51fcb9c453\r\n-" +
     " tag name\r\n- branch name";
             // 
-            // label3
+            // linkGitRevParse
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(12, 219);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(59, 15);
-            this.label3.TabIndex = 4;
-            this.label3.Text = "Go to tag:";
+            this.linkGitRevParse.AutoSize = true;
+            this.linkGitRevParse.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.linkGitRevParse.Location = new System.Drawing.Point(3, 73);
+            this.linkGitRevParse.Name = "linkGitRevParse";
+            this.linkGitRevParse.Size = new System.Drawing.Size(440, 13);
+            this.linkGitRevParse.TabIndex = 0;
+            this.linkGitRevParse.TabStop = true;
+            this.linkGitRevParse.Text = "More see git-rev-parse";
+            this.linkGitRevParse.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkGitRevParse_LinkClicked);
             // 
-            // comboBoxTags
+            // tableLayoutPanel1
             // 
-            this.comboBoxTags.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.comboBoxTags.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.comboBoxTags.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.comboBoxTags.FormattingEnabled = true;
-            this.comboBoxTags.Location = new System.Drawing.Point(155, 216);
-            this.comboBoxTags.Name = "comboBoxTags";
-            this.comboBoxTags.Size = new System.Drawing.Size(287, 23);
-            this.comboBoxTags.TabIndex = 1;
-            this.comboBoxTags.SelectionChangeCommitted += new System.EventHandler(this.comboBoxTags_SelectionChangeCommitted);
-            this.comboBoxTags.TextChanged += new System.EventHandler(this.comboBoxTags_TextChanged);
-            this.comboBoxTags.Enter += new System.EventHandler(this.comboBoxTags_Enter);
-            this.comboBoxTags.KeyUp += new System.Windows.Forms.KeyEventHandler(this.comboBoxTags_KeyUp);
-            // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(12, 261);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(79, 15);
-            this.label4.TabIndex = 5;
-            this.label4.Text = "Go to branch:";
-            // 
-            // comboBoxBranches
-            // 
-            this.comboBoxBranches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.comboBoxBranches.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
-            this.comboBoxBranches.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
-            this.comboBoxBranches.FormattingEnabled = true;
-            this.comboBoxBranches.Location = new System.Drawing.Point(155, 258);
-            this.comboBoxBranches.Name = "comboBoxBranches";
-            this.comboBoxBranches.Size = new System.Drawing.Size(287, 23);
-            this.comboBoxBranches.TabIndex = 2;
-            this.comboBoxBranches.SelectionChangeCommitted += new System.EventHandler(this.comboBoxBranches_SelectionChangeCommitted);
-            this.comboBoxBranches.TextChanged += new System.EventHandler(this.comboBoxBranches_TextChanged);
-            this.comboBoxBranches.Enter += new System.EventHandler(this.comboBoxBranches_Enter);
-            this.comboBoxBranches.KeyUp += new System.Windows.Forms.KeyEventHandler(this.comboBoxBranches_KeyUp);
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.textboxCommitExpression, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.goButton, 1, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(484, 201);
+            this.tableLayoutPanel1.TabIndex = 5;
             // 
             // FormGoToCommit
             // 
             this.AcceptButton = this.goButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(604, 302);
-            this.Controls.Add(this.comboBoxBranches);
-            this.Controls.Add(this.label4);
-            this.Controls.Add(this.comboBoxTags);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.textboxCommitExpression);
-            this.Controls.Add(this.goButton);
+            this.ClientSize = new System.Drawing.Size(484, 201);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(620, 340);
             this.Name = "FormGoToCommit";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Go to commit";
-            this.Load += new System.EventHandler(this.FormGoToCommit_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -181,9 +173,7 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.LinkLabel linkGitRevParse;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.ComboBox comboBoxTags;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.ComboBox comboBoxBranches;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -1,29 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Drawing;
 using System.Windows.Forms;
-using GitCommands;
+using GitExtUtils.GitUI;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
-using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
 {
     public sealed partial class FormGoToCommit : GitModuleForm
     {
-        /// <summary>
-        /// this will be used when Go() is called
-        /// </summary>
-        private string _selectedRevision;
-
-        // these two are used to prepare for _selectedRevision
-        private IGitRef _selectedTag;
-        private IGitRef _selectedBranch;
-
-        private readonly AsyncLoader _tagsLoader = new AsyncLoader();
-        private readonly AsyncLoader _branchesLoader = new AsyncLoader();
-
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormGoToCommit()
         {
@@ -37,25 +23,33 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             InitializeComplete();
         }
 
-        private void FormGoToCommit_Load(object sender, EventArgs e)
+        protected override void OnLoad(EventArgs e)
         {
-            LoadTagsAsync();
-            LoadBranchesAsync();
             SetCommitExpressionFromClipboard();
+            base.OnLoad(e);
+        }
+
+        protected override void OnRuntimeLoad(EventArgs e)
+        {
+            base.OnRuntimeLoad(e);
+
+            // scale up for hi DPI
+            MinimumSize = DpiUtil.Scale(new Size(500, 255));
+            Size = MinimumSize;
         }
 
         /// <summary>
-        /// returns null if revision does not exist (could not be revparsed)
+        /// returns null if revision does not exist (could not be rev-parsed)
         /// </summary>
         [CanBeNull]
         public ObjectId ValidateAndGetSelectedRevision()
         {
-            return Module.RevParse(_selectedRevision);
+            return Module.RevParse(textboxCommitExpression.Text.Trim());
         }
 
         private void commitExpression_TextChanged(object sender, EventArgs e)
         {
-            SetSelectedRevisionByFocusedControl();
+            goButton.Enabled = !string.IsNullOrWhiteSpace(textboxCommitExpression.Text.Trim());
         }
 
         private void Go()
@@ -72,135 +66,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private void linkGitRevParse_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start(@"https://git-scm.com/docs/git-rev-parse#_specifying_revisions");
-        }
-
-        private void LoadTagsAsync()
-        {
-            comboBoxTags.Text = Strings.LoadingData;
-            ThreadHelper.JoinableTaskFactory.RunAsync(() =>
-            {
-                return _tagsLoader.LoadAsync(
-                    () => Module.GetTagRefs(GitModule.GetTagRefsSortOrder.ByCommitDateDescending).ToList(),
-                    list =>
-                    {
-                        comboBoxTags.Text = string.Empty;
-                        comboBoxTags.DataSource = list;
-                        comboBoxTags.DisplayMember = nameof(IGitRef.LocalName);
-                        SetSelectedRevisionByFocusedControl();
-                    });
-            });
-        }
-
-        private void LoadBranchesAsync()
-        {
-            comboBoxBranches.Text = Strings.LoadingData;
-            ThreadHelper.JoinableTaskFactory.RunAsync(() =>
-            {
-                return _branchesLoader.LoadAsync(
-                    () => Module.GetRefs(false).ToList(),
-                    list =>
-                    {
-                        comboBoxBranches.Text = string.Empty;
-                        comboBoxBranches.DataSource = list;
-                        comboBoxBranches.DisplayMember = nameof(IGitRef.LocalName);
-                        SetSelectedRevisionByFocusedControl();
-                    });
-            });
-        }
-
-        private static IReadOnlyList<IGitRef> DataSourceToGitRefs(ComboBox cb)
-        {
-            return (IReadOnlyList<IGitRef>)cb.DataSource;
-        }
-
-        private void comboBoxTags_Enter(object sender, EventArgs e)
-        {
-            SetSelectedRevisionByFocusedControl();
-        }
-
-        private void comboBoxBranches_Enter(object sender, EventArgs e)
-        {
-            SetSelectedRevisionByFocusedControl();
-        }
-
-        private void SetSelectedRevisionByFocusedControl()
-        {
-            if (textboxCommitExpression.Focused)
-            {
-                _selectedRevision = textboxCommitExpression.Text.Trim();
-            }
-            else if (comboBoxTags.Focused)
-            {
-                _selectedRevision = _selectedTag != null ? _selectedTag.Guid : "";
-            }
-            else if (comboBoxBranches.Focused)
-            {
-                _selectedRevision = _selectedBranch != null ? _selectedBranch.Guid : "";
-            }
-        }
-
-        private void comboBoxTags_TextChanged(object sender, EventArgs e)
-        {
-            if (comboBoxTags.DataSource == null)
-            {
-                return;
-            }
-
-            _selectedTag = DataSourceToGitRefs(comboBoxTags).FirstOrDefault(a => a.LocalName == comboBoxTags.Text);
-            SetSelectedRevisionByFocusedControl();
-        }
-
-        private void comboBoxBranches_TextChanged(object sender, EventArgs e)
-        {
-            if (comboBoxBranches.DataSource == null)
-            {
-                return;
-            }
-
-            _selectedBranch = DataSourceToGitRefs(comboBoxBranches).FirstOrDefault(a => a.LocalName == comboBoxBranches.Text);
-            SetSelectedRevisionByFocusedControl();
-        }
-
-        private void comboBoxTags_SelectionChangeCommitted(object sender, EventArgs e)
-        {
-            if (comboBoxTags.SelectedValue == null)
-            {
-                return;
-            }
-
-            _selectedTag = (IGitRef)comboBoxTags.SelectedValue;
-            SetSelectedRevisionByFocusedControl();
-            Go();
-        }
-
-        private void comboBoxBranches_SelectionChangeCommitted(object sender, EventArgs e)
-        {
-            if (comboBoxBranches.SelectedValue == null)
-            {
-                return;
-            }
-
-            _selectedBranch = (IGitRef)comboBoxBranches.SelectedValue;
-            SetSelectedRevisionByFocusedControl();
-            Go();
-        }
-
-        private void comboBoxTags_KeyUp(object sender, KeyEventArgs e)
-        {
-            GoIfEnterKey(sender, e);
-        }
-
-        private void comboBoxBranches_KeyUp(object sender, KeyEventArgs e)
-        {
-            GoIfEnterKey(sender, e);
-        }
-
-        private void GoIfEnterKey(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter)
-            {
-                Go();
-            }
         }
 
         private void SetCommitExpressionFromClipboard()
@@ -227,9 +92,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             if (disposing)
             {
-                _tagsLoader.Dispose();
-                _branchesLoader.Dispose();
-
                 components?.Dispose();
             }
 


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Closes #4869 as obsolete


## Proposed changes

- Since branches and tags can be easily navigated to via the left panel, `FormGoToCommit` can now be simplified to only offer navigation by commit expression.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/51783092-97596d80-2188-11e9-8f1e-5e4765820d3f.png)


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/51783093-c1129480-2188-11e9-970a-39a0eb2c80d2.png)





## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10, 125% scaling

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
