### PR TITLE
Generate avatars with author initials as fallback of gravatar

### DIFF
--- a/GitCommands/Settings/DefaultImageType.cs
+++ b/GitCommands/Settings/DefaultImageType.cs
@@ -11,6 +11,11 @@ namespace GitCommands
         /// </summary>
         None = 0,
 
+        /// <summary>
+        /// Return generated author initials avatar (color based on the email hash).
+        /// </summary>
+        AuthorInitials,
+
 #if false
         /// <summary>
         /// Return a simple, cartoon-style silhouetted outline of a person

--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -37,7 +37,7 @@ namespace GitUI.Avatars
         public event Action CacheCleared;
 
         /// <inheritdoc />
-        public async Task<Image> GetAvatarAsync(string email, int imageSize)
+        public async Task<Image> GetAvatarAsync(string email, string name, int imageSize)
         {
             if (string.IsNullOrWhiteSpace(email))
             {
@@ -103,6 +103,7 @@ namespace GitUI.Avatars
                             case DefaultImageType.Wavatar: return "wavatar";
                             case DefaultImageType.Retro: return "retro";
                             case DefaultImageType.Robohash: return "robohash";
+                            case DefaultImageType.AuthorInitials: return "404";
                             default: return "404";
                         }
                     }

--- a/GitUI/Avatars/AvatarMemoryCache.cs
+++ b/GitUI/Avatars/AvatarMemoryCache.cs
@@ -32,7 +32,7 @@ namespace GitUI.Avatars
         }
 
         /// <inheritdoc />
-        public async Task<Image> GetAvatarAsync(string email, int imageSize)
+        public async Task<Image> GetAvatarAsync(string email, string name, int imageSize)
         {
             lock (_cache)
             {
@@ -42,7 +42,7 @@ namespace GitUI.Avatars
                 }
             }
 
-            var image = await _inner.GetAvatarAsync(email, imageSize);
+            var image = await _inner.GetAvatarAsync(email, name, imageSize);
 
             lock (_cache)
             {

--- a/GitUI/Avatars/AvatarPersistentCache.cs
+++ b/GitUI/Avatars/AvatarPersistentCache.cs
@@ -16,11 +16,13 @@ namespace GitUI.Avatars
         private const int DefaultCacheDays = 30;
 
         private readonly IAvatarProvider _inner;
+        private readonly IAvatarGenerator _avatarGenerator;
         private readonly IFileSystem _fileSystem;
 
-        public AvatarPersistentCache(IAvatarProvider inner, IFileSystem fileSystem = null)
+        public AvatarPersistentCache(IAvatarProvider inner, IAvatarGenerator avatarGenerator, IFileSystem fileSystem = null)
         {
             _inner = inner;
+            _avatarGenerator = avatarGenerator;
             _fileSystem = fileSystem ?? new FileSystem();
         }
 
@@ -32,13 +34,14 @@ namespace GitUI.Avatars
         }
 
         /// <inheritdoc />
