### PR TITLE
Deprecate and remove InvokeAsyncDoNotUseInNewCode

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -527,7 +527,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnActivated(EventArgs e)
         {
-            this.InvokeAsyncDoNotUseInNewCode(OnActivate);
+            this.InvokeAsync(OnActivate).FileAndForget();
             base.OnActivated(e);
         }
 
@@ -949,7 +949,6 @@ namespace GitUI.CommandsDialogs
         private void OnActivate()
         {
             CheckForMergeConflicts();
-
             return;
 
             void CheckForMergeConflicts()

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -215,32 +215,6 @@ namespace GitUI
             action(state);
         }
 
-#pragma warning disable VSTHRD100 // Avoid async void methods
-        /// <summary>
-        /// Use <see cref="InvokeAsync(Control, Action, CancellationToken)"/> instead. If the result of
-        /// <see cref="InvokeAsync(Control, Action, CancellationToken)"/> is not awaited, use
-        /// <see cref="ThreadHelper.FileAndForget(Task, Func{Exception, bool})"/> to ignore it.
-        /// </summary>
-        public static async void InvokeAsyncDoNotUseInNewCode(this Control control, Action action)
-#pragma warning restore VSTHRD100 // Avoid async void methods
-        {
-            if (ThreadHelper.JoinableTaskContext.IsOnMainThread)
-            {
-                await Task.Yield();
-            }
-            else
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            }
-
-            if (control.IsDisposed)
-            {
-                return;
-            }
-
-            action();
-        }
-
         public static void InvokeSync(this Control control, Action action)
         {
             ThreadHelper.JoinableTaskFactory.Run(


### PR DESCRIPTION


Closes #6799



## Proposed changes

- Rewrite the callsite to use `InvokeAsync` instead, that switches the execution context to the UI thread.



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
