### PR TITLE
Some improvments on blame form

### DIFF
--- a/GitCommands/Git/GitBlame.cs
+++ b/GitCommands/Git/GitBlame.cs
@@ -69,9 +69,14 @@ namespace GitCommands
             var s = new StringBuilder();
 
             s.Append("Author: ").AppendLine(Author);
-            s.Append("AuthorTime: ").AppendLine(AuthorTime.ToString(CultureInfo.CurrentCulture));
-            s.Append("Committer: ").AppendLine(Committer);
-            s.Append("CommitterTime: ").AppendLine(CommitterTime.ToString(CultureInfo.CurrentCulture));
+            s.Append("Author date: ").AppendLine(AuthorTime.ToString(CultureInfo.CurrentCulture));
+            if (Author != Committer || AuthorTime != CommitterTime)
+            {
+                s.Append("Committer: ").AppendLine(Committer);
+                s.Append("Commit date: ").AppendLine(CommitterTime.ToString(CultureInfo.CurrentCulture));
+            }
+
+            s.Append("Commit hash: ").AppendLine(ObjectId.ToShortString());
             s.Append("Summary: ").AppendLine(Summary);
             s.AppendLine();
             s.Append("FileName: ").Append(FileName);

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -274,7 +274,7 @@ namespace GitUI.Blame
                 {
                     gutter.Append(line.Commit.Author);
                     gutter.Append(" - ");
-                    gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentUICulture));
+                    gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentCulture));
                     gutter.Append(" - ");
                     gutter.Append(line.Commit.FileName);
                     gutter.Append(' ', 100).AppendLine();

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -268,7 +268,7 @@ namespace GitUI.Blame
             {
                 if (line.Commit == lastCommit)
                 {
-                    gutter.Append(' ', 200).AppendLine();
+                    gutter.Append(' ', 120).AppendLine();
                 }
                 else
                 {
@@ -280,11 +280,11 @@ namespace GitUI.Blame
                     {
                         gutter.Append(" - ");
                         gutter.Append(line.Commit.FileName);
-                        gutter.Append(' ', Math.Max(0, 175 - authorLength - line.Commit.FileName.Length)).AppendLine();
+                        gutter.Append(' ', Math.Max(0, 95 - authorLength - line.Commit.FileName.Length)).AppendLine();
                     }
                     else
                     {
-                        gutter.Append(' ', Math.Max(0, 178 - authorLength)).AppendLine();
+                        gutter.Append(' ', Math.Max(0, 98 - authorLength)).AppendLine();
                     }
                 }
 

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -86,7 +86,7 @@ namespace GitUI.Blame
             _encoding = encoding;
 
             _blameLoader.LoadAsync(() => _blame = Module.Blame(fileName, objectId.ToString(), encoding),
-                () => ProcessBlame(revision, children, controlToMask, line, scrollPos));
+                () => ProcessBlame(fileName, revision, children, controlToMask, line, scrollPos));
         }
 
         private void commitInfo_CommandClicked(object sender, CommandEventArgs e)
@@ -252,7 +252,7 @@ namespace GitUI.Blame
             _changingScrollPosition = false;
         }
 
-        private void ProcessBlame(GitRevision revision, IReadOnlyList<ObjectId> children, Control controlToMask, int lineNumber, int scrollpos)
+        private void ProcessBlame(string filename, GitRevision revision, IReadOnlyList<ObjectId> children, Control controlToMask, int lineNumber, int scrollpos)
         {
             var gutter = new StringBuilder(capacity: 4096);
             var body = new StringBuilder(capacity: 4096);
@@ -275,8 +275,12 @@ namespace GitUI.Blame
                     gutter.Append(line.Commit.Author);
                     gutter.Append(" - ");
                     gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentCulture));
-                    gutter.Append(" - ");
-                    gutter.Append(line.Commit.FileName);
+                    if (filename != line.Commit.FileName)
+                    {
+                        gutter.Append(" - ");
+                        gutter.Append(line.Commit.FileName);
+                    }
+
                     gutter.Append(' ', 100).AppendLine();
                 }
 

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -275,13 +275,17 @@ namespace GitUI.Blame
                     gutter.Append(line.Commit.Author);
                     gutter.Append(" - ");
                     gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentCulture));
