### PR TITLE
refactor: GitModule.GetSortedRefs

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -747,26 +747,6 @@ namespace GitCommands
             return list;
         }
 
-        public IReadOnlyList<string> GetSortedRefs()
-        {
-            var args = new GitArgumentBuilder("for-each-ref")
-            {
-                "--sort=-committerdate",
-                "--sort=-taggerdate",
-                "--format=\"%(refname)\"",
-                "refs/"
-            };
-
-            string tree = _gitExecutable.GetOutput(args);
-            int warningPos = tree.IndexOf("warning:");
-            if (warningPos >= 0)
-            {
-                throw new RefsWarningException(tree.Substring(warningPos).SplitLines()[0]);
-            }
-
-            return tree.Split();
-        }
-
         public async Task<Dictionary<IGitRef, IGitItem>> GetSubmoduleItemsForEachRefAsync(string filename, Func<IGitRef, bool> showRemoteRef, bool noLocks = false)
         {
             string command = GetSortedRefsCommand(noLocks: noLocks);

--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncTestHelper.cs" />
+    <Compile Include="MockExecutable.cs" />
     <Compile Include="SubmoduleTestHelpers.cs" />
     <Compile Include="ConfigureJoinableTaskFactoryAttribute.cs" />
     <Compile Include="EmbeddedResourceLoader.cs" />

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -11,9 +11,9 @@ using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using NUnit.Framework;
 
-namespace GitCommandsTests
+namespace CommonTestUtils
 {
-    internal sealed class MockExecutable : IExecutable
+    public sealed class MockExecutable : IExecutable
     {
         private readonly ConcurrentDictionary<string, ConcurrentStack<(string output, int? exitCode)>> _outputStackByArguments = new ConcurrentDictionary<string, ConcurrentStack<(string output, int? exitCode)>>();
         private readonly ConcurrentDictionary<string, int> _commandArgumentsSet = new ConcurrentDictionary<string, int>();

--- a/UnitTests/GitCommandsTests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ExecutableExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CommonTestUtils;
 using GitCommands;
 using NUnit.Framework;
 

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -69,7 +69,6 @@
     <Compile Include="PlinkTests.cs" />
     <Compile Include="RevisionReaderTests.cs" />
     <Compile Include="StreamExtensionsTests.cs" />
-    <Compile Include="MockExecutable.cs" />
     <Compile Include="RepoNameExtractorTest.cs" />
     <Compile Include="GitModuleTests.cs" />
     <Compile Include="GitRevisionInfoProviderTests.cs" />

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -1,16 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
 using GitUI;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace GitCommandsTests
@@ -668,21 +667,6 @@ namespace GitCommandsTests
             Assert.AreEqual(expected, _gitModule.GetSortedRefsCommand(noLocks).ToString());
         }
 
-        [Test]
-        public void GetSortedRefs_should_throw_on_git_warning()
-        {
-            GitModule module = GetGitModuleWithMockedResultOfGitCommand("refs/heads/master\nwarning: message");
-            ((Action)(() => module.GetSortedRefs())).Should().Throw<RefsWarningException>();
-        }
-
-        [Test]
-        public void GetSortedRefs_should_split_output_if_no_warning()
-        {
-            string output = "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"; // does not contain "warning:"
-            GitModule module = GetGitModuleWithMockedResultOfGitCommand(output);
-            module.GetSortedRefs().Should().BeEquivalentTo(output.Split());
-        }
-
         [TestCase(@"show-ref --dereference", true, true, false)]
         [TestCase(@"show-ref --tags", true, false, false)]
         [TestCase(@"for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", false, true, false)]
@@ -720,13 +704,6 @@ namespace GitCommandsTests
 
             _executable.StageOutput(arguments.ToString(), dummyCommandOutput);
             _gitModule.FormatPatch(from, to, outputFile, start).Should().Be(dummyCommandOutput);
-        }
-
-        private GitModule GetGitModuleWithMockedResultOfGitCommand(string result)
-        {
-            var executable = Substitute.For<IExecutable>();
-            executable.GetOutput(Arg.Any<ArgumentString>()).Returns(x => result);
-            return GetGitModuleWithExecutable(executable: executable);
         }
 
         /// <summary>

--- a/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Git;
+using GitUI;
+using GitUITests.CommandsDialogs;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.CommitInfo
+{
+    [Apartment(ApartmentState.STA)]
+    public class CommitInfoTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private MockExecutable _gitExecutable;
+        private GitUICommands _commands;
+        private GitUI.CommitInfo.CommitInfo _commitInfo;
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository == null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+
+            // mock git executable
+            _gitExecutable = new MockExecutable();
+            typeof(GitModule).GetField("_gitExecutable", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(_commands.Module, _gitExecutable);
+            var cmdRunner = new GitCommandRunner(_gitExecutable, () => GitModule.SystemEncoding);
+            typeof(GitModule).GetField("_gitCommandRunner", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(_commands.Module, cmdRunner);
+
+            var uiCommandsSource = Substitute.For<IGitUICommandsSource>();
+            uiCommandsSource.UICommands.Returns(x => _commands);
+
+            _commitInfo = new GitUI.CommitInfo.CommitInfo
+            {
+                UICommandsSource = uiCommandsSource
+            };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _commands = null;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [Test]
+        public void GetSortedRefs_should_throw_on_git_warning()
+        {
+            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+                "refs/heads/master\nwarning: message");
+
+            ((Action)(() => _commitInfo.GetTestAccessor().GetSortedRefs())).Should().Throw<RefsWarningException>();
+        }
+
+        [Test]
+        public void GetSortedRefs_should_split_output_if_no_warning()
+        {
+            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+                "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"); // does not contain "warning:"
+
+            var expected = new Dictionary<string, int>
+            {
+                ["refs/remotes/origin/master"] = 0,
+                ["refs/heads/master"] = 1,
+                ["refs/heads/warning"] = 2
+            };
+
+            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+
+            refs.Count.Should().Be(3);
+            refs.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void GetSortedRefs_should_load_ref_different_in_case()
+        {
+            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+                "refs/remotes/origin/master\nrefs/heads/master\nrefs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375\nrefs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"); // case sensitive duplicates
+
+            var expected = new Dictionary<string, int>
+            {
+                ["refs/remotes/origin/master"] = 0,
+                ["refs/heads/master"] = 1,
+                ["refs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375"] = 2,
+                ["refs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"] = 3
+            };
+
+            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+
+            refs.Count.Should().Be(4);
+            refs.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void GetSortedRefs_should_load_ref_with_extra_spaces()
+        {
+            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+                "refs/remotes/origin/master\nrefs/heads/master\nrefs/tags/v3.1\nrefs/tags/v3.1 \n refs/tags/v3.1"); // have leading and trailing spaces
+
+            var expected = new Dictionary<string, int>
+            {
+                ["refs/remotes/origin/master"] = 0,
+                ["refs/heads/master"] = 1,
+                ["refs/tags/v3.1"] = 2,
+                ["refs/tags/v3.1 "] = 3,
+                [" refs/tags/v3.1"] = 4
+            };
+
+            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+
+            refs.Count.Should().Be(5);
+            refs.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="CommandsDialogs\RevisionDiffContextMenuControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffControllerTests.cs" />
+    <Compile Include="CommitInfo\CommitInfoTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
     <Compile Include="UserEnvironmentInformationTests.cs" />
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />


### PR DESCRIPTION
## Proposed changes

`GitModule.GetSortedRefs` method has been moved into `CommitInfo` control because that's was its only call site. As such the method added little value and a significant overhead to the public API surface.

To get the tests working,
* `MockExecutable` was moved to `CommonTestUtils` projects to it can now be accessed across all tests; and
* `LoadSortedRefsAsync()` method was refactored and `ToDictionary` method was inlined into `GetSortedRefs()` to facilitate testing.

Also while building tests I discovered the following:
* `CommitInfo` would call `RefreshSortedRefs()` when the control was passed an instance of `UICommandsSource`, which was pretty much at the instantiation time, way before a display of a commit information was requested.
* A second redundant call to `RefreshSortedRefs()` was made when a repository was closed and a user navigated to the dashboard.
* `UpdateCommitMessage()` method could get called with a `null` revision, and that would cause a NRE.

Fixes #6616

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
