### PR TITLE
GitModule Encoding lazy encoding

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -496,7 +496,7 @@ namespace GitCommands
         [CanBeNull]
         public static GitSubmoduleStatus GetCurrentSubmoduleChanges(GitModule module, string fileName, string oldFileName, bool staged, bool noLocks = false)
         {
-            Patch patch = module.GetCurrentChanges(fileName, oldFileName, staged, "", module.FilesEncoding, noLocks: noLocks);
+            Patch patch = module.GetCurrentChanges(fileName, oldFileName, staged, "", noLocks: noLocks);
             string text = patch != null ? patch.Text : "";
             return ParseSubmoduleStatus(text, module, fileName);
         }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2309,7 +2309,7 @@ namespace GitCommands
                 cache: cache,
                 outputEncoding: LosslessEncoding);
 
-            var patches = PatchProcessor.CreatePatchesFromString(patch, encoding).ToList();
+            var patches = PatchProcessor.CreatePatchesFromString(patch, new Lazy<Encoding>(() => encoding)).ToList();
 
             return GetPatch(patches, fileName, oldFileName);
         }
@@ -2593,7 +2593,7 @@ namespace GitCommands
         }
 
         internal GitArgumentBuilder GetCurrentChangesCmd(string fileName, [CanBeNull] string oldFileName, bool staged,
-            string extraDiffArguments, Encoding encoding, bool noLocks)
+            string extraDiffArguments, bool noLocks)
         {
             return new GitArgumentBuilder("diff", gitOptions:
                     noLocks && GitVersion.Current.SupportNoOptionalLocks
@@ -2611,12 +2611,12 @@ namespace GitCommands
         }
 
         [CanBeNull]
-        public Patch GetCurrentChanges(string fileName, [CanBeNull] string oldFileName, bool staged, string extraDiffArguments, Encoding encoding, bool noLocks = false)
+        public Patch GetCurrentChanges(string fileName, [CanBeNull] string oldFileName, bool staged, string extraDiffArguments, Encoding encoding = null, bool noLocks = false)
         {
-            var output = _gitExecutable.GetOutput(GetCurrentChangesCmd(fileName, oldFileName, staged, extraDiffArguments, encoding, noLocks),
+            var output = _gitExecutable.GetOutput(GetCurrentChangesCmd(fileName, oldFileName, staged, extraDiffArguments, noLocks),
                 outputEncoding: LosslessEncoding);
 
-            var patches = PatchProcessor.CreatePatchesFromString(output, encoding).ToList();
+            IReadOnlyList<Patch> patches = PatchProcessor.CreatePatchesFromString(output, new Lazy<Encoding>(() => encoding ?? FilesEncoding)).ToList();
 
             return GetPatch(patches, fileName, oldFileName);
         }
@@ -3949,7 +3949,7 @@ namespace GitCommands
                 return "";
             }
 
-            var patches = PatchProcessor.CreatePatchesFromString(patch, encoding).ToList();
+            var patches = PatchProcessor.CreatePatchesFromString(patch, new Lazy<Encoding>(() => encoding)).ToList();
 
             return GetPatch(patches, filePath, filePath)?.Text;
         }

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -32,7 +32,7 @@ namespace GitCommands.Patches
         /// File paths can be quoted (see <c>core.quotepath</c>). They are unquoted by <see cref="GitModule.ReEncodeFileNameFromLossless"/>.
         /// </remarks>
         [NotNull, ItemNotNull, Pure]
-        public static IEnumerable<Patch> CreatePatchesFromString([NotNull] string patchText, [NotNull] Encoding filesContentEncoding)
+        public static IEnumerable<Patch> CreatePatchesFromString([NotNull] string patchText, [NotNull] Lazy<Encoding> filesContentEncoding)
         {
             // TODO encoding for each file in patch should be obtained separately from .gitattributes
 
@@ -59,7 +59,7 @@ namespace GitCommands.Patches
         }
 
         [CanBeNull]
