### PR TITLE
FormCreateBranch: Improve UX of CheckBox "Checkout after create"

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
@@ -41,7 +41,6 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.CheckoutAfterCreate = new System.Windows.Forms.Label();
             this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -80,6 +79,7 @@
             this.chkbxCheckoutAfterCreate.Name = "chkbxCheckoutAfterCreate";
             this.chkbxCheckoutAfterCreate.Size = new System.Drawing.Size(287, 22);
             this.chkbxCheckoutAfterCreate.TabIndex = 5;
+            this.chkbxCheckoutAfterCreate.Text = "Checkout &after create";
             this.chkbxCheckoutAfterCreate.UseVisualStyleBackColor = true;
             // 
             // label1
@@ -157,7 +157,6 @@
             this.tableLayoutPanel1.Controls.Add(this.BranchNameTextBox, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.CheckoutAfterCreate, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.chkbxCheckoutAfterCreate, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.Ok, 1, 4);
             this.tableLayoutPanel1.Controls.Add(this.gotoUserManualControl1, 0, 4);
@@ -200,18 +199,6 @@
             this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(8, 0, 0, 0);
             this.flowLayoutPanel1.Size = new System.Drawing.Size(426, 23);
             this.flowLayoutPanel1.TabIndex = 1;
-            // 
-            // CheckoutAfterCreate
-            // 
-            this.CheckoutAfterCreate.AutoSize = true;
-            this.CheckoutAfterCreate.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CheckoutAfterCreate.Location = new System.Drawing.Point(3, 59);
-            this.CheckoutAfterCreate.Margin = new System.Windows.Forms.Padding(3);
-            this.CheckoutAfterCreate.Name = "CheckoutAfterCreate";
-            this.CheckoutAfterCreate.Size = new System.Drawing.Size(149, 22);
-            this.CheckoutAfterCreate.TabIndex = 4;
-            this.CheckoutAfterCreate.Text = "Checkout &after create";
-            this.CheckoutAfterCreate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // gotoUserManualControl1
             // 
@@ -267,7 +254,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Button Ok;
         private System.Windows.Forms.CheckBox chkbxCheckoutAfterCreate;
-        private System.Windows.Forms.Label CheckoutAfterCreate;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3703,10 +3703,6 @@ You can unset the template:
         <source>Create branch</source>
         <target />
       </trans-unit>
-      <trans-unit id="CheckoutAfterCreate.Text">
-        <source>Checkout &amp;after create</source>
-        <target />
-      </trans-unit>
       <trans-unit id="ClearOrphan.Text">
         <source>Clear &amp;working directory and index</source>
         <target />
@@ -3729,6 +3725,10 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="_noRevisionSelected.Text">
         <source>Select 1 revision to create the branch on.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="chkbxCheckoutAfterCreate.Text">
+        <source>Checkout &amp;after create</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBox1.Text">


### PR DESCRIPTION


## Proposed changes

make all checkboxes of the form work the same standard way
by setting CheckBox.Text instead of a separate Label
in order to indicate the focus and to make the hotkey work directly 

(I know this won't win a design price. Though I think it's not worth breaking the table layout and trying to align a left-labeled CheckBox under DPI scaling.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

`Checkout after create` _is_ focused:

![grafik](https://user-images.githubusercontent.com/36601201/60134852-ba706380-97a0-11e9-9d40-d33f4d9b854e.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/60134913-e0960380-97a0-11e9-9c84-bde3e47d8c96.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 7b273006d0221522e6fb0a5e6097afbcf777965b
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
