### PR TITLE
Do not parse invalid rev-parse responses

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1132,32 +1132,17 @@ namespace GitCommands
 
         /// <summary>
         /// Gets the commit ID of the currently checked out commit.
-        /// If the repo is bare or has no commits, <c>null</c> is returned.
+        /// If the repo is bare, has no commits or is corrupt, <c>null</c> is returned.
         /// </summary>
         [CanBeNull]
         public ObjectId GetCurrentCheckout()
         {
             var args = new GitArgumentBuilder("rev-parse") { "HEAD" };
-            var output = _gitExecutable.GetOutput(args).TrimEnd();
+            var result = _gitExecutable.Execute(args);
 
-            if (output.StartsWith("HEAD"))
-            {
-                // A bare repo returns:
-                //
-                // HEAD
-                //
-                // A repository with no commits returns:
-                //
-                // HEAD
-                //
-                // fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
-                // Use '--' to separate paths from revisions, like this:
-                // 'git <command> [<revision>...] -- [<file>...]'
-
-                return null;
-            }
-
-            return ObjectId.Parse(output);
+            return result.ExitCode == 0 && ObjectId.TryParse(result.StandardOutput, offset: 0, out var objectId)
+                ? objectId
+                : null;
         }
 
         public bool TryResolvePartialCommitId(string objectIdPrefix, out ObjectId objectId)

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -384,6 +384,32 @@ namespace GitCommandsTests
             }
         }
 
+        [TestCase("fatal: not a git repository:")]
+        [TestCase("error: something went wrong")]
+        [TestCase("HEAD")]
+        [TestCase("master")]
+        public void GetCurrentCheckout_should_query_git_and_return_null_if_response_is_not_sha(string msg)
+        {
+            using (_executable.StageOutput($"rev-parse HEAD", msg, 0))
+            {
+                _gitModule.GetCurrentCheckout().Should().BeNull();
+            }
+        }
+
+        [Test]
+        public void GetCurrentCheckout_should_query_git_and_return_sha_for_HEAD()
+        {
+            ObjectId objectId;
+            var headId = "69a7c7a40230346778e7eebed809773a6bc45268";
+
+            using (_executable.StageOutput("rev-parse HEAD", headId))
+            {
+                objectId = _gitModule.GetCurrentCheckout();
+            }
+
+            Assert.AreEqual(headId, objectId.ToString());
+        }
+
         [Test]
         public void GetRemotes_should_parse_correctly_configured_remotes()
         {


### PR DESCRIPTION
Fixes #6512 for release3.1

Do not parse invalid rev-parse responses

Do not raise exceptions for invalid rev-parse responses

Cherry pick (with conflict in test).

This is not a suggestion that there should be a 3.1.2 release, but if there is, this should be included.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
