### PR TITLE
Include source branch in link to BitBucket create pull request

### DIFF
--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -37,7 +37,7 @@ namespace Bitbucket
                 return false;
             }
 
-            using (var frm = new BitbucketPullRequestForm(settings))
+            using (var frm = new BitbucketPullRequestForm(settings, args.GitModule))
             {
                 frm.ShowDialog(args.OwnerForm);
             }

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands.Git;
 using GitExtUtils;
 using GitUI;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
@@ -19,13 +21,15 @@ namespace Bitbucket
         private readonly TranslationString _success = new TranslationString("Success");
         private readonly TranslationString _error = new TranslationString("Error");
         private readonly TranslationString _linkLabelToolTip = new TranslationString("Right-click to copy link");
-        private readonly string _NO_TRANSLATE_LinkCreatePull = "{0}/projects/{1}/repos/{2}/pull-requests?create";
-        private readonly string _NO_TRANSLATE_LinkViewPull = "{0}/projects/{1}/repos/{2}/pull-requests";
+        private readonly string _NO_TRANSLATE_RepoUrl = "{0}/projects/{1}/repos/{2}/";
+        private readonly string _NO_TRANSLATE_LinkCreatePull = "compare/commits?sourceBranch={0}";
+        private readonly string _NO_TRANSLATE_LinkCreatePullNoBranch = "pull-requests?create";
+        private readonly string _NO_TRANSLATE_LinkViewPull = "pull-requests";
 
         [CanBeNull] private readonly Settings _settings;
         private readonly BindingList<BitbucketUser> _reviewers = new BindingList<BitbucketUser>();
 
-        public BitbucketPullRequestForm([CanBeNull] Settings settings)
+        public BitbucketPullRequestForm([CanBeNull] Settings settings, IGitModule module)
         {
             InitializeComponent();
 
@@ -41,12 +45,17 @@ namespace Bitbucket
                 ReloadRepositories();
             };
 
-            _NO_TRANSLATE_lblLinkCreatePull.Text = string.Format(_NO_TRANSLATE_LinkCreatePull,
+            var repoUrl = _NO_TRANSLATE_RepoUrl = string.Format(_NO_TRANSLATE_RepoUrl,
                                       _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
+            var branch = GitCommands.GitRefName.GetFullBranchName(module.GetSelectedBranch());
+
+            _NO_TRANSLATE_lblLinkCreatePull.Text = repoUrl +
+                ((branch.IsNullOrEmpty() || branch.Equals(DetachedHeadParser.DetachedBranch)) ?
+                _NO_TRANSLATE_LinkCreatePullNoBranch :
+                string.Format(_NO_TRANSLATE_LinkCreatePull, branch));
             toolTipLink.SetToolTip(_NO_TRANSLATE_lblLinkCreatePull, _linkLabelToolTip.Text);
 
-            _NO_TRANSLATE_lblLinkViewPull.Text = string.Format(_NO_TRANSLATE_LinkViewPull,
-                _settings.BitbucketUrl, _settings.ProjectKey, _settings.RepoSlug);
+            _NO_TRANSLATE_lblLinkViewPull.Text = repoUrl + _NO_TRANSLATE_LinkViewPull;
             toolTipLink.SetToolTip(_NO_TRANSLATE_lblLinkViewPull, _linkLabelToolTip.Text);
 
             InitializeComplete();


### PR DESCRIPTION
Part of #4229

## Proposed changes
BitBucket Server has a link (that can be copied) to simplify creating BB PRs. (The BitBucket plugin is a little limited and for instance do not set default reviewers.)
The current link opens the general form.
This PR formats the link so the source address is set, you do not have to select in the list.

This is a minor feature, but simplifies when there are many branches.
No translation strings changed.

## Screenshots

Link changed from
```
<bitbucket-server>/projects/<project>/repos/<repo>/pull-requests
```
to
```
<bitbucket-server>/projects/<project>/repos/<repo>/compare/commits?sourceBranch=<branch>
```

## Test methodology 
Requires BitBucket Server to open the GE form
Click the link and verify that the source branch is filled in

## Test environment(s) 

BitBucket Server 6.0 (believe this is the same in BBS5).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
