### PR TITLE
Move prune/prune all/update in Leftpanel remotes contextual menu

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -67,7 +67,7 @@ namespace GitUI.BranchTreePanel
             // Actions on enabled remotes
             mnubtnFetchAllBranchesFromARemote.Visible = node.Enabled;
             mnubtnDisableRemote.Visible = node.Enabled;
-            pruneToolStripMenuItem.Visible = node.Enabled;
+            mnuBtnPrune.Visible = node.Enabled;
 
             // Actions on disabled remotes
             mnubtnEnableRemote.Visible = !node.Enabled;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -67,6 +67,7 @@ namespace GitUI.BranchTreePanel
             // Actions on enabled remotes
             mnubtnFetchAllBranchesFromARemote.Visible = node.Enabled;
             mnubtnDisableRemote.Visible = node.Enabled;
+            pruneToolStripMenuItem.Visible = node.Enabled;
 
             // Actions on disabled remotes
             mnubtnEnableRemote.Visible = !node.Enabled;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -103,6 +103,7 @@ namespace GitUI.BranchTreePanel
             this.tsmiShowTags = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.updateAllRemotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMain.SuspendLayout();
             this.menuBranch.SuspendLayout();
             this.menuRemotes.SuspendLayout();
@@ -232,6 +233,7 @@ namespace GitUI.BranchTreePanel
             // 
             this.menuRemotes.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuBtnManageRemotesFromRootNode,
+            this.updateAllRemotesToolStripMenuItem,
             this.pruneAllRemotesToolStripMenuItem});
             this.menuRemotes.Name = "contextmenuRemotes";
             this.menuRemotes.Size = new System.Drawing.Size(173, 26);
@@ -616,6 +618,13 @@ namespace GitUI.BranchTreePanel
             this.tsmiShowRemotes.Text = "&Remotes";
             this.tsmiShowRemotes.Click += new System.EventHandler(this.tsmiShowRemotes_Click);
             // 
+            // updateAllRemotesToolStripMenuItem
+            // 
+            this.updateAllRemotesToolStripMenuItem.Name = "updateAllRemotesToolStripMenuItem";
+            this.updateAllRemotesToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
+            this.updateAllRemotesToolStripMenuItem.Text = "Update all remotes";
+            this.updateAllRemotesToolStripMenuItem.Click += new System.EventHandler(this.updateAllRemotesToolStripMenuItem_Click);
+            // 
             // RepoObjectsTree
             // 
             this.Controls.Add(this.repoTreePanel);
@@ -696,5 +705,6 @@ namespace GitUI.BranchTreePanel
         private ToolTip toolTip;
         private ToolStripMenuItem pruneAllRemotesToolStripMenuItem;
         private ToolStripMenuItem pruneToolStripMenuItem;
+        private ToolStripMenuItem updateAllRemotesToolStripMenuItem;
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -62,6 +62,7 @@ namespace GitUI.BranchTreePanel
             this.menuTags = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuRemotes = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnuBtnManageRemotesFromRootNode = new System.Windows.Forms.ToolStripMenuItem();
+            this.pruneAllRemotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuRemote = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnRemoteBranchFetchAndCheckout = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnPullFromRemoteBranch = new System.Windows.Forms.ToolStripMenuItem();
@@ -89,6 +90,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnEnableRemote = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnEnableRemoteAndFetch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnDisableRemote = new System.Windows.Forms.ToolStripMenuItem();
+            this.pruneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.repoTreePanel = new System.Windows.Forms.TableLayoutPanel();
             this.branchSearchPanel = new System.Windows.Forms.TableLayoutPanel();
             this.lblSearchBranch = new System.Windows.Forms.Label();
@@ -229,7 +231,8 @@ namespace GitUI.BranchTreePanel
             // menuRemotes
             // 
             this.menuRemotes.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnuBtnManageRemotesFromRootNode});
+            this.mnuBtnManageRemotesFromRootNode,
+            this.pruneAllRemotesToolStripMenuItem});
             this.menuRemotes.Name = "contextmenuRemotes";
             this.menuRemotes.Size = new System.Drawing.Size(173, 26);
             this.menuRemotes.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
