### PR TITLE
Fix missing RuntimeIdentifier

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -14,6 +14,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>gitcommandkey.snk.pfx</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>GitExtUtils</RootNamespace>
     <AssemblyName>GitExtUtils</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>GitExtensions</RootNamespace>
     <AssemblyName>GitExtensions</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>..\Logo\git-extensions-logo.ico</ApplicationIcon>
     <TargetFrameworkProfile>

--- a/GitExtensionsVSIX/GitExtensionsVSIX.csproj
+++ b/GitExtensionsVSIX/GitExtensionsVSIX.csproj
@@ -12,6 +12,7 @@
     <RootNamespace>GitExtensionsVSIX</RootNamespace>
     <AssemblyName>GitExtensionsVSIX</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile />
     <UseCodebase>true</UseCodebase>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -14,6 +14,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>gituikey.snk.pfx</AssemblyOriginatorKeyFile>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>

--- a/NetSpell.SpellChecker/SpellChecker.csproj
+++ b/NetSpell.SpellChecker/SpellChecker.csproj
@@ -19,6 +19,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>NetSpell.SpellChecker</RootNamespace>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubmodules.csproj
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubmodules.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>AutoCompileSubmodules</RootNamespace>
     <AssemblyName>AutoCompileSubmodules</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BackgroundFetch/BackgroundFetch.csproj
+++ b/Plugins/BackgroundFetch/BackgroundFetch.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>BackgroundFetch</RootNamespace>
     <AssemblyName>BackgroundFetch</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/Bitbucket/Bitbucket.csproj
+++ b/Plugins/Bitbucket/Bitbucket.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Bitbucket</RootNamespace>
     <AssemblyName>Bitbucket</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>AppVeyorIntegration</RootNamespace>
     <AssemblyName>AppVeyorIntegration</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>AzureDevOpsIntegration</RootNamespace>
     <AssemblyName>AzureDevOpsIntegration</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>JenkinsIntegration</RootNamespace>
     <AssemblyName>JenkinsIntegration</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityIntegration.csproj
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityIntegration.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>TeamCityIntegration</RootNamespace>
     <AssemblyName>TeamCityIntegration</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsIntegration.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>TfsIntegration</RootNamespace>
     <AssemblyName>TfsIntegration</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2012/TfsInterop.Vs2012.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2012/TfsInterop.Vs2012.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>TfsInterop.Vs2012</RootNamespace>
     <AssemblyName>TfsInterop.Vs2012</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2013/TfsInterop.Vs2013.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2013/TfsInterop.Vs2013.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>TfsInterop.Vs2013</RootNamespace>
     <AssemblyName>TfsInterop.Vs2013</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>TfsInterop.Vs2015</RootNamespace>
     <AssemblyName>TfsInterop.Vs2015</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Plugins/CreateLocalBranches/CreateLocalBranches.csproj
+++ b/Plugins/CreateLocalBranches/CreateLocalBranches.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>CreateLocalBranches</RootNamespace>
     <AssemblyName>CreateLocalBranches</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranches.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>DeleteUnusedBranches</RootNamespace>
     <AssemblyName>DeleteUnusedBranches</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/FindLargeFiles/FindLargeFiles.csproj
+++ b/Plugins/FindLargeFiles/FindLargeFiles.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>FindLargeFiles</RootNamespace>
     <AssemblyName>FindLargeFiles</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/Gerrit/Gerrit.csproj
+++ b/Plugins/Gerrit/Gerrit.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Gerrit</RootNamespace>
     <AssemblyName>Gerrit</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/GitFlow/GitFlow.csproj
+++ b/Plugins/GitFlow/GitFlow.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>GitFlow</RootNamespace>
     <AssemblyName>GitFlow</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/GitHub3/GitHub3.csproj
+++ b/Plugins/GitHub3/GitHub3.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>GitHub3</RootNamespace>
     <AssemblyName>GitHub3</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>GitUIPluginInterfaces</RootNamespace>
     <AssemblyName>GitUIPluginInterfaces</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/Gource/Gource.csproj
+++ b/Plugins/Gource/Gource.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Gource</RootNamespace>
     <AssemblyName>Gource</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.csproj
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>JiraCommitHintPlugin</RootNamespace>
     <AssemblyName>JiraCommitHintPlugin</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Plugins/ProxySwitcher/ProxySwitcher.csproj
+++ b/Plugins/ProxySwitcher/ProxySwitcher.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>ProxySwitcher</RootNamespace>
     <AssemblyName>ProxySwitcher</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGenerator.csproj
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGenerator.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>ReleaseNotesGenerator</RootNamespace>
     <AssemblyName>ReleaseNotesGenerator</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/Statistics/GitImpact/GitImpact.csproj
+++ b/Plugins/Statistics/GitImpact/GitImpact.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>GitImpact</RootNamespace>
     <AssemblyName>GitImpact</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Plugins/Statistics/GitStatistics/GitStatistics.csproj
+++ b/Plugins/Statistics/GitStatistics/GitStatistics.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>GitStatistics</RootNamespace>
     <AssemblyName>GitStatistics</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/ResourceManager/ResourceManager.csproj
+++ b/ResourceManager/ResourceManager.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>ResourceManager</RootNamespace>
     <AssemblyName>ResourceManager</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/TranslationApp/TranslationApp.csproj
+++ b/TranslationApp/TranslationApp.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>TranslationApp</RootNamespace>
     <AssemblyName>TranslationApp</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>..\Logo\git-extensions-logo.ico</ApplicationIcon>
     <TargetFrameworkProfile>

--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>CommonTestUtils</RootNamespace>
     <AssemblyName>CommonTestUtils</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>GitCommandsTests</RootNamespace>
     <AssemblyName>GitCommandsTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
+++ b/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>GitExtUtilsTests</RootNamespace>
     <AssemblyName>GitExtUtilsTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>GitUITests</RootNamespace>
     <AssemblyName>GitUITests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegrationTests/AppVeyorIntegrationTests.csproj
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegrationTests/AppVeyorIntegrationTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>AppVeyorIntegrationTests</RootNamespace>
     <AssemblyName>AppVeyorIntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegrationTests/AzureDevOpsIntegrationTests.csproj
+++ b/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegrationTests/AzureDevOpsIntegrationTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>AzureDevOpsIntegrationTests</RootNamespace>
     <AssemblyName>AzureDevOpsIntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/Plugins/GitUIPluginInterfacesTests/GitUIPluginInterfacesTests.csproj
+++ b/UnitTests/Plugins/GitUIPluginInterfacesTests/GitUIPluginInterfacesTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>GitUIPluginInterfacesTests</RootNamespace>
     <AssemblyName>GitUIPluginInterfacesTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>ReleaseNotesGeneratorTests</RootNamespace>
     <AssemblyName>ReleaseNotesGeneratorTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>

--- a/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
+++ b/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>ResourceManagerTests</RootNamespace>
     <AssemblyName>ResourceManagerTests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>


### PR DESCRIPTION
It appears MSBuild 15.8 or 15.9 requires explicit `RuntimeIdentifier=win`.

Fixes #6497



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
