### PR TITLE
Fix flaky form commit tests

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -992,11 +992,11 @@ namespace GitUI.CommandsDialogs
             branchNameLabel.Text = $"{currentBranchName} {char.ConvertFromUtf32(0x2192)}";
             remoteNameLabel.Text = pushTo;
 
-            _branchNameLabelOnClick = async (object sender, EventArgs e) =>
+            _branchNameLabelOnClick = (object sender, EventArgs e) => ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 UICommands.StartRemotesDialog(this, null, currentBranchName);
                 await UpdateBranchNameDisplayAsync();
-            };
+            });
             remoteNameLabel.Click += _branchNameLabelOnClick;
             Text = string.Format(_formTitle.Text, currentBranchName, PathUtil.GetDisplayPath(Module.WorkingDir));
         }

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using CommonTestUtils;
 using FluentAssertions;
 using GitUI;
 using GitUI.CommandsDialogs;
@@ -86,64 +85,43 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         [Test]
         public void Should_display_branch_and_no_remote_info_in_statusbar()
         {
-            using (var repository = new ReferenceRepository(new GitModuleTestHelper("branch_and_no_remote")))
+            _referenceRepository.CheckoutMaster();
+            RunFormTest(form =>
             {
-                var commands = new GitUICommands(repository.Module);
-                repository.CheckoutMaster();
-                UITest.RunForm<FormCommit>(
-                    () => { Assert.True(commands.StartCommitDialog(owner: null)); },
-                    form =>
-                    {
-                        var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
-                        var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
+                var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
+                var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 
-                        Assert.AreEqual("master →", currentBranchNameLabelStatus.Text);
-                        Assert.AreEqual("(remote not configured)", remoteNameLabelStatus.Text);
-                        return Task.CompletedTask;
-                    });
-            }
+                Assert.AreEqual("master →", currentBranchNameLabelStatus.Text);
+                Assert.AreEqual("(remote not configured)", remoteNameLabelStatus.Text);
+            });
         }
 
         [Test]
         public void Should_display_detached_head_info_in_statusbar()
         {
-            using (var repository = new ReferenceRepository(new GitModuleTestHelper("detached_head")))
+            _referenceRepository.CheckoutRevision();
+            RunFormTest(form =>
             {
-                var commands = new GitUICommands(repository.Module);
-                repository.CheckoutRevision();
-                UITest.RunForm<FormCommit>(
-                    () => { Assert.True(commands.StartCommitDialog(owner: null)); },
-                    form =>
-                    {
-                        var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
-                        var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
+                var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
+                var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 
-                        Assert.AreEqual("(no branch)", currentBranchNameLabelStatus.Text);
-                        Assert.AreEqual(string.Empty, remoteNameLabelStatus.Text);
-                        return Task.CompletedTask;
-                    });
-            }
+                Assert.AreEqual("(no branch)", currentBranchNameLabelStatus.Text);
+                Assert.AreEqual(string.Empty, remoteNameLabelStatus.Text);
+            });
         }
 
         [Test]
         public void Should_display_branch_and_remote_info_in_statusbar()
         {
-            using (var repository = new ReferenceRepository(new GitModuleTestHelper("branch_and_remote")))
+            _referenceRepository.CreateRemoteForMasterBranch();
+            RunFormTest(form =>
             {
-                var commands = new GitUICommands(repository.Module);
-                repository.CreateRemoteForMasterBranch();
-                UITest.RunForm<FormCommit>(
-                    () => { Assert.True(commands.StartCommitDialog(owner: null)); },
-                    form =>
-                {
-                    var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
-                    var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
+                var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
+                var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 
-                    Assert.AreEqual("master →", currentBranchNameLabelStatus.Text);
-                    Assert.AreEqual("origin/master", remoteNameLabelStatus.Text);
-                    return Task.CompletedTask;
-                });
-            }
+                Assert.AreEqual("master →", currentBranchNameLabelStatus.Text);
+                Assert.AreEqual("origin/master", remoteNameLabelStatus.Text);
+            });
         }
 
         [Test]

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormCommitTests.cs
@@ -86,8 +86,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void Should_display_branch_and_no_remote_info_in_statusbar()
         {
             _referenceRepository.CheckoutMaster();
-            RunFormTest(form =>
+            RunFormTest(async form =>
             {
+                await ThreadHelper.JoinPendingOperationsAsync();
+
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 
@@ -100,8 +102,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void Should_display_detached_head_info_in_statusbar()
         {
             _referenceRepository.CheckoutRevision();
-            RunFormTest(form =>
+            RunFormTest(async form =>
             {
+                await ThreadHelper.JoinPendingOperationsAsync();
+
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 
@@ -114,8 +118,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void Should_display_branch_and_remote_info_in_statusbar()
         {
             _referenceRepository.CreateRemoteForMasterBranch();
-            RunFormTest(form =>
+            RunFormTest(async form =>
             {
+                await ThreadHelper.JoinPendingOperationsAsync();
+
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 

--- a/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
@@ -8,15 +8,12 @@ namespace GitUITests.CommandsDialogs
 {
     public class ReferenceRepository : IDisposable
     {
-        private readonly GitModuleTestHelper _moduleTestHelper;
+        private static GitModuleTestHelper _moduleTestHelper;
+        private static string _commitHash;
 
-        public ReferenceRepository() : this(new GitModuleTestHelper())
+        public ReferenceRepository()
         {
-        }
-
-        public ReferenceRepository(GitModuleTestHelper moduleTestHelper)
-        {
-            _moduleTestHelper = moduleTestHelper;
+            _moduleTestHelper = new GitModuleTestHelper();
 
             using (var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir))
             {
@@ -28,13 +25,13 @@ namespace GitUITests.CommandsDialogs
                 var committer = author;
                 var options = new LibGit2Sharp.CommitOptions();
                 var commit = repository.Commit(message, author, committer, options);
-                CommitHash = commit.Id.Sha;
+                _commitHash = commit.Id.Sha;
             }
         }
 
         public GitModule Module => _moduleTestHelper.Module;
 
-        public string CommitHash { get; }
+        public string CommitHash => _commitHash;
 
         public void CheckoutRevision()
         {

--- a/UnitTests/GitUITests/UITest.cs
+++ b/UnitTests/GitUITests/UITest.cs
@@ -31,7 +31,10 @@ namespace GitUITests
             Func<T, Task> runAsync)
             where T : Form
         {
-            var test = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            // Avoid using ThreadHelper.JoinableTaskFactory for the outermost operation because we don't want the task
+            // tracked by its collection. Otherwise, test code would not be able to wait for pending operations to
+            // complete.
+            var test = ThreadHelper.JoinableTaskContext.Factory.RunAsync(async () =>
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 await WaitForIdleAsync();


### PR DESCRIPTION
Builds on work started by @RussKie, but simplified in the end.

Supersedes #6273

Fixes #6320
Closes #6298 

📝 I tested this by updating `ControlThreadingExtensions.ControlMainThreadAwaiter.OnCompleted` to delay switches:

```csharp
public void OnCompleted(Action continuation)
{
    var awaiter = _awaiter;
    Task.Delay(250).GetAwaiter().OnCompleted(() => awaiter.OnCompleted(continuation));
}
```