### PR TITLE
Fixes 6193: ArgumentOutOfRangeException could occur in graph

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -231,6 +231,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return true;
             }
 
+            if (orderedRowCache.Count == 0)
+            {
+                return false;
+            }
+
             int indexToCompare = orderedRowCache.Count - 1;
             return orderedRowCache[indexToCompare].Revision != orderedNodesCache[indexToCompare];
         }

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -108,6 +108,14 @@ namespace GitUITests.UserControls.RevisionGrid
             Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
         }
 
+        [Test] // github issue #6193
+        public void CacheEmptyGraph()
+        {
+            _revisionGraph.Clear();
+            _revisionGraph.CacheTo(100, 100);
+            _revisionGraph.CacheTo(100, 100);
+        }
+
         [Test] // github issue #6210
         public void DetachedSingleRevision()
         {


### PR DESCRIPTION
Fixes #6193 

## Proposed changes

- Add bounds checking

## Test methodology <!-- How did you ensure quality? -->

- Unit test
- No manual testing, since I cannot simulate in UI

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3221.0
- DPI 96dpi (no scaling)
