### PR TITLE
Checkbox for line numbers hide/show

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1364,6 +1364,12 @@ namespace GitCommands
             set => SetBool("RememberNumberOfContextLines", value);
         }
 
+        public static bool ShowLineNumbers
+        {
+            get => GetBool("ShowLineNumbers", true);
+            set => SetBool("ShowLineNumbers", value);
+        }
+
         public static string GetDictionaryDir()
         {
             return Path.Combine(GetResourceDir(), "Dictionaries");

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -30,6 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanelForDiffViewer = new System.Windows.Forms.TableLayoutPanel();
+            this.chkShowLineNumbers = new System.Windows.Forms.CheckBox();
             this.chkShowDiffForAllParents = new System.Windows.Forms.CheckBox();
             this.chkOpenSubmoduleDiffInSeparateWindow = new System.Windows.Forms.CheckBox();
             this.chkRememberIgnoreWhiteSpacePreference = new System.Windows.Forms.CheckBox();
@@ -50,6 +51,7 @@
             this.tableLayoutPanelForDiffViewer.ColumnCount = 2;
             this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelForDiffViewer.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkShowLineNumbers, 0, 8);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkShowDiffForAllParents, 0, 6);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkOpenSubmoduleDiffInSeparateWindow, 0, 5);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkRememberIgnoreWhiteSpacePreference, 0, 0);
@@ -74,6 +76,17 @@
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.Size = new System.Drawing.Size(1132, 821);
             this.tableLayoutPanelForDiffViewer.TabIndex = 1;
+            // 
+            // chkShowLineNumbers
+            // 
+            this.chkShowLineNumbers.AutoSize = true;
+            this.chkShowLineNumbers.Location = new System.Drawing.Point(3, 190);
+            this.chkShowLineNumbers.Name = "chkShowLineNumbers";
+            this.chkShowLineNumbers.Size = new System.Drawing.Size(115, 17);
+            this.chkShowLineNumbers.TabIndex = 13;
+            this.chkShowLineNumbers.Text = "Show line numbers";
+            this.chkShowLineNumbers.UseVisualStyleBackColor = true;
+            this.chkShowLineNumbers.CheckedChanged += new System.EventHandler(this.chkShowLineNumbers_CheckedChanged);
             // 
             // chkShowDiffForAllParents
             // 
@@ -205,5 +218,6 @@
         private System.Windows.Forms.CheckBox chkShowDiffForAllParents;
         private System.Windows.Forms.NumericUpDown VerticalRulerPosition;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.CheckBox chkShowLineNumbers;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -44,7 +44,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void chkShowLineNumbers_CheckedChanged(object sender, System.EventArgs e)
         {
-            
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -21,6 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkOpenSubmoduleDiffInSeparateWindow.Checked = AppSettings.OpenSubmoduleDiffInSeparateWindow;
             chkShowDiffForAllParents.Checked = AppSettings.ShowDiffForAllParents;
             VerticalRulerPosition.Value = AppSettings.DiffVerticalRulerPosition;
+            chkShowLineNumbers.Checked = AppSettings.ShowLineNumbers;
         }
 
         protected override void PageToSettings()
@@ -33,11 +34,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.OpenSubmoduleDiffInSeparateWindow = chkOpenSubmoduleDiffInSeparateWindow.Checked;
             AppSettings.ShowDiffForAllParents = chkShowDiffForAllParents.Checked;
             AppSettings.DiffVerticalRulerPosition = (int)VerticalRulerPosition.Value;
+            AppSettings.ShowLineNumbers = chkShowLineNumbers.Checked;
         }
 
         public static SettingsPageReference GetPageReference()
         {
             return new SettingsPageReferenceByType(typeof(DiffViewerSettingsPage));
+        }
+
+        private void chkShowLineNumbers_CheckedChanged(object sender, System.EventArgs e)
+        {
+            
         }
     }
 }

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -17,51 +17,52 @@ namespace GitUI.Editor
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.contextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.cherrypickSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyPatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyNewVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyOldVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.findToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.ignoreWhitespaceAtEolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ignoreWhitespaceChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ignoreAllWhitespaceChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.increaseNumberOfLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.decreaseNumberOfLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.showEntireFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.treatAllFilesAsTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.showNonprintableCharactersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.goToLineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileviewerToolbar = new GitUI.ToolStripEx();
-            this.nextChangeButton = new System.Windows.Forms.ToolStripButton();
-            this.previousChangeButton = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.increaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
-            this.decreaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.showEntireFileButton = new System.Windows.Forms.ToolStripButton();
-            this.showNonPrintChars = new System.Windows.Forms.ToolStripButton();
-            this.ignoreWhitespaceAtEol = new System.Windows.Forms.ToolStripButton();
-            this.ignoreWhiteSpaces = new System.Windows.Forms.ToolStripButton();
+			this.components = new System.ComponentModel.Container();
+			this.contextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.cherrypickSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.copyPatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.copyNewVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.copyOldVersionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.findToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.ignoreWhitespaceAtEolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ignoreWhitespaceChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ignoreAllWhitespaceChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.increaseNumberOfLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.decreaseNumberOfLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showEntireFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.treatAllFilesAsTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showNonprintableCharactersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.goToLineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileviewerToolbar = new GitUI.ToolStripEx();
+			this.nextChangeButton = new System.Windows.Forms.ToolStripButton();
+			this.previousChangeButton = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+			this.increaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
+			this.decreaseNumberOfLines = new System.Windows.Forms.ToolStripButton();
+			this.showLineNumbers = new System.Windows.Forms.ToolStripButton();
+			this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+			this.showEntireFileButton = new System.Windows.Forms.ToolStripButton();
+			this.showNonPrintChars = new System.Windows.Forms.ToolStripButton();
+			this.ignoreWhitespaceAtEol = new System.Windows.Forms.ToolStripButton();
+			this.ignoreWhiteSpaces = new System.Windows.Forms.ToolStripButton();
             this.settingsButton = new System.Windows.Forms.ToolStripButton();
             this.encodingToolStripComboBox = new System.Windows.Forms.ToolStripComboBox();
