### PR TITLE
FormCleanupRepository: Add a button to easily add a path to clean up

### DIFF
--- a/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
@@ -62,7 +62,7 @@
             // 
             this.AddPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.AddPath.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.AddPath.Location = new System.Drawing.Point(302, 144);
+            this.AddPath.Location = new System.Drawing.Point(302, 139);
             this.AddPath.Name = "AddPath";
             this.AddPath.Size = new System.Drawing.Size(120, 25);
             this.AddPath.TabIndex = 0;

--- a/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             this.Preview = new System.Windows.Forms.Button();
+            this.AddPath = new System.Windows.Forms.Button();
             this.Cleanup = new System.Windows.Forms.Button();
             this.Cancel = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -43,9 +44,9 @@
             this.labelPathHint = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
-            //
+            // 
             // Preview
-            //
+            // 
             this.Preview.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Preview.Image = global::GitUI.Properties.Images.Preview;
             this.Preview.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -56,9 +57,21 @@
             this.Preview.Text = "Preview";
             this.Preview.UseVisualStyleBackColor = true;
             this.Preview.Click += new System.EventHandler(this.Preview_Click);
-            //
+            // 
+            // AddPath
+            // 
+            this.AddPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.AddPath.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.AddPath.Location = new System.Drawing.Point(302, 144);
+            this.AddPath.Name = "AddPath";
+            this.AddPath.Size = new System.Drawing.Size(120, 25);
+            this.AddPath.TabIndex = 0;
+            this.AddPath.Text = "Add a path...";
+            this.AddPath.UseVisualStyleBackColor = true;
+            this.AddPath.Click += new System.EventHandler(this.AddPath_Click);
+            // 
             // Cleanup
-            //
+            // 
             this.Cleanup.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Cleanup.Image = global::GitUI.Properties.Images.CleanupRepo;
             this.Cleanup.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -69,9 +82,9 @@
             this.Cleanup.Text = "Cleanup";
             this.Cleanup.UseVisualStyleBackColor = true;
             this.Cleanup.Click += new System.EventHandler(this.Cleanup_Click);
-            //
+            // 
             // Cancel
-            //
+            // 
             this.Cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.Cancel.Location = new System.Drawing.Point(302, 278);
@@ -81,10 +94,10 @@
             this.Cancel.Text = "Cancel";
             this.Cancel.UseVisualStyleBackColor = true;
             this.Cancel.Click += new System.EventHandler(this.Cancel_Click);
-            //
+            // 
             // groupBox1
-            //
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.RemoveIgnored);
             this.groupBox1.Controls.Add(this.RemoveNonIgnored);
@@ -95,55 +108,55 @@
             this.groupBox1.TabIndex = 3;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Remove untracked files from working directory";
-            //
+            // 
             // RemoveIgnored
-            //
+            // 
             this.RemoveIgnored.AutoSize = true;
             this.RemoveIgnored.Location = new System.Drawing.Point(7, 67);
             this.RemoveIgnored.Name = "RemoveIgnored";
-            this.RemoveIgnored.Size = new System.Drawing.Size(218, 19);
+            this.RemoveIgnored.Size = new System.Drawing.Size(197, 17);
             this.RemoveIgnored.TabIndex = 2;
             this.RemoveIgnored.Text = "Remove only ignored untracked files";
             this.RemoveIgnored.UseVisualStyleBackColor = true;
-            //
+            // 
             // RemoveNonIgnored
-            //
+            // 
             this.RemoveNonIgnored.AutoSize = true;
             this.RemoveNonIgnored.Location = new System.Drawing.Point(7, 43);
             this.RemoveNonIgnored.Name = "RemoveNonIgnored";
-            this.RemoveNonIgnored.Size = new System.Drawing.Size(244, 19);
+            this.RemoveNonIgnored.Size = new System.Drawing.Size(218, 17);
             this.RemoveNonIgnored.TabIndex = 1;
             this.RemoveNonIgnored.Text = "Remove only non-ignored untracked files";
             this.RemoveNonIgnored.UseVisualStyleBackColor = true;
