### PR TITLE
Separate submodule structure and status

### DIFF
--- a/GitCommands/Submodules/SubmoduleInfo.cs
+++ b/GitCommands/Submodules/SubmoduleInfo.cs
@@ -17,7 +17,7 @@ namespace GitCommands.Submodules
         /// </summary>
         public string Path { get; set; }
 
-        public AsyncLazy<DetailedSubmoduleInfo> Detailed { get; set; }
+        public DetailedSubmoduleInfo Detailed { get; set; }
         public bool Bold { get; set; }
     }
 }

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -18,16 +18,30 @@ namespace GitCommands.Submodules
         event EventHandler StatusUpdating;
         event EventHandler<SubmoduleStatusEventArgs> StatusUpdated;
         void Init();
-        bool HasChangedToNone([CanBeNull] IReadOnlyList<GitItemStatus> allChangedFiles);
-        bool HasStatusChanges([CanBeNull] IReadOnlyList<GitItemStatus> allChangedFiles);
-        void UpdateSubmodulesStatus(bool updateStatus, string workingDirectory, string noBranchText);
+
+        /// <summary>
+        /// Update the submodule structure; find superprojects and submodules
+        /// </summary>
+        /// <param name="workingDirectory">Current module working directory</param>
+        /// <param name="noBranchText">The text where no branch is checked out for the submodule</param>
+        /// <param name="updateStatus">Update the detailed submodule status (set when current module is not top project)</param>
+        void UpdateSubmodulesStructure(string workingDirectory, string noBranchText, bool updateStatus);
+
+        /// <summary>
+        /// Update the submodule status
+        /// </summary>
+        /// <param name="workingDirectory">Current module working directory</param>
+        /// <param name="gitStatus">The Git status for the changes (also other than submodules)</param>
+        void UpdateSubmodulesStatus(string workingDirectory, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus);
     }
 
     public sealed class SubmoduleStatusProvider : ISubmoduleStatusProvider
     {
         private readonly CancellationTokenSequence _submodulesStatusSequence = new CancellationTokenSequence();
         private DateTime _previousSubmoduleUpdateTime;
-        private bool _previousSubmoduleHadChanges;
+        private SubmoduleInfoResult _submoduleInfoResult;
+        private readonly Dictionary<string, SubmoduleInfo> _submoduleInfos = new Dictionary<string, SubmoduleInfo>();
+        private IReadOnlyList<GitItemStatus> _gitStatusWhileUpdatingStructure;
 
         // Singleton accessor
         public static SubmoduleStatusProvider Default { get; } = new SubmoduleStatusProvider();
@@ -46,76 +60,100 @@ namespace GitCommands.Submodules
         public void Init()
         {
             // Cancel any previous async activities:
-            var cancelToken = _submodulesStatusSequence.Next();
-            _previousSubmoduleHadChanges = false;
+            _submodulesStatusSequence.Next();
         }
 
-        public bool HasChangedToNone([CanBeNull] IReadOnlyList<GitItemStatus> allChangedFiles)
+        /// <inheritdoc />
+        public void UpdateSubmodulesStructure(string workingDirectory, string noBranchText, bool updateStatus)
         {
-            if (allChangedFiles == null)
-            {
-                return false;
-            }
-
-            bool anyUpdate = allChangedFiles.Any(i => i.IsSubmodule && (i.IsChanged || !i.IsTracked));
-
-            // If status is changed to none, the status must be cleared
-            bool result = _previousSubmoduleHadChanges && !anyUpdate;
-            _previousSubmoduleHadChanges = anyUpdate;
-            return result;
-        }
-
-        public bool HasStatusChanges([CanBeNull] IReadOnlyList<GitItemStatus> allChangedFiles)
-        {
-            TimeSpan elapsed = DateTime.Now - _previousSubmoduleUpdateTime;
-
-            // Throttle updates triggered from status updates
-            if (allChangedFiles == null || elapsed.TotalSeconds <= 15)
-            {
-                return false;
-            }
-
-            // If any submodules are changed, trigger an update
-            // TBD: This should check the status against last updated list and only update the required modules
-            // (maybe even ignore count)
-            return allChangedFiles.Any(i => i.IsSubmodule && (i.IsChanged || !i.IsTracked));
-        }
-
-        public void UpdateSubmodulesStatus(bool updateStatus, string workingDirectory, string noBranchText)
-        {
+            _submoduleInfoResult = null;
+            _gitStatusWhileUpdatingStructure = null;
+            _submoduleInfos.Clear();
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 // Cancel any previous async activities:
                 var cancelToken = _submodulesStatusSequence.Next();
 
-                // If not updating the status, allow a 'quick' update
-                _previousSubmoduleUpdateTime = updateStatus ? DateTime.Now : DateTime.MinValue;
+                // Do not throttle next status update
+                _previousSubmoduleUpdateTime = DateTime.MinValue;
 
                 OnStatusUpdating();
 
                 await TaskScheduler.Default;
 
-                // Start gathering new submodule information asynchronously.  This makes a significant difference in UI
-                // responsiveness if there are numerous submodules (e.g. > 100).
-                // First task: Gather list of submodules on a background thread.
-
-                // Don't access Module directly because it's not thread-safe.  Use a thread-local version:
-                var threadModule = new GitModule(workingDirectory);
+                // Start gathering new submodule structure asynchronously.
+                var currentModule = new GitModule(workingDirectory);
                 var result = new SubmoduleInfoResult
                 {
-                    Module = threadModule
+                    Module = currentModule
                 };
 
                 // Add all submodules inside the current repository:
-                var submodulesTask = GetRepositorySubmodulesStatusAsync(updateStatus, result, threadModule, cancelToken, noBranchText);
+                GetRepositorySubmodulesStructure(result, noBranchText);
+                GetSuperProjectRepositorySubmodulesStructure(currentModule, result, noBranchText);
 
-                var superTask = GetSuperProjectRepositorySubmodulesStatusAsync(updateStatus, result, threadModule, cancelToken, noBranchText);
-
-                await Task.WhenAll(submodulesTask, superTask);
-
+                // Structure is updated
                 OnStatusUpdated(result, cancelToken);
 
-                _previousSubmoduleUpdateTime = updateStatus ? DateTime.Now : DateTime.MinValue;
+                // Prepare info for status updates (normally triggered by StatusMonitor)
+                foreach (var info in result.OurSubmodules)
+                {
+                    _submoduleInfos[info.Path] = info;
+                }
+
+                foreach (var info in result.SuperSubmodules)
+                {
+                    _submoduleInfos[info.Path] = info;
+                }
+
+                // Start update status for the submodules
+                if (updateStatus)
+                {
+                    if (result.SuperProject != null)
+                    {
+                        // Update from top module (will stop at current)
+                        await GetSubmoduleDetailedStatusAsync(currentModule.GetTopModule(), cancelToken);
+                    }
+
+                    if (_gitStatusWhileUpdatingStructure != null)
+                    {
+                        // Current module must be updated separetly (not in _submoduleInfos)
+                        await UpdateSubmodulesStatusAsync(currentModule, _gitStatusWhileUpdatingStructure, cancelToken);
+                    }
+
+                    OnStatusUpdated(result, cancelToken);
+                }
+
+                _submoduleInfoResult = result;
+            }).FileAndForget();
+        }
+
+        /// <inheritdoc />
+        public void UpdateSubmodulesStatus(string workingDirectory, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus)
+        {
+            if (_submoduleInfoResult == null)
+            {
+                _gitStatusWhileUpdatingStructure = gitStatus;
+                return;
+            }
+
+            // Throttle updates triggered from status updates
+            TimeSpan elapsed = DateTime.Now - _previousSubmoduleUpdateTime;
+            if (gitStatus == null || elapsed.TotalSeconds <= 15)
+            {
+                return;
+            }
+
+            var cancelToken = _submodulesStatusSequence.Next();
+            _gitStatusWhileUpdatingStructure = null;
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await TaskScheduler.Default;
+
+                var currentModule = new GitModule(workingDirectory);
+                await UpdateSubmodulesStatusAsync(currentModule, gitStatus, cancelToken);
+
+                OnStatusUpdated(_submoduleInfoResult, cancelToken);
             }).FileAndForget();
         }
 
