### PR TITLE
Left panel: disable OnSelected when using arrow keys to navigate node…

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -28,6 +28,12 @@ namespace GitUI.BranchTreePanel
                 _doubleClickDecorator = null;
             }
 
+            if (_explorerNavigationDecorator != null)
+            {
+                _explorerNavigationDecorator.AfterSelect -= OnNodeSelected;
+                _explorerNavigationDecorator = null;
+            }
+
             base.Dispose(disposing);
         }
 
@@ -120,7 +126,6 @@ namespace GitUI.BranchTreePanel
             this.treeMain.ShowNodeToolTips = true;
             this.treeMain.Size = new System.Drawing.Size(300, 350);
             this.treeMain.TabIndex = 3;
-            this.treeMain.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnNodeSelected);
             // 
             // menuMain
             // 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -26,6 +26,7 @@ namespace GitUI.BranchTreePanel
 
         private readonly Dictionary<Tree, int> _treeToPositionIndex = new Dictionary<Tree, int>();
         private NativeTreeViewDoubleClickDecorator _doubleClickDecorator;
+        private NativeTreeViewExplorerNavigationDecorator _explorerNavigationDecorator;
         private readonly List<Tree> _rootNodes = new List<Tree>();
         private readonly SearchControl<string> _txtBranchCriterion;
         private TreeNode _branchesTreeRootNode;
@@ -55,8 +56,6 @@ namespace GitUI.BranchTreePanel
 
             treeMain.ShowNodeToolTips = true;
             treeMain.HideSelection = false;
-            treeMain.NodeMouseClick += OnNodeClick;
-            treeMain.NodeMouseDoubleClick += OnNodeDoubleClick;
 
             toolTip.SetToolTip(btnCollapseAll, mnubtnCollapseAll.ToolTipText);
             toolTip.SetToolTip(btnSearch, _searchTooltip.Text);
@@ -67,6 +66,12 @@ namespace GitUI.BranchTreePanel
 
             _doubleClickDecorator = new NativeTreeViewDoubleClickDecorator(treeMain);
             _doubleClickDecorator.BeforeDoubleClickExpandCollapse += BeforeDoubleClickExpandCollapse;
+
+            _explorerNavigationDecorator = new NativeTreeViewExplorerNavigationDecorator(treeMain);
+            _explorerNavigationDecorator.AfterSelect += OnNodeSelected;
+
+            treeMain.NodeMouseClick += OnNodeClick;
+            treeMain.NodeMouseDoubleClick += OnNodeDoubleClick;
 
             mnubtnFilterRemoteBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
             mnubtnFilterLocalBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
@@ -384,14 +389,6 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        private void OnPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
-        {
-            if (e.KeyCode == Keys.F3 || e.KeyCode == Keys.Enter)
-            {
-                OnBtnSearchClicked(null, null);
-            }
-        }
-
         private void OnBtnSettingsClicked(object sender, EventArgs e)
         {
             btnSettings.ContextMenuStrip.Show(btnSettings, 0, btnSettings.Height);
@@ -423,6 +420,14 @@ namespace GitUI.BranchTreePanel
             e.Handled = true;
         }
 
