### PR TITLE
Set the title of the ColorsSettingsPage

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -517,6 +517,7 @@
             this.Name = "ColorsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1410, 852);
+            this.Text = "Colors";
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbRevisionGraph.ResumeLayout(false);


### PR DESCRIPTION
Fixes #6240

## Proposed changes

- just set the title in the designer

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/36601201/52592707-63986c00-2e47-11e9-99f5-baedfdbcdfea.png)

### After

![after](https://user-images.githubusercontent.com/36601201/52592745-7ad75980-2e47-11e9-9f98-ac3d1c30256b.png)

## Test methodology

- manual

## Test environment(s)

- Git Extensions 3.1.0
- Build d92e7749c714efa04c19899025e59d36e6feff19
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
