### PR TITLE
Feature: Download / Install MSI without redirect to Browser

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -155,10 +156,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 progressBar1.Visible = true;
                 btnDownloadNow.Enabled = false;
                 UpdateLabel.Text = _downloadingUpdate.Text;
+                string fileName = Path.GetFileName(UpdateUrl);
 
-                WebClient webClient = new WebClient();
-                string fileName = UpdateUrl.Substring(UpdateUrl.LastIndexOf("/") + 1);
-                await webClient.DownloadFileTaskAsync(new Uri(UpdateUrl), Environment.GetEnvironmentVariable("TEMP") + "\\" + fileName);
+                using (WebClient webClient = new WebClient())
+                {
+                    await webClient.DownloadFileTaskAsync(new Uri(UpdateUrl), Environment.GetEnvironmentVariable("TEMP") + "\\" + fileName);
+                }
 
                 Process process = new Process();
                 process.StartInfo.UseShellExecute = false;

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -16,6 +16,7 @@
     <UIRef Id="WixUI_GitExtensions" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
     <Property Id="SSHCLIENT" Value="PuTTY" Secure="yes" />
+    <Property Id="LAUNCH" Value="0" />
     <WixVariable Id="WixUIDialogBmp" Value="dialog.bmp" />
     <WixVariable Id="WixUIBannerBmp" Value="banner.bmp" />
     <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes" />
@@ -1813,6 +1814,10 @@
         <ComponentRef Id="Protocol.github_mac" />
       </Feature>
     </Feature>
+    <CustomAction Id='LaunchFile' FileKey='GitExtensions.exe' ExeCommand='' Return='asyncNoWait' />
     <UI />
+    <InstallExecuteSequence>
+      <Custom Action='LaunchFile' After='InstallFinalize'>( NOT Installed ) AND ( LAUNCH = "1" )</Custom>
+    </InstallExecuteSequence>
   </Product>
 </Wix>


### PR DESCRIPTION
Relates to #6679

Original Code from my own software adapted to GitExtensions.

## Proposed changes

GitExtensions:
- Download MSI to users temp directory
- Launch MSI to silently upgrade, have basic display progress and set LAUNCH property to 1
- Exit GitExtensions after launching MSI
- After successful upgrade, MSI will auto launch GitExtensions.exe


GitExtensions Installer:
- Add new property called LAUNCH and set value to 0
- Default install / upgrade will not auto launch GitExtensions.exe
- Setting LAUNCH to a value of 1 will launch GitExtensions.exe after successful install / upgrade


## Screenshots <!-- Remove this section if PR does not change UI -->

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/45373169/58453677-62255200-815f-11e9-97b9-fba31b84890c.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
