### PR TITLE
Support Git pre 2.11 for status

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -486,7 +486,7 @@ namespace GitCommands
                     ? (ArgumentString)"--no-optional-locks"
                     : default)
             {
-                $"--porcelain={(GitVersion.Current.SupportStatusPorcelainV2 ? 2 : 1)} -z",
+                $"--porcelain{(GitVersion.Current.SupportStatusPorcelainV2 ? "=2" : "")} -z",
                 untrackedFiles,
                 ignoreSubmodules,
                 { !excludeIgnoredFiles, "--ignored" }


### PR DESCRIPTION
Resolves #6322

## Proposed changes
Fix the options for Git prior to 2.11

Note that Git prior to 2.11 is not officially supported, this patch will not change that.
However, the error messages will be less confusing and the code can be used as an example.
This do not need to be included in Release Notes.

## Test methodology <!-- How did you ensure quality? -->

Primarily: Test that Git 2.21.0 works
Also debugging in the code, viewing the command line argument

## Test environment(s)

- GIT 2.21.0

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
