### PR TITLE
GitHub: easily add upstream remote

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -4046,18 +4046,4 @@ namespace GitCommands
             public GitArgumentBuilder UpdateIndexCmd(bool showErrorsWhenStagingFiles) => _gitModule.UpdateIndexCmd(showErrorsWhenStagingFiles);
         }
     }
-
-    public readonly struct Remote
-    {
-        public string Name { get; }
-        public string PushUrl { get; }
-        public string FetchUrl { get; }
-
-        public Remote(string name, string pushUrl, string fetchUrl)
-        {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
-            PushUrl = pushUrl ?? throw new ArgumentNullException(nameof(pushUrl));
-            FetchUrl = fetchUrl ?? throw new ArgumentNullException(nameof(fetchUrl));
-        }
-    }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -9,6 +9,7 @@ using GitCommands;
 using GitCommands.Remotes;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.Properties;
+using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -188,6 +188,7 @@ namespace GitUI.CommandsDialogs
             this.gitItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.toolPanel = new System.Windows.Forms.ToolStripContainer();
+            this._addUpstreamRemoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
@@ -1510,7 +1511,8 @@ namespace GitUI.CommandsDialogs
             this._repositoryHostsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._forkCloneRepositoryToolStripMenuItem,
             this._viewPullRequestsToolStripMenuItem,
-            this._createPullRequestsToolStripMenuItem});
+            this._createPullRequestsToolStripMenuItem,
+            this._addUpstreamRemoteToolStripMenuItem});
             this._repositoryHostsToolStripMenuItem.Name = "_repositoryHostsToolStripMenuItem";
             this._repositoryHostsToolStripMenuItem.Size = new System.Drawing.Size(114, 20);
             this._repositoryHostsToolStripMenuItem.Text = "(Repository hosts)";
@@ -1730,6 +1732,13 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStrip);
             // 
+            // addUpstreamRemoteToolStripMenuItem
+            // 
+            this._addUpstreamRemoteToolStripMenuItem.Name = "_addUpstreamRemoteToolStripMenuItem";
+            this._addUpstreamRemoteToolStripMenuItem.Size = new System.Drawing.Size(360, 38);
+            this._addUpstreamRemoteToolStripMenuItem.Text = "Add upstream remote";
+            this._addUpstreamRemoteToolStripMenuItem.Click += new System.EventHandler(this._addUpstreamRemoteToolStripMenuItem_Click);
+            // 
             // FormBrowse
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1873,6 +1882,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem _forkCloneRepositoryToolStripMenuItem;
         private ToolStripMenuItem _viewPullRequestsToolStripMenuItem;
         private ToolStripMenuItem _createPullRequestsToolStripMenuItem;
+        private ToolStripMenuItem _addUpstreamRemoteToolStripMenuItem;
         private ToolStripMenuItem dashboardToolStripMenuItem;
         private ToolStripMenuItem manageSubmodulesToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator8;

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             _createBtn.Enabled = false;
             _yourBranchesCB.Text = _strLoading.Text;
