### PR TITLE
Add icons in "Repo" and "Branch" dropdowns

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -367,6 +367,7 @@ namespace GitUI.CommandsDialogs
             // 
             // _NO_TRANSLATE_WorkingDir
             // 
+            this._NO_TRANSLATE_WorkingDir.Image = global::GitUI.Properties.Resources.RepoOpen;
             this._NO_TRANSLATE_WorkingDir.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this._NO_TRANSLATE_WorkingDir.ImageTransparentColor = System.Drawing.Color.Magenta;
             this._NO_TRANSLATE_WorkingDir.Name = "_NO_TRANSLATE_WorkingDir";
@@ -380,6 +381,7 @@ namespace GitUI.CommandsDialogs
             // 
             // branchSelect
             // 
+            this.branchSelect.Image = global::GitUI.Properties.Resources.branch;
             this.branchSelect.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.branchSelect.Name = "branchSelect";
             this.branchSelect.Size = new System.Drawing.Size(60, 22);

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1763,6 +1763,8 @@
     <None Include="Resources\Icons\CommitId.png" />
     <None Include="Resources\Icons\CommitSummary.png" />
     <None Include="Resources\Icons\Message.png" />
+    <None Include="Resources\Icons\branch.png" />
+    <None Include="Resources\Icons\RepoOpen.png" />
     <None Include="Properties\DataSources\GitUI.Script.ScriptInfo.datasource" />
     <None Include="Properties\DataSources\GitCommands.Repository.datasource" />
     <None Include="Properties\DataSources\GitCommands.GitSubmodule.datasource" />

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -61,6 +61,16 @@ namespace GitUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap branch {
+            get {
+                object obj = ResourceManager.GetObject("branch", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changelog
         ///=========
         ///
@@ -162,6 +172,16 @@ namespace GitUI.Properties {
         internal static System.Drawing.Bitmap RecentRepositories {
             get {
                 object obj = ResourceManager.GetObject("RecentRepositories", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap RepoOpen {
+            get {
+                object obj = ResourceManager.GetObject("RepoOpen", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -192,4 +192,10 @@ Alexander Eifler, Marcelo Ghelman, ghanique, olshevskiy87</value>
   <data name="Message" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Icons\Message.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="RepoOpen" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\RepoOpen.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="branch" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\branch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>


### PR DESCRIPTION
## Proposed changes

- Add icons in the "Repo" and "Branch" dropdowns of the Browse form

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/58016261-71702400-7afd-11e9-87aa-0986a276efcd.png)


### After

![image](https://user-images.githubusercontent.com/460196/58016242-64533500-7afd-11e9-9704-88df9d97130a.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 3.1.0
- Build ee10522ce9ea2bcb93f6c30dceaa133b55bf16c0 (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

