### PR TITLE
Standardize revision grid context menu

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7641,9 +7641,17 @@ Do you want to remove it from the recent repositories list?</source>
   </file>
   <file datatype="plaintext" original="RepoObjectsTree" source-language="en">
     <body>
+      <trans-unit id="_searchTooltip.Text">
+        <source>Search</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_showBranchOnly.Text">
         <source>Filter the revision grid to show this branch only
 To show all branches, right click the revision grid, select 'view' and then the 'show all branches'</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_showHideRefsTooltip.Text">
+        <source>Show/hide branches/remotes/tags</source>
         <target />
       </trans-unit>
       <trans-unit id="lblSearchBranch.Text">
@@ -7762,8 +7770,16 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Re&amp;set</source>
         <target />
       </trans-unit>
-      <trans-unit id="showTagsToolStripMenuItem.Text">
-        <source>Show &amp;tags</source>
+      <trans-unit id="tsmiShowBranches.Text">
+        <source>&amp;Branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiShowRemotes.Text">
+        <source>&amp;Remotes</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiShowTags.Text">
+        <source>&amp;Tags</source>
         <target />
       </trans-unit>
     </body>
@@ -8285,7 +8301,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="archiveRevisionToolStripMenuItem.Text">
-        <source>Archive revision</source>
+        <source>Archive this commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="bisectSkipRevisionToolStripMenuItem.Text">
@@ -8293,15 +8309,15 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="checkoutBranchToolStripMenuItem.Text">
-        <source>Checkout branch</source>
+        <source>Checkout branch...</source>
         <target />
       </trans-unit>
       <trans-unit id="checkoutRevisionToolStripMenuItem.Text">
-        <source>Checkout revision</source>
+        <source>Checkout this commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="cherryPickCommitToolStripMenuItem.Text">
-        <source>Cherry pick commit</source>
+        <source>Cherry pick this commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="compareSelectedCommitsMenuItem.Text">
@@ -8333,19 +8349,19 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="createNewBranchToolStripMenuItem.Text">
-        <source>Create new branch</source>
+        <source>Create new branch here...</source>
         <target />
       </trans-unit>
       <trans-unit id="createTagToolStripMenuItem.Text">
-        <source>Create new tag</source>
+        <source>Create new tag here...</source>
         <target />
       </trans-unit>
       <trans-unit id="deleteBranchToolStripMenuItem.Text">
-        <source>Delete branch</source>
+        <source>Delete branch...</source>
         <target />
       </trans-unit>
       <trans-unit id="deleteTagToolStripMenuItem.Text">
-        <source>Delete tag</source>
+        <source>Delete tag...</source>
         <target />
       </trans-unit>
       <trans-unit id="editCommitToolStripMenuItem.Text">
@@ -8353,7 +8369,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="fixupCommitToolStripMenuItem.Text">
-        <source>Create a fixup commit</source>
+        <source>Create a fixup commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="getHelpOnHowToUseTheseFeaturesToolStripMenuItem.Text">
@@ -8373,7 +8389,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="mergeBranchToolStripMenuItem.Text">
-        <source>Merge into current branch</source>
+        <source>Merge into current branch...</source>
         <target />
       </trans-unit>
       <trans-unit id="navigateToolStripMenuItem.Text">
@@ -8385,7 +8401,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="rebaseInteractivelyToolStripMenuItem.Text">
-        <source>Selected commit interactively</source>
+        <source>Selected commit interactively...</source>
         <target />
       </trans-unit>
       <trans-unit id="rebaseOnToolStripMenuItem.Text">
@@ -8401,15 +8417,15 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="renameBranchToolStripMenuItem.Text">
-        <source>Rename branch</source>
+        <source>Rename branch...</source>
         <target />
       </trans-unit>
       <trans-unit id="resetCurrentBranchToHereToolStripMenuItem.Text">
-        <source>Reset current branch to here</source>
+        <source>Reset current branch to here...</source>
         <target />
       </trans-unit>
       <trans-unit id="revertCommitToolStripMenuItem.Text">
-        <source>Revert commit</source>
+        <source>Revert this commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="rewordCommitToolStripMenuItem.Text">
@@ -8425,7 +8441,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="squashCommitToolStripMenuItem.Text">
-        <source>Create a squash commit</source>
+        <source>Create a squash commit...</source>
         <target />
       </trans-unit>
       <trans-unit id="stopBisectToolStripMenuItem.Text">

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -126,8 +126,6 @@ namespace GitUI
             this.renameBranchToolStripMenuItem,
             this.deleteBranchToolStripMenuItem,
             this.toolStripSeparator4,
-            this.compareToolStripMenuItem,
-            this.toolStripSeparator5,
             this.createTagToolStripMenuItem,
             this.deleteTagToolStripMenuItem,
             this.toolStripSeparator2,
@@ -137,6 +135,8 @@ namespace GitUI
             this.archiveRevisionToolStripMenuItem,
             this.manipulateCommitToolStripMenuItem,
             this.toolStripSeparator1,
