### PR TITLE
Clear diff in history form when no file selected

### DIFF
--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -82,6 +82,7 @@ namespace GitUI.UserControls
         {
             if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null)
             {
+                DiffText.Clear();
                 return;
             }
 


### PR DESCRIPTION
Fixes #6271


## Proposed changes

- Clear FileViewer in history form when empty area is clicked (i.e. below the changed files). This is the same behavior as already implemented in the main form and commit form. 


## Screenshots

### Before

![old](https://user-images.githubusercontent.com/46861028/52599659-951a3300-2e59-11e9-9cbd-1906d7f812b9.gif)

### After

![new](https://user-images.githubusercontent.com/46861028/56246994-b7237200-60a3-11e9-9c9e-25080f2fe5a6.gif)


## Test methodology <!-- How did you ensure quality? -->

- manual tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 5d2c8c94ba6b7f3e788e82707dc1ca2c8391f8d0
- Git 2.20.1.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.3324.0
- DPI 120dpi (125% scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
