### PR TITLE
Add script options c/sRemoteBranchName and RepoName

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -27,6 +27,9 @@ User Input:
 Working Dir:
 {WorkingDir}
 
+Repository:
+{RepoName}
+
 Selected Commits:
 {sHashes}
 
@@ -35,6 +38,7 @@ Selected Branch:
 {sBranch}
 {sLocalBranch}
 {sRemoteBranch}
+{sRemoteBranchName}   (without the remote's name)
 {sRemote}
 {sRemoteUrl}
 {sRemotePathFromUrl}
@@ -50,6 +54,7 @@ Current Branch:
 {cBranch}
 {cLocalBranch}
 {cRemoteBranch}
+{cRemoteBranchName}   (without the remote's name)
 {cHash}
 {cMessage}
 {cAuthor}

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -5,6 +5,8 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
+using GitCommands.Git;
+using GitCommands.UserRepositoryHistory;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
@@ -20,6 +22,7 @@ namespace GitUI.Script
             "sBranch",
             "sLocalBranch",
             "sRemoteBranch",
+            "sRemoteBranchName",
             "sRemote",
             "sRemoteUrl",
             "sRemotePathFromUrl",
@@ -33,6 +36,7 @@ namespace GitUI.Script
             "cBranch",
             "cLocalBranch",
             "cRemoteBranch",
+            "cRemoteBranchName",
             "cHash",
             "cMessage",
             "cAuthor",
@@ -42,6 +46,7 @@ namespace GitUI.Script
             "cDefaultRemote",
             "cDefaultRemoteUrl",
             "cDefaultRemotePathFromUrl",
+            "RepoName",
             "UserInput",
             "UserFiles",
             "WorkingDir"
@@ -247,108 +252,45 @@ namespace GitUI.Script
                     break;
 
                 case "sTag":
-                    if (selectedTags.Count == 1)
-                    {
-                        newString = selectedTags[0].Name;
-                    }
-                    else if (selectedTags.Count != 0)
-                    {
-                        newString = AskToSpecify(selectedTags, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(selectedTags);
                     break;
 
                 case "sBranch":
-                    if (selectedBranches.Count == 1)
-                    {
-                        newString = selectedBranches[0].Name;
-                    }
-                    else if (selectedBranches.Count != 0)
-                    {
-                        newString = AskToSpecify(selectedBranches, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(selectedBranches);
                     break;
 
                 case "sLocalBranch":
-                    if (selectedLocalBranches.Count == 1)
-                    {
-                        newString = selectedLocalBranches[0].Name;
-                    }
-                    else if (selectedLocalBranches.Count != 0)
-                    {
-                        newString = AskToSpecify(selectedLocalBranches, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(selectedLocalBranches);
                     break;
 
                 case "sRemoteBranch":
-                    if (selectedRemoteBranches.Count == 1)
-                    {
-                        newString = selectedRemoteBranches[0].Name;
-                    }
-                    else if (selectedRemoteBranches.Count != 0)
-                    {
-                        newString = AskToSpecify(selectedRemoteBranches, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
+                    newString = SelectOneRef(selectedRemoteBranches);
+                    break;
 
+                case "sRemoteBranchName":
+                    newString = StripRemoteName(SelectOneRef(selectedRemoteBranches));
                     break;
 
                 case "sRemote":
-                    if (selectedRemotes.Count == 0)
-                    {
-                        newString = "";
-                    }
-                    else
-                    {
-                        newString = selectedRemotes.Count == 1
-                            ? selectedRemotes[0]
-                            : AskToSpecify(selectedRemotes, revisionGrid);
-                    }
-
+                    newString = SelectOneString(selectedRemotes);
                     break;
 
                 case "sRemoteUrl":
-                    if (selectedRemotes.Count == 0)
+                    newString = SelectOneString(selectedRemotes);
+                    if (!string.IsNullOrEmpty(newString))
                     {
-                        newString = "";
-                    }
-                    else
-                    {
-                        remote = selectedRemotes.Count == 1
-                            ? selectedRemotes[0]
-                            : AskToSpecify(selectedRemotes, revisionGrid);
+                        remote = newString;
                         newString = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
                     }
 
                     break;
 
                 case "sRemotePathFromUrl":
-                    if (selectedRemotes.Count == 0)
+                    newString = SelectOneString(selectedRemotes);
+                    if (!string.IsNullOrEmpty(newString))
                     {
-                        newString = "";
-                    }
-                    else
-                    {
-                        remote = selectedRemotes.Count == 1
-                            ? selectedRemotes[0]
-                            : AskToSpecify(selectedRemotes, revisionGrid);
+                        remote = newString;
+                        newString = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
                         url = module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
                         newString = GetRemotePath(url);
                     }
@@ -380,68 +322,25 @@ namespace GitUI.Script
                     break;
 
                 case "cTag":
-                    if (currentTags.Count == 1)
-                    {
-                        newString = currentTags[0].Name;
-                    }
-                    else if (currentTags.Count != 0)
-                    {
-                        newString = AskToSpecify(currentTags, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(currentTags);
                     break;
 
                 case "cBranch":
-                    if (currentBranches.Count == 1)
-                    {
-                        newString = currentBranches[0].Name;
-                    }
-                    else if (currentBranches.Count != 0)
-                    {
-                        newString = AskToSpecify(currentBranches, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(currentBranches);
                     break;
 
                 case "cLocalBranch":
-                    if (currentLocalBranches.Count == 1)
-                    {
-                        newString = currentLocalBranches[0].Name;
-                    }
-                    else if (currentLocalBranches.Count != 0)
-                    {
-                        newString = AskToSpecify(currentLocalBranches, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(currentLocalBranches);
                     break;
 
                 case "cRemoteBranch":
-                    if (currentRemoteBranches.Count == 1)
-                    {
-                        newString = currentRemoteBranches[0].Name;
-                    }
-                    else if (currentRemoteBranches.Count != 0)
-                    {
-                        newString = AskToSpecify(currentRemoteBranches, revisionGrid);
-                    }
-                    else
-                    {
-                        newString = "";
-                    }
-
+                    newString = SelectOneRef(currentRemoteBranches);
                     break;
+
+                case "cRemoteBranchName":
+                    newString = StripRemoteName(SelectOneRef(currentRemoteBranches));
+                    break;
+
                 case "cHash":
                     newString = currentRevision.Guid;
                     break;
@@ -503,6 +402,10 @@ namespace GitUI.Script
 
                     break;
 
+                case "RepoName":
+                    newString = module == null ? string.Empty : new RepositoryDescriptionProvider(new GitDirectoryResolver()).Get(module.WorkingDir);
+                    break;
+
                 case "UserInput":
                     using (var prompt = new SimplePrompt())
                     {
@@ -526,7 +429,7 @@ namespace GitUI.Script
                     }
 
                 case "WorkingDir":
-                    newString = module.WorkingDir;
+                    newString = module == null ? string.Empty : module.WorkingDir;
                     break;
             }
 
@@ -546,6 +449,45 @@ namespace GitUI.Script
             }
 
             return argument;
+
+            string SelectOneRef(IList<IGitRef> refs) => ScriptOptionsParser.SelectOne(refs, revisionGrid);
+            string SelectOneString(IList<string> strings) => ScriptOptionsParser.SelectOne(strings, revisionGrid);
+        }
+
+        private static string SelectOne(IList<IGitRef> refs, RevisionGridControl revisionGrid)
+        {
+            switch (refs.Count)
+            {
+                case 0: return string.Empty;
+                case 1: return refs[0].Name;
+                default: return AskToSpecify(refs, revisionGrid);
+            }
+        }
+
+        private static string SelectOne(IList<string> strings, RevisionGridControl revisionGrid)
+        {
+            switch (strings.Count)
+            {
+                case 0: return string.Empty;
+                case 1: return strings[0];
+                default: return AskToSpecify(strings, revisionGrid);
+            }
+        }
+
+        private static string StripRemoteName(string remoteBranchName)
+        {
+            if (string.IsNullOrEmpty(remoteBranchName))
+            {
+                return string.Empty;
+            }
+
+            int firstSlashIndex = remoteBranchName.IndexOf('/');
+            if (firstSlashIndex >= 0)
+            {
+                return remoteBranchName.Substring(firstSlashIndex + 1);
+            }
+
+            return remoteBranchName;
         }
 
         internal static TestAccessor GetTestAccessor() => new TestAccessor();

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8706,6 +8706,9 @@ User Input:
 Working Dir:
 {WorkingDir}
 
+Repository:
+{RepoName}
+
 Selected Commits:
 {sHashes}
 
@@ -8714,6 +8717,7 @@ Selected Branch:
 {sBranch}
 {sLocalBranch}
 {sRemoteBranch}
+{sRemoteBranchName}   (without the remote's name)
 {sRemote}
 {sRemoteUrl}
 {sRemotePathFromUrl}
@@ -8729,6 +8733,7 @@ Current Branch:
 {cBranch}
 {cLocalBranch}
 {cRemoteBranch}
+{cRemoteBranchName}   (without the remote's name)
 {cHash}
 {cMessage}
 {cAuthor}

--- a/UnitTests/GitUITests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUITests/Script/ScriptOptionsParserTests.cs
@@ -82,6 +82,114 @@ namespace GitUITests.Script
         }
 
         [Test]
+        public void ScriptOptionsParser_resolve_sRemoteBranch(
+            [Values("", "origin", "upstream", "remote")] string remoteName,
+            [Values("", "branch", "feature/branch")] string branchName)
+        {
+            var option = "sRemoteBranch";
+            var branch = remoteName + '/' + branchName;
+            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                argument: "{" + option + "}", option,
+                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(branch);
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_sRemoteBranchName(
+            [Values("", "origin", "upstream", "remote")] string remoteName,
+            [Values("", "branch", "feature/branch")] string branchName)
+        {
+            var option = "sRemoteBranchName";
+            var branch = remoteName + '/' + branchName;
+            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                argument: "{" + option + "}", option,
+                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(branchName);
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_cRemoteBranch(
+            [Values("", "origin", "upstream", "remote")] string remoteName,
+            [Values("", "branch", "feature/branch")] string branchName)
+        {
+            var option = "cRemoteBranch";
+            var branch = remoteName + '/' + branchName;
+            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                argument: "{" + option + "}", option,
+                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: remoteBranches, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(branch);
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_cRemoteBranchName(
+            [Values("", "origin", "upstream", "remote")] string remoteName,
+            [Values("", "branch", "feature/branch")] string branchName)
+        {
+            var option = "cRemoteBranchName";
+            var branch = remoteName + '/' + branchName;
+            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                argument: "{" + option + "}", option,
+                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: remoteBranches, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(branchName);
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_RepoName_null()
+        {
+            var option = "RepoName";
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                argument: "{" + option + "}", option,
+                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void ScriptOptionsParser_resolve_RepoName()
+        {
+            var option = "RepoName";
+            var dirName = "Windows"; // chose one which will never contain a repo
+            _module.WorkingDir.Returns("C:\\" + dirName);
+
+            var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                argument: "{" + option + "}", option,
+                owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(dirName);
+        }
+
+        [Test]
         public void ScriptOptionsParser_resolve_QuotedWithBackslashAtEnd()
         {
             _module.WorkingDir.Returns("C:\\test path with whitespaces\\");


### PR DESCRIPTION
Fixes #6736

## Proposed changes

- add script options `{cRemoteBranchName}`, `{sRemoteBranchName}` and `{RepoName}`
- update help in `ScriptsSettingsPage.cs`
- factor out methods `SelectOne`
- handle `module == null` for `{WorkingDir}`

## Test methodology <!-- How did you ensure quality? -->

- new NUnit tests

## Test environment(s)

- Git Extensions 3.2.0
- Build 83eee9de9ca55b6e70253aec0218473212a218e1
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
