### PR TITLE
Fix rebase and apply patches displayed patches status

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1994,8 +1994,8 @@ namespace GitCommands
                     {
                         Name = file,
                         FullName = fullFileName,
-                        IsNext = n == next,
-                        IsSkipped = n < next
+                        IsApplied = n < next,
+                        IsNext = n == next
                     };
 
                 if (File.Exists(rebaseDir + file))

--- a/GitCommands/Patches/PatchFile.cs
+++ b/GitCommands/Patches/PatchFile.cs
@@ -19,19 +19,25 @@ namespace GitCommands.Patches
         public bool IsNext { get; set; }
 
         public bool IsSkipped { get; set; }
+        public bool IsApplied { get; set; }
 
         public string Status
         {
             get
             {
-                if (IsNext)
-                {
-                    return "Next to apply";
-                }
-
                 if (IsSkipped)
                 {
                     return "Skipped";
+                }
+
+                if (IsApplied)
+                {
+                    return "Applied";
+                }
+
+                if (IsNext)
+                {
+                    return "Applying...";
                 }
 
                 if (!string.IsNullOrEmpty(FullName) && !File.Exists(FullName))

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using ResourceManager;
@@ -96,7 +97,14 @@ namespace GitUI.CommandsDialogs
                 Abort.Enabled = false;
             }
 
-            patchGrid1.Initialize();
+            if (patchGrid1.PatchFiles == null || patchGrid1.PatchFiles.Count == 0)
+            {
+                patchGrid1.Initialize();
+            }
+            else
+            {
+                patchGrid1.RefreshGrid();
+            }
 
             SolveMergeConflicts.Visible = Module.InTheMiddleOfConflictedMerge();
 
@@ -209,6 +217,12 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
+                var applyingPatch = patchGrid1.PatchFiles.FirstOrDefault(p => p.IsNext);
+                if (applyingPatch != null)
+                {
+                    applyingPatch.IsSkipped = true;
+                }
+
                 FormProcess.ShowDialog(this, GitCommandHelpers.SkipCmd());
                 EnableButtons();
             }

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -157,7 +157,7 @@ namespace GitUI.CommandsDialogs
             this.Skip.Name = "Skip";
             this.Skip.Size = new System.Drawing.Size(162, 25);
             this.Skip.TabIndex = 11;
-            this.Skip.Text = "Skip this commit";
+            this.Skip.Text = "Skip currently applying commit";
             this.Skip.UseVisualStyleBackColor = true;
             this.Skip.Click += new System.EventHandler(this.SkipClick);
             // 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -191,6 +191,12 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
+                var applyingPatch = patchGrid1.PatchFiles.FirstOrDefault(p => p.IsNext);
+                if (applyingPatch != null)
+                {
+                    applyingPatch.IsSkipped = true;
+                }
+
                 FormProcess.ShowDialog(this, GitCommandHelpers.SkipRebaseCmd());
 
                 if (!Module.InTheMiddleOfRebase())
@@ -199,7 +205,8 @@ namespace GitUI.CommandsDialogs
                 }
 
                 EnableButtons();
-                patchGrid1.Initialize();
+
+                patchGrid1.RefreshGrid();
             }
         }
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -46,6 +46,13 @@ namespace GitUI.CommandsDialogs
             {
                 ShowOptions_LinkClicked(null, null);
             }
+
+            Shown += FormRebase_Shown;
+        }
+
+        private void FormRebase_Shown(object sender, EventArgs e)
+        {
+            patchGrid1.SelectCurrentlyApplyingPatch();
         }
 
         public FormRebase(GitUICommands commands, string from, string to, string defaultBranch, bool interactive = false,

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5487,7 +5487,7 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="Skip.Text">
-        <source>Skip this commit</source>
+        <source>Skip currently applying commit</source>
         <target />
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands.Patches;
@@ -10,6 +11,8 @@ namespace GitUI
     public partial class PatchGrid : GitModuleControl
     {
         private readonly TranslationString _unableToShowPatchDetails = new TranslationString("Unable to show details of patch file.");
+
+        public IReadOnlyList<PatchFile> PatchFiles { get; private set; }
 
         public PatchGrid()
         {
@@ -32,12 +35,33 @@ namespace GitUI
             Initialize();
         }
 
+        public void RefreshGrid()
+        {
+            var updatedPatches = GetPatches();
+
+            for (int i = 0; i < updatedPatches.Count; i++)
+            {
+                updatedPatches[i].IsSkipped = PatchFiles[i].IsSkipped;
+            }
+
+            DisplayPatches(updatedPatches);
+        }
+
+        private IReadOnlyList<PatchFile> GetPatches()
+        {
+            return Module.InTheMiddleOfInteractiveRebase()
+                            ? Module.GetInteractiveRebasePatchFiles()
+                            : Module.GetRebasePatchFiles();
+        }
+
         public void Initialize()
         {
-            var patchFiles = Module.InTheMiddleOfInteractiveRebase()
-                ? Module.GetInteractiveRebasePatchFiles()
-                : Module.GetRebasePatchFiles();
+            DisplayPatches(GetPatches());
+        }
 
+        private void DisplayPatches(IReadOnlyList<PatchFile> patchFiles)
+        {
+            PatchFiles = patchFiles;
             Patches.DataSource = patchFiles;
 
             if (patchFiles.Any())

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -70,6 +70,8 @@ namespace GitUI
                 int currentPatchFileIndex = patchFiles.TakeWhile(pf => !pf.IsNext).Count() - 1;
                 Patches.FirstDisplayedScrollingRowIndex = Math.Max(0, currentPatchFileIndex - (rowsInView / 2));
             }
+
+            SelectCurrentlyApplyingPatch();
         }
 
         private void Patches_DoubleClick(object sender, EventArgs e)
@@ -88,6 +90,22 @@ namespace GitUI
             }
 
             UICommands.StartViewPatchDialog(patchFile.FullName);
+        }
+
+        public void SelectCurrentlyApplyingPatch()
+        {
+            if (PatchFiles == null || !PatchFiles.Any())
+            {
+                return;
+            }
+
+            var shouldSelectIndex = PatchFiles.IndexOf(p => p.IsNext);
+
+            if (shouldSelectIndex >= 0)
+            {
+                Patches.ClearSelection();
+                Patches.Rows[shouldSelectIndex].Selected = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes a wrong status displayed 


## Proposed changes

- Form Rebase & Form Apply Patches: The status on each row display the good patch state
- The transiant "skipped" state is handled
- The "skip"button label as been changed to better explain what it does (skip the currently applying patch and not skipping the selected commit/patch)
- Little ergonomical improvement: The "Applying" patch row is selected when opening the form


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The patches applied are wrongly displayed as "skipped"
![image](https://user-images.githubusercontent.com/460196/57201712-0969fb80-6f9d-11e9-967c-c998db40113d.png)


### After

![image](https://user-images.githubusercontent.com/460196/57201809-27842b80-6f9e-11e9-9853-d81f70ec1630.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 1acb4c9940f8bf0d7c828b3a7a3a1ff77c246cc0
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3394.0
- DPI 96dpi (no scaling)

