### PR TITLE
Fix test dependent on file watcher delay

### DIFF
--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
@@ -41,7 +41,9 @@ namespace GitUITests.Editor
         {
             using (var testHelper = new GitModuleTestHelper())
             {
-                testHelper.CreateRepoFile(@".git\config", $"[core]\n\tautocrlf = {autoCRLFType}");
+                testHelper.Module.LocalConfigFile.SetEnum("core.autocrlf", autoCRLFType);
+                testHelper.Module.LocalConfigFile.Save();
+
                 var content = EmbeddedResourceLoader.Load(Assembly.GetExecutingAssembly(), $"{GetType().Namespace}.MockData.{file}.bin");
 
                 var uiCommands = new GitUICommands(testHelper.Module);


### PR DESCRIPTION
Observed this test as flaky in a few builds and tracked it down to a race condition in the configuration file.

Fixes #6329 