### PR TITLE
Fix a bug introduced in #5994 where if active branch is ahead/behind,…

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -217,8 +217,7 @@ namespace GitUI.BranchTreePanel
 
                 if (!token.IsCancellationRequested)
                 {
-                    var selectedNode = treeMain.AllNodes().FirstOrDefault(n =>
-                        _rootNodes.Any(rn => $"{rn.TreeViewNode.FullPath}{treeMain.PathSeparator}{currentBranch}" == n.FullPath));
+                    var selectedNode = treeMain.AllNodes().FirstOrDefault(n => n.Tag is LocalBranchNode branchNode ? branchNode.IsActive : false);
                     if (selectedNode != null)
                     {
                         SetSelectedNode(selectedNode);


### PR DESCRIPTION
… it will not be selected in the left panel

As a result of this bug, the Branches view would remain collapsed upon opening the repo.

## Proposed changes

As described in the commit comment, this fixes the Branches node remaining collapsed when opening a repo where the active branch is ahead/behind it's remote counterpart. This bug was introduced in #5994. Note that this fix is very simple, and I didn't want to go further than this because I actually have a different solution in place in my WIP pubsub work (https://github.com/gitextensions/gitextensions/pull/5669), where the BranchTree itself sets the selected node, rather than the RepoObjectTree.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6893883/51803641-73983500-2225-11e9-8e5c-361c68f83bb0.png)

### After

![image](https://user-images.githubusercontent.com/6893883/51803642-7b57d980-2225-11e9-9e10-02f3ecd96eb7.png)

## Test methodology <!-- How did you ensure quality? -->

- Reset active branch to an earlier commit. Close GE, then open it against the same repo.
- Basical manual testing.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
