### PR TITLE
Dashboard: Add ability to drag and drop a folder from Windows explorer to UserRe…

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -323,6 +323,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             // 
             // RecentRepositoriesList
             // 
+            this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.menuStripRecentMenu);


### PR DESCRIPTION
…positoriesList inside the Dashboard form

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6221 


## Proposed changes

- User can drag and drop a folder with a git repo to the repositories list inside the Dashboard form to open that repository
- The code was taken from the version 2.51 of GitExtensions

## Screenshots <!-- Remove this section if PR does not change UI -->
![dnd](https://user-images.githubusercontent.com/4993430/52886529-a2029380-3185-11e9-905d-e20c22aa64b1.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 7 SP1

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
