### PR TITLE
SubmoduleStatusProvider always sets TopProject

### DIFF
--- a/GitCommands/Submodules/SubmoduleInfoResult.cs
+++ b/GitCommands/Submodules/SubmoduleInfoResult.cs
@@ -8,18 +8,24 @@ namespace GitCommands.Submodules
     /// </summary>
     public class SubmoduleInfoResult
     {
+        // List of SubmoduleInfo for all submodules (recursively) under current module.
         public IList<SubmoduleInfo> OurSubmodules { get; } = new List<SubmoduleInfo>();
+
+        // List of SubmoduleInfo for all submodules under TopProject.
+        // Only populated if current module is a submodule (i.e. is not TopProject)
         public IList<SubmoduleInfo> SuperSubmodules { get; } = new List<SubmoduleInfo>();
 
         // Always set to the top-most module.
         [NotNull]
-        public SubmoduleInfo TopProject { get; set; }
+        public SubmoduleInfo TopProject { get; internal set; }
 
         // Set to the current module's parent, or null if current module is the top one.
         // If current module's parent is also the top-most module, then SuperProject == TopProject.
         [CanBeNull]
-        public SubmoduleInfo SuperProject { get; set; }
+        public SubmoduleInfo SuperProject { get; internal set; }
 
-        public string CurrentSubmoduleName { get; set; }
+        // Name of current module, if it is a submodule. If current module is TopProject, will be null.
+        [CanBeNull]
+        public string CurrentSubmoduleName { get; internal set; }
     }
 }

