### PR TITLE
Avoid freeze when staging many files at once (works only when AppSettings.ShowErrorsWhenStagingFiles==false)

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1747,11 +1747,7 @@ namespace GitCommands
             if (nonDeletedFiles.Count != 0)
             {
                 var execution = _gitExecutable.Execute(
-                    new GitArgumentBuilder("update-index")
-                    {
-                        "--add",
-                        "--stdin"
-                    },
+                    UpdateIndexCmd(AppSettings.ShowErrorsWhenStagingFiles),
                     inputWriter =>
                     {
                         foreach (var file in nonDeletedFiles)
@@ -1889,6 +1885,18 @@ namespace GitCommands
                 $"\"{filename.ToPosixPath()}\"{inputWriter.NewLine}");
 
             inputWriter.BaseStream.Write(bytes, 0, bytes.Length);
+        }
+
+        private GitArgumentBuilder UpdateIndexCmd(bool showErrorsWhenStagingFiles)
+        {
+            return new GitArgumentBuilder("update-index", gitOptions:
+                            showErrorsWhenStagingFiles
+                                ? default
+                                : (ArgumentString)"-c core.safecrlf=false")
+                    {
+                        "--add",
+                        "--stdin"
+                    };
         }
 
         #endregion
@@ -4057,6 +4065,20 @@ namespace GitCommands
                     ? $"{param}=\"{date:yyyy-MM-dd hh:mm:ss}\""
                     : "";
             }
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly GitModule _gitModule;
+
+            public TestAccessor(GitModule gitModule)
+            {
+                _gitModule = gitModule;
+            }
+
+            public GitArgumentBuilder UpdateIndexCmd(bool showErrorsWhenStagingFiles) => _gitModule.UpdateIndexCmd(showErrorsWhenStagingFiles);
         }
     }
 

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -579,5 +579,15 @@ namespace GitCommandsTests
         {
             Assert.AreEqual(expected, _gitModule.GetRefsCmd(tags, branches, noLocks).ToString());
         }
+
+        [TestCase(false, @"-c core.safecrlf=false update-index --add --stdin")]
+        [TestCase(true, @"update-index --add --stdin")]
+        public void UpdateIndexCmd_should_add_core_safecrlf(bool showErrorsWhenStagingFiles, string expected)
+        {
+            var accessor = _gitModule.GetTestAccessor();
+
+            var actual = accessor.UpdateIndexCmd(showErrorsWhenStagingFiles).ToString();
+            Assert.AreEqual(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Fixes part of #6225



## Proposed changes

- Changed how `AppSettings.ShowErrorsWhenStagingFiles=false` works (flag for skipping "warning: LF will be replaced by CRLF" messages). Instead of simply not showing the warning messages after the git command has been executed, pass an additional option to git to not even generate the warning messages.
Advantages:
  - A cleaner implementation.
  - It provides at least a workaround for #6225. Setting `AppSettings.ShowErrorsWhenStagingFiles` to false will allow to stage any number of files, regardless of their line ending and the user's `core.autocrlf` setting. The freeze remains though with `AppSettings.ShowErrorsWhenStagingFiles` true (the default value).


## Test methodology

- manual tests, in particular with the reproduction repo and steps described in https://github.com/gitextensions/gitextensions/issues/6225#issuecomment-465784080


## Test environment(s)
- Git Extensions 3.1.0
- Build c68cf2382d5f5f1d33855619ec37f14d4bfc654b
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.3324.0
- DPI 120dpi (125% scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