@@ -240,6 +243,13 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnManageRemotesFromRootNode.Name = "mnuBtnManageRemotesFromRootNode";
             this.mnuBtnManageRemotesFromRootNode.Size = new System.Drawing.Size(172, 22);
             this.mnuBtnManageRemotesFromRootNode.Text = "&Manage remotes...";
+            // 
+            // pruneAllRemotesToolStripMenuItem
+            // 
+            this.pruneAllRemotesToolStripMenuItem.Name = "pruneAllRemotesToolStripMenuItem";
+            this.pruneAllRemotesToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
+            this.pruneAllRemotesToolStripMenuItem.Text = "Update and prune all remotes";
+            this.pruneAllRemotesToolStripMenuItem.Click += new System.EventHandler(this.pruneAllRemotesToolStripMenuItem_Click);
             // 
             // menuRemote
             // 
@@ -423,7 +433,8 @@ namespace GitUI.BranchTreePanel
             this.mnubtnEnableRemote,
             this.mnubtnEnableRemoteAndFetch,
             this.mnubtnDisableRemote,
-            this.mnubtnFetchAllBranchesFromARemote});
+            this.mnubtnFetchAllBranchesFromARemote,
+            this.pruneToolStripMenuItem});
             this.menuRemoteRepoNode.Name = "contextmenuRemote";
             this.menuRemoteRepoNode.Size = new System.Drawing.Size(173, 120);
             this.menuRemoteRepoNode.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
@@ -460,6 +471,13 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDisableRemote.Name = "mnubtnDisableRemote";
             this.mnubtnDisableRemote.Size = new System.Drawing.Size(172, 22);
             this.mnubtnDisableRemote.Text = "&Deactivate";
+            // 
+            // pruneToolStripMenuItem
+            // 
+            this.pruneToolStripMenuItem.Name = "pruneToolStripMenuItem";
+            this.pruneToolStripMenuItem.Size = new System.Drawing.Size(302, 38);
+            this.pruneToolStripMenuItem.Text = "Prune remote";
+            this.pruneToolStripMenuItem.Click += new System.EventHandler(this.pruneToolStripMenuItem_Click);
             // 
             // repoTreePanel
             // 
@@ -676,5 +694,7 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem tsmiShowBranches;
         private ToolStripMenuItem tsmiShowRemotes;
         private ToolTip toolTip;
+        private ToolStripMenuItem pruneAllRemotesToolStripMenuItem;
+        private ToolStripMenuItem pruneToolStripMenuItem;
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -62,7 +62,7 @@ namespace GitUI.BranchTreePanel
             this.menuTags = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuRemotes = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnuBtnManageRemotesFromRootNode = new System.Windows.Forms.ToolStripMenuItem();
-            this.pruneAllRemotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuBtnPruneAllRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.menuRemote = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnRemoteBranchFetchAndCheckout = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnPullFromRemoteBranch = new System.Windows.Forms.ToolStripMenuItem();
@@ -90,7 +90,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnEnableRemote = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnEnableRemoteAndFetch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnDisableRemote = new System.Windows.Forms.ToolStripMenuItem();
-            this.pruneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuBtnPrune = new System.Windows.Forms.ToolStripMenuItem();
             this.repoTreePanel = new System.Windows.Forms.TableLayoutPanel();
             this.branchSearchPanel = new System.Windows.Forms.TableLayoutPanel();
             this.lblSearchBranch = new System.Windows.Forms.Label();
@@ -103,7 +103,7 @@ namespace GitUI.BranchTreePanel
             this.tsmiShowTags = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.updateAllRemotesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuBtnUpdateAllRemotes = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMain.SuspendLayout();
             this.menuBranch.SuspendLayout();
             this.menuRemotes.SuspendLayout();
@@ -233,8 +233,8 @@ namespace GitUI.BranchTreePanel
             // 
             this.menuRemotes.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnuBtnManageRemotesFromRootNode,
-            this.updateAllRemotesToolStripMenuItem,
-            this.pruneAllRemotesToolStripMenuItem});
+            this.mnuBtnUpdateAllRemotes,
+            this.mnuBtnPruneAllRemotes});
             this.menuRemotes.Name = "contextmenuRemotes";
             this.menuRemotes.Size = new System.Drawing.Size(173, 26);
             this.menuRemotes.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
