### PR TITLE
Commit: Stage/unstage/reset lines null reference

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -830,7 +830,11 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Debug.Assert(_currentItem != null, "_currentItem != null");
+            // File no longer selected
+            if (_currentItem == null)
+            {
+                return;
+            }
 
             byte[] patch;
             if (!_currentItemStaged && _currentItem.IsNew)
@@ -890,16 +894,19 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
+            // File no longer selected
+            if (_currentItem == null)
+            {
+                return;
+            }
+
             if (MessageBox.Show(this, _resetSelectedLinesConfirmation.Text, _resetChangesCaption.Text,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
             {
                 return;
             }
 
-            Debug.Assert(_currentItem != null, "_currentItem != null");
-
             byte[] patch;
-
             if (_currentItemStaged)
             {
                 patch = PatchManager.GetSelectedLinesAsPatch(


### PR DESCRIPTION
Fixes #6583 

## Proposed changes
Check that file is still selected when manipulating lines in FormCommit.
Reported for reset, similar possible for stage/unstage

## Test methodology

Code review, race condition. This is hard to recreate in current master

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
