### PR TITLE
FileStatusList: Show the hint "Filter files..." only when applicable

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -165,7 +165,7 @@ namespace GitUI
             set
             {
                 FilterComboBox.Visible = value;
-                FilterWatermarkLabel.Visible = value;
+                SetFilterWatermarkLabelVisibility();
 
                 int top = value
                     ? FileStatusListView.Margin.Top + FilterComboBox.Bottom + FilterComboBox.Margin.Bottom
@@ -763,6 +763,11 @@ namespace GitUI
             };
 
             process.Start();
+        }
+
+        private void SetFilterWatermarkLabelVisibility()
+        {
+            FilterWatermarkLabel.Visible = FilterVisible && !FilterComboBox.Focused && string.IsNullOrEmpty(FilterComboBox.Text);
         }
 
         private void UpdateFileStatusListView(bool updateCausedByFilter = false)
@@ -1373,15 +1378,12 @@ namespace GitUI
 
         private void FilterComboBox_GotFocus(object sender, EventArgs e)
         {
-            FilterWatermarkLabel.Visible = false;
+            SetFilterWatermarkLabelVisibility();
         }
 
         private void FilterComboBox_LostFocus(object sender, EventArgs e)
         {
-            if (!FilterWatermarkLabel.Visible && string.IsNullOrEmpty(FilterComboBox.Text))
-            {
-                FilterWatermarkLabel.Visible = true;
-            }
+            SetFilterWatermarkLabelVisibility();
         }
 
         private void FilterWatermarkLabel_Click(object sender, EventArgs e)
@@ -1396,5 +1398,21 @@ namespace GitUI
         }
 
         #endregion
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FileStatusList _fileStatusList;
+
+            internal TestAccessor(FileStatusList fileStatusList)
+            {
+                _fileStatusList = fileStatusList;
+            }
+
+            internal ListView FileStatusListView => _fileStatusList.FileStatusListView;
+            internal ComboBox FilterComboBox => _fileStatusList.FilterComboBox;
+            internal bool FilterWatermarkLabelVisible => _fileStatusList.FilterWatermarkLabel.Visible;
+        }
     }
 }

--- a/UnitTests/GitUITests/CommandsDialogs/FileStatusListTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FileStatusListTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Threading;
+using System.Windows.Forms;
+using FluentAssertions;
+using GitUI;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs
+{
+    [Apartment(ApartmentState.STA)]
+    public class FileStatusListTests
+    {
+        // Created once for each test
+        private Form _form;
+        private FileStatusList _fileStatusList;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _form = new Form();
+            _fileStatusList = new FileStatusList();
+            _fileStatusList.Parent = _form;
+            _form.Show(); // must be visible to be able to change the focus
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _fileStatusList = null;
+            _form = null;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _form.Dispose();
+            _fileStatusList.Dispose();
+        }
+
+        [Test]
+        public void Test_FilterWatermarkLabelVisibility_on_FilterVisibleChange(
+            [Values(null, "", "x")] string filterText,
+            [Values(true, false)] bool filterFocused,
+            [Values(true, false)] bool filterVisible)
+        {
+            var accessor = _fileStatusList.GetTestAccessor();
+
+            accessor.FilterComboBox.Text = filterText; // must be set first because it does not need to update the visibility
+
+            _fileStatusList.FilterVisible = !filterVisible; // force a change
+            _fileStatusList.FilterVisible = filterVisible;
+
+            if (filterFocused)
+            {
+                accessor.FilterComboBox.Focus(); // must be done after FilterVisible = true
+            }
+
+            accessor.FilterWatermarkLabelVisible.Should().Be(filterVisible && !filterFocused && string.IsNullOrEmpty(filterText));
+        }
+
+        [Test]
+        public void Test_FilterWatermarkLabelVisibility_on_Focus()
+        {
+            var accessor = _fileStatusList.GetTestAccessor();
+
+            accessor.FilterComboBox.Text = "";
+            _fileStatusList.FilterVisible = true;
+
+            accessor.FilterWatermarkLabelVisible.Should().BeTrue();
+
+            accessor.FilterComboBox.Focus();
+
+            accessor.FilterWatermarkLabelVisible.Should().BeFalse();
+
+            accessor.FileStatusListView.Focus();
+
+            accessor.FilterWatermarkLabelVisible.Should().BeTrue();
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="CommandsDialogs\CommitDialog\FormPullTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormInitTests.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormCommitTests.cs" />
+    <Compile Include="CommandsDialogs\FileStatusListTests.cs" />
     <Compile Include="CommandsDialogs\FormEditorTests.cs" />
     <Compile Include="CommandsDialogs\FormFileHistoryControllerTests.cs" />
     <Compile Include="CommandsDialogs\ReferenceRepository.cs" />


### PR DESCRIPTION
Fixes #6336

## Proposed changes

- never show the hint "Filter files..." if focused or if filter is active

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/53698529-2851e300-3dde-11e9-9c2e-119520a50aaf.png)
![grafik](https://user-images.githubusercontent.com/36601201/53698536-356ed200-3dde-11e9-87b8-30cf80d019e5.png)
![grafik](https://user-images.githubusercontent.com/36601201/53698538-41f32a80-3dde-11e9-91ac-52d582ccdbfc.png)
![grafik](https://user-images.githubusercontent.com/36601201/53698541-5800eb00-3dde-11e9-9ebd-eed21cd755ce.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/53700030-92728400-3dee-11e9-8bd8-f77132e9eb3d.png)

## Test methodology <!-- How did you ensure quality? -->

- added NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build a8093a5192f572f9a552b836e69f94838897fd33
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