-        public async Task<Image> GetAvatarAsync(string email, int imageSize)
+        public async Task<Image> GetAvatarAsync(string email, string name, int imageSize)
         {
             var cacheDir = AppSettings.AvatarImageCachePath;
             var path = Path.Combine(cacheDir, $"{email}.{imageSize}px.png");
 
             var image = ReadImage()
-                ?? await _inner.GetAvatarAsync(email, imageSize);
+                ?? await _inner.GetAvatarAsync(email, name, imageSize)
+                ?? _avatarGenerator.GetAvatarImage(email, name, imageSize);
 
             if (image != null)
             {

--- a/GitUI/Avatars/AvatarService.cs
+++ b/GitUI/Avatars/AvatarService.cs
@@ -4,7 +4,9 @@ namespace GitUI.Avatars
 {
     public static class AvatarService
     {
+        private static InitialsAvatarGenerator AvatarGenerator = new InitialsAvatarGenerator();
         public static IAvatarProvider Default { get; }
-            = new BackupAvatarProvider(new AvatarMemoryCache(new AvatarPersistentCache(new AvatarDownloader())), Images.User80);
+            = new BackupAvatarProvider(new AvatarMemoryCache(new AvatarPersistentCache(new AvatarDownloader(), AvatarGenerator)),
+                Images.User80);
     }
 }

--- a/GitUI/Avatars/BackupAvatarProvider.cs
+++ b/GitUI/Avatars/BackupAvatarProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+using System.Linq;
 using System.Threading.Tasks;
+using GitCommands;
 
 namespace GitUI.Avatars
 {
@@ -23,11 +25,11 @@ namespace GitUI.Avatars
         }
 
         /// <inheritdoc />
-        public async Task<Image> GetAvatarAsync(string email, int imageSize)
+        public async Task<Image> GetAvatarAsync(string email, string name, int imageSize)
         {
             try
             {
-                return await _inner.GetAvatarAsync(email, imageSize) ?? _backupImage;
+                return await _inner.GetAvatarAsync(email, name, imageSize) ?? _backupImage;
             }
             catch
             {

--- a/GitUI/Avatars/IAvatarGenerator.cs
+++ b/GitUI/Avatars/IAvatarGenerator.cs
@@ -1,0 +1,10 @@
+﻿using System.Drawing;
+
+namespace GitUI.Avatars
+{
+    public interface IAvatarGenerator
+    {
+        Image GetAvatarImage(string email, string name, int imageSize);
+        Image GenerateAvatarImage(string email, string name, int imageSize);
+    }
+}

--- a/GitUI/Avatars/IAvatarProvider.cs
+++ b/GitUI/Avatars/IAvatarProvider.cs
@@ -17,7 +17,7 @@ namespace GitUI.Avatars
         /// </summary>
         [NotNull]
         [ItemCanBeNull]
-        Task<Image> GetAvatarAsync([NotNull] string email, int imageSize);
+        Task<Image> GetAvatarAsync([NotNull] string email, string name, int imageSize);
 
         /// <summary>
         /// Clears any cached images before raising <see cref="CacheCleared"/>.

--- a/GitUI/Avatars/InitialsAvatarGenerator.cs
+++ b/GitUI/Avatars/InitialsAvatarGenerator.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Linq;
+using GitCommands;
+
+namespace GitUI.Avatars
+{
+    public class InitialsAvatarGenerator : IAvatarGenerator
+    {
+        private int _unkownCounter = 0;
+
+        public Image GetAvatarImage(string email, string name, int imageSize)
+        {
+            if (AppSettings.GravatarDefaultImageType != DefaultImageType.AuthorInitials)
+            {
+                return null;
+            }
+
+            return GenerateAvatarImage(email, name, imageSize);
+        }
+
+        public Image GenerateAvatarImage(string email, string name, int imageSize)
+        {
+            var (initials, hashCode) = GetInitialsAndHashCode(email, name);
+
+            var avatarColor = _avatarColors[Math.Abs(hashCode) % _avatarColors.Length];
+
+            return DrawText(initials, avatarColor, imageSize);
+        }
+
+        protected internal (string initials, int hashCode) GetInitialsAndHashCode(string email, string name)
+        {
+            string initials;
+            int hashCode;
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                var trimmedName = name.Trim();
+                var indexSpace = trimmedName.IndexOf(' ');
+                initials = trimmedName[0].ToString().ToUpper();
+                if (indexSpace != -1)
+                {
+                    initials += trimmedName[indexSpace + 1].ToString().ToUpper();
+                }
+
+                hashCode = string.IsNullOrWhiteSpace(email) ? name.GetHashCode() : email.GetHashCode();
+            }
+            else if (!string.IsNullOrWhiteSpace(email))
+            {
+                initials = ("" + email.TrimStart().First()).ToUpper();
+                hashCode = email.GetHashCode();
+            }
+            else
+            {
+                initials = "?";
+                hashCode = _unkownCounter;
+                _unkownCounter++;
+            }
+
+            return (initials, hashCode);
+        }
+
+        private readonly Graphics _graphics = Graphics.FromImage(new Bitmap(1, 1));
+        private readonly Brush _textBrush = new SolidBrush(Color.WhiteSmoke);
+        private readonly Color[] _avatarColors =
+        {
+            Color.RoyalBlue,
+            Color.DarkRed,
+            Color.Purple,
+            Color.ForestGreen,
+            Color.DarkOrange
+        };
+
+        private Image DrawText(string text, Color backColor, int size)
+        {
+            lock (_avatarColors)
+            {
+                var fontSizeEstimation = size / 4.0f;
+                var font = new Font(AppSettings.CommitFont.FontFamily, fontSizeEstimation);
+
+                SizeF textSize = _graphics.MeasureString(text, font);
+
+                // Adjust font size with the measure
+                var sizeSquare = Math.Max((int)textSize.Width, (int)textSize.Height);
+                font = new Font(AppSettings.CommitFont.FontFamily, fontSizeEstimation * size / sizeSquare);
+                textSize = _graphics.MeasureString(text, font);
+
+                var img = new Bitmap(size, size);
+
+                using (var drawing = Graphics.FromImage(img))
+                {
+                    drawing.Clear(backColor);
+
+                    drawing.SmoothingMode = SmoothingMode.AntiAlias;
+                    drawing.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+                    var x = textSize.Width >= textSize.Height ? 0 : (textSize.Height - textSize.Width) / 2;
+                    var y = textSize.Width >= textSize.Height ? (textSize.Width - textSize.Height) / 2 : 0;
+                    drawing.DrawString(text, font, _textBrush, x, y);
+
+                    drawing.Save();
+                }
+
+                return img;
+            }
+        }
+    }
+}

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -94,11 +94,11 @@ namespace GitUI.CommitInfo
 
             if (revision == null)
             {
-                avatarControl.LoadImage(null);
+                avatarControl.LoadImage(null, null);
                 return;
             }
 
-            avatarControl.LoadImage(revision.AuthorEmail ?? revision.CommitterEmail);
+            avatarControl.LoadImage(revision.AuthorEmail ?? revision.CommitterEmail, revision.Author ?? revision.Committer);
         }
 
         private void rtbRevisionHeader_ContentsResized(ContentsResizedEventArgs e)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -83,6 +83,8 @@
     <Compile Include="Avatars\AvatarMemoryCache.cs" />
     <Compile Include="Avatars\AvatarPersistentCache.cs" />
     <Compile Include="Avatars\AvatarService.cs" />
+    <Compile Include="Avatars\IAvatarGenerator.cs" />
+    <Compile Include="Avatars\InitialsAvatarGenerator.cs" />
     <Compile Include="Avatars\BackupAvatarProvider.cs" />
     <Compile Include="Avatars\IAvatarProvider.cs" />
     <Compile Include="BranchTreePanel\ContextMenu\LocalBranchMenuItems.cs" />

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -46,16 +46,16 @@ namespace GitUI
             return;
 
             void ClearCache()
-            {
-                ThreadHelper.JoinableTaskFactory
-                    .RunAsync(
-                        async () =>
-                        {
-                            await _avatarProvider.ClearCacheAsync().ConfigureAwait(true);
-                            await UpdateAvatarAsync().ConfigureAwait(false);
-                        })
-                    .FileAndForget();
-            }
+        {
+            ThreadHelper.JoinableTaskFactory
+                .RunAsync(
+                    async () =>
+                    {
+                        await _avatarProvider.ClearCacheAsync().ConfigureAwait(true);
+                        await UpdateAvatarAsync().ConfigureAwait(false);
+                    })
+                .FileAndForget();
+        }
         }
 
         /// <summary>
@@ -77,7 +77,11 @@ namespace GitUI
         [Browsable(false)]
         public string Email { get; private set; }
 
-        public void LoadImage(string email)
+        [CanBeNull]
+        [Browsable(false)]
+        public string AuthorName { get; private set; }
+
+        public void LoadImage(string email, string name)
         {
             if (string.IsNullOrEmpty(email))
             {
@@ -86,6 +90,7 @@ namespace GitUI
             }
 
             Email = email;
+            AuthorName = name;
             ThreadHelper.JoinableTaskFactory.RunAsync(() => UpdateAvatarAsync()).FileAndForget();
         }
 
@@ -115,7 +120,7 @@ namespace GitUI
             }
 
             var token = _cancellationTokenSequence.Next();
