### PR TITLE
Mention regex in label of FileStatusList's filter

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1150,7 +1150,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="FilterWatermarkLabel.Text">
-        <source>Filter files...</source>
+        <source>Filter files using a regular expression...</source>
         <target />
       </trans-unit>
       <trans-unit id="NoFiles.Text">

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -111,7 +111,7 @@
             this.FilterWatermarkLabel.Name = "FilterWatermarkLabel";
             this.FilterWatermarkLabel.Size = new System.Drawing.Size(65, 13);
             this.FilterWatermarkLabel.TabIndex = 0;
-            this.FilterWatermarkLabel.Text = "Filter files...";
+            this.FilterWatermarkLabel.Text = "Filter files using a regular expression...";
             this.FilterWatermarkLabel.Click += new System.EventHandler(this.FilterWatermarkLabel_Click);
             // 
             // FilterToolTip


### PR DESCRIPTION
Fixes #6447

## Proposed changes

- extend the label text

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![before](https://user-images.githubusercontent.com/36601201/55685104-c3e0f100-5952-11e9-935a-64c1e9f53fe2.png)

### After

![after](https://user-images.githubusercontent.com/36601201/55685123-f12d9f00-5952-11e9-9156-0259b1e9b1cd.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 385cf8b60c17f3ab2fbac3f10aa2858a59a51833
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
