### PR TITLE
Refactor "Check for updates" dialog

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -28,85 +28,103 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormUpdates));
-            this.closeButton = new System.Windows.Forms.Button();
             this.UpdateLabel = new System.Windows.Forms.Label();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.linkChangeLog = new System.Windows.Forms.LinkLabel();
-            this.btnDownloadNow = new System.Windows.Forms.Button();
+            this.btnUpdateNow = new System.Windows.Forms.Button();
+            this.linkDirectDownload = new System.Windows.Forms.LinkLabel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // closeButton
-            // 
-            this.closeButton.Location = new System.Drawing.Point(456, 82);
-            this.closeButton.Margin = new System.Windows.Forms.Padding(4);
-            this.closeButton.Name = "closeButton";
-            this.closeButton.Size = new System.Drawing.Size(94, 29);
-            this.closeButton.TabIndex = 0;
-            this.closeButton.Text = "Close";
-            this.closeButton.UseVisualStyleBackColor = true;
-            this.closeButton.Click += new System.EventHandler(this.CloseButtonClick);
             // 
             // UpdateLabel
             // 
             this.UpdateLabel.AutoSize = true;
-            this.UpdateLabel.Location = new System.Drawing.Point(16, 16);
-            this.UpdateLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.UpdateLabel.Location = new System.Drawing.Point(13, 13);
             this.UpdateLabel.Name = "UpdateLabel";
-            this.UpdateLabel.Size = new System.Drawing.Size(154, 20);
-            this.UpdateLabel.TabIndex = 1;
+            this.UpdateLabel.Size = new System.Drawing.Size(111, 13);
+            this.UpdateLabel.TabIndex = 0;
             this.UpdateLabel.Text = "Searching for updates";
             // 
             // progressBar1
             // 
-            this.progressBar1.Location = new System.Drawing.Point(20, 46);
-            this.progressBar1.Margin = new System.Windows.Forms.Padding(4);
+            this.progressBar1.Location = new System.Drawing.Point(16, 35);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(530, 29);
+            this.progressBar1.Size = new System.Drawing.Size(424, 23);
             this.progressBar1.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-            this.progressBar1.TabIndex = 3;
+            this.progressBar1.TabIndex = 1;
             // 
             // linkChangeLog
             // 
             this.linkChangeLog.AutoSize = true;
-            this.linkChangeLog.Location = new System.Drawing.Point(18, 89);
-            this.linkChangeLog.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.linkChangeLog.Location = new System.Drawing.Point(13, 35);
             this.linkChangeLog.Name = "linkChangeLog";
-            this.linkChangeLog.Size = new System.Drawing.Size(124, 20);
+            this.linkChangeLog.Size = new System.Drawing.Size(92, 13);
             this.linkChangeLog.TabIndex = 2;
             this.linkChangeLog.TabStop = true;
-            this.linkChangeLog.Text = "Show ChangeLog";
+            this.linkChangeLog.Text = "Show Change&Log";
             this.linkChangeLog.Visible = false;
             this.linkChangeLog.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkChangeLog_LinkClicked);
             // 
-            // btnDownloadNow
+            // btnUpdateNow
             // 
-            this.btnDownloadNow.Enabled = false;
-            this.btnDownloadNow.Location = new System.Drawing.Point(309, 82);
-            this.btnDownloadNow.Name = "btnDownloadNow";
-            this.btnDownloadNow.Size = new System.Drawing.Size(140, 29);
-            this.btnDownloadNow.TabIndex = 4;
-            this.btnDownloadNow.Text = "Download Now";
-            this.btnDownloadNow.UseVisualStyleBackColor = true;
-            this.btnDownloadNow.Click += new System.EventHandler(this.btnDownloadNow_Click);
+            this.btnUpdateNow.AutoSize = true;
+            this.btnUpdateNow.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.btnUpdateNow.Location = new System.Drawing.Point(253, 3);
+            this.btnUpdateNow.MinimumSize = new System.Drawing.Size(100, 0);
+            this.btnUpdateNow.Name = "btnUpdateNow";
+            this.btnUpdateNow.Size = new System.Drawing.Size(100, 23);
+            this.btnUpdateNow.TabIndex = 0;
+            this.btnUpdateNow.Text = "&Update Now";
+            this.btnUpdateNow.Visible = false;
+            this.btnUpdateNow.UseVisualStyleBackColor = true;
+            this.btnUpdateNow.Click += new System.EventHandler(this.btnUpdateNow_Click);
+            // 
+            // linkDirectDownload
+            // 
+            this.linkDirectDownload.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.linkDirectDownload.AutoSize = true;
+            this.linkDirectDownload.Location = new System.Drawing.Point(359, 0);
+            this.linkDirectDownload.Name = "linkDirectDownload";
+            this.linkDirectDownload.Size = new System.Drawing.Size(86, 29);
+            this.linkDirectDownload.TabIndex = 1;
+            this.linkDirectDownload.TabStop = true;
+            this.linkDirectDownload.Text = "&Direct Download";
+            this.linkDirectDownload.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.linkDirectDownload.Visible = false;
+            this.linkDirectDownload.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkDirectDownload_LinkClicked);
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel1.Controls.Add(this.linkDirectDownload);
+            this.flowLayoutPanel1.Controls.Add(this.btnUpdateNow);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 69);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(0, 0, 4, 2);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(452, 31);
+            this.flowLayoutPanel1.TabIndex = 3;
             // 
             // FormUpdates
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(565, 125);
-            this.Controls.Add(this.btnDownloadNow);
-            this.Controls.Add(this.progressBar1);
+            this.ClientSize = new System.Drawing.Size(452, 100);
+            this.Controls.Add(this.flowLayoutPanel1);
             this.Controls.Add(this.linkChangeLog);
             this.Controls.Add(this.UpdateLabel);
