### PR TITLE
Update ExListView on expand / collapse of a group

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1021,9 +1021,21 @@ namespace GitUI
             if (!_updatingColumnWidth)
             {
                 _updatingColumnWidth = true;
-                columnHeader.Width = GetWidth();
+
+                int width = GetWidth();
+                if (columnHeader.Width != width)
+                {
+                    columnHeader.Width = width;
+
+                    // invalidate the FileStatusListView explicitely and asynchronously
+                    // Else texts will not be redrawn when scrollbars are shown or hidden.
+                    FileStatusListView.BeginInvoke(new Action(() => FileStatusListView.Invalidate()));
+                }
+
                 _updatingColumnWidth = false;
             }
+
+            return;
 
             int GetWidth()
             {


### PR DESCRIPTION
Fixes #6375.

## Proposed changes

- workaround: invalidate ExListView retarded on changed `ColumnHeader` width

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![before](https://user-images.githubusercontent.com/36601201/54498913-d005ff80-490c-11e9-99fb-44f26b441a09.png)

### After

![after double click](https://user-images.githubusercontent.com/36601201/54499161-12c8d700-490f-11e9-8c60-1bfd1165a4f2.png)

## Test methodology <!-- How did you ensure quality? -->

- manual testing
  - [x] double click
  - [x] click the collapse / expand button

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build c4ea6ea42ecd0e9d9b4f1988218145799f88557d
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
