### PR TITLE
Left pane reorder trees

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1597,6 +1597,30 @@ namespace GitCommands
             set => SetBool("RepoObjectsTree.ShowSubmodules", value);
         }
 
+        public static int RepoObjectsTreeBranchesIndex
+        {
+            get => GetInt("RepoObjectsTree.BranchesIndex", 0);
+            set => SetInt("RepoObjectsTree.BranchesIndex", value);
+        }
+
+        public static int RepoObjectsTreeRemotesIndex
+        {
+            get => GetInt("RepoObjectsTree.RemotesIndex", 1);
+            set => SetInt("RepoObjectsTree.RemotesIndex", value);
+        }
+
+        public static int RepoObjectsTreeTagsIndex
+        {
+            get => GetInt("RepoObjectsTree.TagsIndex", 2);
+            set => SetInt("RepoObjectsTree.TagsIndex", value);
+        }
+
+        public static int RepoObjectsTreeSubmodulesIndex
+        {
+            get => GetInt("RepoObjectsTree.SubmodulesIndex", 3);
+            set => SetInt("RepoObjectsTree.SubmodulesIndex", value);
+        }
+
         public static bool IsPortable()
         {
             return Properties.Settings.Default.IsPortable;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -37,17 +37,24 @@ namespace GitUI.BranchTreePanel
             //    Collapse All
             //    Expand All
 
+            Tree treeNode = (contextMenu.SourceControl as TreeView)?.SelectedNode?.Tag as Tree;
+
             if (contextMenu == menuMain)
             {
                 contextMenu.Items.Clear();
                 contextMenu.Items.Add(mnubtnCollapseAll);
                 contextMenu.Items.Add(mnubtnExpandAll);
+                if (treeNode != null)
+                {
+                    AddMoveUpDownMenuItems();
+                }
+
                 return;
             }
 
-            if (!contextMenu.Items.Contains(tsmiSpacer1))
+            if (!contextMenu.Items.Contains(tsmiMainMenuSpacer1))
             {
-                contextMenu.Items.Add(tsmiSpacer1);
+                contextMenu.Items.Add(tsmiMainMenuSpacer1);
             }
 
             if (!contextMenu.Items.Contains(mnubtnCollapseAll))
@@ -58,6 +65,34 @@ namespace GitUI.BranchTreePanel
             if (!contextMenu.Items.Contains(mnubtnExpandAll))
             {
                 contextMenu.Items.Add(mnubtnExpandAll);
+            }
+
+            if (treeNode != null)
+            {
+                AddMoveUpDownMenuItems();
+            }
+
+            return;
+
+            void AddMoveUpDownMenuItems()
+            {
+                if (!contextMenu.Items.Contains(tsmiMainMenuSpacer2))
+                {
+                    contextMenu.Items.Add(tsmiMainMenuSpacer2);
+                }
+
+                if (!contextMenu.Items.Contains(mnubtnMoveUp))
+                {
+                    contextMenu.Items.Add(mnubtnMoveUp);
+                }
+
+                if (!contextMenu.Items.Contains(mnubtnMoveDown))
+                {
+                    contextMenu.Items.Add(mnubtnMoveDown);
+                }
+
+                mnubtnMoveUp.Enabled = treeNode.TreeViewNode.PrevNode != null;
+                mnubtnMoveDown.Enabled = treeNode.TreeViewNode.NextNode != null;
             }
         }
 
@@ -159,6 +194,8 @@ namespace GitUI.BranchTreePanel
 
             RegisterClick(mnubtnCollapseAll, () => treeMain.CollapseAll());
             RegisterClick(mnubtnExpandAll, () => treeMain.ExpandAll());
+            RegisterClick(mnubtnMoveUp, () => ReorderTreeNode(treeMain.SelectedNode, up: true));
+            RegisterClick(mnubtnMoveDown, () => ReorderTreeNode(treeMain.SelectedNode, up: false));
 
             treeMain.NodeMouseClick += OnNodeMouseClick;
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -516,7 +516,7 @@ namespace GitUI.BranchTreePanel
             // tsmiShowRemotes
             // 
             this.tsmiShowSubmodules.CheckOnClick = true;
