### PR TITLE
ignore Ctrl+Backspace in non-editable ComboBox

### DIFF
--- a/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
+++ b/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
@@ -191,8 +191,18 @@ namespace GitUI
             ((Control)sender).KeyDown -= HandleKeyDown;
         }
 
-        private static bool IsReadOnly(object sender) =>
-            sender is TextBoxBase textBox && textBox.ReadOnly;
+        private static bool IsReadOnly(object sender)
+        {
+            switch (sender)
+            {
+                case TextBoxBase textBox:
+                    return textBox.ReadOnly;
+                case ComboBox comboBox:
+                    return comboBox.DropDownStyle == ComboBoxStyle.DropDownList;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
 
         private static readonly MethodInfo _beginUpdateMethod =
             typeof(Control).GetMethod("BeginUpdateInternal",


### PR DESCRIPTION
Follow up #6668

The change is cosmetic, `Ctrl`+`Backspace` does not
affect non-editable ComboBox anyway

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).