@@ -130,15 +168,12 @@ namespace GitCommands.Submodules
             StatusUpdated?.Invoke(this, new SubmoduleStatusEventArgs(info, token));
         }
 
-        private async Task GetRepositorySubmodulesStatusAsync(bool updateStatus, SubmoduleInfoResult result, IGitModule module, CancellationToken cancelToken, string noBranchText)
+        private void GetRepositorySubmodulesStructure(SubmoduleInfoResult result, string noBranchText)
         {
-            await TaskScheduler.Default;
-
-            foreach (var submodule in module.GetSubmodulesLocalPaths().OrderBy(submoduleName => submoduleName))
+            foreach (var submodule in result.Module.GetSubmodulesLocalPaths().OrderBy(submoduleName => submoduleName))
             {
-                cancelToken.ThrowIfCancellationRequested();
                 var name = submodule;
-                string path = module.GetSubmoduleFullPath(submodule);
+                string path = result.Module.GetSubmoduleFullPath(submodule);
                 if (AppSettings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(path))
                 {
                     name = name + " " + GetModuleBranch(path, noBranchText);
@@ -146,80 +181,40 @@ namespace GitCommands.Submodules
 
                 var smi = new SubmoduleInfo { Text = name, Path = path };
                 result.OurSubmodules.Add(smi);
-                GetSubmoduleStatus(updateStatus, smi, cancelToken);
             }
         }
 
-        private void GetSubmoduleStatus(bool updateStatus, SubmoduleInfo info, CancellationToken cancelToken)
+        /// <summary>
+        /// This function always at least sets result.TopProject
+        /// </summary>
+        /// <param name="result">submodule info</param>
+        /// <param name="noBranchText">text with no branches</param>
+        private void GetSuperProjectRepositorySubmodulesStructure(GitModule currentModule, SubmoduleInfoResult result, string noBranchText)
         {
-            if (!updateStatus)
-            {
-                return;
-            }
-
-            cancelToken.ThrowIfCancellationRequested();
-
-            var submodule = new GitModule(info.Path);
-            var supermodule = submodule.SuperprojectModule;
-            var submoduleName = submodule.GetCurrentSubmoduleLocalPath();
-
-            if (string.IsNullOrEmpty(submoduleName) || supermodule == null)
-            {
-                return;
-            }
-
-            info.Detailed = new AsyncLazy<DetailedSubmoduleInfo>(async () =>
-            {
-                cancelToken.ThrowIfCancellationRequested();
-
-                var submoduleStatus = await GitCommandHelpers.GetCurrentSubmoduleChangesAsync(supermodule, submoduleName, noLocks: true).ConfigureAwait(false);
-                if (submoduleStatus != null && submoduleStatus.Commit != submoduleStatus.OldCommit)
-                {
-                    submoduleStatus.CheckSubmoduleStatus(submoduleStatus.GetSubmodule(supermodule));
-                }
-
-                if (submoduleStatus != null)
-                {
-                    return new DetailedSubmoduleInfo()
-                    {
-                        Status = submoduleStatus.Status,
-                        IsDirty = submoduleStatus.IsDirty,
-                        AddedAndRemovedText = submoduleStatus.AddedAndRemovedString()
-                    };
-                }
-
-                return null;
-            }, ThreadHelper.JoinableTaskFactory);
-        }
-
-        private async Task GetSuperProjectRepositorySubmodulesStatusAsync(bool updateStatus, SubmoduleInfoResult result, GitModule module, CancellationToken cancelToken, string noBranchText)
-        {
-            // This function always at least sets result.TopProject
-
-            bool isCurrentTopProject = module.SuperprojectModule == null;
+            bool isCurrentTopProject = currentModule.SuperprojectModule == null;
             if (isCurrentTopProject)
             {
-                string path = module.WorkingDir;
-                string name = Path.GetFileName(Path.GetDirectoryName(module.WorkingDir)) + GetBranchNameSuffix(path, noBranchText);
-                result.TopProject = new SubmoduleInfo { Text = name, Path = module.WorkingDir, Bold = true };
+                string path = result.Module.WorkingDir;
+                string name = Path.GetFileName(Path.GetDirectoryName(result.Module.WorkingDir)) + GetBranchNameSuffix(path, noBranchText);
+                result.TopProject = new SubmoduleInfo { Text = name, Path = result.Module.WorkingDir, Bold = true };
                 return;
             }
 
-            IGitModule topProject = module.SuperprojectModule.GetTopModule();
+            IGitModule topProject = currentModule.SuperprojectModule.GetTopModule();
 
-            bool isParentTopProject = module.SuperprojectModule.WorkingDir == topProject.WorkingDir;
+            bool isParentTopProject = currentModule.SuperprojectModule.WorkingDir == topProject.WorkingDir;
 
             // Set result.SuperProject
-            SetSuperProjectSubmoduleInfo(updateStatus, result, module, cancelToken, noBranchText, topProject, isParentTopProject);
+            SetSuperProjectSubmoduleInfo(currentModule.SuperprojectModule, result, noBranchText, topProject, isParentTopProject);
 
             // Set result.TopProject
-            await SetTopProjectSubmoduleInfoAsync(updateStatus, result, module, cancelToken, noBranchText, topProject, isParentTopProject);
+            SetTopProjectSubmoduleInfo(result, noBranchText, topProject, isParentTopProject);
 
             // Set result.CurrentSubmoduleName and populate result.SuperSubmodules
-            await SetSubmoduleDataAsync(updateStatus, result, module, cancelToken, noBranchText, topProject);
+            SetSubmoduleData(currentModule, result, noBranchText, topProject);
         }
 
-        private void SetSuperProjectSubmoduleInfo(bool updateStatus, SubmoduleInfoResult result, GitModule module, CancellationToken cancelToken, string noBranchText, IGitModule topProject, bool isParentTopProject)
+        private void SetSuperProjectSubmoduleInfo(GitModule superprojectModule, SubmoduleInfoResult result, string noBranchText, IGitModule topProject, bool isParentTopProject)
         {
             string name;
             if (isParentTopProject)
@@ -228,21 +223,18 @@ namespace GitCommands.Submodules
             }
             else
             {
-                var localPath = module.SuperprojectModule.WorkingDir.Substring(topProject.WorkingDir.Length);
+                var localPath = superprojectModule.WorkingDir.Substring(topProject.WorkingDir.Length);
                 localPath = PathUtil.GetDirectoryName(localPath.ToPosixPath());
                 name = localPath;
             }
 
-            string path = module.SuperprojectModule.WorkingDir;
+            string path = superprojectModule.WorkingDir;
             name += GetBranchNameSuffix(path, noBranchText);
-            result.SuperProject = new SubmoduleInfo { Text = name, Path = module.SuperprojectModule.WorkingDir };
-            GetSubmoduleStatus(updateStatus, result.SuperProject, cancelToken);
+            result.SuperProject = new SubmoduleInfo { Text = name, Path = superprojectModule.WorkingDir };
         }
 
