### PR TITLE
Quote submodule path to avoid black screen issue

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1201,7 +1201,7 @@ namespace GitCommands
             {
                 "status",
                 "--cached",
-                SubmodulePath
+                SubmodulePath.Quote()
             };
             var lines = SuperprojectModule.GitExecutable.GetOutput(args).Split('\n');
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -93,7 +93,7 @@ namespace GitCommands
                     }
                 }
 
-                if (!string.IsNullOrEmpty(superprojectPath) && currentPath.StartsWith(superprojectPath))
+                if (!string.IsNullOrEmpty(superprojectPath) && currentPath.ToPosixPath().StartsWith(superprojectPath.ToPosixPath()))
                 {
                     var submodulePath = currentPath.Substring(superprojectPath.Length).ToPosixPath();
                     var configFile = new ConfigFile(Path.Combine(superprojectPath, ".gitmodules"), local: true);

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-Git Extensions Project Contributors Certification of Origin and Rights
+﻿Git Extensions Project Contributors Certification of Origin and Rights
 
 All contributors to Git Extensions must formally agree to abide by this
 certificate of origin by signing on the bottom with their github
@@ -73,5 +73,5 @@ YYYY/MM/DD, github id, Full name, email
 2019/02/25, oriash93, Ori Ashual, oriash93@gmail.com
 2019/02/25, coreyasmith, Corey Smith, coreyas@gmail.com
 2019/02/27, ivangrek, Ivan Grek, kvant@outlook.com
-2019/03/02, seshonaar, Andrei Balint, andrei.balint@gmail.com
-2019/03/04, DeadDuck, Onur Safak, onur.safak@radity.com
+2019/02/28, leorohr, Leo Rohr, rohrleo@gmail.com
+2019/03/02, seshonaar, Andrei Balint, andrei.balint@gmail.com2019/03/04, DeadDuck, Onur Safak, onur.safak@radity.com

--- a/contributors.txt
+++ b/contributors.txt
@@ -74,4 +74,5 @@ YYYY/MM/DD, github id, Full name, email
 2019/02/25, coreyasmith, Corey Smith, coreyas@gmail.com
 2019/02/27, ivangrek, Ivan Grek, kvant@outlook.com
 2019/02/28, leorohr, Leo Rohr, rohrleo@gmail.com
-2019/03/02, seshonaar, Andrei Balint, andrei.balint@gmail.com2019/03/04, DeadDuck, Onur Safak, onur.safak@radity.com
+2019/03/02, seshonaar, Andrei Balint, andrei.balint@gmail.com
+2019/03/04, DeadDuck, Onur Safak, onur.safak@radity.com


### PR DESCRIPTION
Quote SubmodulePath in GetSuperProjectCurrentCheckout to handle paths with spaces

Related to #6268 #6243 #6082 


## Proposed changes

- Quote SubmodulePath in GetSuperProjectCurrentCheckout to handle paths with spaces

## Test methodology <!-- How did you ensure quality? -->

- Manual tests
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT  2.20.1.windows.1 <!-- Add version 2.11 or above -->
- Windows 10 (1709 / 16299.967) <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
