### PR TITLE
FileDiff: Factor in that two line numbers are displayed

### DIFF
--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -31,7 +31,8 @@ namespace GitUI.Editor.Diff
             {
                 if (_visible && _diffLines.Any())
                 {
-                    return textArea.TextView.WideSpaceWidth * ((int)Math.Log10(MaxLineNumber) + TextHorizontalMargin + 3);
+                    int maxDigits = (int)Math.Log10(MaxLineNumber) + 1;
+                    return TextHorizontalMargin + (textArea.TextView.WideSpaceWidth * ((2 * maxDigits) + /* a space behind each number */ 2));
                 }
 
                 return 0;
@@ -51,8 +52,8 @@ namespace GitUI.Editor.Diff
 
         public override void Paint(Graphics g, Rectangle rect)
         {
-            var totalWidth = Width;
-            var leftWidth = (int)(totalWidth / 2.0);
+            var numbersWidth = Width - TextHorizontalMargin;
+            var leftWidth = TextHorizontalMargin + (numbersWidth / 2);
             var rightWidth = rect.Width - leftWidth;
 
             var fontHeight = textArea.TextView.FontHeight;
@@ -120,7 +121,7 @@ namespace GitUI.Editor.Diff
                     g.DrawString(diffLine.RightLineNumber.ToString(),
                         lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
                         drawBrush,
-                        new Point(TextHorizontalMargin + (totalWidth / 2), backgroundRectangle.Top));
+                        new Point(leftWidth, backgroundRectangle.Top));
                 }
             }
         }


### PR DESCRIPTION
Fixes #6031 (and #6568)


## Proposed changes

- width calculation factors in that two line numbers are displayed
- do not multiply `TextHorizontalMargin` by `textArea.TextView.WideSpaceWidth`!

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/58670759-81c7a080-8340-11e9-95bf-1944863b5c61.png) ![grafik](https://user-images.githubusercontent.com/36601201/58670850-d834df00-8340-11e9-86ce-65bd1e13077b.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/58670785-960b9d80-8340-11e9-8cf6-2d126a4c16a3.png) ![grafik](https://user-images.githubusercontent.com/36601201/58670872-e682fb00-8340-11e9-808c-942a31e55424.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 2bfd1153219c59c1c418541d2beee0ae7be5b6fa
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