-        private async Task SetTopProjectSubmoduleInfoAsync(bool updateStatus, SubmoduleInfoResult result, GitModule module, CancellationToken cancelToken, string noBranchText, IGitModule topProject, bool isParentTopProject)
+        private void SetTopProjectSubmoduleInfo(SubmoduleInfoResult result, string noBranchText, IGitModule topProject, bool isParentTopProject)
         {
-            await TaskScheduler.Default;
-
             if (isParentTopProject)
             {
                 result.TopProject = result.SuperProject;
@@ -252,36 +244,31 @@ namespace GitCommands.Submodules
                 string path = topProject.WorkingDir;
                 string name = Path.GetFileName(Path.GetDirectoryName(topProject.WorkingDir)) + GetBranchNameSuffix(path, noBranchText);
                 result.TopProject = new SubmoduleInfo { Text = name, Path = topProject.WorkingDir };
-                GetSubmoduleStatus(updateStatus, result.TopProject, cancelToken);
             }
         }
 
-        private async Task SetSubmoduleDataAsync(bool updateStatus, SubmoduleInfoResult result, GitModule module, CancellationToken cancelToken, string noBranchText, IGitModule topProject)
+        private void SetSubmoduleData(GitModule currentModule, SubmoduleInfoResult result, string noBranchText, IGitModule topProject)
         {
-            await TaskScheduler.Default;
-
             var submodules = topProject.GetSubmodulesLocalPaths().OrderBy(submoduleName => submoduleName).ToArray();
             if (submodules.Any())
             {
-                string localPath = module.WorkingDir.Substring(topProject.WorkingDir.Length);
+                string localPath = result.Module.WorkingDir.Substring(topProject.WorkingDir.Length);
                 localPath = PathUtil.GetDirectoryName(localPath.ToPosixPath());
 
                 foreach (var submodule in submodules)
                 {
-                    cancelToken.ThrowIfCancellationRequested();
                     string path = topProject.GetSubmoduleFullPath(submodule);
                     string name = submodule + GetBranchNameSuffix(path, noBranchText);
 
                     bool bold = false;
                     if (submodule == localPath)
                     {
-                        result.CurrentSubmoduleName = module.GetCurrentSubmoduleLocalPath();
+                        result.CurrentSubmoduleName = currentModule.GetCurrentSubmoduleLocalPath();
                         bold = true;
                     }
 
                     var smi = new SubmoduleInfo { Text = name, Path = path, Bold = bold };
                     result.SuperSubmodules.Add(smi);
-                    GetSubmoduleStatus(updateStatus, smi, cancelToken);
                 }
             }
         }
