### PR TITLE
FormAbout: fix "Git Extensions is open source. Get involved!" text wa…

### DIFF
--- a/GitUI/CommandsDialogs/FormAbout.Designer.cs
+++ b/GitUI/CommandsDialogs/FormAbout.Designer.cs
@@ -216,6 +216,8 @@
             this.label2.TabIndex = 0;
             this.label2.Text = "Git Extensions is open source. Get involved!";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.label2.AutoSize = true;
+            this.label2.MaximumSize = new System.Drawing.Size(133, 0);
             // 
             // flowLayoutPanel1
             // 


### PR DESCRIPTION
…s cropped when scaling is greater than 100%


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![about125_old](https://user-images.githubusercontent.com/4993430/54565564-b386c780-49df-11e9-9adb-4757e8e874a8.png)

### After

![about125](https://user-images.githubusercontent.com/4993430/54565582-bed9f300-49df-11e9-982e-3d103fce955b.png)
![about150](https://user-images.githubusercontent.com/4993430/54565581-bed9f300-49df-11e9-9f62-e55ea31e27b3.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
