### PR TITLE
Fix fileviewer ShowLineNumbers setting that was not honored

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -394,7 +394,6 @@ namespace GitUI.Editor
             this.internalFileViewer.Name = "internalFileViewer";
             this.internalFileViewer.VScrollPosition = 0;
             this.internalFileViewer.ShowEOLMarkers = false;
-            this.internalFileViewer.ShowLineNumbers = true;
             this.internalFileViewer.ShowSpaces = false;
             this.internalFileViewer.ShowTabs = false;
             this.internalFileViewer.Size = new System.Drawing.Size(757, 518);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -191,10 +191,10 @@ namespace GitUI.Editor
             set => internalFileViewer.IsReadOnly = value;
         }
 
-        [DefaultValue(true)]
+        [DefaultValue(null)]
         [Description("If true line numbers are shown in the textarea")]
         [Category("Appearance")]
-        public bool ShowLineNumbers
+        public bool? ShowLineNumbers
         {
             get => internalFileViewer.ShowLineNumbers;
             set => internalFileViewer.ShowLineNumbers = value;

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitUI.Editor.Diff;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
@@ -104,11 +105,7 @@ namespace GitUI.Editor
             return TextEditor.Text;
         }
 
-        public bool ShowLineNumbers
-        {
-            get => TextEditor.ShowLineNumbers;
-            set => TextEditor.ShowLineNumbers = value;
-        }
+        public bool? ShowLineNumbers { get; set; }
 
         public void SetText(string text, Action openWithDifftool, bool isDiff = false)
         {
@@ -137,10 +134,27 @@ namespace GitUI.Editor
 
             // important to set after the text was changed
             // otherwise the may be rendering artifacts as noted in #5568
-            TextEditor.ShowLineNumbers = !isDiff;
+            TextEditor.ShowLineNumbers = ShowLineNumbers ?? !isDiff;
+            if (ShowLineNumbers.HasValue && !ShowLineNumbers.Value)
+            {
+                Padding = new Padding(DpiUtil.Scale(5), Padding.Top, Padding.Right, Padding.Bottom);
+            }
+
             TextEditor.Refresh();
 
             _currentViewPositionCache.Restore(isDiff);
+        }
+
+        protected override void OnPaintBackground(PaintEventArgs e)
+        {
+            if (ShowLineNumbers.HasValue && !ShowLineNumbers.Value)
+            {
+                e.Graphics.FillRectangle(SystemBrushes.Window, e.ClipRectangle);
+            }
+            else
+            {
+                base.OnPaintBackground(e);
+            }
         }
 
         public void SetHighlighting(string syntax)

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -47,7 +47,7 @@ namespace GitUI.Editor
         Action OpenWithDifftool { get; }
         int VScrollPosition { get; set; }
 
-        bool ShowLineNumbers { get; set; }
+        bool? ShowLineNumbers { get; set; }
         bool ShowEOLMarkers { get; set; }
         bool ShowSpaces { get; set; }
         bool ShowTabs { get; set; }


### PR DESCRIPTION
and thus line numbers were displayed in blame even if explicitly set to be hidden

That was the case since 456ea65d7143e1555455c44d8bd385169f2feaf4

See https://github.com/gitextensions/gitextensions/commit/456ea65d7143e1555455c44d8bd385169f2feaf4#diff-555178f3fd75ec9d4f3aebcef1f48882R128

The strategy adopted is to not set the value by default so the setting is determined by the content (actual behavior)
but if explicitly set, the value is used.

Fixes regression (surely introduced in 456ea65d7143e1555455c44d8bd385169f2feaf4 /cc @RussKie ) on blame commiter fileviewer that show the line numbers even if explicitly set to not show them.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The line numbers are displayed even if set to be hidden ( https://github.com/gitextensions/gitextensions/blob/16aea8ca2ad8b3d4bf84f0f26c1c6f71ff0684d0/GitUI/UserControls/BlameControl.cs#L48 )

![image](https://user-images.githubusercontent.com/460196/54887627-9b0e2580-4e95-11e9-99a1-5228f8729372.png)


### After

The line numbers is hidden:
![image](https://user-images.githubusercontent.com/460196/54887685-3f906780-4e96-11e9-97fe-840535fce6de.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 6a6522413da8dc6c740124fde3c614f7eb3ea38f
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)

