### PR TITLE
Update NBug

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -40,6 +40,13 @@ namespace GitExtensions
                 NBug.Settings.StopReportingAfter = 90;
                 NBug.Settings.SleepBeforeSend = 30;
                 NBug.Settings.StoragePath = NBug.Enums.StoragePath.WindowsTemp;
+                NBug.Settings.GetSystemInfo = () =>
+                {
+                    // if the error happens before we had a chance to init the environment information
+                    // the call to GetInformation() will fail. A double Initialise() call is safe.
+                    UserEnvironmentInformation.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty);
+                    return UserEnvironmentInformation.GetInformation();
+                };
 
                 if (!Debugger.IsAttached)
                 {
@@ -161,7 +168,7 @@ namespace GitExtensions
             if (args.Length >= 3)
             {
                 // there is bug in .net
-                // while parsing command line arguments, it unescapes " incorectly
+                // while parsing command line arguments, it unescapes " incorrectly
                 // https://github.com/gitextensions/gitextensions/issues/3489
                 string dirArg = args[2].TrimEnd('"');
 


### PR DESCRIPTION



## Proposed changes

- Follow up on https://github.com/gitextensions/NBug/pull/15 to allow copy exception's info into the clipboard


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![crash screen](https://user-images.githubusercontent.com/10179556/36780028-21ff433c-1c72-11e8-81a7-92f7b0c15b14.png)


### After

![image](https://user-images.githubusercontent.com/4403806/55533736-01007580-56fe-11e9-88db-99f4d075f195.png)




## Test methodology <!-- How did you ensure quality? -->

- Modify the code to throw an exception, e.g.
```diff
diff --git a/GitUI/CommitInfo/CommitInfo.cs b/GitUI/CommitInfo/CommitInfo.cs
index e00813929..b580714d3 100644
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -233,6 +233,11 @@ private void ReloadCommitInfo()
             showMessagesOfAnnotatedTagsToolStripMenuItem.Checked = AppSettings.ShowAnnotatedTagsMessages;
             showTagThisCommitDerivesFromMenuItem.Checked = AppSettings.CommitInfoShowTagThisCommitDerivesFrom;
 
+            if (DateTime.Today.Day == 7)
+            {
+                throw new DivideByZeroException("Boom!");
+            }
+
             _branches = null;
             _annotatedTagsMessages = null;
             _tags = null;
```


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