--- a/GitCommands/Submodules/SubmoduleInfoResult.cs
+++ b/GitCommands/Submodules/SubmoduleInfoResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace GitCommands.Submodules
 {
@@ -9,8 +10,16 @@ namespace GitCommands.Submodules
     {
         public IList<SubmoduleInfo> OurSubmodules { get; } = new List<SubmoduleInfo>();
         public IList<SubmoduleInfo> SuperSubmodules { get; } = new List<SubmoduleInfo>();
+
+        // Always set to the top-most module.
+        [NotNull]
         public SubmoduleInfo TopProject { get; set; }
+
+        // Set to the current module's parent, or null if current module is the top one.
+        // If current module's parent is also the top-most module, then SuperProject == TopProject.
+        [CanBeNull]
         public SubmoduleInfo SuperProject { get; set; }
+
         public string CurrentSubmoduleName { get; set; }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2684,7 +2684,9 @@ namespace GitUI.CommandsDialogs
             if (result.SuperProject != null)
             {
                 newItems.Add(new ToolStripSeparator());
-                if (result.TopProject != null)
+
+                // Show top project only if it's not our super project
+                if (result.TopProject != null && result.TopProject != result.SuperProject)
                 {
                     newItems.Add(CreateSubmoduleMenuItem(cancelToken, result.TopProject, _topProjectModuleFormat.Text));
                 }

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="PathEqualityComparerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Remote\GitRemoteManagerTests.cs" />
+    <Compile Include="Submodules\SubmoduleStatusProviderTests.cs" />
     <Compile Include="UserRepositoryHistory\Legacy\RepositoryCategoryXmlSerialiserTests.cs" />
     <Compile Include="UserRepositoryHistory\Legacy\RepositoryHistoryMigratorTests.cs" />
     <Compile Include="UserRepositoryHistory\Legacy\RepositoryStorageTests.cs" />

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -1,0 +1,174 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Submodules;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Submodules
+{
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
+    [TestFixture]
+    internal class SubmoduleStatusProviderTests
+    {
+        public class IntegrationTests
+        {
+            private GitModuleTestHelper _repo1;
+            private GitModuleTestHelper _repo2;
+            private GitModuleTestHelper _repo3;
+
+            // Note that _repo2Module and _repo3Module point to the submodules under _repo1Module,
+            // not _repo2.Module and _repo3.Module respectively. In general, the tests should here
+            // should interact with these modules, not with _repo2 and _repo3.
+            private GitModule _repo1Module;
+            private GitModule _repo2Module;
+            private GitModule _repo3Module;
+
+            private ISubmoduleStatusProvider _provider;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _repo1 = new GitModuleTestHelper("repo1");
+                _repo2 = new GitModuleTestHelper("repo2");
+                _repo3 = new GitModuleTestHelper("repo3");
+
+                _repo2.AddSubmodule(_repo3, "repo3");
+                _repo1.AddSubmodule(_repo2, "repo2");
+                var submodules = _repo1.GetSubmodulesRecursive();
+
+                _repo1Module = _repo1.Module;
+                _repo2Module = submodules.ElementAt(0);
+                _repo3Module = submodules.ElementAt(1);
+
+                _provider = new SubmoduleStatusProvider();
+            }
+
+            [TearDown]
+            public void TearDown()
+            {
+                _provider.Dispose();
+                _repo1.Dispose();
+                _repo2.Dispose();
+                _repo3.Dispose();
+            }
+
+            [Test]
+            public void UpdateSubmoduleStatus_valid_result_for_top_module()
+            {
+                var result = UpdateSubmoduleStatusAndWaitForResult(_provider, _repo1Module);
+
+                result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
+                result.SuperProject.Should().Be(null);
+                result.CurrentSubmoduleName.Should().Be(null);
+                result.OurSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
+                result.SuperSubmodules.Should().BeEmpty();
+            }
+
+            [Test]
+            public void UpdateSubmoduleStatus_valid_result_for_first_nested_submodule()
+            {
+                var result = UpdateSubmoduleStatusAndWaitForResult(_provider, _repo2Module);
+
+                result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
+                result.SuperProject.Should().Be(result.TopProject);
+                result.CurrentSubmoduleName.Should().Be("repo2");
+                result.OurSubmodules.Select(info => info.Path).Should().ContainSingle(_repo3Module.WorkingDir);
+                result.SuperSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
+            }
+
+            [Test]
+            public void UpdateSubmoduleStatus_valid_result_for_second_nested_submodule()
+            {
+                var result = UpdateSubmoduleStatusAndWaitForResult(_provider, _repo3Module);
+
+                result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
+                result.SuperProject.Path.Should().Be(_repo2Module.WorkingDir);
+                result.CurrentSubmoduleName.Should().Be("repo3");
+                result.OurSubmodules.Select(info => info.Path).Should().BeEmpty();
+                result.SuperSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
+            }
+
+            [Test]
+            public void HasChangedToNone_valid_result()
+            {
+                UpdateSubmoduleStatusAndWaitForResult(_provider, _repo3Module);
+
+                // No changes in repo
+                var changedFiles = GetStatusChangedFiles(_repo1Module);
+                changedFiles.Should().HaveCount(0);
+                _provider.HasChangedToNone(changedFiles).Should().BeFalse();
+
+                // Make a change in repo2
+                _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
+                changedFiles = GetStatusChangedFiles(_repo1Module);
+                changedFiles.Should().HaveCount(1);
+                _provider.HasChangedToNone(changedFiles).Should().BeFalse();
+
+                // Revert the change
+                File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
+                changedFiles = GetStatusChangedFiles(_repo1Module);
+                changedFiles.Should().HaveCount(0);
+                _provider.HasChangedToNone(changedFiles).Should().BeTrue();
+            }
+
+            [Test]
+            public void HasStatusChanges_valid_result()
+            {
+                UpdateSubmoduleStatusAndWaitForResult(_provider, _repo3Module);
+
+                // No changes in repo
+                var changedFiles = GetStatusChangedFiles(_repo1Module);
+                changedFiles.Should().HaveCount(0);
+                _provider.HasStatusChanges(changedFiles).Should().BeFalse();
+
+                // Make a change in repo2
+                _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
+                changedFiles = GetStatusChangedFiles(_repo1Module);
+                changedFiles.Should().HaveCount(1);
+                _provider.HasStatusChanges(changedFiles).Should().BeTrue();
+
+                // Revert the change
+                File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
+                changedFiles = GetStatusChangedFiles(_repo1Module);
+                changedFiles.Should().HaveCount(0);
+                _provider.HasStatusChanges(changedFiles).Should().BeFalse();
+            }
+
+            private static SubmoduleInfoResult UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module)
+            {
+                SubmoduleInfoResult result = null;
+                SemaphoreSlim onUpdateCompleteSignal = new SemaphoreSlim(0, 1);
+
+                provider.UpdateSubmodulesStatus(
+                    updateStatus: false,
+                    workingDirectory: module.WorkingDir,
+                    noBranchText: string.Empty,
+                    onUpdateBegin: () => { },
+                    onUpdateCompleteAsync: async (SubmoduleInfoResult submoduleInfoResult, CancellationToken token) =>
+                    {
+                        await TaskScheduler.Default;
+                        result = submoduleInfoResult;
+                        onUpdateCompleteSignal.Release();
+                    });
+
+                onUpdateCompleteSignal.Wait();
+                return result;
+            }
+
+            private static IReadOnlyList<GitItemStatus> GetStatusChangedFiles(IGitModule module)
+            {
+                var cmd = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.Default, noLocks: true);
+                var output = module.GitExecutable.GetOutput(cmd);
+                return GitCommandHelpers.GetStatusChangedFilesFromString(module, output);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, SubmoduleStatusProvider would only set TopProject if current module's SuperProject was not the TopProject. In other words, when the current module was at least 2 submodules deep from the top module. With this change, we always set the TopProject to the top module. This means that SuperProject == TopProject when current module is 1 submodule deep from the top module. This change makes it easier to retrieve the top project when needed at no extra runtime cost.

## Proposed changes

This change is extracted from my left panel submodules work. In particular, I need this so that I can always display the top module in the left pane. I figured it would be better to introduce this as a small change separately. I'm simply changing the API contract on the SubmoduleInfoResult that the SubmoduleStatusProvider returns. There should be no visual or behavioral changes in GE with this.

## Test methodology <!-- How did you ensure quality? -->

- Ran unit tests
- Manual testing, looking at submodules in a repo with submodules nested 3 levels deep


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
