### PR TITLE
WIP Optimize create copy of GitModule()

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -120,6 +120,18 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Create a thread-safe copy of this module, copying "expensive" properties
+        /// </summary>
+        /// <returns>Copy of the current module</returns>
+        public GitModule Copy()
+        {
+            GitModule module = new GitModule(WorkingDir);
+            module._gitCommonDirectory = _gitCommonDirectory;
+
+            return module;
+        }
+
+        /// <summary>
         /// Gets the directory which contains the git repository.
         /// </summary>
         [NotNull]

--- a/GitCommands/Submodules/SubmoduleInfoResult.cs
+++ b/GitCommands/Submodules/SubmoduleInfoResult.cs
@@ -10,7 +10,7 @@ namespace GitCommands.Submodules
     public class SubmoduleInfoResult
     {
         // Module that was used to gather submodule info
-        public IGitModule Module { get; internal set; }
+        public GitModule Module { get; internal set; }
 
         // List of SubmoduleInfo for all submodules (recursively) under current module.
         public IList<SubmoduleInfo> OurSubmodules { get; } = new List<SubmoduleInfo>();

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -84,7 +84,7 @@ namespace GitCommands.Submodules
                 // Start gathering new submodule structure asynchronously.
                 var result = new SubmoduleInfoResult
                 {
-                    Module = new GitModule(gitModule.WorkingDir)
+                    Module = gitModule.Copy()
                 };
 
                 // Add all submodules inside the current repository:

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -361,14 +361,7 @@ namespace GitUI.CommandsDialogs
 
                         if (AppSettings.ShowSubmoduleStatus)
                         {
-                            if (_submoduleStatusProvider.HasChangedToNone(status))
-                            {
-                                UpdateSubmodulesStructure(updateStatus: false);
-                            }
-                            else if (_submoduleStatusProvider.HasStatusChanges(status))
-                            {
-                                UpdateSubmodulesStructure(updateStatus: true);
-                            }
+                            _submoduleStatusProvider.UpdateSubmodulesStatus(Module, status);
                         }
                     }
                 };
@@ -613,7 +606,7 @@ namespace GitUI.CommandsDialogs
             toolStripButtonPush.DisplayAheadBehindInformation(Module.GetSelectedBranch());
         }
 