+                    var authorLength = line.Commit.Author?.Length ?? 0;
                     if (filename != line.Commit.FileName)
                     {
                         gutter.Append(" - ");
                         gutter.Append(line.Commit.FileName);
+                        gutter.Append(' ', Math.Max(0, 175 - authorLength - line.Commit.FileName.Length)).AppendLine();
                     }
-
-                    gutter.Append(' ', 100).AppendLine();
+                    else
+                    {
+                        gutter.Append(' ', Math.Max(0, 178 - authorLength)).AppendLine();
+                    }
                 }
 
                 body.AppendLine(line.Text);

--- a/UnitTests/GitCommandsTests/Git/GitBlameCommitTests.cs
+++ b/UnitTests/GitCommandsTests/Git/GitBlameCommitTests.cs
@@ -14,19 +14,21 @@ namespace GitCommandsTests.Git
         {
             var committerTime = DateTime.Now;
             var authorTime = DateTime.Now;
+            var commitHash = ObjectId.Random();
 
             var str = new StringBuilder();
 
             str.AppendLine("Author: Author");
-            str.AppendLine("AuthorTime: " + authorTime);
+            str.AppendLine("Author date: " + authorTime);
             str.AppendLine("Committer: committer");
-            str.AppendLine("CommitterTime: " + committerTime);
+            str.AppendLine("Commit date: " + committerTime);
+            str.AppendLine("Commit hash: " + commitHash.ToShortString());
             str.AppendLine("Summary: test summary");
             str.AppendLine();
             str.Append("FileName: fileName.txt");
 
             var commit = new GitBlameCommit(
-                ObjectId.Random(),
+                commitHash,
                 "Author",
                 "author@authormail.com",
                 authorTime,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6389


## Proposed changes

-  Fix date formatting in blame form (fix #6389)
-  Blame: Remove clutter by displaying file path only when not corresponding to the file blamed

Before:

![image](https://user-images.githubusercontent.com/460196/54788467-5e40f500-4c2f-11e9-9f4b-4e074c343dec.png)

After:

![image](https://user-images.githubusercontent.com/460196/54788430-3f426300-4c2f-11e9-8fb2-94ae864e32b2.png)

-  Better not costly approximation to have all the lines of the same size & lines of 120 characters is long enough

Before:

![image](https://user-images.githubusercontent.com/460196/54788527-95170b00-4c2f-11e9-94e5-fcc076e47261.png)

After:  (all the lines are of the same length and shorter)


![image](https://user-images.githubusercontent.com/460196/54788555-b37d0680-4c2f-11e9-9294-03f86aa488a5.png)


-  Better display by inverting date and author

Before:

![image](https://user-images.githubusercontent.com/460196/54788645-140c4380-4c30-11e9-8e36-d97c2fbc0157.png)

After: (all is better aligned and the dates are much more readable without compromising on author readability)

![image](https://user-images.githubusercontent.com/460196/54788672-2ab29a80-4c30-11e9-8be1-433686c99d69.png)

-  Align content of tooltip info with commit info content 

Before:

![image](https://user-images.githubusercontent.com/460196/54788730-68172800-4c30-11e9-9091-95f1b4437eb0.png)

After: (labels updated to the same than the commit info and commit hash added)

![image](https://user-images.githubusercontent.com/460196/54788785-a6144c00-4c30-11e9-824c-fe84afd1f9e2.png)

Note: My only regrets here is that we can't use the translated strings here because the project `ResourceManager` that contains the translated strings has the `GitCommands` (where this code lies) as a dependency 😢 
I also wanted to display relative dates here which would have been of great added value but that's not possible for the same reason. 


After: (committer and commit date not displayed if the same than author and author date --same behavior than in commit info-- )

![image](https://user-images.githubusercontent.com/460196/54788885-03a89880-4c31-11e9-9666-7b4ad072971a.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 4aebb322d358882cdd5fcc174c9faa1583918fad
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)

