### PR TITLE
Updated links to git-scm.com

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -323,7 +323,7 @@ namespace GitCommands
         /// <summary>
         /// Asks git to resolve the given relativePath
         /// git special folders are located in different directories depending on the kind of repo: submodule, worktree, main
-        /// See https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-pathltpathgt
+        /// See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-pathltpathgt
         /// </summary>
         /// <param name="relativePath">A path relative to the .git directory</param>
         public string ResolveGitInternalPath(string relativePath)
@@ -350,7 +350,7 @@ namespace GitCommands
 
         /// <summary>
         /// Returns git common directory
-        /// https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-common-dir
+        /// https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-common-dir
         /// </summary>
         public string GitCommonDirectory
         {

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -60,7 +60,7 @@ namespace GitUIPluginInterfaces
         /// <summary>
         /// Asks git to resolve the given relativePath
         /// git special folders are located in different directories depending on the kind of repo: submodule, worktree, main
-        /// See https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-pathltpathgt
+        /// See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-pathltpathgt
         /// </summary>
         /// <param name="relativePath">A path relative to the .git directory</param>
         string ResolveGitInternalPath(string relativePath);


### PR DESCRIPTION
## Proposed changes

- [git-scm.com](https://www.git-scm.com) recently changed the structure of the HTML anchors in the git reference manual. These are used to link directly to specific options of git commands.
GE has a few of those links in code comments, which still linked to the correct page (i.e. git command), but no longer to the correct section (i.e. option). For example:
  - old: https://git-scm.com/docs/git-rev-parse#git-rev-parse---git-common-dir
  - new: https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-common-dir


## Test methodology <!-- How did you ensure quality? -->

- N/A. This PR changes only some URLs contained in comments. Nothing more. The code is not altered in any way.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
