### PR TITLE
FormCommit: Fix overlapping labels

### DIFF
--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -106,7 +106,7 @@
             // 
             this.FilterWatermarkLabel.AutoSize = true;
             this.FilterWatermarkLabel.BackColor = System.Drawing.SystemColors.Window;
-            this.FilterWatermarkLabel.ForeColor = System.Drawing.SystemColors.WindowText;
+            this.FilterWatermarkLabel.ForeColor = System.Drawing.SystemColors.InactiveCaption;
             this.FilterWatermarkLabel.Location = new System.Drawing.Point(4, 4);
             this.FilterWatermarkLabel.Name = "FilterWatermarkLabel";
             this.FilterWatermarkLabel.Size = new System.Drawing.Size(65, 13);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -58,7 +58,6 @@ namespace GitUI
             _sortByContextMenu = CreateSortByContextMenuItem();
             SetupUnifiedDiffListSorting();
             lblSplitter.Height = DpiUtil.Scale(1);
-            FilterComboBox.Font = new Font(FilterComboBox.Font, FontStyle.Bold);
             InitializeComplete();
             FilterVisible = false;
 
@@ -72,9 +71,13 @@ namespace GitUI
             HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: true);
             Controls.SetChildIndex(NoFiles, 0);
             NoFiles.Font = new Font(NoFiles.Font, FontStyle.Italic);
+            FilterWatermarkLabel.Font = new Font(FilterWatermarkLabel.Font, FontStyle.Italic);
+            FilterComboBox.Font = new Font(FilterComboBox.Font, FontStyle.Bold);
 
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _revisionTester = new GitRevisionTester(_fullPathResolver);
+
+            return;
 
             ImageList CreateImageList()
             {
@@ -210,6 +213,7 @@ namespace GitUI
 
         private bool FilterVisibleInternal
         {
+            get => FilterComboBox.Visible;
             set
             {
                 FilterComboBox.Visible = value;
@@ -817,7 +821,7 @@ namespace GitUI
 
         private void SetFilterWatermarkLabelVisibility()
         {
-            FilterWatermarkLabel.Visible = FilterVisible && !FilterComboBox.Focused && string.IsNullOrEmpty(FilterComboBox.Text);
+            FilterWatermarkLabel.Visible = FilterVisibleInternal && !FilterComboBox.Focused && string.IsNullOrEmpty(FilterComboBox.Text);
         }
 
         private void UpdateFileStatusListView(bool updateCausedByFilter = false)
@@ -1329,7 +1333,7 @@ namespace GitUI
         private string _toolTipText = "";
         private readonly Subject<string> _filterSubject = new Subject<string>();
         [CanBeNull] private Regex _filter;
-        private bool _filterVisible;
+        private bool _filterVisible = true;
 
         public void SetFilter(string value)
         {


### PR DESCRIPTION
Fixes #6532

## Proposed changes

- hide `FilterWatermarkLabel`, too, if `FilterComboBox` is invisible
- make its appearance the same as of "There are no unstaged changes"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/60222156-92eec900-987c-11e9-9917-163ededf1ef5.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/60394786-bbe7b600-9b29-11e9-96fb-64a244528f91.png)
![grafik](https://user-images.githubusercontent.com/36601201/60394773-9d81ba80-9b29-11e9-9f12-5be2ec724e2a.png)

### Intermediate with different fonts

![grafik](https://user-images.githubusercontent.com/36601201/60222032-27a4f700-987c-11e9-99d5-150ca34f56d7.png)

![grafik](https://user-images.githubusercontent.com/36601201/60222067-43100200-987c-11e9-94a2-e4cdcdd59792.png)


## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0.918
- Build b7cd26f9f860aa3f1423e8475ca1c08ad8987cf2 (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
