### PR TITLE
fix build server settings page that could be clipped

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
@@ -29,6 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             // 
             // buildServerSettingsPanel
             // 
+            this.buildServerSettingsPanel.AutoSize = true;
             this.buildServerSettingsPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.SetColumnSpan(this.buildServerSettingsPanel, 2);
             this.buildServerSettingsPanel.Dock = System.Windows.Forms.DockStyle.Fill;


### PR DESCRIPTION

## Proposed changes

- The panel could grow depending on its content


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

We can't see all the fields, just the first one:

![image](https://user-images.githubusercontent.com/460196/52058018-dca1e480-2566-11e9-86b3-45786d99fa00.png)

### After

We could see all the fields :

![image](https://user-images.githubusercontent.com/460196/52058035-e75c7980-2566-11e9-99d1-f0240e34cbe3.png)



## Test methodology <!-- How did you ensure quality? -->

- Launching GE and using my own eyes 😉 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 5ec1507ab077027c3508f4429d8d7e0e2210839d (Dirty)
- Git 2.20.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3260.0
- DPI 192dpi (200% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
