### PR TITLE
Fix blame control click hold move mouse to the right

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -372,7 +372,7 @@ namespace GitUI.Editor
             this.internalFileViewer.Location = new System.Drawing.Point(0, 40);
             this.internalFileViewer.Margin = new System.Windows.Forms.Padding(0);
             this.internalFileViewer.Name = "internalFileViewer";
-            this.internalFileViewer.ScrollPos = 0;
+            this.internalFileViewer.VScrollPosition = 0;
             this.internalFileViewer.ShowEOLMarkers = false;
             this.internalFileViewer.ShowLineNumbers = true;
             this.internalFileViewer.ShowSpaces = false;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -33,6 +33,7 @@ namespace GitUI.Editor
         private readonly TranslationString _largeFileSizeWarning = new TranslationString("This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.");
 
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
+        public event EventHandler HScrollPositionChanged;
         public event EventHandler VScrollPositionChanged;
         public event EventHandler RequestDiffView;
         public new event EventHandler TextChanged;
@@ -138,6 +139,7 @@ namespace GitUI.Editor
 
                 TextChanged?.Invoke(sender, e);
             };
+            internalFileViewer.HScrollPositionChanged += (sender, e) => HScrollPositionChanged?.Invoke(sender, e);
             internalFileViewer.VScrollPositionChanged += (sender, e) => VScrollPositionChanged?.Invoke(sender, e);
             internalFileViewer.SelectedLineChanged += (sender, e) => SelectedLineChanged?.Invoke(sender, e);
             internalFileViewer.DoubleClick += (_, args) => RequestDiffView?.Invoke(this, EventArgs.Empty);
@@ -226,6 +228,14 @@ namespace GitUI.Editor
                     }
                 }).FileAndForget();
             }
+        }
+
+        [DefaultValue(0)]
+        [Browsable(false)]
+        public int HScrollPosition
+        {
+            get => internalFileViewer.HScrollPosition;
+            set => internalFileViewer.HScrollPosition = value;
         }
 
         [DefaultValue(0)]

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -33,7 +33,7 @@ namespace GitUI.Editor
         private readonly TranslationString _largeFileSizeWarning = new TranslationString("This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.");
 
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
-        public event EventHandler ScrollPosChanged;
+        public event EventHandler VScrollPositionChanged;
         public event EventHandler RequestDiffView;
         public new event EventHandler TextChanged;
         public event EventHandler TextLoaded;
@@ -138,7 +138,7 @@ namespace GitUI.Editor
 
                 TextChanged?.Invoke(sender, e);
             };
-            internalFileViewer.ScrollPosChanged += (sender, e) => ScrollPosChanged?.Invoke(sender, e);
+            internalFileViewer.VScrollPositionChanged += (sender, e) => VScrollPositionChanged?.Invoke(sender, e);
             internalFileViewer.SelectedLineChanged += (sender, e) => SelectedLineChanged?.Invoke(sender, e);
             internalFileViewer.DoubleClick += (_, args) => RequestDiffView?.Invoke(this, EventArgs.Empty);
 
@@ -230,10 +230,10 @@ namespace GitUI.Editor
 
         [DefaultValue(0)]
         [Browsable(false)]
-        public int ScrollPos
+        public int VScrollPosition
         {
-            get => internalFileViewer.ScrollPos;
-            set => internalFileViewer.ScrollPos = value;
+            get => internalFileViewer.VScrollPosition;
+            set => internalFileViewer.VScrollPosition = value;
         }
 
         private void OnUICommandsChanged(object sender, [CanBeNull] GitUICommandsChangedEventArgs e)

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -44,7 +44,7 @@ namespace GitUI.Editor
             };
 
             TextEditor.TextChanged += (s, e) => TextChanged?.Invoke(s, e);
-            TextEditor.ActiveTextAreaControl.VScrollBar.ValueChanged += (s, e) => ScrollPosChanged?.Invoke(s, e);
+            TextEditor.ActiveTextAreaControl.VScrollBar.ValueChanged += (s, e) => OnVScrollPositionChanged(EventArgs.Empty);
             TextEditor.ActiveTextAreaControl.TextArea.KeyUp += (s, e) => KeyUp?.Invoke(s, e);
             TextEditor.ActiveTextAreaControl.TextArea.DoubleClick += (s, e) => DoubleClick?.Invoke(s, e);
             TextEditor.ActiveTextAreaControl.TextArea.MouseMove += (s, e) => MouseMove?.Invoke(s, e);
@@ -77,7 +77,7 @@ namespace GitUI.Editor
         public void Find()
         {
             _findAndReplaceForm.ShowFor(TextEditor, false);
-            ScrollPosChanged?.Invoke(this, null);
+            OnVScrollPositionChanged(EventArgs.Empty);
         }
 
         public async Task FindNextAsync(bool searchForwardOrOpenWithDifftool)
