### PR TITLE
FormCommit: No selection and F4 could give null refs

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2673,7 +2673,8 @@ namespace GitUI.CommandsDialogs
             if (list == null /* menu action triggered directly by hotkey */)
             {
                 // The inactive list's selection has been cleared.
-                list = Staged.SelectedItems.Any() ? Staged : Unstaged.SelectedItems.Any() ? list = Unstaged : null;
+                list = Staged.SelectedItems.Any() ? Staged :
+                    Unstaged.SelectedItems.Any() ? Unstaged : null;
             }
 
             return list != null;
@@ -3256,6 +3257,10 @@ namespace GitUI.CommandsDialogs
             {
                 _formCommit = formCommit;
             }
+
+            internal ToolStripMenuItem EditFileToolStripMenuItem => _formCommit.editFileToolStripMenuItem;
+
+            internal FileStatusList UnstagedList => _formCommit.Unstaged;
 
             internal EditNetSpell Message => _formCommit.Message;
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2635,8 +2635,12 @@ namespace GitUI.CommandsDialogs
             }
 
             var item = list.SelectedItem;
-            var fileName = _fullPathResolver.Resolve(item.Name);
+            if (item == null)
+            {
+                return;
+            }
 
+            var fileName = _fullPathResolver.Resolve(item.Name);
             UICommands.StartFileEditorDialog(fileName);
 
             UnstagedSelectionChanged(null, null);

--- a/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
@@ -224,6 +224,22 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 expectedResult: true, expectedMessage, expectedSelectionStart);
         }
 
+        [Test]
+        public void editFileToolStripMenuItem_Click_no_selection_should_not_throw()
+        {
+            RunFormTest(async form =>
+            {
+                await ThreadHelper.JoinPendingOperationsAsync();
+
+                form.GetTestAccessor().UnstagedList.ClearSelected();
+
+                var editFileToolStripMenuItem = form.GetTestAccessor().EditFileToolStripMenuItem;
+
+                // asserting by the virtue of not crashing
+                editFileToolStripMenuItem.PerformClick();
+            });
+        }
+
         private void TestAddSelectionToCommitMessage(
             bool focusSelectedDiff,
             string selectedText,


### PR DESCRIPTION
Fixes #6771

## Proposed changes
Null check before evaluating filename.
This could occur when pressing F4 with no selected files

## Test methodology <!-- How did you ensure quality? -->
Code review, hard to reproduce with the problem

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
