### PR TITLE
Add revision links templates for GitHub and Azure DevOps services

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinksManager.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksManager.cs
@@ -52,6 +52,23 @@ namespace GitCommands.ExternalLinks
         }
 
         /// <summary>
+        /// Adds the provided definitions at the lowest available level.
+        /// </summary>
+        /// <param name="definitions">External link definitions.</param>
+        public void AddRange(IEnumerable<ExternalLinkDefinition> definitions)
+        {
+            if (definitions == null)
+            {
+                throw new ArgumentNullException(nameof(definitions));
+            }
+
+            foreach (var externalLinkDefinition in definitions)
+            {
+                Add(externalLinkDefinition);
+            }
+        }
+
+        /// <summary>
         /// Checks if a definition with the supplied name exists in any level of available settings.
         /// </summary>
         /// <param name="definitionName">The name of the definition to find.</param>

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -122,6 +122,9 @@
     <Compile Include="IDiffListSortService.cs" />
     <Compile Include="Plink.cs" />
     <Compile Include="Remotes\ConfigFileRemoteSettingsManager.cs" />
+    <Compile Include="Remotes\AzureDevOpsRemoteParser.cs" />
+    <Compile Include="Remotes\GitHubRemoteParser.cs" />
+    <Compile Include="Remotes\RemoteParser.cs" />
     <Compile Include="Remotes\RepoNameExtractor.cs" />
     <Compile Include="Settings\AvatarProvider.cs" />
     <Compile Include="Settings\GravatarFallbackAvatarType.cs" />

--- a/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
+++ b/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
@@ -1,0 +1,35 @@
+namespace GitCommands.Remotes
+{
+    public sealed class AzureDevOpsRemoteParser : RemoteParser
+    {
+        private static readonly string VstsHttpsRemoteRegex = @"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$";
+        private static readonly string VstsSshRemoteRegex = @"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$";
+        private static readonly string AzureDevopsHttpsRemoteRegex = @"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$";
+        private static readonly string AzureDevopsSshRemoteRegex = @"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$";
+        private static readonly string[] AzureDevopsRegexes = { AzureDevopsHttpsRemoteRegex, AzureDevopsSshRemoteRegex, VstsHttpsRemoteRegex, VstsSshRemoteRegex };
+
+        public bool IsValidRemoteUrl(string remoteUrl)
+        {
+            return TryExtractAzureDevopsDataFromRemoteUrl(remoteUrl, out _, out _, out _);
+        }
+
+        public bool TryExtractAzureDevopsDataFromRemoteUrl(string remoteUrl, out string owner, out string project, out string repository)
+        {
+            owner = null;
+            project = null;
+            repository = null;
+
+            var m = MatchRegExes(remoteUrl, AzureDevopsRegexes);
+
+            if (m == null || !m.Success)
+            {
+                return false;
+            }
+
+            owner = m.Groups["owner"].Value;
+            project = m.Groups["project"].Value;
+            repository = m.Groups["repo"].Value;
+            return true;
+        }
+    }
+}

--- a/GitCommands/Remotes/GitHubRemoteParser.cs
+++ b/GitCommands/Remotes/GitHubRemoteParser.cs
@@ -1,0 +1,31 @@
+namespace GitCommands.Remotes
+{
+    public sealed class GitHubRemoteParser : RemoteParser
+    {
+        private static readonly string GitHubSshUrlRegex = @"git(?:@|://)github.com[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git";
+        private static readonly string GitHubHttpsUrlRegex = @"https?://(?:[^@:]+)?(?::[^/@:]+)?@?github.com/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?";
+        private static readonly string[] GitHubRegexes = { GitHubHttpsUrlRegex, GitHubSshUrlRegex };
+
+        public bool IsValidRemoteUrl(string remoteUrl)
+        {
+            return TryExtractGitHubDataFromRemoteUrl(remoteUrl, out _, out _);
+        }
+
+        public bool TryExtractGitHubDataFromRemoteUrl(string remoteUrl, out string owner, out string repository)
+        {
+            owner = null;
+            repository = null;
+
+            var m = MatchRegExes(remoteUrl, GitHubRegexes);
+
+            if (m == null || !m.Success)
+            {
+                return false;
+            }
+
+            owner = m.Groups["owner"].Value;
+            repository = m.Groups["repo"].Value.Replace(".git", "");
+            return true;
+        }
+    }
+}

--- a/GitCommands/Remotes/RemoteParser.cs
+++ b/GitCommands/Remotes/RemoteParser.cs
@@ -1,0 +1,22 @@
+using System.Text.RegularExpressions;
+
+namespace GitCommands.Remotes
+{
+    public abstract class RemoteParser
+    {
+        protected Match MatchRegExes(string remoteUrl, string[] regExs)
+        {
+            Match m = null;
+            foreach (var regex in regExs)
+            {
+                m = Regex.Match(remoteUrl, regex);
+                if (m.Success)
+                {
+                    break;
+                }
+            }
+
+            return m;
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -30,8 +30,10 @@
         {
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.Remove = new System.Windows.Forms.Button();
-            this.Add = new System.Windows.Forms.Button();
+            this.toolStripManageCategories = new System.Windows.Forms.ToolStrip();
+            this.Add = new System.Windows.Forms.ToolStripSplitButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.Remove = new System.Windows.Forms.ToolStripButton();
             this._NO_TRANSLATE_Categories = new System.Windows.Forms.ListBox();
             this.CategoriesLabel = new System.Windows.Forms.Label();
             this.LinksGrid = new System.Windows.Forms.DataGridView();
@@ -74,6 +76,7 @@
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
+            this.toolStripManageCategories.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.LinksGrid)).BeginInit();
             this.panel1.SuspendLayout();
             this.detailPanel.SuspendLayout();
@@ -109,7 +112,7 @@
             this.splitContainer1.Panel2.Controls.Add(this.LinksGrid);
             this.splitContainer1.Panel2.Controls.Add(this.panel1);
             this.splitContainer1.Panel2.Controls.Add(this.detailPanel);
-            this.splitContainer1.Size = new System.Drawing.Size(974, 452);
+            this.splitContainer1.Size = new System.Drawing.Size(1174, 549);
             this.splitContainer1.SplitterDistance = 192;
             this.splitContainer1.TabIndex = 2;
             // 
@@ -117,49 +120,55 @@
             // 
             this.tableLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.BackColor = System.Drawing.SystemColors.Control;
-            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.Remove, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.Add, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.toolStripManageCategories, 0, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 423);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 524);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 1;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(192, 29);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(192, 25);
             this.tableLayoutPanel1.TabIndex = 3;
             // 
-            // Remove
+            // toolStripManageCategories
             // 
