### PR TITLE
Use relative submodule references to clone with ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "GitExtensionsDoc"]
 	path = GitExtensionsDoc
-	url = https://github.com/gitextensions/GitExtensionsDoc.git
+	url = ../../gitextensions/GitExtensionsDoc.git
 [submodule "Externals/NBug"]
 	path = Externals/NBug
-	url = https://github.com/gitextensions/NBug.git
+	url = ../../gitextensions/NBug.git
 [submodule "Externals/Git.hub"]
 	path = Externals/Git.hub
-	url = https://github.com/gitextensions/Git.hub.git
+	url = ../../gitextensions/Git.hub.git
 [submodule "Externals/conemu-inside"]
 	path = Externals/conemu-inside
-	url = https://github.com/gitextensions/conemu-inside.git
+	url = ../../gitextensions/conemu-inside.git
 [submodule "Externals/ICSharpCode.TextEditor"]
 	path = Externals/ICSharpCode.TextEditor
-	url = https://github.com/gitextensions/ICSharpCode.TextEditor.git
+	url = ../../gitextensions/ICSharpCode.TextEditor.git


### PR DESCRIPTION
## Proposed changes
GE has currently hardcoded the submodule references like https://github.com/gitextensions/NBug.git
So if you clone the superproject with ssh (or git or file if you have a cloned server for some reason) the submodule references are still using https: It is a little confusing when cloning why you get Git Credential Manager (if GCM is installed) or get prompts for each subrepo.

## Test methodology 
- Clone repo git@github.com:gerhardol/gitextensions.git with branch feature/relative-subm-url recursively
- Verify that the submodule references are using ssh


- Check out branch feature/relative-subm-url
- git submodule sync
- Check that the url for the submodule with base matching the superproject changes (all will not change).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
