### PR TITLE
ParseRemotes: ignore empty lines that could make pair verification fail

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2203,6 +2203,11 @@ namespace GitCommands
                             return remotes;
                         }
 
+                        if (string.IsNullOrWhiteSpace(fetchLine))
+                        {
+                            continue;
+                        }
+
                         if (!enumerator.MoveNext())
                         {
                             throw new Exception("Remote URLs should appear in pairs.");


### PR DESCRIPTION
ParseRemotes: ignore empty lines that could make pair verification fail

Try to fix #6562

As output of `git remote -v` seems good (See https://github.com/gitextensions/gitextensions/issues/6562#issuecomment-492709643 ),
I suspect a problem with a version of git <= 2.16 that return an empty line at the end of the command output
 (all users reporting this error have a not up to date version of git.
See https://github.com/gitextensions/gitextensions/search?q=remote+URLs+should+appear+in+pairs&type=Issues )