-            this.Remove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.Remove.AutoSize = true;
-            this.Remove.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.Remove.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.Remove.Location = new System.Drawing.Point(134, 3);
-            this.Remove.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.Remove.Name = "Remove";
-            this.Remove.Size = new System.Drawing.Size(56, 23);
-            this.Remove.TabIndex = 4;
-            this.Remove.Text = "Remove";
-            this.Remove.UseVisualStyleBackColor = true;
-            this.Remove.Click += new System.EventHandler(this.Remove_Click);
+            this.toolStripManageCategories.AllowMerge = false;
+            this.toolStripManageCategories.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.toolStripManageCategories.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.Add,
+            this.toolStripSeparator1,
+            this.Remove});
+            this.toolStripManageCategories.Location = new System.Drawing.Point(5, 0);
+            this.toolStripManageCategories.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripManageCategories.Name = "toolStripManageCategories";
+            this.toolStripManageCategories.Size = new System.Drawing.Size(182, 25);
+            this.toolStripManageCategories.TabIndex = 5;
+            this.toolStripManageCategories.Text = "toolStrip1";
             // 
             // Add
             // 
-            this.Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.Add.AutoSize = true;
-            this.Add.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Add.BackColor = System.Drawing.SystemColors.Control;
-            this.Add.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.Add.Location = new System.Drawing.Point(2, 3);
-            this.Add.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.Add.Image = global::GitUI.Properties.Resources.FileStatusAdded;
+            this.Add.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.Add.Name = "Add";
-            this.Add.Size = new System.Drawing.Size(36, 23);
-            this.Add.TabIndex = 3;
+            this.Add.Size = new System.Drawing.Size(61, 22);
             this.Add.Text = "Add";
-            this.Add.UseVisualStyleBackColor = true;
-            this.Add.Click += new System.EventHandler(this.Add_Click);
+            this.Add.ButtonClick += new System.EventHandler(this.Add_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            // 
+            // Remove
+            // 
+            this.Remove.Image = global::GitUI.Properties.Resources.FileStatusRemoved;
+            this.Remove.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.Remove.Name = "Remove";
+            this.Remove.Size = new System.Drawing.Size(70, 22);
+            this.Remove.Text = "Remove";
+            this.Remove.Click += new System.EventHandler(this.Remove_Click);
             // 
             // _NO_TRANSLATE_Categories
             // 
@@ -169,7 +178,7 @@
             this._NO_TRANSLATE_Categories.Location = new System.Drawing.Point(0, 22);
             this._NO_TRANSLATE_Categories.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this._NO_TRANSLATE_Categories.Name = "_NO_TRANSLATE_Categories";
-            this._NO_TRANSLATE_Categories.Size = new System.Drawing.Size(192, 430);
+            this._NO_TRANSLATE_Categories.Size = new System.Drawing.Size(192, 527);
             this._NO_TRANSLATE_Categories.TabIndex = 1;
             this._NO_TRANSLATE_Categories.SelectedIndexChanged += new System.EventHandler(this._NO_TRANSLATE_Categories_SelectedIndexChanged);
             // 
@@ -191,14 +200,14 @@
             this.CaptionCol,
             this.URICol});
             this.LinksGrid.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LinksGrid.Location = new System.Drawing.Point(0, 275);
+            this.LinksGrid.Location = new System.Drawing.Point(0, 294);
             this.LinksGrid.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.LinksGrid.MultiSelect = false;
             this.LinksGrid.Name = "LinksGrid";
             this.LinksGrid.RowHeadersVisible = false;
             this.LinksGrid.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
             this.LinksGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.LinksGrid.Size = new System.Drawing.Size(778, 177);
+            this.LinksGrid.Size = new System.Drawing.Size(978, 255);
             this.LinksGrid.TabIndex = 8;
             // 
             // CaptionCol
@@ -219,10 +228,10 @@
             this.panel1.BackColor = System.Drawing.SystemColors.Control;
             this.panel1.Controls.Add(this.label6);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel1.Location = new System.Drawing.Point(0, 260);
+            this.panel1.Location = new System.Drawing.Point(0, 279);
             this.panel1.Name = "panel1";
             this.panel1.Padding = new System.Windows.Forms.Padding(0, 0, 0, 3);
-            this.panel1.Size = new System.Drawing.Size(778, 15);
+            this.panel1.Size = new System.Drawing.Size(978, 15);
             this.panel1.TabIndex = 7;
             // 
             // label6
@@ -233,7 +242,7 @@
             this.label6.Location = new System.Drawing.Point(206, -1);
             this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(30, 13);
+            this.label6.Size = new System.Drawing.Size(32, 13);
             this.label6.TabIndex = 21;
             this.label6.Text = "Links";
             // 
@@ -247,7 +256,7 @@
             this.detailPanel.Location = new System.Drawing.Point(0, 0);
             this.detailPanel.Name = "detailPanel";
             this.detailPanel.Padding = new System.Windows.Forms.Padding(0, 3, 0, 6);
-            this.detailPanel.Size = new System.Drawing.Size(778, 260);
+            this.detailPanel.Size = new System.Drawing.Size(978, 279);
             this.detailPanel.TabIndex = 6;
             // 
             // tableLayoutPanel3
@@ -270,7 +279,7 @@
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(778, 251);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(978, 244);
             this.tableLayoutPanel3.TabIndex = 14;
             // 
             // remoteGrp
@@ -280,9 +289,9 @@
             this.tableLayoutPanel3.SetColumnSpan(this.remoteGrp, 2);
             this.remoteGrp.Controls.Add(this.tableLayoutPanel2);
             this.remoteGrp.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.remoteGrp.Location = new System.Drawing.Point(3, 30);
+            this.remoteGrp.Location = new System.Drawing.Point(3, 29);
             this.remoteGrp.Name = "remoteGrp";
-            this.remoteGrp.Size = new System.Drawing.Size(772, 109);
+            this.remoteGrp.Size = new System.Drawing.Size(972, 106);
             this.remoteGrp.TabIndex = 28;
             this.remoteGrp.TabStop = false;
             this.remoteGrp.Text = "Remote data";
@@ -302,14 +311,14 @@
             this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 1, 1);
             this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel4, 1, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 17);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 3;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(766, 89);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(966, 87);
             this.tableLayoutPanel2.TabIndex = 17;
             // 
             // lblUseRemotes
@@ -317,20 +326,20 @@
             this.lblUseRemotes.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblUseRemotes.AutoSize = true;
             this.lblUseRemotes.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblUseRemotes.Location = new System.Drawing.Point(2, 10);
+            this.lblUseRemotes.Location = new System.Drawing.Point(2, 9);
             this.lblUseRemotes.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblUseRemotes.Name = "lblUseRemotes";
