### PR TITLE
fix: Mark portable version as such

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ for:
           & pwd
           & Setup\BuildInstallers.cmd
           if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-          & Setup\Set-Portable.ps1
+          & Setup\Set-Portable.ps1 -IsPortable
           if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
           & Setup\MakePortableArchive.cmd Release $env:APPVEYOR_BUILD_VERSION
           if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }


### PR DESCRIPTION
It appears we aren't marking portable builds as such:
![image](https://user-images.githubusercontent.com/4403806/57455616-ded6b600-72ae-11e9-90bd-279544d34a88.png)

/cc: @vbjay 