### PR TITLE
#4826: Commit form should have a selection whenever possible

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2034,13 +2034,14 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                SelectedDiff.Clear();
                 if (Unstaged.SelectedItem == null ||
                     MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
                     DialogResult.Yes)
                 {
                     return;
                 }
+
+                SelectedDiff.Clear();
 
                 Unstaged.StoreNextIndexToSelect();
                 foreach (var item in Unstaged.SelectedItems)


### PR DESCRIPTION
Fixes #4826 (partially)


## Proposed changes

- - The `SelectedDiff` is not cleared immediately when user hits `DEL`, but only if the confirmation dialog is actually confirmed (fixes reproduction method 2)


## Test methodology <!-- How did you ensure quality? -->

- manual testing
- ran unit tests


## Test environment(s)

- Git Extensions 3.00.00.4433
- Build fca7cf228b481ee8c1b779cf7b882ccdfbdcd1bc
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.3260.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