-            this.lblUseRemotes.Size = new System.Drawing.Size(67, 13);
+            this.lblUseRemotes.Size = new System.Drawing.Size(66, 13);
             this.lblUseRemotes.TabIndex = 24;
             this.lblUseRemotes.Text = "Use remotes";
             // 
             // _NO_TRANSLATE_RemotePatern
             // 
             this._NO_TRANSLATE_RemotePatern.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_RemotePatern.Location = new System.Drawing.Point(85, 65);
+            this._NO_TRANSLATE_RemotePatern.Location = new System.Drawing.Point(83, 64);
             this._NO_TRANSLATE_RemotePatern.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this._NO_TRANSLATE_RemotePatern.Name = "_NO_TRANSLATE_RemotePatern";
-            this._NO_TRANSLATE_RemotePatern.Size = new System.Drawing.Size(679, 21);
+            this._NO_TRANSLATE_RemotePatern.Size = new System.Drawing.Size(881, 20);
             this._NO_TRANSLATE_RemotePatern.TabIndex = 22;
             this._NO_TRANSLATE_RemotePatern.Leave += new System.EventHandler(this._NO_TRANSLATE_RemotePatern_Leave);
             // 
@@ -339,10 +348,10 @@
             this.lblSearchRemotePattern.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblSearchRemotePattern.AutoSize = true;
             this.lblSearchRemotePattern.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblSearchRemotePattern.Location = new System.Drawing.Point(2, 69);
+            this.lblSearchRemotePattern.Location = new System.Drawing.Point(2, 67);
             this.lblSearchRemotePattern.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblSearchRemotePattern.Name = "lblSearchRemotePattern";
-            this.lblSearchRemotePattern.Size = new System.Drawing.Size(79, 13);
+            this.lblSearchRemotePattern.Size = new System.Drawing.Size(77, 13);
             this.lblSearchRemotePattern.TabIndex = 19;
             this.lblSearchRemotePattern.Text = "Search pattern";
             // 
@@ -351,10 +360,10 @@
             this.lblRemoteSearchIn.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblRemoteSearchIn.AutoSize = true;
             this.lblRemoteSearchIn.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblRemoteSearchIn.Location = new System.Drawing.Point(2, 41);
+            this.lblRemoteSearchIn.Location = new System.Drawing.Point(2, 40);
             this.lblRemoteSearchIn.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblRemoteSearchIn.Name = "lblRemoteSearchIn";
-            this.lblRemoteSearchIn.Size = new System.Drawing.Size(51, 13);
+            this.lblRemoteSearchIn.Size = new System.Drawing.Size(52, 13);
             this.lblRemoteSearchIn.TabIndex = 15;
             this.lblRemoteSearchIn.Text = "Search in";
             // 
@@ -364,9 +373,9 @@
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.flowLayoutPanel1.Controls.Add(this.chxURL);
             this.flowLayoutPanel1.Controls.Add(this.chxPushURL);
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(86, 36);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(84, 35);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(128, 23);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(135, 23);
             this.flowLayoutPanel1.TabIndex = 23;
             // 
             // chxURL
@@ -374,7 +383,7 @@
             this.chxURL.AutoSize = true;
             this.chxURL.Location = new System.Drawing.Point(3, 3);
             this.chxURL.Name = "chxURL";
-            this.chxURL.Size = new System.Drawing.Size(45, 17);
+            this.chxURL.Size = new System.Drawing.Size(48, 17);
             this.chxURL.TabIndex = 0;
             this.chxURL.Text = "URL";
             this.chxURL.UseVisualStyleBackColor = true;
@@ -383,9 +392,9 @@
             // chxPushURL
             // 
             this.chxPushURL.AutoSize = true;
-            this.chxPushURL.Location = new System.Drawing.Point(54, 3);
+            this.chxPushURL.Location = new System.Drawing.Point(57, 3);
             this.chxPushURL.Name = "chxPushURL";
-            this.chxPushURL.Size = new System.Drawing.Size(71, 17);
+            this.chxPushURL.Size = new System.Drawing.Size(75, 17);
             this.chxPushURL.TabIndex = 2;
             this.chxPushURL.Text = "Push URL";
             this.chxPushURL.UseVisualStyleBackColor = true;
@@ -399,9 +408,9 @@
             this.flowLayoutPanel4.Controls.Add(this._NO_TRANSLATE_UseRemotes);
             this.flowLayoutPanel4.Controls.Add(this.chkOnlyFirstRemote);
             this.flowLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel4.Location = new System.Drawing.Point(86, 3);
+            this.flowLayoutPanel4.Location = new System.Drawing.Point(84, 3);
             this.flowLayoutPanel4.Name = "flowLayoutPanel4";
-            this.flowLayoutPanel4.Size = new System.Drawing.Size(677, 27);
+            this.flowLayoutPanel4.Size = new System.Drawing.Size(879, 26);
             this.flowLayoutPanel4.TabIndex = 25;
             // 
             // _NO_TRANSLATE_UseRemotes
@@ -409,7 +418,7 @@
             this._NO_TRANSLATE_UseRemotes.Location = new System.Drawing.Point(2, 3);
             this._NO_TRANSLATE_UseRemotes.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this._NO_TRANSLATE_UseRemotes.Name = "_NO_TRANSLATE_UseRemotes";
-            this._NO_TRANSLATE_UseRemotes.Size = new System.Drawing.Size(218, 21);
+            this._NO_TRANSLATE_UseRemotes.Size = new System.Drawing.Size(218, 20);
             this._NO_TRANSLATE_UseRemotes.TabIndex = 26;
             this._NO_TRANSLATE_UseRemotes.Leave += new System.EventHandler(this._NO_TRANSLATE_UseRemotes_Leave);
             // 
@@ -417,9 +426,9 @@
             // 
             this.chkOnlyFirstRemote.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkOnlyFirstRemote.AutoSize = true;
-            this.chkOnlyFirstRemote.Location = new System.Drawing.Point(225, 5);
+            this.chkOnlyFirstRemote.Location = new System.Drawing.Point(225, 4);
             this.chkOnlyFirstRemote.Name = "chkOnlyFirstRemote";
-            this.chkOnlyFirstRemote.Size = new System.Drawing.Size(141, 17);
+            this.chkOnlyFirstRemote.Size = new System.Drawing.Size(136, 17);
             this.chkOnlyFirstRemote.TabIndex = 27;
             this.chkOnlyFirstRemote.Text = "Only use the first match";
             this.chkOnlyFirstRemote.UseVisualStyleBackColor = true;
@@ -432,9 +441,9 @@
             this.tableLayoutPanel3.SetColumnSpan(this.revisionDataGrp, 2);
             this.revisionDataGrp.Controls.Add(this.tableLayoutPanel4);
             this.revisionDataGrp.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.revisionDataGrp.Location = new System.Drawing.Point(3, 145);
