### PR TITLE
Hotkeys for Open with difftool | First/Selected to working directory

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2144,7 +2144,9 @@ namespace GitUI.CommandsDialogs
             FocusGitConsole = 29,
             FocusBuildServerStatus = 30,
             FocusNextTab = 31,
-            FocusPrevTab = 32
+            FocusPrevTab = 32,
+            OpenWithDifftoolFirstToLocal = 33,
+            OpenWithDifftoolSelectedToLocal = 34
         }
 
         internal Keys GetShortcutKeys(Command cmd)
@@ -2216,6 +2218,8 @@ namespace GitUI.CommandsDialogs
                 case Command.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;
                 case Command.StashPop: UICommands.StashPop(this); break;
                 case Command.OpenWithDifftool: OpenWithDifftool(); break;
+                case Command.OpenWithDifftoolFirstToLocal: OpenWithDifftoolFirstToLocal(); break;
+                case Command.OpenWithDifftoolSelectedToLocal: OpenWithDifftoolSelectedToLocal(); break;
                 case Command.OpenSettings: OnShowSettingsClick(null, null); break;
                 case Command.ToggleBranchTreePanel: toggleBranchTreePanel_Click(null, null); break;
                 case Command.EditFile: EditFile(); break;
@@ -2290,6 +2294,22 @@ namespace GitUI.CommandsDialogs
                 else if (fileTree.Visible)
                 {
                     fileTree.ExecuteCommand(RevisionFileTreeControl.Command.OpenWithDifftool);
+                }
+            }
+
+            void OpenWithDifftoolFirstToLocal()
+            {
+                if (revisionDiff.Visible)
+                {
+                    revisionDiff.ExecuteCommand(RevisionDiffControl.Command.OpenWithDifftoolFirstToLocal);
+                }
+            }
+
+            void OpenWithDifftoolSelectedToLocal()
+            {
+                if (revisionDiff.Visible)
+                {
+                    revisionDiff.ExecuteCommand(RevisionDiffControl.Command.OpenWithDifftoolSelectedToLocal);
                 }
             }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -95,7 +95,9 @@ namespace GitUI.CommandsDialogs
             OpenWithDifftool = 3,
             EditFile = 4,
             OpenAsTempFile = 5,
-            OpenAsTempFileWith = 6
+            OpenAsTempFileWith = 6,
+            OpenWithDifftoolFirstToLocal = 7,
+            OpenWithDifftoolSelectedToLocal = 8
         }
 
         public CommandStatus ExecuteCommand(Command cmd)
@@ -116,6 +118,8 @@ namespace GitUI.CommandsDialogs
                 case Command.ShowHistory: fileHistoryDiffToolstripMenuItem.PerformClick(); break;
                 case Command.Blame: blameToolStripMenuItem.PerformClick(); break;
                 case Command.OpenWithDifftool: firstToSelectedToolStripMenuItem.PerformClick(); break;
+                case Command.OpenWithDifftoolFirstToLocal: firstToLocalToolStripMenuItem.PerformClick(); break;
+                case Command.OpenWithDifftoolSelectedToLocal: selectedToLocalToolStripMenuItem.PerformClick(); break;
                 case Command.EditFile: diffEditWorkingDirectoryFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFile: diffOpenRevisionFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFileWith: diffOpenRevisionFileWithToolStripMenuItem.PerformClick(); break;
@@ -133,6 +137,8 @@ namespace GitUI.CommandsDialogs
             fileHistoryDiffToolstripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ShowHistory);
             blameToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Blame);
             firstToSelectedToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftool);
+            firstToLocalToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftoolFirstToLocal);
+            selectedToLocalToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftoolSelectedToLocal);
             diffEditWorkingDirectoryFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.EditFile);
             diffOpenRevisionFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenAsTempFile);
             diffOpenRevisionFileWithToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenAsTempFileWith);

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -229,6 +229,8 @@ namespace GitUI.Hotkey
             HotkeyCommand Hk(object en, Keys k) => new HotkeyCommand((int)en, en.ToString()) { KeyData = k };
 
             const Keys OpenWithDifftoolHotkey = Keys.F3;
+            const Keys OpenWithDifftoolFirstToLocalHotkey = Keys.Alt | Keys.F3;
+            const Keys OpenWithDifftoolSelectedToLocalHotkey = Keys.Shift | Keys.Alt | Keys.F3;
             const Keys OpenAsTempFileHotkey = Keys.Control | Keys.F3;
             const Keys OpenAsTempFileWithHotkey = Keys.Shift | Keys.Control | Keys.F3;
             const Keys EditFileHotkey = Keys.F4;
@@ -286,6 +288,8 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.OpenAsTempFileWith, OpenAsTempFileWithHotkey),
                     Hk(FormBrowse.Command.OpenSettings, Keys.Control | Keys.Oemcomma),
                     Hk(FormBrowse.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
+                    Hk(FormBrowse.Command.OpenWithDifftoolFirstToLocal, OpenWithDifftoolFirstToLocalHotkey),
+                    Hk(FormBrowse.Command.OpenWithDifftoolSelectedToLocal, OpenWithDifftoolSelectedToLocalHotkey),
                     Hk(FormBrowse.Command.QuickFetch, Keys.Control | Keys.Shift | Keys.Down),
                     Hk(FormBrowse.Command.QuickPull, Keys.Control | Keys.Shift | Keys.P),
                     Hk(FormBrowse.Command.QuickPush, Keys.Control | Keys.Shift | Keys.Up),
@@ -349,6 +353,8 @@ namespace GitUI.Hotkey
                     Hk(RevisionDiffControl.Command.OpenAsTempFile, OpenAsTempFileHotkey),
                     Hk(RevisionDiffControl.Command.OpenAsTempFileWith, OpenAsTempFileWithHotkey),
                     Hk(RevisionDiffControl.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
+                    Hk(RevisionDiffControl.Command.OpenWithDifftoolFirstToLocal, OpenWithDifftoolFirstToLocalHotkey),
+                    Hk(RevisionDiffControl.Command.OpenWithDifftoolSelectedToLocal, OpenWithDifftoolSelectedToLocalHotkey),
                     Hk(RevisionDiffControl.Command.ShowHistory, ShowHistoryHotkey)),
                 new HotkeySettings(
                     RevisionFileTreeControl.HotkeySettingsName,


### PR DESCRIPTION
Fixes #6481

## Proposed changes

- add hotkeys for Open with difftool | First/Selected to working directory
  (active in RevisionDiffControl and FormBrowse)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![before](https://user-images.githubusercontent.com/36601201/56315584-64f05880-6158-11e9-96bc-8ffa41b6b9dc.png)

### After

![after](https://user-images.githubusercontent.com/36601201/56315234-800e9880-6157-11e9-821c-9b4578b1083c.png)
![new settings](https://user-images.githubusercontent.com/36601201/56315748-d4664800-6158-11e9-800a-bb9456755018.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build e3b9bc3bf78d0dc19579f7bc32aa56132f379042
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
