### PR TITLE
FormBrowse: Add support of drag and drop of a file that select it in …

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -774,5 +774,15 @@ See the changes in the commit form.");
                 tvGitTree.Focus();
             }
         }
+
+        public bool SelectFileOrFolder(string filePath)
+        {
+            if (filePath == null || filePath.IndexOf(Module.WorkingDir) != 0)
+            {
+                return false;
+            }
+
+            return _revisionFileTreeController.SelectFileOrFolder(tvGitTree, filePath.Substring(Module.WorkingDir.Length));
+        }
     }
 }


### PR DESCRIPTION
…the file tree

Drag is working from at least:
- File Explorer (DataFormats.FileDrop)
- VSCode File tree (DataFormats.Text)
- VisualStudio Solution Explorer (DataFormats.UnicodeText);

## Proposed changes

- We are now able to drag and drop a file into the browse form and this file, if is belonging to the repository, is selected in the file tree. 

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 1766bf88a2ef8a71de3776955569913343fcd7fa
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
