### PR TITLE
Make sure RestoreSelectedFiles always updates SelectedIndex of both staged and unstaged file list

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1154,10 +1154,8 @@ namespace GitUI.CommandsDialogs
             {
                 _currentFilesList.SelectedItems = newSelection;
             }
-            else
-            {
-                SelectStoredNextIndex();
-            }
+
+            SelectStoredNextIndex();
 
             return;
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -69,6 +69,7 @@ YYYY/MM/DD, github id, Full name, email
 2019/02/09, glen-nicol, Glen Nicol, glen.nicol@live.com
 2019/02/16, mdonatas, Donatas Mačiūnas, mdonatas@gmail.com
 2019/02/16, DmitryZhelnin, Dmitry Zhelnin, mitya_zh@mail.ru
+2019/02/17, monoblaine, Serhan Apaydın, zerhan@gmail.com
 2019/02/18, wachulski, Marcin Wachulski, marcin.wachulski@gmail.com
 2019/02/25, oriash93, Ori Ashual, oriash93@gmail.com
 2019/02/25, coreyasmith, Corey Smith, coreyas@gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6212


## Proposed changes

- Make sure `RestoreSelectedFiles` always calls the local function `SelectStoredNextIndex`

## Test methodology <!-- How did you ensure quality? -->

- Using the steps I've stated in the [issue description](https://github.com/gitextensions/gitextensions/issues/6212).

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows NT 10.0.17134.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