-            this.ignoreAllWhitespaces = new System.Windows.Forms.ToolStripButton();
-            this.PictureBox = new System.Windows.Forms.PictureBox();
+			this.ignoreAllWhitespaces = new System.Windows.Forms.ToolStripButton();
+			this.PictureBox = new System.Windows.Forms.PictureBox();
             this.revertSelectedLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._NO_TRANSLATE_lblShowPreview = new System.Windows.Forms.LinkLabel();
-            this.internalFileViewer = new GitUI.Editor.FileViewerInternal();
-            this.contextMenu.SuspendLayout();
-            this.fileviewerToolbar.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.PictureBox)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // contextMenu
-            // 
-            this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this._NO_TRANSLATE_lblShowPreview = new System.Windows.Forms.LinkLabel();
+			this.internalFileViewer = new GitUI.Editor.FileViewerInternal();
+			this.contextMenu.SuspendLayout();
+			this.fileviewerToolbar.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.PictureBox)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// contextMenu
+			// 
+			this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem,
             this.cherrypickSelectedLinesToolStripMenuItem,
             this.revertSelectedLinesToolStripMenuItem,
@@ -80,143 +81,144 @@ namespace GitUI.Editor
             this.treatAllFilesAsTextToolStripMenuItem,
             this.showNonprintableCharactersToolStripMenuItem,
             this.goToLineToolStripMenuItem});
-            this.contextMenu.Name = "ContextMenu";
+			this.contextMenu.Name = "ContextMenu";
             this.contextMenu.Size = new System.Drawing.Size(244, 346);
-            // 
-            // copyToolStripMenuItem
-            // 
-            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+			// 
+			// copyToolStripMenuItem
+			// 
+			this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+			this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
             this.copyToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.copyToolStripMenuItem.Text = "Copy";
-            this.copyToolStripMenuItem.Click += new System.EventHandler(this.CopyToolStripMenuItemClick);
-            // 
-            // cherrypickSelectedLinesToolStripMenuItem
-            // 
-            this.cherrypickSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.CherryPick;
-            this.cherrypickSelectedLinesToolStripMenuItem.Name = "cherrypickSelectedLinesToolStripMenuItem";
+			this.copyToolStripMenuItem.Text = "Copy";
+			this.copyToolStripMenuItem.Click += new System.EventHandler(this.CopyToolStripMenuItemClick);
+			// 
+			// cherrypickSelectedLinesToolStripMenuItem
+			// 
+			this.cherrypickSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.CherryPick;
+			this.cherrypickSelectedLinesToolStripMenuItem.Name = "cherrypickSelectedLinesToolStripMenuItem";
             this.cherrypickSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.cherrypickSelectedLinesToolStripMenuItem.Text = "Cherry pick selected lines";
-            this.cherrypickSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.cherrypickSelectedLinesToolStripMenuItem_Click);
-            // 
-            // copyPatchToolStripMenuItem
-            // 
-            this.copyPatchToolStripMenuItem.Name = "copyPatchToolStripMenuItem";
+			this.cherrypickSelectedLinesToolStripMenuItem.Text = "Cherry pick selected lines";
+			this.cherrypickSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.cherrypickSelectedLinesToolStripMenuItem_Click);
+			// 
+			// copyPatchToolStripMenuItem
+			// 
+			this.copyPatchToolStripMenuItem.Name = "copyPatchToolStripMenuItem";
             this.copyPatchToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.copyPatchToolStripMenuItem.Text = "Copy patch";
-            this.copyPatchToolStripMenuItem.Click += new System.EventHandler(this.CopyPatchToolStripMenuItemClick);
-            // 
-            // copyNewVersionToolStripMenuItem
-            // 
-            this.copyNewVersionToolStripMenuItem.Name = "copyNewVersionToolStripMenuItem";
+			this.copyPatchToolStripMenuItem.Text = "Copy patch";
+			this.copyPatchToolStripMenuItem.Click += new System.EventHandler(this.CopyPatchToolStripMenuItemClick);
+			// 
+			// copyNewVersionToolStripMenuItem
+			// 
+			this.copyNewVersionToolStripMenuItem.Name = "copyNewVersionToolStripMenuItem";
             this.copyNewVersionToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.copyNewVersionToolStripMenuItem.Text = "Copy new version";
-            this.copyNewVersionToolStripMenuItem.Click += new System.EventHandler(this.copyNewVersionToolStripMenuItem_Click);
-            // 
-            // copyOldVersionToolStripMenuItem
-            // 
-            this.copyOldVersionToolStripMenuItem.Name = "copyOldVersionToolStripMenuItem";
+			this.copyNewVersionToolStripMenuItem.Text = "Copy new version";
+			this.copyNewVersionToolStripMenuItem.Click += new System.EventHandler(this.copyNewVersionToolStripMenuItem_Click);
+			// 
+			// copyOldVersionToolStripMenuItem
+			// 
+			this.copyOldVersionToolStripMenuItem.Name = "copyOldVersionToolStripMenuItem";
             this.copyOldVersionToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.copyOldVersionToolStripMenuItem.Text = "Copy old version";
