### PR TITLE
Skip grid refresh after running a navigational script

### DIFF
--- a/GitCommands/CommandStatus.cs
+++ b/GitCommands/CommandStatus.cs
@@ -1,0 +1,17 @@
+﻿namespace GitCommands
+{
+    public struct CommandStatus
+    {
+        public CommandStatus(bool executed, bool needsGridRefresh)
+        {
+            Executed = executed;
+            NeedsGridRefresh = needsGridRefresh;
+        }
+
+        public static implicit operator CommandStatus(bool executed) => new CommandStatus(executed, false);
+
+        public bool Executed { get; }
+
+        public bool NeedsGridRefresh { get; }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -63,6 +63,7 @@
     <Compile Include="AppTitleGenerator.cs" />
     <Compile Include="ArgumentBuilderExtensions.cs" />
     <Compile Include="AsyncLoader.cs" />
+    <Compile Include="CommandStatus.cs" />
     <Compile Include="CommitData.cs" />
     <Compile Include="CommitDataManager.cs" />
     <Compile Include="CommitTemplateItem.cs" />

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -898,7 +898,7 @@ namespace GitUI.CommandsDialogs
 
                     button.Click += delegate
                     {
-                        if (ScriptRunner.RunScript(this, Module, script.Name, RevisionGrid))
+                        if (ScriptRunner.RunScript(this, Module, script.Name, RevisionGrid).NeedsGridRefresh)
                         {
                             RevisionGrid.RefreshRevisions();
                         }
@@ -2167,7 +2167,7 @@ namespace GitUI.CommandsDialogs
             UICommands.RepoChangedNotifier.Notify();
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             switch ((Command)cmd)
             {
@@ -2286,7 +2286,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        internal bool ExecuteCommand(Command cmd)
+        internal CommandStatus ExecuteCommand(Command cmd)
         {
             return ExecuteCommand((int)cmd);
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -898,7 +898,7 @@ namespace GitUI.CommandsDialogs
 
                     button.Click += delegate
                     {
-                        if (ScriptRunner.RunScript(this, Module, script.Name, RevisionGrid).NeedsGridRefresh)
+                        if (ScriptRunner.RunScript(this, Module, script.Name, UICommands, RevisionGrid).NeedsGridRefresh)
                         {
                             RevisionGrid.RefreshRevisions();
                         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -756,7 +756,7 @@ namespace GitUI.CommandsDialogs
             return true;
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             switch ((Command)cmd)
             {
@@ -3255,7 +3255,7 @@ namespace GitUI.CommandsDialogs
 
             internal ToolStripStatusLabel RemoteNameLabelStatus => _formCommit.remoteNameLabel;
 
-            internal bool ExecuteCommand(Command command)
+            internal CommandStatus ExecuteCommand(Command command)
             {
                 return _formCommit.ExecuteCommand((int)command);
             }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1243,7 +1243,7 @@ namespace GitUI.CommandsDialogs
             ChooseBase = 4
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             var command = (Commands)cmd;
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -95,12 +95,12 @@ namespace GitUI.CommandsDialogs
             EditFile = 4
         }
 
-        public bool ExecuteCommand(Command cmd)
+        public CommandStatus ExecuteCommand(Command cmd)
         {
             return ExecuteCommand((int)cmd);
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             if (DiffFiles.FilterFocused && IsTextEditKey(GetShortcutKeys(cmd)))
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -226,12 +226,12 @@ See the changes in the commit form.");
             EditFile = 5
         }
 
-        public bool ExecuteCommand(Command cmd)
+        public CommandStatus ExecuteCommand(Command cmd)
         {
             return ExecuteCommand((int)cmd);
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             switch ((Command)cmd)
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1167,7 +1167,7 @@ namespace GitUI.Editor
             PreviousChange = 7
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             var command = (Commands)cmd;
 

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -141,12 +141,17 @@ namespace GitUI
         {
         }
 
-        protected override bool ExecuteCommand(int command)
+        protected override CommandStatus ExecuteCommand(int command)
         {
-            return ExecuteScriptCommand()
-                || base.ExecuteCommand(command);
+            var result = ExecuteScriptCommand();
+            if (!result.Executed)
+            {
+                result = base.ExecuteCommand(command);
+            }
 
-            bool ExecuteScriptCommand()
+            return result;
+
+            CommandStatus ExecuteScriptCommand()
             {
                 return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command, this as RevisionGridControl);
             }

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -153,7 +153,7 @@ namespace GitUI
 
             CommandStatus ExecuteScriptCommand()
             {
-                return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command, this as RevisionGridControl);
+                return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command, UICommands, this as RevisionGridControl);
             }
         }
 

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -64,10 +64,16 @@ namespace GitUI
             _uiCommands = commands;
         }
 
-        protected override bool ExecuteCommand(int command)
+        protected override CommandStatus ExecuteCommand(int command)
         {
-            return ScriptRunner.ExecuteScriptCommand(this, Module, command)
-                || base.ExecuteCommand(command);
+            var result = ScriptRunner.ExecuteScriptCommand(this, Module, command);
+
+            if (!result.Executed)
+            {
+                result = base.ExecuteCommand(command);
+            }
+
+            return result;
         }
     }
 }

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -66,7 +66,7 @@ namespace GitUI
 
         protected override CommandStatus ExecuteCommand(int command)
         {
-            var result = ScriptRunner.ExecuteScriptCommand(this, Module, command);
+            var result = ScriptRunner.ExecuteScriptCommand(this, Module, command, UICommands);
 
             if (!result.Executed)
             {

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -59,7 +59,7 @@ namespace GitUI.Script
         {
             foreach (var script in GetScripts().Where(scriptInfo => scriptInfo.Enabled && scriptInfo.OnEvent == scriptEvent))
             {
-                ScriptRunner.RunScript(form, form.Module, script.Name, revisionGrid: null);
+                ScriptRunner.RunScript(form, form.Module, script.Name, form.UICommands, revisionGrid: null);
             }
         }
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -73,10 +73,10 @@ namespace GitUI.Script
                 return false;
             }
 
-            return RunScript(owner, module, script, revisionGrid);
+            return RunScript(owner, module, script, uiCommands, revisionGrid);
         }
 
-        private static CommandStatus RunScript(IWin32Window owner, GitModule module, ScriptInfo scriptInfo, RevisionGridControl revisionGrid)
+        private static CommandStatus RunScript(IWin32Window owner, GitModule module, ScriptInfo scriptInfo, IGitUICommands uiCommands, RevisionGridControl revisionGrid)
         {
             if (scriptInfo.AskConfirmation && MessageBox.Show(owner, $"Do you want to execute '{scriptInfo.Name}'?", "Script", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
             {
@@ -106,7 +106,7 @@ namespace GitUI.Script
                 {
                     if (plugin.Description.ToLower().Equals(command, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        var eventArgs = new GitUIEventArgs(owner, revisionGrid.UICommands);
+                        var eventArgs = new GitUIEventArgs(owner, uiCommands);
                         return new CommandStatus(true, plugin.Execute(eventArgs));
                     }
                 }
@@ -116,6 +116,11 @@ namespace GitUI.Script
 
             if (command.StartsWith(NavigateToPrefix))
             {
+                if (revisionGrid == null)
+                {
+                    return false;
+                }
+
                 command = command.Replace(NavigateToPrefix, string.Empty);
                 if (!command.IsNullOrEmpty())
                 {

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -96,7 +96,7 @@ namespace GitUI.Script
             if (scriptInfo.IsPowerShell)
             {
                 PowerShellHelper.RunPowerShell(command, argument, module.WorkingDir, scriptInfo.RunInBackground);
-                return false;
+                return new CommandStatus(true, false);
             }
 
             if (command.StartsWith(PluginPrefix))
@@ -107,7 +107,7 @@ namespace GitUI.Script
                     if (plugin.Description.ToLower().Equals(command, StringComparison.CurrentCultureIgnoreCase))
                     {
                         var eventArgs = new GitUIEventArgs(owner, revisionGrid.UICommands);
-                        return plugin.Execute(eventArgs);
+                        return new CommandStatus(true, plugin.Execute(eventArgs));
                     }
                 }
 
@@ -127,7 +127,7 @@ namespace GitUI.Script
                     }
                 }
 
-                return false;
+                return new CommandStatus(true, false);
             }
 
             if (!scriptInfo.RunInBackground)
@@ -146,7 +146,7 @@ namespace GitUI.Script
                 }
             }
 
-            return !scriptInfo.RunInBackground;
+            return new CommandStatus(true, !scriptInfo.RunInBackground);
         }
 
         private static string ExpandCommandVariables(string originalCommand, GitModule module)

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -11,7 +11,7 @@ namespace GitUI.Script
     public static class ScriptRunner
     {
         /// <summary>Tries to run scripts identified by a <paramref name="command"/></summary>
-        public static CommandStatus ExecuteScriptCommand(IWin32Window owner, GitModule module, int command, RevisionGridControl revisionGrid = null)
+        public static CommandStatus ExecuteScriptCommand(IWin32Window owner, GitModule module, int command, IGitUICommands uiCommands, RevisionGridControl revisionGrid = null)
         {
             var anyScriptExecuted = false;
             var needsGridRefresh = false;
@@ -20,7 +20,7 @@ namespace GitUI.Script
             {
                 if (script.HotkeyCommandIdentifier == command)
                 {
-                    var result = RunScript(owner, module, script.Name, revisionGrid);
+                    var result = RunScript(owner, module, script.Name, uiCommands, revisionGrid);
                     anyScriptExecuted = true;
                     needsGridRefresh |= result.NeedsGridRefresh;
                 }
@@ -29,7 +29,7 @@ namespace GitUI.Script
             return new CommandStatus(anyScriptExecuted, needsGridRefresh);
         }
 
-        public static CommandStatus RunScript(IWin32Window owner, GitModule module, string scriptKey, RevisionGridControl revisionGrid)
+        public static CommandStatus RunScript(IWin32Window owner, GitModule module, string scriptKey, IGitUICommands uiCommands, RevisionGridControl revisionGrid)
         {
             if (string.IsNullOrEmpty(scriptKey))
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2084,7 +2084,7 @@ namespace GitUI
                         _settingsLoaded = true;
                     }
 
-                    if (ScriptRunner.RunScript(this, Module, sender.ToString(), this))
+                    if (ScriptRunner.RunScript(this, Module, sender.ToString(), this).NeedsGridRefresh)
                     {
                         RefreshRevisions();
                     }
@@ -2195,7 +2195,7 @@ namespace GitUI
             Refresh();
         }
 
-        internal bool ExecuteCommand(Commands cmd)
+        internal CommandStatus ExecuteCommand(Commands cmd)
         {
             return ExecuteCommand((int)cmd);
         }
@@ -2632,7 +2632,7 @@ namespace GitUI
             GoToMergeBaseCommit = 31,
         }
 
-        protected override bool ExecuteCommand(int cmd)
+        protected override CommandStatus ExecuteCommand(int cmd)
         {
             switch ((Commands)cmd)
             {
@@ -2674,8 +2674,12 @@ namespace GitUI
                 case Commands.CompareSelectedCommits: compareSelectedCommitsMenuItem_Click(null, null); break;
                 default:
                     {
-                        bool result = base.ExecuteCommand(cmd);
-                        RefreshRevisions();
+                        var result = base.ExecuteCommand(cmd);
+                        if (result.NeedsGridRefresh)
+                        {
+                            RefreshRevisions();
+                        }
+
                         return result;
                     }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2084,7 +2084,7 @@ namespace GitUI
                         _settingsLoaded = true;
                     }
 
-                    if (ScriptRunner.RunScript(this, Module, sender.ToString(), this).NeedsGridRefresh)
+                    if (ScriptRunner.RunScript(this, Module, sender.ToString(), UICommands, this).NeedsGridRefresh)
                     {
                         RefreshRevisions();
                     }

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -82,7 +82,7 @@ namespace ResourceManager
                 {
                     if (hotkey != null && hotkey.KeyData == keyData)
                     {
-                        return ExecuteCommand(hotkey.CommandCode);
+                        return ExecuteCommand(hotkey.CommandCode).Executed;
                     }
                 }
             }
@@ -103,9 +103,10 @@ namespace ResourceManager
 
         /// <summary>
         /// Override this method to handle form-specific Hotkey commands.
-        /// <remarks>This base method does nothing and returns false.</remarks>
+        /// <remarks>This base method does nothing and returns a <see cref="GitCommands.CommandStatus"/>
+        /// with <see cref="GitCommands.CommandStatus.Executed"/> set to <see langword="false"/></remarks>
         /// </summary>
-        protected virtual bool ExecuteCommand(int command)
+        protected virtual GitCommands.CommandStatus ExecuteCommand(int command)
         {
             return false;
         }

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -51,7 +51,7 @@ namespace ResourceManager
                 {
                     if (hotkey != null && hotkey.KeyData == keyData)
                     {
-                        return ExecuteCommand(hotkey.CommandCode);
+                        return ExecuteCommand(hotkey.CommandCode).Executed;
                     }
                 }
             }
@@ -71,7 +71,7 @@ namespace ResourceManager
         }
 
         /// <summary>Override this method to handle form-specific Hotkey commands.</summary>
