### PR TITLE
Don't load avatars, if network is not available

### DIFF
--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -44,6 +44,12 @@ namespace GitUI.Avatars
                 throw new ArgumentException(nameof(email));
             }
 
+            // check network connectivity
+            if (!NativeMethods.InternetGetConnectedState(out _, 0))
+            {
+                return null;
+            }
+
             var match = _gitHubEmailRegex.Match(email);
 
             return match.Success

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -46,6 +46,7 @@
             this.helpTranslate = new System.Windows.Forms.LinkLabel();
             this.gbAuthorImages = new System.Windows.Forms.GroupBox();
             this.tlpnlAuthor = new System.Windows.Forms.TableLayoutPanel();
+            this.ShowAuthorAvatarInCommitGraph = new System.Windows.Forms.CheckBox();
             this.ShowAuthorAvatar = new System.Windows.Forms.CheckBox();
             this.ClearImageCache = new System.Windows.Forms.Button();
             this.NoImageService = new System.Windows.Forms.ComboBox();
@@ -82,7 +83,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
-            tlpnlMain.Size = new System.Drawing.Size(757, 515);
+            tlpnlMain.Size = new System.Drawing.Size(1122, 753);
             tlpnlMain.TabIndex = 0;
             // 
             // gbGeneral
@@ -93,8 +94,8 @@
             this.gbGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbGeneral.Location = new System.Drawing.Point(3, 3);
             this.gbGeneral.Name = "gbGeneral";
-            this.gbGeneral.Padding = new System.Windows.Forms.Padding(8);
-            this.gbGeneral.Size = new System.Drawing.Size(751, 153);
+            this.gbGeneral.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
+            this.gbGeneral.Size = new System.Drawing.Size(1116, 125);
             this.gbGeneral.TabIndex = 0;
             this.gbGeneral.TabStop = false;
             this.gbGeneral.Text = "General";
@@ -113,14 +114,14 @@
             this.tlpnlGeneral.Controls.Add(this.chkEnableAutoScale, 0, 2);
             this.tlpnlGeneral.Controls.Add(this.chkShowCurrentBranchInVisualStudio, 0, 1);
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlGeneral.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlGeneral.Location = new System.Drawing.Point(8, 21);
             this.tlpnlGeneral.Name = "tlpnlGeneral";
             this.tlpnlGeneral.RowCount = 4;
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlGeneral.Size = new System.Drawing.Size(735, 123);
+            this.tlpnlGeneral.Size = new System.Drawing.Size(1100, 96);
             this.tlpnlGeneral.TabIndex = 0;
             // 
             // chkShowRelativeDate
@@ -130,7 +131,7 @@
             this.chkShowRelativeDate.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowRelativeDate.Location = new System.Drawing.Point(3, 3);
             this.chkShowRelativeDate.Name = "chkShowRelativeDate";
-            this.chkShowRelativeDate.Size = new System.Drawing.Size(281, 17);
+            this.chkShowRelativeDate.Size = new System.Drawing.Size(314, 17);
             this.chkShowRelativeDate.TabIndex = 0;
             this.chkShowRelativeDate.Text = "Show relative date instead of full date";
             this.chkShowRelativeDate.UseVisualStyleBackColor = true;
@@ -145,18 +146,18 @@
             "Compact",
             "Trim start",
             "Filename only"});
-            this.truncatePathMethod.Location = new System.Drawing.Point(130, 99);
+            this.truncatePathMethod.Location = new System.Drawing.Point(129, 72);
             this.truncatePathMethod.Name = "truncatePathMethod";
-            this.truncatePathMethod.Size = new System.Drawing.Size(154, 21);
+            this.truncatePathMethod.Size = new System.Drawing.Size(188, 21);
             this.truncatePathMethod.TabIndex = 4;
             // 
             // truncateLongFilenames
             // 
             this.truncateLongFilenames.AutoSize = true;
             this.truncateLongFilenames.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.truncateLongFilenames.Location = new System.Drawing.Point(3, 96);
+            this.truncateLongFilenames.Location = new System.Drawing.Point(3, 69);
             this.truncateLongFilenames.Name = "truncateLongFilenames";
