### PR TITLE
Fix Git arguments for formatting multiple patches

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1417,7 +1417,7 @@ namespace GitCommands
                 new GitArgumentBuilder("format-patch")
                 {
                     "-M -C -B",
-                    { start != null, $"-- start-number {start}" },
+                    { start != null, $"--start-number {start}" },
                     $"{from.Quote()}..{to.Quote()}",
                     $"-o {output.ToPosixPath().Quote()}"
                 });

--- a/UnitTests/GitCommandsTests/GitModuleTest.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTest.cs
@@ -608,6 +608,26 @@ namespace GitCommandsTests
             Assert.AreEqual(expected, actual);
         }
 
+        [TestCase(new object[] { "123", "567", "output.file", null })]
+        [TestCase(new object[] { "123", "567", "output.file", 1 })]
+        [TestCase(new object[] { "123", "567", "output.file", 2 })]
+        public void Test_FormatPatch(string from, string to, string outputFile, int? start)
+        {
+            var arguments = new StringBuilder();
+            arguments.Append("format-patch -M -C -B");
+            if (start != null)
+            {
+                arguments.AppendFormat(" --start-number {0}", start);
+            }
+
+            arguments.AppendFormat(" \"{0}\"..\"{1}\" -o \"{2}\"", from, to, outputFile);
+
+            string dummyCommandOutput = "The answer is 42. Just check that the Git arguments are as expected.";
+
+            _executable.StageOutput(arguments.ToString(), dummyCommandOutput);
+            _gitModule.FormatPatch(from, to, outputFile, start).Should().Be(dummyCommandOutput);
+        }
+
         private GitModule GetGitModuleWithMockedResultOfGitCommand(string result)
         {
             var executable = Substitute.For<IExecutable>();


### PR DESCRIPTION
Fixes #5923

Replaces #6356 because
- @NOYB has no dev environment (https://github.com/gitextensions/gitextensions/issues/6355#issuecomment-471221075),
- has not signed the CLA and
- @vbjay found the reason (https://github.com/gitextensions/gitextensions/issues/6355#issuecomment-471215388)

## Proposed changes

- fix typo in Git command arguments for "format-patch" for the case of multiple patches, i.e. with a start number

## Test methodology <!-- How did you ensure quality? -->

- added a NUnit test for the Git command arguments
- manual tests of `Commands | Format patch...`

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build ebc44475d44e878e26ba74e7ebcca419914d3d38
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).