### PR TITLE
Show changed images in all diff tabs

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3347,11 +3347,9 @@ namespace GitCommands
         [CanBeNull]
         public ObjectId GetFileBlobHash(string fileName, ObjectId objectId)
         {
-            if (objectId == ObjectId.WorkTreeId)
+            if (objectId == ObjectId.WorkTreeId || objectId == ObjectId.CombinedDiffId)
             {
-                // working directory changes
-                Debug.Assert(false, "Tried to get blob for worktree file");
-                return null;
+                throw new ArgumentException($"Tried to get blob for unsupported revision: {objectId} and file: {fileName}");
             }
 
             // TODO use regex for parsing

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1204,17 +1204,14 @@ namespace GitUI.CommandsDialogs
         private async Task SetSelectedDiffAsync(GitItemStatus item, bool staged)
         {
             Action openWithDiffTool = () => (staged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick();
-            if (item.Name.EndsWith(".png"))
+            if (!item.IsTracked || FileHelper.IsImage(item.Name))
             {
-                await SelectedDiff.ViewFileAsync(item.Name, openWithDiffTool);
-            }
-            else if (item.IsTracked)
-            {
-                SelectedDiff.ViewCurrentChanges(item, staged, openWithDiffTool);
+                var guid = staged ? ObjectId.IndexId : ObjectId.WorkTreeId;
+                await SelectedDiff.ViewGitItemRevisionAsync(item.Name, guid, openWithDiffTool);
             }
             else
             {
-                await SelectedDiff.ViewFileAsync(item.Name);
+                SelectedDiff.ViewCurrentChanges(item, staged, openWithDiffTool);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -652,7 +652,7 @@ namespace GitUI.CommandsDialogs
             var gitItemStatus = DiffFiles.SelectedItem;
             var revisionId = DiffFiles.Revision?.ObjectId;
 
-            if (gitItemStatus?.Name == null || revisionId == null)
+            if (gitItemStatus?.Name == null || revisionId == null || revisionId == ObjectId.CombinedDiffId)
             {
                 return;
             }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -98,12 +98,13 @@ namespace GitUI
             [NotNull] string defaultText,
             [CanBeNull] Action openWithDifftool)
         {
-            if (firstRevision == null)
+            if (firstRevision == null || FileHelper.IsImage(file.Name))
             {
                 // The previous commit does not exist, nothing to compare with
-                if (file.TreeGuid == null)
+                if (file.TreeGuid != null)
                 {
-                    return diffViewer.ViewGitItemAsync(file.Name, file.TreeGuid);
+                    // blob guid exists
+                    return diffViewer.ViewGitItemAsync(file.Name, file.TreeGuid, openWithDifftool);
                 }
 
                 if (secondRevision == null)
@@ -111,7 +112,8 @@ namespace GitUI
                     throw new ArgumentNullException(nameof(secondRevision));
                 }
 
-                return diffViewer.ViewGitItemRevisionAsync(file.Name, secondRevision);
+                // Get blob guid from revision
+                return diffViewer.ViewGitItemRevisionAsync(file.Name, secondRevision, openWithDifftool);
             }
 
             return diffViewer.ViewPatchAsync(() =>


### PR DESCRIPTION
Resolves #1391

Previously, images were displayed as binary diffs, except some in
FormCommit:  .png and new worktree images

Other:
* FormCommit always show the worktree commit for index .png
* Show all images in FormCommit
(i.e. show index images and changed other than .png)
* Regression from a94a30af90ddcb8bad08220e171af20fd1f31b19 (ObjectId)
where blob guid were ignored if existing "cache miss" and attempted to be used if null
(not sure where this is seen, blob id is not always fetched though)
* Combined guid should never be used to get file blob guid - assert added
* openWithDiffTool action were not called from stash and RevisionDiff


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/6248932/59956656-c81ca500-9491-11e9-9929-8f67039583f0.png)

![image](https://user-images.githubusercontent.com/6248932/59956664-de2a6580-9491-11e9-9037-f694dfc9a934.png)


### After

![image](https://user-images.githubusercontent.com/6248932/59956640-b5a26b80-9491-11e9-9dee-ee8e18214550.png)

![image](https://user-images.githubusercontent.com/6248932/59956678-f4d0bc80-9491-11e9-98a2-49b7d7227283.png)


## Test methodology <!-- How did you ensure quality? -->

Manual, change and stage image files

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
