### PR TITLE
Refactor and optimize AheadBehind code in left panel

### DIFF
--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -26,8 +26,14 @@ namespace GitCommands.Git
             _getGitExecutable = getGitExecutable;
         }
 
+        [CanBeNull]
         public IDictionary<string, AheadBehindData> GetData(string branchName = "")
         {
+            if (!AppSettings.ShowAheadBehindData)
+            {
+                return null;
+            }
+
             return GetData(null, branchName);
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using GitCommands;
 using GitCommands.Git;
 using GitUI.Properties;
 using JetBrains.Annotations;
@@ -240,11 +239,7 @@ namespace GitUI.BranchTreePanel
 
                 #endregion
 
-                IDictionary<string, AheadBehindData> aheadBehindData = null;
-                if (_aheadBehindDataProvider != null && AppSettings.ShowAheadBehindData)
-                {
-                    aheadBehindData = _aheadBehindDataProvider.GetData();
-                }
+                var aheadBehindData = _aheadBehindDataProvider?.GetData();
 
                 var currentBranch = Module.GetSelectedBranch();
                 var nodes = new Dictionary<string, BaseBranchNode>();

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -9,10 +9,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
 using GitUI.UserControls;
+using JetBrains.Annotations;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel
@@ -32,6 +34,7 @@ namespace GitUI.BranchTreePanel
         private RemoteBranchTree _remoteTree;
         private List<TreeNode> _searchResult;
         private FilterBranchHelper _filterBranchHelper;
+        private IAheadBehindDataProvider _aheadBehindDataProvider;
         private bool _searchCriteriaChanged;
 
         public RepoObjectsTree()
@@ -177,8 +180,9 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        public void SetBranchFilterer(FilterBranchHelper filterBranchHelper)
+        public void Initialize([CanBeNull]IAheadBehindDataProvider aheadBehindDataProvider, FilterBranchHelper filterBranchHelper)
         {
+            _aheadBehindDataProvider = aheadBehindDataProvider;
             _filterBranchHelper = filterBranchHelper;
         }
 
@@ -246,7 +250,7 @@ namespace GitUI.BranchTreePanel
                 ImageKey = nameof(Images.BranchLocalRoot),
                 SelectedImageKey = nameof(Images.BranchLocalRoot),
             };
