### PR TITLE
Add settings to configure blame display

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1610,16 +1610,16 @@ namespace GitCommands
             set => SetInt("RepoObjectsTree.SubmodulesIndex", value);
         }
 
-        public static bool BlameDisplayCommitterFirst
+        public static bool BlameDisplayAuthorFirst
         {
-            get => GetBool("Blame.DisplayCommitterFirst", false);
-            set => SetBool("Blame.DisplayCommitterFirst", value);
+            get => GetBool("Blame.DisplayAuthorFirst", false);
+            set => SetBool("Blame.DisplayAuthorFirst", value);
         }
 
-        public static bool BlameHideCommitter
+        public static bool BlameHideAuthor
         {
-            get => GetBool("Blame.HideCommitter", false);
-            set => SetBool("Blame.HideCommitter", value);
+            get => GetBool("Blame.HideAuthor", false);
+            set => SetBool("Blame.HideAuthor", value);
         }
 
         public static bool BlameHideAuthorDate

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1640,6 +1640,12 @@ namespace GitCommands
             set => SetBool("Blame.ShowLineNumbers", value);
         }
 
+        public static bool BlameShowOriginalFilePath
+        {
+            get => GetBool("Blame.ShowOriginalFilePath", true);
+            set => SetBool("Blame.ShowOriginalFilePath", value);
+        }
+
         public static bool IsPortable()
         {
             return Properties.Settings.Default.IsPortable;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1616,22 +1616,22 @@ namespace GitCommands
             set => SetBool("Blame.DisplayAuthorFirst", value);
         }
 
-        public static bool BlameHideAuthor
+        public static bool BlameShowAuthor
         {
-            get => GetBool("Blame.HideAuthor", false);
-            set => SetBool("Blame.HideAuthor", value);
+            get => GetBool("Blame.ShowAuthor", true);
+            set => SetBool("Blame.ShowAuthor", value);
         }
 
-        public static bool BlameHideAuthorDate
+        public static bool BlameShowAuthorDate
         {
-            get => GetBool("Blame.HideAuthorDate", false);
-            set => SetBool("Blame.HideAuthorDate", value);
+            get => GetBool("Blame.ShowAuthorDate", true);
+            set => SetBool("Blame.ShowAuthorDate", value);
         }
 
-        public static bool BlameHideAuthorTime
+        public static bool BlameShowAuthorTime
         {
-            get => GetBool("Blame.HideAuthorTime", false);
-            set => SetBool("Blame.HideAuthorTime", value);
+            get => GetBool("Blame.ShowAuthorTime", true);
+            set => SetBool("Blame.ShowAuthorTime", value);
         }
 
         public static bool BlameShowLineNumbers

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1610,6 +1610,36 @@ namespace GitCommands
             set => SetInt("RepoObjectsTree.SubmodulesIndex", value);
         }
 
+        public static bool BlameDisplayCommitterFirst
+        {
+            get => GetBool("Blame.DisplayCommitterFirst", false);
+            set => SetBool("Blame.DisplayCommitterFirst", value);
+        }
+
+        public static bool BlameHideCommitter
+        {
+            get => GetBool("Blame.HideCommitter", false);
+            set => SetBool("Blame.HideCommitter", value);
+        }
+
+        public static bool BlameHideAuthorDate
+        {
+            get => GetBool("Blame.HideAuthorDate", false);
+            set => SetBool("Blame.HideAuthorDate", value);
+        }
+
+        public static bool BlameHideAuthorTime
+        {
+            get => GetBool("Blame.HideAuthorTime", false);
+            set => SetBool("Blame.HideAuthorTime", value);
+        }
+
+        public static bool BlameShowLineNumbers
+        {
+            get => GetBool("Blame.ShowLineNumbers", false);
+            set => SetBool("Blame.ShowLineNumbers", value);
+        }
+
         public static bool IsPortable()
         {
             return Properties.Settings.Default.IsPortable;

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -62,9 +62,9 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.displaySettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.displayAuthorFirstToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.hideAuthorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.hideAuthorDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.hideAuthorTimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAuthorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAuthorDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAuthorTimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showLineNumbersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -480,9 +480,9 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5,
             this.displaySettingsToolStripMenuItem,
             this.displayAuthorFirstToolStripMenuItem,
-            this.hideAuthorToolStripMenuItem,
-            this.hideAuthorDateToolStripMenuItem,
-            this.hideAuthorTimeToolStripMenuItem,
+            this.showAuthorToolStripMenuItem,
+            this.showAuthorDateToolStripMenuItem,
+            this.showAuthorTimeToolStripMenuItem,
             this.showLineNumbersToolStripMenuItem});
             this.toolStripBlameOptions.Image = global::GitUI.Properties.Images.Blame;
             this.toolStripBlameOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -538,26 +538,26 @@ namespace GitUI.CommandsDialogs
             this.displayAuthorFirstToolStripMenuItem.Text = "Display author first";
             this.displayAuthorFirstToolStripMenuItem.Click += new System.EventHandler(this.displayAuthorFirstToolStripMenuItem_Click);
             // 
-            // hideAuthorToolStripMenuItem
+            // showAuthorToolStripMenuItem
             // 
-            this.hideAuthorToolStripMenuItem.Name = "hideAuthorToolStripMenuItem";
-            this.hideAuthorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.hideAuthorToolStripMenuItem.Text = "Hide author";
-            this.hideAuthorToolStripMenuItem.Click += new System.EventHandler(this.hideAuthorToolStripMenuItem_Click);
+            this.showAuthorToolStripMenuItem.Name = "showAuthorToolStripMenuItem";
+            this.showAuthorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.showAuthorToolStripMenuItem.Text = "Show author";
+            this.showAuthorToolStripMenuItem.Click += new System.EventHandler(this.showAuthorToolStripMenuItem_Click);
             // 
-            // hideAuthorDateToolStripMenuItem
+            // showAuthorDateToolStripMenuItem
             // 
-            this.hideAuthorDateToolStripMenuItem.Name = "hideAuthorDateToolStripMenuItem";
-            this.hideAuthorDateToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.hideAuthorDateToolStripMenuItem.Text = "Hide author date";
-            this.hideAuthorDateToolStripMenuItem.Click += new System.EventHandler(this.hideAuthorDateToolStripMenuItem_Click);
+            this.showAuthorDateToolStripMenuItem.Name = "showAuthorDateToolStripMenuItem";
+            this.showAuthorDateToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.showAuthorDateToolStripMenuItem.Text = "Show author date";
+            this.showAuthorDateToolStripMenuItem.Click += new System.EventHandler(this.showAuthorDateToolStripMenuItem_Click);
             // 
-            // hideAuthorTimeToolStripMenuItem
+            // showAuthorTimeToolStripMenuItem
             // 
