### PR TITLE
feat: Submit issue to GitHub

### DIFF
--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -159,9 +159,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 		GitExtensions.ruleset = GitExtensions.ruleset
 		GitExtensionsTest.ruleset = GitExtensionsTest.ruleset
-		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		LICENSE.md = LICENSE.md
-		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -175,7 +173,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{472B72D9
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{17FD2A6B-4005-41DC-BFAC-59F936DF33AA}"
 	ProjectSection(SolutionItems) = preProject
-		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 	EndProjectSection
 EndProject
@@ -190,6 +187,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureDevOpsIntegrationTests", "UnitTests\Plugins\BuildServerIntegration\AzureDevOpsIntegrationTests\AzureDevOpsIntegrationTests.csproj", "{6E2BE70D-0B5C-45D6-9D42-4497A46C370D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppVeyorIntegrationTests", "UnitTests\Plugins\BuildServerIntegration\AppVeyorIntegrationTests\AppVeyorIntegrationTests.csproj", "{2828E531-7EB3-4A52-A71E-DCE73B9907FC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{95A371C3-77B9-437A-892E-17CA0097106B}"
+	ProjectSection(SolutionItems) = preProject
+		.github\ISSUE_TEMPLATE\bug_report.md = .github\ISSUE_TEMPLATE\bug_report.md
+		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -428,6 +431,7 @@ Global
 		{BC90FFE0-7770-4979-884E-9F9F294C58C0} = {C2276A26-13DF-485A-8B2C-414CF507798F}
 		{6E2BE70D-0B5C-45D6-9D42-4497A46C370D} = {BC90FFE0-7770-4979-884E-9F9F294C58C0}
 		{2828E531-7EB3-4A52-A71E-DCE73B9907FC} = {BC90FFE0-7770-4979-884E-9F9F294C58C0}
+		{95A371C3-77B9-437A-892E-17CA0097106B} = {17FD2A6B-4005-41DC-BFAC-59F936DF33AA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ECECB7EA-BCCF-44AD-B63E-C2FA45589FB0}


### PR DESCRIPTION




<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Closes #5064


## Proposed changes

GitHub allows submitting issues by navigating a dedicated URL supplying issue data via query string parameters.
More info: https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters

Whenever Git Extensions experiences an issue that is handled by NBug, a user is presented with an option to submit an issue to our GitHub repo.

By clicking "Send and quit" button the following occurs:
* an issue payload is generated,
* the payload gets encoded into a url, and
* the user is navigated to the generated url in a browser of their choice


## Screenshots <!-- Remove this section if PR does not change UI -->


### After

![image](https://user-images.githubusercontent.com/4403806/55793752-f5022280-5b06-11e9-9a28-2f90c1e5d423.png)



## Test methodology <!-- How did you ensure quality? -->

- manual, added an exception to `CommitInfo` control and observed it handled by the NBug.

```diff
diff --git a/GitUI/CommitInfo/CommitInfo.cs b/GitUI/CommitInfo/CommitInfo.cs
index e00813929..78d564d44 100644
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -233,6 +233,11 @@ private void ReloadCommitInfo()
             showMessagesOfAnnotatedTagsToolStripMenuItem.Checked = AppSettings.ShowAnnotatedTagsMessages;
             showTagThisCommitDerivesFromMenuItem.Checked = AppSettings.CommitInfoShowTagThisCommitDerivesFrom;
 
+            if (DateTime.Today.Month == 4)
+            {
+                throw new DivideByZeroException("Boom!");
+            }
+
             _branches = null;
             _annotatedTagsMessages = null;
             _tags = null;
```

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 259c501a27db6de9723fbcddbdd40638a9498f24 (Dirty)
- Git 2.19.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 144dpi (150% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