-            AddTree(new BranchTree(localBranchesRootNode, source));
+            AddTree(new BranchTree(localBranchesRootNode, source, _aheadBehindDataProvider));
 
             var remoteBranchesRootNode = new TreeNode(Strings.Remotes)
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1917,7 +1917,6 @@ namespace GitUI.CommandsDialogs
             UICommands = new GitUICommands(module);
             if (Module.IsValidGitWorkingDir())
             {
-                repoObjectsTree.InitializeAheadBehindProvider();
                 var path = Module.WorkingDir;
                 ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
                 AppSettings.RecentWorkingDir = path;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -96,6 +96,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFormBrowseController _controller;
         private readonly ICommitDataManager _commitDataManager;
         private readonly IAppTitleGenerator _appTitleGenerator;
+        private readonly IAheadBehindDataProvider _aheadBehindDataProvider;
         private readonly WindowsJumpListManager _windowsJumpListManager;
         private readonly SubmoduleStatusProvider _submoduleStatusProvider;
 
@@ -178,7 +179,9 @@ namespace GitUI.CommandsDialogs
 
             _filterRevisionsHelper = new FilterRevisionsHelper(toolStripRevisionFilterTextBox, toolStripRevisionFilterDropDownButton, RevisionGrid, toolStripRevisionFilterLabel, ShowFirstParent, form: this);
             _filterBranchHelper = new FilterBranchHelper(toolStripBranchFilterComboBox, toolStripBranchFilterDropDownButton, RevisionGrid);
-            repoObjectsTree.SetBranchFilterer(_filterBranchHelper);
+            _aheadBehindDataProvider = GitVersion.Current.SupportAheadBehindData ? new AheadBehindDataProvider(() => Module.GitExecutable) : null;
+
+            repoObjectsTree.Initialize(_aheadBehindDataProvider, _filterBranchHelper);
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
             revisionDiff.Bind(RevisionGrid, fileTree);
 
@@ -503,7 +506,7 @@ namespace GitUI.CommandsDialogs
             UpdateSubmodulesStructure();
             UpdateStashCount();
 
-            toolStripButtonPush.Initialize(new AheadBehindDataProvider(() => Module.GitExecutable), GitVersion.Current.SupportAheadBehindData);
+            toolStripButtonPush.Initialize(_aheadBehindDataProvider);
             toolStripButtonPush.DisplayAheadBehindInformation(Module.GetSelectedBranch());
 
             base.OnLoad(e);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -96,7 +96,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFormBrowseController _controller;
         private readonly ICommitDataManager _commitDataManager;
         private readonly IAppTitleGenerator _appTitleGenerator;
-        private readonly IAheadBehindDataProvider _aheadBehindDataProvider;
+        [CanBeNull] private readonly IAheadBehindDataProvider _aheadBehindDataProvider;
         private readonly WindowsJumpListManager _windowsJumpListManager;
         private readonly SubmoduleStatusProvider _submoduleStatusProvider;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -59,6 +59,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowCurrentChangesInRevisionGraph.Checked = AppSettings.RevisionGraphShowWorkingDirChanges;
             chkShowStashCountInBrowseWindow.Checked = AppSettings.ShowStashCount;
             chkShowAheadBehindDataInBrowseWindow.Checked = AppSettings.ShowAheadBehindData;
+            chkShowAheadBehindDataInBrowseWindow.Enabled = GitVersion.Current.SupportAheadBehindData;
             chkShowGitStatusInToolbar.Checked = AppSettings.ShowGitStatusInBrowseToolbar;
             chkShowGitStatusForArtificialCommits.Checked = AppSettings.ShowGitStatusForArtificialCommits;
             chkShowSubmoduleStatusInBrowse.Checked = AppSettings.ShowSubmoduleStatus;

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
 using GitUI.Properties;
+using JetBrains.Annotations;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -17,9 +18,9 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _behindCommitsTointegrateOrForcePush =
             new TranslationString("{0} commit(s) should be integrated (or will be lost if force pushed)");
 
-        private IAheadBehindDataProvider _aheadBehindDataProvider;
+        [CanBeNull] private IAheadBehindDataProvider _aheadBehindDataProvider;
 
-        public void Initialize(IAheadBehindDataProvider aheadBehindDataProvider)
+        public void Initialize([CanBeNull]IAheadBehindDataProvider aheadBehindDataProvider)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
             ResetToDefaultState();
@@ -27,14 +28,9 @@ namespace GitUI.CommandsDialogs
 
         public void DisplayAheadBehindInformation(string branchName)
         {
-            if (_aheadBehindDataProvider == null || !AppSettings.ShowAheadBehindData)
-            {
-                return;
-            }
-
             ResetToDefaultState();
 
-            var aheadBehindData = _aheadBehindDataProvider.GetData(branchName);
+            var aheadBehindData = _aheadBehindDataProvider?.GetData(branchName);
             if (aheadBehindData == null || aheadBehindData.Count < 1 || !aheadBehindData.ContainsKey(branchName))
             {
                 return;

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -18,18 +18,16 @@ namespace GitUI.CommandsDialogs
             new TranslationString("{0} commit(s) should be integrated (or will be lost if force pushed)");
 
         private IAheadBehindDataProvider _aheadBehindDataProvider;
-        private bool _supportsAheadBehindData;
 
-        public void Initialize(IAheadBehindDataProvider aheadBehindDataProvider, bool supportsAheadBehindData)
+        public void Initialize(IAheadBehindDataProvider aheadBehindDataProvider)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
-            _supportsAheadBehindData = supportsAheadBehindData;
             ResetToDefaultState();
         }
 
         public void DisplayAheadBehindInformation(string branchName)
         {
-            if (!_supportsAheadBehindData || !AppSettings.ShowAheadBehindData)
+            if (_aheadBehindDataProvider == null || !AppSettings.ShowAheadBehindData)
             {
                 return;
             }

--- a/UnitTests/GitUITests/UserControls/ToolStripPushButtonTests.cs
+++ b/UnitTests/GitUITests/UserControls/ToolStripPushButtonTests.cs
@@ -28,7 +28,7 @@ namespace GitUITests.UserControls
             _aheadBehindDataProvider = Substitute.For<IAheadBehindDataProvider>();
 
             _sut = new ToolStripPushButton();
-            _sut.Initialize(_aheadBehindDataProvider, true);
+            _sut.Initialize(_aheadBehindDataProvider);
         }
 
         [TearDown]
@@ -40,7 +40,7 @@ namespace GitUITests.UserControls
         [Test]
         public void DisplayAheadBehindInformation_should_not_display_anything_if_does_not_support_ahead_behind()
         {
-            _sut.Initialize(_aheadBehindDataProvider, false);
+            _sut.Initialize(null);
 
             _sut.DisplayAheadBehindInformation("any-branchName");
 
@@ -157,8 +157,6 @@ namespace GitUITests.UserControls
             _sut.ToolTipText.Should().NotContain("99 new commit(s) will be pushed");
             _sut.ToolTipText.Should().NotContain("3 commit(s) should be integrated");
             _sut.Image.RawFormat.GetHashCode().Should().Be(Images.Unstage.RawFormat.GetHashCode());
-
-            _aheadBehindDataProvider.DidNotReceive().GetData(Arg.Any<string>());
         }
     }
 }


### PR DESCRIPTION
Moved ownership of the AheadBehindDataProvider to BranchTree, which represents the "Branches" top node in the panel. Also allows us to avoid having to recurse the entire tree to update the AheadBehind string as we now set it as soon as we construct the BranchTree node.

## Proposed changes

- This refactors some code introduced in https://github.com/gitextensions/gitextensions/pull/5994 recently.
- This localizes the AheadBehind code to the right place for the left panel, and allows us to optimize the setting of the AheadBehind string, as described in the commit comment.
- This also simplifies the rework I have to do in my left panel pubsub change (https://github.com/gitextensions/gitextensions/pull/5669)

## Test methodology <!-- How did you ensure quality? -->

- Although I didn't change any of that code, I made sure the AheadBehind unit and integration tests still pass.
- I reset current branch to different places in GE to make sure the AheadBehind text in the left panel still changes.
- I reset current branch to different places outside of GE, then refreshed in GE to make sure the left panel reflects the change.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
