### PR TITLE
Manually handle Ctrl+Backspace on TextBox and ComboBox controls

### DIFF
--- a/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
+++ b/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
@@ -63,10 +63,9 @@ namespace GitUI
                     // after the word is selected and before it is erased.
                     _beginUpdateMethod.Invoke(sender, parameters: null);
 
-                    SetText(text.Substring(0, from) + text.Substring(from + length));
-
                     SetSelectionStart(from);
-                    SetSelectionLength(0);
+                    SetSelectionLength(length);
+                    ClearSelectedText();
 
                     _endUpdateMethod.Invoke(sender, parameters: null);
 
@@ -111,9 +110,6 @@ namespace GitUI
 
                 string GetText() =>
                     ((Control)sender).Text;
-
-                void SetText(string value) =>
-                    ((Control)sender).Text = value;
 
                 int GetSelectionStart()
                 {
@@ -170,6 +166,22 @@ namespace GitUI
                             throw new NotSupportedException();
                     }
                 }
+
+                void ClearSelectedText()
+                {
+                    switch (sender)
+                    {
+                        case TextBoxBase t:
+                            _setSelectedTextInternalMethod.Invoke(t,
+                                new object[] { string.Empty, /* clear undo */ false });
+                            return;
+                        case ComboBox cb:
+                            cb.SelectedText = string.Empty;
+                            return;
+                        default:
+                            throw new NotSupportedException();
+                    }
+                }
             }
         }
 
@@ -190,5 +202,9 @@ namespace GitUI
                 binder: null,
                 types: new Type[0],
                 modifiers: new ParameterModifier[0]);
+
+        private static readonly MethodInfo _setSelectedTextInternalMethod =
+            typeof(TextBoxBase).GetMethod("SetSelectedTextInternal",
+                BindingFlags.Instance | BindingFlags.NonPublic);
     }
 }

--- a/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
+++ b/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
@@ -50,10 +50,10 @@ namespace GitUI
                 }
                 else
                 {
-                    int previousWordBreak = FindPreviousWordStart(text, selectionStart);
-                    if (previousWordBreak >= 0)
+                    int previousBreak = FindPreviousBreak(text, selectionStart);
+                    if (previousBreak >= 0)
                     {
-                        RemoveTextRange(previousWordBreak, selectionStart - previousWordBreak);
+                        RemoveTextRange(previousBreak, selectionStart - previousBreak);
                     }
                 }
 
@@ -73,17 +73,40 @@ namespace GitUI
                     (sender as ComboBox)?.Refresh();
                 }
 
-                int FindPreviousWordStart(string value, int position)
+                int FindPreviousBreak(string value, int position)
                 {
                     for (int i = position - 1; i >= 0; i--)
                     {
-                        if (i == 0 || (!char.IsLetterOrDigit(value[i - 1]) && char.IsLetterOrDigit(value[i])))
+                        if (i == 0)
+                        {
+                            return i;
+                        }
+
+                        int previousType = GetCharType(value[i - 1]);
+                        int currentType = GetCharType(value[i]);
+
+                        if (previousType != currentType && currentType != ' ')
                         {
                             return i;
                         }
                     }
 
                     return -1;
+
+                    char GetCharType(char c)
+                    {
+                        if (char.IsLetterOrDigit(c))
+                        {
+                            return 'w';
+                        }
+
+                        if (char.IsWhiteSpace(c))
+                        {
+                            return ' ';
+                        }
+
+                        return c;
+                    }
                 }
 
                 string GetText() =>


### PR DESCRIPTION
Fixes problems introduced by #6029

## Proposed changes

1. Removing word on `Ctrl`+`Backspace` manually instead of using `SendKeys.Send("^+{LEFT} {BACKSPACE}")`

turns out `SendKeys.Send` solution is
- Unreliable: in some environments, maybe depending on keyboard type, the second and subsequent words are not removed by 1 `Backspace` click.
[proof](https://github.com/gitextensions/gitextensions/pull/6049#issuecomment-464287771)

- Incomplete: Only `LeftCtrl` + `Backspace` was handled correctly

2. Apply the same fix to `ComboBox`es

## Test methodology
manual

## Test environment(s)

- Windows 7SP1

----
:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).