### PR TITLE
#6170 Fix PathTooLongException for files whose path is shorter than 260 characters

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -405,12 +405,7 @@ namespace GitUI.Editor
 
             long GetFileLength()
             {
-                var file = new FileInfo(fileName);
-
-                if (!file.Exists)
-                {
-                    file = new FileInfo(_fullPathResolver.Resolve(fileName));
-                }
+                var file = GetFileInfo(fileName);
 
                 if (file.Exists)
                 {
@@ -565,8 +560,7 @@ namespace GitUI.Editor
 
             async Task<string> SummariseBinaryFileAsync()
             {
-                var fullPath = Path.GetFullPath(_fullPathResolver.Resolve(fileName));
-                var fileInfo = new FileInfo(fullPath);
+                var fileInfo = GetFileInfo(fileName);
 
                 var str = new StringBuilder()
                     .AppendLine("Binary file:")
@@ -583,7 +577,7 @@ namespace GitUI.Editor
                     var displayByteCount = (int)Math.Min(fileInfo.Length, maxLength);
                     var bytes = new byte[displayByteCount];
 
-                    using (var stream = File.OpenRead(fullPath))
+                    using (var stream = File.OpenRead(fileInfo.FullName))
                     {
                         var offset = 0;
                         while (offset < displayByteCount)
@@ -608,6 +602,12 @@ namespace GitUI.Editor
 
                 return str.ToString();
             }
+        }
+
+        private FileInfo GetFileInfo(string fileName)
+        {
+            var resolvedPath = _fullPathResolver.Resolve(fileName);
+            return new FileInfo(resolvedPath);
         }
 
         public static string ToHexDump(byte[] bytes, StringBuilder str, int columnWidth = 8, int columnCount = 2)

--- a/contributors.txt
+++ b/contributors.txt
@@ -78,3 +78,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/03/04, DeadDuck, Onur Safak, onur.safak@radity.com
 2019/03/12, Carl-Hugo, Carl-Hugo Marcotte, carlhugo@gmail.com
 2019/03/20, ignacioerrico, Ignacio Errico, ignacio.errico@gmail.com
+2019/03/24, fschmied, Fabian Schmied, fabian.schmied(at)gmail.com


### PR DESCRIPTION
Fixes #6170 

## Proposed changes
- FileViewer should directly use the `IFullPathResolver` without probing a relative path first when calculating the file length, as the latter could lead to erroneous `PathTooLongExceptions`. (It already does so when summarizing binary files.)
- The `FileInfo` code in `GetFileLength` and `SummariseBinaryFileAsync` should be consolidated for symmetry.

### Before
- A `PathTooLongException` would sometimes be thrown for files whose path wasn't really longer than 260 characters. This happened when the GitExtensions process was started in some longish working directory (as done, e.g., by the VSIX) and the file viewer then combined a file's relative path (relative to the repository, that is) with that current working directory. If that path (which was usually wrong anyway) exceeded 260 characters, the exception was thrown, even though the actual file path wasn't that long.
- The `FileViewer` tried to resolve the file's path from the current working directory first before resolving it from the repository path when calculating an items length. It did not do that in other situations (e.g., when summarizing a binary file), so that behavior was inconsistent anyway.

### After
- A `PathTooLongException` is only thrown (in this specific call path) when the item's path itself exceeds 260 characters.
- The `FileViewer` no longer tries to resolve the file from the current working directory, but immediately uses the repository's path to do so.

## Test methodology <!-- How did you ensure quality? -->
- Created a repro sample that exhibited the problematic behavior, applied the fix, then manually tested that the behavior was gone.
- Also exercised the "summarize binary file" code path manually to ensure it still works.

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
