### PR TITLE
Refactor: Create an enum GitProtocol.cs

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -438,11 +438,11 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             if (repo != null)
             {
-                bool multipleProtocols = repo.SupportedCloneProtocols.Length > 0;
+                bool multipleProtocols = repo.SupportedCloneProtocols.Any();
 
                 if (multipleProtocols && updateProtocols)
                 {
-                    var currentSelection = (string)ProtocolDropdownList.SelectedItem;
+                    var currentSelection = (GitProtocol)(ProtocolDropdownList.SelectedItem ?? repo.SupportedCloneProtocols.First());
                     ProtocolDropdownList.DataSource = CurrentySelectedGitRepo.SupportedCloneProtocols;
                     if (CurrentySelectedGitRepo.SupportedCloneProtocols.Contains(currentSelection))
                     {
@@ -535,7 +535,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void ProtocolSelectionChanged(object sender, EventArgs e)
         {
-            CurrentySelectedGitRepo.CloneProtocol = (string)ProtocolDropdownList.SelectedItem;
+            CurrentySelectedGitRepo.CloneProtocol = (GitProtocol)ProtocolDropdownList.SelectedItem;
             SetCloneInfoText(CurrentySelectedGitRepo);
         }
     }

--- a/Plugins/GitHub3/GitHubRepo.cs
+++ b/Plugins/GitHub3/GitHubRepo.cs
@@ -70,23 +70,7 @@ namespace GitHub3
             }
         }
 
-        public string CloneReadWriteUrl
-        {
-            get
-            {
-                string url;
-                if (CloneProtocol == "SSH")
-                {
-                    url = _repo.SshUrl;
-                }
-                else
-                {
-                    url = _repo.CloneUrl;
-                }
-
-                return url;
-            }
-        }
+        public string CloneReadWriteUrl => CloneProtocol == GitProtocol.Ssh ? _repo.SshUrl : _repo.CloneUrl;
 
         public string CloneReadOnlyUrl => _repo.GitUrl;
 
@@ -134,9 +118,9 @@ namespace GitHub3
             return pullRequest.Number;
         }
 
-        public string CloneProtocol { get; set; } = "SSH";
+        public GitProtocol CloneProtocol { get; set; } = GitProtocol.Ssh;
 
-        public string[] SupportedCloneProtocols { get; set; } = new string[] { "SSH", "HTTPS" };
+        public IReadOnlyList<GitProtocol> SupportedCloneProtocols { get; set; } = new[] { GitProtocol.Ssh, GitProtocol.Https };
 
         public override string ToString() => $"{Owner}/{Name}";
     }

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -92,6 +92,8 @@
     <Compile Include="IProcess.cs" />
     <Compile Include="ISettingControlBinding.cs" />
     <Compile Include="PluginsPathScanner.cs" />
+    <Compile Include="RepositoryHosts\GitProtocol.cs" />
+    <Compile Include="RepositoryHosts\GitProtocolExtensions.cs" />
     <Compile Include="SettingLevel.cs" />
     <Compile Include="ISettingsValueGetter.cs" />
     <Compile Include="ObjectId.cs" />

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/GitProtocol.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/GitProtocol.cs
@@ -1,0 +1,9 @@
+﻿namespace GitUIPluginInterfaces.RepositoryHosts
+{
+    // https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols
+    public enum GitProtocol
+    {
+        Https = 0,
+        Ssh
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/GitProtocolExtensions.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/GitProtocolExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace GitUIPluginInterfaces.RepositoryHosts
+{
+    public static class GitProtocolExtensions
+    {
+        public static bool IsUrlUsingHttp(this string url)
+        {
+            return url.StartsWith($"https://", StringComparison.CurrentCultureIgnoreCase) ||
+                url.StartsWith($"http://", StringComparison.CurrentCultureIgnoreCase);
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
@@ -47,9 +47,9 @@ namespace GitUIPluginInterfaces.RepositoryHosts
         /// <returns>Pull request number</returns>
         int CreatePullRequest(string myBranch, string remoteBranch, string title, string body);
 
-        string CloneProtocol { get; set; }
+        GitProtocol CloneProtocol { get; set; }
 
-        string[] SupportedCloneProtocols { get; set; }
+        IReadOnlyList<GitProtocol> SupportedCloneProtocols { get; set; }
     }
 
     public interface IHostedBranch

--- a/UnitTests/Plugins/GitUIPluginInterfacesTests/GitProtocolTests.cs
+++ b/UnitTests/Plugins/GitUIPluginInterfacesTests/GitProtocolTests.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using GitUIPluginInterfaces.RepositoryHosts;
+using NUnit.Framework;
+
+namespace GitUIPluginInterfacesTests
+{
+    [TestFixture]
+    public class GitProtocolTests
+    {
+        [TestCase("https://github.com/gitextensions/gitextensions.git", true)]
+        [TestCase("htTps://github.com/gitextensions/gitextensions.git", true)]
+        [TestCase("HTTPS://github.com/gitextensions/gitextensions.git", true)]
+        [TestCase("http://github.com/gitextensions/gitextensions.git", true)]
+        [TestCase("https_github.com/gitextensions/gitextensions.git", false)]
+        [TestCase("ssh://git@github.com/gitextensions/gitextensions.git", false)]
+        [TestCase("git@github.com/gitextensions/gitextensions.git", false)]
+        [TestCase("github.com/gitextensions/gitextensions.git", false)]
+        public void IsUrlUsingHttp(string url, bool expected)
+        {
+            url.IsUrlUsingHttp().Should().Be(expected);
+        }
+    }
+}

--- a/UnitTests/Plugins/GitUIPluginInterfacesTests/GitUIPluginInterfacesTests.csproj
+++ b/UnitTests/Plugins/GitUIPluginInterfacesTests/GitUIPluginInterfacesTests.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GitProtocolTests.cs" />
     <Compile Include="FontParserTests.cs" />
     <Compile Include="ManagedExtensibilityTests.cs" />
     <Compile Include="PluginsPathScannerTests.cs" />


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Refactoring, so fixes nothing...


## Proposed changes

- Introduce a class (edit: after some refactorings, that end up as an enum) `GitProtocol` to handle supported git protocol (a refactoring required to be used in 2 PR #6328 and #6515)
- Easier to review and merge before the 2 PRs...

## Test methodology <!-- How did you ensure quality? -->

- Added some unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 9602479c6bb5464dee4add337527ffcf47fb35fc (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3394.0
- DPI 192dpi (200% scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