-            this.copyOldVersionToolStripMenuItem.Click += new System.EventHandler(this.copyOldVersionToolStripMenuItem_Click);
-            // 
-            // findToolStripMenuItem
-            // 
-            this.findToolStripMenuItem.Name = "findToolStripMenuItem";
-            this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
+			this.copyOldVersionToolStripMenuItem.Text = "Copy old version";
+			this.copyOldVersionToolStripMenuItem.Click += new System.EventHandler(this.copyOldVersionToolStripMenuItem_Click);
+			// 
+			// findToolStripMenuItem
+			// 
+			this.findToolStripMenuItem.Name = "findToolStripMenuItem";
+			this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
             this.findToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.findToolStripMenuItem.Text = "Find";
-            this.findToolStripMenuItem.Click += new System.EventHandler(this.FindToolStripMenuItemClick);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.findToolStripMenuItem.Text = "Find";
+			this.findToolStripMenuItem.Click += new System.EventHandler(this.FindToolStripMenuItemClick);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(240, 6);
-            // 
-            // ignoreWhitespaceAtEolToolStripMenuItem
-            // 
-            this.ignoreWhitespaceAtEolToolStripMenuItem.Name = "ignoreWhitespaceAtEolToolStripMenuItem";
+			// 
+			// ignoreWhitespaceAtEolToolStripMenuItem
+			// 
+			this.ignoreWhitespaceAtEolToolStripMenuItem.Name = "ignoreWhitespaceAtEolToolStripMenuItem";
             this.ignoreWhitespaceAtEolToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.ignoreWhitespaceAtEolToolStripMenuItem.Text = "Ignore whitespace changes at end of line";
-            this.ignoreWhitespaceAtEolToolStripMenuItem.Click += new System.EventHandler(this.IgnoreWhitespaceAtEolToolStripMenuItem_Click);
-            // 
-            // ignoreWhitespaceChangesToolStripMenuItem
-            // 
-            this.ignoreWhitespaceChangesToolStripMenuItem.Name = "ignoreWhitespaceChangesToolStripMenuItem";
+			this.ignoreWhitespaceAtEolToolStripMenuItem.Text = "Ignore whitespace changes at end of line";
+			this.ignoreWhitespaceAtEolToolStripMenuItem.Click += new System.EventHandler(this.IgnoreWhitespaceAtEolToolStripMenuItem_Click);
+			// 
+			// ignoreWhitespaceChangesToolStripMenuItem
+			// 
+			this.ignoreWhitespaceChangesToolStripMenuItem.Name = "ignoreWhitespaceChangesToolStripMenuItem";
             this.ignoreWhitespaceChangesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.ignoreWhitespaceChangesToolStripMenuItem.Text = "Ignore changes in amount of whitespace";
-            this.ignoreWhitespaceChangesToolStripMenuItem.Click += new System.EventHandler(this.IgnoreWhitespaceChangesToolStripMenuItemClick);
-            // 
-            // ignoreAllWhitespaceChangesToolStripMenuItem
-            // 
-            this.ignoreAllWhitespaceChangesToolStripMenuItem.Name = "ignoreAllWhitespaceChangesToolStripMenuItem";
+			this.ignoreWhitespaceChangesToolStripMenuItem.Text = "Ignore changes in amount of whitespace";
+			this.ignoreWhitespaceChangesToolStripMenuItem.Click += new System.EventHandler(this.IgnoreWhitespaceChangesToolStripMenuItemClick);
+			// 
+			// ignoreAllWhitespaceChangesToolStripMenuItem
+			// 
+			this.ignoreAllWhitespaceChangesToolStripMenuItem.Name = "ignoreAllWhitespaceChangesToolStripMenuItem";
             this.ignoreAllWhitespaceChangesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.ignoreAllWhitespaceChangesToolStripMenuItem.Text = "Ignore all whitespace changes";
-            this.ignoreAllWhitespaceChangesToolStripMenuItem.Click += new System.EventHandler(this.IgnoreAllWhitespaceChangesToolStripMenuItem_Click);
-            // 
-            // increaseNumberOfLinesToolStripMenuItem
-            // 
-            this.increaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesIncrease;
-            this.increaseNumberOfLinesToolStripMenuItem.Name = "increaseNumberOfLinesToolStripMenuItem";
+			this.ignoreAllWhitespaceChangesToolStripMenuItem.Text = "Ignore all whitespace changes";
+			this.ignoreAllWhitespaceChangesToolStripMenuItem.Click += new System.EventHandler(this.IgnoreAllWhitespaceChangesToolStripMenuItem_Click);
+			// 
+			// increaseNumberOfLinesToolStripMenuItem
+			// 
+			this.increaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesIncrease;
+			this.increaseNumberOfLinesToolStripMenuItem.Name = "increaseNumberOfLinesToolStripMenuItem";
             this.increaseNumberOfLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.increaseNumberOfLinesToolStripMenuItem.Text = "Increase the number of lines of context";