-            this.tsmiShowSubmodules.Image = global::GitUI.Properties.Images.BranchRemoteRoot;
+            this.tsmiShowSubmodules.Image = global::GitUI.Properties.Images.FolderSubmodule;
             this.tsmiShowSubmodules.Name = "tsmiShowSubmodules";
             this.tsmiShowSubmodules.Size = new System.Drawing.Size(154, 22);
             this.tsmiShowSubmodules.Text = "&Submodules";

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -57,7 +57,8 @@ namespace GitUI.BranchTreePanel
             this.components = new System.ComponentModel.Container();
             this.treeMain = new GitUI.UserControls.NativeTreeView();
             this.menuMain = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.tsmiSpacer1 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsmiMainMenuSpacer1 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsmiMainMenuSpacer2 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnCollapseAll = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnExpandAll = new System.Windows.Forms.ToolStripMenuItem();
             this.menuBranch = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -101,6 +102,8 @@ namespace GitUI.BranchTreePanel
             this.menuSubmodule = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnUpdateSubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.menuAllSubmodules = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.mnubtnMoveUp = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnMoveDown = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnManageSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnSynchronizeSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMain.SuspendLayout();
@@ -136,16 +139,22 @@ namespace GitUI.BranchTreePanel
             // 
             this.menuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnubtnCollapseAll,
-            this.mnubtnExpandAll});
+            this.mnubtnExpandAll,
+            this.mnubtnMoveUp,
+            this.mnubtnMoveDown});
             this.menuMain.Name = "menuMain";
             this.menuMain.Size = new System.Drawing.Size(137, 76);
             this.menuMain.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
-            // tsmiSpacer1
+            // tsmiMainMenuSpacer1
             // 
-            this.tsmiSpacer1.Name = "tsmiSpacer1";
-            this.tsmiSpacer1.Size = new System.Drawing.Size(133, 6);
+            this.tsmiMainMenuSpacer1.Name = "tsmiMainMenuSpacer1";
+            this.tsmiMainMenuSpacer1.Size = new System.Drawing.Size(133, 6);
             // 
+            // tsmiMainMenuSpacer2
+            // 
+            this.tsmiMainMenuSpacer2.Name = "tsmiMainMenuSpacer2";
+            this.tsmiMainMenuSpacer2.Size = new System.Drawing.Size(133, 6);
             // mnubtnCollapseAll
             // 
             this.mnubtnCollapseAll.Image = global::GitUI.Properties.Images.CollapseAll;
@@ -547,6 +556,22 @@ namespace GitUI.BranchTreePanel
             this.menuAllSubmodules.Size = new System.Drawing.Size(196, 26);
             this.menuAllSubmodules.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             // 
+            // mnubtnMoveUp
+            // 
+            this.mnubtnMoveUp.Image = global::GitUI.Properties.Images.ArrowUp;
+            this.mnubtnMoveUp.Name = "mnubtnMoveUp";
+            this.mnubtnMoveUp.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnMoveUp.Text = "Move Up";
+            this.mnubtnMoveUp.ToolTipText = "Move node up";
+            // 
+            // mnubtnMoveDown
+            // 
+            this.mnubtnMoveDown.Image = global::GitUI.Properties.Images.ArrowDown;
+            this.mnubtnMoveDown.Name = "mnubtnMoveDown";
+            this.mnubtnMoveDown.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnMoveDown.Text = "Move Down";
+            this.mnubtnMoveDown.ToolTipText = "Move node down";
+            // 
             // mnubtnManageSubmodules
             // 
             this.mnubtnManageSubmodules.Image = global::GitUI.Properties.Images.SubmodulesManage;
@@ -620,7 +645,8 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnubtnRemoteBranchFetchAndCheckout;
         private ToolStripMenuItem mnubtnFetchRebase;
         private ToolStripMenuItem mnubtnFetchCreateBranch;
