### PR TITLE
Fix Ctrl+Backspace affecting ReadOnly TextBox

### DIFF
--- a/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
+++ b/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
@@ -35,7 +35,7 @@ namespace GitUI
 
         private static void HandleKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyData == (Keys.Control | Keys.Back))
+            if (e.KeyData == (Keys.Control | Keys.Back) && !IsReadOnly(sender))
             {
                 e.Handled = true;
                 e.SuppressKeyPress = true;
@@ -190,6 +190,9 @@ namespace GitUI
             ((Control)sender).Disposed -= HandleDisposed;
             ((Control)sender).KeyDown -= HandleKeyDown;
         }
+
+        private static bool IsReadOnly(object sender) =>
+            sender is TextBoxBase textBox && textBox.ReadOnly;
 
         private static readonly MethodInfo _beginUpdateMethod =
             typeof(Control).GetMethod("BeginUpdateInternal",


### PR DESCRIPTION
Fixes #6667 introduced by #6256

## Test methodology

Manually verified the problem from screenshot below was fixed.

![image](https://user-images.githubusercontent.com/12046452/58371841-e8eaec80-7f1d-11e9-8bc7-707ed143d3a8.png)

## Test environment(s)

- Windows 7 SP1

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
