### PR TITLE
Clean and unify build status label and tooltip

### DIFF
--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -386,13 +386,13 @@ namespace AppVeyorIntegration
             {
                 int failedTestCount = buildDescription["failedTestsCount"].ToObject<int>();
                 int skippedTestCount = testCount - buildDescription["passedTestsCount"].ToObject<int>();
-                var testResults = " : " + testCount + " tests";
+                var testResults = testCount + " tests";
                 if (failedTestCount != 0 || skippedTestCount != 0)
                 {
                     testResults += string.Format(" ( {0} failed, {1} skipped )", failedTestCount, skippedTestCount);
                 }
 
-                buildDetails.TestsResultText = " " + testResults;
+                buildDetails.TestsResultText = testResults;
             }
         }
 
@@ -527,9 +527,9 @@ namespace AppVeyorIntegration
 
         public void UpdateDescription()
         {
-            Description = _buildDurationFormatter.Format(Duration) + TestsResultText + (!string.IsNullOrWhiteSpace(PullRequestText) ? " " + PullRequestText : string.Empty) + " " + Id;
+            Description = _buildDurationFormatter.Format(Duration) + " " + TestsResultText + (!string.IsNullOrWhiteSpace(PullRequestText) ? " " + PullRequestText : string.Empty) + " " + Id;
             Tooltip = DisplayStatus + Environment.NewLine
-                      + _buildDurationFormatter.Format(Duration) + Environment.NewLine
+                      + (Duration.HasValue ? _buildDurationFormatter.Format(Duration) + Environment.NewLine : string.Empty)
                       + (!string.IsNullOrWhiteSpace(TestsResultText) ? TestsResultText + Environment.NewLine : string.Empty)
                       + (!string.IsNullOrWhiteSpace(PullRequestText) ? PullRequestText + ": " + PullRequestTitle + Environment.NewLine : string.Empty)
                       + Id;

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Text;
@@ -34,6 +35,7 @@ namespace AzureDevOpsIntegration
         private IBuildServerWatcher _buildServerWatcher;
         private IntegrationSettings _settings;
         private ApiClient _apiClient;
+        private static readonly IBuildDurationFormatter _buildDurationFormatter = new BuildDurationFormatter();
 
         public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
@@ -74,7 +76,7 @@ namespace AzureDevOpsIntegration
             return Observable.Create<BuildInfo>((observer, cancellationToken) => ObserveBuildsAsync(sinceDate, running, observer, cancellationToken));
         }
 
-        private async Task ObserveBuildsAsync(DateTime? sinceDate, bool? running, IObserver<GitUIPluginInterfaces.BuildServerIntegration.BuildInfo> observer, CancellationToken cancellationToken)
+        private async Task ObserveBuildsAsync(DateTime? sinceDate, bool? running, IObserver<BuildInfo> observer, CancellationToken cancellationToken)
         {
             try
             {
@@ -104,11 +106,11 @@ namespace AzureDevOpsIntegration
             {
                 if (buildDetail.Status == "inProgress")
                 {
-                    duration = GetDuration(DateTime.UtcNow - buildDetail.StartTime.Value);
+                    duration = _buildDurationFormatter.Format((long)(DateTime.UtcNow - buildDetail.StartTime.Value).TotalMilliseconds);
                 }
                 else
                 {
-                    duration = buildDetail.FinishTime.HasValue ? GetDuration(buildDetail.FinishTime.Value - buildDetail.StartTime.Value) : "???";
+                    duration = buildDetail.FinishTime.HasValue ? _buildDurationFormatter.Format((long)(buildDetail.FinishTime.Value - buildDetail.StartTime.Value).TotalMilliseconds) : "???";
                 }
             }
 
@@ -117,8 +119,8 @@ namespace AzureDevOpsIntegration
                 Id = buildDetail.BuildNumber,
                 StartDate = buildDetail.StartTime ?? DateTime.Now.AddHours(1),
                 Status = buildDetail.IsInProgress ? BuildInfo.BuildStatus.InProgress : MapResult(buildDetail.Result),
-                Description = duration + " (" + buildDetail.BuildNumber + ")",
-                Tooltip = (buildDetail.IsInProgress ? buildDetail.Status : buildDetail.Result) + Environment.NewLine + duration + Environment.NewLine + buildDetail.BuildNumber,
+                Description = duration + " " + buildDetail.BuildNumber,
+                Tooltip = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(buildDetail.IsInProgress ? buildDetail.Status : buildDetail.Result) + Environment.NewLine + duration + Environment.NewLine + buildDetail.BuildNumber,
                 CommitHashList = new[] { ObjectId.Parse(buildDetail.SourceVersion) },
                 Url = buildDetail._links.Web.Href,
                 ShowInBuildReportTab = false
@@ -142,23 +144,6 @@ namespace AzureDevOpsIntegration
                 default:
                     return BuildInfo.BuildStatus.Unknown;
             }
-        }
-
-        private static string GetDuration(TimeSpan duration)
-        {
-            var s = new StringBuilder();
-            if (duration.Hours != 0)
-            {
-                s.Append($"{duration.Hours}h");
-            }
-
-            if (duration.Minutes != 0)
-            {
-                s.Append($"{duration.Minutes:00}m");
-            }
-
-            s.Append($"{duration.Seconds:00}s");
-            return s.ToString();
         }
 
         public void Dispose()


### PR DESCRIPTION
Follow up to #6116

## Proposed changes

- Remove sometimes empty line in tooltip
- Display duration in the same format in all CI plugins
- other small tweaks


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

I will try to do it later... (if needed)

### After

Appveyor:
![image](https://user-images.githubusercontent.com/460196/53205837-bfc17400-362f-11e9-8e01-53091020aaa0.png)
