### PR TITLE
Detailed submodule status in dropdown menu was not updated

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2720,12 +2720,13 @@ namespace GitUI.CommandsDialogs
             // then refresh all items at once with a single switch to the main thread
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                var loadDetalils = newItems.Select(e => e.loadDetails).Where(e => e != null);
+                var loadDetails = newItems.Select(e => e.loadDetails).Where(e => e != null);
                 var refreshActions = new List<Action>();
-                foreach (var loadFunc in loadDetalils)
+                foreach (var loadFunc in loadDetails)
                 {
                     cancelToken.ThrowIfCancellationRequested();
                     var action = await loadFunc();
+                    refreshActions.Add(action);
                 }
 
                 await this.SwitchToMainThreadAsync(cancelToken);


### PR DESCRIPTION
Regression from #6372

## Proposed changes
The submenu status in the dropdown menu was not updated after rework in #6372 
As a not released regression, this is not added to the 3.1.0 milestone

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/55675523-2fc84880-58c4-11e9-95cd-9c2afcfa7627.png)

### After

![image](https://user-images.githubusercontent.com/6248932/55675543-90f01c00-58c4-11e9-8bcc-2e8dbefddcda.png)


## Test methodology <!-- How did you ensure quality? -->
Manual test: Make a test to a submodule

## Test environment(s) <!-- Remove any that don't apply -->
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