@@ -248,10 +248,10 @@ namespace GitUI.BranchTreePanel
             // 
             // pruneAllRemotesToolStripMenuItem
             // 
-            this.pruneAllRemotesToolStripMenuItem.Name = "pruneAllRemotesToolStripMenuItem";
-            this.pruneAllRemotesToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
-            this.pruneAllRemotesToolStripMenuItem.Text = "Update and prune all remotes";
-            this.pruneAllRemotesToolStripMenuItem.Click += new System.EventHandler(this.pruneAllRemotesToolStripMenuItem_Click);
+            this.mnuBtnPruneAllRemotes.Name = "mnuBtnPruneAllRemotes";
+            this.mnuBtnPruneAllRemotes.Size = new System.Drawing.Size(428, 38);
+            this.mnuBtnPruneAllRemotes.Text = "Update and prune all remotes";
+            this.mnuBtnPruneAllRemotes.Click += new System.EventHandler(this.mnuBtnPruneAllRemotes_Click);
             // 
             // menuRemote
             // 
@@ -436,7 +436,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnEnableRemoteAndFetch,
             this.mnubtnDisableRemote,
             this.mnubtnFetchAllBranchesFromARemote,
-            this.pruneToolStripMenuItem});
+            this.mnuBtnPrune});
             this.menuRemoteRepoNode.Name = "contextmenuRemote";
             this.menuRemoteRepoNode.Size = new System.Drawing.Size(173, 120);
             this.menuRemoteRepoNode.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
@@ -476,10 +476,10 @@ namespace GitUI.BranchTreePanel
             // 
             // pruneToolStripMenuItem
             // 
-            this.pruneToolStripMenuItem.Name = "pruneToolStripMenuItem";
-            this.pruneToolStripMenuItem.Size = new System.Drawing.Size(302, 38);
-            this.pruneToolStripMenuItem.Text = "Prune remote";
-            this.pruneToolStripMenuItem.Click += new System.EventHandler(this.pruneToolStripMenuItem_Click);
+            this.mnuBtnPrune.Name = "mnuBtnPrune";
+            this.mnuBtnPrune.Size = new System.Drawing.Size(302, 38);
+            this.mnuBtnPrune.Text = "Prune remote";
+            this.mnuBtnPrune.Click += new System.EventHandler(this.mnuBtnPrune_Click);
             // 
             // repoTreePanel
             // 
@@ -620,10 +620,10 @@ namespace GitUI.BranchTreePanel
             // 
             // updateAllRemotesToolStripMenuItem
             // 
-            this.updateAllRemotesToolStripMenuItem.Name = "updateAllRemotesToolStripMenuItem";
-            this.updateAllRemotesToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
-            this.updateAllRemotesToolStripMenuItem.Text = "Update all remotes";
-            this.updateAllRemotesToolStripMenuItem.Click += new System.EventHandler(this.updateAllRemotesToolStripMenuItem_Click);
+            this.mnuBtnUpdateAllRemotes.Name = "mnuBtnUpdateAllRemotes";
+            this.mnuBtnUpdateAllRemotes.Size = new System.Drawing.Size(428, 38);
+            this.mnuBtnUpdateAllRemotes.Text = "Update all remotes";
+            this.mnuBtnUpdateAllRemotes.Click += new System.EventHandler(this.mnuBtnUpdateAllRemotes_Click);
             // 
             // RepoObjectsTree
             // 
@@ -703,8 +703,8 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem tsmiShowBranches;
         private ToolStripMenuItem tsmiShowRemotes;
         private ToolTip toolTip;
-        private ToolStripMenuItem pruneAllRemotesToolStripMenuItem;
-        private ToolStripMenuItem pruneToolStripMenuItem;
-        private ToolStripMenuItem updateAllRemotesToolStripMenuItem;
+        private ToolStripMenuItem mnuBtnPruneAllRemotes;
+        private ToolStripMenuItem mnuBtnPrune;
+        private ToolStripMenuItem mnuBtnUpdateAllRemotes;
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -469,5 +469,15 @@ namespace GitUI.BranchTreePanel
 
             public NativeTreeView TreeView { get; }
         }
+
+        private void pruneAllRemotesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote update --prune");
+        }
+
+        private void pruneToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote prune " + treeMain.SelectedNode.Name);
+        }
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -470,17 +470,17 @@ namespace GitUI.BranchTreePanel
             public NativeTreeView TreeView { get; }
         }
 