-            this.hideAuthorTimeToolStripMenuItem.Name = "hideAuthorTimeToolStripMenuItem";
-            this.hideAuthorTimeToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.hideAuthorTimeToolStripMenuItem.Text = "Hide author time";
-            this.hideAuthorTimeToolStripMenuItem.Click += new System.EventHandler(this.hideAuthorTimeToolStripMenuItem_Click);
+            this.showAuthorTimeToolStripMenuItem.Name = "showAuthorTimeToolStripMenuItem";
+            this.showAuthorTimeToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.showAuthorTimeToolStripMenuItem.Text = "Show author time";
+            this.showAuthorTimeToolStripMenuItem.Click += new System.EventHandler(this.showAuthorTimeToolStripMenuItem_Click);
             // 
             // showLineNumbersToolStripMenuItem
             // 
@@ -645,11 +645,11 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripMenuItem displayAuthorFirstToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem hideAuthorDateToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem hideAuthorTimeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAuthorDateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAuthorTimeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showLineNumbersToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem blameSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem displaySettingsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem hideAuthorToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAuthorToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -61,8 +61,8 @@ namespace GitUI.CommandsDialogs
             this.detectMoveAndCopyInAllFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.displaySettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.displayCommitterFirstToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.hideCommitterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.displayAuthorFirstToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideAuthorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hideAuthorDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hideAuthorTimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showLineNumbersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -479,8 +479,8 @@ namespace GitUI.CommandsDialogs
             this.detectMoveAndCopyInAllFilesToolStripMenuItem,
             this.toolStripSeparator5,
             this.displaySettingsToolStripMenuItem,
-            this.displayCommitterFirstToolStripMenuItem,
-            this.hideCommitterToolStripMenuItem,
+            this.displayAuthorFirstToolStripMenuItem,
+            this.hideAuthorToolStripMenuItem,
             this.hideAuthorDateToolStripMenuItem,
             this.hideAuthorTimeToolStripMenuItem,
             this.showLineNumbersToolStripMenuItem});
@@ -531,19 +531,19 @@ namespace GitUI.CommandsDialogs
             this.displaySettingsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
             this.displaySettingsToolStripMenuItem.Text = "Display result settings:";
             // 
-            // displayCommitterFirstToolStripMenuItem
+            // displayAuthorFirstToolStripMenuItem
             // 
-            this.displayCommitterFirstToolStripMenuItem.Name = "displayCommitterFirstToolStripMenuItem";
-            this.displayCommitterFirstToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.displayCommitterFirstToolStripMenuItem.Text = "Display committer first";
-            this.displayCommitterFirstToolStripMenuItem.Click += new System.EventHandler(this.displayCommitterFirstToolStripMenuItem_Click);
+            this.displayAuthorFirstToolStripMenuItem.Name = "displayAuthorFirstToolStripMenuItem";
+            this.displayAuthorFirstToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.displayAuthorFirstToolStripMenuItem.Text = "Display author first";
+            this.displayAuthorFirstToolStripMenuItem.Click += new System.EventHandler(this.displayAuthorFirstToolStripMenuItem_Click);
             // 
-            // hideCommitterToolStripMenuItem
+            // hideAuthorToolStripMenuItem
             // 
-            this.hideCommitterToolStripMenuItem.Name = "hideCommitterToolStripMenuItem";
-            this.hideCommitterToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.hideCommitterToolStripMenuItem.Text = "Hide committer";
-            this.hideCommitterToolStripMenuItem.Click += new System.EventHandler(this.hideCommitterToolStripMenuItem_Click);
+            this.hideAuthorToolStripMenuItem.Name = "hideAuthorToolStripMenuItem";
+            this.hideAuthorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.hideAuthorToolStripMenuItem.Text = "Hide author";
+            this.hideAuthorToolStripMenuItem.Click += new System.EventHandler(this.hideAuthorToolStripMenuItem_Click);
             // 
             // hideAuthorDateToolStripMenuItem
             // 
@@ -644,12 +644,12 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem simplifyMergesContextMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-        private System.Windows.Forms.ToolStripMenuItem displayCommitterFirstToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem displayAuthorFirstToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem hideAuthorDateToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem hideAuthorTimeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showLineNumbersToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem blameSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem displaySettingsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem hideCommitterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hideAuthorToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -66,6 +66,7 @@ namespace GitUI.CommandsDialogs
             this.showAuthorDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAuthorTimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showLineNumbersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showOriginalFilePathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -483,7 +484,8 @@ namespace GitUI.CommandsDialogs
             this.showAuthorToolStripMenuItem,
             this.showAuthorDateToolStripMenuItem,
             this.showAuthorTimeToolStripMenuItem,
-            this.showLineNumbersToolStripMenuItem});
+            this.showLineNumbersToolStripMenuItem,
+            this.showOriginalFilePathToolStripMenuItem});
             this.toolStripBlameOptions.Image = global::GitUI.Properties.Images.Blame;
             this.toolStripBlameOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripBlameOptions.Name = "toolStripBlameOptions";
@@ -565,6 +567,13 @@ namespace GitUI.CommandsDialogs
             this.showLineNumbersToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
             this.showLineNumbersToolStripMenuItem.Text = "Show line numbers";
             this.showLineNumbersToolStripMenuItem.Click += new System.EventHandler(this.showLineNumbersToolStripMenuItem_Click);
+            // 
+            // showOriginalFilePathToolStripMenuItem
+            // 
+            this.showOriginalFilePathToolStripMenuItem.Name = "showOriginalFilePathToolStripMenuItem";
+            this.showOriginalFilePathToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.showOriginalFilePathToolStripMenuItem.Text = "Show original file path";
+            this.showOriginalFilePathToolStripMenuItem.Click += new System.EventHandler(this.showOriginalFilePathToolStripMenuItem_Click);
             // 
             // FormFileHistory
             // 
@@ -651,5 +660,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem blameSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem displaySettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showAuthorToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showOriginalFilePathToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -55,9 +55,17 @@ namespace GitUI.CommandsDialogs
             this.showFullHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.simplifyMergesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripBlameOptions = new System.Windows.Forms.ToolStripDropDownButton();
+            this.blameSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ignoreWhitespaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.detectMoveAndCopyInThisFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.detectMoveAndCopyInAllFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.displaySettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.displayCommitterFirstToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideCommitterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideAuthorDateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hideAuthorTimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showLineNumbersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -116,7 +124,7 @@ namespace GitUI.CommandsDialogs
             this.simplifyMergesContextMenuItem,
             this.toolStripSeparator4});
             this.FileHistoryContextMenu.Name = "DiffContextMenu";
