### PR TITLE
Move ArtificialCommits from Settings to grid View menu

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -38,7 +38,6 @@
             this.chkShowStashCountInBrowseWindow = new System.Windows.Forms.CheckBox();
             this.chkShowSubmoduleStatusInBrowse = new System.Windows.Forms.CheckBox();
             this.chkUseFastChecks = new System.Windows.Forms.CheckBox();
-            this.chkShowCurrentChangesInRevisionGraph = new System.Windows.Forms.CheckBox();
             this.lblCommitsLimit = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_MaxCommits = new System.Windows.Forms.NumericUpDown();
             this.groupBoxEmailSettings = new System.Windows.Forms.GroupBox();
@@ -115,20 +114,19 @@
             this.tlpnlPerformance.ColumnCount = 2;
             this.tlpnlPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlPerformance.Controls.Add(this.chkShowAheadBehindDataInBrowseWindow, 0, 6);
-            this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 7);
+            this.tlpnlPerformance.Controls.Add(this.chkShowAheadBehindDataInBrowseWindow, 0, 5);
+            this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 6);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusInToolbar, 0, 0);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusForArtificialCommits, 0, 1);
-            this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 5);
+            this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 4);
             this.tlpnlPerformance.Controls.Add(this.chkShowSubmoduleStatusInBrowse, 0, 2);
-            this.tlpnlPerformance.Controls.Add(this.chkUseFastChecks, 0, 4);
-            this.tlpnlPerformance.Controls.Add(this.chkShowCurrentChangesInRevisionGraph, 0, 3);
-            this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 8);
-            this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 8);
+            this.tlpnlPerformance.Controls.Add(this.chkUseFastChecks, 0, 3);
+            this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 7);
+            this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 7);
             this.tlpnlPerformance.Dock = System.Windows.Forms.DockStyle.Top;
             this.tlpnlPerformance.Location = new System.Drawing.Point(8, 21);
             this.tlpnlPerformance.Name = "tlpnlPerformance";
-            this.tlpnlPerformance.RowCount = 9;
+            this.tlpnlPerformance.RowCount = 8;
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -222,17 +220,6 @@
             this.chkUseFastChecks.TabIndex = 4;
             this.chkUseFastChecks.Text = "Use FileSystemWatcher to check if index is changed";
             this.chkUseFastChecks.UseVisualStyleBackColor = true;
-            // 
-            // chkShowCurrentChangesInRevisionGraph
-            // 
-            this.chkShowCurrentChangesInRevisionGraph.AutoSize = true;
-            this.chkShowCurrentChangesInRevisionGraph.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkShowCurrentChangesInRevisionGraph.Location = new System.Drawing.Point(3, 72);
-            this.chkShowCurrentChangesInRevisionGraph.Name = "chkShowCurrentChangesInRevisionGraph";
-            this.chkShowCurrentChangesInRevisionGraph.Size = new System.Drawing.Size(347, 17);
-            this.chkShowCurrentChangesInRevisionGraph.TabIndex = 3;
-            this.chkShowCurrentChangesInRevisionGraph.Text = "Show current working directory changes as an artificial commit";
-            this.chkShowCurrentChangesInRevisionGraph.UseVisualStyleBackColor = true;
             // 
             // lblCommitsLimit
             // 
@@ -598,7 +585,6 @@
         private System.Windows.Forms.CheckBox chkCheckForUncommittedChangesInCheckoutBranch;
         private System.Windows.Forms.CheckBox chkShowGitStatusInToolbar;
         private System.Windows.Forms.CheckBox chkShowGitStatusForArtificialCommits;
-        private System.Windows.Forms.CheckBox chkShowCurrentChangesInRevisionGraph;
         private System.Windows.Forms.CheckBox chkUseFastChecks;
         private System.Windows.Forms.CheckBox chkShowStashCountInBrowseWindow;
         private System.Windows.Forms.CheckBox chkShowSubmoduleStatusInBrowse;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -56,7 +56,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             RevisionGridQuickSearchTimeout.Value = AppSettings.RevisionGridQuickSearchTimeout;
             chkFollowRenamesInFileHistory.Checked = AppSettings.FollowRenamesInFileHistory;
             chkStashUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInAutoStash;
-            chkShowCurrentChangesInRevisionGraph.Checked = AppSettings.RevisionGraphShowWorkingDirChanges;
             chkShowStashCountInBrowseWindow.Checked = AppSettings.ShowStashCount;
             chkShowAheadBehindDataInBrowseWindow.Checked = AppSettings.ShowAheadBehindData;
             chkShowAheadBehindDataInBrowseWindow.Enabled = GitVersion.Current.SupportAheadBehindData;
@@ -96,7 +95,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.UseFastChecks = chkUseFastChecks.Checked;
             AppSettings.MaxRevisionGraphCommits = (int)_NO_TRANSLATE_MaxCommits.Value;
             AppSettings.RevisionGridQuickSearchTimeout = (int)RevisionGridQuickSearchTimeout.Value;
-            AppSettings.RevisionGraphShowWorkingDirChanges = chkShowCurrentChangesInRevisionGraph.Checked;
             AppSettings.ShowStashCount = chkShowStashCountInBrowseWindow.Checked;
             AppSettings.ShowAheadBehindData = chkShowAheadBehindDataInBrowseWindow.Checked;
             AppSettings.ShowSubmoduleStatus = chkShowSubmoduleStatusInBrowse.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.1.0">