-        private ToolStripSeparator tsmiSpacer1;
+        private ToolStripSeparator tsmiMainMenuSpacer1;
+        private ToolStripSeparator tsmiMainMenuSpacer2;
         private ToolStripMenuItem mnubtnEnableRemote;
         private ToolStripMenuItem mnubtnEnableRemoteAndFetch;
         private ToolStripMenuItem mnubtnDisableRemote;
@@ -638,5 +664,7 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnubtnSynchronizeSubmodules;
         private ToolStripMenuItem mnubtnUpdateSubmodule;
         private ToolStripMenuItem mnubtnOpenSubmodule;
+        private ToolStripMenuItem mnubtnMoveUp;
+        private ToolStripMenuItem mnubtnMoveDown;
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -128,6 +128,7 @@ namespace GitUI.BranchTreePanel
                 Nodes = new Nodes(this);
                 _uiCommandsSource = uiCommands;
                 TreeViewNode = treeNode;
+                treeNode.Tag = this;
 
                 uiCommands.UICommandsChanged += (a, e) =>
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
@@ -9,6 +8,26 @@ namespace GitUI.BranchTreePanel
 {
     public partial class RepoObjectsTree
     {
+        /// <summary>
+        /// We assume tree to position indices are 0-based and sequential. In case this
+        /// is no longer true, because for e.g. user has reverted to an earlier version,
+        /// this function will fix the indices, attempting to maintain the existing order.
+        /// </summary>
+        private void FixInvalidTreeToPositionIndices()
+        {
+            // Sort by index, then force assign 0-based sequential indices
+            var treeToIndex = GetTreeToPositionIndex();
+
+            int i = 0;
+            foreach (var kvp in treeToIndex.OrderBy(kvp => kvp.Value))
+            {
+                treeToIndex[kvp.Key] = i;
+                ++i;
+            }
+
+            SaveTreeToPositionIndex(treeToIndex);
+        }
+
         private Dictionary<Tree, int> GetTreeToPositionIndex()
         {
             return new Dictionary<Tree, int>

--- a/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -1,30 +1,120 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows.Forms;
 using GitCommands;
 
 namespace GitUI.BranchTreePanel
 {
     public partial class RepoObjectsTree
     {
+        private Dictionary<Tree, int> GetTreeToPositionIndex()
+        {
+            return new Dictionary<Tree, int>
+            {
+                [_branchesTree] = AppSettings.RepoObjectsTreeBranchesIndex,
+                [_remotesTree] = AppSettings.RepoObjectsTreeRemotesIndex,
+                [_tagTree] = AppSettings.RepoObjectsTreeTagsIndex,
+                [_submoduleTree] = AppSettings.RepoObjectsTreeSubmodulesIndex
+            };
+        }
+
+        private void SaveTreeToPositionIndex(Dictionary<Tree, int> treeToPositionIndex)
+        {
+            AppSettings.RepoObjectsTreeBranchesIndex = treeToPositionIndex[_branchesTree];
+            AppSettings.RepoObjectsTreeRemotesIndex = treeToPositionIndex[_remotesTree];
+            AppSettings.RepoObjectsTreeTagsIndex = treeToPositionIndex[_tagTree];
+            AppSettings.RepoObjectsTreeSubmodulesIndex = treeToPositionIndex[_submoduleTree];
+        }
+
+        private void RebuildMenuSettings()
+        {
+            var indexToTree = GetTreeToPositionIndex().ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+            treeMain.BeginUpdate();
+
+            // For now, the only items in menuSettings are the "show" items, so just clear it all,
+            // and re-add them in current index order.
+            menuSettings.Items.Clear();
+            var treeToShowMenuItem = new Dictionary<Tree, ToolStripMenuItem>
+            {
+                [_branchesTree] = tsmiShowBranches,
+                [_remotesTree] = tsmiShowRemotes,
+                [_tagTree] = tsmiShowTags,
+                [_submoduleTree] = tsmiShowSubmodules
+            };
+            for (int i = 0; i < treeToShowMenuItem.Count(); ++i)
+            {
+                var tsmi = treeToShowMenuItem[indexToTree[i]];
+                menuSettings.Items.Add(tsmi);
+            }
+
+            treeMain.EndUpdate();
+        }
+
+        private void ReorderTreeNode(TreeNode node, bool up)
+        {
+            var tree = (Tree)node.Tag;
+            var treeToIndex = GetTreeToPositionIndex();
+            var indexToTree = treeToIndex.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+            int currIndex = treeToIndex[tree];
+
+            // Find next visible tree to swap with, if any
+            int swapIndex = currIndex;
+            do
+            {
+                swapIndex = up ? swapIndex - 1 : swapIndex + 1;
+
+                // If there are no visible nodes to swap with, we're done
+                if (swapIndex < 0 || swapIndex >= treeToIndex.Count())
+                {
+                    return;
+                }
+            }
+            while (!indexToTree[swapIndex].TreeViewNode.IsVisible);
+
+            var swapWithTree = indexToTree[swapIndex];
+
+            // Swap indices
+            treeToIndex[tree] = treeToIndex[swapWithTree];
+            treeToIndex[swapWithTree] = currIndex;
+
+            // Save new indices
+            SaveTreeToPositionIndex(treeToIndex);
+
+            // Remove all trees, then show enabled ones at new indices
+            RemoveTree(_branchesTree);
+            RemoveTree(_remotesTree);
+            RemoveTree(_tagTree);
+            RemoveTree(_submoduleTree);
+            ShowEnabledTrees();
+
+            // Update order of "show" menuSettings to match tree order
+            RebuildMenuSettings();
+        }
+
         private void ShowEnabledTrees()
         {
             if (tsmiShowBranches.Checked)
             {
-                AddTree(_branchesTree, 0);
+                AddTree(_branchesTree);
             }
 
             if (tsmiShowRemotes.Checked)
             {
-                AddTree(_remotesTree, 1);
+                AddTree(_remotesTree);
             }
 
             if (tsmiShowTags.Checked)
             {
-                AddTree(_tagTree, 2);
+                AddTree(_tagTree);
             }
 
             if (tsmiShowSubmodules.Checked)
             {
-                AddTree(_submoduleTree, 3);
+                AddTree(_submoduleTree);
             }
         }
 
@@ -34,7 +124,7 @@ namespace GitUI.BranchTreePanel
             _searchResult = null;
             if (tsmiShowBranches.Checked)
             {
-                AddTree(_branchesTree, 0);
+                AddTree(_branchesTree);
                 _searchResult = null;
             }
             else
@@ -49,7 +139,7 @@ namespace GitUI.BranchTreePanel
             _searchResult = null;
             if (tsmiShowRemotes.Checked)
             {
-                AddTree(_remotesTree, 1);
+                AddTree(_remotesTree);
                 _searchResult = null;
             }
             else
@@ -64,7 +154,7 @@ namespace GitUI.BranchTreePanel
             _searchResult = null;
             if (tsmiShowTags.Checked)
             {
-                AddTree(_tagTree, 2);
+                AddTree(_tagTree);
                 _searchResult = null;
             }
             else
@@ -79,7 +169,7 @@ namespace GitUI.BranchTreePanel
             _searchResult = null;
             if (tsmiShowSubmodules.Checked)
             {
-                AddTree(_submoduleTree, 3);
+                AddTree(_submoduleTree);
                 _searchResult = null;
             }
             else

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -480,6 +480,29 @@ namespace GitUI.BranchTreePanel
             }
 
             public NativeTreeView TreeView => _repoObjectsTree.treeMain;
+
+            public void ReorderTreeNode(TreeNode node, bool up)
+            {
+                _repoObjectsTree.ReorderTreeNode(node, up);
+            }
+
+            public void SetTreeVisibleByIndex(int index, bool visible)
+            {
+                var tree = _repoObjectsTree.GetTreeToPositionIndex().FirstOrDefault(kvp => kvp.Value == index).Key;
+                if (tree.TreeViewNode.IsVisible == visible)
+                {
+                    return;
+                }
+
+                if (visible)
+                {
+                    _repoObjectsTree.AddTree(tree);
+                }
+                else
+                {
+                    _repoObjectsTree.RemoveTree(tree);
+                }
+            }
         }
 
         private void mnuBtnUpdateAllRemotes_Click(object sender, EventArgs e)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -226,6 +226,7 @@ namespace GitUI.BranchTreePanel
             CreateTags();
             CreateSubmodules();
 
+            FixInvalidTreeToPositionIndices();
             ShowEnabledTrees();
             RebuildMenuSettings();
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -25,7 +25,6 @@ namespace GitUI.BranchTreePanel
         private readonly TranslationString _searchTooltip = new TranslationString("Search");
         private readonly TranslationString _showHideRefsTooltip = new TranslationString("Show/hide branches/remotes/tags");
 
-        private readonly Dictionary<Tree, int> _treeToPositionIndex = new Dictionary<Tree, int>();
         private NativeTreeViewDoubleClickDecorator _doubleClickDecorator;
         private NativeTreeViewExplorerNavigationDecorator _explorerNavigationDecorator;
         private readonly List<Tree> _rootNodes = new List<Tree>();
@@ -76,6 +75,8 @@ namespace GitUI.BranchTreePanel
             mnubtnFilterRemoteBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
             mnubtnFilterLocalBranchInRevisionGrid.ToolTipText = _showBranchOnly.Text;
 
+            return;
+
             void InitImageList()
             {
                 const int rowPadding = 1; // added to top and bottom, so doubled -- this value is scaled *after*, so consider 96dpi here
@@ -85,6 +86,8 @@ namespace GitUI.BranchTreePanel
                     ImageSize = DpiUtil.Scale(new Size(16, 16 + rowPadding + rowPadding)), // Scale ImageSize and images scale automatically
                     Images =
                     {
+                        { nameof(Images.ArrowUp), Pad(Images.ArrowUp) },
+                        { nameof(Images.ArrowDown), Pad(Images.ArrowDown) },
                         { nameof(Images.FolderClosed), Pad(Images.FolderClosed) },
                         { nameof(Images.BranchDocument), Pad(Images.BranchDocument) },
                         { nameof(Images.Branch), Pad(Images.Branch) },
@@ -97,7 +100,6 @@ namespace GitUI.BranchTreePanel
                         { nameof(Images.BranchRemote), Pad(Images.BranchRemote) },
                         { nameof(Images.BranchFolder), Pad(Images.BranchFolder) },
                         { nameof(Images.TagHorizontal), Pad(Images.TagHorizontal) },
-                        { nameof(Images.FolderClosed), Pad(Images.FolderClosed) },
                         { nameof(Images.EyeOpened), Pad(Images.EyeOpened) },
                         { nameof(Images.EyeClosed), Pad(Images.EyeClosed) },
                         { nameof(Images.RemoteEnableAndFetch), Pad(Images.RemoteEnableAndFetch) },
@@ -225,6 +227,7 @@ namespace GitUI.BranchTreePanel
             CreateSubmodules();
 
             ShowEnabledTrees();
+            RebuildMenuSettings();
         }
 
         private static void AddTreeNodeToSearchResult(ICollection<TreeNode> ret, TreeNode node)
@@ -279,13 +282,10 @@ namespace GitUI.BranchTreePanel
             _submoduleTree = new SubmoduleTree(rootNode, UICommandsSource);
         }
 
-        private void AddTree(Tree tree, int positionIndex)
+        private void AddTree(Tree tree)
         {
             tree.TreeViewNode.SelectedImageKey = tree.TreeViewNode.ImageKey;
             tree.TreeViewNode.Tag = tree;
-
-            // Remember current Tree's position index
-            _treeToPositionIndex[tree] = positionIndex;
 
             // Add Tree's node in position index order. Because TreeNodeCollections cannot be sorted,
             // we create a list from it, sort it, then clear and re-add the nodes back to the collection.
@@ -293,7 +293,8 @@ namespace GitUI.BranchTreePanel
             List<TreeNode> nodeList = treeMain.Nodes.OfType<TreeNode>().ToList();
             nodeList.Add(tree.TreeViewNode);
             treeMain.Nodes.Clear();
-            treeMain.Nodes.AddRange(nodeList.OrderBy(treeNode => _treeToPositionIndex[treeNode.Tag as Tree]).ToArray());
+            var treeToPositionIndex = GetTreeToPositionIndex();
+            treeMain.Nodes.AddRange(nodeList.OrderBy(treeNode => treeToPositionIndex[treeNode.Tag as Tree]).ToArray());
             treeMain.EndUpdate();
 
             treeMain.Font = AppSettings.Font;

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.ReorderNodes.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.ReorderNodes.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs.CommitDialog
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormBrowseLeftPanelReorderNodesTest
+    {
+        // Created once for each test
+        private GitUICommands _commands;
+        private bool _originalShowAuthorAvatarColumn;
+        private List<bool> _originalRepoObjectsTreeShow = new List<bool>();
+
+        private GitModuleTestHelper _repo1;
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            _originalShowAuthorAvatarColumn = AppSettings.ShowAuthorAvatarColumn;
+
+            // we don't want avatars during tests, otherwise we will be attempting to download them from gravatar....
+            AppSettings.ShowAuthorAvatarColumn = false;
+
+            // Show all root nodes for test, restore when done
+            _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowBranches);
+            _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowRemotes);
+            _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowTags);
+            _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowSubmodules);
+            AppSettings.RepoObjectsTreeShowBranches = true;
+            AppSettings.RepoObjectsTreeShowRemotes = true;
+            AppSettings.RepoObjectsTreeShowTags = true;
+            AppSettings.RepoObjectsTreeShowSubmodules = true;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            AppSettings.ShowAuthorAvatarColumn = _originalShowAuthorAvatarColumn;
+
+            AppSettings.RepoObjectsTreeShowBranches = _originalRepoObjectsTreeShow[0];
+            AppSettings.RepoObjectsTreeShowRemotes = _originalRepoObjectsTreeShow[1];
+            AppSettings.RepoObjectsTreeShowTags = _originalRepoObjectsTreeShow[2];
+            AppSettings.RepoObjectsTreeShowSubmodules = _originalRepoObjectsTreeShow[3];
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _repo1 = new GitModuleTestHelper("repo1");
+            _commands = new GitUICommands(_repo1.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _commands = null;
+            _repo1.Dispose();
+        }
+
+        [Test]
+        public void RepoObjectTree_moving_first_up_and_last_down_does_nothing()
+        {
+            RunFormTest(
+                form =>
+                {
+                    // act
+                    var repoObjectTree = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor();
+                    var currNodes = repoObjectTree.TreeView.Nodes;
+                    List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
+
+                    // assert
+                    currNodes.Count.Should().Be(4);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+
+                    int first = 0;
+                    int last = currNodes.Count - 1;
+
+                    // Trying to move first node up should do nothing
+                    repoObjectTree.ReorderTreeNode(currNodes[first], up: true);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+
+                    // Similarly, moving last node down should do nothing
+                    repoObjectTree.ReorderTreeNode(currNodes[last], up: false);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                });
+        }
+
+        [Test]
+        public void RepoObjectTree_moving_node_legally_moves_it()
+        {
+            RunFormTest(
+                form =>
+                {
+                    // act
+                    var repoObjectTree = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor();
+                    var currNodes = repoObjectTree.TreeView.Nodes;
+                    List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
+
+                    // assert
+                    currNodes.Count.Should().Be(4);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+
+                    // Move first down
+                    repoObjectTree.ReorderTreeNode(currNodes[0], up: false);
+                    ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3);
+                    repoObjectTree.ReorderTreeNode(currNodes[1], up: false);
+                    ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3);
+                    repoObjectTree.ReorderTreeNode(currNodes[2], up: false);
+                    ValidateOrder(initialNodes, currNodes, 1, 2, 3, 0);
+
+                    // Then back up
+                    repoObjectTree.ReorderTreeNode(currNodes[3], up: true);
+                    ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3);
+                    repoObjectTree.ReorderTreeNode(currNodes[2], up: true);
+                    ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3);
+                    repoObjectTree.ReorderTreeNode(currNodes[1], up: true);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                });
+        }
+
+        [Test]
+        public void RepoObjectTree_moving_node_across_hidden_trees_skips_them()
+        {
+            RunFormTest(
+                form =>
+                {
+                    // act
+                    var repoObjectTree = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor();
+
+                    List<TreeNode> initialNodes = repoObjectTree.TreeView.Nodes.OfType<TreeNode>().ToList();
+
+                    // Hide nodes between first and last
+                    repoObjectTree.SetTreeVisibleByIndex(1, false);
+                    repoObjectTree.SetTreeVisibleByIndex(2, false);
+
+                    // assert
+                    var currNodes = repoObjectTree.TreeView.Nodes;
+                    currNodes.Count.Should().Be(2);
+
+                    // Move node 0 down, which should move it to index 3
+                    repoObjectTree.ReorderTreeNode(currNodes[0], up: false);
+
+                    // Unhide nodes between first and last
+                    repoObjectTree.SetTreeVisibleByIndex(1, true);
+                    repoObjectTree.SetTreeVisibleByIndex(2, true);
+
+                    // Reset currNodes, should be back to 4
+                    currNodes = repoObjectTree.TreeView.Nodes;
+                    currNodes.Count.Should().Be(4);
+
+                    // Only first and last nodes should have swapped
+                    ValidateOrder(initialNodes, currNodes, 3, 1, 2, 0);
+                });
+        }
+
+        private void ValidateOrder(List<TreeNode> initialNodes, TreeNodeCollection currNodes, params int[] expectedOrder)
+        {
+            initialNodes.Count.Should().Be(currNodes.Count);
+            initialNodes.Count.Should().Be(expectedOrder.Count());
+
+            for (int i = 0; i < initialNodes.Count; ++i)
+            {
+                currNodes[i].Should().Be(initialNodes[expectedOrder[i]]);
+            }
+        }
+
+        private void RunFormTest(Action<FormBrowse> testDriver)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                });
+        }
+
+        private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    Assert.True(_commands.StartBrowseDialog(owner: null));
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Avatars\BackupAvatarProviderTests.cs" />
     <Compile Include="BranchTreePanel\GitRefMenuItemsTest.cs" />
     <Compile Include="CancellationTokenSequenceTests.cs" />