-            this.FileHistoryContextMenu.Size = new System.Drawing.Size(340, 248);
+            this.FileHistoryContextMenu.Size = new System.Drawing.Size(340, 226);
             this.FileHistoryContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileHistoryContextMenuOpening);
             // 
             // copyToClipboardToolStripMenuItem
@@ -465,15 +473,30 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripBlameOptions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.toolStripBlameOptions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.blameSettingsToolStripMenuItem,
             this.ignoreWhitespaceToolStripMenuItem,
             this.detectMoveAndCopyInThisFileToolStripMenuItem,
-            this.detectMoveAndCopyInAllFilesToolStripMenuItem});
+            this.detectMoveAndCopyInAllFilesToolStripMenuItem,
+            this.toolStripSeparator5,
+            this.displaySettingsToolStripMenuItem,
+            this.displayCommitterFirstToolStripMenuItem,
+            this.hideCommitterToolStripMenuItem,
+            this.hideAuthorDateToolStripMenuItem,
+            this.hideAuthorTimeToolStripMenuItem,
+            this.showLineNumbersToolStripMenuItem});
             this.toolStripBlameOptions.Image = global::GitUI.Properties.Images.Blame;
             this.toolStripBlameOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripBlameOptions.Name = "toolStripBlameOptions";
             this.toolStripBlameOptions.Size = new System.Drawing.Size(29, 22);
             this.toolStripBlameOptions.Text = "Blame options";
             this.toolStripBlameOptions.ToolTipText = "Blame options";
+            // 
+            // blameSettingsToolStripMenuItem
+            // 
+            this.blameSettingsToolStripMenuItem.Enabled = false;
+            this.blameSettingsToolStripMenuItem.Name = "blameSettingsToolStripMenuItem";
+            this.blameSettingsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.blameSettingsToolStripMenuItem.Text = "Blame settings:";
             // 
             // ignoreWhitespaceToolStripMenuItem
             // 
@@ -495,6 +518,53 @@ namespace GitUI.CommandsDialogs
             this.detectMoveAndCopyInAllFilesToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
             this.detectMoveAndCopyInAllFilesToolStripMenuItem.Text = "Detect move and copy in all files";
             this.detectMoveAndCopyInAllFilesToolStripMenuItem.Click += new System.EventHandler(this.detectMoveAndCopyInAllFilesToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator5
+            // 
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(244, 6);
+            // 
+            // displaySettingsToolStripMenuItem
+            // 
+            this.displaySettingsToolStripMenuItem.Enabled = false;
+            this.displaySettingsToolStripMenuItem.Name = "displaySettingsToolStripMenuItem";
+            this.displaySettingsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.displaySettingsToolStripMenuItem.Text = "Display result settings:";
+            // 
+            // displayCommitterFirstToolStripMenuItem
+            // 
+            this.displayCommitterFirstToolStripMenuItem.Name = "displayCommitterFirstToolStripMenuItem";
+            this.displayCommitterFirstToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.displayCommitterFirstToolStripMenuItem.Text = "Display committer first";
+            this.displayCommitterFirstToolStripMenuItem.Click += new System.EventHandler(this.displayCommitterFirstToolStripMenuItem_Click);
+            // 
+            // hideCommitterToolStripMenuItem
+            // 
+            this.hideCommitterToolStripMenuItem.Name = "hideCommitterToolStripMenuItem";
+            this.hideCommitterToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.hideCommitterToolStripMenuItem.Text = "Hide committer";
+            this.hideCommitterToolStripMenuItem.Click += new System.EventHandler(this.hideCommitterToolStripMenuItem_Click);
+            // 
+            // hideAuthorDateToolStripMenuItem
+            // 
+            this.hideAuthorDateToolStripMenuItem.Name = "hideAuthorDateToolStripMenuItem";
+            this.hideAuthorDateToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.hideAuthorDateToolStripMenuItem.Text = "Hide author date";
+            this.hideAuthorDateToolStripMenuItem.Click += new System.EventHandler(this.hideAuthorDateToolStripMenuItem_Click);
+            // 
+            // hideAuthorTimeToolStripMenuItem
+            // 
+            this.hideAuthorTimeToolStripMenuItem.Name = "hideAuthorTimeToolStripMenuItem";
+            this.hideAuthorTimeToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.hideAuthorTimeToolStripMenuItem.Text = "Hide author time";
+            this.hideAuthorTimeToolStripMenuItem.Click += new System.EventHandler(this.hideAuthorTimeToolStripMenuItem_Click);
+            // 
+            // showLineNumbersToolStripMenuItem
+            // 
+            this.showLineNumbersToolStripMenuItem.Name = "showLineNumbersToolStripMenuItem";
+            this.showLineNumbersToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.showLineNumbersToolStripMenuItem.Text = "Show line numbers";
+            this.showLineNumbersToolStripMenuItem.Click += new System.EventHandler(this.showLineNumbersToolStripMenuItem_Click);
             // 
             // FormFileHistory
             // 
@@ -573,5 +643,13 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem simplifyMergesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem simplifyMergesContextMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+        private System.Windows.Forms.ToolStripMenuItem displayCommitterFirstToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hideAuthorDateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hideAuthorTimeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showLineNumbersToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem blameSettingsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem displaySettingsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hideCommitterToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -130,8 +130,8 @@ namespace GitUI.CommandsDialogs
                 ignoreWhitespaceToolStripMenuItem.Checked = AppSettings.IgnoreWhitespaceOnBlame;
                 detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
                 detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
-                displayCommitterFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayCommitterFirst;
-                hideCommitterToolStripMenuItem.Checked = AppSettings.BlameHideCommitter;
+                displayAuthorFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayAuthorFirst;
+                hideAuthorToolStripMenuItem.Checked = AppSettings.BlameHideAuthor;
                 hideAuthorDateToolStripMenuItem.Checked = AppSettings.BlameHideAuthorDate;
                 hideAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameHideAuthorTime;
                 showLineNumbersToolStripMenuItem.Checked = AppSettings.BlameShowLineNumbers;
@@ -637,19 +637,19 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        private void displayCommitterFirstToolStripMenuItem_Click(object sender, EventArgs e)
+        private void displayAuthorFirstToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.BlameDisplayCommitterFirst = !AppSettings.BlameDisplayCommitterFirst;
-            displayCommitterFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayCommitterFirst;
+            AppSettings.BlameDisplayAuthorFirst = !AppSettings.BlameDisplayAuthorFirst;
+            displayAuthorFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayAuthorFirst;
             UpdateSelectedFileViewers(true);
         }
 
-        private void hideCommitterToolStripMenuItem_Click(object sender, EventArgs e)
+        private void hideAuthorToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.BlameHideCommitter = !AppSettings.BlameHideCommitter;
-            hideCommitterToolStripMenuItem.Checked = AppSettings.BlameHideCommitter;
+            AppSettings.BlameHideAuthor = !AppSettings.BlameHideAuthor;
+            hideAuthorToolStripMenuItem.Checked = AppSettings.BlameHideAuthor;
 