@@ -301,6 +288,121 @@ namespace GitCommands.Submodules
             var branch = GitModule.GetSelectedBranchFast(path);
             var text = DetachedHeadParser.IsDetachedHead(branch) ? noBranchText : branch;
             return $"[{text}]";
+        }
+
+        /// <summary>
+        /// Update the detailed status from the git status
+        /// </summary>
+        /// <param name="module">Current module</param>
+        /// <param name="gitStatus">git status</param>
+        /// <param name="cancelToken">Cancellation token</param>
+        /// <returns>The task</returns>
+        private async Task UpdateSubmodulesStatusAsync(GitModule module, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus, CancellationToken cancelToken)
+        {
+            _previousSubmoduleUpdateTime = DateTime.Now;
+            await TaskScheduler.Default;
+
+            var changedSubmodules = gitStatus.Where(i => i.IsSubmodule);
+            foreach (var submoduleName in module.GetSubmodulesLocalPaths(false).Where(s => !changedSubmodules.Any(i => i.Name == s)))
+            {
+                SetSubmoduleEmptyDetailedStatus(module, submoduleName);
+            }
+
+            foreach (var submoduleName in changedSubmodules)
+            {
+                cancelToken.ThrowIfCancellationRequested();
+
+                await GetSubmoduleDetailedStatusAsync(module, submoduleName.Name, cancelToken);
+            }
+        }
+
+        /// <summary>
+        /// Get the detailed submodule status submodules below 'module' (but not this module)
+        /// </summary>
+        /// <param name="module">Module to compare to</param>
+        /// <param name="cancelToken">Cancelation token</param>
+        /// <returns>The task</returns>
+        private async Task GetSubmoduleDetailedStatusAsync(GitModule module, CancellationToken cancelToken)
+        {
+            foreach (var name in module.GetSubmodulesLocalPaths(false))
+            {
+                cancelToken.ThrowIfCancellationRequested();
+
+                await GetSubmoduleDetailedStatusAsync(module, name, cancelToken);
+            }
+        }
+
+        /// <summary>
+        /// Get the detailed submodule status for 'submoduleName' and below
+        /// </summary>
+        /// <param name="superModule">Module to compare to</param>
+        /// <param name="submoduleName">Name of the submodule</param>
+        /// <param name="cancelToken">Cancelation token</param>
+        /// <returns>the task</returns>
+        private async Task GetSubmoduleDetailedStatusAsync(GitModule superModule, string submoduleName, CancellationToken cancelToken)
+        {
+            if (superModule == null || submoduleName.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var path = superModule.GetSubmoduleFullPath(submoduleName);
+            if (!_submoduleInfos.ContainsKey(path) || _submoduleInfos[path] == null)
+            {
+                return;
+            }
+
+            var info = _submoduleInfos[path];
+            cancelToken.ThrowIfCancellationRequested();
+
+            var submoduleStatus = await GitCommandHelpers.GetCurrentSubmoduleChangesAsync(superModule, submoduleName, noLocks: true)
+            .ConfigureAwait(false);
+            if (submoduleStatus != null && submoduleStatus.Commit != submoduleStatus.OldCommit)
+            {
+                submoduleStatus.CheckSubmoduleStatus(submoduleStatus.GetSubmodule(superModule));
+            }
+
+            info.Detailed = submoduleStatus == null ?
+                null :
+                new DetailedSubmoduleInfo()
+                {
+                    Status = submoduleStatus.Status,
+                    IsDirty = submoduleStatus.IsDirty,
+                    AddedAndRemovedText = submoduleStatus.AddedAndRemovedString()
+                };
+
+            // Recursively update submodules
+            var module = new GitModule(path);
+            await GetSubmoduleDetailedStatusAsync(module, cancelToken);
+        }
+
+        /// <summary>
+        /// Set empty submodule status for 'submoduleName' and below
+        /// </summary>
+        /// <param name="superModule">The module to compare to</param>
+        /// <param name="submoduleName">Name of the submodule</param>
+        private void SetSubmoduleEmptyDetailedStatus(GitModule superModule, string submoduleName)
+        {
+            if (superModule == null || string.IsNullOrEmpty(submoduleName))
+            {
+                return;
+            }
+
+            string path = superModule.GetSubmoduleFullPath(submoduleName);
+            if (!_submoduleInfos.ContainsKey(path) || _submoduleInfos[path] == null)
+            {
+                return;
+            }
+
+            // null is default status
+            var info = _submoduleInfos[path];
+            info.Detailed = null;
+
+            var module = new GitModule(path);
+            foreach (var name in module.GetSubmodulesLocalPaths(false))
+            {
+                SetSubmoduleEmptyDetailedStatus(module, name);
+            }
         }
     }
 }

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using GitCommands;
 using GitCommands.Submodules;
