### PR TITLE
SettingsCache: Tempfile in temp dir

### DIFF
--- a/UnitTests/GitCommandsTests/GitCommandsTests.csproj
+++ b/UnitTests/GitCommandsTests/GitCommandsTests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="ExternalLinks\ExternalLinksManagerIntegrationTests.cs" />
     <Compile Include="ExternalLinks\ExternalLinksStorageIntegrationTests.cs" />
     <Compile Include="FileAssociatedIconProviderTests.cs" />
+    <Compile Include="Settings\FileSettingsCacheTests.cs" />
     <Compile Include="FullPathResolverTests.cs" />
     <Compile Include="GitItemStatusFileExtensionComparerTests.cs" />
     <Compile Include="Git\AheadBehindDataProviderTests.cs" />

--- a/UnitTests/GitCommandsTests/Settings/FileSettingsCacheTests.cs
+++ b/UnitTests/GitCommandsTests/Settings/FileSettingsCacheTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using GitCommands.Settings;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Settings
+{
+    [TestFixture]
+    public class FileSettingsCacheTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("C:\\" + "\t")]
+        [TestCase("boo")]
+        public void ctor_FileWatcher_Path_should_not_set_if_invalid_dir(string settingsFilePath)
+        {
+            new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().FileSystemWatcher.Path.Should().BeNullOrEmpty();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("C:\\" + "\t")]
+        [TestCase("boo")]
+        public void ctor_FileWatcher_Filter_should_be_default_if_invalid_dir(string settingsFilePath)
+        {
+            new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().FileSystemWatcher.Filter.Should().Be("*.*");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("C:\\" + "\t")]
+        [TestCase("boo")]
+        public void ctor_FileWatcher_EnableRaisingEvents_should_be_false_if_invalid_dir(string settingsFilePath)
+        {
+            new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().FileSystemWatcher.EnableRaisingEvents.Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("C:\\" + "\t")]
+        [TestCase("boo")]
+        public void ctor_CanEnableFileWatcher_should_be_false_if_invalid_dir(string settingsFilePath)
+        {
+            new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().CanEnableFileWatcher.Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("C:\\" + "\t")]
+        public void SaveImpl_should_throw_if_invalid_path(string settingsFilePath)
+        {
+            var cache = new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor();
+            cache.SetLastModificationDate(DateTime.Now);
+            ((Action)(() => cache.SaveImpl())).Should().Throw<Exception>();
+        }
+
+        private class MockFileSettingsCache : FileSettingsCache
+        {
+            public MockFileSettingsCache(string settingsFilePath, bool autoSave = true)
+                : base(settingsFilePath, autoSave)
+            {
+            }
+
+            protected override void ClearImpl()
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override string GetValueImpl(string key)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void ReadSettings(string fileName)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void SetValueImpl(string key, string value)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            protected override void WriteSettings(string fileName)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6783 

## Proposed changes

 * Use Path.GetTempFileName() instead of a temp file in the settings directory to avoid various access errors.
 * Ignore copy errors to create the backup file, if the settings file is in a directory where no new files can be created.
 * If the settings file has no valid path, an exception would be raised. Not seen in any logs, seen when reviewing other occurrences of #6834 .  

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