+<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.2.0">
   <file datatype="plaintext" original="AdvancedSettingsPage" source-language="en">
     <body>
       <trans-unit id="$this.Text">
@@ -4127,6 +4127,10 @@ If you are not sure just close this window.</source>
         <source>Build Report</source>
         <target />
       </trans-unit>
+      <trans-unit id="blameSettingsToolStripMenuItem.Text">
+        <source>Blame settings:</source>
+        <target />
+      </trans-unit>
       <trans-unit id="cherryPickThisCommitToolStripMenuItem.Text">
         <source>Cherry pick commit</source>
         <target />
@@ -4145,6 +4149,14 @@ If you are not sure just close this window.</source>
       </trans-unit>
       <trans-unit id="diffToolRemoteLocalStripMenuItem.Text">
         <source>Difftool selected &lt; - &gt; local</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="displayAuthorFirstToolStripMenuItem.Text">
+        <source>Display author first</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="displaySettingsToolStripMenuItem.Text">
+        <source>Display result settings:</source>
         <target />
       </trans-unit>
       <trans-unit id="followFileHistoryRenamesToolStripMenuItem.Text">
@@ -4187,8 +4199,28 @@ If you are not sure just close this window.</source>
         <source>Save as</source>
         <target />
       </trans-unit>
+      <trans-unit id="showAuthorDateToolStripMenuItem.Text">
+        <source>Show author date</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="showAuthorTimeToolStripMenuItem.Text">
+        <source>Show author time</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="showAuthorToolStripMenuItem.Text">
+        <source>Show author</source>
+        <target />
+      </trans-unit>
       <trans-unit id="showFullHistoryToolStripMenuItem.Text">
         <source>Show Full History</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="showLineNumbersToolStripMenuItem.Text">
+        <source>Show line numbers</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="showOriginalFilePathToolStripMenuItem.Text">
+        <source>Show original file path</source>
         <target />
       </trans-unit>
       <trans-unit id="simplifyMergesContextMenuItem.Text">
@@ -4331,6 +4363,10 @@ Change the default behaviour only if you experience problems.</source>
       </trans-unit>
       <trans-unit id="_currentBranchText.Text">
         <source>Current branch:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_failCreatePatch.Text">
+        <source>Unable to create patch file(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="_noEmailEnteredText.Text">
@@ -7011,10 +7047,6 @@ Context menu for additional operations</source>
         <source>Show ahead and behind information on status bar in browse window</source>
         <target />
       </trans-unit>
-      <trans-unit id="chkShowCurrentChangesInRevisionGraph.Text">
-        <source>Show current working directory changes as an artificial commit</source>
-        <target />
-      </trans-unit>
       <trans-unit id="chkShowGitCommandLine.Text">
         <source>Show console window when executing git process</source>
         <target />
@@ -8266,6 +8298,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="ShowAllBranches.Text">
         <source>Show all branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ShowArtificialCommits.Text">
+        <source>Show artificial commits</source>
         <target />
       </trans-unit>
       <trans-unit id="ShowCurrentBranchOnly.Text">

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1827,6 +1827,12 @@ namespace GitUI
             _gridView.Invalidate();
         }
 
+        internal void ToggleShowArtificialCommits()
+        {
+            AppSettings.RevisionGraphShowWorkingDirChanges = !AppSettings.RevisionGraphShowWorkingDirChanges;
+            ForceRefreshRevisions();
+        }
+
         internal void ToggleShowReflogReferences()
         {
             AppSettings.ShowReflogReferences = !AppSettings.ShowReflogReferences;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -203,6 +203,13 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
+                    Name = "ShowArtificialCommits",
+                    Text = "Show artificial commits",
+                    ExecuteAction = () => _revisionGrid.ToggleShowArtificialCommits(),
+                    IsCheckedFunc = () => AppSettings.RevisionGraphShowWorkingDirChanges
+                },
+                new MenuCommand
+                {
                     Name = "ShowReflogReferences",
                     Text = "Show reflog references",
                     ExecuteAction = () => _revisionGrid.ToggleShowReflogReferences(),


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/issues/4033#issuecomment-491493535

## Proposed changes
Move the toggle to view artificial commits (working directory and Index commits) in the revision grid from Settings to the View menu.
This is consistent with other grid 'decorations'.
This setting was maybe affecting the performance when first added but has no direct effect right now. The General tab is also too crowded right now.

Note: The old setting was called "Show current working directory changes as an artificial commit".
I choose to call the new "Show artificial commits". As the setting now is closer to the change, it should be easier to understand. (This will have to be described in the documentation.)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/6248932/58201518-90291300-7cd5-11e9-8efb-bfe0a5ab0434.png)

![image](https://user-images.githubusercontent.com/6248932/58201576-b2229580-7cd5-11e9-99f7-f8bfd3a1244e.png)

### After
![image](https://user-images.githubusercontent.com/6248932/58201629-d2525480-7cd5-11e9-98a3-a101993e496d.png)

![image](https://user-images.githubusercontent.com/6248932/58201658-e39b6100-7cd5-11e9-9320-cadb075192d4.png)

## Test methodology <!-- How did you ensure quality? -->
Manual test

## Test environment(s) 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
