### PR TITLE
fix: Settings path has changed

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -78,11 +78,10 @@ namespace GitCommands
                 {
                     return GetGitExtensionsDirectory();
                 }
-                else
-                {
-                    // Make ApplicationDataPath version independent
-                    return Application.UserAppDataPath.Replace(Application.ProductVersion, string.Empty);
-                }
+
+                // Make ApplicationDataPath version independent
+                return Application.UserAppDataPath.Replace(Application.ProductVersion, string.Empty)
+                                                  .Replace("Git Extensions", "GitExtensions"); // 'GitExtensions' has been changed to 'Git Extensions' in v3.0
             });
 
             LocalApplicationDataPath = new Lazy<string>(() =>


### PR DESCRIPTION
Since the application name has been updated in AssemblyInfo (in fce96e3), `Application.UserAppDataPath` has started pointing to a different directory, thus losing the original app settings.

Remove introduced " " (space) chars from the path.

Closes #6696



## Test methodology <!-- How did you ensure quality? -->

- manual checks


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