+            this.revisionDataGrp.Location = new System.Drawing.Point(3, 141);
             this.revisionDataGrp.Name = "revisionDataGrp";
-            this.revisionDataGrp.Size = new System.Drawing.Size(772, 103);
+            this.revisionDataGrp.Size = new System.Drawing.Size(972, 100);
             this.revisionDataGrp.TabIndex = 27;
             this.revisionDataGrp.TabStop = false;
             this.revisionDataGrp.Text = "Revision data";
@@ -454,7 +463,7 @@
             this.tableLayoutPanel4.Controls.Add(this.nestedPatternLab, 0, 2);
             this.tableLayoutPanel4.Controls.Add(this.flowLayoutPanel3, 1, 0);
             this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 17);
+            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             this.tableLayoutPanel4.RowCount = 3;
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -462,26 +471,26 @@
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(766, 83);
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(966, 81);
             this.tableLayoutPanel4.TabIndex = 16;
             // 
             // _NO_TRANSLATE_SearchPatternEdit
             // 
             this._NO_TRANSLATE_SearchPatternEdit.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_SearchPatternEdit.Location = new System.Drawing.Point(86, 32);
+            this._NO_TRANSLATE_SearchPatternEdit.Location = new System.Drawing.Point(83, 32);
             this._NO_TRANSLATE_SearchPatternEdit.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this._NO_TRANSLATE_SearchPatternEdit.Name = "_NO_TRANSLATE_SearchPatternEdit";
-            this._NO_TRANSLATE_SearchPatternEdit.Size = new System.Drawing.Size(678, 21);
+            this._NO_TRANSLATE_SearchPatternEdit.Size = new System.Drawing.Size(881, 20);
             this._NO_TRANSLATE_SearchPatternEdit.TabIndex = 22;
             this._NO_TRANSLATE_SearchPatternEdit.Leave += new System.EventHandler(this._NO_TRANSLATE_SearchPatternEdit_Leave);
             // 
             // _NO_TRANSLATE_NestedPatternEdit
             // 
             this._NO_TRANSLATE_NestedPatternEdit.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._NO_TRANSLATE_NestedPatternEdit.Location = new System.Drawing.Point(86, 59);
+            this._NO_TRANSLATE_NestedPatternEdit.Location = new System.Drawing.Point(83, 58);
             this._NO_TRANSLATE_NestedPatternEdit.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this._NO_TRANSLATE_NestedPatternEdit.Name = "_NO_TRANSLATE_NestedPatternEdit";
-            this._NO_TRANSLATE_NestedPatternEdit.Size = new System.Drawing.Size(678, 21);
+            this._NO_TRANSLATE_NestedPatternEdit.Size = new System.Drawing.Size(881, 20);
             this._NO_TRANSLATE_NestedPatternEdit.TabIndex = 21;
             this._NO_TRANSLATE_NestedPatternEdit.Leave += new System.EventHandler(this._NO_TRANSLATE_NestedPatternEdit_Leave);
             // 
@@ -490,10 +499,10 @@
             this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label2.AutoSize = true;
             this.label2.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label2.Location = new System.Drawing.Point(2, 36);
+            this.label2.Location = new System.Drawing.Point(2, 35);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(79, 13);
+            this.label2.Size = new System.Drawing.Size(77, 13);
             this.label2.TabIndex = 19;
             this.label2.Text = "Search pattern";
             // 
@@ -505,7 +514,7 @@
             this.label5.Location = new System.Drawing.Point(2, 8);
             this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(51, 13);
+            this.label5.Size = new System.Drawing.Size(52, 13);
             this.label5.TabIndex = 15;
             this.label5.Text = "Search in";
             // 
@@ -514,10 +523,10 @@
             this.nestedPatternLab.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.nestedPatternLab.AutoSize = true;
             this.nestedPatternLab.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.nestedPatternLab.Location = new System.Drawing.Point(2, 63);
+            this.nestedPatternLab.Location = new System.Drawing.Point(2, 61);
             this.nestedPatternLab.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nestedPatternLab.Name = "nestedPatternLab";
-            this.nestedPatternLab.Size = new System.Drawing.Size(80, 13);
+            this.nestedPatternLab.Size = new System.Drawing.Size(77, 13);
             this.nestedPatternLab.TabIndex = 20;
             this.nestedPatternLab.Text = "Nested pattern";
             // 
@@ -529,9 +538,9 @@
             this.flowLayoutPanel3.Controls.Add(this.MessageChx);
             this.flowLayoutPanel3.Controls.Add(this.LocalBranchChx);
             this.flowLayoutPanel3.Controls.Add(this.RemoteBranchChx);
-            this.flowLayoutPanel3.Location = new System.Drawing.Point(87, 3);
+            this.flowLayoutPanel3.Location = new System.Drawing.Point(84, 3);
             this.flowLayoutPanel3.Name = "flowLayoutPanel3";
-            this.flowLayoutPanel3.Size = new System.Drawing.Size(329, 23);
+            this.flowLayoutPanel3.Size = new System.Drawing.Size(332, 23);
             this.flowLayoutPanel3.TabIndex = 23;
             // 
             // MessageChx
@@ -539,7 +548,7 @@
             this.MessageChx.AutoSize = true;
             this.MessageChx.Location = new System.Drawing.Point(3, 3);
             this.MessageChx.Name = "MessageChx";
-            this.MessageChx.Size = new System.Drawing.Size(68, 17);
+            this.MessageChx.Size = new System.Drawing.Size(69, 17);
             this.MessageChx.TabIndex = 0;
             this.MessageChx.Text = "Message";
             this.MessageChx.UseVisualStyleBackColor = true;
@@ -548,9 +557,9 @@
             // LocalBranchChx
             // 
             this.LocalBranchChx.AutoSize = true;
-            this.LocalBranchChx.Location = new System.Drawing.Point(77, 3);
+            this.LocalBranchChx.Location = new System.Drawing.Point(78, 3);
             this.LocalBranchChx.Name = "LocalBranchChx";
-            this.LocalBranchChx.Size = new System.Drawing.Size(115, 17);
+            this.LocalBranchChx.Size = new System.Drawing.Size(117, 17);
             this.LocalBranchChx.TabIndex = 1;
             this.LocalBranchChx.Text = "Local branch name";
             this.LocalBranchChx.UseVisualStyleBackColor = true;
@@ -559,7 +568,7 @@
             // RemoteBranchChx
             // 
             this.RemoteBranchChx.AutoSize = true;
