### PR TITLE
Check that PushUrl has a valid protocol

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -266,7 +266,7 @@ namespace GitUI.CommandsDialogs
         private bool PushChanges(IWin32Window owner)
         {
             ErrorOccurred = false;
-            if (PushToUrl.Checked && string.IsNullOrEmpty(PushDestination.Text))
+            if (PushToUrl.Checked && !PathUtil.IsUrl(PushDestination.Text))
             {
                 MessageBox.Show(owner, _selectDestinationDirectory.Text);
                 return false;


### PR DESCRIPTION
Fixes #6717

## Proposed changes

When selecting a specific URL to push to, FormPush validates that the push url is not empty.
RepositoryHistoryManager.Remotes.AddAsMostRecentAsync() will raise an exception if the url does not seem to be a vaild URL (not starting with ssh, http, git) and raises an exception.
If URL starts with a correct protocol but is invalid, git will report that the URL is unavailable. (This should be understandable by the user).

FormPush should check the protocol to avoid that RepositoryHistoryManager raises exceptions.
The warning popup is good enough already.

## Screenshots 
No GUI change, 
### Before

Exception

### After

![image](https://user-images.githubusercontent.com/6248932/59566446-b0dc5280-9060-11e9-824b-d39b9c3312f0.png)

![image](https://user-images.githubusercontent.com/6248932/59566476-06186400-9061-11e9-9385-3e5dec4c0d59.png)

## Test methodology <!-- How did you ensure quality? -->
manual testing
FormPush.PushChanges() is a GUI method, not worth it to add tests.
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