+            this.compareToolStripMenuItem,
+            this.toolStripSeparator5,
             this.navigateToolStripMenuItem,
             this.viewToolStripMenuItem,
             this.runScriptToolStripMenuItem,
@@ -192,7 +192,7 @@ namespace GitUI
             this.checkoutBranchToolStripMenuItem.Image = global::GitUI.Properties.Images.BranchCheckout;
             this.checkoutBranchToolStripMenuItem.Name = "checkoutBranchToolStripMenuItem";
             this.checkoutBranchToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.checkoutBranchToolStripMenuItem.Text = "Checkout branch";
+            this.checkoutBranchToolStripMenuItem.Text = "Checkout branch...";
             this.checkoutBranchToolStripMenuItem.Click += new System.EventHandler(this.deleteBranchTagToolStripMenuItem_Click);
             // 
             // mergeBranchToolStripMenuItem
@@ -200,7 +200,7 @@ namespace GitUI
             this.mergeBranchToolStripMenuItem.Image = global::GitUI.Properties.Images.Merge;
             this.mergeBranchToolStripMenuItem.Name = "mergeBranchToolStripMenuItem";
             this.mergeBranchToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.mergeBranchToolStripMenuItem.Text = "Merge into current branch";
+            this.mergeBranchToolStripMenuItem.Text = "Merge into current branch...";
             this.mergeBranchToolStripMenuItem.Click += new System.EventHandler(this.deleteBranchTagToolStripMenuItem_Click);
             // 
             // rebaseOnToolStripMenuItem
@@ -220,7 +220,7 @@ namespace GitUI
             this.resetCurrentBranchToHereToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetCurrentBranchToHere;
             this.resetCurrentBranchToHereToolStripMenuItem.Name = "resetCurrentBranchToHereToolStripMenuItem";
             this.resetCurrentBranchToHereToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
-            this.resetCurrentBranchToHereToolStripMenuItem.Text = "Reset current branch to here";
+            this.resetCurrentBranchToHereToolStripMenuItem.Text = "Reset current branch to here...";
             this.resetCurrentBranchToHereToolStripMenuItem.Click += new System.EventHandler(this.ResetCurrentBranchToHereToolStripMenuItemClick);
             // 
             // toolStripSeparator3
@@ -234,7 +234,7 @@ namespace GitUI
             this.createNewBranchToolStripMenuItem.Name = "createNewBranchToolStripMenuItem";
             this.createNewBranchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
             this.createNewBranchToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.createNewBranchToolStripMenuItem.Text = "Create new branch";
+            this.createNewBranchToolStripMenuItem.Text = "Create new branch here...";
             this.createNewBranchToolStripMenuItem.Click += new System.EventHandler(this.CreateNewBranchToolStripMenuItemClick);
             // 
             // renameBranchToolStripMenuItem
@@ -242,7 +242,7 @@ namespace GitUI
             this.renameBranchToolStripMenuItem.Image = global::GitUI.Properties.Images.Renamed;
             this.renameBranchToolStripMenuItem.Name = "renameBranchToolStripMenuItem";
             this.renameBranchToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
-            this.renameBranchToolStripMenuItem.Text = "Rename branch";
+            this.renameBranchToolStripMenuItem.Text = "Rename branch...";
             this.renameBranchToolStripMenuItem.Click += new System.EventHandler(this.renameBranchToolStripMenuItem_Click);
             // 
             // deleteBranchToolStripMenuItem
@@ -250,7 +250,7 @@ namespace GitUI
             this.deleteBranchToolStripMenuItem.Image = global::GitUI.Properties.Images.BranchDelete;
             this.deleteBranchToolStripMenuItem.Name = "deleteBranchToolStripMenuItem";
             this.deleteBranchToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.deleteBranchToolStripMenuItem.Text = "Delete branch";
+            this.deleteBranchToolStripMenuItem.Text = "Delete branch...";
             this.deleteBranchToolStripMenuItem.Click += new System.EventHandler(this.deleteBranchTagToolStripMenuItem_Click);
             // 
             // toolStripSeparator4
@@ -328,7 +328,7 @@ namespace GitUI
             this.createTagToolStripMenuItem.Name = "createTagToolStripMenuItem";
             this.createTagToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
             this.createTagToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.createTagToolStripMenuItem.Text = "Create new tag";
+            this.createTagToolStripMenuItem.Text = "Create new tag here...";
             this.createTagToolStripMenuItem.Click += new System.EventHandler(this.CreateTagToolStripMenuItemClick);
             // 
             // deleteTagToolStripMenuItem
@@ -336,7 +336,7 @@ namespace GitUI
             this.deleteTagToolStripMenuItem.Image = global::GitUI.Properties.Images.TagDelete;
             this.deleteTagToolStripMenuItem.Name = "deleteTagToolStripMenuItem";
             this.deleteTagToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.deleteTagToolStripMenuItem.Text = "Delete tag";