-            this.truncateLongFilenames.Size = new System.Drawing.Size(121, 27);
+            this.truncateLongFilenames.Size = new System.Drawing.Size(120, 27);
             this.truncateLongFilenames.TabIndex = 3;
             this.truncateLongFilenames.Text = "Truncate long filenames";
             this.truncateLongFilenames.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -168,7 +169,7 @@
             this.chkEnableAutoScale.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkEnableAutoScale.Location = new System.Drawing.Point(3, 49);
             this.chkEnableAutoScale.Name = "chkEnableAutoScale";
-            this.chkEnableAutoScale.Size = new System.Drawing.Size(281, 17);
+            this.chkEnableAutoScale.Size = new System.Drawing.Size(314, 17);
             this.chkEnableAutoScale.TabIndex = 2;
             this.chkEnableAutoScale.Text = "Auto scale user interface when high DPI is used";
             this.chkEnableAutoScale.UseVisualStyleBackColor = true;
@@ -180,7 +181,7 @@
             this.chkShowCurrentBranchInVisualStudio.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowCurrentBranchInVisualStudio.Location = new System.Drawing.Point(3, 26);
             this.chkShowCurrentBranchInVisualStudio.Name = "chkShowCurrentBranchInVisualStudio";
-            this.chkShowCurrentBranchInVisualStudio.Size = new System.Drawing.Size(281, 17);
+            this.chkShowCurrentBranchInVisualStudio.Size = new System.Drawing.Size(314, 17);
             this.chkShowCurrentBranchInVisualStudio.TabIndex = 1;
             this.chkShowCurrentBranchInVisualStudio.Text = "Show current branch in Visual Studio";
             this.chkShowCurrentBranchInVisualStudio.UseVisualStyleBackColor = true;
@@ -191,10 +192,10 @@
             this.gbLanguages.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gbLanguages.Controls.Add(this.tlpnlLanguage);
             this.gbLanguages.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbLanguages.Location = new System.Drawing.Point(3, 304);
+            this.gbLanguages.Location = new System.Drawing.Point(3, 297);
             this.gbLanguages.Name = "gbLanguages";
-            this.gbLanguages.Padding = new System.Windows.Forms.Padding(8);
-            this.gbLanguages.Size = new System.Drawing.Size(751, 84);
+            this.gbLanguages.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
+            this.gbLanguages.Size = new System.Drawing.Size(1116, 83);
             this.gbLanguages.TabIndex = 2;
             this.gbLanguages.TabStop = false;
             this.gbLanguages.Text = "Language";
@@ -215,12 +216,12 @@
             this.tlpnlLanguage.Controls.Add(this.Language, 1, 0);
             this.tlpnlLanguage.Controls.Add(this.helpTranslate, 2, 0);
             this.tlpnlLanguage.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlLanguage.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlLanguage.Location = new System.Drawing.Point(8, 21);
             this.tlpnlLanguage.Name = "tlpnlLanguage";
             this.tlpnlLanguage.RowCount = 2;
             this.tlpnlLanguage.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlLanguage.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlLanguage.Size = new System.Drawing.Size(735, 54);
+            this.tlpnlLanguage.Size = new System.Drawing.Size(1100, 54);
             this.tlpnlLanguage.TabIndex = 0;
             // 
             // Dictionary
@@ -228,7 +229,7 @@
             this.Dictionary.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Dictionary.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Dictionary.FormattingEnabled = true;
-            this.Dictionary.Location = new System.Drawing.Point(159, 30);
+            this.Dictionary.Location = new System.Drawing.Point(158, 30);
             this.Dictionary.Name = "Dictionary";
             this.Dictionary.Size = new System.Drawing.Size(86, 21);
             this.Dictionary.TabIndex = 4;
@@ -239,9 +240,9 @@
             this.downloadDictionary.AutoSize = true;
             this.downloadDictionary.Dock = System.Windows.Forms.DockStyle.Fill;
             this.downloadDictionary.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.downloadDictionary.Location = new System.Drawing.Point(251, 27);
+            this.downloadDictionary.Location = new System.Drawing.Point(250, 27);
             this.downloadDictionary.Name = "downloadDictionary";
-            this.downloadDictionary.Size = new System.Drawing.Size(104, 27);
+            this.downloadDictionary.Size = new System.Drawing.Size(103, 27);
             this.downloadDictionary.TabIndex = 5;
             this.downloadDictionary.TabStop = true;
             this.downloadDictionary.Text = "Download dictionary";
