### PR TITLE
Remove duplicated implementation and call of function LoadSortedRefsAsync

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Reactive.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -203,25 +202,17 @@ namespace GitUI.CommitInfo
             ReloadCommitInfo();
         }
 
-        private async Task LoadSortedRefsAsync(CancellationToken cancellationToken = default)
+        private async Task LoadSortedRefsAsync()
         {
-            if (cancellationToken == default)
-            {
-                ThreadHelper.AssertOnUIThread();
-                _refsOrderDict = null;
+            ThreadHelper.AssertOnUIThread();
+            _refsOrderDict = null;
 
-                await TaskScheduler.Default.SwitchTo();
-            }
-            else
-            {
-                await TaskScheduler.Default;
-            }
-
+            await TaskScheduler.Default.SwitchTo();
             try
             {
                 var refsOrderDict = ToDictionary(Module.GetSortedRefs());
 
-                await this.SwitchToMainThreadAsync(cancellationToken);
+                await this.SwitchToMainThreadAsync();
                 _refsOrderDict = refsOrderDict;
                 UpdateRevisionInfo();
             }
@@ -299,11 +290,6 @@ namespace GitUI.CommitInfo
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    if (_refsOrderDict == null)
-                    {
-                        await LoadSortedRefsAsync(cancellationToken);
-                    }
-
                     // No branch/tag data for artificial commands
                     if (AppSettings.CommitInfoShowContainedInBranches)
                     {


### PR DESCRIPTION
Fixes #6516

## Proposed changes

- remove the unnecessary call of the function `LoadSortedRefsAsync` from `StartAsyncDataLoad`,
  which results in `GetSortedRefs` being called three times on startup
- remove the duplicated implementation which does not handle the possible `RefsWarningException`

## Test methodology <!-- How did you ensure quality? -->

- manual tests
  finding: On startup, `StartAsyncDataLoad` is called twice. I.e. the startup actions should be optimized. -> #6520

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build e0cfed7d0d82a5ebb5c2d20f103b25a56bbec874
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).