-        #region IBrowseRepo
+#region IBrowseRepo
 
         public void GoToRef(string refName, bool showNoRevisionMsg)
         {
@@ -623,7 +616,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        #endregion
+#endregion
 
         private void ShowDashboard()
         {
@@ -1061,7 +1054,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        #region Working directory combo box
+#region Working directory combo box
 
         /// <summary>Updates the text shown on the combo button itself.</summary>
         private void RefreshWorkingDirComboText()
@@ -1155,7 +1148,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        #endregion
+#endregion
 
         private void RebaseClick(object sender, EventArgs e)
         {
@@ -2105,7 +2098,7 @@ namespace GitUI.CommandsDialogs
             UICommands.StartCreatePullRequest(this, repoHost);
         }
 
-        #region Hotkey commands
+#region Hotkey commands
 
         public static readonly string HotkeySettingsName = "Browse";
 
@@ -2311,7 +2304,7 @@ namespace GitUI.CommandsDialogs
             return ExecuteCommand((int)cmd);
         }
 
-        #endregion
+#endregion
 
         public static void OpenContainingFolder(FileStatusList diffFiles, GitModule module)
         {
@@ -2568,7 +2561,7 @@ namespace GitUI.CommandsDialogs
             PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
-        #region Submodules
+#region Submodules
 
         private (ToolStripItem item, Func<Task<Action>> loadDetails)
             CreateSubmoduleMenuItem(CancellationToken cancelToken, SubmoduleInfo info, string textFormat = "{0}")
@@ -2640,13 +2633,13 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void UpdateSubmodulesStructure(bool updateStatus = false)
+        private void UpdateSubmodulesStructure()
         {
-            // Submodule status is updated on git-status updates. To make sure supermodule status is updated, update immediately
-            updateStatus = updateStatus || (AppSettings.ShowSubmoduleStatus && _gitStatusMonitor.Active && (Module.SuperprojectModule != null));
+            // Submodule status is updated on git-status updates. To make sure supermodule status is updated, update immediately (once)
+            var updateStatus = AppSettings.ShowSubmoduleStatus && _gitStatusMonitor.Active && (Module.SuperprojectModule != null);
 
             toolStripButtonLevelUp.ToolTipText = "";
-            _submoduleStatusProvider.UpdateSubmodulesStatus(updateStatus, Module.WorkingDir, _noBranchTitle.Text);
+            _submoduleStatusProvider.UpdateSubmodulesStructure(Module, _noBranchTitle.Text, updateStatus);
         }
 
         private void SubmoduleStatusProvider_StatusUpdating(object sender, EventArgs e)
@@ -2750,7 +2743,7 @@ namespace GitUI.CommandsDialogs
             toolStripButtonLevelUp.DropDownItems.Clear();
         }
 
-        #endregion
+#endregion
 
         private void toolStripButtonLevelUp_ButtonClick(object sender, EventArgs e)
         {
@@ -2980,7 +2973,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        #region Layout management
+#region Layout management
 
         private void toggleSplitViewLayout_Click(object sender, EventArgs e)
         {
@@ -3091,7 +3084,7 @@ namespace GitUI.CommandsDialogs
             RevisionsSplitContainer.ResumeLayout(performLayout: true);
         }
 
-        #endregion
+#endregion
 
         private void manageWorktreeToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2720,12 +2720,13 @@ namespace GitUI.CommandsDialogs
             // then refresh all items at once with a single switch to the main thread
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                var loadDetalils = newItems.Select(e => e.loadDetails).Where(e => e != null);
+                var loadDetails = newItems.Select(e => e.loadDetails).Where(e => e != null);
                 var refreshActions = new List<Action>();
-                foreach (var loadFunc in loadDetalils)
+                foreach (var loadFunc in loadDetails)
                 {
                     cancelToken.ThrowIfCancellationRequested();
                     var action = await loadFunc();
+                    refreshActions.Add(action);
                 }
 
                 await this.SwitchToMainThreadAsync(cancelToken);

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -8,14 +8,14 @@ namespace CommonTestUtils
 {
     public class SubmoduleTestHelpers
     {
-        public static SubmoduleInfoResult UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        public static SubmoduleInfoResult UpdateSubmoduleStructureAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
         {
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStatus(
+            provider.UpdateSubmodulesStructure(
                 updateStatus: updateStatus,
-                workingDirectory: module.WorkingDir,
+                gitModule: module,
                 noBranchText: string.Empty);
 
             AsyncTestHelper.WaitForPendingOperations();

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -62,9 +62,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStatus_valid_result_for_top_module()
+            public void UpdateSubmoduleStructure_valid_result_for_top_module()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo1Module);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(null);
@@ -74,9 +74,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStatus_valid_result_for_first_nested_submodule()
+            public void UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo2Module);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo2Module);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(result.TopProject);
@@ -86,61 +86,15 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStatus_valid_result_for_second_nested_submodule()
+            public void UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo3Module);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo3Module);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Path.Should().Be(_repo2Module.WorkingDir);
                 result.CurrentSubmoduleName.Should().Be("repo3");
                 result.OurSubmodules.Select(info => info.Path).Should().BeEmpty();
                 result.SuperSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
-            }
-
-            [Test]
-            public void HasChangedToNone_valid_result()
-            {
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo3Module);
-
-                // No changes in repo
-                var changedFiles = GetStatusChangedFiles(_repo1Module);
-                changedFiles.Should().HaveCount(0);
-                _provider.HasChangedToNone(changedFiles).Should().BeFalse();
-
-                // Make a change in repo2
-                _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
-                changedFiles = GetStatusChangedFiles(_repo1Module);
-                changedFiles.Should().HaveCount(1);
-                _provider.HasChangedToNone(changedFiles).Should().BeFalse();
-
-                // Revert the change
-                File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-                changedFiles = GetStatusChangedFiles(_repo1Module);
-                changedFiles.Should().HaveCount(0);
-                _provider.HasChangedToNone(changedFiles).Should().BeTrue();
-            }
-
-            [Test]
-            public void HasStatusChanges_valid_result()
-            {
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo3Module);
-
-                // No changes in repo
-                var changedFiles = GetStatusChangedFiles(_repo1Module);
-                changedFiles.Should().HaveCount(0);
-                _provider.HasStatusChanges(changedFiles).Should().BeFalse();
-
-                // Make a change in repo2
-                _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
-                changedFiles = GetStatusChangedFiles(_repo1Module);
-                changedFiles.Should().HaveCount(1);
-                _provider.HasStatusChanges(changedFiles).Should().BeTrue();
-
-                // Revert the change
-                File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-                changedFiles = GetStatusChangedFiles(_repo1Module);
-                changedFiles.Should().HaveCount(0);
-                _provider.HasStatusChanges(changedFiles).Should().BeFalse();
             }
 
             private static IReadOnlyList<GitItemStatus> GetStatusChangedFiles(IGitModule module)

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Submodules.cs
@@ -89,7 +89,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 form =>
                 {
                     // act
-                    SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo1Module);
+                    SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
 
                     // assert
                     var submodulesNode = GetSubmoduleNode(form);


### PR DESCRIPTION
Part of #6357 

Separating the second part of #6359 to not mixup discussions
https://github.com/gitextensions/gitextensions/pull/6359/files/07b797b3460c0ceef870f73cab169e9a7cafacdf#diff-a77f67d7f76305a8eeaae638ef09120a

## Proposed changes

Make a copy of gitModule instead of creating a new GitModule.
This is the pattern used in similar situations, for instance GitStatusMonitor.

This avoids a call to ```git rev-parse --common-dir``` when querying submodules structure/status.
This is not critical in itself, but it is a distraction for #6359.

Note: A previous version (in #6357) used an optimized constructor to create a new instance. This is maybe the pattern that should be used in all similar situations.

## Test methodology

* Open refresh a repo with changes in several submodule. For example GE repo with extra files in the submodules
* Verify that there is not a separate call to git-rev-parse for each of the modified repos

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
