### PR TITLE
Checkout branch: Fix inopportune line return in message box message

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -33,8 +33,7 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Don't show me this message again.");
 
         private readonly TranslationString _resetNonFastForwardBranch =
-            new TranslationString("You are going to reset the “{0}” branch to a new location\n" +
-                "discarding ALL the commited changes since the {1} revision.\n\nAre you sure?");
+            new TranslationString("You are going to reset the “{0}” branch to a new location discarding ALL the commited changes since the {1} revision.\n\nAre you sure?");
         private readonly TranslationString _resetCaption = new TranslationString("Reset branch");
         #endregion
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2632,8 +2632,7 @@ Enter valid branch name or select predefined value.</source>
         <target />
       </trans-unit>
       <trans-unit id="_resetNonFastForwardBranch.Text">
-        <source>You are going to reset the “{0}” branch to a new location
-discarding ALL the commited changes since the {1} revision.
+        <source>You are going to reset the “{0}” branch to a new location discarding ALL the commited changes since the {1} revision.
 
 Are you sure?</source>
         <target />


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6507

## Proposed changes

- Checkout branch: Remove inopportune line return in message box message

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/56643384-d9a42500-6679-11e9-91aa-f63f7a72cdfb.png)

### After

![image](https://user-images.githubusercontent.com/460196/56668475-db88db00-66af-11e9-944d-2c464b641336.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 290db968d32089960a018a67e30da65c65182b40 (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3394.0
- DPI 192dpi (200% scaling)
