### PR TITLE
issue #4826: Commit form should have a selection whenever possible

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1180,7 +1180,7 @@ namespace GitUI.CommandsDialogs
 
         private void ClearDiffViewIfNoFilesLeft()
         {
-            if ((Staged.IsEmpty && Unstaged.IsEmpty) || (!Unstaged.SelectedItems.Any() && !Staged.SelectedItems.Any()))
+            if (Staged.IsEmpty && Unstaged.IsEmpty)
             {
                 SelectedDiff.Clear();
             }
@@ -1515,12 +1515,13 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ClearDiffViewIfNoFilesLeft();
-
             if (!Unstaged.SelectedItems.Any())
             {
+                Unstaged.SelectFirstVisibleItem();
                 return;
             }
+
+            ClearDiffViewIfNoFilesLeft();
 
             Staged.ClearSelected();
 
@@ -1775,6 +1776,12 @@ namespace GitUI.CommandsDialogs
         {
             if (_currentFilesList != Staged || _skipUpdate)
             {
+                return;
+            }
+
+            if (!Staged.SelectedItems.Any())
+            {
+                Staged.SelectFirstVisibleItem();
                 return;
             }
 
@@ -2034,13 +2041,14 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                SelectedDiff.Clear();
                 if (Unstaged.SelectedItem == null ||
                     MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
                     DialogResult.Yes)
                 {
                     return;
                 }
+
+                SelectedDiff.Clear();
 
                 Unstaged.StoreNextIndexToSelect();
                 foreach (var item in Unstaged.SelectedItems)


### PR DESCRIPTION
Fixes #4826 


## Proposed changes

- When the user clicks not exactly on a item (i.e. the empty space of the unstaged or staged area), the first visible item in that area is automatically selected (fixes reproduction method 1).
This fix works well when you have only one modified file, because the same file will be re-selected. 
However, when you have 2 or more modified files, you might get a somehow  unxpected behaviour: when you have the second file selected and than click on the empty space, it will change the selected file to the first one in the list.

- The `SelectedDiff` is not cleared immediately when user hits `DEL`, but only if the confirmation dialog is actually confirmed (fixes reproduction method 2)


## Test methodology

- manual testing
- ran unit tests

## Test environment(s)

- Git Extensions 3.00.00.4433
- Build fca7cf228b481ee8c1b779cf7b882ccdfbdcd1bc
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.3260.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).