+    <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.ReorderNodes.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.Submodules.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.LeftPanel.Remotes.cs" />
     <Compile Include="CommandsDialogs\CommitDialog\FormBrowseTests.cs" />


### PR DESCRIPTION
## Proposed changes

- Add the ability to reorder root Tree nodes in left panel: Branches, Remotes, Tags, and Submodules.
- This is done by right-clicking the root node and selecting from "Move Up" or "Move Down" context actions.
- The "Show" menu items in the left panel settings menu are also reordered to match.

## Screenshots <!-- Remove this section if PR does not change UI -->

Context menu action, note that because it's the top-most node, "Move Up" is disabled:
![image](https://user-images.githubusercontent.com/6893883/53924062-84b83b00-4048-11e9-8e3e-e2efa72b3bdd.png)

Similarly, if bottom-most node is selected, "Move Down" is disabled. And there's only one node (because the other three are hidden), then both are disabled:

![image](https://user-images.githubusercontent.com/6893883/53924099-b6310680-4048-11e9-90c9-ba44a7d072ff.png)

The settings menu where you can show/hide Trees matches the order:

![image](https://user-images.githubusercontent.com/6893883/53924129-d9f44c80-4048-11e9-857b-9672fcf8b2f5.png)

If Trees are hidden, reordering still works as expected. For instance, say Tags and Branches is hidden like so:

![image](https://user-images.githubusercontent.com/6893883/53924163-0019ec80-4049-11e9-87aa-b2f4781593fb.png)

If we right-click Submodules and move it down:

![image](https://user-images.githubusercontent.com/6893883/53924175-0c05ae80-4049-11e9-92c6-47fd270c2a47.png)

It will swap it with Remotes, but Branches and Tags keep their positions:

![image](https://user-images.githubusercontent.com/6893883/53924191-2a6baa00-4049-11e9-993b-599c8f27c7d3.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.19.1.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
