### PR TITLE
correctly detect/handle script options

### DIFF
--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -191,6 +191,7 @@ namespace GitUI.Script
                 if (revisionGrid == null)
                 {
                     var currentRevisionGuid = module.GetCurrentCheckout();
+                    currentRevision = new GitRevision(currentRevisionGuid);
                     refs = module.GetRefs(true, true).Where(gitRef => gitRef.ObjectId == currentRevisionGuid).ToList();
                 }
                 else

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -57,7 +57,7 @@ namespace GitUI.Script
                     continue;
                 }
 
-                if (!option.StartsWith("{s"))
+                if (!option.StartsWith("s"))
                 {
                     continue;
                 }


### PR DESCRIPTION
Fixes #6285

## Proposed changes

- resolve regression introduced by 1b8bb93c7121cd291a17303edfdd313c8edb9f88
  by correctly detecting script options starting with "s" again
  The regression was a NRE instead of the message (see screenshot).
- bugfix: The script options {cHash}, {cMessage}, {cAuthor}, {cCommitter}, {cAuthorDate}, {cCommitDate} did not work due to currentRevision being null when the script was not run from RevisionGridControl.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

before 1b8bb93c7121cd291a17303edfdd313c8edb9f88
![grafik](https://user-images.githubusercontent.com/36601201/53131024-02ba1380-356c-11e9-80c3-4d92b20c42bb.png)

since 1b8bb93c7121cd291a17303edfdd313c8edb9f88
NRE 

### After

messagebox if the RevisionGrid is not focused

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build ca548259cc4cbee4b99ae6724a75345e57ab023c
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