-            if (AppSettings.BlameHideCommitter)
+            if (AppSettings.BlameHideAuthor)
             {
                 hideAuthorDateToolStripMenuItem.Checked = false;
                 AppSettings.BlameHideAuthorDate = false;
@@ -667,8 +667,8 @@ namespace GitUI.CommandsDialogs
 
             if (AppSettings.BlameHideAuthorDate)
             {
-                hideCommitterToolStripMenuItem.Checked = false;
-                AppSettings.BlameHideCommitter = false;
+                hideAuthorToolStripMenuItem.Checked = false;
+                AppSettings.BlameHideAuthor = false;
             }
 
             UpdateSelectedFileViewers(true);

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -135,6 +135,7 @@ namespace GitUI.CommandsDialogs
                 showAuthorDateToolStripMenuItem.Checked = AppSettings.BlameShowAuthorDate;
                 showAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameShowAuthorTime;
                 showLineNumbersToolStripMenuItem.Checked = AppSettings.BlameShowLineNumbers;
+                showOriginalFilePathToolStripMenuItem.Checked = AppSettings.BlameShowOriginalFilePath;
             }
 
             if (filterByRevision && revision?.Guid != null)
@@ -686,6 +687,13 @@ namespace GitUI.CommandsDialogs
             AppSettings.BlameShowLineNumbers = !AppSettings.BlameShowLineNumbers;
             showLineNumbersToolStripMenuItem.Checked = AppSettings.BlameShowLineNumbers;
             Blame.UpdateShowLineNumbers();
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void showOriginalFilePathToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameShowOriginalFilePath = !AppSettings.BlameShowOriginalFilePath;
+            showOriginalFilePathToolStripMenuItem.Checked = AppSettings.BlameShowOriginalFilePath;
             UpdateSelectedFileViewers(true);
         }
     }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -130,6 +130,11 @@ namespace GitUI.CommandsDialogs
                 ignoreWhitespaceToolStripMenuItem.Checked = AppSettings.IgnoreWhitespaceOnBlame;
                 detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
                 detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
+                displayCommitterFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayCommitterFirst;
+                hideCommitterToolStripMenuItem.Checked = AppSettings.BlameHideCommitter;
+                hideAuthorDateToolStripMenuItem.Checked = AppSettings.BlameHideAuthorDate;
+                hideAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameHideAuthorTime;
+                showLineNumbersToolStripMenuItem.Checked = AppSettings.BlameShowLineNumbers;
             }
 
             if (filterByRevision && revision?.Guid != null)
@@ -631,5 +636,57 @@ namespace GitUI.CommandsDialogs
         }
 
         #endregion
+
+        private void displayCommitterFirstToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameDisplayCommitterFirst = !AppSettings.BlameDisplayCommitterFirst;
+            displayCommitterFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayCommitterFirst;
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void hideCommitterToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameHideCommitter = !AppSettings.BlameHideCommitter;
+            hideCommitterToolStripMenuItem.Checked = AppSettings.BlameHideCommitter;
+
+            if (AppSettings.BlameHideCommitter)
+            {
+                hideAuthorDateToolStripMenuItem.Checked = false;
+                AppSettings.BlameHideAuthorDate = false;
+            }
+
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void hideAuthorDateToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameHideAuthorDate = !AppSettings.BlameHideAuthorDate;
+            hideAuthorDateToolStripMenuItem.Checked = AppSettings.BlameHideAuthorDate;
+
+            hideAuthorTimeToolStripMenuItem.Enabled = !AppSettings.BlameHideAuthorDate;
+
+            if (AppSettings.BlameHideAuthorDate)
+            {
+                hideCommitterToolStripMenuItem.Checked = false;
+                AppSettings.BlameHideCommitter = false;
+            }
+
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void hideAuthorTimeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameHideAuthorTime = !AppSettings.BlameHideAuthorTime;
+            hideAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameHideAuthorTime;
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void showLineNumbersToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameShowLineNumbers = !AppSettings.BlameShowLineNumbers;
+            showLineNumbersToolStripMenuItem.Checked = AppSettings.BlameShowLineNumbers;
+            Blame.UpdateShowLineNumbers();
+            UpdateSelectedFileViewers(true);
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -131,9 +131,9 @@ namespace GitUI.CommandsDialogs
                 detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
                 detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
                 displayAuthorFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayAuthorFirst;
-                hideAuthorToolStripMenuItem.Checked = AppSettings.BlameHideAuthor;
-                hideAuthorDateToolStripMenuItem.Checked = AppSettings.BlameHideAuthorDate;
-                hideAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameHideAuthorTime;
+                showAuthorToolStripMenuItem.Checked = AppSettings.BlameShowAuthor;
+                showAuthorDateToolStripMenuItem.Checked = AppSettings.BlameShowAuthorDate;
+                showAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameShowAuthorTime;
                 showLineNumbersToolStripMenuItem.Checked = AppSettings.BlameShowLineNumbers;
             }
 
@@ -644,40 +644,40 @@ namespace GitUI.CommandsDialogs
             UpdateSelectedFileViewers(true);
         }
 
-        private void hideAuthorToolStripMenuItem_Click(object sender, EventArgs e)
+        private void showAuthorToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.BlameHideAuthor = !AppSettings.BlameHideAuthor;
-            hideAuthorToolStripMenuItem.Checked = AppSettings.BlameHideAuthor;
+            AppSettings.BlameShowAuthor = !AppSettings.BlameShowAuthor;
+            showAuthorToolStripMenuItem.Checked = AppSettings.BlameShowAuthor;
 
-            if (AppSettings.BlameHideAuthor)
+            if (!AppSettings.BlameShowAuthor)
             {
-                hideAuthorDateToolStripMenuItem.Checked = false;
-                AppSettings.BlameHideAuthorDate = false;
+                showAuthorDateToolStripMenuItem.Checked = true;
+                AppSettings.BlameShowAuthorDate = true;
             }
 
             UpdateSelectedFileViewers(true);
         }
 
-        private void hideAuthorDateToolStripMenuItem_Click(object sender, EventArgs e)
+        private void showAuthorDateToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.BlameHideAuthorDate = !AppSettings.BlameHideAuthorDate;
-            hideAuthorDateToolStripMenuItem.Checked = AppSettings.BlameHideAuthorDate;
+            AppSettings.BlameShowAuthorDate = !AppSettings.BlameShowAuthorDate;
+            showAuthorDateToolStripMenuItem.Checked = AppSettings.BlameShowAuthorDate;
 
