### PR TITLE
WIP: Fix viewing file history for files that don't exist in current HEAD

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
@@ -29,6 +30,7 @@ namespace GitUI.CommandsDialogs
         private readonly FormFileHistoryController _controller = new FormFileHistoryController();
 
         private BuildReportTabPageExtension _buildReportTabPageExtension;
+        private Task<(string revision, string path)> _fileChangesFilterBuildTask;
 
         private string FileName { get; set; }
 
@@ -187,7 +189,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            _asyncLoader.LoadAsync(
+            _fileChangesFilterBuildTask = _asyncLoader.LoadAsync(
                 () => BuildFilter(),
                 filter =>
                 {
@@ -631,5 +633,17 @@ namespace GitUI.CommandsDialogs
         }
 
         #endregion
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        public readonly struct TestAccessor
+        {
+            public TestAccessor(FormFileHistory form)
+            {
+                FileChangesFilterBuildTask = form._fileChangesFilterBuildTask;
+            }
+
+            public Task<(string revision, string path)> FileChangesFilterBuildTask { get; }
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -206,9 +206,9 @@ namespace GitUI.CommandsDialogs
                 // we will need this later to look up proper casing for the file
                 var fullFilePath = _fullPathResolver.Resolve(fileName);
 
-                if (_controller.TryGetExactPath(fullFilePath, out fileName))
+                if (_controller.TryGetExactPath(fullFilePath, out string exactPath))
                 {
-                    fileName = fileName.Substring(Module.WorkingDir.Length);
+                    fileName = exactPath.Substring(Module.WorkingDir.Length);
                 }
 
                 // Replace windows path separator to Linux path separator.

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormFileHistoryTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormFileHistoryTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonTestUtils;
+using GitCommands;
+using GitUI;
+using GitUI.CommandsDialogs;
+using LibGit2Sharp;
+using NUnit.Framework;
+using ObjectId = GitUIPluginInterfaces.ObjectId;
+using ResetMode = LibGit2Sharp.ResetMode;
+
+namespace GitUITests.CommandsDialogs.CommitDialog
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormFileHistoryTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+        private GitModuleTestHelper _gitModuleTestHelper;
+
+        // Created once for each test
+        private GitUICommands _commands;
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository == null)
+            {
+                _gitModuleTestHelper = new GitModuleTestHelper();
+                _referenceRepository = new ReferenceRepository(_gitModuleTestHelper);
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _commands = null;
+        }
+
+        [Test]
+        public async Task FormFileHistory_should_produce_revision_filter_for_file_not_in_current_HEAD()
+        {
+            // Arrange repository with new file in another branch
+            GitRevision featureBranchBCommitRevision;
+
+            using (var repository = new Repository(_referenceRepository.Module.WorkingDir))
+            {
+                repository.Reset(ResetMode.Hard);
+
+                var initialHead = repository.Head;
+
+                // Create another branch with a new file commited to it
+                var featureBranch = repository.CreateBranch("feature-b");
+                Commands.Checkout(repository, featureBranch);
+                _gitModuleTestHelper.CreateRepoFile("B.txt", "B");
+                repository.Index.Add("B.txt");
+                repository.Index.Write();
+
+                var message = "B commit message";
+                var author = new Signature("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
+                var committer = author;
+                var options = new CommitOptions();
+                var commit = repository.Commit(message, author, committer, options);
+                featureBranchBCommitRevision = new GitRevision(ObjectId.Parse(commit.Id.ToString()));
+
+                // Return back to initial HEAD
+                Commands.Checkout(repository, initialHead);
+            }
+
+            Task<(string revision, string path)> fileChangesFilterBuildTask = null;
+
+            RunFormTest(
+                form =>
+                {
+                    fileChangesFilterBuildTask = form.GetTestAccessor().FileChangesFilterBuildTask;
+                    return fileChangesFilterBuildTask;
+                }, "B.txt", featureBranchBCommitRevision);
+
+            Assert.NotNull(fileChangesFilterBuildTask);
+            Assert.AreEqual("B.txt".Quote(), (await fileChangesFilterBuildTask).path);
+        }
+
+        private void RunFormTest(Func<FormFileHistory, Task> testDriverAsync, string fileName, GitRevision revision)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    _commands.StartFileHistoryDialog(owner: null, fileName, revision);
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Avatars\AvatarTestBase.cs" />
     <Compile Include="Avatars\BackupAvatarProviderTests.cs" />
     <Compile Include="CancellationTokenSequenceTests.cs" />
+    <Compile Include="CommandsDialogs\CommitDialog\FormFileHistoryTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormPullTests.cs" />


### PR DESCRIPTION
## Fixes
When trying to view history for a file which does not exist in currect HEAD (i.g. has just been created in another branch) an empty History/Blame form opens and doesn't load any changes to display.

## Proposed changes

- Because same variable was re-used to retrieve exact file path in the case of failure it would be reset to null and thus later could not be used to load history for it. Fix: Use separate variable for exact path check.

## Test methodology

- Manual testing by viewing history of the file which does not exist in current HEAD


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
