### PR TITLE
Use `Ben.Demystifier` to display or report better stacktraces

### DIFF
--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -84,6 +84,7 @@
     <PackageReference Include="AdysTech.CredentialManager">
       <Version>1.7.0</Version>
     </PackageReference>
+    <PackageReference Include="Ben.Demystifier" Version="0.1.4" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple">

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -107,7 +107,7 @@ namespace GitUI
                     catch (Exception ex) when (fileOnlyIf?.Invoke(ex) ?? true)
                     {
                         await JoinableTaskFactory.SwitchToMainThreadAsync();
-                        Application.OnThreadException(ex);
+                        Application.OnThreadException(ex.Demystify());
                     }
                 });
         }

--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -478,6 +478,8 @@ xcopy /y /i ..\GitExtensions\bin\%Configuration%\NBug.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\GitExtensions\bin\%Configuration%\SmartFormat.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
+xcopy /y /i ..\GitExtensions\bin\%Configuration%\Ben.Demystifier.dll GitExtensions\
+IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\GitExtensions\bin\%Configuration%\NetSpell.SpellChecker.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\GitExtensions\bin\%Configuration%\PSTaskDialog.dll GitExtensions\

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -153,6 +153,9 @@
       <Component Id="SmartFormat.dll" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\SmartFormat.dll" />
       </Component>
+      <Component Id="Ben.Demystifier.dll" Guid="*">
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\Ben.Demystifier.dll" />
+      </Component>
       <Component Id="System.Reactive.Core.dll" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.Core.dll" />
       </Component>
@@ -723,7 +726,7 @@
       <Component Id="English.Plugins.xlf" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\Translation\English.Plugins.xlf" />
       </Component>
-      <!-- 
+      <!--
       <Component Id="Czech.xlf" Guid="*">
         <File Source="..\GitUI\Translation\Czech.xlf" />
       </Component>
@@ -1557,6 +1560,7 @@
       <ComponentRef Id="System.ValueTuple.dll" />
       <ComponentRef Id="NBug.dll" />
       <ComponentRef Id="SmartFormat.dll" />
+      <ComponentRef Id="Ben.Demystifier.dll" />
       <ComponentRef Id="NetSpell.SpellChecker.dll" />
       <ComponentRef Id="ResourceManager.dll" />
       <ComponentRef Id="GitUIPluginInterfaces.dll" />


### PR DESCRIPTION
with smaller stacktraces and matching the real source code

Fixes #6569

### Before

```
System.Exception: This is a test
   at GitCommands.GitModule.<GetRemotesAsync>g__ParseRemotes|155_0(IEnumerable`1 lines) in C:\...\gitextensions\GitCommands\Git\GitModule.cs:line 2196
   at GitCommands.GitModule.<GetRemotesAsync>d__155.MoveNext() in C:\...\gitextensions\GitCommands\Git\GitModule.cs:line 2163
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.VisualStudio.Threading.AwaitExtensions.ExecuteContinuationSynchronouslyAwaiter`1.GetResult()
   at GitUI.BranchTreePanel.RepoObjectsTree.RemoteBranchTree.<LoadNodesAsync>d__4.MoveNext() in C:\...\gitextensions\GitUI\BranchTreePanel\RepoObjectsTree.Nodes.Remotes.cs:line 53
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at GitUI.BranchTreePanel.RepoObjectsTree.Tree.<ReloadNodesAsync>d__27.MoveNext() in C:\...\gitextensions\GitUI\BranchTreePanel\RepoObjectsTree.Nodes.cs:line 220
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at GitUI.BranchTreePanel.RepoObjectsTree.<>c__DisplayClass69_0.<<AddTree>b__1>d.MoveNext() in C:\...\gitextensions\GitUI\BranchTreePanel\RepoObjectsTree.cs:line 310
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at GitUI.ThreadHelper.<>c__DisplayClass13_0.<<FileAndForget>b__0>d.MoveNext() in C:\...\gitextensions\GitExtUtils\GitUI\ThreadHelper.cs:line 101
```

### After

```
System.Exception: This is a test
   at Task<IReadOnlyList<Remote>> GitCommands.GitModule.GetRemotesAsync()+ParseRemotes(IEnumerable<string> lines) in C:/.../gitextensions/GitCommands/Git/GitModule.cs:line 2196
   at async Task<IReadOnlyList<Remote>> GitCommands.GitModule.GetRemotesAsync() in C:/.../gitextensions/GitCommands/Git/GitModule.cs:line 2163
   at T Microsoft.VisualStudio.Threading.AwaitExtensions+ExecuteContinuationSynchronouslyAwaiter<T>.GetResult()
   at async Task<Nodes> GitUI.BranchTreePanel.RepoObjectsTree+RemoteBranchTree.LoadNodesAsync(CancellationToken token) in C:/.../gitextensions/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs:line 53
   at async Task GitUI.BranchTreePanel.RepoObjectsTree+Tree.ReloadNodesAsync(Func<CancellationToken, Task<Nodes>> loadNodesTask) in C:/.../gitextensions/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs:line 220
   at void GitUI.BranchTreePanel.RepoObjectsTree+<>c__DisplayClass69_0+<<AddTree>b__1>d.MoveNext() in C:/.../gitextensions/GitUI/BranchTreePanel/RepoObjectsTree.cs:line 310
   at void GitUI.ThreadHelper+<>c__DisplayClass13_0+<<FileAndForget>b__0>d.MoveNext() in C:/.../gitextensions/GitExtUtils/GitUI/ThreadHelper.cs:line 101
```


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build 7ff8254262b3fc7dd66c561cd15f2e7f9ba7b7a1 (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)