-            var image = await _avatarProvider.GetAvatarAsync(email, Math.Max(size.Width, size.Height));
+            var image = await _avatarProvider.GetAvatarAsync(email, AuthorName, Math.Max(size.Width, size.Height));
 
             if (!token.IsCancellationRequested)
             {

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -49,7 +49,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             var imageSize = e.CellBounds.Height - padding - padding;
 
             Image image;
-            var imageTask = _avatarProvider.GetAvatarAsync(revision.AuthorEmail, imageSize);
+            var imageTask = _avatarProvider.GetAvatarAsync(revision.AuthorEmail, revision.Author, imageSize);
 
             if (imageTask.Status == TaskStatus.RanToCompletion)
             {

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -112,7 +112,7 @@ namespace Gource
             {
                 try
                 {
-                    var image = await AvatarService.Default.GetAvatarAsync(author.email, imageSize: 90);
+                    var image = await AvatarService.Default.GetAvatarAsync(author.email, author.name, imageSize: 90);
                     var filePath = Path.Combine(gourceAvatarsDir, author + ".png");
                     image.Save(filePath, ImageFormat.Png);
                 }

--- a/UnitTests/GitUITests/Avatars/AvatarCacheTestBase.cs
+++ b/UnitTests/GitUITests/Avatars/AvatarCacheTestBase.cs
@@ -9,17 +9,17 @@ namespace GitUITests.Avatars
         [Test]
         public async Task GetAvatarAsync_returns_correct_image()
         {
-            Assert.AreSame(_img1, await _cache.GetAvatarAsync(_email1, _size));
-            Assert.AreSame(_img2, await _cache.GetAvatarAsync(_email2, _size));
-            Assert.AreSame(_img3, await _cache.GetAvatarAsync(_email3, _size));
+            Assert.AreSame(_img1, await _cache.GetAvatarAsync(_email1, _name1, _size));
+            Assert.AreSame(_img2, await _cache.GetAvatarAsync(_email2, _name2, _size));
+            Assert.AreSame(_img3, await _cache.GetAvatarAsync(_email3, _name3, _size));
         }
 
         [Test]
         public async Task ClearCacheAsync_removes_all_images_from_cache()
         {
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
 
             await _cache.ClearCacheAsync();
 
@@ -27,9 +27,9 @@ namespace GitUITests.Avatars
             _inner.Received(1).ClearCacheAsync();
 #pragma warning restore 4014
 
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
         }
     }
 }

--- a/UnitTests/GitUITests/Avatars/AvatarMemoryCacheTests.cs
+++ b/UnitTests/GitUITests/Avatars/AvatarMemoryCacheTests.cs
@@ -17,45 +17,45 @@ namespace GitUITests.Avatars
         [Test]
         public async Task GetAvatarAsync_calls_inner_the_first_time()
         {
-            await MissAsync(_email1, _img1);
-            await HitAsync(_email1, _img1);
+            await MissAsync(_email1, _name1, _img1);
+            await HitAsync(_email1, _name1, _img1);
         }
 
         [Test]
         public async Task GetAvatarAsync_calls_inner_when_not_present_in_cache()
         {
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
-            await MissAsync(_email4, _img4);
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
-            await MissAsync(_email4, _img4);
-            await HitAsync(_email2, _img2);
-            await HitAsync(_email3, _img3);
-            await HitAsync(_email4, _img4);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
+            await MissAsync(_email4, _name4, _img4);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
+            await MissAsync(_email4, _name4, _img4);
+            await HitAsync(_email2, _name2, _img2);
+            await HitAsync(_email3, _name3, _img3);
+            await HitAsync(_email4, _name4, _img4);
         }
 
         [Test]
         public async Task GetAvatarAsync_cleans_oldest_images()
         {
             // Populate the cache with three images, so that it is full
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
 
             // Try getting the first image again
-            await HitAsync(_email1, _img1);
+            await HitAsync(_email1, _name1, _img1);
 
             // At this point image 2 is the oldest
 
             // Try getting image 4
-            await MissAsync(_email4, _img4);
+            await MissAsync(_email4, _name4, _img4);
 
             // That should have pushed images 2 and 3 out of the cache
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
         }
     }
 }

