### PR TITLE
Fixes 6210: support single detached commits without segment

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -121,7 +121,15 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                 _segmentLanes = newSegmentLanes;
                 _laneCount = laneIndex;
-                _revisionLane = currentRevisionLane;
+                if (currentRevisionLane >= 0)
+                {
+                    _revisionLane = currentRevisionLane;
+                }
+                else
+                {
+                    _revisionLane = _laneCount;
+                    _laneCount++;
+                }
             }
         }
 

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -108,6 +108,35 @@ namespace GitUITests.UserControls.RevisionGrid
             Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
         }
 
+        [Test] // github issue #6210
+        public void DetachedSingleRevision()
+        {
+            _revisionGraph.Clear();
+
+            /* Visualization of commit graph:
+             *     Commit1
+             *        |
+             *        |       Commit2 (detached)
+             *        |
+             *     Commit3
+             */
+
+            GitRevision commit1 = new GitRevision(ObjectId.Random());
+
+            GitRevision commit2 = new GitRevision(ObjectId.Random());
+
+            GitRevision commit3 = new GitRevision(ObjectId.Random());
+            commit1.ParentIds = new ObjectId[] { commit3.ObjectId };
+
+            _revisionGraph.Add(commit1, RevisionNodeFlags.None);
+            _revisionGraph.Add(commit2, RevisionNodeFlags.None);
+            _revisionGraph.Add(commit3, RevisionNodeFlags.None);
+
+            _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
+
+            Assert.AreEqual(1, _revisionGraph.GetSegmentsForRow(1).GetCurrentRevisionLane());
+        }
+
         private static IEnumerable<GitRevision> Revisions
         {
             get


### PR DESCRIPTION
Fixes #6210

## Proposed changes

- Support nodes in the graph that do not have parent or child.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/38675/52204714-38c17d00-2875-11e9-9d1d-f7bf0923150f.png)

### After

![image](https://user-images.githubusercontent.com/38675/52204691-2c3d2480-2875-11e9-8933-f431a480e2f2.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.00.00.4433
- Build 3fb70f85257aa59bf35537d079e51605d5e1077d (Dirty)
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3221.0
- DPI 96dpi (no scaling)