-            this.Controls.Add(this.closeButton);
+            this.Controls.Add(this.progressBar1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FormUpdates";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Check for update";
             this.TopMost = true;
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -114,10 +132,11 @@
 
         #endregion
 
-        private System.Windows.Forms.Button closeButton;
         private System.Windows.Forms.Label UpdateLabel;
         private System.Windows.Forms.ProgressBar progressBar1;
         private System.Windows.Forms.LinkLabel linkChangeLog;
-        private System.Windows.Forms.Button btnDownloadNow;
+        private System.Windows.Forms.Button btnUpdateNow;
+        private System.Windows.Forms.LinkLabel linkDirectDownload;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.resx
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.resx
@@ -117,5 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 </root>

--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.1.0">
+<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.2.0">
   <file datatype="plaintext" original="AppVeyorSettingsUserControl" source-language="en">
     <body>
       <trans-unit id="cbLoadTestResults.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -111,8 +111,8 @@ This action will be performed without warning while checking out branch.</source
   </file>
   <file datatype="plaintext" original="AppearanceSettingsPage" source-language="en">
     <body>
-      <trans-unit id="$this.Text">
-        <source>Appearance</source>
+      <trans-unit id="AvatarProvider.Text">
+        <source>Gravatar</source>
         <target />
       </trans-unit>
       <trans-unit id="ClearImageCache.Text">
@@ -137,7 +137,7 @@ This action will be performed without warning while checking out branch.</source
       </trans-unit>
       <trans-unit id="_noImageServiceTooltip.Text">
         <source>A default image, if an email address has no matching Gravatar image.
-See http://en.gravatar.com/site/implement/images/ for more details.</source>
+See http://en.gravatar.com/site/implement/images#default-image for more details.</source>
         <target />
       </trans-unit>
       <trans-unit id="chkEnableAutoScale.Text">
@@ -170,6 +170,10 @@ See http://en.gravatar.com/site/implement/images/ for more details.</source>
       </trans-unit>
       <trans-unit id="helpTranslate.Text">
         <source>Help translate</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblAvatarProvider.Text">
+        <source>Avatar provider</source>
         <target />
       </trans-unit>
       <trans-unit id="lblCacheDays.Text">
@@ -212,11 +216,15 @@ See http://en.gravatar.com/site/implement/images/ for more details.</source>
   </file>
   <file datatype="plaintext" original="AvatarControl" source-language="en">
     <body>
+      <trans-unit id="avatarProviderToolStripMenuItem.Text">
+        <source>Avatar provider</source>
+        <target />
+      </trans-unit>
       <trans-unit id="clearImagecacheToolStripMenuItem.Text">
         <source>Clear image cache</source>
         <target />
       </trans-unit>
-      <trans-unit id="defaultImageToolStripMenuItem.Text">
+      <trans-unit id="fallbackAvatarStyleToolStripMenuItem.Text">
         <source>Fallback generated avatar style</source>
         <target />
       </trans-unit>
@@ -6846,6 +6854,10 @@ Do you want to select a language code first?</source>
         <source>Searching for updates</source>
         <target />
       </trans-unit>
+      <trans-unit id="_downloadingUpdate.Text">
+        <source>Downloading update...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_newVersionAvailable.Text">
         <source>There is a new version {0} of Git Extensions available</source>
         <target />
@@ -6854,16 +6866,16 @@ Do you want to select a language code first?</source>
         <source>No updates found</source>
         <target />
       </trans-unit>
-      <trans-unit id="btnDownloadNow.Text">
-        <source>Download Now</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="closeButton.Text">
-        <source>Close</source>
+      <trans-unit id="btnUpdateNow.Text">
+        <source>&amp;Update Now</source>
         <target />
       </trans-unit>
       <trans-unit id="linkChangeLog.Text">
-        <source>Show ChangeLog</source>
+        <source>Show Change&amp;Log</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="linkDirectDownload.Text">
+        <source>&amp;Direct Download</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6738


## Proposed changes

Updated button text from "Download Now" to "Update Now".

Updated Update Now button / event names.

Moved Update Now button position to where the Close button was located.

Added a new link called "Direct Download" which restores original functionality of launching default browser to download MSI.


## Screenshots <!-- Remove this section if PR does not change UI -->

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/45373169/59495806-74c7b700-8ed3-11e9-94cd-d370cbde4245.png)
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
