### PR TITLE
Format patch: fix patch creation when selection order is invalid (master) 

### DIFF
--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -34,6 +34,8 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Patch result");
         private readonly TranslationString _noGitMailConfigured =
             new TranslationString("There is no email address configured in the settings dialog.");
+        private readonly TranslationString _failCreatePatch =
+            new TranslationString("Unable to create patch file(s)");
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormFormatPatch()
@@ -186,8 +188,15 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            MessageBox.Show(this, result, _patchResultCaption.Text);
-            Close();
+            if (string.IsNullOrEmpty(result))
+            {
+                MessageBox.Show(this, _failCreatePatch.Text, _revisionsNeededCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            else
+            {
+                MessageBox.Show(this, result, _patchResultCaption.Text);
+                Close();
+            }
         }
 
         private bool SendMail(string dir)

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.DirectoryServices;
 using System.IO;
 using System.Net;
 using System.Net.Mail;
@@ -127,7 +128,7 @@ namespace GitUI.CommandsDialogs
             string rev2 = "";
             string result = "";
 
-            var revisions = RevisionGrid.GetSelectedRevisions();
+            var revisions = RevisionGrid.GetSelectedRevisions(SortDirection.Descending);
             if (revisions.Count > 0)
             {
                 if (revisions.Count == 1)


### PR DESCRIPTION
Note : same than #6525 but merge in master

Fixes :

When selecting 2 revisions in the wrong order (even if it seems the more logical one: from selected first and to selected last), the patchs are not generated and a blank message box is displayed

When selecting more than 2 revisions, patch are generated in the wrong order.


## Proposed changes

- Order of selection of revisions should not have effect on what is generated (patches are now generated in chronological order). Patches are generated successfully in any selection order.
- prevent an empty message box when no file generated (replace by an error message)
- Don't close form when generation failed


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![gitextensions_format_patch](https://user-images.githubusercontent.com/460196/57138071-f6df9e80-6db1-11e9-8f51-68dd218f53e4.gif)
And patches are not generated.

### After

* Patches are generated successfully in any selection order.

* New error message (even if I can't display it anymore due to the fix on selection order):

![image](https://user-images.githubusercontent.com/460196/57138433-f0055b80-6db2-11e9-8573-c9ca1c481c1e.png)




## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 9602479c6bb5464dee4add337527ffcf47fb35fc (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3394.0
- DPI 192dpi (200% scaling)
