### PR TITLE
Check that directory (still) exists

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -198,8 +198,16 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     case GitStatusMonitorState.Running:
                         {
                             _timerRefresh.Start();
-                            _workTreeWatcher.EnableRaisingEvents = true;
-                            _gitDirWatcher.EnableRaisingEvents = !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
+                            if (Directory.Exists(_workTreeWatcher.Path))
+                            {
+                                _workTreeWatcher.EnableRaisingEvents = true;
+                            }
+
+                            if (Directory.Exists(_gitDirWatcher.Path))
+                            {
+                                _gitDirWatcher.EnableRaisingEvents = !_gitDirWatcher.Path.StartsWith(_workTreeWatcher.Path);
+                            }
+
                             ScheduleNextInteractiveTime();
                         }
 
@@ -321,11 +329,18 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             _commandIsRunning = true;
             _nextIsInteractive = false;
-            var commandStartTime = Environment.TickCount;
-            _workTreeWatcher.EnableRaisingEvents = true;
 
             // Schedule update every 5 min, even if we don't know that anything changed
             ScheduleNextUpdateTime(PeriodicUpdateInterval);
+
+            if (!Directory.Exists(_workTreeWatcher.Path))
+            {
+                // The directory no longer exists, watcher cannot be enabled
+                return;
+            }
+
+            var commandStartTime = Environment.TickCount;
+            _workTreeWatcher.EnableRaisingEvents = true;
 
             // capture a consistent state in the main thread
             IGitModule module = Module;


### PR DESCRIPTION
before renabling the the FileWatcher for GitStatusMonitor

Fixes #6812

## Proposed changes

FileSystemWatcher is deactivated when the need for an update is determined and restarted when the timer fires and GE is to start a new git-status.
When (re)activating FileSystemWatcher the control raises an exception if the directory does not exist.
This change skips starting file system watcher (and git-status) and relies on the periodic 5 minute timer retry. (Normally, if a directory is no longer available the user should know about it and refresh if necessary.) 

## Test methodology

Manual (see the issue).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
