### PR TITLE
WIP - Fix #5944 by fixing --follow and revision reading

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -231,6 +231,7 @@ namespace GitUI.CommandsDialogs
                     {
                         "--format=\"%n\"",
                         "--name-only",
+                        "--follow",
                         GitCommandHelpers.FindRenamesAndCopiesOpts(),
                         "--",
                         fileName.Quote()


### PR DESCRIPTION
Quickfix for #5944 based on release/3.1, no tests, no big refactoring.

Intended as a placeholder until #6132 is done.

## Proposed changes
- a306eb6 by mistake removed the "--follow" option when getting the git log for history. This is reverted by this PR.
- 1f6b0ca by mistake removed parsing of the file name data into GitRevision.Name. This is also reverted by this PR.
- Together, these should fix rename tracking in the file history.

"WIP" label because #6132 was first and I don't intend to steal this issue.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