-            this.increaseNumberOfLinesToolStripMenuItem.Click += new System.EventHandler(this.IncreaseNumberOfLinesToolStripMenuItemClick);
-            // 
+			this.increaseNumberOfLinesToolStripMenuItem.Text = "Increase the number of lines of context";
+			this.increaseNumberOfLinesToolStripMenuItem.Click += new System.EventHandler(this.IncreaseNumberOfLinesToolStripMenuItemClick);
+			// 
             // descreaseNumberOfLinesToolStripMenuItem
-            // 
-            this.decreaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
-            this.decreaseNumberOfLinesToolStripMenuItem.Name = "decreaseNumberOfLinesToolStripMenuItem";
+			// 
+			this.decreaseNumberOfLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
+			this.decreaseNumberOfLinesToolStripMenuItem.Name = "decreaseNumberOfLinesToolStripMenuItem";
             this.decreaseNumberOfLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.decreaseNumberOfLinesToolStripMenuItem.Text = "Decrease the number of lines of context";
-            this.decreaseNumberOfLinesToolStripMenuItem.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
-            // 
-            // showEntireFileToolStripMenuItem
-            // 
-            this.showEntireFileToolStripMenuItem.Image = global::GitUI.Properties.Images.ShowEntireFile;
-            this.showEntireFileToolStripMenuItem.Name = "showEntireFileToolStripMenuItem";
+			this.decreaseNumberOfLinesToolStripMenuItem.Text = "Decrease the number of lines of context";
+			this.decreaseNumberOfLinesToolStripMenuItem.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
+			// 
+			// showEntireFileToolStripMenuItem
+			// 
+			this.showEntireFileToolStripMenuItem.Image = global::GitUI.Properties.Images.ShowEntireFile;
+			this.showEntireFileToolStripMenuItem.Name = "showEntireFileToolStripMenuItem";
             this.showEntireFileToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.showEntireFileToolStripMenuItem.Text = "Show entire file";
-            this.showEntireFileToolStripMenuItem.Click += new System.EventHandler(this.ShowEntireFileToolStripMenuItemClick);
-            // 
-            // toolStripSeparator2
-            // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
+			this.showEntireFileToolStripMenuItem.Text = "Show entire file";
+			this.showEntireFileToolStripMenuItem.Click += new System.EventHandler(this.ShowEntireFileToolStripMenuItemClick);
+			// 
+			// toolStripSeparator2
+			// 
+			this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(240, 6);
-            // 
-            // treatAllFilesAsTextToolStripMenuItem
-            // 
-            this.treatAllFilesAsTextToolStripMenuItem.Name = "treatAllFilesAsTextToolStripMenuItem";
+			// 
+			// treatAllFilesAsTextToolStripMenuItem
+			// 
+			this.treatAllFilesAsTextToolStripMenuItem.Name = "treatAllFilesAsTextToolStripMenuItem";
             this.treatAllFilesAsTextToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.treatAllFilesAsTextToolStripMenuItem.Text = "Treat all files as text";
-            this.treatAllFilesAsTextToolStripMenuItem.Click += new System.EventHandler(this.TreatAllFilesAsTextToolStripMenuItemClick);
-            // 
-            // showNonprintableCharactersToolStripMenuItem
-            // 
-            this.showNonprintableCharactersToolStripMenuItem.Image = global::GitUI.Properties.Images.ShowWhitespace;
-            this.showNonprintableCharactersToolStripMenuItem.Name = "showNonprintableCharactersToolStripMenuItem";
+			this.treatAllFilesAsTextToolStripMenuItem.Text = "Treat all files as text";
+			this.treatAllFilesAsTextToolStripMenuItem.Click += new System.EventHandler(this.TreatAllFilesAsTextToolStripMenuItemClick);
+			// 
+			// showNonprintableCharactersToolStripMenuItem
+			// 
+			this.showNonprintableCharactersToolStripMenuItem.Image = global::GitUI.Properties.Images.ShowWhitespace;
+			this.showNonprintableCharactersToolStripMenuItem.Name = "showNonprintableCharactersToolStripMenuItem";
             this.showNonprintableCharactersToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.showNonprintableCharactersToolStripMenuItem.Text = "Show nonprinting characters";
-            this.showNonprintableCharactersToolStripMenuItem.Click += new System.EventHandler(this.ShowNonprintableCharactersToolStripMenuItemClick);
-            // 
-            // goToLineToolStripMenuItem
-            // 
-            this.goToLineToolStripMenuItem.Name = "goToLineToolStripMenuItem";
+			this.showNonprintableCharactersToolStripMenuItem.Text = "Show nonprinting characters";
+			this.showNonprintableCharactersToolStripMenuItem.Click += new System.EventHandler(this.ShowNonprintableCharactersToolStripMenuItemClick);
+			// 
+			// goToLineToolStripMenuItem
+			// 
+			this.goToLineToolStripMenuItem.Name = "goToLineToolStripMenuItem";
             this.goToLineToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.goToLineToolStripMenuItem.Text = "Go to line";
