### PR TITLE
Clarify quick search by adding a prefix

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9169,6 +9169,10 @@ Details: Is {1} expected {2}</source>
         <source>Comments</source>
         <target />
       </trans-unit>
+      <trans-unit id="_searchingFor.Text">
+        <source>Searching for: </source>
+        <target />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
 using GitUI.UserControls.RevisionGrid;
+using ResourceManager;
 
 namespace GitUI
 {
@@ -118,7 +119,7 @@ namespace GitUI
         {
             _label.Visible = true;
             _label.BringToFront();
-            _label.Text = _quickSearchString;
+            _label.Text = Strings.SearchingFor + _quickSearchString;
             _label.AutoSize = true;
         }
 

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -47,6 +47,7 @@ namespace ResourceManager
         public static string Submodules => _instance.Value._submodulesText.Text;
 
         public static string BodyNotLoaded => _instance.Value._bodyNotLoaded.Text;
+        public static string SearchingFor => _instance.Value._searchingFor.Text;
 
         private readonly TranslationString _dateText = new TranslationString("Date");
         private readonly TranslationString _authorText = new TranslationString("{0:Author|Authors}");
@@ -63,12 +64,13 @@ namespace ResourceManager
         private readonly TranslationString _indexText = new TranslationString("Commit index");
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
-        private readonly TranslationString _branchText     = new TranslationString("Branch");
+        private readonly TranslationString _branchText = new TranslationString("Branch");
         private readonly TranslationString _branchesText = new TranslationString("Branches");
         private readonly TranslationString _remotesText = new TranslationString("Remotes");
         private readonly TranslationString _tagsText = new TranslationString("Tags");
         private readonly TranslationString _submodulesText = new TranslationString("Submodules");
-        private readonly TranslationString _bodyNotLoaded  = new TranslationString("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
+        private readonly TranslationString _bodyNotLoaded = new TranslationString("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
+        private readonly TranslationString _searchingFor = new TranslationString("Searching for: ");
 
         private readonly TranslationString _parentsText = new TranslationString("{0:Parent|Parents}");
         private readonly TranslationString _childrenText = new TranslationString("{0:Child|Children}");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6419

## Proposed changes

- Added a string "Searching for: " before the query when performing a quick search, to clarify it's purpose.
- I only changed the label string, so it does not affect the search query nor the logic behind it.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![Untitled3](https://user-images.githubusercontent.com/14019835/55686080-d57fc400-5965-11e9-8a73-6872d2aa16d8.png)

<!-- TODO -->

### After

![Untitled2](https://user-images.githubusercontent.com/14019835/55686079-d57fc400-5965-11e9-8de9-d7d1f84c658a.png)
<!-- TODO -->



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