-            //
+            // 
             // RemoveAll
-            //
+            // 
             this.RemoveAll.AutoSize = true;
             this.RemoveAll.Checked = true;
             this.RemoveAll.Location = new System.Drawing.Point(7, 20);
             this.RemoveAll.Name = "RemoveAll";
-            this.RemoveAll.Size = new System.Drawing.Size(163, 19);
+            this.RemoveAll.Size = new System.Drawing.Size(150, 17);
             this.RemoveAll.TabIndex = 0;
             this.RemoveAll.TabStop = true;
             this.RemoveAll.Text = "Remove all untracked files";
             this.RemoveAll.UseVisualStyleBackColor = true;
-            //
+            // 
             // RemoveDirectories
-            //
+            // 
             this.RemoveDirectories.AutoSize = true;
             this.RemoveDirectories.Checked = true;
             this.RemoveDirectories.CheckState = System.Windows.Forms.CheckState.Checked;
             this.RemoveDirectories.Location = new System.Drawing.Point(19, 119);
             this.RemoveDirectories.Name = "RemoveDirectories";
-            this.RemoveDirectories.Size = new System.Drawing.Size(183, 19);
+            this.RemoveDirectories.Size = new System.Drawing.Size(168, 17);
             this.RemoveDirectories.TabIndex = 4;
             this.RemoveDirectories.Text = "Remove untracked directories";
             this.RemoveDirectories.UseVisualStyleBackColor = true;
-            //
+            // 
             // PreviewOutput
-            //
-            this.PreviewOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.PreviewOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.PreviewOutput.Location = new System.Drawing.Point(12, 343);
             this.PreviewOutput.Multiline = true;
@@ -152,19 +165,19 @@
             this.PreviewOutput.Size = new System.Drawing.Size(410, 87);
             this.PreviewOutput.TabIndex = 5;
             this.PreviewOutput.WordWrap = false;
-            //
+            // 
             // label1
-            //
+            // 
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(9, 325);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(30, 15);
+            this.label1.Size = new System.Drawing.Size(28, 13);
             this.label1.TabIndex = 6;
             this.label1.Text = "Log:";
-            //
+            // 
             // textBoxPaths
-            //
-            this.textBoxPaths.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            // 
+            this.textBoxPaths.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxPaths.Location = new System.Drawing.Point(48, 169);
             this.textBoxPaths.Multiline = true;
@@ -172,30 +185,31 @@
             this.textBoxPaths.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.textBoxPaths.Size = new System.Drawing.Size(374, 63);
             this.textBoxPaths.TabIndex = 1;
-            //
+            // 
             // checkBoxPathFilter
-            //
+            // 
             this.checkBoxPathFilter.AutoSize = true;
             this.checkBoxPathFilter.Location = new System.Drawing.Point(19, 144);
             this.checkBoxPathFilter.Name = "checkBoxPathFilter";
-            this.checkBoxPathFilter.Size = new System.Drawing.Size(200, 19);
+            this.checkBoxPathFilter.Size = new System.Drawing.Size(176, 17);
             this.checkBoxPathFilter.TabIndex = 0;
             this.checkBoxPathFilter.Text = "Affect the following path(s) only:";
             this.checkBoxPathFilter.UseVisualStyleBackColor = true;
             this.checkBoxPathFilter.CheckedChanged += new System.EventHandler(this.checkBoxPathFilter_CheckedChanged);
-            //
+            // 
             // labelPathHint
-            //
+            // 
             this.labelPathHint.AutoSize = true;
             this.labelPathHint.Location = new System.Drawing.Point(50, 236);
             this.labelPathHint.Name = "labelPathHint";
-            this.labelPathHint.Size = new System.Drawing.Size(104, 15);
+            this.labelPathHint.Size = new System.Drawing.Size(92, 13);
             this.labelPathHint.TabIndex = 7;
             this.labelPathHint.Text = "(one path per line)";
-            //
+            // 
             // FormCleanupRepository
-            //
+            // 
             this.AcceptButton = this.Preview;