-            this.goToLineToolStripMenuItem.Click += new System.EventHandler(this.goToLineToolStripMenuItem_Click);
-            // 
-            // fileviewerToolbar
-            // 
-            this.fileviewerToolbar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.fileviewerToolbar.BackColor = System.Drawing.SystemColors.Control;
-            this.fileviewerToolbar.ClickThrough = true;
-            this.fileviewerToolbar.Dock = System.Windows.Forms.DockStyle.None;
-            this.fileviewerToolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.goToLineToolStripMenuItem.Text = "Go to line";
+			this.goToLineToolStripMenuItem.Click += new System.EventHandler(this.goToLineToolStripMenuItem_Click);
+			// 
+			// fileviewerToolbar
+			// 
+			this.fileviewerToolbar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.fileviewerToolbar.BackColor = System.Drawing.SystemColors.Control;
+			this.fileviewerToolbar.ClickThrough = true;
+			this.fileviewerToolbar.Dock = System.Windows.Forms.DockStyle.None;
+			this.fileviewerToolbar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.nextChangeButton,
             this.previousChangeButton,
             this.toolStripSeparator3,
             this.increaseNumberOfLines,
             this.decreaseNumberOfLines,
+            this.showLineNumbers,
             this.toolStripSeparator4,
             this.showEntireFileButton,
             this.showNonPrintChars,
@@ -227,119 +229,129 @@ namespace GitUI.Editor
             this.settingsButton});
             this.fileviewerToolbar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.StackWithOverflow;
             this.fileviewerToolbar.Location = new System.Drawing.Point(458, 0);
-            this.fileviewerToolbar.Name = "fileviewerToolbar";
+			this.fileviewerToolbar.Name = "fileviewerToolbar";
             this.fileviewerToolbar.Size = new System.Drawing.Size(393, 23);
             this.fileviewerToolbar.Visible = false;
-            this.fileviewerToolbar.TabIndex = 0;
-            this.fileviewerToolbar.VisibleChanged += new System.EventHandler(this.fileviewerToolbar_VisibleChanged);
-            // 
-            // nextChangeButton
-            // 
-            this.nextChangeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.nextChangeButton.Image = global::GitUI.Properties.Images.ArrowDown;
-            this.nextChangeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.nextChangeButton.Name = "nextChangeButton";
+			this.fileviewerToolbar.TabIndex = 0;
+			this.fileviewerToolbar.VisibleChanged += new System.EventHandler(this.fileviewerToolbar_VisibleChanged);
+			// 
+			// nextChangeButton
+			// 
+			this.nextChangeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.nextChangeButton.Image = global::GitUI.Properties.Images.ArrowDown;
+			this.nextChangeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.nextChangeButton.Name = "nextChangeButton";
             this.nextChangeButton.Size = new System.Drawing.Size(23, 20);
-            this.nextChangeButton.ToolTipText = "Next change";
-            this.nextChangeButton.Click += new System.EventHandler(this.NextChangeButtonClick);
-            // 
-            // previousChangeButton
-            // 
-            this.previousChangeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.previousChangeButton.Image = global::GitUI.Properties.Images.ArrowUp;
-            this.previousChangeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.previousChangeButton.Name = "previousChangeButton";
+			this.nextChangeButton.ToolTipText = "Next change";
+			this.nextChangeButton.Click += new System.EventHandler(this.NextChangeButtonClick);
+			// 
+			// previousChangeButton
+			// 
+			this.previousChangeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.previousChangeButton.Image = global::GitUI.Properties.Images.ArrowUp;
+			this.previousChangeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.previousChangeButton.Name = "previousChangeButton";
             this.previousChangeButton.Size = new System.Drawing.Size(23, 20);
-            this.previousChangeButton.ToolTipText = "Previous change";
-            this.previousChangeButton.Click += new System.EventHandler(this.PreviousChangeButtonClick);
-            // 
-            // toolStripSeparator3
-            // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
+			this.previousChangeButton.ToolTipText = "Previous change";
+			this.previousChangeButton.Click += new System.EventHandler(this.PreviousChangeButtonClick);
+			// 
+			// toolStripSeparator3
+			// 
+			this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(6, 23);
-            // 
-            // increaseNumberOfLines
-            // 
-            this.increaseNumberOfLines.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.increaseNumberOfLines.Image = global::GitUI.Properties.Images.NumberOfLinesIncrease;
-            this.increaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.increaseNumberOfLines.Name = "increaseNumberOfLines";
+			// 
+			// increaseNumberOfLines
+			// 
+			this.increaseNumberOfLines.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.increaseNumberOfLines.Image = global::GitUI.Properties.Images.NumberOfLinesIncrease;
+			this.increaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.increaseNumberOfLines.Name = "increaseNumberOfLines";
             this.increaseNumberOfLines.Size = new System.Drawing.Size(23, 20);
-            this.increaseNumberOfLines.ToolTipText = "Increase the number of lines of context";
-            this.increaseNumberOfLines.Click += new System.EventHandler(this.IncreaseNumberOfLinesToolStripMenuItemClick);
-            // 
+			this.increaseNumberOfLines.ToolTipText = "Increase the number of lines of context";
+			this.increaseNumberOfLines.Click += new System.EventHandler(this.IncreaseNumberOfLinesToolStripMenuItemClick);
+			// 
             // DecreaseNumberOfLines
-            // 
-            this.decreaseNumberOfLines.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.decreaseNumberOfLines.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
-            this.decreaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.decreaseNumberOfLines.Name = "decreaseNumberOfLines";
+			// 
+			this.decreaseNumberOfLines.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.decreaseNumberOfLines.Image = global::GitUI.Properties.Images.NumberOfLinesDecrease;
+			this.decreaseNumberOfLines.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.decreaseNumberOfLines.Name = "decreaseNumberOfLines";
             this.decreaseNumberOfLines.Size = new System.Drawing.Size(23, 20);
