### PR TITLE
fix: Pull dialog not remember user selection

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -697,10 +697,22 @@ namespace GitCommands
             Default
         }
 
+        /// <summary>
+        /// Gets or sets the default pull action that is performed by the toolbar icon when it is clicked on.
+        /// </summary>
         public static PullAction DefaultPullAction
         {
             get => GetEnum("DefaultPullAction", PullAction.Merge);
             set => SetEnum("DefaultPullAction", value);
+        }
+
+        /// <summary>
+        /// Gets or sets the default pull action as configured in the FormPull dialog.
+        /// </summary>
+        public static PullAction FormPullAction
+        {
+            get => GetEnum("FormPullAction", PullAction.Merge);
+            set => SetEnum("FormPullAction", value);
         }
 
         public static string SmtpServer

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2396,7 +2396,7 @@ namespace GitUI.CommandsDialogs
         private void PullToolStripMenuItemClick(object sender, EventArgs e)
         {
             // "Pull/Fetch..." menu item always opens the dialog
-            DoPull(pullAction: AppSettings.DefaultPullAction, isSilent: false);
+            DoPull(pullAction: AppSettings.FormPullAction, isSilent: false);
         }
 
         private void ToolStripButtonPullClick(object sender, EventArgs e)
@@ -2404,13 +2404,15 @@ namespace GitUI.CommandsDialogs
             // Clicking on the Pull button toolbar button will perform the default selected action silently,
             // except if that action is to open the dialog (PullAction.None)
             bool isSilent = AppSettings.DefaultPullAction != AppSettings.PullAction.None;
-            DoPull(pullAction: AppSettings.DefaultPullAction, isSilent: isSilent);
+            var pullAction = AppSettings.DefaultPullAction != AppSettings.PullAction.None ?
+                AppSettings.DefaultPullAction : AppSettings.FormPullAction;
+            DoPull(pullAction: pullAction, isSilent: isSilent);
         }
 
         private void pullToolStripMenuItem1_Click(object sender, EventArgs e)
         {
             // "Open Pull Dialog..." toolbar menu item always open the dialog with the current default action
-            DoPull(pullAction: AppSettings.DefaultPullAction, isSilent: false);
+            DoPull(pullAction: AppSettings.FormPullAction, isSilent: false);
         }
 
         private void mergeToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -138,6 +138,7 @@ namespace GitUI.CommandsDialogs
 
             switch (pullAction)
             {
+                case AppSettings.PullAction.None:
                 case AppSettings.PullAction.Merge:
                     Merge.Checked = true;
                     Prune.Enabled = true;
@@ -352,6 +353,8 @@ namespace GitUI.CommandsDialogs
                 return DialogResult.No;
             }
 
+            UpdateSettingsDuringPull();
+
             DialogResult dr = ShouldRebaseMergeCommit();
             if (dr != DialogResult.Yes)
             {
@@ -554,6 +557,16 @@ namespace GitUI.CommandsDialogs
                     UICommands.StashPop(owner);
                 }
             }
+        }
+
+        private void UpdateSettingsDuringPull()
+        {
+            AppSettings.FormPullAction =
+                Merge.Checked ? AppSettings.PullAction.Merge :
+                Rebase.Checked ? AppSettings.PullAction.Rebase :
+                Fetch.Checked ? AppSettings.FormPullAction = AppSettings.PullAction.Fetch : AppSettings.PullAction.Default;
+
+            AppSettings.AutoStash = AutoStash.Checked;
         }
 
         private DialogResult ShouldRebaseMergeCommit()
@@ -1045,6 +1058,8 @@ namespace GitUI.CommandsDialogs
             public CheckBox Prune => _form.Prune;
             public ComboBox Remotes => _form._NO_TRANSLATE_Remotes;
             public TextBox LocalBranch => _form.localBranch;
+
+            public void UpdateSettingsDuringPull() => _form.UpdateSettingsDuringPull();
         }
     }
 }


### PR DESCRIPTION
If "Open Pull dialog ..." is set as a default pull operation, the pull dialog does not have correct settings preselected upon open.
Also since refactors in v3 pull dialog does not remember user selection (such as `Auto stash`).


Fixes #6503

(cherry picked from commit 691c45b52016d3698bb0a4c60eba938d217e36c0)


## Proposed changes

- The fix restores `FormPullAction` setting that remembers user's selection in the dialog.
- The fix also restores the capture of `AutoStash` selection.



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/58022757-7ced3a80-7b51-11e9-9ec5-3ed96e0c3909.png)


### After

![image](https://user-images.githubusercontent.com/4403806/58022946-f08f4780-7b51-11e9-9bdb-78e297758016.png)



## Test methodology <!-- How did you ensure quality? -->

- reproduced the issue / compared with v2.51.04
- manual tests
- unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.1
- Build 691c45b52016d3698bb0a4c60eba938d217e36c0
- Git 2.16.1.windows.4
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3324.0
- DPI 144dpi (150% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