--- a/UnitTests/GitUITests/Avatars/AvatarTestBase.cs
+++ b/UnitTests/GitUITests/Avatars/AvatarTestBase.cs
@@ -16,11 +16,19 @@ namespace GitUITests.Avatars
         protected const string _email2 = "b@b.b";
         protected const string _email3 = "c@c.c";
         protected const string _email4 = "d@d.d";
+        protected const string _emailMissing = "missing@avatar.com";
+
+        protected const string _name1 = "John Lennon";
+        protected const string _name2 = "Paul McCartney";
+        protected const string _name3 = "George Harrison";
+        protected const string _name4 = "Ringo Starr";
+        protected const string _nameMissing = "Fifth Beatle";
 
         protected Image _img1;
         protected Image _img2;
         protected Image _img3;
         protected Image _img4;
+        protected Image _imgGenerated;
 
         protected IAvatarProvider _inner;
         protected IAvatarProvider _cache;
@@ -32,6 +40,7 @@ namespace GitUITests.Avatars
             _img2 = new Bitmap(_size, _size);
             _img3 = new Bitmap(_size, _size);
             _img4 = new Bitmap(_size, _size);
+            _imgGenerated = new Bitmap(_size, _size);
         }
 
         [OneTimeTearDown]
@@ -48,21 +57,22 @@ namespace GitUITests.Avatars
         {
             _inner = Substitute.For<IAvatarProvider>();
 
-            _inner.GetAvatarAsync(_email1, _size).Returns(Task.FromResult(_img1));
-            _inner.GetAvatarAsync(_email2, _size).Returns(Task.FromResult(_img2));
-            _inner.GetAvatarAsync(_email3, _size).Returns(Task.FromResult(_img3));
-            _inner.GetAvatarAsync(_email4, _size).Returns(Task.FromResult(_img4));
+            _inner.GetAvatarAsync(_email1, _name1, _size).Returns(Task.FromResult(_img1));
+            _inner.GetAvatarAsync(_email2, _name2, _size).Returns(Task.FromResult(_img2));
+            _inner.GetAvatarAsync(_email3, _name3, _size).Returns(Task.FromResult(_img3));
+            _inner.GetAvatarAsync(_email4, _name4, _size).Returns(Task.FromResult(_img4));
+            _inner.GetAvatarAsync(_emailMissing, _nameMissing, _size).Returns(Task.FromResult((Image)null));
         }
 
 #pragma warning disable 4014
 
