### PR TITLE
#5949 - Update EditNetSpell to respect comment line limits

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -432,20 +432,37 @@ namespace GitUI.SpellChecker
                 return;
             }
 
+            int limit1 = AppSettings.CommitValidationMaxCntCharsFirstLine;
+            int limitX = AppSettings.CommitValidationMaxCntCharsPerLine;
+            bool empty2 = AppSettings.CommitValidationSecondLineMustBeEmpty;
+
             var numLines = TextBox.Lines.Length;
             var chars = 0;
             for (var curLine = 0; curLine < numLines; ++curLine)
             {
                 var curLength = TextBox.Lines[curLine].Length;
-                var curMaxLength = 72;
+                var curMaxLength = limitX;
                 if (curLine == 0)
                 {
-                    curMaxLength = 50;
+                    curMaxLength = limit1;
+                    if (limit1 == 0)
+                    {
+                        // Disable limit checking if setting is set to 0.
+                        curMaxLength = curLength;
+                    }
                 }
-
-                if (curLine == 1)
+                else if (curLine == 1 && empty2)
                 {
                     curMaxLength = 0;
+                }
+                else
+                {
+                    curMaxLength = limitX;
+                    if (limitX == 0)
+                    {
+                        // Disable limit checking if setting is set to 0.
+                        curMaxLength = curLength;
+                    }
                 }
 
                 if (curLength > curMaxLength)

--- a/contributors.txt
+++ b/contributors.txt
@@ -85,3 +85,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/05/24, cryham, Crystal Hammer, cryham(at)gmail.com
 2019/05/29, Johno-ACSLive, Jonathon Aroutsidis, thunder2518(at)hotmail.com
 2019/06/05, AOrlov, Andrei Orlov, gooshift(at)gmail.com
+2019/06/09, lukevp, Luke Paireepinart, lukepdev(at)live.com


### PR DESCRIPTION
- Update EditNetSpell to respect the line limits configured in the commit settings rather than highlighting based on hardcoded values.

Fixes #


## Proposed changes

- Update the spell check code to respect line length settings in appsettings rather than being hardcoded


## Screenshots

### Before

![image](https://user-images.githubusercontent.com/1251016/59164856-714dbd80-8ad8-11e9-8ce2-652b9cb53df8.png)
![image](https://user-images.githubusercontent.com/1251016/59164868-993d2100-8ad8-11e9-86d8-8309881aed96.png)


### After

No highlighting with settings disabled
![image](https://user-images.githubusercontent.com/1251016/59164881-b245d200-8ad8-11e9-8b95-c50da9561070.png)

With settings enabled, highlights as before.
![image](https://user-images.githubusercontent.com/1251016/59164890-c25db180-8ad8-11e9-926f-220b9765ae9b.png)
![image](https://user-images.githubusercontent.com/1251016/59164893-cd184680-8ad8-11e9-849e-f61036a4d0b4.png)

## Test methodology 

- Tested with settings enabled and disabled and ensured proper functionality.

## Test environment(s) 

- GIT 2.22.0.windows.1
- Windows 10 Pro 1903 Build 18362.53

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
