### PR TITLE
refactor: Rename IGitRemoteManager to IConfigFileRemoteSettingsManager

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -13,11 +13,11 @@ namespace GitCommands.ExternalLinks
 
     public sealed class ExternalLinkRevisionParser : IExternalLinkRevisionParser
     {
-        private readonly IGitRemoteManager _gitRemoteManager;
+        private readonly IConfigFileRemoteSettingsManager _remotesManager;
 
-        public ExternalLinkRevisionParser(IGitRemoteManager gitRemoteManager)
+        public ExternalLinkRevisionParser(IConfigFileRemoteSettingsManager remotesManager)
         {
-            _gitRemoteManager = gitRemoteManager;
+            _remotesManager = remotesManager;
         }
 
         public IEnumerable<ExternalLink> Parse(GitRevision revision, ExternalLinkDefinition definition)
@@ -26,14 +26,14 @@ namespace GitCommands.ExternalLinks
             return remoteMatches.SelectMany(remoteMatch => ParseRevision(revision, definition, remoteMatch));
         }
 
-        private static IEnumerable<GitRemote> GetMatchingRemotes(ExternalLinkDefinition definition, IEnumerable<GitRemote> remotes)
+        private static IEnumerable<ConfigFileRemote> GetMatchingRemotes(ExternalLinkDefinition definition, IEnumerable<ConfigFileRemote> remotes)
         {
             if (definition.UseRemotesPattern.IsNullOrWhiteSpace() || definition.UseRemotesRegex.Value == null)
             {
                 return remotes;
             }
 
-            IEnumerable<GitRemote> matchingRemotes = remotes.Where(r => definition.UseRemotesRegex.Value.IsMatch(r.Name))
+            IEnumerable<ConfigFileRemote> matchingRemotes = remotes.Where(r => definition.UseRemotesRegex.Value.IsMatch(r.Name))
                                                             .OrderBy(r => definition.UseRemotesPattern.IndexOf(r.Name, StringComparison.OrdinalIgnoreCase));
             if (definition.UseOnlyFirstRemote)
             {
@@ -55,7 +55,7 @@ namespace GitCommands.ExternalLinks
 
             var remoteUrls = new List<string>();
 
-            var remotes = _gitRemoteManager.LoadRemotes(false);
+            var remotes = _remotesManager.LoadRemotes(false);
             var matchingRemotes = GetMatchingRemotes(definition, remotes);
 
             foreach (var remote in matchingRemotes)

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -118,7 +118,7 @@
     <Compile Include="Git\Tag\TagOperationExtensions.cs" />
     <Compile Include="IDiffListSortService.cs" />
     <Compile Include="Plink.cs" />
-    <Compile Include="Remotes\GitRemoteManager.cs" />
+    <Compile Include="Remotes\ConfigFileRemoteSettingsManager.cs" />
     <Compile Include="Remotes\RepoNameExtractor.cs" />
     <Compile Include="Settings\DefaultImageType.cs" />
     <Compile Include="Submodules\DetailedSubmoduleInfo.cs" />
@@ -146,8 +146,8 @@
     <Compile Include="Git\GitTreeParser.cs" />
     <Compile Include="PathEqualityComparer.cs" />
     <Compile Include="RemoteActionResult.cs" />
-    <Compile Include="Remotes\GitRemote.cs" />
-    <Compile Include="Remotes\GitRemoteSaveResult.cs" />
+    <Compile Include="Remotes\ConfigFileRemote.cs" />
+    <Compile Include="Remotes\ConfigFileRemoteSaveResult.cs" />
     <Compile Include="Settings\BasicSettingTypes.cs" />
     <Compile Include="Settings\CommonSettingsTypes.cs" />
     <Compile Include="Settings\ConfigFileSettings.cs" />

--- a/GitCommands/Remotes/ConfigFileRemote.cs
+++ b/GitCommands/Remotes/ConfigFileRemote.cs
@@ -3,7 +3,7 @@ using GitCommands.Config;
 
 namespace GitCommands.Remotes
 {
-    public class GitRemote
+    public class ConfigFileRemote
     {
         /// <summary>
         /// Gets or sets value indicating whether the remote is enabled or not.

--- a/GitCommands/Remotes/ConfigFileRemoteSaveResult.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSaveResult.cs
@@ -1,11 +1,11 @@
 namespace GitCommands.Remotes
 {
     /// <summary>
-    /// Represents a result of <see cref="GitRemoteManager.SaveRemote"/> operation.
+    /// Represents a result of <see cref="ConfigFileRemoteSettingsManager.SaveRemote"/> operation.
     /// </summary>
-    public class GitRemoteSaveResult
+    public class ConfigFileRemoteSaveResult
     {
-        public GitRemoteSaveResult(string message, bool shouldUpdateRemote)
+        public ConfigFileRemoteSaveResult(string message, bool shouldUpdateRemote)
         {
             UserMessage = message;
             ShouldUpdateRemote = shouldUpdateRemote;

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
 
         private const string AllRemotes = "[ All ]";
 
-        private readonly IGitRemoteManager _remoteManager;
+        private readonly IConfigFileRemoteSettingsManager _remotesManager;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly string _branch;
 
@@ -127,7 +127,7 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Visible = !AppSettings.DontShowHelpImages;
             helpImageDisplayUserControl1.IsOnHoverShowImage2NoticeText = _hoverShowImageLabelText.Text;
 
-            _remoteManager = new GitRemoteManager(() => Module);
+            _remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
             _branch = Module.GetSelectedBranch();
             BindRemotesDropDown(defaultRemote);
 
@@ -195,11 +195,11 @@ namespace GitUI.CommandsDialogs
         private void BindRemotesDropDown(string selectedRemoteName)
         {
             // refresh registered git remotes
-            var remotes = _remoteManager.LoadRemotes(false);
+            var remotes = _remotesManager.LoadRemotes(false);
 
             _NO_TRANSLATE_Remotes.Sorted = false;
-            _NO_TRANSLATE_Remotes.DataSource = new[] { new GitRemote { Name = AllRemotes } }.Union(remotes).ToList();
-            _NO_TRANSLATE_Remotes.DisplayMember = nameof(GitRemote.Name);
+            _NO_TRANSLATE_Remotes.DataSource = new[] { new ConfigFileRemote { Name = AllRemotes } }.Union(remotes).ToList();
+            _NO_TRANSLATE_Remotes.DisplayMember = nameof(ConfigFileRemote.Name);
             _NO_TRANSLATE_Remotes.SelectedIndex = -1;
             _NO_TRANSLATE_Remotes.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
@@ -815,7 +815,7 @@ namespace GitUI.CommandsDialogs
 
                 if (IsPullAll())
                 {
-                    foreach (var remote in (IEnumerable<GitRemote>)_NO_TRANSLATE_Remotes.DataSource)
+                    foreach (var remote in (IEnumerable<ConfigFileRemote>)_NO_TRANSLATE_Remotes.DataSource)
                     {
                         if (!remote.Name.IsNullOrWhiteSpace() && remote.Name != AllRemotes)
                         {

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -31,13 +31,13 @@ namespace GitUI.CommandsDialogs
         private const string DeleteColumnName = "Delete";
 
         private string _currentBranchName;
-        private GitRemote _currentBranchRemote;
+        private ConfigFileRemote _currentBranchRemote;
         private bool _candidateForRebasingMergeCommit;
         private string _selectedBranch;
-        private GitRemote _selectedRemote;
+        private ConfigFileRemote _selectedRemote;
         private string _selectedRemoteBranchName;
         private IReadOnlyList<IGitRef> _gitRefs;
-        private readonly IGitRemoteManager _remoteManager;
+        private readonly IConfigFileRemoteSettingsManager _remotesManager;
 
         public bool ErrorOccurred { get; private set; }
 
@@ -116,7 +116,7 @@ namespace GitUI.CommandsDialogs
 
             // can't be set in OnLoad, because after PushAndShowDialogWhenFailed()
             // they are reset to false
-            _remoteManager = new GitRemoteManager(() => Module);
+            _remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
             Init();
 
             void Init()
@@ -140,7 +140,7 @@ namespace GitUI.CommandsDialogs
                 _currentBranchName = Module.GetSelectedBranch();
 
                 // refresh registered git remotes
-                UserGitRemotes = _remoteManager.LoadRemotes(false).ToList();
+                UserGitRemotes = _remotesManager.LoadRemotes(false).ToList();
                 BindRemotesDropDown(null);
 
                 UpdateBranchDropDown();
@@ -158,7 +158,7 @@ namespace GitUI.CommandsDialogs
         /// <summary>
         /// Gets the list of remotes configured in .git/config file.
         /// </summary>
-        private List<GitRemote> UserGitRemotes { get; set; }
+        private List<ConfigFileRemote> UserGitRemotes { get; set; }
 
         public DialogResult PushAndShowDialogWhenFailed(IWin32Window owner = null)
         {
@@ -198,7 +198,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            UserGitRemotes = _remoteManager.LoadRemotes(false).ToList();
+            UserGitRemotes = _remotesManager.LoadRemotes(false).ToList();
             BindRemotesDropDown(selectedRemoteName);
         }
 
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.TextUpdate -= RemotesUpdated;
             _NO_TRANSLATE_Remotes.Sorted = false;
             _NO_TRANSLATE_Remotes.DataSource = UserGitRemotes;
-            _NO_TRANSLATE_Remotes.DisplayMember = nameof(GitRemote.Name);
+            _NO_TRANSLATE_Remotes.DisplayMember = nameof(ConfigFileRemote.Name);
             _NO_TRANSLATE_Remotes.SelectedIndex = -1;
 
             _NO_TRANSLATE_Remotes.SelectedIndexChanged += RemotesUpdated;
@@ -293,7 +293,7 @@ namespace GitUI.CommandsDialogs
                 // If the current branch is not the default push, and not known by the remote
                 // (as far as we know since we are disconnected....)
                 if (_NO_TRANSLATE_Branch.Text != AllRefs &&
-                    RemoteBranch.Text != _remoteManager.GetDefaultPushRemote(_selectedRemote, _NO_TRANSLATE_Branch.Text) &&
+                    RemoteBranch.Text != _remotesManager.GetDefaultPushRemote(_selectedRemote, _NO_TRANSLATE_Branch.Text) &&
                     !IsBranchKnownToRemote(selectedRemoteName, RemoteBranch.Text))
                 {
                     // Ask if this is really what the user wants
@@ -726,7 +726,7 @@ namespace GitUI.CommandsDialogs
                     {
                         if (_selectedRemote != null)
                         {
-                            string defaultRemote = _remoteManager.GetDefaultPushRemote(_selectedRemote,
+                            string defaultRemote = _remotesManager.GetDefaultPushRemote(_selectedRemote,
                                 branch.Name);
                             if (!defaultRemote.IsNullOrEmpty())
                             {
@@ -795,7 +795,7 @@ namespace GitUI.CommandsDialogs
 
         private void RemotesUpdated(object sender, EventArgs e)
         {
-            _selectedRemote = _NO_TRANSLATE_Remotes.SelectedItem as GitRemote;
+            _selectedRemote = _NO_TRANSLATE_Remotes.SelectedItem as ConfigFileRemote;
             if (_selectedRemote == null)
             {
                 return;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     {
         private readonly TranslationString _noneItem =
             new TranslationString("None");
-        private IGitRemoteManager _gitRemoteManager;
+        private IConfigFileRemoteSettingsManager _remotesManager;
         private JoinableTask<object> _populateBuildServerTypeTask;
 
         public BuildServerIntegrationSettingsPage()
@@ -30,7 +30,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             base.Init(pageHost);
 
-            _gitRemoteManager = new GitRemoteManager(() => Module);
+            _remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
             _populateBuildServerTypeTask = ThreadHelper.JoinableTaskFactory.RunAsync(
                 async () =>
                 {
@@ -121,7 +121,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             if (selectedExport != null)
             {
                 var buildServerSettingsUserControl = selectedExport.Value;
-                var remoteUrls = _gitRemoteManager.LoadRemotes(false).Select(r => string.IsNullOrEmpty(r.PushUrl) ? r.Url : r.PushUrl);
+                var remoteUrls = _remotesManager.LoadRemotes(false).Select(r => string.IsNullOrEmpty(r.PushUrl) ? r.Url : r.PushUrl);
 
                 buildServerSettingsUserControl.Initialize(defaultProjectName, remoteUrls);
                 return buildServerSettingsUserControl;

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -62,7 +62,7 @@ namespace GitUI.CommitInfo
         private readonly IConfiguredLinkDefinitionsProvider _effectiveLinkDefinitionsProvider;
         private readonly IGitRevisionExternalLinksParser _gitRevisionExternalLinksParser;
         private readonly IExternalLinkRevisionParser _externalLinkRevisionParser;
-        private readonly IGitRemoteManager _gitRemoteManager;
+        private readonly IConfigFileRemoteSettingsManager _remotesManager;
         private readonly GitDescribeProvider _gitDescribeProvider;
         private readonly CancellationTokenSequence _asyncLoadCancellation = new CancellationTokenSequence();
 
@@ -106,8 +106,8 @@ namespace GitUI.CommitInfo
             _commitDataBodyRenderer = new CommitDataBodyRenderer(() => Module, _linkFactory);
             _externalLinksStorage = new ExternalLinksStorage();
             _effectiveLinkDefinitionsProvider = new ConfiguredLinkDefinitionsProvider(_externalLinksStorage);
-            _gitRemoteManager = new GitRemoteManager(() => Module);
-            _externalLinkRevisionParser = new ExternalLinkRevisionParser(_gitRemoteManager);
+            _remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
+            _externalLinkRevisionParser = new ExternalLinkRevisionParser(_remotesManager);
             _gitRevisionExternalLinksParser = new GitRevisionExternalLinksParser(_effectiveLinkDefinitionsProvider, _externalLinkRevisionParser);
             _gitDescribeProvider = new GitDescribeProvider(() => Module);
 

--- a/GitUI/UserControls/RemotesComboboxControl.cs
+++ b/GitUI/UserControls/RemotesComboboxControl.cs
@@ -41,8 +41,8 @@ namespace GitUI.UserControls
                 return;
             }
 
-            var remoteManager = new GitRemoteManager(() => Module);
-            comboBoxRemotes.DataSource = remoteManager.LoadRemotes(false).Select(x => x.Name).ToList();
+            var remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
+            comboBoxRemotes.DataSource = remotesManager.LoadRemotes(false).Select(x => x.Name).ToList();
         }
     }
 }

--- a/UnitTests/GitCommandsTests/ExternalLinks/ExternalLinkRevisionParserTests.cs
+++ b/UnitTests/GitCommandsTests/ExternalLinks/ExternalLinkRevisionParserTests.cs
@@ -18,7 +18,7 @@ namespace GitCommandsTests.ExternalLinks
     [TestFixture]
     public class ExternalLinkRevisionParserTests
     {
-        private IGitRemoteManager _remoteManager;
+        private IConfigFileRemoteSettingsManager _remotesManager;
         private ExternalLinkRevisionParser _parser;
         private ExternalLinkDefinition _linkDef;
         private GitRevision _revision;
@@ -30,10 +30,10 @@ namespace GitCommandsTests.ExternalLinks
 
             _revision = new GitRevision(ObjectId.Random());
 
-            _remoteManager = Substitute.For<IGitRemoteManager>();
-            _remoteManager.LoadRemotes(false).Returns(GetDefaultRemotes());
+            _remotesManager = Substitute.For<IConfigFileRemoteSettingsManager>();
+            _remotesManager.LoadRemotes(false).Returns(GetDefaultRemotes());
 
-            _parser = new ExternalLinkRevisionParser(_remoteManager);
+            _parser = new ExternalLinkRevisionParser(_remotesManager);
         }
 
         [Test]
@@ -109,22 +109,22 @@ namespace GitCommandsTests.ExternalLinks
             actualLinks.Should().Equal(expectedLinks);
         }
 
-        private static BindingList<GitRemote> GetDefaultRemotes()
+        private static BindingList<ConfigFileRemote> GetDefaultRemotes()
         {
-            var remotes = new BindingList<GitRemote>();
-            remotes.Add(new GitRemote
+            var remotes = new BindingList<ConfigFileRemote>();
+            remotes.Add(new ConfigFileRemote
             {
                 Name = "origin",
                 Url = "https://github.com/jbialobr/gitextensions.git"
             });
 
-            remotes.Add(new GitRemote
+            remotes.Add(new ConfigFileRemote
             {
                 Name = "upstream",
                 Url = "https://github.com/gitextensions/gitextensions.git"
             });
 
-            remotes.Add(new GitRemote
+            remotes.Add(new ConfigFileRemote
             {
                 Name = "RussKie",
                 Url = "https://github.com/russkie/gitextensions.git"

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -98,7 +98,7 @@
     <Compile Include="Patches\PatchTest.cs" />
     <Compile Include="PathEqualityComparerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Remote\GitRemoteManagerTests.cs" />
+    <Compile Include="Remote\ConfigFileRemoteSettingsManagerTests.cs" />
     <Compile Include="Submodules\SubmoduleStatusProviderTests.cs" />
     <Compile Include="DiffListSortServiceTests.cs" />
     <Compile Include="UserRepositoryHistory\Legacy\RepositoryCategoryXmlSerialiserTests.cs" />

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Remotes.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Remotes.cs
@@ -21,7 +21,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
 
         // Created once for each test
         private GitUICommands _commands;
-        private IGitRemoteManager _remotesManager;
+        private IConfigFileRemoteSettingsManager _remotesManager;
         private bool _originalShowAuthorAvatarColumn;
         private static readonly string[] RemoteNames = new[] { "remote1", "remote5", "remote3", "remote4", "remote2" };
 
@@ -55,7 +55,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             }
 
             _commands = new GitUICommands(_referenceRepository.Module);
-            _remotesManager = new GitRemoteManager(() => _referenceRepository.Module);
+            _remotesManager = new ConfigFileRemoteSettingsManager(() => _referenceRepository.Module);
         }
 
         [TearDown]


### PR DESCRIPTION
`IGitRemoteManager` only interacts with configured remotes in .gitconfig so it is renamed to `IConfigFileRemoteSettingsManager` to better reflect its nature.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