-            _hostedRemotes = _repoHost.GetHostedRemotesForModule(Module);
+            _hostedRemotes = _repoHost.GetHostedRemotesForModule();
             this.Mask();
             _remoteLoader.LoadAsync(
                 () => _hostedRemotes.Where(r => !r.IsOwnedByMe).ToArray(),

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _loader.LoadAsync(
                 () =>
                 {
-                    var t = _gitHoster.GetHostedRemotesForModule(Module).ToList();
+                    var t = _gitHoster.GetHostedRemotesForModule().ToList();
                     foreach (var el in t)
                     {
                         el.GetHostedRepository(); // We do this now because we want to do it in the async part.

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1352,7 +1352,7 @@ namespace GitUI
         public void StartCreatePullRequest(IWin32Window owner)
         {
             List<IRepositoryHostPlugin> relevantHosts =
-                PluginRegistry.GitHosters.Where(gh => gh.GitModuleIsRelevantToMe(Module)).ToList();
+                PluginRegistry.GitHosters.Where(gh => gh.GitModuleIsRelevantToMe()).ToList();
 
             if (relevantHosts.Count == 0)
             {

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -60,7 +60,7 @@ namespace GitUI
                 return null;
             }
 
-            return GitHosters.FirstOrDefault(gitHoster => gitHoster.GitModuleIsRelevantToMe(module));
+            return GitHosters.FirstOrDefault(gitHoster => gitHoster.GitModuleIsRelevantToMe());
         }
 
         public static void Register(IGitUICommands gitUiCommands)

--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -567,8 +567,8 @@ Are you sure you want to continue?</source>
         <source>&amp;Publish</source>
         <target />
       </trans-unit>
-      <trans-unit id="labelPublishType.Text">
-        <source>Publish Type</source>
+      <trans-unit id="PublishType.Text">
+        <source>For Review</source>
         <target />
       </trans-unit>
       <trans-unit id="_publishCaption.Text">
@@ -579,12 +579,8 @@ Are you sure you want to continue?</source>
         <source>Publish Gerrit Change</source>
         <target />
       </trans-unit>
-      <trans-unit id="_selectBranch.Text">
-        <source>Please enter a branch</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_selectRemote.Text">
-        <source>Please select a remote repository</source>
+      <trans-unit id="_publishTypePrivate.Text">
+        <source>Private</source>
         <target />
       </trans-unit>
       <trans-unit id="_publishTypeReview.Text">
@@ -595,12 +591,20 @@ Are you sure you want to continue?</source>
         <source>Work-in-Progress</source>
         <target />
       </trans-unit>
-      <trans-unit id="_publishTypePrivate.Text">
-        <source>Private</source>
+      <trans-unit id="_selectBranch.Text">
+        <source>Please enter a branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_selectRemote.Text">
+        <source>Please select a remote repository</source>
         <target />
       </trans-unit>
       <trans-unit id="labelBranch.Text">
         <source>Branch:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="labelPublishType.Text">
+        <source>Publish Type</source>
         <target />
       </trans-unit>
       <trans-unit id="labelRemote.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1999,6 +1999,10 @@ compare with first:</source>
         <source>File tree</source>
         <target />
       </trans-unit>
+      <trans-unit id="_addUpstreamRemoteToolStripMenuItem.Text">
+        <source>Add upstream remote</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_buildReportTabCaption.Text">
         <source>Build Report</source>
         <target />

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -180,7 +180,7 @@ namespace GitHub3
 
                     if (m.Success)
                     {
-                        var hostedRemote = new GitHubHostedRemote(remote, m.Groups[1].Value, m.Groups[2].Value.Replace(".git", ""));
+                        var hostedRemote = new GitHubHostedRemote(remote, m.Groups[1].Value, m.Groups[2].Value.Replace(".git", ""), url);
 
                         if (set.Add(hostedRemote))
                         {

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -156,8 +156,8 @@ namespace GitHub3
 
         public async Task<string> AddUpstreamRemoteAsync()
         {
-            var module = _currentGitUiCommands.GitModule;
-            var hostedRemote = GetHostedRemotesForModule(module).FirstOrDefault(r => r.IsOwnedByMe);
+            var gitModule = _currentGitUiCommands.GitModule;
+            var hostedRemote = GetHostedRemotesForModule().FirstOrDefault(r => r.IsOwnedByMe);
             if (hostedRemote == null)
             {
                 return null;
@@ -169,34 +169,35 @@ namespace GitHub3
                 return null;
             }
 
-            if ((await module.GetRemotesAsync()).Any(r => r.Name == UpstreamConventionName || r.FetchUrl == hostedRepository.ParentReadOnlyUrl))
+            if ((await gitModule.GetRemotesAsync()).Any(r => r.Name == UpstreamConventionName || r.FetchUrl == hostedRepository.ParentReadOnlyUrl))
             {
                 return null;
             }
 
-            module.AddRemote(UpstreamConventionName, hostedRepository.ParentReadOnlyUrl);
+            gitModule.AddRemote(UpstreamConventionName, hostedRepository.ParentReadOnlyUrl);
             return UpstreamConventionName;
         }
 
-        public bool GitModuleIsRelevantToMe(IGitModule module)
+        public bool GitModuleIsRelevantToMe()
         {
-            return GetHostedRemotesForModule(module).Count > 0;
+            return GetHostedRemotesForModule().Count > 0;
         }
 
         /// <summary>
         /// Returns all relevant github-remotes for the current working directory
         /// </summary>
-        public IReadOnlyList<IHostedRemote> GetHostedRemotesForModule(IGitModule module)
+        public IReadOnlyList<IHostedRemote> GetHostedRemotesForModule()
         {
+            var gitModule = _currentGitUiCommands.GitModule;
             return Remotes().ToList();
 
             IEnumerable<IHostedRemote> Remotes()
             {
                 var set = new HashSet<IHostedRemote>();
 
-                foreach (string remote in module.GetRemoteNames())
+                foreach (string remote in gitModule.GetRemoteNames())
                 {
-                    var url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
+                    var url = gitModule.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
 
                     if (string.IsNullOrEmpty(url))
                     {

--- a/Plugins/GitHub3/GitHubHostedRemote.cs
+++ b/Plugins/GitHub3/GitHubHostedRemote.cs
@@ -6,18 +6,23 @@ namespace GitHub3
     {
         private GitHubRepo _repo;
 
-        public GitHubHostedRemote(string name, string owner, string remoteRepositoryName)
+        public GitHubHostedRemote(string name, string owner, string remoteRepositoryName, string url)
         {
             Name = name;
             Owner = owner;
             RemoteRepositoryName = remoteRepositoryName;
+            RemoteUrl = url;
+            CloneProtocol = url.IsUrlUsingHttp() ? GitProtocol.Https : GitProtocol.Ssh;
         }
 
         public IHostedRepository GetHostedRepository()
         {
             if (_repo == null)
             {
-                _repo = new GitHubRepo(GitHub3Plugin.GitHub.getRepository(Owner, RemoteRepositoryName));
+                _repo = new GitHubRepo(GitHub3Plugin.GitHub.getRepository(Owner, RemoteRepositoryName))
+                {
+                    CloneProtocol = CloneProtocol
+                };
             }
 
             return _repo;
@@ -39,6 +44,10 @@ namespace GitHub3
         /// git@github.com:mabako/Git.hub.git this is 'Git.hub'
         /// </summary>
         public string RemoteRepositoryName { get; }
+
+        public string RemoteUrl { get; }
+
+        public GitProtocol CloneProtocol { get; }
 
         public string Data => Owner + "/" + RemoteRepositoryName;
         public string DisplayData => Data;

--- a/Plugins/GitHub3/GitHubRepo.cs
+++ b/Plugins/GitHub3/GitHubRepo.cs
@@ -43,7 +43,7 @@ namespace GitHub3
                     _repo = GitHub3Plugin.GitHub.getRepository(Owner, Name);
                 }
 
-                return _repo.Parent?.GitUrl;
+                return CloneProtocol == GitProtocol.Ssh ? _repo.Parent?.GitUrl : _repo.Parent?.CloneUrl;
             }
         }
 

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -98,6 +98,7 @@
     <Compile Include="ISettingsValueGetter.cs" />
     <Compile Include="ObjectId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Remote.cs" />
     <Compile Include="Settings\BoolSetting.cs" />
     <Compile Include="ISetting.cs" />
     <Compile Include="ISettingsSource.cs" />

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace GitUIPluginInterfaces
@@ -107,6 +108,8 @@ namespace GitUIPluginInterfaces
 
         /// <summary>Gets the remote of the current branch; or "" if no remote is configured.</summary>
         string GetCurrentRemote();
+
+        Task<IReadOnlyList<Remote>> GetRemotesAsync();
 
         string GetSetting(string setting);
         string GetEffectiveSetting(string setting);

--- a/Plugins/GitUIPluginInterfaces/Remote.cs
+++ b/Plugins/GitUIPluginInterfaces/Remote.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace GitUIPluginInterfaces
+{
+    public readonly struct Remote
+    {
+        public string Name { get; }
+        public string PushUrl { get; }
+        public string FetchUrl { get; }
+
+        public Remote(string name, string pushUrl, string fetchUrl)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            PushUrl = pushUrl ?? throw new ArgumentNullException(nameof(pushUrl));
+            FetchUrl = fetchUrl ?? throw new ArgumentNullException(nameof(fetchUrl));
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRemote.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRemote.cs
@@ -17,5 +17,12 @@ namespace GitUIPluginInterfaces.RepositoryHosts
         string DisplayData { get; }
 
         bool IsOwnedByMe { get; }
+
+        string Owner { get; }
+
+        string RemoteRepositoryName { get; }
+
+        string RemoteUrl { get; }
+        GitProtocol CloneProtocol { get; }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IRepositoryHostPlugin.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IRepositoryHostPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GitUIPluginInterfaces.RepositoryHosts
 {
@@ -14,5 +15,8 @@ namespace GitUIPluginInterfaces.RepositoryHosts
 
         bool GitModuleIsRelevantToMe(IGitModule module);
         IReadOnlyList<IHostedRemote> GetHostedRemotesForModule(IGitModule module);
+        string OwnerLogin { get; }
+
+        Task<string> AddUpstreamRemoteAsync();
     }
 }

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IRepositoryHostPlugin.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IRepositoryHostPlugin.cs
@@ -13,8 +13,8 @@ namespace GitUIPluginInterfaces.RepositoryHosts
 
         bool ConfigurationOk { get; }
 
-        bool GitModuleIsRelevantToMe(IGitModule module);
-        IReadOnlyList<IHostedRemote> GetHostedRemotesForModule(IGitModule module);
+        bool GitModuleIsRelevantToMe();
+        IReadOnlyList<IHostedRemote> GetHostedRemotesForModule();
         string OwnerLogin { get; }
 
         Task<string> AddUpstreamRemoteAsync();


### PR DESCRIPTION
## Proposed changes

~~Note: better reviewable and merged after #6514 (a small part of the refactoring done in this PR was extracted in #6514)~~ done.

- Add a menu item to easily add the "upstream" remote to the repository
- refactoring:  also introduce a refactoring on `GitHubHostedRemote` where the underneath repository should be initialized with the `GitProtocol` already used ( make use of `GitHubHostedRemote` easier)

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/460196/53642088-2f87be00-3c31-11e9-8c99-b65554761fc5.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 9c567e63a5bfb30af412bce86e356e169735d5af
- Git 2.20.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 192dpi (200% scaling)