-            hideAuthorTimeToolStripMenuItem.Enabled = !AppSettings.BlameHideAuthorDate;
+            showAuthorTimeToolStripMenuItem.Enabled = AppSettings.BlameShowAuthorDate;
 
-            if (AppSettings.BlameHideAuthorDate)
+            if (!AppSettings.BlameShowAuthorDate)
             {
-                hideAuthorToolStripMenuItem.Checked = false;
-                AppSettings.BlameHideAuthor = false;
+                showAuthorToolStripMenuItem.Checked = true;
+                AppSettings.BlameShowAuthor = true;
             }
 
             UpdateSelectedFileViewers(true);
         }
 
-        private void hideAuthorTimeToolStripMenuItem_Click(object sender, EventArgs e)
+        private void showAuthorTimeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AppSettings.BlameHideAuthorTime = !AppSettings.BlameHideAuthorTime;
-            hideAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameHideAuthorTime;
+            AppSettings.BlameShowAuthorTime = !AppSettings.BlameShowAuthorTime;
+            showAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameShowAuthorTime;
             UpdateSelectedFileViewers(true);
         }
 

--- a/GitUI/UserControls/BlameControl.Designer.cs
+++ b/GitUI/UserControls/BlameControl.Designer.cs
@@ -19,7 +19,7 @@
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.CommitInfo = new GitUI.CommitInfo.CommitInfo();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
-            this.BlameCommitter = new GitUI.Editor.FileViewer();
+            this.BlameAuthor = new GitUI.Editor.FileViewer();
             this.contextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.blamePreviousRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -80,7 +80,7 @@
             // 
             // splitContainer2.Panel1
             // 
-            this.splitContainer2.Panel1.Controls.Add(this.BlameCommitter);
+            this.splitContainer2.Panel1.Controls.Add(this.BlameAuthor);
             // 
             // splitContainer2.Panel2
             // 
@@ -91,15 +91,15 @@
             // 
             // BlameCommitter
             // 
-            this.BlameCommitter.ContextMenuStrip = this.contextMenu;
-            this.BlameCommitter.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BlameCommitter.IsReadOnly = false;
-            this.BlameCommitter.Location = new System.Drawing.Point(0, 0);
-            this.BlameCommitter.Margin = new System.Windows.Forms.Padding(0);
-            this.BlameCommitter.Name = "BlameCommitter";
-            this.BlameCommitter.Size = new System.Drawing.Size(186, 576);
-            this.BlameCommitter.TabIndex = 5;
-            this.BlameCommitter.TabStop = false;
+            this.BlameAuthor.ContextMenuStrip = this.contextMenu;
+            this.BlameAuthor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BlameAuthor.IsReadOnly = false;
+            this.BlameAuthor.Location = new System.Drawing.Point(0, 0);
+            this.BlameAuthor.Margin = new System.Windows.Forms.Padding(0);
+            this.BlameAuthor.Name = "BlameAuthor";
+            this.BlameAuthor.Size = new System.Drawing.Size(186, 576);
+            this.BlameAuthor.TabIndex = 5;
+            this.BlameAuthor.TabStop = false;
             // 
             // contextMenu
             // 
@@ -203,7 +203,7 @@
         private System.Windows.Forms.SplitContainer splitContainer1;
         private CommitInfo.CommitInfo CommitInfo;
         private System.Windows.Forms.SplitContainer splitContainer2;
-        private GitUI.Editor.FileViewer BlameCommitter;
+        private GitUI.Editor.FileViewer BlameAuthor;
         private GitUI.Editor.FileViewer BlameFile;
         private System.Windows.Forms.ToolTip blameTooltip;
         private System.Windows.Forms.ContextMenuStrip contextMenu;

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -296,7 +296,7 @@ namespace GitUI.Blame
                 }
                 else
                 {
-                    BuildAuthorLine(line);
+                    BuildAuthorLine(line, lineBuilder, dateTimeFormat, filename);
 
                     gutter.Append(lineBuilder);
                     gutter.Append(' ', lineLength - lineBuilder.Length).AppendLine();
@@ -328,38 +328,38 @@ namespace GitUI.Blame
             CommitInfo.SetRevisionWithChildren(revision, children);
 
             controlToMask?.UnMask();
+        }
 
-            void BuildAuthorLine(GitBlameLine line)
+        private void BuildAuthorLine(GitBlameLine line, StringBuilder lineBuilder, string dateTimeFormat, string filename)
+        {
+            if (!AppSettings.BlameHideAuthor && AppSettings.BlameDisplayAuthorFirst)
             {
-                if (!AppSettings.BlameHideAuthor && AppSettings.BlameDisplayAuthorFirst)
-                {
-                    lineBuilder.Append(line.Commit.Author);
-                    if (!AppSettings.BlameHideAuthorDate)
-                    {
-                        lineBuilder.Append(" - ");
-                    }
-                }
-
+                lineBuilder.Append(line.Commit.Author);
                 if (!AppSettings.BlameHideAuthorDate)
                 {
-                    lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
+                    lineBuilder.Append(" - ");
                 }
+            }
 
-                if (!AppSettings.BlameHideAuthor && !AppSettings.BlameDisplayAuthorFirst)
-                {
-                    if (!AppSettings.BlameHideAuthorDate)
-                    {
-                        lineBuilder.Append(" - ");
-                    }
+            if (!AppSettings.BlameHideAuthorDate)
+            {
+                lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
+            }
 
-                    lineBuilder.Append(line.Commit.Author);
-                }
-
-                if (filename != line.Commit.FileName)
+            if (!AppSettings.BlameHideAuthor && !AppSettings.BlameDisplayAuthorFirst)
+            {
+                if (!AppSettings.BlameHideAuthorDate)
                 {
                     lineBuilder.Append(" - ");
-                    lineBuilder.Append(line.Commit.FileName);
                 }
+
+                lineBuilder.Append(line.Commit.Author);
+            }
+
+            if (filename != line.Commit.FileName)
+            {
+                lineBuilder.Append(" - ");
+                lineBuilder.Append(line.Commit.FileName);
             }
         }
 

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -356,7 +356,7 @@ namespace GitUI.Blame
                 lineBuilder.Append(line.Commit.Author);
             }
 
