### PR TITLE
Fixed Gerrit plugin using deprecated features

### DIFF
--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -567,8 +567,8 @@ Are you sure you want to continue?</source>
         <source>&amp;Publish</source>
         <target />
       </trans-unit>
-      <trans-unit id="PublishDraft.Text">
-        <source>Submit review as draft</source>
+      <trans-unit id="labelPublishType.Text">
+        <source>Publish Type</source>
         <target />
       </trans-unit>
       <trans-unit id="_publishCaption.Text">
@@ -585,6 +585,18 @@ Are you sure you want to continue?</source>
       </trans-unit>
       <trans-unit id="_selectRemote.Text">
         <source>Please select a remote repository</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_publishTypeReview.Text">
+        <source>For Review</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_publishTypeWip.Text">
+        <source>Work-in-Progress</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_publishTypePrivate.Text">
+        <source>Private</source>
         <target />
       </trans-unit>
       <trans-unit id="labelBranch.Text">

--- a/Plugins/Gerrit/FormGerritPublish.Designer.cs
+++ b/Plugins/Gerrit/FormGerritPublish.Designer.cs
@@ -33,13 +33,14 @@
             this.AddRemote = new System.Windows.Forms.Button();
             this._NO_TRANSLATE_Remotes = new System.Windows.Forms.ComboBox();
             this.labelRemote = new System.Windows.Forms.Label();
-            this.PublishDraft = new System.Windows.Forms.CheckBox();
             this.labelBranch = new System.Windows.Forms.Label();
             this.labelTopic = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_Branch = new System.Windows.Forms.TextBox();
             this._NO_TRANSLATE_Topic = new System.Windows.Forms.TextBox();
             this._NO_TRANSLATE_Reviewers = new System.Windows.Forms.TextBox();
             this.labelReviewers = new System.Windows.Forms.Label();
+            this.PublishType = new System.Windows.Forms.ComboBox();
+            this.labelPublishType = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // Publish
@@ -86,19 +87,9 @@
             this.labelRemote.Size = new System.Drawing.Size(48, 13);
             this.labelRemote.TabIndex = 0;
             this.labelRemote.Text = "Remote:";
-            // 
-            // PublishDraft
-            // 
-            this.PublishDraft.AutoSize = true;
-            this.PublishDraft.Location = new System.Drawing.Point(101, 144);
-            this.PublishDraft.Name = "PublishDraft";
-            this.PublishDraft.Size = new System.Drawing.Size(134, 17);
-            this.PublishDraft.TabIndex = 9;
-            this.PublishDraft.Text = "Submit review as draft";
-            this.PublishDraft.UseVisualStyleBackColor = true;
-            // 
+            //
             // labelBranch
-            // 
+            //
             this.labelBranch.AutoSize = true;
             this.labelBranch.Location = new System.Drawing.Point(13, 52);
             this.labelBranch.Name = "labelBranch";
@@ -150,20 +141,42 @@
             this.labelReviewers.Size = new System.Drawing.Size(69, 13);
             this.labelReviewers.TabIndex = 7;
             this.labelReviewers.Text = "Reviewer(s):";
-            // 
+            //
+            // PublishType
+            //
+            this.PublishType.DisplayMember = "Key";
+            this.PublishType.FormattingEnabled = true;
+            this.PublishType.Location = new System.Drawing.Point(101, 137);
+            this.PublishType.Margin = new System.Windows.Forms.Padding(4);
+            this.PublishType.Name = "PublishType";
+            this.PublishType.Size = new System.Drawing.Size(121, 21);
+            this.PublishType.TabIndex = 11;
+            this.PublishType.ValueMember = "Value";
+            //
+            // labelPublishType
+            //
+            this.labelPublishType.AutoSize = true;
+            this.labelPublishType.Location = new System.Drawing.Point(13, 140);
+            this.labelPublishType.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelPublishType.Name = "labelPublishType";
+            this.labelPublishType.Size = new System.Drawing.Size(68, 13);
+            this.labelPublishType.TabIndex = 12;
+            this.labelPublishType.Text = "Publish Type";
+            //
             // FormGerritPublish
             // 
             this.AcceptButton = this.Publish;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(644, 173);
