### PR TITLE
Existing branch combobox could be empty

### DIFF
--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -109,7 +109,11 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             {
                 "add",
                 WorktreeDirectory.Quote(),
-                { radioButtonCreateNewBranch.Checked, $"-b {textBoxNewBranchName.Text}", ((GitRef)comboBoxBranches.SelectedItem).Name }
+                {
+                    radioButtonCreateNewBranch.Checked,
+                    $"-b {textBoxNewBranchName.Text}",
+                    comboBoxBranches.SelectedItem != null ? ((GitRef)comboBoxBranches.SelectedItem).Name : null
+                }
             };
 
             UICommands.StartGitCommandProcessDialog(this, args);


### PR DESCRIPTION
Fix for gitextensions/gitextensions/issues/6277
