### PR TITLE
Remove executable arg for GitModule

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -40,13 +40,13 @@ namespace GitCommands
         private readonly IGitCommandRunner _gitCommandRunner;
         private readonly IExecutable _gitExecutable;
 
-        public GitModule([CanBeNull] string workingDir, [CanBeNull] IExecutable executable = null)
+        public GitModule([CanBeNull] string workingDir)
         {
             WorkingDir = (workingDir ?? "").NormalizePath().EnsureTrailingPathSeparator();
             WorkingDirGitDir = GitDirectoryResolverInstance.Resolve(WorkingDir);
             _indexLockManager = new IndexLockManager(this);
             _commitDataManager = new CommitDataManager(() => this);
-            _gitExecutable = executable ?? new Executable(() => AppSettings.GitCommand, WorkingDir);
+            _gitExecutable = new Executable(() => AppSettings.GitCommand, WorkingDir);
             _gitCommandRunner = new GitCommandRunner(_gitExecutable, () => SystemEncoding);
 
             // If this is a submodule, populate relevant properties.


### PR DESCRIPTION

Fixes #6487 


## Proposed changes

Only affects test code

This is only used for mocking in tests and should be avoided in the public API.
A TestAccessor is not straightforward (this is a readonly field),
reflection is used instead.

## Test methodology <!-- How did you ensure quality? -->
Tests still working

## Test environment(s)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