-        protected virtual bool ExecuteCommand(int command)
+        protected virtual CommandStatus ExecuteCommand(int command)
         {
             return false;
         }

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -244,7 +244,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 ta.Message.Text = message;
                 ta.Message.SelectionStart = selectionStart;
                 ta.Message.SelectionLength = selectionLength;
-                ta.ExecuteCommand(FormCommit.Command.AddSelectionToCommitMessage).Should().Be(expectedResult);
+                ta.ExecuteCommand(FormCommit.Command.AddSelectionToCommitMessage).Should().Be((GitCommands.CommandStatus)expectedResult);
                 ta.Message.Text.Should().Be(expectedMessage);
                 ta.Message.SelectionStart.Should().Be(expectedSelectionStart);
                 ta.Message.SelectionLength.Should().Be(expectedResult ? 0 : selectionLength);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5834.

## Proposed changes

- methods executing a command now return a new `struct CommandStatus` instead of a simple bool. Besides specifying whether the command was actually executed, it also contains a flag indicating whether the revision grid should be refreshed.
- navigational scripts no longer cause the grid refresh

## Test methodology <!-- How did you ensure quality? -->

- Manual testing (running commands both from context menu and using a hotkey)


## Test environment(s) <!-- Remove any that don't apply -->

- git version 2.20.1.windows.1
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