-            if (filename != line.Commit.FileName)
+            if (AppSettings.BlameShowOriginalFilePath && filename != line.Commit.FileName)
             {
                 lineBuilder.Append(" - ");
                 lineBuilder.Append(line.Commit.FileName);

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -270,9 +270,9 @@ namespace GitUI.Blame
 
             GitBlameCommit lastCommit = null;
 
-            var dateTimeFormat = AppSettings.BlameHideAuthorTime
-                ? CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern
-                : CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern + " " + CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern;
+            var dateTimeFormat = AppSettings.BlameShowAuthorTime
+                ? CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern + " " + CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern
+                : CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
 
             // NOTE EOL white-space supports highlight on mouse-over.
             // Highlighting is done via text background colour.
@@ -332,23 +332,23 @@ namespace GitUI.Blame
 
         private void BuildAuthorLine(GitBlameLine line, StringBuilder lineBuilder, string dateTimeFormat, string filename)
         {
-            if (!AppSettings.BlameHideAuthor && AppSettings.BlameDisplayAuthorFirst)
+            if (AppSettings.BlameShowAuthor && AppSettings.BlameDisplayAuthorFirst)
             {
                 lineBuilder.Append(line.Commit.Author);
-                if (!AppSettings.BlameHideAuthorDate)
+                if (AppSettings.BlameShowAuthorDate)
                 {
                     lineBuilder.Append(" - ");
                 }
             }
 
-            if (!AppSettings.BlameHideAuthorDate)
+            if (AppSettings.BlameShowAuthorDate)
             {
                 lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
             }
 
-            if (!AppSettings.BlameHideAuthor && !AppSettings.BlameDisplayAuthorFirst)
+            if (AppSettings.BlameShowAuthor && !AppSettings.BlameDisplayAuthorFirst)
             {
-                if (!AppSettings.BlameHideAuthorDate)
+                if (AppSettings.BlameShowAuthorDate)
                 {
                     lineBuilder.Append(" - ");
                 }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -278,9 +278,9 @@ namespace GitUI.Blame
                 }
                 else
                 {
-                    gutter.Append(line.Commit.Author);
-                    gutter.Append(" - ");
                     gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentCulture));
+                    gutter.Append(" - ");
+                    gutter.Append(line.Commit.Author);
                     var authorLength = line.Commit.Author?.Length ?? 0;
                     if (filename != line.Commit.FileName)
                     {

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -287,43 +287,16 @@ namespace GitUI.Blame
             var lineLength = Math.Max(80, lineLengthEstimate);
             var lineBuilder = new StringBuilder(lineLength + 2);
             var gutter = new StringBuilder(capacity: lineBuilder.Capacity * _blame.Lines.Count);
+            var emptyLine = new string(' ', lineLength);
             foreach (var line in _blame.Lines)
             {
                 if (line.Commit == lastCommit)
                 {
-                    gutter.Append(' ', lineLength).AppendLine();
+                    gutter.AppendLine(emptyLine);
                 }
                 else
                 {
-                    if (!AppSettings.BlameHideCommitter && AppSettings.BlameDisplayCommitterFirst)
-                    {
-                        lineBuilder.Append(line.Commit.Author);
-                        if (!AppSettings.BlameHideAuthorDate)
-                        {
-                            lineBuilder.Append(" - ");
-                        }
-                    }
-
-                    if (!AppSettings.BlameHideAuthorDate)
-                    {
-                        lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
-                    }
-
-                    if (!AppSettings.BlameHideCommitter && !AppSettings.BlameDisplayCommitterFirst)
-                    {
-                        if (!AppSettings.BlameHideAuthorDate)
-                        {
-                            lineBuilder.Append(" - ");
-                        }
-
-                        lineBuilder.Append(line.Commit.Author);
-                    }
-
-                    if (filename != line.Commit.FileName)
-                    {
-                        lineBuilder.Append(" - ");
-                        lineBuilder.Append(line.Commit.FileName);
-                    }
+                    BuildAuthorLine(line);
 
                     gutter.Append(lineBuilder);
                     gutter.Append(' ', lineLength - lineBuilder.Length).AppendLine();
@@ -355,6 +328,39 @@ namespace GitUI.Blame
             CommitInfo.SetRevisionWithChildren(revision, children);
 
             controlToMask?.UnMask();
+
+            void BuildAuthorLine(GitBlameLine line)
+            {
+                if (!AppSettings.BlameHideCommitter && AppSettings.BlameDisplayCommitterFirst)
+                {
+                    lineBuilder.Append(line.Commit.Author);
+                    if (!AppSettings.BlameHideAuthorDate)
+                    {
+                        lineBuilder.Append(" - ");
+                    }
+                }
+
+                if (!AppSettings.BlameHideAuthorDate)
+                {
+                    lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
+                }
+
+                if (!AppSettings.BlameHideCommitter && !AppSettings.BlameDisplayCommitterFirst)
+                {
+                    if (!AppSettings.BlameHideAuthorDate)
+                    {
+                        lineBuilder.Append(" - ");
+                    }
+
+                    lineBuilder.Append(line.Commit.Author);
+                }
+
+                if (filename != line.Commit.FileName)
+                {
+                    lineBuilder.Append(" - ");
+                    lineBuilder.Append(line.Commit.FileName);
+                }
+            }
         }
 
         private void ActiveTextAreaControlDoubleClick(object sender, EventArgs e)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -44,16 +44,16 @@ namespace GitUI.Blame
             InitializeComponent();
             InitializeComplete();
 
-            BlameCommitter.IsReadOnly = true;
-            BlameCommitter.EnableScrollBars(false);
+            BlameAuthor.IsReadOnly = true;
+            BlameAuthor.EnableScrollBars(false);
             UpdateShowLineNumbers();
-            BlameCommitter.HScrollPositionChanged += BlameCommitter_HScrollPositionChanged;
-            BlameCommitter.VScrollPositionChanged += BlameCommitter_VScrollPositionChanged;
-            BlameCommitter.MouseMove += BlameCommitter_MouseMove;
-            BlameCommitter.MouseLeave += BlameCommitter_MouseLeave;
-            BlameCommitter.SelectedLineChanged += SelectedLineChanged;
-            BlameCommitter.RequestDiffView += ActiveTextAreaControlDoubleClick;
-            BlameCommitter.EscapePressed += () => EscapePressed?.Invoke();
+            BlameAuthor.HScrollPositionChanged += BlameAuthor_HScrollPositionChanged;
+            BlameAuthor.VScrollPositionChanged += BlameAuthor_VScrollPositionChanged;
+            BlameAuthor.MouseMove += BlameAuthor_MouseMove;
+            BlameAuthor.MouseLeave += BlameAuthor_MouseLeave;
+            BlameAuthor.SelectedLineChanged += SelectedLineChanged;
+            BlameAuthor.RequestDiffView += ActiveTextAreaControlDoubleClick;
+            BlameAuthor.EscapePressed += () => EscapePressed?.Invoke();
 
             BlameFile.IsReadOnly = true;
             BlameFile.VScrollPositionChanged += BlameFile_VScrollPositionChanged;
@@ -67,7 +67,7 @@ namespace GitUI.Blame
 
         public void UpdateShowLineNumbers()
         {
-            BlameCommitter.ShowLineNumbers = AppSettings.BlameShowLineNumbers;
+            BlameAuthor.ShowLineNumbers = AppSettings.BlameShowLineNumbers;
         }
 
         public void LoadBlame(GitRevision revision, [CanBeNull] IReadOnlyList<ObjectId> children, string fileName, RevisionGridControl revGrid, Control controlToMask, Encoding encoding, int? initialLine = null, bool force = false)
@@ -101,12 +101,12 @@ namespace GitUI.Blame
             CommandClick?.Invoke(sender, e);
         }
 
-        private void BlameCommitter_MouseLeave(object sender, EventArgs e)
+        private void BlameAuthor_MouseLeave(object sender, EventArgs e)
         {
             blameTooltip.Hide(this);
         }
 
-        private void BlameCommitter_MouseMove(object sender, MouseEventArgs e)
+        private void BlameAuthor_MouseMove(object sender, MouseEventArgs e)
         {
             if (!BlameFile.Focused)
             {
@@ -118,7 +118,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            var lineIndex = BlameCommitter.GetLineFromVisualPosY(e.Y);
+            var lineIndex = BlameAuthor.GetLineFromVisualPosY(e.Y);
 
             var blameCommit = lineIndex < _blame.Lines.Count
                 ? _blame.Lines[lineIndex].Commit
@@ -168,7 +168,7 @@ namespace GitUI.Blame
 
             _highlightedCommit = commit;
 
-            BlameCommitter.ClearHighlighting();
+            BlameAuthor.ClearHighlighting();
             BlameFile.ClearHighlighting();
 
             if (commit == null)
@@ -184,7 +184,7 @@ namespace GitUI.Blame
                 {
                     if (prevLine != i - 1 && startLine != -1)
                     {
-                        BlameCommitter.HighlightLines(startLine, prevLine, SystemColors.ControlLight);
+                        BlameAuthor.HighlightLines(startLine, prevLine, SystemColors.ControlLight);
                         BlameFile.HighlightLines(startLine, prevLine, SystemColors.ControlLight);
                         startLine = -1;
                     }
@@ -199,11 +199,11 @@ namespace GitUI.Blame
 
             if (startLine != -1)
             {
-                BlameCommitter.HighlightLines(startLine, prevLine, SystemColors.ControlLight);
+                BlameAuthor.HighlightLines(startLine, prevLine, SystemColors.ControlLight);
                 BlameFile.HighlightLines(startLine, prevLine, SystemColors.ControlLight);
             }
 
-            BlameCommitter.Refresh();
+            BlameAuthor.Refresh();
             BlameFile.Refresh();
         }
 
@@ -228,27 +228,27 @@ namespace GitUI.Blame
             CommitInfo.Revision = Module.GetRevision(_lastBlameLine.Commit.ObjectId);
         }
 
-        private void BlameCommitter_HScrollPositionChanged(object sender, EventArgs e)
+        private void BlameAuthor_HScrollPositionChanged(object sender, EventArgs e)
         {
-            BlameCommitter.HScrollPosition = 0;
+            BlameAuthor.HScrollPosition = 0;
         }
 
-        private void BlameCommitter_VScrollPositionChanged(object sender, EventArgs e)
+        private void BlameAuthor_VScrollPositionChanged(object sender, EventArgs e)
         {
             if (!_changingScrollPosition)
             {
                 _changingScrollPosition = true;
-                BlameFile.VScrollPosition = BlameCommitter.VScrollPosition;
+                BlameFile.VScrollPosition = BlameAuthor.VScrollPosition;
                 _changingScrollPosition = false;
             }
 
-            Rectangle rect = BlameCommitter.ClientRectangle;
-            rect = BlameCommitter.RectangleToScreen(rect);
+            Rectangle rect = BlameAuthor.ClientRectangle;
+            rect = BlameAuthor.RectangleToScreen(rect);
             if (rect.Contains(MousePosition))
             {
-                Point p = BlameCommitter.PointToClient(MousePosition);
+                Point p = BlameAuthor.PointToClient(MousePosition);
                 var me = new MouseEventArgs(0, 0, p.X, p.Y, 0);
-                BlameCommitter_MouseMove(null, me);
+                BlameAuthor_MouseMove(null, me);
             }
         }
 
@@ -260,7 +260,7 @@ namespace GitUI.Blame
             }
 
             _changingScrollPosition = true;
-            BlameCommitter.VScrollPosition = BlameFile.VScrollPosition;
+            BlameAuthor.VScrollPosition = BlameFile.VScrollPosition;
             _changingScrollPosition = false;
         }
 
@@ -309,7 +309,7 @@ namespace GitUI.Blame
             }
 
             ThreadHelper.JoinableTaskFactory.RunAsync(
-                () => BlameCommitter.ViewTextAsync("committer.txt", gutter.ToString()));
+                () => BlameAuthor.ViewTextAsync("committer.txt", gutter.ToString()));
             ThreadHelper.JoinableTaskFactory.RunAsync(
                 () => BlameFile.ViewTextAsync(_fileName, body.ToString()));
 
