### PR TITLE
Fix unit test that fails only on CI server

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -85,6 +85,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         [Test]
         public void Should_display_branch_and_no_remote_info_in_statusbar()
         {
+            _referenceRepository.CheckoutMaster();
             RunFormTest(form =>
             {
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;

--- a/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
@@ -41,6 +41,14 @@ namespace GitUITests.CommandsDialogs
             }
         }
 
+        public void CheckoutMaster()
+        {
+            using (var repository = new LibGit2Sharp.Repository(Module.WorkingDir))
+            {
+                Commands.Checkout(repository, "master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+            }
+        }
+
         public void CreateRemoteForMasterBranch()
         {
             using (var repository = new LibGit2Sharp.Repository(Module.WorkingDir))


### PR DESCRIPTION
Test failing: FormCommitTests.Should_display_branch_and_no_remote_info_in_statusbar()
