### PR TITLE
artificial context fixes

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -279,7 +279,7 @@ namespace GitUI.CommandsDialogs
             bool firstIsParent = _revisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents, DiffFiles.Revision);
             bool localExists = _revisionTester.AnyLocalFileExists(DiffFiles.SelectedItemsWithParent.Select(i => i.Item));
 
-            var selectedItemParentRevs = DiffFiles.Revision.ParentIds;
+            var selectedItemParentRevs = DiffFiles.SelectedItemParents.Select(i => i.ObjectId).ToList();
             bool allAreNew = DiffFiles.SelectedItemsWithParent.All(i => i.Item.IsNew);
             bool allAreDeleted = DiffFiles.SelectedItemsWithParent.All(i => i.Item.IsDeleted);
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -810,29 +810,28 @@ namespace GitUI.CommandsDialogs
                 }
 
                 var selectedItems = DiffFiles.SelectedItems;
-                if (DiffFiles.Revision.ObjectId == ObjectId.IndexId)
-                {
-                    var files = new List<GitItemStatus>();
-                    var stagedItems = selectedItems.Where(item => item.Staged == StagedStatus.Index);
-                    foreach (var item in stagedItems)
-                    {
-                        if (!item.IsNew)
-                        {
-                            Module.UnstageFileToRemove(item.Name);
 
-                            if (item.IsRenamed)
-                            {
-                                Module.UnstageFileToRemove(item.OldName);
-                            }
-                        }
-                        else
+                // If any file is staged, it must be unstaged
+                var files = new List<GitItemStatus>();
+                var stagedItems = selectedItems.Where(item => item.Staged == StagedStatus.Index);
+                foreach (var item in stagedItems)
+                {
+                    if (!item.IsNew)
+                    {
+                        Module.UnstageFileToRemove(item.Name);
+
+                        if (item.IsRenamed)
                         {
-                            files.Add(item);
+                            Module.UnstageFileToRemove(item.OldName);
                         }
                     }
-
-                    Module.UnstageFiles(files);
+                    else
+                    {
+                        files.Add(item);
+                    }
                 }
+
+                Module.UnstageFiles(files);
 
                 DiffFiles.StoreNextIndexToSelect();
                 var items = DiffFiles.SelectedItems.Where(item => !item.IsSubmodule);

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -838,7 +838,16 @@ namespace GitUI.CommandsDialogs
                 var items = DiffFiles.SelectedItems.Where(item => !item.IsSubmodule);
                 foreach (var item in items)
                 {
-                    File.Delete(_fullPathResolver.Resolve(item.Name));
+                    var path = _fullPathResolver.Resolve(item.Name);
+                    bool isDir = (File.GetAttributes(path) & FileAttributes.Directory) == FileAttributes.Directory;
+                    if (isDir)
+                    {
+                        Directory.Delete(path, true);
+                    }
+                    else
+                    {
+                        File.Delete(path);
+                    }
                 }
 
                 RefreshArtificial();


### PR DESCRIPTION
## Proposed changes

Some minor issues seen 

- FormDiff: Compare Worktree to worktree. 
FormDiff should be aligned to https://github.com/gitextensions/gitextensions/blob/master/GitUI/CommandsDialogs/RevisionDiffControl.cs#L682

- RevisionDiff: Delete worktree directories
Directories (like deleted submodules) could not be deleted, only files
This is only possible with Delete key, context menu only allows deletion of single files. (DEL also allows deleting several files at the same time.)
 
- RevisionDiff: Delete multiple files must unstage
If Selected revision was not Index (for instance HEAD to worktree) the file was not unstaged.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/59161840-dfe64780-8ae7-11e9-944e-940d12fbb762.png)

### After

![image](https://user-images.githubusercontent.com/6248932/59161831-be855b80-8ae7-11e9-95e3-64d110879eb4.png)

## Test methodology <!-- How did you ensure quality? -->

Manual tests - there are unittests already

## Test environment(s) <!-- Remove any that don't apply -->

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