+            this.deleteTagToolStripMenuItem.Text = "Delete tag...";
             this.deleteTagToolStripMenuItem.Click += new System.EventHandler(this.deleteBranchTagToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
@@ -349,7 +349,7 @@ namespace GitUI
             this.checkoutRevisionToolStripMenuItem.Image = global::GitUI.Properties.Images.Checkout;
             this.checkoutRevisionToolStripMenuItem.Name = "checkoutRevisionToolStripMenuItem";
             this.checkoutRevisionToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.checkoutRevisionToolStripMenuItem.Text = "Checkout revision";
+            this.checkoutRevisionToolStripMenuItem.Text = "Checkout this commit...";
             this.checkoutRevisionToolStripMenuItem.Click += new System.EventHandler(this.CheckoutRevisionToolStripMenuItemClick);
             // 
             // revertCommitToolStripMenuItem
@@ -357,7 +357,7 @@ namespace GitUI
             this.revertCommitToolStripMenuItem.Image = global::GitUI.Properties.Images.RevertCommit;
             this.revertCommitToolStripMenuItem.Name = "revertCommitToolStripMenuItem";
             this.revertCommitToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.revertCommitToolStripMenuItem.Text = "Revert commit";
+            this.revertCommitToolStripMenuItem.Text = "Revert this commit...";
             this.revertCommitToolStripMenuItem.Click += new System.EventHandler(this.RevertCommitToolStripMenuItemClick);
             // 
             // cherryPickCommitToolStripMenuItem
@@ -365,7 +365,7 @@ namespace GitUI
             this.cherryPickCommitToolStripMenuItem.Image = global::GitUI.Properties.Images.CherryPick;
             this.cherryPickCommitToolStripMenuItem.Name = "cherryPickCommitToolStripMenuItem";
             this.cherryPickCommitToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.cherryPickCommitToolStripMenuItem.Text = "Cherry pick commit";
+            this.cherryPickCommitToolStripMenuItem.Text = "Cherry pick this commit...";
             this.cherryPickCommitToolStripMenuItem.Click += new System.EventHandler(this.CherryPickCommitToolStripMenuItemClick);
             // 
             // archiveRevisionToolStripMenuItem
@@ -373,7 +373,7 @@ namespace GitUI
             this.archiveRevisionToolStripMenuItem.Image = global::GitUI.Properties.Images.ArchiveRevision;
             this.archiveRevisionToolStripMenuItem.Name = "archiveRevisionToolStripMenuItem";
             this.archiveRevisionToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
-            this.archiveRevisionToolStripMenuItem.Text = "Archive revision";
+            this.archiveRevisionToolStripMenuItem.Text = "Archive this commit...";
             this.archiveRevisionToolStripMenuItem.Click += new System.EventHandler(this.ArchiveRevisionToolStripMenuItemClick);
             // 
             // manipulateCommitToolStripMenuItem
@@ -393,14 +393,14 @@ namespace GitUI
             // 
             this.fixupCommitToolStripMenuItem.Name = "fixupCommitToolStripMenuItem";
             this.fixupCommitToolStripMenuItem.Size = new System.Drawing.Size(180, 24);
-            this.fixupCommitToolStripMenuItem.Text = "Create a fixup commit";
+            this.fixupCommitToolStripMenuItem.Text = "Create a fixup commit...";
             this.fixupCommitToolStripMenuItem.Click += new System.EventHandler(this.FixupCommitToolStripMenuItemClick);
             // 
             // squashCommitToolStripMenuItem
             // 
             this.squashCommitToolStripMenuItem.Name = "squashCommitToolStripMenuItem";
             this.squashCommitToolStripMenuItem.Size = new System.Drawing.Size(180, 24);
-            this.squashCommitToolStripMenuItem.Text = "Create a squash commit";
+            this.squashCommitToolStripMenuItem.Text = "Create a squash commit...";
             this.squashCommitToolStripMenuItem.Click += new System.EventHandler(this.SquashCommitToolStripMenuItemClick);
             // 
             // toolStripSeparator1
@@ -473,7 +473,7 @@ namespace GitUI
             // 
             this.rebaseInteractivelyToolStripMenuItem.Name = "rebaseInteractivelyToolStripMenuItem";
             this.rebaseInteractivelyToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
-            this.rebaseInteractivelyToolStripMenuItem.Text = "Selected commit interactively";
+            this.rebaseInteractivelyToolStripMenuItem.Text = "Selected commit interactively...";
             this.rebaseInteractivelyToolStripMenuItem.Click += new System.EventHandler(this.OnRebaseInteractivelyClicked);
             // 
             // toolStripSeparator10


### PR DESCRIPTION
Fixes #5786

## Proposed changes

- standardize revision grid context menu:
  - "*this* commit"
  - "Create branch/tag *here...*"
  - "commit" instead of "revision"
  - add ellipsis "..." where a dialog will be opened
- move "Compare" below "Create/Delete tag...", right above "Navigate"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/52511432-39a13880-2c00-11e9-8e16-30e6158fce42.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/52533087-f396c280-2d2e-11e9-891a-94099f358fa8.png)

## Test methodology <!-- How did you ensure quality? -->

- manual testing

## Test environment

- Git Extensions 3.1.0
- Build aa2e8fc3e20a340b9a1e366dde127dcb537ff9e4
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).