@@ -254,7 +255,7 @@
             this.lblSpellingDictionary.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblSpellingDictionary.Location = new System.Drawing.Point(3, 27);
             this.lblSpellingDictionary.Name = "lblSpellingDictionary";
-            this.lblSpellingDictionary.Size = new System.Drawing.Size(150, 27);
+            this.lblSpellingDictionary.Size = new System.Drawing.Size(149, 27);
             this.lblSpellingDictionary.TabIndex = 3;
             this.lblSpellingDictionary.Text = "Dictionary for spelling checker";
             this.lblSpellingDictionary.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -265,7 +266,7 @@
             this.lblLanguage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblLanguage.Location = new System.Drawing.Point(3, 0);
             this.lblLanguage.Name = "lblLanguage";
-            this.lblLanguage.Size = new System.Drawing.Size(150, 27);
+            this.lblLanguage.Size = new System.Drawing.Size(149, 27);
             this.lblLanguage.TabIndex = 0;
             this.lblLanguage.Text = "Language (restart required)";
             this.lblLanguage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -275,7 +276,7 @@
             this.Language.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Language.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.Language.FormattingEnabled = true;
-            this.Language.Location = new System.Drawing.Point(159, 3);
+            this.Language.Location = new System.Drawing.Point(158, 3);
             this.Language.Name = "Language";
             this.Language.Size = new System.Drawing.Size(86, 21);
             this.Language.TabIndex = 1;
@@ -285,9 +286,9 @@
             this.helpTranslate.AutoSize = true;
             this.helpTranslate.Dock = System.Windows.Forms.DockStyle.Fill;
             this.helpTranslate.LinkColor = System.Drawing.SystemColors.HotTrack;
-            this.helpTranslate.Location = new System.Drawing.Point(251, 0);
+            this.helpTranslate.Location = new System.Drawing.Point(250, 0);
             this.helpTranslate.Name = "helpTranslate";
-            this.helpTranslate.Size = new System.Drawing.Size(104, 27);
+            this.helpTranslate.Size = new System.Drawing.Size(103, 27);
             this.helpTranslate.TabIndex = 2;
             this.helpTranslate.TabStop = true;
             this.helpTranslate.Text = "Help translate";
@@ -300,10 +301,10 @@
             this.gbAuthorImages.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gbAuthorImages.Controls.Add(this.tlpnlAuthor);
             this.gbAuthorImages.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbAuthorImages.Location = new System.Drawing.Point(3, 162);
+            this.gbAuthorImages.Location = new System.Drawing.Point(3, 134);
             this.gbAuthorImages.Name = "gbAuthorImages";
-            this.gbAuthorImages.Padding = new System.Windows.Forms.Padding(8);
-            this.gbAuthorImages.Size = new System.Drawing.Size(751, 136);
+            this.gbAuthorImages.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
+            this.gbAuthorImages.Size = new System.Drawing.Size(1116, 157);
             this.gbAuthorImages.TabIndex = 1;
             this.gbAuthorImages.TabStop = false;
             this.gbAuthorImages.Text = "Author images";
@@ -316,32 +317,46 @@
             this.tlpnlAuthor.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlAuthor.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlAuthor.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatar, 0, 0);
-            this.tlpnlAuthor.Controls.Add(this.ClearImageCache, 1, 3);
-            this.tlpnlAuthor.Controls.Add(this.NoImageService, 1, 2);
-            this.tlpnlAuthor.Controls.Add(this.lblCacheDays, 0, 1);
-            this.tlpnlAuthor.Controls.Add(this.lblNoImageService, 0, 2);
-            this.tlpnlAuthor.Controls.Add(this._NO_TRANSLATE_DaysToCacheImages, 1, 1);
+            this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatarInCommitGraph, 0, 0);
+            this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatar, 0, 1);
+            this.tlpnlAuthor.Controls.Add(this.ClearImageCache, 1, 4);
+            this.tlpnlAuthor.Controls.Add(this.NoImageService, 1, 3);
+            this.tlpnlAuthor.Controls.Add(this.lblCacheDays, 0, 2);
+            this.tlpnlAuthor.Controls.Add(this.lblNoImageService, 0, 3);
+            this.tlpnlAuthor.Controls.Add(this._NO_TRANSLATE_DaysToCacheImages, 1, 2);
             this.tlpnlAuthor.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlAuthor.Location = new System.Drawing.Point(8, 22);
