### PR TITLE
Check for empty language selection

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -67,7 +67,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void lvTranslations_ItemActivate(object sender, EventArgs e)
         {
-            AppSettings.Translation = ((ListView)sender).SelectedItems[0].Tag.ToString();
+            // take the selection if any, else see the fallback in FormChooseTranslation_FormClosing
+            var selectedItems = ((ListView)sender).SelectedItems;
+            if (selectedItems.Count > 0)
+            {
+                AppSettings.Translation = selectedItems[0].Tag.ToString();
+            }
+
             Close();
         }
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6726

## Proposed changes

- use the `FormChooseTranslation`'s fallback in case of empty selection

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s)

- Git Extensions 3.2.0
- Build 3972aa02f5e29c9a4256ff56d51eb42219a636ea
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