@@ -89,12 +89,12 @@ namespace GitUI.Editor
             }
 
             await _findAndReplaceForm.FindNextAsync(viaF3: true, !searchForwardOrOpenWithDifftool, "Text not found");
-            ScrollPosChanged?.Invoke(this, null);
+            OnVScrollPositionChanged(EventArgs.Empty);
         }
 
         #region IFileViewer Members
 
-        public event EventHandler ScrollPosChanged;
+        public event EventHandler VScrollPositionChanged;
         public new event EventHandler TextChanged;
 
         public string GetText()
@@ -213,7 +213,7 @@ namespace GitUI.Editor
             _diffHighlightService.AddPatchHighlighting(TextEditor.Document);
         }
 
-        public int ScrollPos
+        public int VScrollPosition
         {
             get { return TextEditor.ActiveTextAreaControl.VScrollBar?.Value ?? 0; }
             set
@@ -340,6 +340,11 @@ namespace GitUI.Editor
         public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _findAndReplaceForm.SetFileLoader(fileLoader);
+        }
+
+        private void OnVScrollPositionChanged(EventArgs e)
+        {
+            VScrollPositionChanged?.Invoke(this, e);
         }
 
         #endregion

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -44,6 +44,7 @@ namespace GitUI.Editor
             };
 
             TextEditor.TextChanged += (s, e) => TextChanged?.Invoke(s, e);
+            TextEditor.ActiveTextAreaControl.HScrollBar.ValueChanged += (s, e) => OnHScrollPositionChanged(EventArgs.Empty);
             TextEditor.ActiveTextAreaControl.VScrollBar.ValueChanged += (s, e) => OnVScrollPositionChanged(EventArgs.Empty);
             TextEditor.ActiveTextAreaControl.TextArea.KeyUp += (s, e) => KeyUp?.Invoke(s, e);
             TextEditor.ActiveTextAreaControl.TextArea.DoubleClick += (s, e) => DoubleClick?.Invoke(s, e);
@@ -94,6 +95,7 @@ namespace GitUI.Editor
 
         #region IFileViewer Members
 
+        public event EventHandler HScrollPositionChanged;
         public event EventHandler VScrollPositionChanged;
         public new event EventHandler TextChanged;
 
@@ -211,6 +213,23 @@ namespace GitUI.Editor
         public void AddPatchHighlighting()
         {
             _diffHighlightService.AddPatchHighlighting(TextEditor.Document);
+        }
+
+        public int HScrollPosition
+        {
+            get { return TextEditor.ActiveTextAreaControl.HScrollBar?.Value ?? 0; }
+            set
+            {
+                var scrollBar = TextEditor.ActiveTextAreaControl.HScrollBar;
+                if (scrollBar == null)
+                {
+                    return;
+                }
+
+                int max = scrollBar.Maximum - scrollBar.LargeChange;
+                max = Math.Max(max, scrollBar.Minimum);
+                scrollBar.Value = max > value ? value : max;
+            }
         }
 
         public int VScrollPosition
@@ -340,6 +359,11 @@ namespace GitUI.Editor
         public void SetFileLoader(GetNextFileFnc fileLoader)
         {
             _findAndReplaceForm.SetFileLoader(fileLoader);
+        }
+
+        private void OnHScrollPositionChanged(EventArgs e)
+        {
+            HScrollPositionChanged?.Invoke(this, e);
         }
 
         private void OnVScrollPositionChanged(EventArgs e)

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -22,7 +22,7 @@ namespace GitUI.Editor
         event EventHandler MouseEnter;
         event EventHandler MouseLeave;
         event EventHandler TextChanged;
-        event EventHandler ScrollPosChanged;
+        event EventHandler VScrollPositionChanged;
         event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
         event KeyEventHandler KeyDown;
         event KeyEventHandler KeyUp;
@@ -44,7 +44,7 @@ namespace GitUI.Editor
         int GetSelectionLength();
         void AddPatchHighlighting();
         Action OpenWithDifftool { get; }
-        int ScrollPos { get; set; }
+        int VScrollPosition { get; set; }
 
         bool ShowLineNumbers { get; set; }
         bool ShowEOLMarkers { get; set; }

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -22,6 +22,7 @@ namespace GitUI.Editor
         event EventHandler MouseEnter;
         event EventHandler MouseLeave;
         event EventHandler TextChanged;