+            this.tlpnlAuthor.Location = new System.Drawing.Point(8, 21);
             this.tlpnlAuthor.Name = "tlpnlAuthor";
-            this.tlpnlAuthor.RowCount = 4;
+            this.tlpnlAuthor.RowCount = 5;
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlAuthor.Size = new System.Drawing.Size(735, 106);
+            this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlAuthor.Size = new System.Drawing.Size(1100, 128);
             this.tlpnlAuthor.TabIndex = 0;
+            // 
+            // ShowAuthorAvatarInCommitGraph
+            // 
+            this.ShowAuthorAvatarInCommitGraph.AutoSize = true;
+            this.tlpnlAuthor.SetColumnSpan(this.ShowAuthorAvatarInCommitGraph, 2);
+            this.ShowAuthorAvatarInCommitGraph.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ShowAuthorAvatarInCommitGraph.Location = new System.Drawing.Point(3, 3);
+            this.ShowAuthorAvatarInCommitGraph.Name = "ShowAuthorAvatarInCommitGraph";
+            this.ShowAuthorAvatarInCommitGraph.Size = new System.Drawing.Size(294, 17);
+            this.ShowAuthorAvatarInCommitGraph.TabIndex = 0;
+            this.ShowAuthorAvatarInCommitGraph.Text = "Show author's avatar column in the commit graph";
+            this.ShowAuthorAvatarInCommitGraph.UseVisualStyleBackColor = true;
             // 
             // ShowAuthorAvatar
             // 
             this.ShowAuthorAvatar.AutoSize = true;
             this.tlpnlAuthor.SetColumnSpan(this.ShowAuthorAvatar, 2);
             this.ShowAuthorAvatar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ShowAuthorAvatar.Location = new System.Drawing.Point(3, 3);
+            this.ShowAuthorAvatar.Location = new System.Drawing.Point(3, 26);
             this.ShowAuthorAvatar.Name = "ShowAuthorAvatar";
-            this.ShowAuthorAvatar.Size = new System.Drawing.Size(217, 17);
-            this.ShowAuthorAvatar.TabIndex = 0;
+            this.ShowAuthorAvatar.Size = new System.Drawing.Size(294, 17);
+            this.ShowAuthorAvatar.TabIndex = 1;
             this.ShowAuthorAvatar.Text = "Show author's avatar in the commit info view";
             this.ShowAuthorAvatar.UseVisualStyleBackColor = true;
             // 
@@ -350,10 +365,10 @@
             this.ClearImageCache.AutoSize = true;
             this.ClearImageCache.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.ClearImageCache.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ClearImageCache.Location = new System.Drawing.Point(116, 80);
+            this.ClearImageCache.Location = new System.Drawing.Point(114, 102);
             this.ClearImageCache.Name = "ClearImageCache";
-            this.ClearImageCache.Size = new System.Drawing.Size(104, 23);
-            this.ClearImageCache.TabIndex = 5;
+            this.ClearImageCache.Size = new System.Drawing.Size(183, 23);
+            this.ClearImageCache.TabIndex = 6;
             this.ClearImageCache.Text = "Clear image cache";
             this.ClearImageCache.UseVisualStyleBackColor = true;
             this.ClearImageCache.Click += new System.EventHandler(this.ClearImageCache_Click);
@@ -363,19 +378,19 @@
             this.NoImageService.Dock = System.Windows.Forms.DockStyle.Fill;
             this.NoImageService.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.NoImageService.FormattingEnabled = true;
-            this.NoImageService.Location = new System.Drawing.Point(116, 53);
+            this.NoImageService.Location = new System.Drawing.Point(114, 75);
             this.NoImageService.Name = "NoImageService";
-            this.NoImageService.Size = new System.Drawing.Size(104, 21);
-            this.NoImageService.TabIndex = 4;
+            this.NoImageService.Size = new System.Drawing.Size(183, 21);
+            this.NoImageService.TabIndex = 5;
             // 
             // lblCacheDays
             // 
             this.lblCacheDays.AutoSize = true;
             this.lblCacheDays.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblCacheDays.Location = new System.Drawing.Point(3, 23);
