### PR TITLE
Highlight the new name in the FileStatusList

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/PathFormatterTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/PathFormatterTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+using GitUI;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs
+{
+    public class PathFormatterTests
+    {
+        [TestCase("new.ext", null, "new.ext", null)]
+        [TestCase("new.ext", "", "new.ext", null)]
+        [TestCase("path/new.ext", null, "new.ext", null)]
+        [TestCase("/path/new.ext", null, "new.ext", null)]
+        [TestCase("C:/path/new.ext", null, "new.ext", null)]
+        [TestCase("path\\new.ext", null, "new.ext", null)]
+        [TestCase("C:\\path\\new.ext", null, "new.ext", null)]
+        [TestCase("path/new.ext", "old.ext", "new.ext", " (old.ext)")]
+        [TestCase("path/new.ext", "oldPath/old.ext", "new.ext", " (old.ext)")]
+        [TestCase("path/new.ext", "/oldPath/old.ext", "new.ext", " (old.ext)")]
+        [TestCase("path/new.ext", "C:/oldPath/old.ext", "new.ext", " (old.ext)")]
+        [TestCase("path/new.ext", "C:\\oldPath\\old.ext", "new.ext", " (old.ext)")]
+        [TestCase("path/new.ext", "oldPath\\old.ext", "new.ext", " (old.ext)")]
+        public void Test_FormatTextForFileNameOnly(string name, string oldName, string expectedText, string expectedSuffix)
+        {
+            PathFormatter.FormatTextForFileNameOnly(name, oldName).Should().Be((expectedText, expectedSuffix));
+        }
+
+        [TestCase(null, null)]
+        [TestCase("", null)]
+        [TestCase("filename.ext", " (filename.ext)")]
+        [TestCase("/filename.ext", " (/filename.ext)")]
+        [TestCase("path/filename.ext", " (path/filename.ext)")]
+        [TestCase("nested/path/filename.ext", " (nested/path/filename.ext)")]
+        [TestCase("/nested/path/filename.ext", " (/nested/path/filename.ext)")]
+        [TestCase("path\\filename.ext", " (path\\filename.ext)")]
+        public void Test_FormatOldName(string oldName, string expectedSuffix)
+        {
+            PathFormatter.TestAccessor.FormatOldName(oldName).Should().Be(expectedSuffix);
+        }
+
+        [TestCase(null, null, null)]
+        [TestCase("", null, "")]
+        [TestCase(" ", null, " ")]
+        [TestCase("filename.ext", null, "filename.ext")]
+        [TestCase("/filename.ext", "/", "filename.ext")]
+        [TestCase("path/filename.ext", "path/", "filename.ext")]
+        [TestCase("nested/path/filename.ext", "nested/path/", "filename.ext")]
+        [TestCase("/nested/path/filename.ext", "/nested/path/", "filename.ext")]
+        [TestCase("path\\filename.ext", null, "path\\filename.ext")]
+        public void Test_SplitPathName(string name, string expectedPath, string expectedFileName)
+        {
+            PathFormatter.TestAccessor.SplitPathName(name).Should().Be((expectedPath, expectedFileName));
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CommandsDialogs\FileStatusListTests.cs" />
     <Compile Include="CommandsDialogs\FormEditorTests.cs" />
     <Compile Include="CommandsDialogs\FormFileHistoryControllerTests.cs" />
+    <Compile Include="CommandsDialogs\PathFormatterTests.cs" />
     <Compile Include="CommandsDialogs\ReferenceRepository.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffContextMenuControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />


### PR DESCRIPTION
Fixes #6465

## Proposed changes

- detect renamed/copied files
- draw only the new filename black

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![before moved](https://user-images.githubusercontent.com/36601201/55987027-ecddea80-5ca0-11e9-9bf4-34bb90c294a5.png)
![before renamed without path](https://user-images.githubusercontent.com/36601201/55993895-8cef4000-5cb0-11e9-9936-aae42b0d3838.png)

### After

![after moved](https://user-images.githubusercontent.com/36601201/55993991-d475cc00-5cb0-11e9-8325-7391ee26e57a.png)
![after renamed without path](https://user-images.githubusercontent.com/36601201/55993934-a6908780-5cb0-11e9-84c3-94292474497e.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 4ba5be25f33398170adc8651825b3c0107092ae2
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
