### PR TITLE
fix: Throws on `git remote` call outside git repo

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2183,7 +2183,7 @@ namespace GitCommands
                         var fetchLine = enumerator.Current;
 
                         // An invalid module is not an error; we simply return an empty list of remotes
-                        if (fetchLine.Contains("not a git repository"))
+                        if (fetchLine.IndexOf("not a git repository", StringComparison.OrdinalIgnoreCase) >= 0)
                         {
                             return remotes;
                         }

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -385,24 +385,49 @@ namespace GitCommandsTests
             Assert.AreEqual(headId, objectId.ToString());
         }
 
+        [TestCase("fatal: not a git repository (or any of the parent directories): .git")] // git version 2.20.1 (Apple Git-117)
+        [TestCase("fatal: Not a git repository (or any of the parent directories): .git")] // git version 2.16.1.windows.4
+        public void GetRemotes_should_return_empty_list_not_inside_git_repo(string warning)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                using (_executable.StageOutput("remote -v", warning))
+                {
+                    var remotes = await _gitModule.GetRemotesAsync();
+
+                    remotes.Should().BeEmpty();
+                }
+            });
+        }
+
+        [TestCase("fatal: not a git repository (or any of the parent directories): .git")] // git version 2.20.1 (Apple Git-117)
+        [TestCase("fatal: Not a git repository (or any of the parent directories): .git")] // git version 2.16.1.windows.4
+        public void GetRemotes_should_not_throw_if_not_inside_git_repo(string warning)
+        {
+            using (_executable.StageOutput("remote -v", warning))
+            {
+                Assert.DoesNotThrowAsync(async () => await _gitModule.GetRemotesAsync());
+            }
+        }
+
         [Test]
-        public void GetRemotes()
+        public void GetRemotes_should_parse_correctly_configured_remotes()
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 var lines = new[]
                 {
-                "RussKie\tgit://github.com/RussKie/gitextensions.git (fetch)",
-                "RussKie\tgit://github.com/RussKie/gitextensions.git (push)",
-                "origin\tgit@github.com:drewnoakes/gitextensions.git (fetch)",
-                "origin\tgit@github.com:drewnoakes/gitextensions.git (push)",
-                "upstream\tgit@github.com:gitextensions/gitextensions.git (fetch)",
-                "upstream\tgit@github.com:gitextensions/gitextensions.git (push)",
-                "asymmetrical\thttps://github.com/gitextensions/fetch.git (fetch)",
-                "asymmetrical\thttps://github.com/gitextensions/push.git (push)",
-                "with-space\tc:\\Bare Repo (fetch)",
-                "with-space\tc:\\Bare Repo (push)"
-            };
+                    "RussKie\tgit://github.com/RussKie/gitextensions.git (fetch)",
+                    "RussKie\tgit://github.com/RussKie/gitextensions.git (push)",
+                    "origin\tgit@github.com:drewnoakes/gitextensions.git (fetch)",
+                    "origin\tgit@github.com:drewnoakes/gitextensions.git (push)",
+                    "upstream\tgit@github.com:gitextensions/gitextensions.git (fetch)",
+                    "upstream\tgit@github.com:gitextensions/gitextensions.git (push)",
+                    "asymmetrical\thttps://github.com/gitextensions/fetch.git (fetch)",
+                    "asymmetrical\thttps://github.com/gitextensions/push.git (push)",
+                    "with-space\tc:\\Bare Repo (fetch)",
+                    "with-space\tc:\\Bare Repo (push)"
+                };
 
                 using (_executable.StageOutput("remote -v", string.Join("\n", lines)))
                 {


### PR DESCRIPTION
It looks like there was a change in wording after git 2.16 that changed from "fatal: Not a git..." to "fatal: not a git...".

The existing parser expected the warning to be in the lower case, and thus failed for earlier versions of git.
![image](https://user-images.githubusercontent.com/4403806/57851120-21eed700-7823-11e9-8184-83bb4ba23ec3.png)


Fixes #6562
Closes #6563
Closes #6565
Closes #6570
Closes #6571
Closes #6574
Closes #6577
Closes #6571



## Proposed changes

- The fix makes the check case insensitive.




## Test methodology <!-- How did you ensure quality? -->

- downgraded to git 2.16.4
- manual repro
- unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.1
- Build bb1687f6bd0450d0c1a2bae10a37c65493fc1294 (Dirty)
- Git 2.16.1.windows.4
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 144dpi (150% scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
