### PR TITLE
Fix #5944 by fixing --follow and revision reading

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -237,6 +237,7 @@ namespace GitUI.CommandsDialogs
                     {
                         "--format=\"%n\"",
                         "--name-only",
+                        "--follow",
                         GitCommandHelpers.FindRenamesAndCopiesOpts(),
                         "--",
                         fileName.Quote()


### PR DESCRIPTION
This is a cherry-pick of #6807 for master
Author unchanged from @fschmied (cla signed)

Quickfix for #5944 based on release/3.1, no tests, no big refactoring.

Intended as a placeholder until #6132 is done.

## Proposed changes

See #6807 - restore follow rename files

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6248932/60389608-f408dd80-9ac4-11e9-8b58-3948116a654b.png)

### After

![image](https://user-images.githubusercontent.com/6248932/60389619-0be06180-9ac5-11e9-9bb7-a1a334e7b044.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

Note:
If test cases must be added to merge this, someone else should drive this PR

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