-            this.RemoteBranchChx.Location = new System.Drawing.Point(198, 3);
+            this.RemoteBranchChx.Location = new System.Drawing.Point(201, 3);
             this.RemoteBranchChx.Name = "RemoteBranchChx";
             this.RemoteBranchChx.Size = new System.Drawing.Size(128, 17);
             this.RemoteBranchChx.TabIndex = 2;
@@ -572,10 +581,10 @@
             this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label1.AutoSize = true;
             this.label1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.label1.Location = new System.Drawing.Point(2, 7);
+            this.label1.Location = new System.Drawing.Point(2, 6);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(34, 13);
+            this.label1.Size = new System.Drawing.Size(35, 13);
             this.label1.TabIndex = 7;
             this.label1.Text = "Name";
             // 
@@ -587,10 +596,10 @@
             this.flowLayoutPanel2.Controls.Add(this._NO_TRANSLATE_Name);
             this.flowLayoutPanel2.Controls.Add(this.EnabledChx);
             this.flowLayoutPanel2.Controls.Add(this.gotoUserManualControl1);
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(38, 0);
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(39, 0);
             this.flowLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(422, 27);
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(423, 26);
             this.flowLayoutPanel2.TabIndex = 24;
             // 
             // _NO_TRANSLATE_Name
@@ -598,7 +607,7 @@
             this._NO_TRANSLATE_Name.Location = new System.Drawing.Point(2, 3);
             this._NO_TRANSLATE_Name.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this._NO_TRANSLATE_Name.Name = "_NO_TRANSLATE_Name";
-            this._NO_TRANSLATE_Name.Size = new System.Drawing.Size(272, 21);
+            this._NO_TRANSLATE_Name.Size = new System.Drawing.Size(272, 20);
             this._NO_TRANSLATE_Name.TabIndex = 11;
             this._NO_TRANSLATE_Name.Leave += new System.EventHandler(this._NO_TRANSLATE_Name_Leave);
             // 
@@ -606,9 +615,9 @@
             // 
             this.EnabledChx.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.EnabledChx.AutoSize = true;
-            this.EnabledChx.Location = new System.Drawing.Point(279, 5);
+            this.EnabledChx.Location = new System.Drawing.Point(279, 4);
             this.EnabledChx.Name = "EnabledChx";
-            this.EnabledChx.Size = new System.Drawing.Size(64, 17);
+            this.EnabledChx.Size = new System.Drawing.Size(65, 17);
             this.EnabledChx.TabIndex = 22;
             this.EnabledChx.Text = "Enabled";
             this.EnabledChx.UseVisualStyleBackColor = true;
@@ -619,21 +628,21 @@
             this.gotoUserManualControl1.AutoSize = true;
             this.gotoUserManualControl1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gotoUserManualControl1.Dock = System.Windows.Forms.DockStyle.Right;
-            this.gotoUserManualControl1.Location = new System.Drawing.Point(349, 3);
+            this.gotoUserManualControl1.Location = new System.Drawing.Point(350, 3);
             this.gotoUserManualControl1.ManualSectionAnchorName = "git-extensions-revision-links";
             this.gotoUserManualControl1.ManualSectionSubfolder = "settings";
             this.gotoUserManualControl1.MinimumSize = new System.Drawing.Size(70, 20);
             this.gotoUserManualControl1.Name = "gotoUserManualControl1";
-            this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 21);
+            this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 20);
             this.gotoUserManualControl1.TabIndex = 26;
             // 
             // RevisionLinksSettingsPage
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            this.Controls.Add(this.splitContainer1);
             this.BackColor = System.Drawing.SystemColors.Control;
+            this.Controls.Add(this.splitContainer1);
             this.Name = "RevisionLinksSettingsPage";
-            this.Size = new System.Drawing.Size(974, 452);
+            this.Size = new System.Drawing.Size(1174, 549);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);
@@ -642,6 +651,8 @@
             this.splitContainer1.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.toolStripManageCategories.ResumeLayout(false);
+            this.toolStripManageCategories.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.LinksGrid)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
@@ -673,8 +684,6 @@
 
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Button Remove;
-        private System.Windows.Forms.Button Add;
         private System.Windows.Forms.ListBox _NO_TRANSLATE_Categories;
         private System.Windows.Forms.Label CategoriesLabel;
         private System.Windows.Forms.Panel detailPanel;
@@ -712,5 +721,9 @@
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel4;
         private System.Windows.Forms.TextBox _NO_TRANSLATE_UseRemotes;
         private System.Windows.Forms.CheckBox chkOnlyFirstRemote;
