### PR TITLE
fix missing dashboard highlighting on right click

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -529,7 +529,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             var textOffset = spacing2 + imageList1.ImageSize.Width + spacing2;
             int textWidth = e.Bounds.Width - (int)textOffset;
 
-            if (e.Item == HoveredItem)
+            if (e.Item == HoveredItem || e.Item.Selected)
             {
                 e.Graphics.FillRectangle(_hoverColorBrush, e.Bounds);
             }
@@ -612,6 +612,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 // client coordinates within the given ListView
                 Point localPoint = listView1.PointToClient(Cursor.Position);
                 _rightClickedItem = listView1.GetItemAt(localPoint.X, localPoint.Y);
+
+                if (_rightClickedItem != null)
+                {
+                    _rightClickedItem.Selected = true;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- whenever a context menu would get opened, the item that was right clicked would lose the highlighting. This PR addresses the issue


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/52481160-dadcbe80-2c01-11e9-848e-9de19012a88c.png)


### After

![image](https://user-images.githubusercontent.com/4403806/52481283-2c854900-2c02-11e9-9aca-448abb786f31.png)


## Test methodology <!-- How did you ensure quality? -->

- manually

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
