### PR TITLE
Throw OperationCanceledException on cts.Next() when cts is disposed.

### DIFF
--- a/GitExtUtils/GitUI/CancellationTokenSequence.cs
+++ b/GitExtUtils/GitUI/CancellationTokenSequence.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 
 namespace GitUI
@@ -46,7 +46,7 @@ namespace GitUI
         /// <para>This method is thread-safe.</para>
         /// </remarks>
         /// <returns>A <see cref="CancellationToken"/> to be used by the commencing asynchronous operation.</returns>
-        /// <exception cref="ObjectDisposedException">This object is disposed.</exception>
+        /// <exception cref="OperationCanceledException">This object is disposed.</exception>
         public CancellationToken Next()
         {
             var next = new CancellationTokenSource();
@@ -76,8 +76,9 @@ namespace GitUI
             // Detect and handle the case where the sequence was already disposed
             if (prior is null)
             {
+                next.Cancel();
                 next.Dispose();
-                throw new ObjectDisposedException(nameof(CancellationTokenSequence));
+                nextToken.ThrowIfCancellationRequested();
             }
 
             prior.Cancel();

--- a/UnitTests/GitUITests/CancellationTokenSequenceTests.cs
+++ b/UnitTests/GitUITests/CancellationTokenSequenceTests.cs
@@ -33,7 +33,7 @@ namespace GitUITests
 
             sequence.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => sequence.Next());
+            Assert.Throws<OperationCanceledException>(() => sequence.Next());
         }
 
         [Test]


### PR DESCRIPTION
CancellationTokenSequence is written in a thread-safe manner but it can not be accessed when it is disposed. To properly deal with this, any async call that can access cts would have to be tracked and awaited before disposing cts. 
I propose to throw OperationCanceledException instead of ObjectDisposedException
so it is possible to access cts from a Task without worrying of cts being disposed or not.

The problem occurred in https://github.com/gitextensions/gitextensions/pull/5617