+            this.lblCacheDays.Location = new System.Drawing.Point(3, 46);
             this.lblCacheDays.Name = "lblCacheDays";
-            this.lblCacheDays.Size = new System.Drawing.Size(107, 27);
-            this.lblCacheDays.TabIndex = 1;
+            this.lblCacheDays.Size = new System.Drawing.Size(105, 26);
+            this.lblCacheDays.TabIndex = 2;
             this.lblCacheDays.Text = "Cache images (days)";
             this.lblCacheDays.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -383,24 +398,24 @@
             // 
             this.lblNoImageService.AutoSize = true;
             this.lblNoImageService.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblNoImageService.Location = new System.Drawing.Point(3, 50);
+            this.lblNoImageService.Location = new System.Drawing.Point(3, 72);
             this.lblNoImageService.Name = "lblNoImageService";
-            this.lblNoImageService.Size = new System.Drawing.Size(107, 27);
-            this.lblNoImageService.TabIndex = 3;
+            this.lblNoImageService.Size = new System.Drawing.Size(105, 27);
+            this.lblNoImageService.TabIndex = 4;
             this.lblNoImageService.Text = "No image service";
             this.lblNoImageService.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_DaysToCacheImages
             // 
-            this._NO_TRANSLATE_DaysToCacheImages.Location = new System.Drawing.Point(116, 26);
+            this._NO_TRANSLATE_DaysToCacheImages.Location = new System.Drawing.Point(114, 49);
             this._NO_TRANSLATE_DaysToCacheImages.Maximum = new decimal(new int[] {
             400,
             0,
             0,
             0});
             this._NO_TRANSLATE_DaysToCacheImages.Name = "_NO_TRANSLATE_DaysToCacheImages";
-            this._NO_TRANSLATE_DaysToCacheImages.Size = new System.Drawing.Size(38, 21);
-            this._NO_TRANSLATE_DaysToCacheImages.TabIndex = 2;
+            this._NO_TRANSLATE_DaysToCacheImages.Size = new System.Drawing.Size(38, 20);
+            this._NO_TRANSLATE_DaysToCacheImages.TabIndex = 3;
             this._NO_TRANSLATE_DaysToCacheImages.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // fixedWidthFontDialog
@@ -426,9 +441,8 @@
             this.Controls.Add(tlpnlMain);
             this.MinimumSize = new System.Drawing.Size(258, 255);
             this.Name = "AppearanceSettingsPage";
-            this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(773, 531);
-            this.Text = "Appearance";
+            this.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
+            this.Size = new System.Drawing.Size(1138, 769);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbGeneral.ResumeLayout(false);
@@ -476,5 +490,6 @@
         private System.Windows.Forms.TableLayoutPanel tlpnlLanguage;
         private System.Windows.Forms.TableLayoutPanel tlpnlGeneral;
         private System.Windows.Forms.TableLayoutPanel tlpnlAuthor;
+        private System.Windows.Forms.CheckBox ShowAuthorAvatarInCommitGraph;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -47,7 +47,7 @@
             this.gbAuthorImages = new System.Windows.Forms.GroupBox();
             this.tlpnlAuthor = new System.Windows.Forms.TableLayoutPanel();
             this.ShowAuthorAvatarInCommitGraph = new System.Windows.Forms.CheckBox();
-            this.ShowAuthorAvatar = new System.Windows.Forms.CheckBox();
+            this.ShowAuthorAvatarInCommitInfo = new System.Windows.Forms.CheckBox();
             this.ClearImageCache = new System.Windows.Forms.Button();
             this.NoImageService = new System.Windows.Forms.ComboBox();
             this.lblCacheDays = new System.Windows.Forms.Label();
@@ -318,7 +318,7 @@
             this.tlpnlAuthor.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlAuthor.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatarInCommitGraph, 0, 0);
-            this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatar, 0, 1);
+            this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatarInCommitInfo, 0, 1);
             this.tlpnlAuthor.Controls.Add(this.ClearImageCache, 1, 4);
             this.tlpnlAuthor.Controls.Add(this.NoImageService, 1, 3);
             this.tlpnlAuthor.Controls.Add(this.lblCacheDays, 0, 2);