-        protected async Task MissAsync(string email, Image expected = null)
+        protected async Task MissAsync(string email, string name,  Image expected = null)
         {
             _inner.ClearReceivedCalls();
 
-            var actual = await _cache.GetAvatarAsync(email, _size);
+            var actual = await _cache.GetAvatarAsync(email, name, _size);
 
-            _inner.Received(1).GetAvatarAsync(email, _size);
+            _inner.Received(1).GetAvatarAsync(email, name, _size);
 
             if (expected != null)
             {
@@ -70,13 +80,13 @@ namespace GitUITests.Avatars
             }
         }
 
-        protected async Task HitAsync(string email, Image expected = null)
+        protected async Task HitAsync(string email, string name, Image expected = null)
         {
             _inner.ClearReceivedCalls();
 
-            var actual = await _cache.GetAvatarAsync(email, _size);
+            var actual = await _cache.GetAvatarAsync(email, name, _size);
 
-            _inner.Received(0).GetAvatarAsync(email, _size);
+            _inner.Received(0).GetAvatarAsync(email, name, _size);
 
             if (expected != null)
             {

--- a/UnitTests/GitUITests/Avatars/BackupAvatarProviderTests.cs
+++ b/UnitTests/GitUITests/Avatars/BackupAvatarProviderTests.cs
@@ -20,23 +20,23 @@ namespace GitUITests.Avatars
         [Test]
         public async Task GetAvatarAsync_return_backup_image_if_inner_throws()
         {
-            _inner.GetAvatarAsync(Arg.Any<string>(), Arg.Any<int>()).Throws(new Exception());
+            _inner.GetAvatarAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()).Throws(new Exception());
 
-            Assert.AreSame(_img4, await _cache.GetAvatarAsync(_email1, _size));
+            Assert.AreSame(_img4, await _cache.GetAvatarAsync(_email1, _name1, _size));
         }
 
         [Test]
         public async Task GetAvatarAsync_returns_image_from_inner()
         {
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email1, _img1);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email2, _img2);
-            await MissAsync(_email3, _img3);
-            await MissAsync(_email3, _img3);
-            await MissAsync(_email4, _img4);
-            await MissAsync(_email4, _img4);
-            await MissAsync(_email4, _img4);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email1, _name1, _img1);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email2, _name2, _img2);
+            await MissAsync(_email3, _name3, _img3);
+            await MissAsync(_email3, _name3, _img3);
+            await MissAsync(_email4, _name4, _img4);
+            await MissAsync(_email4, _name4, _img4);
+            await MissAsync(_email4, _name4, _img4);
         }
     }
 }

