### PR TITLE
Improve blame contextual menu

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1852,6 +1852,12 @@
   <ItemGroup>
     <None Include="Resources\Icons\DocumentTree.png" />
     <None Include="Resources\Icons\pullRequest.png" />
+    <None Include="Resources\Icons\information.png" />
+    <None Include="Resources\Icons\RecentRepositories.png" />
+    <None Include="Resources\Icons\CopyToClipboard.png" />
+    <None Include="Resources\Icons\CommitId.png" />
+    <None Include="Resources\Icons\CommitSummary.png" />
+    <None Include="Resources\Icons\Message.png" />
     <Content Include="Translation\Czech.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -64,21 +64,18 @@ namespace GitUI.Properties {
         ///   Looks up a localized string similar to Changelog
         ///=========
         ///
-        ///### [Version 2.51.05] (2 September 2018)
+        ///### Version 3.0.2 (16 Feb 2019)
         ///
         ///#### Fixes:
-        ///* Git config log.showSignature breaks revision grid - Issue [5179]
+        ///* QuickPull&apos;s hotkey is not working - Issue [6200]
+        ///* Can&apos;t delete a repository included in the categories of the dashboard - Issue [6192]
+        ///* Fix loading of some plugins that failed - PR [6159]
+        ///* Regression: Pull Dialog Title when changing merge option - Issue [6150]
+        ///* Shell Extension Menu Pull  - Issue [6144]
+        ///* gitexe.cmd pull - always opens dialog window in do not merge, only fetch changes - Issue [6060]
         ///
-        ///#### Fixes (Mono specific):
-        ///* Settings causes crash under linux/mono - Issue [5311]
-        ///* Git Extension crashes when trying to access settings page in Ubuntu 16.04 - Issue [5187]
-        ///* Diff view options are positioned wrong, cannot be selected under linux/mono - Issue [4978]
         ///