@@ -350,15 +350,15 @@
             // 
             // ShowAuthorAvatar
             // 
-            this.ShowAuthorAvatar.AutoSize = true;
-            this.tlpnlAuthor.SetColumnSpan(this.ShowAuthorAvatar, 2);
-            this.ShowAuthorAvatar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ShowAuthorAvatar.Location = new System.Drawing.Point(3, 26);
-            this.ShowAuthorAvatar.Name = "ShowAuthorAvatar";
-            this.ShowAuthorAvatar.Size = new System.Drawing.Size(294, 17);
-            this.ShowAuthorAvatar.TabIndex = 1;
-            this.ShowAuthorAvatar.Text = "Show author's avatar in the commit info view";
-            this.ShowAuthorAvatar.UseVisualStyleBackColor = true;
+            this.ShowAuthorAvatarInCommitInfo.AutoSize = true;
+            this.tlpnlAuthor.SetColumnSpan(this.ShowAuthorAvatarInCommitInfo, 2);
+            this.ShowAuthorAvatarInCommitInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ShowAuthorAvatarInCommitInfo.Location = new System.Drawing.Point(3, 26);
+            this.ShowAuthorAvatarInCommitInfo.Name = "ShowAuthorAvatarInCommitInfo";
+            this.ShowAuthorAvatarInCommitInfo.Size = new System.Drawing.Size(294, 17);
+            this.ShowAuthorAvatarInCommitInfo.TabIndex = 1;
+            this.ShowAuthorAvatarInCommitInfo.Text = "Show author's avatar in the commit info view";
+            this.ShowAuthorAvatarInCommitInfo.UseVisualStyleBackColor = true;
             // 
             // ClearImageCache
             // 
@@ -483,7 +483,7 @@
         private System.Windows.Forms.NumericUpDown _NO_TRANSLATE_DaysToCacheImages;
         private System.Windows.Forms.Label lblCacheDays;
         private System.Windows.Forms.Button ClearImageCache;
-        private System.Windows.Forms.CheckBox ShowAuthorAvatar;
+        private System.Windows.Forms.CheckBox ShowAuthorAvatarInCommitInfo;
         private System.Windows.Forms.FontDialog fixedWidthFontDialog;
         private System.Windows.Forms.FontDialog applicationDialog;
         private System.Windows.Forms.FontDialog commitFontDialog;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             chkShowCurrentBranchInVisualStudio.Checked = AppSettings.ShowCurrentBranchInVisualStudio;
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
-            ShowAuthorAvatar.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
+            ShowAuthorAvatarInCommitInfo.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
             ShowAuthorAvatarInCommitGraph.Checked = AppSettings.ShowAuthorAvatarColumn;
             NoImageService.Text = AppSettings.GravatarDefaultImageType.ToString();
 
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.TruncatePathMethod = GetTruncatePathMethodString(truncatePathMethod.SelectedIndex);
             AppSettings.ShowCurrentBranchInVisualStudio = chkShowCurrentBranchInVisualStudio.Checked;
             AppSettings.ShowAuthorAvatarColumn = ShowAuthorAvatarInCommitGraph.Checked;
