### PR TITLE
Feature/authordateorder

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -178,6 +178,7 @@ namespace GitCommands
                     new ArgumentBuilder
                     {
                         { AppSettings.ShowReflogReferences, "--reflog" },
+                        { AppSettings.SortByAuthorDate, "--author-date-order" },
                         {
                             refFilterOptions.HasFlag(RefFilterOptions.All),
                             "--all",

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -430,6 +430,12 @@ namespace GitCommands
             set => SetBool("showgitstatusforartificialcommits", value);
         }
 
+        public static bool SortByAuthorDate
+        {
+            get => GetBool("sortbyauthordate", false);
+            set => SetBool("sortbyauthordate", value);
+        }
+
         public static bool CommitInfoShowContainedInBranches => CommitInfoShowContainedInBranchesLocal ||
                                                                 CommitInfoShowContainedInBranchesRemote ||
                                                                 CommitInfoShowContainedInBranchesRemoteIfNoLocal;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -31,6 +31,7 @@
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
             this.gbGeneral = new System.Windows.Forms.GroupBox();
             this.tlpnlGeneral = new System.Windows.Forms.TableLayoutPanel();
+            this.chkSortByAuthorDate = new System.Windows.Forms.CheckBox();
             this.chkShowRelativeDate = new System.Windows.Forms.CheckBox();
             this.truncatePathMethod = new System.Windows.Forms.ComboBox();
             this.truncateLongFilenames = new System.Windows.Forms.Label();
@@ -112,6 +113,7 @@
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlGeneral.Controls.Add(this.chkSortByAuthorDate, 0, 4);
             this.tlpnlGeneral.Controls.Add(this.chkShowRelativeDate, 0, 0);
             this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 3);
             this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 3);
@@ -120,13 +122,23 @@
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlGeneral.Location = new System.Drawing.Point(8, 21);
             this.tlpnlGeneral.Name = "tlpnlGeneral";
-            this.tlpnlGeneral.RowCount = 4;
+            this.tlpnlGeneral.RowCount = 5;
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlGeneral.Size = new System.Drawing.Size(1520, 96);
+            this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlGeneral.Size = new System.Drawing.Size(1035, 119);
             this.tlpnlGeneral.TabIndex = 0;
+            // 
+            // chkSortByAuthorDate
+            // 
+            this.chkSortByAuthorDate.AutoSize = true;
+            this.chkSortByAuthorDate.Location = new System.Drawing.Point(3, 99);
+            this.chkSortByAuthorDate.Name = "chkSortByAuthorDate";
+            this.chkSortByAuthorDate.Size = new System.Drawing.Size(116, 17);
+            this.chkSortByAuthorDate.TabIndex = 12;
+            this.chkSortByAuthorDate.Text = "Sort by author date";
             // 
             // chkShowRelativeDate
             // 
@@ -538,5 +550,6 @@
         private System.Windows.Forms.PictureBox pictureAvatarHelp;
         private System.Windows.Forms.Label lblAvatarProvider;
         private System.Windows.Forms.ComboBox AvatarProvider;
+        private System.Windows.Forms.CheckBox chkSortByAuthorDate;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -69,6 +69,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
             ShowAuthorAvatarInCommitInfo.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
             ShowAuthorAvatarInCommitGraph.Checked = AppSettings.ShowAuthorAvatarColumn;
+            chkSortByAuthorDate.Checked = AppSettings.SortByAuthorDate;
             AvatarProvider.SelectedValue = AppSettings.AvatarProvider;
             _NO_TRANSLATE_NoImageService.SelectedValue = AppSettings.GravatarFallbackAvatarType;
             ManageGravatarOptionsDisplay();
@@ -128,6 +129,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowAuthorAvatarColumn = ShowAuthorAvatarInCommitGraph.Checked;
             AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatarInCommitInfo.Checked;
             AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
+            AppSettings.SortByAuthorDate = chkSortByAuthorDate.Checked;
 
             AppSettings.Translation = Language.Text;
             ResourceManager.Strings.Reinitialize();

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -156,6 +156,10 @@ See http://en.gravatar.com/site/implement/images#default-image for more details.
         <source>Show relative date instead of full date</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkSortByAuthorDate.Text">
+        <source>Sort by author date</source>
+        <target />
+      </trans-unit>
       <trans-unit id="downloadDictionary.Text">
         <source>Download dictionary</source>
         <target />
@@ -8342,6 +8346,10 @@ See the changes in the commit form.</source>
   </file>
   <file datatype="plaintext" original="RevisionGrid" source-language="en">
     <body>
+      <trans-unit id="AuthorDateSort.Text">
+        <source>Sort commits by author date</source>
+        <target />
+      </trans-unit>
       <trans-unit id="GotoChildCommit.Text">
         <source>Go to child commit</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1836,6 +1836,12 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
+        internal void ToggleAuthorDateSort()
+        {
+            AppSettings.SortByAuthorDate = !AppSettings.SortByAuthorDate;
+            ForceRefreshRevisions();
+        }
+
         internal void ToggleShowReflogReferences()
         {
             AppSettings.ShowReflogReferences = !AppSettings.ShowReflogReferences;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -303,6 +303,13 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
+                    Name = "AuthorDateSort",
+                    Text = "Sort commits by author date",
+                    ExecuteAction = () => _revisionGrid.ToggleAuthorDateSort(),
+                    IsCheckedFunc = () => AppSettings.SortByAuthorDate
+                },
+                new MenuCommand
+                {
                     Name = "showAuthorDateToolStripMenuItem",
                     Text = "Show author date",
                     ExecuteAction = () => _revisionGrid.ToggleShowAuthorDate(),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6826 

## Proposed changes

Add option to view commits sorted by author-date rather than commit-date. Option is accessible through View menu, and under Appearance Settings.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Sorted by author-date](https://i.imgur.com/HmgRDkm.png)

### After

![Sorted by commit-date](https://i.imgur.com/5o9SgCS.png)

## Test methodology 
Tested with one repository where author-dates are not the same as commit-dates. Tried enabling and disabling setting through View menu and under Appearance Settings; both methods yielded the expected result in terms of commit-ordering.

## Test environment(s) 

- GIT 2.17.1.windows.2
- Windows NT 10.0.17763.0
- .NET 4.7.3416.0

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
