### PR TITLE
Fix exception thrown GitModule.GetRemotes on an invalid git directory

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2183,6 +2183,12 @@ namespace GitCommands
                     {
                         var fetchLine = enumerator.Current;
 
+                        // An invalid module is not an error; we simply return an empty list of remotes
+                        if (fetchLine.Contains("not a git repository"))
+                        {
+                            return remotes;
+                        }
+
                         if (!enumerator.MoveNext())
                         {
                             throw new Exception("Remote URLs should appear in pairs.");

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1447,7 +1447,7 @@ namespace GitUI.CommandsDialogs
 
             _dashboard?.RefreshContent();
 
-            _gitStatusMonitor.Active = NeedsGitStatusMonitor();
+            _gitStatusMonitor.Active = NeedsGitStatusMonitor() && Module.IsValidGitWorkingDir();
         }
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -310,7 +310,10 @@ namespace GitUI
             }
             finally
             {
-                RepoChangedNotifier.UnLock(changesRepo && actionDone);
+                // The action may not have required a valid working directory to run, but if there isn't one,
+                // we shouldn't send a "repo changed" notify.
+                bool requestNotify = actionDone && changesRepo && Module.IsValidGitWorkingDir();
+                RepoChangedNotifier.UnLock(requestNotify);
             }
 
             return actionDone;


### PR DESCRIPTION
Fixes #6093 


## Proposed changes

- GitModule.GetRemotes no longer throws an exception if the module opened isn't a valid Git module; rather, it returns an empty list.
- Opening and closing Settings dialog doesn't throw an exception if a valid module isn't open.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.19.1.windows.1
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
