### PR TITLE
Fix TryParseAsciiHex bytes bounds check

### DIFF
--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -274,6 +274,18 @@ namespace GitUIPluginInterfaces
         {
             // TODO get rid of this overload? slice the array segment instead
 
+            if (bytes.Array == null)
+            {
+                objectId = default;
+                return false;
+            }
+
+            if (index < 0 || bytes.Offset + index + Sha1CharCount > bytes.Array.Length)
+            {
+                objectId = default;
+                return false;
+            }
+
             return TryParseAsciiHexBytes(
                 new ArraySegment<byte>(bytes.Array, bytes.Offset + index, Sha1CharCount),
                 out objectId);

--- a/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ObjectIdTests.cs
@@ -258,6 +258,27 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
+        public void TryParseAsciiHexBytes_returns_false_when_array_null()
+        {
+            Assert.False(ObjectId.TryParseAsciiHexBytes(default, out ObjectId objectId));
+            Assert.Null(objectId);
+            Assert.False(ObjectId.TryParseAsciiHexBytes(default(ArraySegment<byte>), 0, out objectId));
+            Assert.Null(objectId);
+        }
+
+        [Test]
+        public void TryParseAsciiHexBytes_returns_false_when_bounds_check_fails()
+        {
+            var bytes = new byte[ObjectId.Sha1CharCount];
+            var segment = new ArraySegment<byte>(bytes);
+
+            Assert.False(ObjectId.TryParseAsciiHexBytes(segment, -1, out ObjectId objectId));
+            Assert.Null(objectId);
+            Assert.False(ObjectId.TryParseAsciiHexBytes(segment, 1, out objectId));
+            Assert.Null(objectId);
+        }
+
+        [Test]
         [SuppressMessage("ReSharper", "ReturnValueOfPureMethodIsNotUsed")]
         public void ToShortString()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Relates to #6872.

## Proposed changes

- Make `ObjectId.TryParseAsciiHexBytes` return `false` when various invalid inputs are provided, rather than throwing an exception.

## Test methodology <!-- How did you ensure quality? -->

- Added unit tests.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
