### PR TITLE
Fix freezing when staging many files with autocrlf

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -295,6 +295,11 @@ namespace GitCommands
 
             using (var process = executable.Start(arguments, createWindow: false, redirectInput: writeInput != null, redirectOutput: true, outputEncoding))
             {
+                var outputBuffer = new MemoryStream();
+                var errorBuffer = new MemoryStream();
+                var outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);
+                var errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer);
+
                 if (writeInput != null)
                 {
                     // TODO do we want to make this async?
@@ -302,10 +307,6 @@ namespace GitCommands
                     process.StandardInput.Close();
                 }
 
-                var outputBuffer = new MemoryStream();
-                var errorBuffer = new MemoryStream();
-                var outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);
-                var errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer);
                 var exitTask = process.WaitForExitAsync();
 
                 await Task.WhenAll(outputTask, errorTask, exitTask);

--- a/contributors.txt
+++ b/contributors.txt
@@ -81,3 +81,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/03/24, fschmied, Fabian Schmied, fabian.schmied(at)gmail.com
 2019/03/29, realkompot, Andrei Matsei, therealkompot@gmail.com
 2019/04/09, vbjay, Jay Asbury, vbjay.net@gmail.com
+2019/04/20, Hemaolle, Oskari Leppäaho, oskari.leppaaho@gmail.com


### PR DESCRIPTION
Fix by setting up reading from output & error buffers before starting to
write to input. When staging files one by one git process will write to
error buffer at the same time as we write commands to the input buffer.
If we don't read from the error buffer before all the input has be
written, the output buffer can fill up, resulting in Git blocking to
wait until we read something.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6225

## Test methodology <!-- How did you ensure quality? -->

- Tested that the issue is fixed on a repository with 1000 files with LF line endings and core.autorcrlf = true.
- Also a case where the files have CRLF line endings and core.autocrlf=input was tested.
- Ran unit tests.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT git version 2.20.1.windows.1
- Windows 10 version 1803

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