-            this.decreaseNumberOfLines.ToolTipText = "Decrease the number of lines of context";
-            this.decreaseNumberOfLines.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
-            // 
-            // toolStripSeparator4
-            // 
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
+			this.decreaseNumberOfLines.ToolTipText = "Decrease the number of lines of context";
+			this.decreaseNumberOfLines.Click += new System.EventHandler(this.DecreaseNumberOfLinesToolStripMenuItemClick);
+			// 
+			// showLineNumbers
+			// 
+			this.showLineNumbers.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.showLineNumbers.Image = global::GitUI.Properties.Resources.CommitId;
+			this.showLineNumbers.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.showLineNumbers.Name = "showLineNumbers";
+			this.showLineNumbers.Size = new System.Drawing.Size(23, 22);
+			this.showLineNumbers.Text = "Show line numbers";
+			this.showLineNumbers.Click += new System.EventHandler(this.showLineNumbers_Click);
+			// 
+			// toolStripSeparator4
+			// 
+			this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(6, 23);
-            // 
-            // showEntireFileButton
-            // 
-            this.showEntireFileButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.showEntireFileButton.Image = global::GitUI.Properties.Images.ShowEntireFile;
-            this.showEntireFileButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.showEntireFileButton.Name = "showEntireFileButton";
+			// 
+			// showEntireFileButton
+			// 
+			this.showEntireFileButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.showEntireFileButton.Image = global::GitUI.Properties.Images.ShowEntireFile;
+			this.showEntireFileButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.showEntireFileButton.Name = "showEntireFileButton";
             this.showEntireFileButton.Size = new System.Drawing.Size(23, 20);
-            this.showEntireFileButton.ToolTipText = "Show entire file";
-            this.showEntireFileButton.Click += new System.EventHandler(this.ShowEntireFileToolStripMenuItemClick);
-            // 
-            // showNonPrintChars
-            // 
-            this.showNonPrintChars.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.showNonPrintChars.Image = global::GitUI.Properties.Images.ShowWhitespace;
-            this.showNonPrintChars.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.showNonPrintChars.Name = "showNonPrintChars";
+			this.showEntireFileButton.ToolTipText = "Show entire file";
+			this.showEntireFileButton.Click += new System.EventHandler(this.ShowEntireFileToolStripMenuItemClick);
+			// 
+			// showNonPrintChars
+			// 
+			this.showNonPrintChars.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.showNonPrintChars.Image = global::GitUI.Properties.Images.ShowWhitespace;
+			this.showNonPrintChars.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.showNonPrintChars.Name = "showNonPrintChars";
             this.showNonPrintChars.Size = new System.Drawing.Size(23, 20);
-            this.showNonPrintChars.ToolTipText = "Show nonprinting characters";
-            this.showNonPrintChars.Click += new System.EventHandler(this.ShowNonprintableCharactersToolStripMenuItemClick);
-            // 
-            // ignoreWhitespaceAtEol
-            // 
-            this.ignoreWhitespaceAtEol.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.ignoreWhitespaceAtEol.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.ignoreWhitespaceAtEol.Name = "ignoreWhitespaceAtEol";
+			this.showNonPrintChars.ToolTipText = "Show nonprinting characters";
+			this.showNonPrintChars.Click += new System.EventHandler(this.ShowNonprintableCharactersToolStripMenuItemClick);
+			// 
+			// ignoreWhitespaceAtEol
+			// 
+			this.ignoreWhitespaceAtEol.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.ignoreWhitespaceAtEol.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.ignoreWhitespaceAtEol.Name = "ignoreWhitespaceAtEol";
             this.ignoreWhitespaceAtEol.Size = new System.Drawing.Size(23, 4);
-            this.ignoreWhitespaceAtEol.ToolTipText = "Ignore whitespace changes at end of line";
-            this.ignoreWhitespaceAtEol.Click += new System.EventHandler(this.IgnoreWhitespaceAtEolToolStripMenuItem_Click);
-            // 
-            // ignoreWhiteSpaces
-            // 
-            this.ignoreWhiteSpaces.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.ignoreWhiteSpaces.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.ignoreWhiteSpaces.Name = "ignoreWhiteSpaces";
+			this.ignoreWhitespaceAtEol.ToolTipText = "Ignore whitespace changes at end of line";
+			this.ignoreWhitespaceAtEol.Click += new System.EventHandler(this.IgnoreWhitespaceAtEolToolStripMenuItem_Click);
+			// 
+			// ignoreWhiteSpaces
+			// 
+			this.ignoreWhiteSpaces.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.ignoreWhiteSpaces.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.ignoreWhiteSpaces.Name = "ignoreWhiteSpaces";
             this.ignoreWhiteSpaces.Size = new System.Drawing.Size(23, 4);
-            this.ignoreWhiteSpaces.ToolTipText = "Ignore changes in amount of whitespace";
-            this.ignoreWhiteSpaces.Click += new System.EventHandler(this.IgnoreWhitespaceChangesToolStripMenuItemClick);
-            // 
-            // encodingToolStripComboBox
-            // 
-            this.encodingToolStripComboBox.BackColor = System.Drawing.SystemColors.Control;
-            this.encodingToolStripComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.encodingToolStripComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.encodingToolStripComboBox.Name = "encodingToolStripComboBox";
+			this.ignoreWhiteSpaces.ToolTipText = "Ignore changes in amount of whitespace";
+			this.ignoreWhiteSpaces.Click += new System.EventHandler(this.IgnoreWhitespaceChangesToolStripMenuItemClick);
+			// 
+			// encodingToolStripComboBox
+			// 
+			this.encodingToolStripComboBox.BackColor = System.Drawing.SystemColors.Control;
+			this.encodingToolStripComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.encodingToolStripComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+			this.encodingToolStripComboBox.Name = "encodingToolStripComboBox";
             this.encodingToolStripComboBox.Size = new System.Drawing.Size(140, 23);
