### PR TITLE
AppVeyor plugin: Prevent crash when trying to add the same project again

### DIFF
--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -153,12 +153,15 @@ namespace AppVeyorIntegration
             foreach (var projectName in projectNames)
             {
                 var projectId = accountName.Combine("/", projectName);
-                Projects.Add(projectName, new Project
+                if (!Projects.ContainsKey(projectName))
                 {
-                    Name = projectName,
-                    Id = projectId,
-                    QueryUrl = BuildQueryUrl(projectId)
-                });
+                    Projects.Add(projectName, new Project
+                    {
+                        Name = projectName,
+                        Id = projectId,
+                        QueryUrl = BuildQueryUrl(projectId)
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
that could happens if you open a form that display CI results
quickly after starting GitExtensions (and that the plugin has not finished
to be initialized in the browse form)

# Steps to reproduce

* Open GitExtension repository (which use AppVeyor CI build)
* Very quickly , open the blame form
* Crash!

#Screenshots

##Before

![image](https://user-images.githubusercontent.com/460196/55281412-6508ef80-5334-11e9-90ed-811e836e99e2.png)

##After

No more exception.

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 6c855242d9ba489004643e717f48b0ea344f401a (Dirty)
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 96dpi (no scaling)


:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
