### PR TITLE
Do not split paths at trailing slash of submodules

### DIFF
--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -168,7 +168,7 @@ namespace GitUI
                 return (null, null);
             }
 
-            int slashIndex = name.LastIndexOf(PathUtil.PosixDirectorySeparatorChar);
+            int slashIndex = name.TrimEnd(PathUtil.PosixDirectorySeparatorChar).LastIndexOf(PathUtil.PosixDirectorySeparatorChar);
             if (slashIndex >= 0 && slashIndex < name.Length)
             {
                 string path = name.Substring(0, slashIndex + 1);

--- a/UnitTests/GitUITests/CommandsDialogs/PathFormatterTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/PathFormatterTests.cs
@@ -46,6 +46,12 @@ namespace GitUITests.CommandsDialogs
         [TestCase("nested/path/filename.ext", "nested/path/", "filename.ext")]
         [TestCase("/nested/path/filename.ext", "/nested/path/", "filename.ext")]
         [TestCase("path\\filename.ext", null, "path\\filename.ext")]
+        [TestCase("path\\submodule.dir\\", null, "path\\submodule.dir\\")]
+        [TestCase("/", null, "/")]
+        [TestCase("submodule.dir/", null, "submodule.dir/")]
+        [TestCase("/submodule.dir/", "/", "submodule.dir/")]
+        [TestCase("path/submodule.dir/", "path/", "submodule.dir/")]
+        [TestCase("/path/submodule.dir/", "/path/", "submodule.dir/")]
         public void Test_SplitPathName(string name, string expectedPath, string expectedFileName)
         {
             PathFormatter.TestAccessor.SplitPathName(name).Should().Be((expectedPath, expectedFileName));


### PR DESCRIPTION
Fixes #6559

## Proposed changes

- do not split paths at trailing slash of submodules

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/58130790-3cf38980-7c1d-11e9-98a4-9c24854ebbdd.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/58130817-51378680-7c1d-11e9-8d79-80ef81d8650e.png)

## Test methodology <!-- How did you ensure quality? -->

- added NUnit test cases

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 9190a2cdd2ee3bde4693e58cf32a4a49f0d30be9
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3362.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