+        private void OnPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+        {
+            if (e.KeyCode == Keys.F3)
+            {
+                OnBtnSearchClicked(null, null);
+            }
+        }
+
         private void OnNodeSelected(object sender, TreeViewEventArgs e)
         {
             Node.OnNode<Node>(e.Node, node => node.OnSelected());
@@ -430,7 +435,6 @@ namespace GitUI.BranchTreePanel
 
         private void OnNodeClick(object sender, TreeNodeMouseClickEventArgs e)
         {
-            treeMain.SelectedNode = e.Node;
             Node.OnNode<Node>(e.Node, node => node.OnClick());
         }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -399,6 +399,7 @@
     <Compile Include="TaskbarProgress.cs" />
     <Compile Include="UserControls\GitItemStatusWithParent.cs" />
     <Compile Include="UserControls\NativeTreeViewDoubleClickDecorator.cs" />
+    <Compile Include="UserControls\NativeTreeViewExplorerNavigationDecorator.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />
     <Compile Include="UserControls\ListViewGroupHitInfo.cs" />
     <Compile Include="UserControls\RevisionGrid\Graph\LaneInfoProvider.cs" />

--- a/GitUI/UserControls/NativeTreeViewExplorerNavigationDecorator.cs
+++ b/GitUI/UserControls/NativeTreeViewExplorerNavigationDecorator.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Forms;
+
+namespace GitUI.UserControls
+{
+    // Add explorer-like navigation to NativeTreeView:
+    // * Arrow key navigation to highlight without selecting node
+    // * Space or Enter key to select node
+    // * Mouse clicking highlighted node selects it
+    //
+    // As this decorator sets TreeView.SelectedNode, you should avoid hooking into
+    // node selection-based events. Instead, hook into AfterSelect on this decorator
+    // to know when a node has been selected (either by Space/Enter, or mouse click).
+    public class NativeTreeViewExplorerNavigationDecorator
+    {
+        private readonly NativeTreeView _treeView;
+        private DateTime _lastKeyNavigateTime = DateTime.MinValue;
+        private readonly Func<DateTime> _getCurrentTime;
+
+        public event TreeViewEventHandler AfterSelect;
+
+        public NativeTreeViewExplorerNavigationDecorator(NativeTreeView treeView, Func<DateTime> getCurrentTime)
+        {
+            _treeView = treeView;
+            _getCurrentTime = getCurrentTime;
+
+            _treeView.KeyDown += OnKeyDown;
+            _treeView.PreviewKeyDown += OnPreviewKeyDown;
+            _treeView.AfterSelect += OnAfterSelect;
+            _treeView.NodeMouseClick += OnNodeMouseClick;
+        }
+
+        public NativeTreeViewExplorerNavigationDecorator(NativeTreeView treeView)
+            : this(treeView, () => DateTime.Now)
+        {
+        }
+
+        private void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            // Supress the "ding" when Enter is pressed
+            if (e.KeyCode == Keys.Enter)
+            {
+                e.SuppressKeyPress = true;
+            }
+        }
+
+        private void OnPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+        {
+            if (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down || e.KeyCode == Keys.Left || e.KeyCode == Keys.Right)
+            {
+                _lastKeyNavigateTime = _getCurrentTime();
+            }
+            else if (e.KeyCode == Keys.Space || e.KeyCode == Keys.Enter)
+            {
+                // Force a reselection of the current node
+                _lastKeyNavigateTime = DateTime.MinValue;
+                var currNode = _treeView.SelectedNode;
+                _treeView.SelectedNode = null;
+                _treeView.SelectedNode = currNode;
+            }
+        }
+
+        private void OnAfterSelect(object sender, TreeViewEventArgs e)
+        {
+            // If arrow key was used to navigate to this node, don't send OnSelected
+            int delta = (int)DateTime.Now.Subtract(_lastKeyNavigateTime).TotalMilliseconds;
+            if (delta >= 0 && delta < 500)
+            {
+                return;
+            }
+
+            AfterSelect(sender, e);
+        }
+
+        private void OnNodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
+        {
+            // If selected node is clicked, make sure to force re-selection. This way, if user
+            // navigates to a node by keyboard, then clicks on the same node with the mouse, it
+            // will perform the AfterSelect action (i.e. select revision in revision graph).
+            if (_treeView.SelectedNode == e.Node)
+            {
+                _treeView.SelectedNode = null;
+            }
+
+            _treeView.SelectedNode = e.Node;
+        }
+    }
+}


### PR DESCRIPTION
…s, must press Space (mouse click still works)

Fixes #6072

## Proposed changes

- Make left panel treeview behave like Explorer
  - Arrow key navigation to highlight without selecting node
  - Space or Enter key to select node
  - Mouse clicking highlighted node selects it

Code is wrapped up in a decorator so it can be reused.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.19.1.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
