### PR TITLE
Fix reset function for copied files

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -302,8 +302,8 @@ namespace GitUI.CommandsDialogs
             else
             {
                 // acts as parent
-                // if file is new to the parent, it has to be removed
-                var addedItems = selectedItems.Where(item => item.IsNew);
+                // if file is new to the parent or is copied, it has to be removed
+                var addedItems = selectedItems.Where(item => item.IsNew || item.IsCopied);
                 Module.RemoveFiles(addedItems.Select(item => item.Name).ToList(), false);
 
                 foreach (var parent in DiffFiles.SelectedItemParents)


### PR DESCRIPTION
Fixes #6297


## Proposed changes

- Reset to first function will now work for copied files too

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.16.1.windows.4
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
