### PR TITLE
#6246: NullReferenceException in commit dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -404,6 +404,7 @@ namespace GitUI.CommandsDialogs
             this.stagedEditFileToolStripMenuItem11});
             this.StagedFileContext.Name = "StagedFileContext";
             this.StagedFileContext.Size = new System.Drawing.Size(233, 198);
+            this.StagedFileContext.Opening += StagedFileContext_Opening;
             //
             // stagedResetChanges
             //

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1557,6 +1557,17 @@ namespace GitUI.CommandsDialogs
             viewFileHistoryToolStripItem.Enabled = isTrackedSelected;
         }
 
+        private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            // Do not show if no item selected
+            e.Cancel = !Staged.SelectedItems.Any() || Module.IsBareRepository();
+
+            var isNewSelected = Staged.SelectedItems.Any(s => s.IsNew);
+
+            stagedFileHistoryToolStripMenuItem6.Enabled = !isNewSelected;
+            stagedOpenDifftoolToolStripMenuItem9.Enabled = !isNewSelected;
+        }
+
         private void Unstaged_Enter(object sender, EventArgs e)
         {
             if (_currentFilesList != Unstaged)


### PR DESCRIPTION
Fixes #6246


## Proposed changes

- right clicking in the staged file viewer does not open the context menu, unless the user clicked on an item
- the context menu has two options grayed out when the file is new: `View file history` and `Open with difftool`


## Screenshots

![newfile](https://user-images.githubusercontent.com/46861028/52746286-78a90280-2fe1-11e9-9a1f-bea4e0e0d4d4.png)

![changedfile](https://user-images.githubusercontent.com/46861028/52746287-78a90280-2fe1-11e9-90a6-14ea2bbe3811.png)


## Test methodology <!-- How did you ensure quality? -->

- manual tests
- ran unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build c661fcb9e9719387a5c4da1e7590016270eb6c3a (Dirty)
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.3260.0
- DPI 120dpi (125% scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
