### PR TITLE
Detect and display Git warning on broken refs

### DIFF
--- a/GitCommands/Git/GitException.cs
+++ b/GitCommands/Git/GitException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GitCommands.Git
+{
+    public class GitException : Exception
+    {
+        public GitException(string message)
+            : base(message)
+        {
+        }
+
+        public GitException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -757,7 +757,12 @@ namespace GitCommands
                 "refs/"
             };
 
-            var tree = _gitExecutable.GetOutput(args);
+            string tree = _gitExecutable.GetOutput(args);
+            int warningPos = tree.IndexOf("warning:");
+            if (warningPos >= 0)
+            {
+                throw new RefsWarningException(tree.Substring(warningPos).SplitLines()[0]);
+            }
 
             return tree.Split();
         }

--- a/GitCommands/Git/RefsWarningException.cs
+++ b/GitCommands/Git/RefsWarningException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GitCommands.Git
+{
+    public class RefsWarningException : GitException
+    {
+        public RefsWarningException(string message)
+            : base(message)
+        {
+        }
+
+        public RefsWarningException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Git\FileDeleteException.cs" />
     <Compile Include="Git\GitBranchNameNormaliser.cs" />
     <Compile Include="Git\GitBranchNameOptions.cs" />
+    <Compile Include="Git\GitException.cs" />
+    <Compile Include="Git\RefsWarningException.cs" />
     <Compile Include="Git\Extensions\GitRevisionExtensions.cs" />
     <Compile Include="Git\Executable.cs" />
     <Compile Include="Git\GitItemStatusFileExtensionComparer.cs" />


### PR DESCRIPTION
Fixes #6442.

## Proposed changes

- detect the Git warning returned by the command "for-each-ref" (although the exit code is 0)
- cancel loading refs
- display the warning

## Screenshots

### Before

![exception](https://user-images.githubusercontent.com/36601201/55625266-86406480-57a8-11e9-8596-6626f69babf2.png)

### After

![warning](https://user-images.githubusercontent.com/36601201/55688869-2996a280-597e-11e9-96e8-275148f36a9e.png)

## Test methodology <!-- How did you ensure quality? -->

- manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 400b68461b38c7d51a9bee8b1d15bd751bb97a87
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