--- a/UnitTests/GitUITests/Avatars/InitialsAvatarGeneratorTests.cs
+++ b/UnitTests/GitUITests/Avatars/InitialsAvatarGeneratorTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using GitUI.Avatars;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace GitUITests.Avatars
+{
+    [TestFixture]
+    public sealed class InitialsAvatarGeneratorTests
+    {
+        [Test]
+        public void GetInitialsAndHashCode_return_initials_of_a_user()
+        {
+            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode("albert.einstein@noreply.com", "albert einstein");
+
+            Assert.AreEqual("AE", initials);
+        }
+
+        [Test]
+        public void GetInitialsAndHashCode_return_the_initial_of_a_user_based_on_its_name()
+        {
+            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode("albert.einstein@noreply.com", "albert");
+
+            Assert.AreEqual("A", initials);
+        }
+
+        [Test]
+        public void GetInitialsAndHashCode_return_the_initial_of_a_user_based_on_its_email()
+        {
+            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode("albert.einstein@noreply.com", null);
+
+            Assert.AreEqual("A", initials);
+        }
+
+        [Test]
+        public void GetInitialsAndHashCode_return_question_mark_when_no_data_provided()
+        {
+            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode(null, null);
+
+            Assert.AreEqual("?", initials);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Avatars\AvatarMemoryCacheTests.cs" />
     <Compile Include="Avatars\AvatarPersistentCacheTests.cs" />
     <Compile Include="Avatars\AvatarTestBase.cs" />
+    <Compile Include="Avatars\InitialsAvatarGeneratorTests.cs" />
     <Compile Include="Avatars\BackupAvatarProviderTests.cs" />
     <Compile Include="BranchTreePanel\GitRefMenuItemsTest.cs" />
     <Compile Include="CancellationTokenSequenceTests.cs" />


### PR DESCRIPTION
A smaller step than #6417 as it requires no ("not everyone agrees") UI changes but bringing most of the added value...

## Proposed changes

- Add a new new gravatar fallback possibility with avatars generated from author initials


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/460196/56504937-7ea7ec00-651a-11e9-9ef4-ea54afd93641.png)

![image](https://user-images.githubusercontent.com/460196/56504959-8d8e9e80-651a-11e9-915a-976aeb1f283c.png)

### After

![image](https://user-images.githubusercontent.com/460196/56504814-10632980-651a-11e9-9a73-230888c1dfac.png)

![image](https://user-images.githubusercontent.com/460196/56505064-d21a3a00-651a-11e9-8331-2f52ca8de055.png)

## Test methodology <!-- How did you ensure quality? -->

* Unit tests
* Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build c937777048244969bee4b89f19e641543dd9a6e7
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3362.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
