### PR TITLE
Blame: Fix "blame previous revision" feature

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1866,6 +1866,9 @@
     <None Include="Resources\bug.png" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Resources\Icons\Blame.png" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="Resources\Icons\FileStatusAdded.png" />
   </ItemGroup>
   <ItemGroup>

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -63,6 +63,16 @@ namespace GitUI.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        internal static System.Drawing.Bitmap Blame {
+            get {
+                object obj = ResourceManager.GetObject("Blame", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap branch {
             get {
                 object obj = ResourceManager.GetObject("branch", resourceCulture);

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -213,4 +213,7 @@ Alexander Eifler, Marcelo Ghelman, ghanique, olshevskiy87</value>
   <data name="bug" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\bug.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="Blame" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\Blame.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -248,6 +248,10 @@ See http://en.gravatar.com/site/implement/images#default-image for more details.
         <source>Blame previous revision</source>
         <target />
       </trans-unit>
+      <trans-unit id="blameRevisionToolStripMenuItem.Text">
+        <source>Blame this revision</source>
+        <target />
+      </trans-unit>
       <trans-unit id="commitHashToolStripMenuItem.Text">
         <source>Commit hash</source>
         <target />

--- a/GitUI/UserControls/BlameControl.Designer.cs
+++ b/GitUI/UserControls/BlameControl.Designer.cs
@@ -21,6 +21,7 @@
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.BlameAuthor = new GitUI.Editor.FileViewer();
             this.contextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.blameRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.blamePreviousRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -104,6 +105,7 @@
             // contextMenu
             // 
             this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.blameRevisionToolStripMenuItem,
             this.blamePreviousRevisionToolStripMenuItem,
             this.showChangesToolStripMenuItem,
             this.toolStripSeparator1,
@@ -116,6 +118,11 @@
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(235, 6);
+            this.blameRevisionToolStripMenuItem.Image = global::GitUI.Properties.Resources.Blame;
+            this.blameRevisionToolStripMenuItem.Name = "blameRevisionToolStripMenuItem";
+            this.blameRevisionToolStripMenuItem.Size = new System.Drawing.Size(199, 22);
+            this.blameRevisionToolStripMenuItem.Text = "Blame this revision";
+            this.blameRevisionToolStripMenuItem.Click += new System.EventHandler(this.blameRevisionToolStripMenuItem_Click);
             // 
             // blamePreviousRevisionToolStripMenuItem
             // 
@@ -214,5 +221,6 @@
         private System.Windows.Forms.ToolStripMenuItem commitHashToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem commitMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem allCommitInfoToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem blameRevisionToolStripMenuItem;
     }
 }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -466,24 +466,25 @@ namespace GitUI.Blame
             }
 
             var objectId = _blame.Lines[line].Commit.ObjectId;
-            int originalLine = _blame.Lines[line].OriginLineNumber;
-            GitBlame blame = Module.Blame(_fileName, objectId + "^", _encoding, originalLine + ",+1");
-            if (blame.Lines.Count > 0)
+
+            var selectedRevision = _revGrid.GetRevision(objectId);
+            if (selectedRevision == null)
             {
-                var revision = blame.Lines[0].Commit.ObjectId;
-                if (_revGrid != null)
-                {
-                    _clickedBlameLine = blame.Lines[0];
-                    _revGrid.SetSelectedRevision(revision);
-                }
-                else
-                {
-                    using (var frm = new FormCommitDiff(UICommands, revision))
-                    {
-                        frm.ShowDialog(this);
-                    }
-                }
+                return;
             }
+
+            if (!selectedRevision.HasParent)
+            {
+                _revGrid.SetSelectedRevision(selectedRevision);
+                using (var frm = new FormCommitDiff(UICommands, selectedRevision.ObjectId))
+                {
+                    frm.ShowDialog(this);
+                }
+
+                return;
+            }
+
+            _revGrid.SetSelectedRevision(selectedRevision.FirstParentGuid);
         }
 
         private void showChangesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -457,18 +457,34 @@ namespace GitUI.Blame
             CopyToClipboard(c => c.ObjectId.ToString());
         }
 
-        private void blamePreviousRevisionToolStripMenuItem_Click(object sender, EventArgs e)
+        private bool TryGetSelectedRevision(out GitRevision selectedRevision)
         {
+            selectedRevision = null;
             int line = (int?)contextMenu.Tag ?? -1;
             if (line < 0)
             {
-                return;
+                return false;
             }
 
             var objectId = _blame.Lines[line].Commit.ObjectId;
 
-            var selectedRevision = _revGrid.GetRevision(objectId);
-            if (selectedRevision == null)
+            selectedRevision = _revGrid.GetRevision(objectId);
+            return selectedRevision != null;
+        }
+
+        private void blameRevisionToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!TryGetSelectedRevision(out var selectedRevision))
+            {
+                return;
+            }
+
+            _revGrid.SetSelectedRevision(selectedRevision);
+        }
+
+        private void blamePreviousRevisionToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!TryGetSelectedRevision(out var selectedRevision))
             {
                 return;
             }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -415,6 +415,16 @@ namespace GitUI.Blame
         private void contextMenu_Opened(object sender, EventArgs e)
         {
             contextMenu.Tag = GetBlameLine();
+
+            if (_revGrid == null || !TryGetSelectedRevision(out var selectedRevision))
+            {
+                blameRevisionToolStripMenuItem.Enabled = false;
+                blamePreviousRevisionToolStripMenuItem.Enabled = false;
+                return;
+            }
+
+            blameRevisionToolStripMenuItem.Enabled = true;
+            blamePreviousRevisionToolStripMenuItem.Enabled = selectedRevision.HasParent;
         }
 
         [CanBeNull]
@@ -482,16 +492,12 @@ namespace GitUI.Blame
 
         private void blamePreviousRevisionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!TryGetSelectedRevision(out var selectedRevision))
+            if (!TryGetSelectedRevision(out var selectedRevision) || !selectedRevision.HasParent)
             {
                 return;
             }
 
-            var blameRevision = selectedRevision.HasParent
-                ? selectedRevision.FirstParentGuid
-                : selectedRevision.ObjectId;
-
-            BlameRevision(blameRevision);
+            BlameRevision(selectedRevision.FirstParentGuid);
         }
 
         private void BlameRevision(ObjectId revisionId)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Partly fixes #6605 (other part will be fixed by #6807 or #6132)


## Proposed changes

- Fix "Blame to previous revision" behavior to select the first commit before the one introducing the changes (so the previous, no!?!) as explained in https://github.com/gitextensions/gitextensions/issues/6605#issuecomment-493797272

- While I was at it, I have added a context menu item to blame selected revision to make explicit what could be done by double-clicking (because I realised with https://github.com/gitextensions/gitextensions/issues/6832#issuecomment-504363872 that it was probably not evident for new users)


## Screenshots <!-- Remove this section if PR does not change UI -->

For the 2nd point (the 1st change nothing to the ui)
### Before

Focus only on the menu (and not the colors of the lines)

![image](https://user-images.githubusercontent.com/460196/59965000-f7bac400-9508-11e9-94cb-a01dca83ce89.png)


### After

![image](https://user-images.githubusercontent.com/460196/59964992-d9ed5f00-9508-11e9-804d-cc8f68670c92.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 8e4b5fc9c5f62b1bb3f937f4e49819b081863c9b (Dirty)
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)
