### PR TITLE
Show fixed shortcuts in context menu, too

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -232,6 +232,7 @@ namespace GitUI
             // 
             this.createNewBranchToolStripMenuItem.Image = global::GitUI.Properties.Images.BranchCreate;
             this.createNewBranchToolStripMenuItem.Name = "createNewBranchToolStripMenuItem";
+            this.createNewBranchToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
             this.createNewBranchToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
             this.createNewBranchToolStripMenuItem.Text = "Create new branch";
             this.createNewBranchToolStripMenuItem.Click += new System.EventHandler(this.CreateNewBranchToolStripMenuItemClick);
@@ -325,6 +326,7 @@ namespace GitUI
             // 
             this.createTagToolStripMenuItem.Image = global::GitUI.Properties.Images.TagCreate;
             this.createTagToolStripMenuItem.Name = "createTagToolStripMenuItem";
+            this.createTagToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
             this.createTagToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
             this.createTagToolStripMenuItem.Text = "Create new tag";
             this.createTagToolStripMenuItem.Click += new System.EventHandler(this.CreateTagToolStripMenuItemClick);


### PR DESCRIPTION
Somewhat related to #5433 (which I still cannot reproduce)

## Proposed changes

Very few commands of FormBrowse have shortcuts assigned in the designer, i.e. which cannot be altered using the Hotkey manager.
Display their shortcuts in the context menu, too. 
(I *copied* them from the `FormBrowse.Designer.cs` to the `RevisionGridControl.Designer.cs`. Else these private context menu items needed to be made accessible for FormBrowse.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/52520556-96393d80-2c6a-11e9-9a7a-ea727174d791.png)   ![grafik](https://user-images.githubusercontent.com/36601201/52520407-114e2400-2c6a-11e9-9fc9-0dbba7307ad1.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/52520410-275be480-2c6a-11e9-885a-bf7a7a536580.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build c84fffcb6f94c07130974152fa472a94b2312f25
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../../blob/master/contributors.txt).
