### PR TITLE
Restore title of AppearanceSettingsPage

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -483,6 +483,7 @@
             this.Controls.Add(tlpnlMain);
             this.MinimumSize = new System.Drawing.Size(258, 255);
             this.Name = "AppearanceSettingsPage";
+            this.Text = "Appearance";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1558, 497);
             tlpnlMain.ResumeLayout(false);

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -111,6 +111,10 @@ This action will be performed without warning while checking out branch.</source
   </file>
   <file datatype="plaintext" original="AppearanceSettingsPage" source-language="en">
     <body>
+      <trans-unit id="$this.Text">
+        <source>Appearance</source>
+        <target />
+      </trans-unit>
       <trans-unit id="AvatarProvider.Text">
         <source>Gravatar</source>
         <target />


### PR DESCRIPTION
## Proposed changes

- restore the title of the `AppearanceSettingsPage`

(Lost in 5814698d982b34b36d415f6de41f3bea40898ab4. Perhaps the same effect which led to #6242.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/59980342-dfc06e80-95f4-11e9-83dd-30fc460a44ce.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/59980386-70974a00-95f5-11e9-9a14-82996c803c93.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s)

- Git Extensions 3.2.0
- Build a68be687b7a21f467d5718afda51f12507e6b342
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