-            this.encodingToolStripComboBox.SelectedIndexChanged += new System.EventHandler(this.encodingToolStripComboBox_SelectedIndexChanged);
-            // 
-            // settingsButton
-            // 
-            this.settingsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.settingsButton.Image = global::GitUI.Properties.Images.Settings;
-            this.settingsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.settingsButton.Name = "settingsButton";
+			this.encodingToolStripComboBox.SelectedIndexChanged += new System.EventHandler(this.encodingToolStripComboBox_SelectedIndexChanged);
+			// 
+			// settingsButton
+			// 
+			this.settingsButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.settingsButton.Image = global::GitUI.Properties.Images.Settings;
+			this.settingsButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+			this.settingsButton.Name = "settingsButton";
             this.settingsButton.Size = new System.Drawing.Size(23, 20);
-            this.settingsButton.ToolTipText = "Settings";
-            this.settingsButton.Click += new System.EventHandler(this.settingsButton_Click);
-            // 
+			this.settingsButton.ToolTipText = "Settings";
+			this.settingsButton.Click += new System.EventHandler(this.settingsButton_Click);
+			// 
             // ignoreAllWhitespaces
             // 
             this.ignoreAllWhitespaces.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -349,22 +361,22 @@ namespace GitUI.Editor
             this.ignoreAllWhitespaces.ToolTipText = "Ignore all whitespace changes";
             this.ignoreAllWhitespaces.Click += new System.EventHandler(this.IgnoreAllWhitespaceChangesToolStripMenuItem_Click);
             // 
-            // PictureBox
-            // 
-            this.PictureBox.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.PictureBox.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.PictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.PictureBox.Location = new System.Drawing.Point(0, 0);
-            this.PictureBox.Margin = new System.Windows.Forms.Padding(0);
-            this.PictureBox.Name = "PictureBox";
-            this.PictureBox.Size = new System.Drawing.Size(757, 518);
-            this.PictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.PictureBox.TabIndex = 7;
-            this.PictureBox.TabStop = false;
-            this.PictureBox.Visible = false;
-            // 
+			// PictureBox
+			// 
+			this.PictureBox.BackColor = System.Drawing.SystemColors.ControlLightLight;
+			this.PictureBox.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+			this.PictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.PictureBox.Location = new System.Drawing.Point(0, 0);
+			this.PictureBox.Margin = new System.Windows.Forms.Padding(0);
+			this.PictureBox.Name = "PictureBox";
+			this.PictureBox.Size = new System.Drawing.Size(757, 518);
+			this.PictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+			this.PictureBox.TabIndex = 7;
+			this.PictureBox.TabStop = false;
+			this.PictureBox.Visible = false;
+			// 
             // resetSelectedLinesToolStripMenuItem
-            // 
+			// 
             this.revertSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetFileTo;
             this.revertSelectedLinesToolStripMenuItem.Name = "revertSelectedLinesToolStripMenuItem";
             this.revertSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
@@ -373,49 +385,49 @@ namespace GitUI.Editor
             //
             // llShowPreview
             //
-            this._NO_TRANSLATE_lblShowPreview.AutoSize = true;
-            this._NO_TRANSLATE_lblShowPreview.BackColor = System.Drawing.Color.White;
-            this._NO_TRANSLATE_lblShowPreview.Location = new System.Drawing.Point(43, 23);
-            this._NO_TRANSLATE_lblShowPreview.Name = "_NO_TRANSLATE_lblShowPreview";
-            this._NO_TRANSLATE_lblShowPreview.Size = new System.Drawing.Size(214, 13);
-            this._NO_TRANSLATE_lblShowPreview.TabIndex = 2;
-            this._NO_TRANSLATE_lblShowPreview.TabStop = true;
-            this._NO_TRANSLATE_lblShowPreview.Text = "This file is over 5 MB. Click to show preview";
-            this._NO_TRANSLATE_lblShowPreview.Visible = false;
-            this._NO_TRANSLATE_lblShowPreview.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llShowPreview_LinkClicked);
-            // 
+			this._NO_TRANSLATE_lblShowPreview.AutoSize = true;
+			this._NO_TRANSLATE_lblShowPreview.BackColor = System.Drawing.Color.White;
+			this._NO_TRANSLATE_lblShowPreview.Location = new System.Drawing.Point(43, 23);
+			this._NO_TRANSLATE_lblShowPreview.Name = "_NO_TRANSLATE_lblShowPreview";
+			this._NO_TRANSLATE_lblShowPreview.Size = new System.Drawing.Size(214, 13);
+			this._NO_TRANSLATE_lblShowPreview.TabIndex = 2;
+			this._NO_TRANSLATE_lblShowPreview.TabStop = true;
+			this._NO_TRANSLATE_lblShowPreview.Text = "This file is over 5 MB. Click to show preview";
+			this._NO_TRANSLATE_lblShowPreview.Visible = false;
+			this._NO_TRANSLATE_lblShowPreview.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llShowPreview_LinkClicked);
+			// 
             // internalFileViewerControl
