### PR TITLE
#6147 inverted diffs after refresh

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -355,13 +355,6 @@ namespace GitUI.UserControls.RevisionGrid
             return _revisionGraph.GetNodeForRow(rowIndex)?.GitRevision;
         }
 
-        public void Prune()
-        {
-            _revisionGraph.Clear();
-
-            SetRowCount(_revisionGraph.Count);
-        }
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Justification = "It looks like such lock was made intentionally but it is better to rewrite this")]
         private void SetRowCount(int count)
         {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -178,11 +177,21 @@ namespace GitUI.UserControls.RevisionGrid
 
         internal AuthorRevisionHighlighting AuthorHighlighting { get; set; }
 
-        // Contains the object Id's that will be selected as soon as they are loaded.
-        public HashSet<ObjectId> ToBeSelectedObjectIds { get; set; } = new HashSet<ObjectId>();
+        // Contains the object Id's that will be selected as soon as all of them have been loaded.
+        // The object Id's are in the order in which they were originally selected.
+        public List<ObjectId> ToBeSelectedObjectIds { get; set; } = new List<ObjectId>();
 
-        // The ToBeSelectedObjectId's should be converted to indexes. This queue is then used to select the correct index. This is used cross-threads.
-        private ConcurrentQueue<int> ToBeSelectedRowIndexes { get; set; } = new ConcurrentQueue<int>();
+        // The ToBeSelectedObjectIds's should be converted to indexes.
+        // Since revisions are read in order, this list stores those indexes along with information on the order in which they were selected.
+        private List<RowIndexToBeSelectedWithOrderInfo> ToBeSelectedRowIndexes { get; set; } = new List<RowIndexToBeSelectedWithOrderInfo>();
+
+        private class RowIndexToBeSelectedWithOrderInfo
+        {
+            public int RowIndex { get; set; }
+
+            // Order in which the row should be selected.
+            public int SelectionOrder { get; set; }
+        }
 
         public bool HasSelection()
         {
@@ -290,9 +299,15 @@ namespace GitUI.UserControls.RevisionGrid
         {
             _revisionGraph.Add(revision, types);
 
-            if (ToBeSelectedObjectIds.Remove(revision.ObjectId))
+            if (ToBeSelectedObjectIds.Contains(revision.ObjectId))
             {
-                ToBeSelectedRowIndexes.Enqueue(_revisionGraph.Count - 1);
+                var rowIndexToBeSelectedWithOrderInfo = new RowIndexToBeSelectedWithOrderInfo
+                {
+                    RowIndex = _revisionGraph.Count - 1,
+                    SelectionOrder = ToBeSelectedObjectIds.IndexOf(revision.ObjectId)
+                };
+
+                ToBeSelectedRowIndexes.Add(rowIndexToBeSelectedWithOrderInfo);
             }
 
             UpdateVisibleRowRange();
@@ -309,7 +324,7 @@ namespace GitUI.UserControls.RevisionGrid
             // Set rowcount to 0 first, to ensure it is not possible to select or redraw, since we are about te delete the data
             SetRowCount(0);
             _revisionGraph.Clear();
-            ToBeSelectedRowIndexes = new ConcurrentQueue<int>();
+            ToBeSelectedRowIndexes = new List<RowIndexToBeSelectedWithOrderInfo>();
 
             // The graphdata is stored in one of the columnproviders, clear this last
             foreach (var columnProvider in _columnProviders)
@@ -377,29 +392,51 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     RowCount = count;
                 }
-
-                if (ToBeSelectedRowIndexes.TryPeek(out int toBeSelectedRowIndex) &&
-                    count > toBeSelectedRowIndex)
-                {
-                    try
-                    {
-                        ToBeSelectedRowIndexes.TryDequeue(out _);
-                        Rows[toBeSelectedRowIndex].Selected = true;
-                        if (CurrentCell == null)
-                        {
-                            CurrentCell = Rows[toBeSelectedRowIndex].Cells[1];
-                        }
-                    }
-                    catch (ArgumentOutOfRangeException)
-                    {
-                        // Not worth crashing for. Ignore exception.
-                    }
-                }
             }
             finally
             {
                 UpdatingVisibleRows = false;
             }
+        }
+
+        private void SelectRowsIfReady(int rowCount)
+        {
+            // Wait till we have all the row indexes to be selected.
+            if (!ToBeSelectedRowIndexes.Any() || ToBeSelectedRowIndexes.Count < ToBeSelectedObjectIds.Count)
+            {
+                return;
+            }
+
+            if (rowCount > ToBeSelectedRowIndexes.Max(ri => ri.RowIndex))
+            {
+                try
+                {
+                    var rowIndicesToBeSelectedInOriginalOrder = ToBeSelectedRowIndexes.OrderBy(ri => ri.SelectionOrder).Select(ri => ri.RowIndex);
+
+                    foreach (var rowIndexToBeSelected in rowIndicesToBeSelectedInOriginalOrder)
+                    {
+                        Rows[rowIndexToBeSelected].Selected = true;
+
+                        if (CurrentCell == null)
+                        {
+                            CurrentCell = Rows[rowIndexToBeSelected].Cells[1];
+                        }
+                    }
+
+                    // The rows to be selected have just been selected. Prevent from selecting them again.
+                    ToBeSelectedRowIndexes.Clear();
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Not worth crashing for. Ignore exception.
+                }
+            }
+        }
+
+        private void SetRowCountAndSelectRowsIfReady(int rowCount)
+        {
+            SetRowCount(rowCount);
+            SelectRowsIfReady(rowCount);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Justification = "It looks like such lock was made intentionally but it is better to rewrite this")]
@@ -445,7 +482,7 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     if (RowCount < _revisionGraph.Count)
                     {
-                        this.InvokeAsync(() => { SetRowCount(_revisionGraph.Count); }).FileAndForget();
+                        this.InvokeAsync(() => { SetRowCountAndSelectRowsIfReady(_revisionGraph.Count); }).FileAndForget();
                     }
                 }
             }
@@ -464,7 +501,7 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     if (RowCount < _revisionGraph.Count)
                     {
-                        SetRowCount(_revisionGraph.Count);
+                        SetRowCountAndSelectRowsIfReady(_revisionGraph.Count);
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1087,7 +1087,7 @@ namespace GitUI
                 selectedObjectIds = new ObjectId[] { Module.GetCurrentCheckout() };
             }
 
-            _gridView.ToBeSelectedObjectIds = selectedObjectIds.ToHashSet();
+            _gridView.ToBeSelectedObjectIds = selectedObjectIds.ToList();
             _selectedObjectIds = null;
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6147 


## Proposed changes

- The `HashSet ToBeSelectedObjectIds` should be a `List`, because order matters.
- There is no need for `ToBeSelectedRowIndexes` to be a `ConcurrentQueue`, since we want to wait till we have all the rows to be selected and, when we have them, we select them. The list of indices can thus be stored in a `List` that includes order information.

### Before

The grid attempts to select a commit as soon as it is loaded. Consequently, rows are being selected in the order in which revisions are read, not in the order in which they had originally been selected.

### After

By waiting till all rows to be selected have been added to the grid before attempting to select them, we can select them in the correct order. With the current implementation, that's the best that can be done if we don't want to wait till all commits have been loaded before attempting to select the rows.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing. I followed the same steps as indicated in the ticket, and verified that the behavior is as expected.
  - I considered special cases, like selection of many commits, and selection of commits at both ends of the commit history. (By the way, without these changes, a selection scattered throughout the commit history, would produce a new random selection when refreshing.)

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3324.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
