### PR TITLE
Add support for Robohash no image service

### DIFF
--- a/GitCommands/Settings/DefaultImageType.cs
+++ b/GitCommands/Settings/DefaultImageType.cs
@@ -38,6 +38,11 @@ namespace GitCommands
         /// <summary>
         /// Return an 8-bit-style face based on the email hash.
         /// </summary>
-        Retro
+        Retro,
+
+        /// <summary>
+        /// Return a generated robot based on the email hash.
+        /// </summary>
+        Robohash
     }
 }

--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -102,6 +102,7 @@ namespace GitUI.Avatars
                             case DefaultImageType.MonsterId: return "monsterid";
                             case DefaultImageType.Wavatar: return "wavatar";
                             case DefaultImageType.Retro: return "retro";
+                            case DefaultImageType.Robohash: return "robohash";
                             default: return "404";
                         }
                     }

--- a/contributors.txt
+++ b/contributors.txt
@@ -71,3 +71,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/02/16, DmitryZhelnin, Dmitry Zhelnin, mitya_zh@mail.ru
 2019/02/18, wachulski, Marcin Wachulski, marcin.wachulski@gmail.com
 2019/02/25, oriash93, Ori Ashual, oriash93@gmail.com
+2019/02/25, coreyasmith, Corey Smith, coreyas@gmail.com


### PR DESCRIPTION
Fixes #6311

## Proposed changes

- Add [Robohash][1] as a  `No image service` option under `Author Images` in `Appearance` settings.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6156761/53387727-31fac700-3956-11e9-90da-e8a8dc8368e6.png)
![image](https://user-images.githubusercontent.com/6156761/53387755-5191ef80-3956-11e9-9a0a-4ebad95d980f.png)
![image](https://user-images.githubusercontent.com/6156761/53387774-5eaede80-3956-11e9-96ec-6c12e4dd7aab.png)
![image](https://user-images.githubusercontent.com/6156761/53387783-6a020a00-3956-11e9-802f-f74915d59de3.png)

### After

![image](https://user-images.githubusercontent.com/6156761/53387558-68841200-3955-11e9-9a03-d6cff807bcae.png)
![image](https://user-images.githubusercontent.com/6156761/53387679-f233df80-3955-11e9-802a-0e39718a51b2.png)
![image](https://user-images.githubusercontent.com/6156761/53387684-fb24b100-3955-11e9-9cd8-abe716bc5ce0.png)
![image](https://user-images.githubusercontent.com/6156761/53387692-01b32880-3956-11e9-8ca8-71b59ff6f6fb.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 5a3c150acb55848b0716417b7c6d76f8fa105cde
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).

[1]: https://robohash.org/