### PR TITLE
Remove .vsix from Wix installer

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -72,7 +72,6 @@
         <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
       </Component>
     </Directory>
-    <PropertyRef Id="VS2015DEVENV" />
     <DirectoryRef Id="INSTALLDIR">
       <Component Id="gitextensions.ico" Guid="*">
         <File Source="..\Logo\git-extensions-logo.ico" />
@@ -544,10 +543,6 @@
         <RegistryKey Root="HKCR" Key="github-mac\shell\open\command">
           <RegistryValue Value="&quot;[INSTALLDIR]GitExtensions.exe&quot; %1" Type="string" />
         </RegistryKey>
-      </Component>
-      <Component Id="VS2015_VSIX" Guid="*">
-        <VSExtension:VsixPackage File="GitExtensionsVSIX.vsix" PackageId="GitExtensions..3166f76a-2b07-410a-a72a-509d6a2d146c" Target="community" TargetVersion="14.0" Vital="no" Permanent="no" />
-        <File Source="..\GitExtensionsVSIX\bin\$(var.Configuration)\GitExtensionsVSIX.vsix" />
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="PluginsDir">
@@ -1801,12 +1796,6 @@
       </Feature>
       <Feature Id="AddToPath" Title="Add installation directory to PATH" Level="1">
         <ComponentRef Id="Path" />
-      </Feature>
-      <Feature Id="VSExtension" Title="Visual Studio extension" Level="1">
-        <Feature Id="VS2015FeatureId" Title="Visual Studio 2015/2017 integration" Level="1">
-          <Condition Level="2">NOT VS2015DEVENV</Condition>
-          <ComponentRef Id="VS2015_VSIX" />
-        </Feature>
       </Feature>
       <Feature Id="Protocol.git" Title="Assign with git://-links" Level="1">
         <ComponentRef Id="Protocol.git" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,6 +111,7 @@ for:
     # upload the generated portable archive only
     - path: 'Setup/GitExtensions-Portable-*.zip'
     - path: 'Setup/GitExtensions-pdbs-*.zip'
+    - path: 'GitExtensionsVSIX/bin/Release/GitExtensionsVSIX.vsix'
 
 # configuration for release branches ONLY
 -
@@ -154,6 +155,7 @@ for:
           Exit-AppVeyorBuild
           return
       }
+      Push-AppveyorArtifact .\GitExtensionsVSIX\bin\Release\GitExtensionsVSIX.vsix
       # continue on with signing
       & Setup\Sign-Artifacts.ps1
       if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }


### PR DESCRIPTION
Upload vsix as a separate artifact to Appveyor

Fixes #5979


## Proposed changes

- Remove .vsix from Wix installer. It was included in the bundle, ticking installation only unpacked the file to the GE install dir.
- Upload vsix as a separate artifact to Appveyor

The current handling is a remain from when the old VS addin ran from the GE installer.
The vsix can be installed from the marketplace, but the current version should be offered for PR/master builds and I see no reason to not offer the vsix for releases too.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/52170929-e63c6f80-2753-11e9-8739-24070a3dbd4e.png)

### After

![image](https://user-images.githubusercontent.com/6248932/52170914-7ded8e00-2753-11e9-8a2e-75ad1ef3507d.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual iinstall
 
## Test environment(s) 