### PR TITLE
CommitInfo: Bugfix "Contained in branches/tags"

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -97,8 +97,10 @@ namespace GitUI.CommitInfo
             {
                 this.InvokeAsync(() =>
                 {
-                    UICommandsSource.UICommandsChanged += UICommandsSource_UICommandsChanged;
-                    ReloadCommitInfo();
+                    UICommandsSource.UICommandsChanged += delegate { RefreshSortedRefs(); };
+
+                    // call this event handler also now (necessary for "Contained in branches/tags")
+                    RefreshSortedRefs();
                 }).FileAndForget();
             };
 
@@ -136,18 +138,13 @@ namespace GitUI.CommitInfo
             commitInfoHeader.SetContextMenuStrip(commitInfoContextMenuStrip);
         }
 
-        private void UICommandsSource_UICommandsChanged(object sender, GitUICommandsChangedEventArgs e)
+        private void RefreshSortedRefs()
         {
             if (!Module.IsValidGitWorkingDir())
             {
                 return;
             }
 
-            RefreshSortedRefs();
-        }
-
-        private void RefreshSortedRefs()
-        {
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await LoadSortedRefsAsync();
@@ -284,6 +281,8 @@ namespace GitUI.CommitInfo
                 UpdateRevisionInfo();
                 StartAsyncDataLoad();
             }
+
+            return;
 
             void UpdateCommitMessage()
             {

--- a/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
@@ -49,10 +49,16 @@ namespace GitUITests.CommitInfo
             var uiCommandsSource = Substitute.For<IGitUICommandsSource>();
             uiCommandsSource.UICommands.Returns(x => _commands);
 
+            // the following assignment of _commitInfo.UICommandsSource will already call this command
+            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/", "");
+
             _commitInfo = new GitUI.CommitInfo.CommitInfo
             {
                 UICommandsSource = uiCommandsSource
             };
+
+            // let the async call be executed before the mockup of _gitExecutable will be changed
+            Thread.Sleep(100);
         }
 
         [TearDown]


### PR DESCRIPTION
Fixes #6725

## Proposed changes

- restore call of `RefreshSortedRefs` in the `UICommandsSourceSet` event handler
- remove unnecessary call of `ReloadCommitInfo`
- adapt test setup

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/58738830-c9652f80-8407-11e9-9e2b-0607d28e86fd.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/58738809-ad618e00-8407-11e9-9600-ca0664696306.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build a62ac4df274a67c0811011181011ad8e33ba82dd
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