+        event EventHandler HScrollPositionChanged;
         event EventHandler VScrollPositionChanged;
         event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
         event KeyEventHandler KeyDown;

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -46,6 +46,7 @@ namespace GitUI.Blame
             BlameCommitter.IsReadOnly = true;
             BlameCommitter.EnableScrollBars(false);
             BlameCommitter.ShowLineNumbers = false;
+            BlameCommitter.HScrollPositionChanged += BlameCommitter_HScrollPositionChanged;
             BlameCommitter.VScrollPositionChanged += BlameCommitter_VScrollPositionChanged;
             BlameCommitter.MouseMove += BlameCommitter_MouseMove;
             BlameCommitter.MouseLeave += BlameCommitter_MouseLeave;
@@ -219,6 +220,11 @@ namespace GitUI.Blame
 
             _lastBlameLine = newBlameLine;
             CommitInfo.Revision = Module.GetRevision(_lastBlameLine.Commit.ObjectId);
+        }
+
+        private void BlameCommitter_HScrollPositionChanged(object sender, EventArgs e)
+        {
+            BlameCommitter.HScrollPosition = 0;
         }
 
         private void BlameCommitter_VScrollPositionChanged(object sender, EventArgs e)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -46,7 +46,7 @@ namespace GitUI.Blame
             BlameCommitter.IsReadOnly = true;
             BlameCommitter.EnableScrollBars(false);
             BlameCommitter.ShowLineNumbers = false;
-            BlameCommitter.ScrollPosChanged += BlameCommitter_ScrollPosChanged;
+            BlameCommitter.VScrollPositionChanged += BlameCommitter_VScrollPositionChanged;
             BlameCommitter.MouseMove += BlameCommitter_MouseMove;
             BlameCommitter.MouseLeave += BlameCommitter_MouseLeave;
             BlameCommitter.SelectedLineChanged += SelectedLineChanged;
@@ -54,7 +54,7 @@ namespace GitUI.Blame
             BlameCommitter.EscapePressed += () => EscapePressed?.Invoke();
 
             BlameFile.IsReadOnly = true;
-            BlameFile.ScrollPosChanged += BlameFile_ScrollPosChanged;
+            BlameFile.VScrollPositionChanged += BlameFile_VScrollPositionChanged;
             BlameFile.SelectedLineChanged += SelectedLineChanged;
             BlameFile.RequestDiffView += ActiveTextAreaControlDoubleClick;
             BlameFile.MouseMove += BlameFile_MouseMove;
@@ -75,7 +75,7 @@ namespace GitUI.Blame
 
             controlToMask?.Mask();
 
-            var scrollPos = BlameFile.ScrollPos;
+            var scrollPos = BlameFile.VScrollPosition;
 
             var line = _clickedBlameLine != null && _clickedBlameLine.Commit.ObjectId == objectId
                 ? _clickedBlameLine.OriginLineNumber
@@ -221,12 +221,12 @@ namespace GitUI.Blame
             CommitInfo.Revision = Module.GetRevision(_lastBlameLine.Commit.ObjectId);
         }
 
-        private void BlameCommitter_ScrollPosChanged(object sender, EventArgs e)
+        private void BlameCommitter_VScrollPositionChanged(object sender, EventArgs e)
         {
             if (!_changingScrollPosition)
             {
                 _changingScrollPosition = true;
-                BlameFile.ScrollPos = BlameCommitter.ScrollPos;
+                BlameFile.VScrollPosition = BlameCommitter.VScrollPosition;
                 _changingScrollPosition = false;
             }
 
@@ -240,7 +240,7 @@ namespace GitUI.Blame
             }
         }
 
-        private void BlameFile_ScrollPosChanged(object sender, EventArgs e)
+        private void BlameFile_VScrollPositionChanged(object sender, EventArgs e)
         {
             if (_changingScrollPosition)
             {
@@ -248,7 +248,7 @@ namespace GitUI.Blame
             }
 
             _changingScrollPosition = true;
-            BlameCommitter.ScrollPos = BlameFile.ScrollPos;
+            BlameCommitter.VScrollPosition = BlameFile.VScrollPosition;
             _changingScrollPosition = false;
         }
 
@@ -296,7 +296,7 @@ namespace GitUI.Blame
             }
             else
             {
-                BlameFile.ScrollPos = scrollpos;
+                BlameFile.VScrollPosition = scrollpos;
             }
 
             _clickedBlameLine = null;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

As noted in https://github.com/gitextensions/gitextensions/pull/6393#issuecomment-475447254 if you "click-hold-move-mouse-to-the-right" to move to the right in
the pane to see the rest of the text, there is no way to ever move back.

The fix handles horizontal scroll for the committer and blocks the hscroll.


## Test methodology <!-- How did you ensure quality? -->

- manual tests to ensure there is no hscroll in the committer control.


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
