### PR TITLE
Add Git "Last supported" and "Recommended" versions in reports

### DIFF
--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -25,24 +25,47 @@ namespace GitUI
             string gitVer;
             try
             {
-                gitVer = GitVersion.Current?.Full ?? "";
+                gitVer = GitVersion.Current?.Full;
             }
             catch (Exception)
             {
-                gitVer = "";
+                gitVer = null;
             }
+
+            var gitVersionInfo = GetGitVersionInfo(gitVer, GitVersion.LastSupportedVersion, GitVersion.LastRecommendedVersion);
 
             // Build and open FormAbout design to make sure info still looks good if you change this code.
             StringBuilder sb = new StringBuilder();
 
             sb.AppendLine($"- Git Extensions {AppSettings.ProductVersion}");
             sb.AppendLine($"- Build {_sha}{(_dirty ? " (Dirty)" : "")}");
-            sb.AppendLine($"- Git {gitVer}");
+            sb.AppendLine($"- Git {gitVersionInfo}");
             sb.AppendLine($"- {Environment.OSVersion}");
             sb.AppendLine($"- {RuntimeInformation.FrameworkDescription}");
             sb.AppendLine($"- DPI {DpiUtil.DpiX}dpi ({(DpiUtil.ScaleX == 1 ? "no" : $"{Math.Round(DpiUtil.ScaleX * 100)}%")} scaling)");
 
             return sb.ToString();
+        }
+
+        public static string GetGitVersionInfo(string gitVersion, GitVersion lastSupportedVersion, GitVersion recommendedVersion)
+        {
+            if (string.IsNullOrWhiteSpace(gitVersion))
+            {
+                return $"- (minimum: {lastSupportedVersion}, recommended: {recommendedVersion})";
+            }
+
+            var actualVersion = new GitVersion(gitVersion);
+            if (actualVersion < lastSupportedVersion)
+            {
+                return $"{gitVersion} (minimum: {lastSupportedVersion}, please update!)";
+            }
+
+            if (actualVersion < recommendedVersion)
+            {
+                return $"{gitVersion} (recommended: {recommendedVersion} or later)";
+            }
+
+            return gitVersion;
         }
 
         public static void Initialise(string sha, bool isDirty)

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffControllerTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
+    <Compile Include="UserEnvironmentInformationTests.cs" />
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />
     <Compile Include="Editor\FileViewerTests.cs" />
     <Compile Include="Editor\FileViewerTextTests.cs" />

--- a/UnitTests/GitUITests/UserEnvironmentInformationTests.cs
+++ b/UnitTests/GitUITests/UserEnvironmentInformationTests.cs
@@ -1,0 +1,42 @@
+﻿using GitCommands;
+using GitUI;
+using NUnit.Framework;
+
+namespace GitUITests
+{
+    [TestFixture]
+    public sealed class UserEnvironmentInformationTests
+    {
+        [Test]
+        public void GitVersion_is_good()
+        {
+            var gitString = UserEnvironmentInformation.GetGitVersionInfo("2.21.0.windows.1", new GitVersion("2.18.0"),
+                new GitVersion("2.21.0"));
+            Assert.AreEqual("2.21.0.windows.1", gitString);
+        }
+
+        [Test]
+        public void GitVersion_is_old_but_supported()
+        {
+            var gitString = UserEnvironmentInformation.GetGitVersionInfo("2.20.1.windows.1", new GitVersion("2.18.0"),
+                new GitVersion("2.21.0"));
+            Assert.AreEqual("2.20.1.windows.1 (recommended: 2.21.0 or later)", gitString);
+        }
+
+        [Test]
+        public void GitVersion_is_not_supported()
+        {
+            var gitString = UserEnvironmentInformation.GetGitVersionInfo("1.6.5.windows.1", new GitVersion("2.18.0"),
+                new GitVersion("2.21.0"));
+            Assert.AreEqual("1.6.5.windows.1 (minimum: 2.18.0, please update!)", gitString);
+        }
+
+        [Test]
+        public void GitVersion_is_unknown_then_return_all_data()
+        {
+            var gitString = UserEnvironmentInformation.GetGitVersionInfo(null, new GitVersion("2.18.0"),
+                new GitVersion("2.21.0"));
+            Assert.AreEqual("- (minimum: 2.18.0, recommended: 2.21.0)", gitString);
+        }
+    }
+}


### PR DESCRIPTION
Fixes something evoked there: https://github.com/gitextensions/gitextensions/issues/6562#issuecomment-493673925


## Proposed changes

- Add "Last supported" and "Recommended" versions of git in the about form and reports message to let us more easily process bug reports.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

```
- Git Extensions 3.1.0
- Build f5c59e63703641975d3bf3616c94e5eed0f4157b (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)
```

### After

```
- Git Extensions 3.1.0
- Build f5c59e63703641975d3bf3616c94e5eed0f4157b (Dirty)
- Git 2.21.0.windows.1 (Last supported: 2.11.0 / Minimum recommended: 2.20.1)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)
```


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build f5c59e63703641975d3bf3616c94e5eed0f4157b (Dirty)
- Git 2.21.0.windows.1 (Last supported: 2.11.0 / Minimum recommended: 2.20.1)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)