@@ -391,9 +391,9 @@ namespace GitUI.Blame
                 return -1;
             }
 
-            Point position = BlameCommitter.PointToClient(MousePosition);
+            Point position = BlameAuthor.PointToClient(MousePosition);
 
-            int line = BlameCommitter.GetLineFromVisualPosY(position.Y);
+            int line = BlameAuthor.GetLineFromVisualPosY(position.Y);
 
             if (line >= _blame.Lines.Count)
             {

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -331,7 +331,7 @@ namespace GitUI.Blame
 
             void BuildAuthorLine(GitBlameLine line)
             {
-                if (!AppSettings.BlameHideCommitter && AppSettings.BlameDisplayCommitterFirst)
+                if (!AppSettings.BlameHideAuthor && AppSettings.BlameDisplayAuthorFirst)
                 {
                     lineBuilder.Append(line.Commit.Author);
                     if (!AppSettings.BlameHideAuthorDate)
@@ -345,7 +345,7 @@ namespace GitUI.Blame
                     lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
                 }
 
-                if (!AppSettings.BlameHideCommitter && !AppSettings.BlameDisplayCommitterFirst)
+                if (!AppSettings.BlameHideAuthor && !AppSettings.BlameDisplayAuthorFirst)
                 {
                     if (!AppSettings.BlameHideAuthorDate)
                     {

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -278,7 +278,7 @@ namespace GitUI.Blame
                 }
                 else
                 {
-                    gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentCulture));
+                    gutter.Append(line.Commit.AuthorTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern));
                     gutter.Append(" - ");
                     gutter.Append(line.Commit.Author);
                     var authorLength = line.Commit.Author?.Length ?? 0;
@@ -286,11 +286,11 @@ namespace GitUI.Blame
                     {
                         gutter.Append(" - ");
                         gutter.Append(line.Commit.FileName);
-                        gutter.Append(' ', Math.Max(0, 95 - authorLength - line.Commit.FileName.Length)).AppendLine();
+                        gutter.Append(' ', Math.Max(0, 104 - authorLength - line.Commit.FileName.Length)).AppendLine();
                     }
                     else
                     {
-                        gutter.Append(' ', Math.Max(0, 98 - authorLength)).AppendLine();
+                        gutter.Append(' ', Math.Max(0, 107 - authorLength)).AppendLine();
                     }
                 }
 

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="ThreadHelperTests.cs" />
     <Compile Include="TranslationTest.cs" />
     <Compile Include="UITest.cs" />