+            this.Controls.Add(this.labelPublishType);
+            this.Controls.Add(this.PublishType);
             this.Controls.Add(this._NO_TRANSLATE_Reviewers);
             this.Controls.Add(this.labelReviewers);
             this.Controls.Add(this._NO_TRANSLATE_Topic);
             this.Controls.Add(this._NO_TRANSLATE_Branch);
             this.Controls.Add(this.labelTopic);
             this.Controls.Add(this.labelBranch);
-            this.Controls.Add(this.PublishDraft);
             this.Controls.Add(this.labelRemote);
             this.Controls.Add(this.AddRemote);
             this.Controls.Add(this._NO_TRANSLATE_Remotes);
@@ -186,12 +199,13 @@
         private System.Windows.Forms.Button AddRemote;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_Remotes;
         private System.Windows.Forms.Label labelRemote;
-        private System.Windows.Forms.CheckBox PublishDraft;
         private System.Windows.Forms.Label labelBranch;
         private System.Windows.Forms.Label labelTopic;
         private System.Windows.Forms.TextBox _NO_TRANSLATE_Branch;
         private System.Windows.Forms.TextBox _NO_TRANSLATE_Topic;
         private System.Windows.Forms.TextBox _NO_TRANSLATE_Reviewers;
         private System.Windows.Forms.Label labelReviewers;
+        private System.Windows.Forms.ComboBox PublishType;
+        private System.Windows.Forms.Label labelPublishType;
     }
 }

--- a/contributors.txt
+++ b/contributors.txt
@@ -85,3 +85,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/05/24, cryham, Crystal Hammer, cryham(at)gmail.com
 2019/05/29, Johno-ACSLive, Jonathon Aroutsidis, thunder2518(at)hotmail.com
 2019/06/05, AOrlov, Andrei Orlov, gooshift(at)gmail.com
+2019/06/07, veremenko-y, Yaroslav Veremenko, yaroslav(at)veremenko.info


### PR DESCRIPTION
Fixes #6127
Changed deprecated options for publish type and topic in Gerrit to support newer version

## Proposed changes

Changed push reference to use /refs/for with %wip and %private for instead of deprecated /refs/publish and /refs/draft
Changed the way topic is passed into gerrit to use new `-o topic=TOPIC` format.

## Version compatibility

Draft changes (that are currently used in Git Extensions) have been marked obsolete in Gerrit 2.15 in 2017 (
https://github.com/GerritCodeReview/gerrit/commit/4b44bdc7022653cec0cf0322b1161a210d46b8fb).
`refs/publish` have been removed last year (https://github.com/GerritCodeReview/gerrit/commit/605941e57f1fefd029e8c6b6af63a04dfbcaf08d)
`refs/for` syntax used in this PR to publish changes, have been introduced around 2011-2013, and were synonym of `refs/publish`. This change will break pushing "draft" changes, but it should not break basic publish for older versions of Gerrit.

As of Gerrit 3.0.0 `refs/draft` and `refs/publish` are deprecated and removed from the system. Instead, private and work-in-progress should be used.

Current changes in this PR are based on current 3.0.0 documentation https://gerrit-documentation.storage.googleapis.com/Documentation/3.0.0/user-upload.html#push_create

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/4127660/59119292-a65ae400-890f-11e9-83f7-e275be7923e6.png)

### After

![image](https://user-images.githubusercontent.com/4127660/59119754-cfc83f80-8910-11e9-92ad-6ddcbfcbd56f.png)

## Test methodology

Tested on Gerrit 3.0.0 with combinations of Publish Type and topic

## Test environment(s)

- GIT 2.21.0.windows.1
- Windows 10
- Gerrit 3.0.0

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