+        private System.Windows.Forms.ToolStrip toolStripManageCategories;
+        private System.Windows.Forms.ToolStripSplitButton Add;
+        private System.Windows.Forms.ToolStripButton Remove;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.resx
@@ -117,10 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolStripManageCategories.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 3</value>
+  </metadata>
   <metadata name="CaptionCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="URICol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
   </metadata>
 </root>

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands.ExternalLinks;
+using GitCommands.Remotes;
+using GitUI.Properties;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public sealed class AzureDevopsExternalLinkDefinitionExtractor : ExternalLinkDefinitionExtractor
+    {
+        public override string ServiceName => "Azure DevOps";
+        public override Image Icon => Images.VisualStudioTeamServices;
+        private readonly AzureDevOpsRemoteParser _azureDevOpsRemoteParser = new AzureDevOpsRemoteParser();
+
+        public override bool IsValidRemoteUrl(string remoteUrl)
+        {
+            return _azureDevOpsRemoteParser.IsValidRemoteUrl(remoteUrl);
+        }
+
+        public override IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl)
+        {
+            var externalLinkDefinitions = new List<ExternalLinkDefinition>();
+            string accountName = null;
+            string repoName = null;
+
+            if (!string.IsNullOrWhiteSpace(remoteUrl))
+            {
+                _azureDevOpsRemoteParser.TryExtractAzureDevopsDataFromRemoteUrl(remoteUrl, out accountName, out _, out repoName);
+            }
+
+            accountName = accountName ?? "ACCOUNT_NAME";
+            repoName = repoName ?? "REPO_NAME";
+
+            var azureDevopsUrl = $"https://dev.azure.com/{accountName}";
+            var definition = new ExternalLinkDefinition
+            {
+                Name = string.Format(CodeLink.Text, ServiceName),
+                Enabled = true,
+                SearchInParts = { ExternalLinkDefinition.RevisionPart.Message },
+                SearchPattern = @".*",
+                LinkFormats =
+                {
+                    new ExternalLinkFormat { Caption = string.Format(ViewCommitLink.Text, ServiceName), Format = $"{azureDevopsUrl}/_git/{repoName}/commit/%COMMIT_HASH%" },
+                    new ExternalLinkFormat { Caption = string.Format(ViewProjectLink.Text, ServiceName), Format = $"{azureDevopsUrl}/{repoName}" }
+                }
+            };
+            externalLinkDefinitions.Add(definition);
+
+            externalLinkDefinitions.Add(new ExternalLinkDefinition
+            {
+                Name = string.Format(IssuesLink.Text, ServiceName),
+                Enabled = true,
+                SearchInParts = { ExternalLinkDefinition.RevisionPart.Message },
+                SearchPattern = @"#(\d+)",
+                LinkFormats = { new ExternalLinkFormat { Caption = "#{0}", Format = $"{azureDevopsUrl}/{repoName}/_workitems/edit/{{0}}" } }
+            });
+
+            return externalLinkDefinitions;
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/CloudProviderExternalLinkDefinitionExtractorFactory.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/CloudProviderExternalLinkDefinitionExtractorFactory.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public sealed class CloudProviderExternalLinkDefinitionExtractorFactory : ICloudProviderExternalLinkDefinitionExtractorFactory
+    {
+        public ICloudProviderExternalLinkDefinitionExtractor Get(CloudProviderKind cloudProviderKind)
+        {
+            switch (cloudProviderKind)
+            {
+                case CloudProviderKind.GitHub:
+                    return new GitHubExternalLinkDefinitionExtractor();
+                case CloudProviderKind.AzureDevOps:
+                    return new AzureDevopsExternalLinkDefinitionExtractor();
+            }
+
+            return null;
+        }
+
+        public IEnumerable<ICloudProviderExternalLinkDefinitionExtractor> GetAllExtractor()
+        {
+            var cloudProviderKinds = Enum.GetValues(typeof(CloudProviderKind)).OfType<CloudProviderKind>();
+            var cloudProviderExternalLinkDefinitionExtractorFactory = new CloudProviderExternalLinkDefinitionExtractorFactory();
+            return cloudProviderKinds.Select(c => cloudProviderExternalLinkDefinitionExtractorFactory.Get(c))
+                .Where(e => e != null);
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/CloudProviderKind.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/CloudProviderKind.cs
@@ -1,0 +1,9 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public enum CloudProviderKind
+    {
+        None = 0,
+        GitHub,
+        AzureDevOps,
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/ExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/ExternalLinkDefinitionExtractor.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands.ExternalLinks;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public abstract class ExternalLinkDefinitionExtractor : ICloudProviderExternalLinkDefinitionExtractor
+    {
+        private protected static readonly TranslationString CodeLink = new TranslationString("{0} - Code");
+        private protected static readonly TranslationString IssuesLink = new TranslationString("{0} - Issues");
+        private protected static readonly TranslationString PullRequestsLink = new TranslationString("{0} - Pull Requests");
+        private protected static readonly TranslationString ViewCommitLink = new TranslationString("View commit in {0}");
+        private protected static readonly TranslationString ViewProjectLink = new TranslationString("View project in {0}");
+
+        public abstract string ServiceName { get; }
+        public abstract Image Icon { get; }
+
+        public abstract bool IsValidRemoteUrl(string remoteUrl);
+        public abstract IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl);
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands.ExternalLinks;
+using GitCommands.Remotes;
+using GitUI.Properties;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public sealed class GitHubExternalLinkDefinitionExtractor : ExternalLinkDefinitionExtractor
+    {
+        public override string ServiceName => "GitHub";
+        public override Image Icon => Images.GitHub;
+        private readonly GitHubRemoteParser _remoteParser = new GitHubRemoteParser();
+
+        public override bool IsValidRemoteUrl(string remoteUrl)
+        {
+            return _remoteParser.IsValidRemoteUrl(remoteUrl);
+        }
+
+        public override IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl)
+        {
+            var externalLinkDefinitions = new List<ExternalLinkDefinition>();
+            string organizationName = null;
+            string repoName = null;
+
+            if (!string.IsNullOrWhiteSpace(remoteUrl))
+            {
+                _remoteParser.TryExtractGitHubDataFromRemoteUrl(remoteUrl, out organizationName, out repoName);
+            }
+
+            organizationName = organizationName ?? "ORGANIZATION_NAME";
+            repoName = repoName ?? "REPO_NAME";
+
+            var gitHubUrl = $"https://github.com/{organizationName}/{repoName}";
+            var definition = new ExternalLinkDefinition
+            {
+                Name = string.Format(CodeLink.Text, ServiceName),
+                Enabled = true,
+                SearchInParts = { ExternalLinkDefinition.RevisionPart.Message },
+                SearchPattern = ".*",
+                LinkFormats =
+                {
+                    new ExternalLinkFormat { Caption = string.Format(ViewCommitLink.Text, ServiceName), Format = gitHubUrl + "/commit/%COMMIT_HASH%" },
+                    new ExternalLinkFormat { Caption = string.Format(ViewProjectLink.Text, ServiceName), Format = gitHubUrl }
+                }
+            };
+            externalLinkDefinitions.Add(definition);
+
+            externalLinkDefinitions.Add(new ExternalLinkDefinition
+            {
+                Name = string.Format(IssuesLink.Text, ServiceName),
+                Enabled = true,
+                SearchInParts = { ExternalLinkDefinition.RevisionPart.Message, ExternalLinkDefinition.RevisionPart.LocalBranches },
+                SearchPattern = @"(?i)(?<!pull request |pr[ _]?)(#|(((feat(ure)?)|fix)[/_-]))\d+",
+                NestedSearchPattern = @"\d+",
+                LinkFormats = { new ExternalLinkFormat { Caption = "#{0}", Format = gitHubUrl + "/issues/{0}" } }
+            });
+
+            externalLinkDefinitions.Add(new ExternalLinkDefinition
+            {
+                Name = string.Format(PullRequestsLink.Text, ServiceName),
+                Enabled = true,
+                SearchInParts = { ExternalLinkDefinition.RevisionPart.Message, ExternalLinkDefinition.RevisionPart.LocalBranches, ExternalLinkDefinition.RevisionPart.RemoteBranches },
+                SearchPattern = @"(?i)(pull request |pr[ _]?)#?\d+",
+                NestedSearchPattern = @"\d+",
+                LinkFormats = { new ExternalLinkFormat { Caption = "PR #{0}", Format = gitHubUrl + "/pull/{0}" } }
+            });
+
+            return externalLinkDefinitions;
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/ICloudProviderExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/ICloudProviderExternalLinkDefinitionExtractor.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands.ExternalLinks;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public interface ICloudProviderExternalLinkDefinitionExtractor
+    {
+        string ServiceName { get; }
+        Image Icon { get; }
+        bool IsValidRemoteUrl(string remoteUrl);
+        IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl);
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/ICloudProviderExternalLinkDefinitionExtractorFactory.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/ICloudProviderExternalLinkDefinitionExtractorFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
+{
+    public interface ICloudProviderExternalLinkDefinitionExtractorFactory
+    {
+        ICloudProviderExternalLinkDefinitionExtractor Get(CloudProviderKind cloudProviderKind);
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -313,6 +313,13 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\AzureDevopsExternalLinkDefinitionExtractor.cs" />
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\CloudProviderExternalLinkDefinitionExtractorFactory.cs" />
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\CloudProviderKind.cs" />
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\GitHubExternalLinkDefinitionExtractor.cs" />
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\ICloudProviderExternalLinkDefinitionExtractor.cs" />
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\ICloudProviderExternalLinkDefinitionExtractorFactory.cs" />
+    <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\ExternalLinkDefinitionExtractor.cs" />
     <Compile Include="CommandsDialogs\ToolStripPushButton.cs">
       <SubType>Component</SubType>
     </Compile>
@@ -1857,6 +1864,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\bug.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\Icons\FileStatusAdded.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\Icons\FileStatusRemoved.png" />
   </ItemGroup>
   <Target Name="CopyTranslations" AfterTargets="AfterBuild">
     <ItemGroup>

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -207,6 +207,26 @@ namespace GitUI.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap FileStatusAdded {
+            get {
+                object obj = ResourceManager.GetObject("FileStatusAdded", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap FileStatusRemoved {
+            get {
+                object obj = ResourceManager.GetObject("FileStatusRemoved", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap RepoOpen {
             get {
                 object obj = ResourceManager.GetObject("RepoOpen", resourceCulture);

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -124,6 +124,12 @@
   <data name="Team" xml:space="preserve">
     <value>Henk Westhuis, Arkady Shapkin, Janusz Białobrzewski, Igor Velikorossov aka RussKie, Gerhard Olsson, Drew Noakes</value>
   </data>
+  <data name="FileStatusAdded" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\FileStatusAdded.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="FileStatusRemoved" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\FileStatusRemoved.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="Coders" xml:space="preserve">
     <value>Steffen Forkmann, Jacob Stanley, Nick Mayer, Kevin Moore, Davide,
 Dominique Plante, Grzegorz Pachocki, Seth Behunin, bleis-tift, Chris Meaney, Nathanael Schmied, Adrian Codrington,

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8623,6 +8623,10 @@ See the changes in the commit form.</source>
         <source>URI</source>
         <target />
       </trans-unit>
+      <trans-unit id="_addTemplate.Text">
+        <source>Add {0} templates</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkOnlyFirstRemote.Text">
         <source>Only use the first match</source>
         <target />
@@ -8673,6 +8677,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="revisionDataGrp.Text">
         <source>Revision data</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toolStripManageCategories.Text">
+        <source>toolStrip1</source>
         <target />
       </trans-unit>
     </body>

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Git.hub;
 using GitCommands.Config;
+using GitCommands.Remotes;
 using GitHub3.Properties;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.RepositoryHosts;
@@ -204,15 +205,9 @@ namespace GitHub3
                         continue;
                     }
 
-                    var m = Regex.Match(url, @"git(?:@|://)github.com[:/]([^/]+)/([\w_\.\-]+)\.git");
-                    if (!m.Success)
+                    if (new GitHubRemoteParser().TryExtractGitHubDataFromRemoteUrl(url, out var owner, out var repository))
                     {
-                        m = Regex.Match(url, @"https?://(?:[^@:]+)?(?::[^/@:]+)?@?github.com/([^/]+)/([\w_\.\-]+)(?:.git)?");
-                    }
-
-                    if (m.Success)
-                    {
-                        var hostedRemote = new GitHubHostedRemote(remote, m.Groups[1].Value, m.Groups[2].Value.Replace(".git", ""), url);
+                        var hostedRemote = new GitHubHostedRemote(remote, owner, repository, url);
 
                         if (set.Add(hostedRemote))
                         {

--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Git\GitDescribeProviderTests.cs" />
     <Compile Include="Git\GitRefNameTests.cs" />
     <Compile Include="PlinkTests.cs" />
+    <Compile Include="Remote\AzureDevOpsRemoteParserTests.cs" />
+    <Compile Include="Remote\GitHubRemoteParserTests.cs" />
     <Compile Include="RevisionReaderTests.cs" />
     <Compile Include="StreamExtensionsTests.cs" />
     <Compile Include="RepoNameExtractorTest.cs" />

--- a/UnitTests/GitCommandsTests/Remote/AzureDevOpsRemoteParserTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/AzureDevOpsRemoteParserTests.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using GitCommands.Remotes;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Remote
+{
+    [TestFixture]
+    public class AzureDevOpsRemoteParserTests
+    {
+        [TestCase("https://owner@dev.azure.com/owner/project/_git/repo")]
+        [TestCase("git@ssh.dev.azure.com:v3/owner/project/repo")]
+        [TestCase("https://owner.visualstudio.com/project/_git/repo")]
+        [TestCase("owner@vs-ssh.visualstudio.com:v3/owner/project/repo")]
+        public void Should_succeed_in_parsing_valid_url(string url)
+        {
+            var azureDevOpsRemoteParser = new AzureDevOpsRemoteParser();
+            azureDevOpsRemoteParser.TryExtractAzureDevopsDataFromRemoteUrl(url, out var owner, out var project, out var repository).Should().BeTrue();
+            owner.Should().Be("owner");
+            project.Should().Be("project");
+            repository.Should().Be("repo");
+
+            azureDevOpsRemoteParser.IsValidRemoteUrl(url).Should().BeTrue();
+        }
+
+        [Test]
+        public void Should_fail_in_parsing_invalid_url()
+        {
+            var azureDevOpsRemoteParser = new AzureDevOpsRemoteParser();
+            var url = "https://owner@dev.bad.com/owner/project/_git/repo";
+            azureDevOpsRemoteParser.TryExtractAzureDevopsDataFromRemoteUrl(url, out var owner, out var project, out var repository).Should().BeFalse();
+            owner.Should().BeNull();
+            project.Should().BeNull();
+            repository.Should().BeNull();
+
+            azureDevOpsRemoteParser.IsValidRemoteUrl(url).Should().BeFalse();
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/Remote/GitHubRemoteParserTests.cs
+++ b/UnitTests/GitCommandsTests/Remote/GitHubRemoteParserTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+using GitCommands.Remotes;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Remote
+{
+    [TestFixture]
+    public class GitHubRemoteParserTests
+    {
+        [TestCase("https://github.com/owner/repo.git")]
+        [TestCase("http://github.com/owner/repo.git")]
+        [TestCase("https://github.com/owner/repo")]
+        [TestCase("ssh://git@github.com/owner/repo.git")]
+        [TestCase("git@github.com/owner/repo.git")]
+        public void TryExtractGitHubDataFromRemoteUrl(string url)
+        {
+            new GitHubRemoteParser().TryExtractGitHubDataFromRemoteUrl(url, out var owner, out var repository).Should().BeTrue();
+            owner.Should().Be("owner");
+            repository.Should().Be("repo");
+        }
+
+        [Test]
+        public void Should_fail_in_parsing_invalid_url()
+        {
+            var gitHubRemoteParser = new GitHubRemoteParser();
+            var url = "https://owner@dev.bad.com/owner/project/_git/repo";
+            gitHubRemoteParser.TryExtractGitHubDataFromRemoteUrl(url, out var owner, out var repository).Should().BeFalse();
+            owner.Should().BeNull();
+            repository.Should().BeNull();
+
+            gitHubRemoteParser.IsValidRemoteUrl(url).Should().BeFalse();
+        }
+    }
+}

--- a/UnitTests/GitUITests/CommandsDialogs/Settings/AzureDevOpsExternalLinkDefinitionExtractorTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/Settings/AzureDevOpsExternalLinkDefinitionExtractorTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using GitCommands.ExternalLinks;
+using GitUI.CommandsDialogs.SettingsDialog.RevisionLinks;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs.Settings
+{
+    [TestFixture]
+    public class AzureDevOpsExternalLinkDefinitionExtractorTests
+    {
+        [TestCase("https://owner@dev.azure.com/owner/project/_git/repo")]
+        [TestCase("git@ssh.dev.azure.com:v3/owner/project/repo")]
+        [TestCase("https://owner.visualstudio.com/project/_git/repo")]
+        [TestCase("owner@vs-ssh.visualstudio.com:v3/owner/project/repo")]
+        public void Should_get_link_definitions_When_successfuly_parsing_remote_url(string url)
+        {
+            var externalLinkDefinitions = new AzureDevopsExternalLinkDefinitionExtractor().GetDefinitions(url);
+            externalLinkDefinitions.Should().HaveCount(2);
+            foreach (ExternalLinkDefinition externalLinkDefinition in externalLinkDefinitions)
+            {
+                externalLinkDefinition.LinkFormats.Should().HaveCountGreaterOrEqualTo(1);
+                foreach (ExternalLinkFormat externalLinkFormat in externalLinkDefinition.LinkFormats)
+                {
+                    externalLinkFormat.Format.Should().Contain("owner").And.Contain("repo");
+                }
+            }
+        }
+
+        [Test]
+        public void Should_get_link_definitions_When_no_remote_url_provided()
+        {
+            var externalLinkDefinitions = new AzureDevopsExternalLinkDefinitionExtractor().GetDefinitions(null);
+            externalLinkDefinitions.Should().HaveCount(2);
+            foreach (ExternalLinkDefinition externalLinkDefinition in externalLinkDefinitions)
+            {
+                externalLinkDefinition.LinkFormats.Should().HaveCountGreaterOrEqualTo(1);
+                foreach (ExternalLinkFormat externalLinkFormat in externalLinkDefinition.LinkFormats)
+                {
+                    externalLinkFormat.Format.Should().Contain("ACCOUNT_NAME").And.Contain("REPO_NAME");
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/GitUITests/CommandsDialogs/Settings/GitHubExternalLinkDefinitionExtractorTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/Settings/GitHubExternalLinkDefinitionExtractorTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using GitCommands.ExternalLinks;
+using GitUI.CommandsDialogs.SettingsDialog.RevisionLinks;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs.Settings
+{
+    [TestFixture]
+    public class GitHubExternalLinkDefinitionExtractorTests
+    {
+        [TestCase("https://github.com/owner/repo.git")]
+        [TestCase("http://github.com/owner/repo.git")]
+        [TestCase("https://github.com/owner/repo")]
+        [TestCase("ssh://git@github.com/owner/repo.git")]
+        [TestCase("git@github.com/owner/repo.git")]
+        public void Should_get_link_definitions(string url)
+        {
+            var externalLinkDefinitions = new GitHubExternalLinkDefinitionExtractor().GetDefinitions(url);
+            externalLinkDefinitions.Should().HaveCount(3);
+            foreach (ExternalLinkDefinition externalLinkDefinition in externalLinkDefinitions)
+            {
+                externalLinkDefinition.LinkFormats.Should().HaveCountGreaterOrEqualTo(1);
+                foreach (ExternalLinkFormat externalLinkFormat in externalLinkDefinition.LinkFormats)
+                {
+                    externalLinkFormat.Format.Should().Contain("owner").And.Contain("repo");
+                }
+            }
+        }
+
+        [Test]
+        public void Should_get_link_definitions_When_no_remote_url_provided()
+        {
+            var externalLinkDefinitions = new GitHubExternalLinkDefinitionExtractor().GetDefinitions(null);
+            externalLinkDefinitions.Should().HaveCount(3);
+            foreach (ExternalLinkDefinition externalLinkDefinition in externalLinkDefinitions)
+            {
+                externalLinkDefinition.LinkFormats.Should().HaveCountGreaterOrEqualTo(1);
+                foreach (ExternalLinkFormat externalLinkFormat in externalLinkDefinition.LinkFormats)
+                {
+                    externalLinkFormat.Format.Should().Contain("ORGANIZATION_NAME").And.Contain("REPO_NAME");
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -81,6 +81,8 @@
     <Compile Include="CommandsDialogs\RevisionDiffContextMenuControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionFileTreeControllerTests.cs" />
     <Compile Include="CommandsDialogs\RevisionDiffControllerTests.cs" />
+    <Compile Include="CommandsDialogs\Settings\GitHubExternalLinkDefinitionExtractorTests.cs" />
+    <Compile Include="CommandsDialogs\Settings\AzureDevOpsExternalLinkDefinitionExtractorTests.cs" />
     <Compile Include="CommitInfo\CommitInfoTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
     <Compile Include="UserEnvironmentInformationTests.cs" />


### PR DESCRIPTION
## Proposed changes

- Being able to easily add revision links for GitHub and Azure DevOps services

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/59349009-e9a2c180-8d18-11e9-9b46-729a721e1e04.png)


### After

![image](https://user-images.githubusercontent.com/460196/59349147-3dada600-8d19-11e9-8fba-852083b3e686.png)

That create:

![image](https://user-images.githubusercontent.com/460196/59349204-54ec9380-8d19-11e9-9262-cb803191bf80.png)

Result: 

![image](https://user-images.githubusercontent.com/460196/59349265-81081480-8d19-11e9-8fbf-e76379fb60f6.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual and some Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build dee6de4cdfb281f0b42bb102ae9ea295ae032b98 (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