-            // 
-            this.internalFileViewer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.internalFileViewer.FirstVisibleLine = 0;
-            this.internalFileViewer.IsReadOnly = false;
+			// 
+			this.internalFileViewer.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.internalFileViewer.FirstVisibleLine = 0;
+			this.internalFileViewer.IsReadOnly = false;
             this.internalFileViewer.Location = new System.Drawing.Point(0, 40);
-            this.internalFileViewer.Margin = new System.Windows.Forms.Padding(0);
-            this.internalFileViewer.Name = "internalFileViewer";
+			this.internalFileViewer.Margin = new System.Windows.Forms.Padding(0);
+			this.internalFileViewer.Name = "internalFileViewer";
             this.internalFileViewer.VScrollPosition = 0;
-            this.internalFileViewer.ShowEOLMarkers = false;
-            this.internalFileViewer.ShowSpaces = false;
-            this.internalFileViewer.ShowTabs = false;
-            this.internalFileViewer.Size = new System.Drawing.Size(757, 518);
-            this.internalFileViewer.TabIndex = 1;
-            // 
-            // FileViewer
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this._NO_TRANSLATE_lblShowPreview);
-            this.Controls.Add(this.internalFileViewer);
-            this.Controls.Add(this.PictureBox);
-            this.Controls.Add(this.fileviewerToolbar);
-            this.Margin = new System.Windows.Forms.Padding(0);
-            this.Name = "FileViewer";
-            this.Size = new System.Drawing.Size(757, 518);
-            this.contextMenu.ResumeLayout(false);
-            this.fileviewerToolbar.ResumeLayout(false);
-            this.fileviewerToolbar.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.PictureBox)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.internalFileViewer.ShowEOLMarkers = false;
+			this.internalFileViewer.ShowSpaces = false;
+			this.internalFileViewer.ShowTabs = false;
+			this.internalFileViewer.Size = new System.Drawing.Size(757, 518);
+			this.internalFileViewer.TabIndex = 1;
+			// 
+			// FileViewer
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+			this.Controls.Add(this._NO_TRANSLATE_lblShowPreview);
+			this.Controls.Add(this.internalFileViewer);
+			this.Controls.Add(this.PictureBox);
+			this.Controls.Add(this.fileviewerToolbar);
+			this.Margin = new System.Windows.Forms.Padding(0);
+			this.Name = "FileViewer";
+			this.Size = new System.Drawing.Size(757, 518);
+			this.contextMenu.ResumeLayout(false);
+			this.fileviewerToolbar.ResumeLayout(false);
+			this.fileviewerToolbar.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.PictureBox)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 
@@ -457,5 +469,6 @@ namespace GitUI.Editor
         private System.Windows.Forms.ToolStripButton ignoreAllWhitespaces;
         private System.Windows.Forms.ToolStripMenuItem ignoreAllWhitespaceChangesToolStripMenuItem;
         private LinkLabel _NO_TRANSLATE_lblShowPreview;
+        private ToolStripButton showLineNumbers;
     }
 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -113,6 +113,11 @@ namespace GitUI.Editor
             showNonprintableCharactersToolStripMenuItem.Checked = AppSettings.ShowNonPrintingChars;
             ToggleNonPrintingChars(AppSettings.ShowNonPrintingChars);
 
+            if (!AppSettings.ShowLineNumbers)
+            {
+                ShowLineNumbers = false;
+            }
+
             IsReadOnly = true;
 
             internalFileViewer.MouseMove += (_, e) =>

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -109,6 +109,7 @@ namespace GitUI.Editor
             showEntireFileToolStripMenuItem.Checked = ShowEntireFile;
             SetStateOfContextLinesButtons();
 
+            showLineNumbers.Checked = AppSettings.ShowLineNumbers;
             showNonPrintChars.Checked = AppSettings.ShowNonPrintingChars;
             showNonprintableCharactersToolStripMenuItem.Checked = AppSettings.ShowNonPrintingChars;
             ToggleNonPrintingChars(AppSettings.ShowNonPrintingChars);
@@ -955,6 +956,13 @@ namespace GitUI.Editor
             }
 
             AppSettings.NumberOfContextLines = NumberOfContextLines;
+            OnExtraDiffArgumentsChanged();
+        }
+
+        private void showLineNumbers_Click(object sender, EventArgs e)
+        {
+            AppSettings.ShowLineNumbers = !AppSettings.ShowLineNumbers;
+            showLineNumbers.Checked = AppSettings.ShowLineNumbers;
             OnExtraDiffArgumentsChanged();
         }
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -112,6 +112,13 @@ namespace GitUI.Editor
             _currentViewPositionCache.Capture();
 
             OpenWithDifftool = openWithDifftool;
+            if (!AppSettings.ShowLineNumbers)
+            {
+                isDiff = false;
+            }
+
+            TextEditor.ShowLineNumbers = false;
+
             _lineNumbersControl.Clear(isDiff);
             _lineNumbersControl.SetVisibility(isDiff);
 


### PR DESCRIPTION
## Proposed changes
I added a checkbox in Settings on Detailed - Diff viewer (DiffViewerSettingsPage) for line numbers hide/show.
Works right for Diff page, but on File tree page it works on next run..

## Screenshot
![screen](https://i.imgur.com/7zAYBjj.png)

## Test methodology
Manually.

## Test environment(s)
- GIT 2.21
- Windows 7 SP1

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