-        private void updateAllRemotesToolStripMenuItem_Click(object sender, EventArgs e)
+        private void mnuBtnUpdateAllRemotes_Click(object sender, EventArgs e)
         {
             FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote update");
         }
 
-        private void pruneAllRemotesToolStripMenuItem_Click(object sender, EventArgs e)
+        private void mnuBtnPruneAllRemotes_Click(object sender, EventArgs e)
         {
             FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote update --prune");
         }
 
-        private void pruneToolStripMenuItem_Click(object sender, EventArgs e)
+        private void mnuBtnPrune_Click(object sender, EventArgs e)
         {
             FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote prune " + treeMain.SelectedNode.Name);
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -470,6 +470,11 @@ namespace GitUI.BranchTreePanel
             public NativeTreeView TreeView { get; }
         }
 
+        private void updateAllRemotesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote update");
+        }
+
         private void pruneAllRemotesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             FormRemoteProcess.ShowDialog((GitModuleForm)ParentForm, "remote update --prune");

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -80,7 +80,6 @@ namespace GitUI.CommandsDialogs
             this.label6 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.flpnlRemoteManagement.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
@@ -102,7 +101,6 @@ namespace GitUI.CommandsDialogs
             this.splitContainer3.Panel2.SuspendLayout();
             this.splitContainer3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.RemoteBranches)).BeginInit();
-            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // flpnlRemoteManagement
@@ -575,7 +573,6 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel2.ColumnCount = 1;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.Controls.Add(this.splitContainer3, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 3);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
@@ -724,17 +721,6 @@ namespace GitUI.CommandsDialogs
             this.label4.TabIndex = 0;
             this.label4.Text = "Local branch name";
             // 
-            // flowLayoutPanel1
-            // 
-            this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 265);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(724, 31);
-            this.flowLayoutPanel1.TabIndex = 1;
-            this.flowLayoutPanel1.WrapContents = false;
-            // 
             // FormRemotes
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -778,8 +764,6 @@ namespace GitUI.CommandsDialogs
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).EndInit();
             this.splitContainer3.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.RemoteBranches)).EndInit();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -816,7 +800,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private UserControls.FolderBrowserButton folderBrowserButtonUrl;
         private UserControls.FolderBrowserButton folderBrowserButtonPushUrl;
         private System.Windows.Forms.FlowLayoutPanel panelButtons;

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -81,7 +81,6 @@ namespace GitUI.CommandsDialogs
             this.label5 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.UpdateBranch = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.flpnlRemoteManagement.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
@@ -728,7 +727,6 @@ namespace GitUI.CommandsDialogs
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.Controls.Add(this.UpdateBranch);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 265);
@@ -736,17 +734,6 @@ namespace GitUI.CommandsDialogs
             this.flowLayoutPanel1.Size = new System.Drawing.Size(724, 31);
             this.flowLayoutPanel1.TabIndex = 1;
             this.flowLayoutPanel1.WrapContents = false;
-            // 
-            // UpdateBranch
-            // 
-            this.UpdateBranch.AutoSize = true;
-            this.UpdateBranch.Location = new System.Drawing.Point(472, 3);
-            this.UpdateBranch.Name = "UpdateBranch";
-            this.UpdateBranch.Size = new System.Drawing.Size(249, 25);
-            this.UpdateBranch.TabIndex = 1;
-            this.UpdateBranch.Text = "Update all remote branch info";
-            this.UpdateBranch.UseVisualStyleBackColor = true;
-            this.UpdateBranch.Click += new System.EventHandler(this.UpdateBranchClick);
             // 
             // FormRemotes
             // 
@@ -803,7 +790,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabPage1;
         private System.Windows.Forms.TabPage tabPage2;
-        private System.Windows.Forms.Button UpdateBranch;
         private System.Windows.Forms.Button LoadSSHKey;
         private System.Windows.Forms.TextBox PuttySshKey;
         private System.Windows.Forms.Button TestConnection;

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -82,7 +82,6 @@ namespace GitUI.CommandsDialogs
             this.label4 = new System.Windows.Forms.Label();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.UpdateBranch = new System.Windows.Forms.Button();
