### PR TITLE
CreatePullRequestForm: prevent multiple same call to github api

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -141,9 +141,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         comboBox.Items.Clear();
 
                         var selectItem = 0;
+                        var defaultBranch = hostedRepository.GetDefaultBranch();
                         for (var i = 0; i < branches.Count; i++)
                         {
-                            if (branches[i].Name == hostedRepository.GetDefaultBranch())
+                            if (branches[i].Name == defaultBranch)
                             {
                                 selectItem = i;
                             }


### PR DESCRIPTION
Part of a solution to #6757

## Proposed changes

- Move a call to a github api outside of a for loop to do only one call


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.1.0
- Build c501b6ac6f64d845dc35af19b009fea50570f14c
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3394.0
- DPI 96dpi (no scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
