### PR TITLE
FormCommit no longer show the committer info

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -366,17 +366,22 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnApplicationActivated()
         {
-            if (!_bypassActivatedEventHandler)
+            if (!_bypassActivatedEventHandler && AppSettings.RefreshCommitDialogOnFormFocus)
             {
-                if (AppSettings.RefreshCommitDialogOnFormFocus)
-                {
-                    RescanChanges();
-                }
-
-                UpdateAuthorInfo();
+                RescanChanges();
             }
 
             base.OnApplicationActivated();
+        }
+
+        protected override void OnActivated(EventArgs e)
+        {
+            if (!_bypassActivatedEventHandler)
+            {
+                UpdateAuthorInfo();
+            }
+
+            base.OnActivated(e);
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
@@ -408,6 +413,8 @@ namespace GitUI.CommandsDialogs
             {
                 Initialize();
             }
+
+            UpdateAuthorInfo();
 
             string message;
 
@@ -3190,6 +3197,8 @@ namespace GitUI.CommandsDialogs
             internal FileViewer SelectedDiff => _formCommit.SelectedDiff;
 
             internal ToolStripDropDownButton CommitMessageToolStripMenuItem => _formCommit.commitMessageToolStripMenuItem;
+
+            internal ToolStripStatusLabel CommitAuthorStatusToolStripStatusLabel => _formCommit.commitAuthorStatus;
 
             internal bool ExecuteCommand(Command command)
             {

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -27,7 +27,7 @@ namespace CommonTestUtils
 
             // Don't assume global user/email
             Module.RunGitCmd(@"config user.name ""author""");
-            Module.RunGitCmd(@"config user.email ""<author@mail.com>""");
+            Module.RunGitCmd(@"config user.email ""author@mail.com""");
 
             return;
 

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using FluentAssertions;
 using GitUI;
 using GitUI.CommandsDialogs;
@@ -44,6 +45,41 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void OneTimeTearDown()
         {
             _referenceRepository.Dispose();
+        }
+
+        [Test]
+        public void Should_show_committer_info_on_open()
+        {
+            RunFormTest(form =>
+            {
+                var commitAuthorStatus = form.GetTestAccessor().CommitAuthorStatusToolStripStatusLabel;
+
+                Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
+            });
+        }
+
+        [Test]
+        public void Should_update_committer_info_on_form_activated()
+        {
+            RunFormTest(form =>
+            {
+                var commitAuthorStatus = form.GetTestAccessor().CommitAuthorStatusToolStripStatusLabel;
+
+                Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
+
+                using (var tempForm = new Form())
+                {
+                    tempForm.Show();
+                    tempForm.Focus();
+
+                    _referenceRepository.Module.RunGitCmd(@"config user.name ""new author""");
+                    _referenceRepository.Module.RunGitCmd(@"config user.email ""new_author@mail.com""");
+                }
+
+                form.Focus();
+
+                Assert.AreEqual("Committer new author <new_author@mail.com>", commitAuthorStatus.Text);
+            });
         }
 
         [Test]


### PR DESCRIPTION
The regression is caused by changes in #6134

Fixes #6201

## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests

/cc: @pmiossec could you confirm the fix please

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