-            this.Prune = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.flpnlRemoteManagement.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
@@ -730,7 +729,6 @@ namespace GitUI.CommandsDialogs
             // 
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.Controls.Add(this.UpdateBranch);
-            this.flowLayoutPanel1.Controls.Add(this.Prune);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 265);
@@ -749,17 +747,6 @@ namespace GitUI.CommandsDialogs
             this.UpdateBranch.Text = "Update all remote branch info";
             this.UpdateBranch.UseVisualStyleBackColor = true;
             this.UpdateBranch.Click += new System.EventHandler(this.UpdateBranchClick);
-            // 
-            // Prune
-            // 
-            this.Prune.AutoSize = true;
-            this.Prune.Location = new System.Drawing.Point(217, 3);
-            this.Prune.Name = "Prune";
-            this.Prune.Size = new System.Drawing.Size(249, 25);
-            this.Prune.TabIndex = 0;
-            this.Prune.Text = "Prune remote branches";
-            this.Prune.UseVisualStyleBackColor = true;
-            this.Prune.Click += new System.EventHandler(this.PruneClick);
             // 
             // FormRemotes
             // 
@@ -817,7 +804,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.TabPage tabPage1;
         private System.Windows.Forms.TabPage tabPage2;
         private System.Windows.Forms.Button UpdateBranch;
-        private System.Windows.Forms.Button Prune;
         private System.Windows.Forms.Button LoadSSHKey;
         private System.Windows.Forms.TextBox PuttySshKey;
         private System.Windows.Forms.Button TestConnection;

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -529,16 +529,6 @@ Inactive remote is completely invisible to git.");
                 .FileAndForget();
         }
 
-        private void PruneClick(object sender, EventArgs e)
-        {
-            if (_selectedRemote == null)
-            {
-                return;
-            }
-
-            FormRemoteProcess.ShowDialog(this, "remote prune " + _selectedRemote.Name);
-        }
-
         private void RemoteBranchesDataError(object sender, DataGridViewDataErrorEventArgs e)
         {
             MessageBox.Show(this,

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -663,11 +663,6 @@ Inactive remote is completely invisible to git.");
             flpnlRemoteManagement.Enabled = !_selectedRemote.Disabled;
         }
 
-        private void UpdateBranchClick(object sender, EventArgs e)
-        {
-            FormRemoteProcess.ShowDialog(this, "remote update");
-        }
-
         private void checkBoxSepPushUrl_CheckedChanged(object sender, EventArgs e)
         {
             ShowSeparatePushUrl(checkBoxSepPushUrl.Checked);


### PR DESCRIPTION
Fixes #6284


## Proposed changes

- Add "prune remote" in contextual menu of a remote in left panel (moved from FormRemote)
- Add "Update all remotes" in contextual menu of remotes in left panel (moved from FormRemote)
- Add "Update and prune all remotes" in contextual menu of remote in left panel (because just "prune all" like requested in #6284  is not something provided by git and I don't want to do it myself)
- Remove "Prune remote branches" and "Update all remote branch info" from FormRemotes

## Screenshots <!-- Remove this section if PR does not change UI -->

Left panel (enabled only) remote:
### Before
![image](https://user-images.githubusercontent.com/460196/53209112-afae9200-3639-11e9-9ae4-04c8bdbd658d.png)

### After
![image](https://user-images.githubusercontent.com/460196/53209123-bccb8100-3639-11e9-9a21-ec3ae26cab50.png)

Left panel remotes:
### Before

![image](https://user-images.githubusercontent.com/460196/53209173-f0a6a680-3639-11e9-86f3-5aa8b04da89d.png)

### After

![image](https://user-images.githubusercontent.com/460196/53209191-ff8d5900-3639-11e9-904d-3aeeca559b5e.png)

### Before
![image](https://user-images.githubusercontent.com/460196/53209224-25b2f900-363a-11e9-8d3c-ee108f584432.png)


### After
![image](https://user-images.githubusercontent.com/460196/53209254-3b282300-363a-11e9-9b72-4c0a1389e9c7.png)

### Before

## Test methodology <!-- How did you ensure quality? -->

- Manual 


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build debc4f89828705b57937e7a11e8f65ac3517f8c0 (Dirty)
- Git 2.20.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 192dpi (200% scaling)