@@ -8,15 +9,15 @@ namespace CommonTestUtils
 {
     public class SubmoduleTestHelpers
     {
-        public static SubmoduleInfoResult UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        public static SubmoduleInfoResult UpdateSubmoduleStructureAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
         {
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStatus(
-                updateStatus: updateStatus,
+            provider.UpdateSubmodulesStructure(
                 workingDirectory: module.WorkingDir,
-                noBranchText: string.Empty);
+                noBranchText: string.Empty,
+                updateStatus: updateStatus);
 
             AsyncTestHelper.WaitForPendingOperations();
 
@@ -27,6 +28,26 @@ namespace CommonTestUtils
             void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
             {
                 result = e.Info;
+            }
+        }
+
+        public static void UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
+        {
+            List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
+            provider.StatusUpdated += Provider_StatusUpdated;
+
+            provider.UpdateSubmodulesStatus(
+                workingDirectory: module.WorkingDir,
+                gitStatus: gitStatus);
+
+            AsyncTestHelper.WaitForPendingOperations();
+
+            provider.StatusUpdated -= Provider_StatusUpdated;
+
+            return;
+
+            void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
+            {
             }
         }
     }

--- a/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/CommitDialog/FormBrowseTests.LeftPanel.Submodules.cs
@@ -89,7 +89,7 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 form =>
                 {
                     // act
-                    SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, _repo1Module);
+                    SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
 
                     // assert
                     var submodulesNode = GetSubmoduleNode(form);


### PR DESCRIPTION
Part of #5769
(closes the issue with #6373 that may be dropped)

## Proposed changes
Submodule structure is separated from detailed status
Previously, the structure was always recalculated when status was updated
Also, the status is only calculated for the submodule trees where
git-status has detected changes.

This has simplified the code as well decreased the time before the
detailed status is displayed. The status was also flashing for several
seconds while updating (occurred regularly if any submodule had a change).

The normal use case with submodules is that most changes are done in the top project and that there are no or few changes in submodules.
#5777 (3.1.0) changed to only get the detailed status if there were any changes in submodules so the no-change scenario is handled already in master.
However, a change to any submodule would still require the status for all submodules.
Before #6372 this handling could hang the UI.
In addition to quicker update, the cpu load decreases with this PR. 

For a tree like below, previously was 5+8x6 git-diff commands required, with the update 1+2x6 (this is still an example where there are many dirty submodule trees).
This could of course be further improved by git-status on "dirty" levels, but the cost will likely be larger than the benefit (and complexity be increased).

![image](https://user-images.githubusercontent.com/6248932/55676420-4fb43800-58d5-11e9-96b3-1110f016e3bf.png)

Open:
 * Maybe update the test for submodule status handling (no such test existed before)
 * ~~AsyncLazy is not really needed, the status is serialized anyway~~

## Screenshots 
No change to the UI

## Test methodology
Test by making changes to submodules on several levels.
See #6357 for hints how to set this up
Check the Git Command log for expected commands

## Test environment(s)
See #6357 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
