### PR TITLE
TestHelper used GitExecutable for superproject

### DIFF
--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -124,7 +124,7 @@ namespace CommonTestUtils
             Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(helper.Module.WorkingDir.ToPosixPath(), path, null, true));
             Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
 
-            return new GitModule(Path.Combine(Module.WorkingDir, path).ToPosixPath(), Module.GitExecutable);
+            return new GitModule(Path.Combine(Module.WorkingDir, path).ToPosixPath());
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace CommonTestUtils
         {
             Module.GitExecutable.GetOutput(@"submodule update --init --recursive");
             var paths = Module.GetSubmodulesLocalPaths(recursive: true);
-            return paths.Select(path => new GitModule(Path.Combine(Module.WorkingDir, path).ToNativePath(), Module.GitExecutable));
+            return paths.Select(path => new GitModule(Path.Combine(Module.WorkingDir, path).ToNativePath()));
         }
 
         public void Dispose()


### PR DESCRIPTION
Executing path for submodule was incorrect.

The following command executes from repo1 instead of repo2, it just happens to return the correct answer:
https://github.com/gitextensions/gitextensions/blob/master/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs#L135

Part of #6487 

## Proposed changes
Do not use incorrect git executable in submodule tests

## Test methodology <!-- How did you ensure quality? -->
Run tets


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
