### PR TITLE
#6147 inverted diffs after refresh

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1097,7 +1097,7 @@ namespace GitUI
                 selectedObjectIds = new ObjectId[] { Module.GetCurrentCheckout() };
             }
 
-            _gridView.ToBeSelectedObjectIds = selectedObjectIds.ToHashSet();
+            _gridView.ToBeSelectedObjectIds = selectedObjectIds.ToList();
             _selectedObjectIds = null;
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6147 


## Proposed changes

- The `HashSet ToBeSelectedObjectIds` should be a `List`, because order matters.
- There is no need for `ToBeSelectedRowIndexes` to be a `ConcurrentQueue`, since we want to wait till we have all the rows to be selected and, when we have them, we select them. The list of indices can thus be stored in a `List` that includes order information.

### Before

The grid attempts to select a commit as soon as it is loaded. Consequently, rows are being selected in the order in which revisions are read, not in the order in which they had originally been selected.

### After

By waiting till all rows to be selected have been added to the grid before attempting to select them, we can select them in the correct order. With the current implementation, that's the best that can be done if we don't want to wait till all commits have been loaded before attempting to select the rows.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing. I followed the same steps as indicated in the ticket, and verified that the behavior is as expected.
  - I considered special cases, like selection of many commits, and selection of commits at both ends of the commit history. (By the way, without these changes, a selection scattered throughout the commit history, would produce a new random selection when refreshing.)

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3324.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt), which I signed in [this pull request](https://github.com/gitextensions/gitextensions/pull/6384).
