### PR TITLE
Do not parse invalid rev-parse responses

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1166,6 +1166,11 @@ namespace GitCommands
 
                 return null;
             }
+            else if (output.StartsWith("fatal: ") || output.StartsWith("error: "))
+            {
+                // Not a Git repo or a submodule with incorrect ref to a superproject
+                return null;
+            }
 
             return ObjectId.Parse(output);
         }

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -359,6 +359,16 @@ namespace GitCommandsTests
             }
         }
 
+        [TestCase("fatal: not a git repository:")]
+        [TestCase("error: something went wrong")]
+        public void GetCurrentCheckout_should_query_git_and_return_null_if_invalid_response(string msg)
+        {
+            using (_executable.StageOutput($"rev-parse HEAD", msg, 0))
+            {
+                _gitModule.GetCurrentCheckout().Should().BeNull();
+            }
+        }
+
         [Test]
         public void GetRemotes()
         {

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -361,12 +361,28 @@ namespace GitCommandsTests
 
         [TestCase("fatal: not a git repository:")]
         [TestCase("error: something went wrong")]
-        public void GetCurrentCheckout_should_query_git_and_return_null_if_invalid_response(string msg)
+        [TestCase("HEAD")]
+        [TestCase("master")]
+        public void GetCurrentCheckout_should_query_git_and_return_null_if_response_is_not_sha(string msg)
         {
             using (_executable.StageOutput($"rev-parse HEAD", msg, 0))
             {
                 _gitModule.GetCurrentCheckout().Should().BeNull();
             }
+        }
+
+        [Test]
+        public void GetCurrentCheckout_should_query_git_and_return_sha_for_HEAD()
+        {
+            ObjectId objectId;
+            var headId = "69a7c7a40230346778e7eebed809773a6bc45268";
+
+            using (_executable.StageOutput("rev-parse HEAD", headId))
+            {
+                objectId = _gitModule.GetCurrentCheckout();
+            }
+
+            Assert.AreEqual(headId, objectId.ToString());
         }
 
         [Test]


### PR DESCRIPTION
Fixes #6512

## Proposed changes

Do not parse invalid rev-parse responses

## Test methodology 

Added a unit test
See issue for how to reproduce

## Test environment(s) 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
