### PR TITLE
Fix vertical ruler position not correctly read from settings

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -379,7 +379,6 @@ namespace GitUI.Editor
             this.internalFileViewer.ShowTabs = false;
             this.internalFileViewer.Size = new System.Drawing.Size(757, 518);
             this.internalFileViewer.TabIndex = 1;
-            this.internalFileViewer.VRulerPosition = 80;
             // 
             // FileViewer
             // 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -257,6 +257,7 @@ namespace GitUI.Editor
             if (commandSource?.UICommands != null)
             {
                 commandSource.UICommands.PostSettings += UICommands_PostSettings;
+                UICommands_PostSettings(commandSource.UICommands, null);
             }
 
             Encoding = null;
@@ -264,7 +265,11 @@ namespace GitUI.Editor
 
         private void UICommands_PostSettings(object sender, GitUIPostActionEventArgs e)
         {
-            internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition;
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await internalFileViewer.SwitchToMainThreadAsync();
+                internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition;
+            }).FileAndForget();
         }
 
         protected override void OnRuntimeLoad()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6391 

## Proposed changes
-  Apply settings right after command source has changed in `FileViewer`.
-  Remove default value of 80 that is set to the `FileViewerInternal.VRulerPosition` property in `FileViewer`'s `InitializeComponent` method. The `FileViewerInternal` gets actual value for vertical ruler from app settings in its constructor.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 7a5680d2fe317c08a4cb99f66a3f5e5e1c1c6c81 (Dirty)
- Git 2.20.0.windows.1
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
