### PR TITLE
Retain newlines in commit message

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -343,7 +343,7 @@ namespace GitCommands
             set => SetBool("showerrorswhenstagingfiles", value);
         }
 
-        public static bool AddNewlineToCommitMessageWhenMissing
+        public static bool EnsureCommitMessageSecondLineEmpty
         {
             get => GetBool("addnewlinetocommitmessagewhenmissing", true);
             set => SetBool("addnewlinetocommitmessagewhenmissing", value);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2206,26 +2206,27 @@ namespace GitUI.CommandsDialogs
 
             using (var textWriter = new StreamWriter(path, false, encoding))
             {
-                var ensureCommitMessageSecondLineEmpty = AppSettings.EnsureCommitMessageSecondLineEmpty;
+                bool ensureCommitMessageSecondLineEmpty = AppSettings.EnsureCommitMessageSecondLineEmpty;
+                bool usingCommitTemplate = !string.IsNullOrEmpty(_commitTemplate);
 
-                var lineNumber = 0;
+                var lineNumber = 1;
                 foreach (var line in commitMessageText.Split('\n'))
                 {
-                    // When a committemplate is used, skip comments
-                    // otherwise: "#" is probably not used for comment but for issue number
-                    if ((!string.IsNullOrEmpty(line) && !line.StartsWith("#")) ||
-                        string.IsNullOrEmpty(_commitTemplate))
-                    {
-                        if (ensureCommitMessageSecondLineEmpty)
-                        {
-                            if (lineNumber == 1)
-                            {
-                                textWriter.WriteLine();
-                            }
-                        }
+                    string nonNullLine = line ?? string.Empty;
 
-                        textWriter.WriteLine(line);
+                    // When a committemplate is used, skip comments and do not count them as line.
+                    // otherwise: "#" is probably not used for comment but for issue number
+                    if (usingCommitTemplate && nonNullLine.StartsWith("#"))
+                    {
+                        continue;
                     }
+
+                    if (ensureCommitMessageSecondLineEmpty && lineNumber == 2 && !string.IsNullOrEmpty(nonNullLine))
+                    {
+                        textWriter.WriteLine();
+                    }
+
+                    textWriter.WriteLine(nonNullLine);
 
                     lineNumber++;
                 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2206,7 +2206,7 @@ namespace GitUI.CommandsDialogs
 
             using (var textWriter = new StreamWriter(path, false, encoding))
             {
-                var addNewlineToCommitMessageWhenMissing = AppSettings.AddNewlineToCommitMessageWhenMissing;
+                var ensureCommitMessageSecondLineEmpty = AppSettings.EnsureCommitMessageSecondLineEmpty;
 
                 var lineNumber = 0;
                 foreach (var line in commitMessageText.Split('\n'))
@@ -2216,7 +2216,7 @@ namespace GitUI.CommandsDialogs
                     if ((!string.IsNullOrEmpty(line) && !line.StartsWith("#")) ||
                         string.IsNullOrEmpty(_commitTemplate))
                     {
-                        if (addNewlineToCommitMessageWhenMissing)
+                        if (ensureCommitMessageSecondLineEmpty)
                         {
                             if (lineNumber == 1)
                             {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2189,12 +2189,50 @@ namespace GitUI.CommandsDialogs
             Initialize();
         }
 
+        private static string FormatCommitMessageFromTextBox(
+            string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
+        {
+            if (commitMessageText == null)
+            {
+                return string.Empty;
+            }
+
+            var formattedCommitMessage = new StringBuilder();
+
+            var lineNumber = 1;
+            foreach (var line in commitMessageText.Split('\n'))
+            {
+                string nonNullLine = line ?? string.Empty;
+
+                // When a committemplate is used, skip comments and do not count them as line.
+                // otherwise: "#" is probably not used for comment but for issue number
+                if (usingCommitTemplate && nonNullLine.StartsWith("#"))
+                {
+                    continue;
+                }
+
+                if (ensureCommitMessageSecondLineEmpty && lineNumber == 2 && !string.IsNullOrEmpty(nonNullLine))
+                {
+                    formattedCommitMessage.AppendLine();
+                }
+
+                formattedCommitMessage.AppendLine(nonNullLine);
+
+                lineNumber++;
+            }
+
+            return formattedCommitMessage.ToString();
+        }
+
         private void SetCommitMessageFromTextBox(string commitMessageText)
         {
             // Save last commit message in settings. This way it can be used in multiple repositories.
             AppSettings.LastCommitMessage = commitMessageText;
 
             var path = _commitMessageManager.CommitMessagePath;
+
+            var formattedCommitMessage = FormatCommitMessageFromTextBox(
+                commitMessageText, usingCommitTemplate: !string.IsNullOrEmpty(_commitTemplate), AppSettings.EnsureCommitMessageSecondLineEmpty);
 
             // Commit messages are UTF-8 by default unless otherwise in the config file.
             // The git manual states:
@@ -2204,33 +2242,7 @@ namespace GitUI.CommandsDialogs
             //  this is to have i18n.commitencoding in .git/config file, like this:...
             Encoding encoding = Module.CommitEncoding;
 
-            using (var textWriter = new StreamWriter(path, false, encoding))
-            {
-                bool ensureCommitMessageSecondLineEmpty = AppSettings.EnsureCommitMessageSecondLineEmpty;
-                bool usingCommitTemplate = !string.IsNullOrEmpty(_commitTemplate);
-
-                var lineNumber = 1;
-                foreach (var line in commitMessageText.Split('\n'))
-                {
-                    string nonNullLine = line ?? string.Empty;
-
-                    // When a committemplate is used, skip comments and do not count them as line.
-                    // otherwise: "#" is probably not used for comment but for issue number
-                    if (usingCommitTemplate && nonNullLine.StartsWith("#"))
-                    {
-                        continue;
-                    }
-
-                    if (ensureCommitMessageSecondLineEmpty && lineNumber == 2 && !string.IsNullOrEmpty(nonNullLine))
-                    {
-                        textWriter.WriteLine();
-                    }
-
-                    textWriter.WriteLine(nonNullLine);
-
-                    lineNumber++;
-                }
-            }
+            File.WriteAllText(path, formattedCommitMessage, encoding);
         }
 
         private void DeleteAllUntrackedFilesToolStripMenuItemClick(object sender, EventArgs e)
@@ -3279,10 +3291,11 @@ namespace GitUI.CommandsDialogs
 
             internal ToolStripStatusLabel RemoteNameLabelStatus => _formCommit.remoteNameLabel;
 
-            internal CommandStatus ExecuteCommand(Command command)
-            {
-                return _formCommit.ExecuteCommand((int)command);
-            }
+            internal CommandStatus ExecuteCommand(Command command) => _formCommit.ExecuteCommand((int)command);
+
+            internal static string FormatCommitMessageFromTextBox(
+                string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
+                => FormCommit.FormatCommitMessageFromTextBox(commitMessageText, usingCommitTemplate, ensureCommitMessageSecondLineEmpty);
         }
 
         private void stopTrackingThisFileToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -41,7 +41,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.chkShowCommitAndPush = new System.Windows.Forms.CheckBox();
             this.chkShowResetWorkTreeChanges = new System.Windows.Forms.CheckBox();
             this.chkShowResetAllChanges = new System.Windows.Forms.CheckBox();
-            this.chkAddNewlineToCommitMessageWhenMissing = new System.Windows.Forms.CheckBox();
+            this.chkEnsureCommitMessageSecondLineEmpty = new System.Windows.Forms.CheckBox();
             this.groupBoxBehaviour.SuspendLayout();
             this.tableLayoutPanelBehaviour.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).BeginInit();
@@ -74,7 +74,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.tableLayoutPanelBehaviour.Controls.Add(this.chkShowErrorsWhenStagingFiles, 0, 1);
             this.tableLayoutPanelBehaviour.Controls.Add(this.chkWriteCommitMessageInCommitWindow, 0, 3);
             this.tableLayoutPanelBehaviour.Controls.Add(this.grpAdditionalButtons, 0, 7);
-            this.tableLayoutPanelBehaviour.Controls.Add(this.chkAddNewlineToCommitMessageWhenMissing, 0, 2);
+            this.tableLayoutPanelBehaviour.Controls.Add(this.chkEnsureCommitMessageSecondLineEmpty, 0, 2);
             this.tableLayoutPanelBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanelBehaviour.Location = new System.Drawing.Point(3, 17);
             this.tableLayoutPanelBehaviour.Name = "tableLayoutPanelBehaviour";
@@ -223,13 +223,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             // 
             // chkAddNewlineToCommitMessageWhenMissing
             // 
-            this.chkAddNewlineToCommitMessageWhenMissing.AutoSize = true;
-            this.chkAddNewlineToCommitMessageWhenMissing.Location = new System.Drawing.Point(3, 49);
-            this.chkAddNewlineToCommitMessageWhenMissing.Name = "chkAddNewlineToCommitMessageWhenMissing";
-            this.chkAddNewlineToCommitMessageWhenMissing.Size = new System.Drawing.Size(271, 17);
-            this.chkAddNewlineToCommitMessageWhenMissing.TabIndex = 2;
-            this.chkAddNewlineToCommitMessageWhenMissing.Text = "Ensure the second line of commit message is empty";
-            this.chkAddNewlineToCommitMessageWhenMissing.UseVisualStyleBackColor = true;
+            this.chkEnsureCommitMessageSecondLineEmpty.AutoSize = true;
+            this.chkEnsureCommitMessageSecondLineEmpty.Location = new System.Drawing.Point(3, 49);
+            this.chkEnsureCommitMessageSecondLineEmpty.Name = "chkAddNewlineToCommitMessageWhenMissing";
+            this.chkEnsureCommitMessageSecondLineEmpty.Size = new System.Drawing.Size(271, 17);
+            this.chkEnsureCommitMessageSecondLineEmpty.TabIndex = 2;
+            this.chkEnsureCommitMessageSecondLineEmpty.Text = "Ensure the second line of commit message is empty";
+            this.chkEnsureCommitMessageSecondLineEmpty.UseVisualStyleBackColor = true;
             // 
             // CommitDialogSettingsPage
             // 
@@ -266,7 +266,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private System.Windows.Forms.CheckBox chkShowCommitAndPush;
         private System.Windows.Forms.CheckBox chkShowResetWorkTreeChanges;
         private System.Windows.Forms.CheckBox chkShowResetAllChanges;
-        private System.Windows.Forms.CheckBox chkAddNewlineToCommitMessageWhenMissing;
+        private System.Windows.Forms.CheckBox chkEnsureCommitMessageSecondLineEmpty;
         private System.Windows.Forms.CheckBox chkAutocomplete;
         private System.Windows.Forms.CheckBox cbRememberAmendCommitState;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void SettingsToPage()
         {
             chkShowErrorsWhenStagingFiles.Checked = AppSettings.ShowErrorsWhenStagingFiles;
-            chkAddNewlineToCommitMessageWhenMissing.Checked = AppSettings.AddNewlineToCommitMessageWhenMissing;
+            chkEnsureCommitMessageSecondLineEmpty.Checked = AppSettings.EnsureCommitMessageSecondLineEmpty;
             chkWriteCommitMessageInCommitWindow.Checked = AppSettings.UseFormCommitMessage;
             _NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value = AppSettings.CommitDialogNumberOfPreviousMessages;
             chkShowCommitAndPush.Checked = AppSettings.ShowCommitAndPush;
@@ -27,7 +27,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             AppSettings.ShowErrorsWhenStagingFiles = chkShowErrorsWhenStagingFiles.Checked;
-            AppSettings.AddNewlineToCommitMessageWhenMissing = chkAddNewlineToCommitMessageWhenMissing.Checked;
+            AppSettings.EnsureCommitMessageSecondLineEmpty = chkEnsureCommitMessageSecondLineEmpty.Checked;
             AppSettings.UseFormCommitMessage = chkWriteCommitMessageInCommitWindow.Checked;
             AppSettings.CommitDialogNumberOfPreviousMessages = (int)_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value;
             AppSettings.ShowCommitAndPush = chkShowCommitAndPush.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -681,12 +681,12 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember 'Amend commit' checkbox on commit form close</source>
         <target />
       </trans-unit>
-      <trans-unit id="chkAddNewlineToCommitMessageWhenMissing.Text">
-        <source>Ensure the second line of commit message is empty</source>
-        <target />
-      </trans-unit>
       <trans-unit id="chkAutocomplete.Text">
         <source>Provide auto-completion in commit dialog</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="chkEnsureCommitMessageSecondLineEmpty.Text">
+        <source>Ensure the second line of commit message is empty</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowCommitAndPush.Text">

--- a/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
@@ -185,6 +185,14 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             });
         }
 
+        [Test, TestCaseSource(typeof(FormatCommitMessageTestData), "TestCases")]
+        public void FormatCommitMessageFromTextBox(
+            string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty, string expectedMessage)
+        {
+            FormCommit.TestAccessor.FormatCommitMessageFromTextBox(commitMessageText, usingCommitTemplate, ensureCommitMessageSecondLineEmpty)
+                .Should().Be(expectedMessage);
+        }
+
         [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
         public void AddSelectionToCommitMessage_shall_be_ignored_unless_diff_is_focused(
             string message,
@@ -308,6 +316,43 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                     }
                 },
                 testDriverAsync);
+        }
+    }
+
+    public class FormatCommitMessageTestData
+    {
+        private static readonly string NL = Environment.NewLine;
+
+        public static IEnumerable TestCases
+        {
+            get
+            {
+                // string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty, string expectedMessage
+                yield return new TestCaseData(new object[] { null, false, false, "" });
+                yield return new TestCaseData(new object[] { null, true, false, "" });
+                yield return new TestCaseData(new object[] { null, false, true, "" });
+                yield return new TestCaseData(new object[] { null, true, true, "" });
+                yield return new TestCaseData(new object[] { "", false, false, NL });
+                yield return new TestCaseData(new object[] { "", true, false, NL });
+                yield return new TestCaseData(new object[] { "", false, true, NL });
+                yield return new TestCaseData(new object[] { "", true, true, NL });
+                yield return new TestCaseData(new object[] { "\n", false, false, NL + NL });
+                yield return new TestCaseData(new object[] { "\n", true, false, NL + NL });
+                yield return new TestCaseData(new object[] { "\n", false, true, NL + NL });
+                yield return new TestCaseData(new object[] { "\n", true, true, NL + NL });
+                yield return new TestCaseData(new object[] { "1", true, false, "1" + NL });
+                yield return new TestCaseData(new object[] { "#1", false, false, "#1" + NL });
+                yield return new TestCaseData(new object[] { "#1", true, false, "" });
+                yield return new TestCaseData(new object[] { "1\n\n3", false, false, "1" + NL + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "1\n\n3", false, true, "1" + NL + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "1\n2\n3", false, false, "1" + NL + "2" + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "1\n2\n3", false, true, "1" + NL + NL + "2" + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "#0\n1\n\n3", true, false, "1" + NL + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "#0\n1\n\n3", true, true, "1" + NL + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "#0\n1\n2\n3", true, false, "1" + NL + "2" + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "#0\n1\n2\n3", true, true, "1" + NL + NL + "2" + NL + "3" + NL });
+                yield return new TestCaseData(new object[] { "#0\n1\n#0\n2\n3", true, true, "1" + NL + NL + "2" + NL + "3" + NL });
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5908
Supersedes #6539

## Proposed changes

- do not skip empty lines of commit messages
- rename to `AppSettings.EnsureCommitMessageSecondLineEmpty`
- factor out method `FormatCommitMessageFromTextBox` and add tests

## Test methodology <!-- How did you ensure quality? -->

- NUnit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 6aa762c35e6bdf63cfda6e560c4f364d7e883bce
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