-            AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatar.Checked;
+            AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatarInCommitInfo.Checked;
             AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
 
             AppSettings.Translation = Language.Text;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -12,6 +12,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     {
         private readonly TranslationString _noDictFile = new TranslationString("None");
         private readonly TranslationString _noDictFilesFound = new TranslationString("No dictionary files found in: {0}");
+        private readonly TranslationString _noImageServiceTooltip = new TranslationString("A default image, if an email address has no matching Gravatar image.\r\nSee http://en.gravatar.com/site/implement/images/ for more details.");
 
         public AppearanceSettingsPage()
         {
@@ -24,6 +25,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void OnRuntimeLoad()
         {
             base.OnRuntimeLoad();
+
+            ToolTip.SetToolTip(NoImageService, _noImageServiceTooltip.Text);
 
             // align 1st columns across all tables
             tlpnlGeneral.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -53,6 +53,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowCurrentBranchInVisualStudio.Checked = AppSettings.ShowCurrentBranchInVisualStudio;
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
             ShowAuthorAvatar.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
+            ShowAuthorAvatarInCommitGraph.Checked = AppSettings.ShowAuthorAvatarColumn;
             NoImageService.Text = AppSettings.GravatarDefaultImageType.ToString();
 
             Language.Items.Clear();
@@ -107,13 +108,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.EnableAutoScale = chkEnableAutoScale.Checked;
             AppSettings.TruncatePathMethod = GetTruncatePathMethodString(truncatePathMethod.SelectedIndex);
             AppSettings.ShowCurrentBranchInVisualStudio = chkShowCurrentBranchInVisualStudio.Checked;
+            AppSettings.ShowAuthorAvatarColumn = ShowAuthorAvatarInCommitGraph.Checked;
+            AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatar.Checked;
+            AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
 
             AppSettings.Translation = Language.Text;
             Strings.Reinitialize();
-
-            AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
-
-            AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatar.Checked;
 
             if (Enum.TryParse<DefaultImageType>(NoImageService.Text, ignoreCase: true, out var type))
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.resx
@@ -120,13 +120,13 @@
   <metadata name="tlpnlMain.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="diffFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>196, 17</value>
+  <metadata name="fixedWidthFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="applicationDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>346, 17</value>
+    <value>471, 17</value>
   </metadata>
   <metadata name="commitFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>257, 17</value>
   </metadata>
 </root>

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.Designer.cs
@@ -1,0 +1,23 @@
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs.SettingsDialog
+{
+    partial class SettingsPageBase
+    {
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.SuspendLayout();
+            // 
+            // SettingsPageBase
+            // 
+            this.Name = "SettingsPageBase";
+            this.ResumeLayout(false);
+
+        }
+
+        private ToolTip toolTip1;
+        private System.ComponentModel.IContainer components;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -13,10 +13,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     /// <summary>
     /// set Text property in derived classes to set the title
     /// </summary>
-    public abstract class SettingsPageBase : GitExtensionsControl, ISettingsPage
+    public abstract partial class SettingsPageBase : GitExtensionsControl, ISettingsPage
     {
         private readonly List<ISettingControlBinding> _controlBindings = new List<ISettingControlBinding>();
         private ISettingsPageHost _pageHost;
+
+        protected SettingsPageBase()
+        {
+            InitializeComponent();
+        }
+
         protected ISettingsPageHost PageHost
         {
             get
@@ -31,9 +37,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         }
 
         protected CheckSettingsLogic CheckSettingsLogic => PageHost.CheckSettingsLogic;
+
         protected CommonLogic CommonLogic => CheckSettingsLogic.CommonLogic;
 
         protected GitModule Module => CommonLogic.Module;
+
+        protected ToolTip ToolTip => toolTip1;
 
         protected virtual void Init(ISettingsPageHost pageHost)
         {

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -831,6 +831,9 @@
     </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\SettingsPageBase.cs">
       <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\SettingsPageBase.Designer.cs">
+      <DependentUpon>SettingsPageBase.cs</DependentUpon>
     </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\SettingsPageReference.cs" />
     <Compile Include="CommandsDialogs\SettingsDialog\SettingsTreeViewUserControl.cs">

--- a/GitUI/Native.cs
+++ b/GitUI/Native.cs
@@ -116,6 +116,9 @@ namespace GitUI
         [DllImport("uxtheme", ExactSpelling = true, CharSet = CharSet.Unicode)]
         internal static extern int GetThemeFont(IntPtr hTheme, IntPtr hdc, int iPartId, int iStateId, int iPropId, out LOGFONT pFont);
 
+        [DllImport("wininet.dll")]
+        internal static extern bool InternetGetConnectedState(out int description, int reservedValue);
+
         #endregion
     }
 


### PR DESCRIPTION
Fixes #5828
Fixes #6223


## Proposed changes

- Check whether a client is connected to Internet before attempting to
fetch avatars.
- Add tooltip to clarify purpose of "No image" dropdown
![image](https://user-images.githubusercontent.com/4403806/53298615-a1a08180-3884-11e9-8193-99c6f610114c.png)
- Add a setting to show author's avatar column
![image](https://user-images.githubusercontent.com/4403806/53299441-3c518e00-388e-11e9-81c0-79b21bf89210.png)


## Test methodology <!-- How did you ensure quality? -->

- manual
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
