### PR TITLE
Show remote branch in Commit dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -146,6 +146,7 @@ namespace GitUI.CommandsDialogs
             this.commitAuthorStatus = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusBranchIcon = new System.Windows.Forms.ToolStripStatusLabel();
             this.branchNameLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.remoteNameLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.commitStagedCountLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.commitStagedCount = new System.Windows.Forms.ToolStripStatusLabel();
             this.commitCursorLineLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -1357,6 +1358,7 @@ namespace GitUI.CommandsDialogs
             this.commitAuthorStatus,
             this.toolStripStatusBranchIcon,
             this.branchNameLabel,
+            this.remoteNameLabel,
             this.commitStagedCountLabel,
             this.commitStagedCount,
             this.commitCursorLineLabel,
@@ -1395,11 +1397,22 @@ namespace GitUI.CommandsDialogs
             // branchNameLabel
             // 
             this.branchNameLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.branchNameLabel.Margin = new System.Windows.Forms.Padding(0, 3, 25, 2);
+            this.branchNameLabel.Margin = new System.Windows.Forms.Padding(0, 3, 0, 2);
             this.branchNameLabel.Name = "branchNameLabel";
             this.branchNameLabel.Size = new System.Drawing.Size(85, 17);
             this.branchNameLabel.Text = "(Branch name)";
-            this.branchNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.branchNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // remoteNameLabel
+            // 
+            this.remoteNameLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.remoteNameLabel.IsLink = true;
+            this.remoteNameLabel.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
+            this.remoteNameLabel.Margin = new System.Windows.Forms.Padding(0, 3, 25, 2);
+            this.remoteNameLabel.Name = "remoteNameLabel";
+            this.remoteNameLabel.Size = new System.Drawing.Size(85, 17);
+            this.remoteNameLabel.Text = "(Remote name)";
+            this.remoteNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // commitStagedCountLabel
             //
@@ -1643,6 +1656,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripButton createBranchToolStripButton;
         private ToolStripStatusLabel toolStripStatusBranchIcon;
         private ToolStripStatusLabel branchNameLabel;
+        private ToolStripStatusLabel remoteNameLabel;
         private ToolStripSeparator toolStripSeparator14;
         private ToolStripTextBox toolStripGpgKeyTextBox;
         private ToolStripComboBox gpgSignCommitToolStripComboBox;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -954,13 +954,15 @@ namespace GitUI
         }
 
         /// <param name="preselectRemote">makes the FormRemotes initially select the given remote</param>
-        public bool StartRemotesDialog(IWin32Window owner, string preselectRemote = null)
+        /// <param name="preselectLocal">makes the FormRemotes initially show tab "Default push behavior" and select the given local</param>
+        public bool StartRemotesDialog(IWin32Window owner, string preselectRemote = null, string preselectLocal = null)
         {
             bool Action()
             {
                 using (var form = new FormRemotes(this))
                 {
                     form.PreselectRemoteOnLoad = preselectRemote;
+                    form.PreselectLocalOnLoad = preselectLocal;
                     form.ShowDialog(owner);
                 }
 

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -83,6 +83,47 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         }
 
         [Test]
+        public void Should_display_branch_and_no_remote_info_in_statusbar()
+        {
+            RunFormTest(form =>
+            {
+                var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
+                var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
+
+                Assert.AreEqual("master →", currentBranchNameLabelStatus.Text);
+                Assert.AreEqual("(remote not configured)", remoteNameLabelStatus.Text);
+            });
+        }
+
+        [Test]
+        public void Should_display_detached_head_info_in_statusbar()
+        {
+            _referenceRepository.CheckoutRevision();
+            RunFormTest(form =>
+            {
+                var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
+                var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
+
+                Assert.AreEqual("(no branch)", currentBranchNameLabelStatus.Text);
+                Assert.AreEqual(string.Empty, remoteNameLabelStatus.Text);
+            });
+        }
+
+        [Test]
+        public void Should_display_branch_and_remote_info_in_statusbar()
+        {
+            _referenceRepository.CreateRemoteForMasterBranch();
+            RunFormTest(form =>
+            {
+                var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
+                var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
+
+                Assert.AreEqual("master →", currentBranchNameLabelStatus.Text);
+                Assert.AreEqual("origin/master", remoteNameLabelStatus.Text);
+            });
+        }
+
+        [Test]
         public void PreserveCommitMessageOnReopen()
         {
             var generatedCommitMessage = Guid.NewGuid().ToString();

--- a/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using CommonTestUtils;
 using GitCommands;
+using LibGit2Sharp;
+using Remote = LibGit2Sharp.Remote;
 
 namespace GitUITests.CommandsDialogs
 {
@@ -30,6 +32,29 @@ namespace GitUITests.CommandsDialogs
         public GitModule Module => _moduleTestHelper.Module;
 
         public string CommitHash => _commitHash;
+
+        public void CheckoutRevision()
+        {
+            using (var repository = new LibGit2Sharp.Repository(Module.WorkingDir))
+            {
+                Commands.Checkout(repository, CommitHash, new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+            }
+        }
+
+        public void CreateRemoteForMasterBranch()
+        {
+            using (var repository = new LibGit2Sharp.Repository(Module.WorkingDir))
+            {
+                repository.Network.Remotes.Add("origin", "http://useless.url");
+                Remote remote = repository.Network.Remotes["origin"];
+
+                var masterBranch = repository.Branches["master"];
+
+                repository.Branches.Update(masterBranch,
+                    b => b.Remote = remote.Name,
+                    b => b.UpstreamBranch = masterBranch.CanonicalName);
+            }
+        }
 
         public void Reset()
         {


### PR DESCRIPTION
Update with some fixes of PR #6158 ( intended to fix issue #6118) 


## Proposed changes

- Added remote branch to status bar item branchNameLabel
- Added click event to open "Default pull behavior" for current branch

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/52092972-d852e700-25b9-11e9-994c-25d59584f17d.png)


### After

![image](https://user-images.githubusercontent.com/460196/52092950-c113f980-25b9-11e9-916c-1d5f9f48e019.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 595c2b99ca427defe82894e3b22e286ebdfdeeb8
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3260.0
- DPI 96dpi (no scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