+            this.AcceptButton = this.AddPath;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.Cancel;
@@ -210,6 +224,7 @@
             this.Controls.Add(this.Cancel);
             this.Controls.Add(this.Cleanup);
             this.Controls.Add(this.Preview);
+            this.Controls.Add(this.AddPath);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(450, 480);
@@ -226,6 +241,7 @@
         #endregion
 
         private System.Windows.Forms.Button Preview;
+        private System.Windows.Forms.Button AddPath;
         private System.Windows.Forms.Button Cleanup;
         private System.Windows.Forms.Button Cancel;
         private System.Windows.Forms.GroupBox groupBox1;

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
@@ -13,6 +14,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _reallyCleanupQuestion =
             new TranslationString("Are you sure you want to cleanup the repository?");
         private readonly TranslationString _reallyCleanupQuestionCaption = new TranslationString("Cleanup");
+        private readonly TranslationString _directoryToCleanupCaption = new TranslationString("Select a directory to clean up");
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCleanupRepository()
@@ -104,6 +106,29 @@ namespace GitUI.CommandsDialogs
             bool filterByPath = checkBoxPathFilter.Checked;
             textBoxPaths.Enabled = filterByPath;
             labelPathHint.Visible = filterByPath;
+        }
+
+        private void AddPath_Click(object sender, EventArgs e)
+        {
+            var dialog = new FolderBrowserDialog { SelectedPath = Module.WorkingDir, ShowNewFolderButton = false, Description = _directoryToCleanupCaption.Text };
+
+            var result = dialog.ShowDialog();
+            if (result == DialogResult.OK)
+            {
+                if (!dialog.SelectedPath.StartsWith(Module.WorkingDir) || !Directory.Exists(dialog.SelectedPath))
+                {
+                    return;
+                }
+
+                checkBoxPathFilter.Checked = true;
+                textBoxPaths.Enabled = true;
+                if (textBoxPaths.Text.Length != 0)
+                {
+                    textBoxPaths.Text += Environment.NewLine;
+                }
+
+                textBoxPaths.Text += dialog.SelectedPath;
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _reallyCleanupQuestion =
             new TranslationString("Are you sure you want to cleanup the repository?");
         private readonly TranslationString _reallyCleanupQuestionCaption = new TranslationString("Cleanup");
-        private readonly TranslationString _directoryToCleanupCaption = new TranslationString("Select a directory to clean up");
+        private readonly TranslationString _directoryToCleanupCaption = new TranslationString("Select a subfolder of your repository to clean up");
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormCleanupRepository()
@@ -110,7 +110,24 @@ namespace GitUI.CommandsDialogs
 
         private void AddPath_Click(object sender, EventArgs e)
         {
-            var dialog = new FolderBrowserDialog { SelectedPath = Module.WorkingDir, ShowNewFolderButton = false, Description = _directoryToCleanupCaption.Text };
+            string selectedFolder;
+            try
+            {
+                selectedFolder = Directory.EnumerateDirectories(Module.WorkingDir).OrderBy(d => d)
+                    .FirstOrDefault(d => d != Module.WorkingDirGitDir.TrimEnd(Path.DirectorySeparatorChar)) ?? Module.WorkingDir;
+            }
+            catch
+            {
+                selectedFolder = Module.WorkingDir;
+            }
+
+            var dialog = new FolderBrowserDialog
+            {
+                RootFolder = Environment.SpecialFolder.MyComputer,
+                SelectedPath = selectedFolder,
+                ShowNewFolderButton = false,
+                Description = _directoryToCleanupCaption.Text
+            };
 
             var result = dialog.ShowDialog();
             if (result == DialogResult.OK)


### PR DESCRIPTION
## Proposed changes

- Being able to open a dialog to select a directory inside the working directory


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

No button. We have to type or copy/paste the path from explorer

### After

We could open a directory chooser to select a path

![image](https://user-images.githubusercontent.com/460196/52824865-b3cb3480-30ba-11e9-8526-fda98a86d472.png)



## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 04710c19a5d0fd1bbfbc56890a21dbd53ec2fe79 (Dirty)
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)

