### PR TITLE
Bugfix/settings appearance

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -49,7 +49,7 @@
             this.ShowAuthorAvatarInCommitGraph = new System.Windows.Forms.CheckBox();
             this.ShowAuthorAvatarInCommitInfo = new System.Windows.Forms.CheckBox();
             this.ClearImageCache = new System.Windows.Forms.Button();
-            this.NoImageService = new System.Windows.Forms.ComboBox();
+            this._NO_TRANSLATE_NoImageService = new System.Windows.Forms.ComboBox();
             this.lblCacheDays = new System.Windows.Forms.Label();
             this.lblNoImageService = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_DaysToCacheImages = new System.Windows.Forms.NumericUpDown();
@@ -320,7 +320,7 @@
             this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatarInCommitGraph, 0, 0);
             this.tlpnlAuthor.Controls.Add(this.ShowAuthorAvatarInCommitInfo, 0, 1);
             this.tlpnlAuthor.Controls.Add(this.ClearImageCache, 1, 4);
-            this.tlpnlAuthor.Controls.Add(this.NoImageService, 1, 3);
+            this.tlpnlAuthor.Controls.Add(this._NO_TRANSLATE_NoImageService, 1, 3);
             this.tlpnlAuthor.Controls.Add(this.lblCacheDays, 0, 2);
             this.tlpnlAuthor.Controls.Add(this.lblNoImageService, 0, 3);
             this.tlpnlAuthor.Controls.Add(this._NO_TRANSLATE_DaysToCacheImages, 1, 2);
@@ -373,15 +373,15 @@
             this.ClearImageCache.UseVisualStyleBackColor = true;
             this.ClearImageCache.Click += new System.EventHandler(this.ClearImageCache_Click);
             // 
-            // NoImageService
+            // _NO_TRANSLATE_NoImageService
             // 
-            this.NoImageService.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.NoImageService.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.NoImageService.FormattingEnabled = true;
-            this.NoImageService.Location = new System.Drawing.Point(114, 75);
-            this.NoImageService.Name = "NoImageService";
-            this.NoImageService.Size = new System.Drawing.Size(183, 21);
-            this.NoImageService.TabIndex = 5;
+            this._NO_TRANSLATE_NoImageService.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_NoImageService.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_NoImageService.FormattingEnabled = true;
+            this._NO_TRANSLATE_NoImageService.Location = new System.Drawing.Point(114, 75);
+            this._NO_TRANSLATE_NoImageService.Name = "_NO_TRANSLATE_NoImageService";
+            this._NO_TRANSLATE_NoImageService.Size = new System.Drawing.Size(183, 21);
+            this._NO_TRANSLATE_NoImageService.TabIndex = 5;
             // 
             // lblCacheDays
             // 
@@ -479,7 +479,7 @@
         private System.Windows.Forms.Label truncateLongFilenames;
         private System.Windows.Forms.ComboBox truncatePathMethod;
         private System.Windows.Forms.GroupBox gbAuthorImages;
-        private System.Windows.Forms.ComboBox NoImageService;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_NoImageService;
         private System.Windows.Forms.Label lblNoImageService;
         private System.Windows.Forms.NumericUpDown _NO_TRANSLATE_DaysToCacheImages;
         private System.Windows.Forms.Label lblCacheDays;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -441,6 +441,7 @@
             this.Controls.Add(tlpnlMain);
             this.MinimumSize = new System.Drawing.Size(258, 255);
             this.Name = "AppearanceSettingsPage";
+            this.Text = "Appearance";
             this.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
             this.Size = new System.Drawing.Size(1138, 769);
             tlpnlMain.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -19,14 +19,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComponent();
             InitializeComplete();
 
