### PR TITLE
Create branch or tag: Not for artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1955,7 +1955,7 @@ namespace GitUI.CommandsDialogs
 
         private void CreateBranchToolStripMenuItemClick(object sender, EventArgs e)
         {
-            UICommands.StartCreateBranchDialog(this, RevisionGrid.GetSelectedRevisions().FirstOrDefault()?.ObjectId);
+            UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId);
         }
 
         private void GitBashClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -35,6 +35,11 @@ namespace GitUI.CommandsDialogs
 
             groupBox1.AutoSize = true;
 
+            if (objectId != null && objectId.IsArtificial)
+            {
+                objectId = null;
+            }
+
             objectId = objectId ?? Module.GetCurrentCheckout();
             if (objectId != null)
             {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -40,6 +40,11 @@ namespace GitUI.CommandsDialogs
 
             tagMessage.MistakeFont = new Font(tagMessage.MistakeFont, FontStyle.Underline);
 
+            if (objectId != null && objectId.IsArtificial)
+            {
+                objectId = null;
+            }
+
             objectId = objectId ?? Module.GetCurrentCheckout();
             if (objectId != null)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1379,14 +1379,9 @@ namespace GitUI
         {
             var revision = LatestSelectedRevision;
 
-            if (revision == null)
-            {
-                return;
-            }
-
             UICommands.DoActionOnRepo(() =>
                 {
-                    using (var frm = new FormCreateTag(UICommands, revision.ObjectId))
+                    using (var frm = new FormCreateTag(UICommands, revision?.ObjectId))
                     {
                         return frm.ShowDialog(this) == DialogResult.OK;
                     }
@@ -1408,14 +1403,9 @@ namespace GitUI
         {
             var revision = LatestSelectedRevision;
 
-            if (revision == null)
-            {
-                return;
-            }
-
             UICommands.DoActionOnRepo(() =>
                 {
-                    var frm = new FormCreateBranch(UICommands, revision.ObjectId);
+                    var frm = new FormCreateBranch(UICommands, revision?.ObjectId);
 
                     return frm.ShowDialog(this) == DialogResult.OK;
                 });


### PR DESCRIPTION

Fixes #6597

Low priority

## Proposed changes
For artificial commits, use HEAD instead
This affected commands invoked by the hardcoded Ctrl-B and Ctrl-T shortcuts only (the shortcut in FormBrowse is not invoved).

The menu items are disabled for artificial commands already, the shortcut is not blocked though. The commands could be blocked in RevisionGridControl (as well as FormBrowse, even if that code will not be executed as the menu items are checked). However, the Form should check this anyway and it seem OK that the HEAD is used here.

## Screenshots
See issue

## Test methodology

Manual test:
- Select an an artificial command
- Ctrl-B/Ctrl-T to invoke the dialogs
- Verify that HEAD is set as base version


## Test environment(s)
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
