### PR TITLE
Remove duplicated implementation and call of function LoadSortedRefsAsync

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -290,11 +290,6 @@ namespace GitUI.CommitInfo
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    if (_refsOrderDict == null)
-                    {
-                        await LoadSortedRefsAsync();
-                    }
-
                     // No branch/tag data for artificial commands
                     if (AppSettings.CommitInfoShowContainedInBranches)
                     {
@@ -356,26 +351,6 @@ namespace GitUI.CommitInfo
                         }
 
                         return $"{WebUtility.HtmlEncode(_trsLinksRelatedToRevision.Text)} {result}";
-                    }
-                }
-
-                async Task LoadSortedRefsAsync()
-                {
-                    await TaskScheduler.Default;
-                    _refsOrderDict = ToDictionary(Module.GetSortedRefs());
-
-                    await this.SwitchToMainThreadAsync(cancellationToken);
-                    UpdateRevisionInfo();
-
-                    IDictionary<string, int> ToDictionary(IReadOnlyList<string> list)
-                    {
-                        var dict = new Dictionary<string, int>();
-                        for (int i = 0; i < list.Count; i++)
-                        {
-                            dict.Add(list[i], i);
-                        }
-
-                        return dict;
                     }
                 }
 


### PR DESCRIPTION
Copy of #6519 for the branch release/3.1

Fixes #6516

## Proposed changes

- remove the unnecessary call of the function `LoadSortedRefsAsync` from `StartAsyncDataLoad`,
  which results in `GetSortedRefs` being called three times on startup
- remove the duplicated implementation which does not handle the possible `RefsWarningException`

## Test methodology <!-- How did you ensure quality? -->

- manual tests

## Test environment(s)

- Git Extensions 3.1.0
- Build d5291bc17b80e3c57f9c5e6b65d1db8fc000b801
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).