### PR TITLE
Avoid loading data of incoherent revisions

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -286,7 +286,9 @@ namespace GitUI.CommitInfo
             {
                 var cancellationToken = _asyncLoadCancellation.Next();
 
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () => { await LoadLinksForRevisionAsync(_revision); }).FileAndForget();
+                var initialRevision = _revision;
+
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () => { await LoadLinksForRevisionAsync(initialRevision); }).FileAndForget();
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
@@ -294,25 +296,25 @@ namespace GitUI.CommitInfo
                     if (AppSettings.CommitInfoShowContainedInBranches)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadBranchInfoAsync(_revision.ObjectId);
+                        await LoadBranchInfoAsync(initialRevision.ObjectId);
                     }
 
                     if (AppSettings.ShowAnnotatedTagsMessages)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadAnnotatedTagInfoAsync(_revision.Refs);
+                        await LoadAnnotatedTagInfoAsync(initialRevision.Refs);
                     }
 
                     if (AppSettings.CommitInfoShowContainedInTags)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadTagInfoAsync(_revision.ObjectId);
+                        await LoadTagInfoAsync(initialRevision.ObjectId);
                     }
 
                     if (AppSettings.CommitInfoShowTagThisCommitDerivesFrom)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadDescribeInfoAsync(_revision.ObjectId);
+                        await LoadDescribeInfoAsync(initialRevision.ObjectId);
                     }
                 }).FileAndForget();
 


### PR DESCRIPTION
Fixes #6535

## Proposed changes

- avoid loading data of incoherent revisions
  by loading all data for the same revision

**Drawback:** The initial commit is selected again when the loading has finished.

## Test methodology <!-- How did you ensure quality? -->

- manual tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build c14ba78cca3a50f5daa6519d615f819fb0ede1f7
- Git 2.21.0.windows.1
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.2117.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
