### PR TITLE
#6775 - Add Support for Commit+Push to Commit window

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2694,17 +2694,24 @@ namespace GitUI.CommandsDialogs
 
         private void Message_KeyUp(object sender, KeyEventArgs e)
         {
+            // Ctrl + Shift + Enter = Commit and Push
+            if (e.Control && e.Shift && e.KeyCode == Keys.Enter)
+            {
+                ExecuteCommitCommand(push: true);
+                e.Handled = true;
+            }
+
             // Ctrl + Enter = Commit
-            if (e.Control && e.KeyCode == Keys.Enter)
+            else if (e.Control && e.KeyCode == Keys.Enter)
             {
                 ExecuteCommitCommand();
                 e.Handled = true;
             }
         }
 
-        private void ExecuteCommitCommand()
+        private void ExecuteCommitCommand(bool push = false)
         {
-            CheckForStagedAndCommit(Amend.Checked, push: false);
+            CheckForStagedAndCommit(Amend.Checked, push: push);
         }
 
         private void Message_KeyDown(object sender, KeyEventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2694,17 +2694,11 @@ namespace GitUI.CommandsDialogs
 
         private void Message_KeyUp(object sender, KeyEventArgs e)
         {
-            // Ctrl + Shift + Enter = Commit and Push
-            if (e.Control && e.Shift && e.KeyCode == Keys.Enter)
+            if (e.Control && e.KeyCode == Keys.Enter)
             {
-                ExecuteCommitCommand(push: true);
-                e.Handled = true;
-            }
-
-            // Ctrl + Enter = Commit
-            else if (e.Control && e.KeyCode == Keys.Enter)
-            {
-                ExecuteCommitCommand();
+                // Ctrl + Enter = Commit
+                // Ctrl + Shift + Enter = Commit and Push
+                ExecuteCommitCommand(e.Shift);
                 e.Handled = true;
             }
         }

--- a/contributors.txt
+++ b/contributors.txt
@@ -85,3 +85,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/05/24, cryham, Crystal Hammer, cryham(at)gmail.com
 2019/05/29, Johno-ACSLive, Jonathon Aroutsidis, thunder2518(at)hotmail.com
 2019/06/05, AOrlov, Andrei Orlov, gooshift(at)gmail.com
+2019/06/09, lukevp, Luke Paireepinart, lukepdev(at)live.com


### PR DESCRIPTION
Add support for Ctrl+Shift+Enter hotkey to do a Commit and Push for feature #6775
Add lukevp to Contributors file and sign contributors.txt

Fixes #6775


## Proposed changes
Add support for Ctrl+Shift+Enter hotkey to do a Commit and Push

## Test methodology 
- Tested in debug mode with old hotkey and new hotkey.  One functions as before, and the new hotkey functions properly and does both a commit and a push.
- Implemented with minimum changes while matching style of existing hotkey.

## Test environment(s) 
- Git Extensions 3.2.0
- Build 4884278fff6acbc4b8b091b6c0723060bd19232e (Dirty)
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.3752.0
- DPI 96dpi (no scaling)
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