+    <Compile Include="UserControls\BlameControlTests.cs" />
     <Compile Include="UserControls\AuthorRevisionHighlightingTests.cs" />
     <Compile Include="UserControls\ConsoleEmulatorOutputControlFixture.cs" />
     <Compile Include="Editor\Diff\DiffLineNumAnalyzerTests.cs" />

--- a/UnitTests/GitUITests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUITests/UserControls/BlameControlTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using FluentAssertions;
+using GitCommands;
+using GitUI;
+using GitUI.Blame;
+using GitUIPluginInterfaces;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class BlameControlTests
+    {
+        private BlameControl.TestAccessor _sut;
+        private GitBlameLine _gitBlameLine;
+
+        [SetUp]
+        public void SetUp()
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("EN-GB");
+            var blameControlTask = ThreadHelper.JoinableTaskContext.Factory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return new BlameControl();
+            });
+
+            var blameControl = blameControlTask.Join();
+            _sut = new BlameControl.TestAccessor(blameControl);
+
+            var blameCommit1 = new GitBlameCommit(
+                ObjectId.Random(),
+                "author1",
+                "author1@mail.fake",
+                new DateTime(2010, 2, 3, 12, 01, 02),
+                "authorTimeZone",
+                "committer1",
+                "committer1@authormail.com",
+                new DateTime(2010, 2, 3, 13, 01, 02),
+                "committerTimeZone",
+                "test summary commit1",
+                "fileName.txt");
+
+            var blameCommit2 = new GitBlameCommit(
+                ObjectId.Random(),
+                "author2",
+                "author2@mail.fake",
+                new DateTime(2011, 2, 3, 12, 01, 02),
+                "authorTimeZone",
+                "committer2",
+                "committer2@authormail.com",
+                new DateTime(2011, 2, 3, 13, 01, 02),
+                "committerTimeZone",
+                "test summary commit2",
+                "fileName.txt");
+
+            _gitBlameLine = new GitBlameLine(blameCommit1, 1, 1, "line1");
+            _sut.Blame = new GitBlame(new GitBlameLine[]
+            {
+                _gitBlameLine,
+                new GitBlameLine(blameCommit1, 2, 2, "line2"),
+                new GitBlameLine(blameCommit2, 3, 3, "line3"),
+                new GitBlameLine(blameCommit2, 4, 4, "line4"),
+            });
+        }
+
+        [TestCase(true, true, true, true, "author1 - 03/02/2010 - fileName.txt")]
+        [TestCase(true, true, true, false, "03/02/2010 - author1 - fileName.txt")]
+        [TestCase(false, true, true, false, "author1 - fileName.txt")]
+        [TestCase(true, false, true, false, "03/02/2010 - fileName.txt")]
+        [TestCase(true, true, false, false, "03/02/2010 - author1")]
+        public void BuildAuthorLine_When_FilePath_IsDifferent(bool showAuthorDate, bool showAuthor, bool showFilePath, bool displayAuthorFirst, string expectedResult)
+        {
+            var sut = new BlameControl.TestAccessor(new BlameControl());
+
+            var line = new StringBuilder();
+            sut.BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, "fileName_different.txt", showAuthor, showAuthorDate, showFilePath, displayAuthorFirst);
+
+            line.ToString().Should().StartWith(expectedResult);
+        }
+
+        [Test]
+        public void BuildAuthorLine_When_FilePath_Is_Identic()
+        {
+            var sut = new BlameControl.TestAccessor(new BlameControl());
+
+            var line = new StringBuilder();
+            sut.BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, "fileName.txt", true, true, true, false);
+
+            line.ToString().Should().StartWith("03/02/2010 - author1");
+        }
+
+        [Test]
+        public void BuildBlameContents_WithDateAndTime()
+        {
+            AppSettings.BlameShowAuthorTime = true;
+            var (gutter, content) = _sut.BuildBlameContents("fileName.txt");
+
+            content.Should().Be($"line1{Environment.NewLine}line2{Environment.NewLine}line3{Environment.NewLine}line4{Environment.NewLine}");
+            var gutterLines = gutter.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            gutterLines[0].TrimEnd().Should().Be("03/02/2010 12:01 - author1");
+            gutterLines[1].Should().NotBeNullOrEmpty().And.BeNullOrWhiteSpace();
+            gutterLines[2].TrimEnd().Should().Be("03/02/2011 12:01 - author2");
+            gutterLines[3].Should().NotBeNullOrEmpty().And.BeNullOrWhiteSpace();
+
+            // All the lines have the same length
+            gutterLines.Select(l => l.Length).Should().AllBeEquivalentTo(gutterLines[0].Length);
+        }
+
+        [Test]
+        public void BuildBlameContents_WithDateButNotTime()
+        {
+            // Given
+            AppSettings.BlameShowAuthorTime = false;
+
+            // When
+            var (gutter, content) = _sut.BuildBlameContents("fileName.txt");
+
+            // Then
+            content.Should().Be($"line1{Environment.NewLine}line2{Environment.NewLine}line3{Environment.NewLine}line4{Environment.NewLine}");
+            var gutterLines = gutter.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            gutterLines[0].TrimEnd().Should().Be($"03/02/2010 - author1");
+            gutterLines[1].Should().NotBeNullOrEmpty().And.BeNullOrWhiteSpace();
+            gutterLines[2].TrimEnd().Should().Be($"03/02/2011 - author2");
+            gutterLines[3].Should().NotBeNullOrEmpty().And.BeNullOrWhiteSpace();
+
+            // All the lines have the same length
+            gutterLines.Select(l => l.Length).Should().AllBeEquivalentTo(gutterLines[0].Length);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Add settings to customize blame display (see screenshot for list of settings)
- Also improve a little more memory usage when building the commiter text

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/55405110-a5958280-5559-11e9-876f-372e136ae7b7.png)

### After

![image](https://user-images.githubusercontent.com/460196/57076321-a866cd00-6ce9-11e9-9b59-aa532f5f0b99.png)

Result with some settings enabled:

![image](https://user-images.githubusercontent.com/460196/55405398-3ff5c600-555a-11e9-89db-213aecd81b9b.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual 


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 84b65c3f6542f6adb817c308906522c66c611009
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3362.0
- DPI 192dpi (200% scaling)