-        private static Patch CreatePatchFromString([ItemNotNull, NotNull] string[] lines, [NotNull] Encoding filesContentEncoding, ref int lineIndex)
+        private static Patch CreatePatchFromString([ItemNotNull, NotNull] string[] lines, [NotNull] Lazy<Encoding> filesContentEncoding, ref int lineIndex)
         {
             if (lineIndex >= lines.Length)
             {
@@ -270,7 +270,7 @@ namespace GitCommands.Patches
                 if (state == PatchProcessorState.InBody && line.StartsWithAny(new[] { " ", "-", "+", "@" }))
                 {
                     // diff content
-                    line = GitModule.ReEncodeStringFromLossless(line, filesContentEncoding);
+                    line = GitModule.ReEncodeStringFromLossless(line, filesContentEncoding.Value);
                 }
                 else
                 {

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -122,7 +122,7 @@ namespace GitUI.AutoCompletion
         [CanBeNull]
         private static string GetChangedFileText(GitModule module, GitItemStatus file)
         {
-            var changes = module.GetCurrentChanges(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000", module.FilesEncoding);
+            var changes = module.GetCurrentChanges(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000");
 
             if (changes != null)
             {

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Patches;
@@ -82,7 +83,7 @@ namespace GitUI.CommandsDialogs
             try
             {
                 var text = System.IO.File.ReadAllText(PatchFileNameEdit.Text, GitModule.LosslessEncoding);
-                var patches = PatchProcessor.CreatePatchesFromString(text, Module.FilesEncoding).ToList();
+                var patches = PatchProcessor.CreatePatchesFromString(text, new Lazy<Encoding>(() => Module.FilesEncoding)).ToList();
 
                 GridChangedFiles.DataSource = patches;
             }

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -547,14 +547,14 @@ namespace GitCommandsTests
             Assert.AreEqual(expected, _gitModule.GetStashesCmd(noLocks).ToString());
         }
 
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", null, false)]
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color extra -- ""new""", "new", "old", false, "extra", null, false)]
-        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", null, true)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, [CanBeNull] string oldFileName, bool staged,
-            string extraDiffArguments, Encoding encoding, bool noLocks)
+            string extraDiffArguments, bool noLocks)
         {
             Assert.AreEqual(expected, _gitModule.GetCurrentChangesCmd(fileName, oldFileName, staged,
-                extraDiffArguments, encoding, noLocks).ToString());
+                extraDiffArguments, noLocks).ToString());
         }
 
         [TestCase(@"for-each-ref --sort=-committerdate --format=""%(objectname) %(refname)"" refs/heads/", false)]

--- a/UnitTests/GitCommandsTests/Patches/PatchProcessorTest.cs
+++ b/UnitTests/GitCommandsTests/Patches/PatchProcessorTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -33,7 +34,7 @@ namespace GitCommandsTests.Patches
         {
             TestPatch expectedPatch = CreateSmallPatchExample();
 
-            var patches = PatchProcessor.CreatePatchesFromString(expectedPatch.PatchOutput, Encoding.UTF8);
+            var patches = PatchProcessor.CreatePatchesFromString(expectedPatch.PatchOutput, new Lazy<Encoding>(() => Encoding.UTF8));
 
             Patch createdPatch = patches.First();
 
@@ -49,7 +50,7 @@ namespace GitCommandsTests.Patches
         {
             TestPatch expectedPatch = CreateSmallPatchExample(reverse: true);
 
-            var patches = PatchProcessor.CreatePatchesFromString(expectedPatch.PatchOutput, Encoding.UTF8);
+            var patches = PatchProcessor.CreatePatchesFromString(expectedPatch.PatchOutput, new Lazy<Encoding>(() => Encoding.UTF8));
 
             Patch createdPatch = patches.First();
 
@@ -63,7 +64,7 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestCorrectlyLoadsTheRightNumberOfDiffsInAPatchFile()
         {
-            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, Encoding.UTF8);
+            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, new Lazy<Encoding>(() => Encoding.UTF8));
 
             Assert.AreEqual(17, patches.Count());
         }
@@ -71,7 +72,7 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestCorrectlyLoadsTheRightFileNamesInAPatchFile()
         {
-            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, Encoding.UTF8).ToList();
+            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, new Lazy<Encoding>(() => Encoding.UTF8)).ToList();
 
             Assert.AreEqual(17, patches.Select(p => p.FileNameA).Distinct().Count());
             Assert.AreEqual(17, patches.Select(p => p.FileNameB).Distinct().Count());
@@ -80,7 +81,7 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestCorrectlyLoadsBinaryPatch()
         {
-            var patches = PatchProcessor.CreatePatchesFromString(_bigBinPatch, Encoding.UTF8);
+            var patches = PatchProcessor.CreatePatchesFromString(_bigBinPatch, new Lazy<Encoding>(() => Encoding.UTF8));
 
             Assert.AreEqual(248, patches.Count(p => p.FileType == PatchFileType.Binary));
         }
@@ -88,7 +89,7 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestCorrectlyLoadsOneNewFile()
         {
-            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, Encoding.UTF8);
+            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, new Lazy<Encoding>(() => Encoding.UTF8));
 
             Assert.AreEqual(1, patches.Count(p => p.ChangeType == PatchChangeType.NewFile));
         }
@@ -96,7 +97,7 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestCorrectlyLoadsOneDeleteFile()
         {
-            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, Encoding.UTF8);
+            var patches = PatchProcessor.CreatePatchesFromString(_bigPatch, new Lazy<Encoding>(() => Encoding.UTF8));
 
             Assert.AreEqual(1, patches.Count(p => p.ChangeType == PatchChangeType.DeleteFile));
         }
@@ -104,17 +105,17 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestCorrectlyLoadsChangeFiles()
         {
-            var bigPatches = PatchProcessor.CreatePatchesFromString(_bigPatch, Encoding.UTF8);
+            var bigPatches = PatchProcessor.CreatePatchesFromString(_bigPatch, new Lazy<Encoding>(() => Encoding.UTF8));
             Assert.AreEqual(15, bigPatches.Count(p => p.ChangeType == PatchChangeType.ChangeFile));
 
-            var smallPatches = PatchProcessor.CreatePatchesFromString(CreateSmallPatchExample().PatchOutput, Encoding.UTF8);
+            var smallPatches = PatchProcessor.CreatePatchesFromString(CreateSmallPatchExample().PatchOutput, new Lazy<Encoding>(() => Encoding.UTF8));
             Assert.AreEqual(1, smallPatches.Count(p => p.ChangeType == PatchChangeType.ChangeFile));
         }
 
         [Test]
         public void TestCorrectlyLoadsRebaseDiff()
         {
-            var patches = PatchProcessor.CreatePatchesFromString(_rebaseDiff, Encoding.UTF8).ToList();
+            var patches = PatchProcessor.CreatePatchesFromString(_rebaseDiff, new Lazy<Encoding>(() => Encoding.UTF8)).ToList();
 
             Assert.AreEqual(13, patches.Count);
             Assert.AreEqual(3, patches.Count(p => p.IsCombinedDiff));
@@ -133,7 +134,7 @@ index cdf8bebba,55ff37bb9..000000000
 +++ b/UnitTests/GitCommandsTests/Patches/PatchProcessorTest.cs
 ";
 
-            var patches = PatchProcessor.CreatePatchesFromString(diff, Encoding.UTF8).ToList();
+            var patches = PatchProcessor.CreatePatchesFromString(diff, new Lazy<Encoding>(() => Encoding.UTF8)).ToList();
 
             Assert.AreEqual(2, patches.Count);
             Assert.IsTrue(patches.All(p => p.IsCombinedDiff));


### PR DESCRIPTION
Part of #6357 

## Proposed changes
- Lazy evaluation of GitModule.FileEncoding 
~~- Optimize copy GitModule copy~~ #6373

This fixes the performance problem I see in my "real" repos even if the core problem should be fixed too.

## Test methodology

See #6357 for a test setup
This is verified by git-rev-parse calls for only the modules with changes

## Test environment(s)
See #6357 , a submodule with changes required

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
