### PR TITLE
Set recommended Git version to 2.22.0

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -21,7 +21,7 @@ namespace GitCommands
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
 
         public static readonly GitVersion LastSupportedVersion = v2_11_0;
-        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.20.1");
+        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.22.0");
 
         private static GitVersion _current;
 


### PR DESCRIPTION
## Proposed changes
Set recommended version to 2.22


## Test methodology <!-- How did you ensure quality? -->

- Review of Release Notes.  
No major changes in this release, similar to the stable 2.21.0. 
git-diff --no-index --dir-diff is no longer allowed, not used together in ST.

- Use of Git - to be in use for week or so before removing WIP

## Test environment(s) <!-- Remove any that don't apply -->

n/a

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