-            NoImageService.Items.AddRange(Enum.GetNames(typeof(DefaultImageType)));
+            _NO_TRANSLATE_NoImageService.Items.AddRange(Enum.GetNames(typeof(DefaultImageType)));
         }
 
         protected override void OnRuntimeLoad()
         {
             base.OnRuntimeLoad();
 
-            ToolTip.SetToolTip(NoImageService, _noImageServiceTooltip.Text);
+            ToolTip.SetToolTip(_NO_TRANSLATE_NoImageService, _noImageServiceTooltip.Text);
 
             // align 1st columns across all tables
             tlpnlGeneral.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
@@ -36,9 +36,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             // align 2nd columns across all tables
             truncatePathMethod.AdjustWidthToFitContent();
             Language.AdjustWidthToFitContent();
-            tlpnlGeneral.AdjustWidthToSize(1, truncatePathMethod, NoImageService, Language);
-            tlpnlAuthor.AdjustWidthToSize(1, truncatePathMethod, NoImageService, Language);
-            tlpnlLanguage.AdjustWidthToSize(1, truncatePathMethod, NoImageService, Language);
+            tlpnlGeneral.AdjustWidthToSize(1, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
+            tlpnlAuthor.AdjustWidthToSize(1, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
+            tlpnlLanguage.AdjustWidthToSize(1, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
         }
 
         public static SettingsPageReference GetPageReference()
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
             ShowAuthorAvatarInCommitInfo.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
             ShowAuthorAvatarInCommitGraph.Checked = AppSettings.ShowAuthorAvatarColumn;
-            NoImageService.Text = AppSettings.GravatarDefaultImageType.ToString();
+            _NO_TRANSLATE_NoImageService.Text = AppSettings.GravatarDefaultImageType.ToString();
 
             Language.Items.Clear();
             Language.Items.Add("English");
@@ -115,7 +115,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.Translation = Language.Text;
             Strings.Reinitialize();
 
-            if (Enum.TryParse<DefaultImageType>(NoImageService.Text, ignoreCase: true, out var type))
+            if (Enum.TryParse<DefaultImageType>(_NO_TRANSLATE_NoImageService.Text, ignoreCase: true, out var type))
             {
                 AppSettings.GravatarDefaultImageType = type;
             }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -111,6 +111,10 @@ This action will be performed without warning while checking out branch.</source
   </file>
   <file datatype="plaintext" original="AppearanceSettingsPage" source-language="en">
     <body>
+      <trans-unit id="$this.Text">
+        <source>Appearance</source>
+        <target />
+      </trans-unit>
       <trans-unit id="ClearImageCache.Text">
         <source>Clear image cache</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -119,30 +119,6 @@ This action will be performed without warning while checking out branch.</source
         <source>Clear image cache</source>
         <target />
       </trans-unit>
-      <trans-unit id="NoImageService.Item0">
-        <source>None</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="NoImageService.Item1">
-        <source>MonsterId</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="NoImageService.Item2">
-        <source>Wavatar</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="NoImageService.Item3">
-        <source>Identicon</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="NoImageService.Item4">
-        <source>Retro</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="NoImageService.Item5">
-        <source>Robohash</source>
-        <target />
-      </trans-unit>
       <trans-unit id="ShowAuthorAvatarInCommitGraph.Text">
         <source>Show author's avatar column in the commit graph</source>
         <target />


### PR DESCRIPTION

## Proposed changes

Translation related
- Settings-Appearance got lost earlier in 3.1 (#6287 c28c023b5b9bdc50af97962a306818ea0e158cb2),(visible after TranslationApp ran). This is now being updated in the translations, the English.xlf source should be pushed again.
- NoImageService items were translated, with anonymous references. The newly added AuthorInitials in #6499 screwed up this list as it was added first (this is the correct place for this service, but adding must not reorder translations). 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/6248932/56616572-04f92680-661e-11e9-9a31-3485ba89408b.png)

### After

![image](https://user-images.githubusercontent.com/6248932/56616707-4d184900-661e-11e9-8b44-d6ccf262e5f5.png)


## Test methodology 
Manual

To avoid issues like this, we must enforce running the TranslationApp at updates, and fail builds if there are updates.

## Test environment(s)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