-        ///
-        ///### [Version 2.51.04] (8 July 2018)
-        ///
-        ///#### Fixes:
-        ///* A number of changed files on Co [rest of string was truncated]&quot;;.
+        ///[6200]:https://github. [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ChangeLog {
             get {
@@ -101,11 +98,71 @@ namespace GitUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap CommitId {
+            get {
+                object obj = ResourceManager.GetObject("CommitId", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap CommitSummary {
+            get {
+                object obj = ResourceManager.GetObject("CommitSummary", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap CopyToClipboard {
+            get {
+                object obj = ResourceManager.GetObject("CopyToClipboard", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Andréj Telle, Oliver Friedrich.
         /// </summary>
         internal static string Designers {
             get {
                 return ResourceManager.GetString("Designers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap information {
+            get {
+                object obj = ResourceManager.GetObject("information", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap Message {
+            get {
+                object obj = ResourceManager.GetObject("Message", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap RecentRepositories {
+            get {
+                object obj = ResourceManager.GetObject("RecentRepositories", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
             }
         }
         

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -174,4 +174,22 @@ Jasper Chien, Arkadiy Shapkin, ferow2k, Thibault D'Archivio, australiensun, Aira
 diegoaossas, hogelog, Philippe Miossec, Michael Benz (Copro), KUNIMI Taiyoh, Victor Shih, bygreencn, mrahn80,
 Alexander Eifler, Marcelo Ghelman, ghanique, olshevskiy87</value>
   </data>
+  <data name="information" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RecentRepositories" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\RecentRepositories.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CopyToClipboard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\CopyToClipboard.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommitId" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\CommitId.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommitSummary" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\CommitSummary.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Message" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\Message.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/GitUI/UserControls/BlameControl.Designer.cs
+++ b/GitUI/UserControls/BlameControl.Designer.cs
@@ -21,10 +21,13 @@
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.BlameCommitter = new GitUI.Editor.FileViewer();
             this.contextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.copyLogMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.blamePreviousRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.copyToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.commitHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.commitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.allCommitInfoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.BlameFile = new GitUI.Editor.FileViewer();
             this.blameTooltip = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -101,20 +104,13 @@
             // contextMenu
             // 
             this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.copyLogMessageToolStripMenuItem,
-            this.toolStripSeparator1,
             this.blamePreviousRevisionToolStripMenuItem,
-            this.showChangesToolStripMenuItem});
+            this.showChangesToolStripMenuItem,
+            this.toolStripSeparator1,
+            this.copyToClipboardToolStripMenuItem});
             this.contextMenu.Name = "ContextMenu";
             this.contextMenu.Size = new System.Drawing.Size(239, 76);
             this.contextMenu.Opened += new System.EventHandler(this.contextMenu_Opened);
-            // 
-            // copyLogMessageToolStripMenuItem
-            // 
-            this.copyLogMessageToolStripMenuItem.Name = "copyLogMessageToolStripMenuItem";
-            this.copyLogMessageToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
-            this.copyLogMessageToolStripMenuItem.Text = "Copy log message to clipboard";
-            this.copyLogMessageToolStripMenuItem.Click += new System.EventHandler(this.copyLogMessageToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
@@ -123,6 +119,7 @@
             // 
             // blamePreviousRevisionToolStripMenuItem
             // 
+            this.blamePreviousRevisionToolStripMenuItem.Image = global::GitUI.Properties.Resources.RecentRepositories;
             this.blamePreviousRevisionToolStripMenuItem.Name = "blamePreviousRevisionToolStripMenuItem";
             this.blamePreviousRevisionToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
             this.blamePreviousRevisionToolStripMenuItem.Text = "Blame previous revision";
@@ -130,10 +127,46 @@
             // 
             // showChangesToolStripMenuItem
             // 
+            this.showChangesToolStripMenuItem.Image = global::GitUI.Properties.Resources.information;
             this.showChangesToolStripMenuItem.Name = "showChangesToolStripMenuItem";
             this.showChangesToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
             this.showChangesToolStripMenuItem.Text = "Show changes";
             this.showChangesToolStripMenuItem.Click += new System.EventHandler(this.showChangesToolStripMenuItem_Click);
+            // 
+            // copyToClipboardToolStripMenuItem
+            // 
+            this.copyToClipboardToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.commitHashToolStripMenuItem,
+            this.commitMessageToolStripMenuItem,
+            this.allCommitInfoToolStripMenuItem});
+            this.copyToClipboardToolStripMenuItem.Image = global::GitUI.Properties.Resources.CopyToClipboard;
+            this.copyToClipboardToolStripMenuItem.Name = "copyToClipboardToolStripMenuItem";
+            this.copyToClipboardToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
+            this.copyToClipboardToolStripMenuItem.Text = "Copy to clipboard";
+            // 
+            // commitHashToolStripMenuItem
+            // 
+            this.commitHashToolStripMenuItem.Image = global::GitUI.Properties.Resources.CommitId;
+            this.commitHashToolStripMenuItem.Name = "commitHashToolStripMenuItem";
+            this.commitHashToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.commitHashToolStripMenuItem.Text = "Commit hash";
+            this.commitHashToolStripMenuItem.Click += new System.EventHandler(this.copyCommitHashToClipboardToolStripMenuItem_Click);
+            // 
+            // commitMessageToolStripMenuItem
+            // 
+            this.commitMessageToolStripMenuItem.Image = global::GitUI.Properties.Resources.Message;
+            this.commitMessageToolStripMenuItem.Name = "commitMessageToolStripMenuItem";
+            this.commitMessageToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.commitMessageToolStripMenuItem.Text = "Commit message";
+            this.commitMessageToolStripMenuItem.Click += new System.EventHandler(this.copyLogMessageToolStripMenuItem_Click);
+            // 
+            // allCommitInfoToolStripMenuItem
+            // 
+            this.allCommitInfoToolStripMenuItem.Image = global::GitUI.Properties.Resources.CommitSummary;
+            this.allCommitInfoToolStripMenuItem.Name = "allCommitInfoToolStripMenuItem";
+            this.allCommitInfoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.allCommitInfoToolStripMenuItem.Text = "All commit info";
+            this.allCommitInfoToolStripMenuItem.Click += new System.EventHandler(this.copyAllCommitInfoToClipboardToolStripMenuItem_Click);
             // 
             // BlameFile
             // 
@@ -174,9 +207,12 @@
         private GitUI.Editor.FileViewer BlameFile;
         private System.Windows.Forms.ToolTip blameTooltip;
         private System.Windows.Forms.ContextMenuStrip contextMenu;
-        private System.Windows.Forms.ToolStripMenuItem copyLogMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem blamePreviousRevisionToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showChangesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyToClipboardToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem commitHashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem commitMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem allCommitInfoToolStripMenuItem;
     }
 }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -367,6 +367,11 @@ namespace GitUI.Blame
 
         private void copyLogMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            CopyToClipboard(c => c.Summary);
+        }
+
+        private void CopyToClipboard(Func<GitBlameCommit, string> formatter)
+        {
             var commit = GetBlameCommit();
 
             if (commit == null)
@@ -374,7 +379,17 @@ namespace GitUI.Blame
                 return;
             }
 
-            ClipboardUtil.TrySetText(commit.Summary);
+            ClipboardUtil.TrySetText(formatter(commit));
+        }
+
+        private void copyAllCommitInfoToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            CopyToClipboard(c => c.ToString());
+        }
+
+        private void copyCommitHashToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            CopyToClipboard(c => c.ObjectId.ToString());
         }
 
         private void blamePreviousRevisionToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
(Like asked in https://github.com/gitextensions/gitextensions/pull/6393#issuecomment-476001787 a new PR for the blame contextual menu improvments)

## Proposed changes

* Reorder items in contextual menu
* Add icons in contextual menu
* Add a "Copy to clipboard" menu items
* with a new copy "all commit info" entry
* with a new copy "commit hash" entry

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/460196/54866032-60aa6880-4d6f-11e9-81fc-177d90950ed5.png)

### After

![image](https://user-images.githubusercontent.com/460196/54865992-ef6ab580-4d6e-11e9-987f-f3d5544fab05.png)

