### PR TITLE
Execute scripts also if RevisionGrid is not focused

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -122,6 +122,8 @@ namespace GitUI.CommandsDialogs
 
         private UpdateTargets _selectedRevisionUpdatedTargets = UpdateTargets.None;
 
+        public override RevisionGridControl RevisionGridControl { get => RevisionGrid; }
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormBrowse()
         {

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -153,7 +153,13 @@ namespace GitUI
 
             CommandStatus ExecuteScriptCommand()
             {
-                return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command, UICommands, this as RevisionGridControl);
+                var revisionGridControl = this as RevisionGridControl;
+                if (revisionGridControl == null)
+                {
+                    revisionGridControl = (FindForm() as GitModuleForm)?.RevisionGridControl;
+                }
+
+                return Script.ScriptRunner.ExecuteScriptCommand(this, Module, command, UICommands, revisionGridControl);
             }
         }
 

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -21,6 +21,8 @@ namespace GitUI
         /// </summary>
         internal static bool IsUnitTestActive { get; set; }
 
+        public virtual RevisionGridControl RevisionGridControl { get => null; }
+
         [CanBeNull] private GitUICommands _uiCommands;
 
         /// <inheritdoc />
@@ -68,7 +70,7 @@ namespace GitUI
 
         protected override CommandStatus ExecuteCommand(int command)
         {
-            var result = ScriptRunner.ExecuteScriptCommand(this, Module, command, UICommands);
+            var result = ScriptRunner.ExecuteScriptCommand(this, Module, command, UICommands, RevisionGridControl);
 
             if (!result.Executed)
             {

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -107,6 +107,10 @@ namespace GitUI.Script
                 if (currentRevision == null && option.StartsWith("c"))
                 {
                     currentRevision = GetCurrentRevision(module, revisionGrid, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches);
+                    if (currentRevision == null)
+                    {
+                        return (arguments: null, abort: true);
+                    }
 
                     if (currentLocalBranches.Count == 1)
                     {
@@ -126,6 +130,10 @@ namespace GitUI.Script
                 {
                     allSelectedRevisions = revisionGrid.GetSelectedRevisions();
                     selectedRevision = CalculateSelectedRevision(revisionGrid, selectedRemoteBranches, selectedRemotes, selectedLocalBranches, selectedBranches, selectedTags);
+                    if (selectedRevision == null)
+                    {
+                        return (arguments: null, abort: true);
+                    }
                 }
 
                 arguments = ParseScriptArguments(arguments, option, owner, revisionGrid, module, allSelectedRevisions, selectedTags, selectedBranches, selectedLocalBranches, selectedRemoteBranches, selectedRemotes, selectedRevision, currentTags, currentBranches, currentLocalBranches, currentRemoteBranches, currentRevision, currentRemote);
@@ -165,6 +173,11 @@ namespace GitUI.Script
             List<IGitRef> selectedBranches, List<IGitRef> selectedTags)
         {
             GitRevision selectedRevision = revisionGrid.LatestSelectedRevision;
+            if (selectedRevision == null)
+            {
+                return null;
+            }
+
             foreach (var head in selectedRevision.Refs)
             {
                 if (head.IsTag)
@@ -202,7 +215,7 @@ namespace GitUI.Script
             if (revisionGrid == null)
             {
                 var currentRevisionGuid = module.GetCurrentCheckout();
-                currentRevision = new GitRevision(currentRevisionGuid);
+                currentRevision = currentRevisionGuid == null ? null : new GitRevision(currentRevisionGuid);
                 refs = module.GetRefs(true, true).Where(gitRef => gitRef.ObjectId == currentRevisionGuid).ToList();
             }
             else

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -50,27 +50,18 @@ namespace GitUI.Script
             }
 
             string argument = script.Arguments;
-            foreach (string option in ScriptOptionsParser.Options)
+            if (!string.IsNullOrEmpty(argument) && revisionGrid == null)
             {
-                if (string.IsNullOrEmpty(argument) || !argument.Contains(option))
+                foreach (string option in ScriptOptionsParser.Options)
                 {
-                    continue;
+                    if (argument.Contains(option) && option.StartsWith("{s"))
+                    {
+                        MessageBox.Show(owner,
+                            $"Option {option} is only supported when started from revision grid.",
+                            "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return false;
+                    }
                 }
-
-                if (!option.StartsWith("s"))
-                {
-                    continue;
-                }
-
-                if (revisionGrid != null)
-                {
-                    continue;
-                }
-
-                MessageBox.Show(owner,
-                    $"Option {option} is only supported when started from revision grid.",
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return false;
             }
 
             return RunScript(owner, module, script, uiCommands, revisionGrid);

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -49,18 +49,18 @@ namespace GitUI.Script
                 return false;
             }
 
-            string argument = script.Arguments;
-            if (!string.IsNullOrEmpty(argument) && revisionGrid == null)
+            string arguments = script.Arguments;
+            if (!string.IsNullOrEmpty(arguments) && revisionGrid == null)
             {
-                foreach (string option in ScriptOptionsParser.Options)
+                string optionDependingOnSelectedRevision
+                    = ScriptOptionsParser.Options.FirstOrDefault(option => ScriptOptionsParser.DependsOnSelectedRevision(option)
+                        && ScriptOptionsParser.Contains(arguments, option));
+                if (optionDependingOnSelectedRevision != null)
                 {
-                    if (argument.Contains(option) && option.StartsWith("{s"))
-                    {
-                        MessageBox.Show(owner,
-                            $"Option {option} is only supported when started from revision grid.",
-                            "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        return false;
-                    }
+                    MessageBox.Show(owner,
+                        $"Option {optionDependingOnSelectedRevision} is only supported when started from revision grid.",
+                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return false;
                 }
             }
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -11,7 +11,7 @@ namespace GitUI.Script
     public static class ScriptRunner
     {
         /// <summary>Tries to run scripts identified by a <paramref name="command"/></summary>
-        public static CommandStatus ExecuteScriptCommand(IWin32Window owner, GitModule module, int command, IGitUICommands uiCommands, RevisionGridControl revisionGrid = null)
+        public static CommandStatus ExecuteScriptCommand(IWin32Window owner, GitModule module, int command, IGitUICommands uiCommands, RevisionGridControl revisionGrid)
         {
             var anyScriptExecuted = false;
             var needsGridRefresh = false;

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -29,7 +29,14 @@ namespace GitUI.Script
             return new CommandStatus(anyScriptExecuted, needsGridRefresh);
         }
 
-        public static CommandStatus RunScript(IWin32Window owner, GitModule module, string scriptKey, IGitUICommands uiCommands, RevisionGridControl revisionGrid)
+        public static CommandStatus RunScript(IWin32Window owner, IGitModule module, string scriptKey, IGitUICommands uiCommands, RevisionGridControl revisionGrid)
+        {
+            return RunScript(owner, module, scriptKey, uiCommands, revisionGrid,
+                msg => MessageBox.Show(owner, msg, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error));
+        }
+
+        public static CommandStatus RunScript(IWin32Window owner, IGitModule module, string scriptKey, IGitUICommands uiCommands,
+            RevisionGridControl revisionGrid, Action<string> showError)
         {
             if (string.IsNullOrEmpty(scriptKey))
             {
@@ -40,7 +47,7 @@ namespace GitUI.Script
 
             if (script == null)
             {
-                MessageBox.Show(owner, "Cannot find script: " + scriptKey, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                showError("Cannot find script: " + scriptKey);
                 return false;
             }
 
@@ -57,17 +64,16 @@ namespace GitUI.Script
                         && ScriptOptionsParser.Contains(arguments, option));
                 if (optionDependingOnSelectedRevision != null)
                 {
-                    MessageBox.Show(owner,
-                        $"Option {optionDependingOnSelectedRevision} is only supported when started from revision grid.",
-                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    showError($"Option {optionDependingOnSelectedRevision} is only supported when started with revision grid available.");
                     return false;
                 }
             }
 
-            return RunScript(owner, module, script, uiCommands, revisionGrid);
+            return RunScript(owner, module, script, uiCommands, revisionGrid, showError);
         }
 
-        private static CommandStatus RunScript(IWin32Window owner, GitModule module, ScriptInfo scriptInfo, IGitUICommands uiCommands, RevisionGridControl revisionGrid)
+        private static CommandStatus RunScript(IWin32Window owner, IGitModule module, ScriptInfo scriptInfo, IGitUICommands uiCommands,
+            RevisionGridControl revisionGrid, Action<string> showError)
         {
             if (scriptInfo.AskConfirmation && MessageBox.Show(owner, $"Do you want to execute '{scriptInfo.Name}'?", "Script", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
             {
@@ -78,6 +84,7 @@ namespace GitUI.Script
             (string argument, bool abort) = ScriptOptionsParser.Parse(scriptInfo.Arguments, module, owner, revisionGrid);
             if (abort)
             {
+                showError($"There must be a revision in order to substitute the argument option(s) for the script to run.");
                 return false;
             }
 
@@ -145,7 +152,7 @@ namespace GitUI.Script
             return new CommandStatus(true, !scriptInfo.RunInBackground);
         }
 
-        private static string ExpandCommandVariables(string originalCommand, GitModule module)
+        private static string ExpandCommandVariables(string originalCommand, IGitModule module)
         {
             return originalCommand.Replace("{WorkingDir}", module.WorkingDir);
         }

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="ControlUtilTests.cs" />
     <Compile Include="LinqExtensionsTests.cs" />
     <Compile Include="Script\ScriptOptionsParserTests.cs" />
+    <Compile Include="Script\ScriptRunnerTests.cs" />
     <Compile Include="SpellChecker\WordAtCursorExtractorTests.cs" />
     <Compile Include="SplitterManagerTest.cs" />
     <Compile Include="StringBuilderExtensionsTests.cs" />

--- a/UnitTests/GitUITests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUITests/Script/ScriptOptionsParserTests.cs
@@ -24,7 +24,7 @@ namespace GitUITests.Script
         public void ScriptOptionsParser_resolve_cDefaultRemotePathFromUrl_currentRemote_unset()
         {
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
+                arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -40,7 +40,7 @@ namespace GitUITests.Script
             _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote)).Returns("https://gitlab.com/gitlabhq/gitlabhq.git");
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
+                arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
                 owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -55,7 +55,7 @@ namespace GitUITests.Script
             var noSelectedRemotes = new List<string>();
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
+                arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, noSelectedRemotes, selectedRevision: null,
                 currentTags: null,
@@ -72,7 +72,7 @@ namespace GitUITests.Script
             _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote)).Returns("https://gitlab.com/gitlabhq/gitlabhq.git");
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
+                arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
                 owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes, selectedRevision: null,
                 currentTags: null,
@@ -91,7 +91,7 @@ namespace GitUITests.Script
             var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{" + option + "}", option,
+                arguments: "{" + option + "}", option,
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -110,7 +110,7 @@ namespace GitUITests.Script
             var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{" + option + "}", option,
+                arguments: "{" + option + "}", option,
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -129,7 +129,7 @@ namespace GitUITests.Script
             var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{" + option + "}", option,
+                arguments: "{" + option + "}", option,
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -148,7 +148,7 @@ namespace GitUITests.Script
             var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{" + option + "}", option,
+                arguments: "{" + option + "}", option,
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -163,7 +163,7 @@ namespace GitUITests.Script
             var option = "RepoName";
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{" + option + "}", option,
+                arguments: "{" + option + "}", option,
                 owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
@@ -180,7 +180,7 @@ namespace GitUITests.Script
             _module.WorkingDir.Returns("C:\\" + dirName);
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
-                argument: "{" + option + "}", option,
+                arguments: "{" + option + "}", option,
                 owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,

--- a/UnitTests/GitUITests/Script/ScriptRunnerTests.cs
+++ b/UnitTests/GitUITests/Script/ScriptRunnerTests.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using FluentAssertions;
+using GitCommands;
+using GitUI;
+using GitUI.CommandsDialogs;
+using GitUI.Script;
+using GitUIPluginInterfaces;
+using GitUITests.CommandsDialogs;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.Script
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class ScriptRunnerTests
+    {
+        // The scripts available during the tests are created by ScriptManager's GetDefaultScripts().
+        // We will adapt the script named "Example" for the needs of the test cases in this file.
+        private const string _keyOfExampleScript = "Example";
+
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _uiCommands;
+        private IGitModule _module;
+        private ScriptInfo _exampleScript;
+
+        [SetUp]
+        public void Setup()
+        {
+            if (_referenceRepository == null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _uiCommands = new GitUICommands(_referenceRepository.Module);
+
+            _module = Substitute.For<IGitModule>();
+            _module.GetCurrentRemote().ReturnsForAnyArgs("origin");
+            _module.GetCurrentCheckout().ReturnsForAnyArgs(ObjectId.WorkTreeId);
+            _exampleScript = ScriptManager.GetScript(_keyOfExampleScript);
+            _exampleScript.AskConfirmation = false; // avoid any dialogs popping up
+            _exampleScript.RunInBackground = true; // avoid any dialogs popping up
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _uiCommands = null;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [Test]
+        public void RunScript_without_scriptKey_shall_return_false([Values(null, "")] string scriptKey)
+        {
+            var result = ScriptRunner.RunScript(null, _module, scriptKey, uiCommands: null, revisionGrid: null);
+
+            result.Executed.Should().BeFalse();
+        }
+
+        [Test]
+        public void RunScript_with_invalid_scriptKey_shall_display_error_and_return_false()
+        {
+            const string invalidScriptKey = "InVaLid ScRiPt KeY";
+            string errorMessage = null;
+
+            var result = ScriptRunner.RunScript(null, _module, invalidScriptKey, uiCommands: null, revisionGrid: null, error => errorMessage = error);
+
+            result.Executed.Should().BeFalse();
+            errorMessage.Should().Be("Cannot find script: " + invalidScriptKey);
+        }
+
+        [Test]
+        public void RunScript_without_command_shall_return_false([Values(null, "")] string command)
+        {
+            _exampleScript.Command = command;
+
+            var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null);
+
+            result.Executed.Should().BeFalse();
+        }
+
+        [Test]
+        public void RunScript_without_arguments_shall_succeed()
+        {
+            _exampleScript.Command = "{git}";
+            _exampleScript.Arguments = "";
+
+            var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null);
+
+            result.Should().BeEquivalentTo(new CommandStatus(true, needsGridRefresh: false));
+        }
+
+        [Test]
+        public void RunScript_with_arguments_without_options_shall_succeed()
+        {
+            _exampleScript.Command = "{git}";
+            _exampleScript.Arguments = "--version";
+
+            var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null);
+
+            result.Should().BeEquivalentTo(new CommandStatus(true, needsGridRefresh: false));
+        }
+
+        [Test]
+        public void RunScript_with_arguments_with_c_option_shall_succeed()
+        {
+            _exampleScript.Command = "cmd";
+            _exampleScript.Arguments = "/c echo {cHash}";
+
+            var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null);
+
+            result.Should().BeEquivalentTo(new CommandStatus(true, needsGridRefresh: false));
+        }
+
+        [Test]
+        public void RunScript_with_arguments_with_c_option_without_revision_shall_display_error_and_return_false()
+        {
+            _exampleScript.Command = "cmd";
+            _exampleScript.Arguments = "/c echo {cHash}";
+
+            _module.GetCurrentCheckout().Returns((ObjectId)null);
+
+            string errorMessage = null;
+
+            var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null, error => errorMessage = error);
+
+            result.Should().BeEquivalentTo(new CommandStatus(executed: false, needsGridRefresh: false));
+            errorMessage.Should().Be($"There must be a revision in order to substitute the argument option(s) for the script to run.");
+        }
+
+        [Test]
+        public void RunScript_with_arguments_with_s_option_without_RevisionGrid_shall_display_error_and_return_false()
+        {
+            _exampleScript.Command = "cmd";
+            _exampleScript.Arguments = "/c echo {sHash}";
+
+            string errorMessage = null;
+
+            var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null, error => errorMessage = error);
+
+            result.Executed.Should().BeFalse();
+            errorMessage.Should().Be($"Option sHash is only supported when started with revision grid available.");
+        }
+
+        [Test]
+        public void RunScript_with_arguments_with_s_option_with_RevisionGrid_without_selection_shall_display_error_and_return_false()
+        {
+            _exampleScript.Command = "cmd";
+            _exampleScript.Arguments = "/c echo {sHash}";
+
+            _uiCommands = new GitUICommands("C:\\");
+
+            string errorMessage = null;
+
+            RunFormTest(formBrowse =>
+            {
+                var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, _uiCommands, formBrowse.RevisionGridControl, error => errorMessage = error);
+                formBrowse.RevisionGridControl.LatestSelectedRevision.Should().BeNull(); // check for correct test setup
+
+                result.Should().BeEquivalentTo(new CommandStatus(executed: false, needsGridRefresh: false));
+                errorMessage.Should().Be($"There must be a revision in order to substitute the argument option(s) for the script to run.");
+            });
+        }
+
+        [Test]
+        public void RunScript_with_arguments_with_s_option_with_RevisionGrid_with_selection_shall_succeed()
+        {
+            _exampleScript.Command = "cmd";
+            _exampleScript.Arguments = "/c echo {sHash}";
+            _referenceRepository.CheckoutRevision();
+
+            RunFormTest(formBrowse =>
+            {
+                // wait until the revisions are loaded
+                while (formBrowse.RevisionGridControl.LatestSelectedRevision == null)
+                {
+                    Application.DoEvents();
+                }
+
+                var result = ScriptRunner.RunScript(null, _referenceRepository.Module, _keyOfExampleScript, _uiCommands, formBrowse.RevisionGridControl);
+
+                result.Should().BeEquivalentTo(new CommandStatus(executed: true, needsGridRefresh: false));
+            });
+        }
+
+        private void RunFormTest(Action<FormBrowse> testDriver)
+        {
+            RunFormTest(form =>
+            {
+                testDriver(form);
+                return Task.CompletedTask;
+            });
+        }
+
+        private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
+        {
+            UITest.RunForm(() => _uiCommands.StartBrowseDialog().Should().BeTrue(), testDriverAsync);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6285

## Proposed changes

1. commit: refactoring
  - ScriptOptionsParser.GetCurrentRevision: remove argument that is always null
  - ScriptRunner.RunScript: positive logic in conditions for message
2. commit: resolve regressions introduced by 1b8bb93c7121cd291a17303edfdd313c8edb9f88
  The regression was a NRE instead of the message (see screenshot).
  A second minor regression was that the options were searched without the surrounding '{' and '}'.
  - ScriptOptionsParser to do all parsing (correctly) with factored out methods
  - script.Arguments always in plural
3. commit: feature implementation
  - GitModuleForm and GitModuleControl to provide the RevisionGridControl instance to ScriptRunner
4. commit: tests with a litte refactoring
5. commit: bugfix
  - The script options {cHash}, {cMessage}, {cAuthor}, {cCommitter}, {cAuthorDate}, {cCommitDate} did not work due to currentRevision being null when the script was not run from RevisionGridControl.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

before 1b8bb93c7121cd291a17303edfdd313c8edb9f88
![grafik](https://user-images.githubusercontent.com/36601201/53131024-02ba1380-356c-11e9-80c3-4d92b20c42bb.png)

since 1b8bb93c7121cd291a17303edfdd313c8edb9f88
NRE 

### After

script is executed without neither exception nor message

## Test methodology <!-- How did you ensure quality? -->

- manual
- added NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 7fb79b9aab842d6635e5908c3cdea27a1437dd38
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
