### PR TITLE
Redesign form commit template settings

### DIFF
--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.Designer.cs
@@ -32,77 +32,78 @@
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.buttonOk = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
-            this.groupBoxCommitValidation = new System.Windows.Forms.GroupBox();
+            this.tabControl1 = new System.Windows.Forms.TabControl();
+            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelCommitTemplate = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_comboBoxCommitTemplates = new System.Windows.Forms.ComboBox();
+            this.labelCommitTemplateName = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_textCommitTemplateText = new System.Windows.Forms.TextBox();
+            this._NO_TRANSLATE_textBoxCommitTemplateName = new System.Windows.Forms.TextBox();
+            this.tabPage2 = new System.Windows.Forms.TabPage();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
             this.labelUseIndent = new System.Windows.Forms.Label();
             this.labelMaxLineLength = new System.Windows.Forms.Label();
             this.labelMaxFirstLineLength = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_numericMaxLineLength = new System.Windows.Forms.NumericUpDown();
             this._NO_TRANSLATE_numericMaxFirstLineLength = new System.Windows.Forms.NumericUpDown();
-            this.labelSecondLineEmpty = new System.Windows.Forms.Label();
-            this.checkBoxSecondLineEmpty = new System.Windows.Forms.CheckBox();
             this.labelRegExCheck = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_textBoxCommitValidationRegex = new System.Windows.Forms.TextBox();
             this.checkBoxUseIndent = new System.Windows.Forms.CheckBox();
-            this.groupBoxCommitTemplates = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-            this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
-            this.labelCommitTemplate = new System.Windows.Forms.Label();
-            this.labelCommitTemplateName = new System.Windows.Forms.Label();
-            this._NO_TRANSLATE_textCommitTemplateText = new System.Windows.Forms.TextBox();
-            this._NO_TRANSLATE_textBoxCommitTemplateName = new System.Windows.Forms.TextBox();
-            this._NO_TRANSLATE_comboBoxCommitTemplates = new System.Windows.Forms.ComboBox();
+            this.labelSecondLineEmpty = new System.Windows.Forms.Label();
             this.labelAutoWrap = new System.Windows.Forms.Label();
+            this.checkBoxSecondLineEmpty = new System.Windows.Forms.CheckBox();
             this.checkBoxAutoWrap = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
-            this.groupBoxCommitValidation.SuspendLayout();
+            this.tabControl1.SuspendLayout();
+            this.tabPage1.SuspendLayout();
+            this.tableLayoutPanel5.SuspendLayout();
+            this.tabPage2.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_numericMaxLineLength)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_numericMaxFirstLineLength)).BeginInit();
-            this.groupBoxCommitTemplates.SuspendLayout();
-            this.tableLayoutPanel4.SuspendLayout();
-            this.tableLayoutPanel5.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.groupBoxCommitValidation, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.groupBoxCommitTemplates, 0, 0);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.tabControl1, 0, 0);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.Size = new System.Drawing.Size(698, 394);
             this.tableLayoutPanel1.TabIndex = 60;
             // 
             // tableLayoutPanel2
             // 
+            this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.AutoSize = true;
+            this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel2.ColumnCount = 3;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.Controls.Add(this.buttonOk, 1, 0);
             this.tableLayoutPanel2.Controls.Add(this.buttonCancel, 2, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 361);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(533, 362);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(692, 30);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(162, 29);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // buttonOk
             // 
-            this.buttonOk.Location = new System.Drawing.Point(533, 3);
+            this.buttonOk.Location = new System.Drawing.Point(3, 3);
             this.buttonOk.Name = "buttonOk";
             this.buttonOk.Size = new System.Drawing.Size(75, 23);
             this.buttonOk.TabIndex = 6;
@@ -112,7 +113,7 @@
             // 
             // buttonCancel
             // 
-            this.buttonCancel.Location = new System.Drawing.Point(614, 3);
+            this.buttonCancel.Location = new System.Drawing.Point(84, 3);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 7;
@@ -120,22 +121,124 @@
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
             // 
-            // groupBoxCommitValidation
+            // tabControl1
             // 
-            this.groupBoxCommitValidation.Controls.Add(this.tableLayoutPanel3);
-            this.groupBoxCommitValidation.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxCommitValidation.Location = new System.Drawing.Point(3, 182);
-            this.groupBoxCommitValidation.Name = "groupBoxCommitValidation";
-            this.groupBoxCommitValidation.Size = new System.Drawing.Size(692, 173);
-            this.groupBoxCommitValidation.TabIndex = 1;
-            this.groupBoxCommitValidation.TabStop = false;
-            this.groupBoxCommitValidation.Text = "Commit validation";
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tabControl1.Controls.Add(this.tabPage1);
+            this.tabControl1.Controls.Add(this.tabPage2);
+            this.tabControl1.Location = new System.Drawing.Point(3, 3);
+            this.tabControl1.Name = "tabControl1";
+            this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.Size = new System.Drawing.Size(692, 353);
+            this.tabControl1.TabIndex = 4;
+            // 
+            // tabPage1
+            // 
+            this.tabPage1.Controls.Add(this.tableLayoutPanel5);
+            this.tabPage1.Location = new System.Drawing.Point(4, 22);
+            this.tabPage1.Name = "tabPage1";
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage1.Size = new System.Drawing.Size(684, 327);
+            this.tabPage1.TabIndex = 0;
+            this.tabPage1.Text = "Commit templates";
+            this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanel5
+            // 
+            this.tableLayoutPanel5.ColumnCount = 2;
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel5.Controls.Add(this.labelCommitTemplate, 0, 2);
+            this.tableLayoutPanel5.Controls.Add(this._NO_TRANSLATE_comboBoxCommitTemplates, 0, 0);
+            this.tableLayoutPanel5.Controls.Add(this.labelCommitTemplateName, 0, 1);
+            this.tableLayoutPanel5.Controls.Add(this._NO_TRANSLATE_textCommitTemplateText, 1, 2);
+            this.tableLayoutPanel5.Controls.Add(this._NO_TRANSLATE_textBoxCommitTemplateName, 1, 1);
+            this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel5.Name = "tableLayoutPanel5";
+            this.tableLayoutPanel5.RowCount = 3;
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel5.Size = new System.Drawing.Size(678, 321);
+            this.tableLayoutPanel5.TabIndex = 1;
+            // 
+            // labelCommitTemplate
+            // 
+            this.labelCommitTemplate.AutoSize = true;
+            this.labelCommitTemplate.Location = new System.Drawing.Point(3, 59);
+            this.labelCommitTemplate.Margin = new System.Windows.Forms.Padding(3, 6, 3, 0);
+            this.labelCommitTemplate.Name = "labelCommitTemplate";
+            this.labelCommitTemplate.Size = new System.Drawing.Size(87, 13);
+            this.labelCommitTemplate.TabIndex = 5;
+            this.labelCommitTemplate.Text = "Commit template:";
+            // 
+            // _NO_TRANSLATE_comboBoxCommitTemplates
+            // 
+            this._NO_TRANSLATE_comboBoxCommitTemplates.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel5.SetColumnSpan(this._NO_TRANSLATE_comboBoxCommitTemplates, 2);
+            this._NO_TRANSLATE_comboBoxCommitTemplates.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_comboBoxCommitTemplates.FormattingEnabled = true;
+            this._NO_TRANSLATE_comboBoxCommitTemplates.Location = new System.Drawing.Point(3, 3);
+            this._NO_TRANSLATE_comboBoxCommitTemplates.Name = "_NO_TRANSLATE_comboBoxCommitTemplates";
+            this._NO_TRANSLATE_comboBoxCommitTemplates.Size = new System.Drawing.Size(672, 21);
+            this._NO_TRANSLATE_comboBoxCommitTemplates.TabIndex = 0;
+            this._NO_TRANSLATE_comboBoxCommitTemplates.SelectedIndexChanged += new System.EventHandler(this.comboBoxCommitTemplates_SelectedIndexChanged);
+            // 
+            // labelCommitTemplateName
+            // 
+            this.labelCommitTemplateName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelCommitTemplateName.AutoSize = true;
+            this.labelCommitTemplateName.Location = new System.Drawing.Point(3, 33);
+            this.labelCommitTemplateName.Name = "labelCommitTemplateName";
+            this.labelCommitTemplateName.Size = new System.Drawing.Size(87, 13);
+            this.labelCommitTemplateName.TabIndex = 7;
+            this.labelCommitTemplateName.Text = "Name:";
+            // 
+            // _NO_TRANSLATE_textCommitTemplateText
+            // 
+            this._NO_TRANSLATE_textCommitTemplateText.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this._NO_TRANSLATE_textCommitTemplateText.Location = new System.Drawing.Point(96, 56);
+            this._NO_TRANSLATE_textCommitTemplateText.Multiline = true;
+            this._NO_TRANSLATE_textCommitTemplateText.Name = "_NO_TRANSLATE_textCommitTemplateText";
+            this._NO_TRANSLATE_textCommitTemplateText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this._NO_TRANSLATE_textCommitTemplateText.Size = new System.Drawing.Size(579, 262);
+            this._NO_TRANSLATE_textCommitTemplateText.TabIndex = 2;
+            this._NO_TRANSLATE_textCommitTemplateText.TextChanged += new System.EventHandler(this.textCommitTemplateText_TextChanged);
+            // 
+            // _NO_TRANSLATE_textBoxCommitTemplateName
+            // 
+            this._NO_TRANSLATE_textBoxCommitTemplateName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this._NO_TRANSLATE_textBoxCommitTemplateName.Location = new System.Drawing.Point(96, 30);
+            this._NO_TRANSLATE_textBoxCommitTemplateName.Name = "_NO_TRANSLATE_textBoxCommitTemplateName";
+            this._NO_TRANSLATE_textBoxCommitTemplateName.Size = new System.Drawing.Size(579, 20);
+            this._NO_TRANSLATE_textBoxCommitTemplateName.TabIndex = 1;
+            this._NO_TRANSLATE_textBoxCommitTemplateName.TextChanged += new System.EventHandler(this.textBoxCommitTemplateName_TextChanged);
+            // 
+            // tabPage2
+            // 
+            this.tabPage2.Controls.Add(this.tableLayoutPanel3);
+            this.tabPage2.Location = new System.Drawing.Point(4, 22);
+            this.tabPage2.Name = "tabPage2";
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(684, 327);
+            this.tabPage2.TabIndex = 1;
+            this.tabPage2.Text = "Commit validation";
+            this.tabPage2.UseVisualStyleBackColor = true;
             // 
             // tableLayoutPanel3
             // 
+            this.tableLayoutPanel3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel3.AutoSize = true;
             this.tableLayoutPanel3.ColumnCount = 2;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Controls.Add(this.labelUseIndent, 0, 4);
             this.tableLayoutPanel3.Controls.Add(this.labelMaxLineLength, 0, 1);
             this.tableLayoutPanel3.Controls.Add(this.labelMaxFirstLineLength, 0, 0);
@@ -148,37 +251,36 @@
             this.tableLayoutPanel3.Controls.Add(this.labelAutoWrap, 0, 2);
             this.tableLayoutPanel3.Controls.Add(this.checkBoxSecondLineEmpty, 1, 5);
             this.tableLayoutPanel3.Controls.Add(this.checkBoxAutoWrap, 1, 2);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 19);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 6;
+            this.tableLayoutPanel3.RowCount = 7;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(686, 151);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(686, 142);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // labelUseIndent
-            //
+            // 
             this.labelUseIndent.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.labelUseIndent.AutoSize = true;
-            this.labelUseIndent.Location = new System.Drawing.Point(3, 109);
+            this.labelUseIndent.Location = new System.Drawing.Point(3, 101);
             this.labelUseIndent.Name = "labelUseIndent";
-            this.labelUseIndent.Size = new System.Drawing.Size(143, 15);
+            this.labelUseIndent.Size = new System.Drawing.Size(126, 13);
             this.labelUseIndent.TabIndex = 11;
             this.labelUseIndent.Text = "Indent lines after first line:";
-            //
+            // 
             // labelMaxLineLength
             // 
             this.labelMaxLineLength.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.labelMaxLineLength.AutoSize = true;
-            this.labelMaxLineLength.Location = new System.Drawing.Point(3, 36);
+            this.labelMaxLineLength.Location = new System.Drawing.Point(3, 32);
             this.labelMaxLineLength.Name = "labelMaxLineLength";
-            this.labelMaxLineLength.Size = new System.Drawing.Size(336, 15);
+            this.labelMaxLineLength.Size = new System.Drawing.Size(298, 13);
             this.labelMaxLineLength.TabIndex = 4;
             this.labelMaxLineLength.Text = "Maximum numbers of characters per line (0 = check disabled):";
             // 
@@ -186,179 +288,81 @@
             // 
             this.labelMaxFirstLineLength.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.labelMaxFirstLineLength.AutoSize = true;
-            this.labelMaxFirstLineLength.Location = new System.Drawing.Point(3, 7);
+            this.labelMaxFirstLineLength.Location = new System.Drawing.Point(3, 6);
             this.labelMaxFirstLineLength.Name = "labelMaxFirstLineLength";
-            this.labelMaxFirstLineLength.Size = new System.Drawing.Size(352, 15);
+            this.labelMaxFirstLineLength.Size = new System.Drawing.Size(310, 13);
             this.labelMaxFirstLineLength.TabIndex = 0;
             this.labelMaxFirstLineLength.Text = "Maximum numbers of characters in first line (0 = check disabled):";
             // 
             // _NO_TRANSLATE_numericMaxLineLength
             // 
-            this._NO_TRANSLATE_numericMaxLineLength.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this._NO_TRANSLATE_numericMaxLineLength.Location = new System.Drawing.Point(623, 32);
+            this._NO_TRANSLATE_numericMaxLineLength.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._NO_TRANSLATE_numericMaxLineLength.Location = new System.Drawing.Point(319, 29);
             this._NO_TRANSLATE_numericMaxLineLength.Name = "_NO_TRANSLATE_numericMaxLineLength";
-            this._NO_TRANSLATE_numericMaxLineLength.Size = new System.Drawing.Size(60, 23);
+            this._NO_TRANSLATE_numericMaxLineLength.Size = new System.Drawing.Size(60, 20);
             this._NO_TRANSLATE_numericMaxLineLength.TabIndex = 4;
             // 
             // _NO_TRANSLATE_numericMaxFirstLineLength
             // 
-            this._NO_TRANSLATE_numericMaxFirstLineLength.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this._NO_TRANSLATE_numericMaxFirstLineLength.Location = new System.Drawing.Point(623, 3);
+            this._NO_TRANSLATE_numericMaxFirstLineLength.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._NO_TRANSLATE_numericMaxFirstLineLength.Location = new System.Drawing.Point(319, 3);
             this._NO_TRANSLATE_numericMaxFirstLineLength.Name = "_NO_TRANSLATE_numericMaxFirstLineLength";
-            this._NO_TRANSLATE_numericMaxFirstLineLength.Size = new System.Drawing.Size(60, 23);
+            this._NO_TRANSLATE_numericMaxFirstLineLength.Size = new System.Drawing.Size(60, 20);
             this._NO_TRANSLATE_numericMaxFirstLineLength.TabIndex = 3;
-            // 
-            // labelSecondLineEmpty
-            // 
-            this.labelSecondLineEmpty.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelSecondLineEmpty.AutoSize = true;
-            this.labelSecondLineEmpty.Location = new System.Drawing.Point(3, 131);
-            this.labelSecondLineEmpty.Name = "labelSecondLineEmpty";
-            this.labelSecondLineEmpty.Size = new System.Drawing.Size(154, 15);
-            this.labelSecondLineEmpty.TabIndex = 6;
-            this.labelSecondLineEmpty.Text = "Second line must be empty:";
             // 
             // labelRegExCheck
             // 
             this.labelRegExCheck.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.labelRegExCheck.AutoSize = true;
-            this.labelRegExCheck.Location = new System.Drawing.Point(3, 85);
+            this.labelRegExCheck.Location = new System.Drawing.Point(3, 78);
             this.labelRegExCheck.Name = "labelRegExCheck";
-            this.labelRegExCheck.Size = new System.Drawing.Size(345, 15);
+            this.labelRegExCheck.Size = new System.Drawing.Size(302, 13);
             this.labelRegExCheck.TabIndex = 7;
             this.labelRegExCheck.Text = "Commit must match following RegEx (Empty = check disabled):";
             // 
             // _NO_TRANSLATE_textBoxCommitValidationRegex
             // 
             this._NO_TRANSLATE_textBoxCommitValidationRegex.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this._NO_TRANSLATE_textBoxCommitValidationRegex.Location = new System.Drawing.Point(450, 81);
+            this._NO_TRANSLATE_textBoxCommitValidationRegex.Location = new System.Drawing.Point(319, 75);
             this._NO_TRANSLATE_textBoxCommitValidationRegex.Name = "_NO_TRANSLATE_textBoxCommitValidationRegex";
-            this._NO_TRANSLATE_textBoxCommitValidationRegex.Size = new System.Drawing.Size(233, 23);
+            this._NO_TRANSLATE_textBoxCommitValidationRegex.Size = new System.Drawing.Size(364, 20);
             this._NO_TRANSLATE_textBoxCommitValidationRegex.TabIndex = 8;
             // 
             // checkBoxUseIndent
-            //
-            this.checkBoxUseIndent.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            // 
+            this.checkBoxUseIndent.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.checkBoxUseIndent.AutoSize = true;
-            this.checkBoxUseIndent.Location = new System.Drawing.Point(668, 110);
+            this.checkBoxUseIndent.Location = new System.Drawing.Point(319, 101);
             this.checkBoxUseIndent.Name = "checkBoxUseIndent";
             this.checkBoxUseIndent.Size = new System.Drawing.Size(15, 14);
             this.checkBoxUseIndent.TabIndex = 10;
             this.checkBoxUseIndent.UseVisualStyleBackColor = true;
-            //
-            // groupBoxCommitTemplates
             // 
-            this.groupBoxCommitTemplates.Controls.Add(this.tableLayoutPanel4);
-            this.groupBoxCommitTemplates.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxCommitTemplates.Location = new System.Drawing.Point(3, 3);
-            this.groupBoxCommitTemplates.Name = "groupBoxCommitTemplates";
-            this.groupBoxCommitTemplates.Size = new System.Drawing.Size(692, 173);
-            this.groupBoxCommitTemplates.TabIndex = 0;
-            this.groupBoxCommitTemplates.TabStop = false;
-            this.groupBoxCommitTemplates.Text = "Commit templates";
+            // labelSecondLineEmpty
             // 
-            // tableLayoutPanel4
-            // 
-            this.tableLayoutPanel4.ColumnCount = 2;
-            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel4.Controls.Add(this.tableLayoutPanel5, 1, 0);
-            this.tableLayoutPanel4.Controls.Add(this._NO_TRANSLATE_comboBoxCommitTemplates, 0, 0);
-            this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 19);
-            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
-            this.tableLayoutPanel4.RowCount = 1;
-            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(686, 151);
-            this.tableLayoutPanel4.TabIndex = 3;
-            // 
-            // tableLayoutPanel5
-            // 
-            this.tableLayoutPanel5.ColumnCount = 2;
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel5.Controls.Add(this.labelCommitTemplate, 0, 1);
-            this.tableLayoutPanel5.Controls.Add(this.labelCommitTemplateName, 0, 0);
-            this.tableLayoutPanel5.Controls.Add(this._NO_TRANSLATE_textCommitTemplateText, 1, 1);
-            this.tableLayoutPanel5.Controls.Add(this._NO_TRANSLATE_textBoxCommitTemplateName, 1, 0);
-            this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel5.Location = new System.Drawing.Point(130, 3);
-            this.tableLayoutPanel5.Name = "tableLayoutPanel5";
-            this.tableLayoutPanel5.RowCount = 2;
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel5.Size = new System.Drawing.Size(553, 145);
-            this.tableLayoutPanel5.TabIndex = 1;
-            // 
-            // labelCommitTemplate
-            // 
-            this.labelCommitTemplate.AutoSize = true;
-            this.labelCommitTemplate.Location = new System.Drawing.Point(3, 35);
-            this.labelCommitTemplate.Margin = new System.Windows.Forms.Padding(3, 6, 3, 0);
-            this.labelCommitTemplate.Name = "labelCommitTemplate";
-            this.labelCommitTemplate.Size = new System.Drawing.Size(104, 15);
-            this.labelCommitTemplate.TabIndex = 5;
-            this.labelCommitTemplate.Text = "Commit template:";
-            // 
-            // labelCommitTemplateName
-            // 
-            this.labelCommitTemplateName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelCommitTemplateName.AutoSize = true;
-            this.labelCommitTemplateName.Location = new System.Drawing.Point(3, 7);
-            this.labelCommitTemplateName.Name = "labelCommitTemplateName";
-            this.labelCommitTemplateName.Size = new System.Drawing.Size(104, 15);
-            this.labelCommitTemplateName.TabIndex = 7;
-            this.labelCommitTemplateName.Text = "Name:";
-            // 
-            // _NO_TRANSLATE_textCommitTemplateText
-            // 
-            this._NO_TRANSLATE_textCommitTemplateText.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._NO_TRANSLATE_textCommitTemplateText.Location = new System.Drawing.Point(113, 32);
-            this._NO_TRANSLATE_textCommitTemplateText.Multiline = true;
-            this._NO_TRANSLATE_textCommitTemplateText.Name = "_NO_TRANSLATE_textCommitTemplateText";
-            this._NO_TRANSLATE_textCommitTemplateText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this._NO_TRANSLATE_textCommitTemplateText.Size = new System.Drawing.Size(437, 110);
-            this._NO_TRANSLATE_textCommitTemplateText.TabIndex = 2;
-            this._NO_TRANSLATE_textCommitTemplateText.TextChanged += new System.EventHandler(this.textCommitTemplateText_TextChanged);
-            // 
-            // _NO_TRANSLATE_textBoxCommitTemplateName
-            // 
-            this._NO_TRANSLATE_textBoxCommitTemplateName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this._NO_TRANSLATE_textBoxCommitTemplateName.Location = new System.Drawing.Point(113, 3);
-            this._NO_TRANSLATE_textBoxCommitTemplateName.Name = "_NO_TRANSLATE_textBoxCommitTemplateName";
-            this._NO_TRANSLATE_textBoxCommitTemplateName.Size = new System.Drawing.Size(437, 23);
-            this._NO_TRANSLATE_textBoxCommitTemplateName.TabIndex = 1;
-            this._NO_TRANSLATE_textBoxCommitTemplateName.TextChanged += new System.EventHandler(this.textBoxCommitTemplateName_TextChanged);
-            // 
-            // _NO_TRANSLATE_comboBoxCommitTemplates
-            // 
-            this._NO_TRANSLATE_comboBoxCommitTemplates.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._NO_TRANSLATE_comboBoxCommitTemplates.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this._NO_TRANSLATE_comboBoxCommitTemplates.FormattingEnabled = true;
-            this._NO_TRANSLATE_comboBoxCommitTemplates.Location = new System.Drawing.Point(3, 3);
-            this._NO_TRANSLATE_comboBoxCommitTemplates.Name = "_NO_TRANSLATE_comboBoxCommitTemplates";
-            this._NO_TRANSLATE_comboBoxCommitTemplates.Size = new System.Drawing.Size(121, 23);
-            this._NO_TRANSLATE_comboBoxCommitTemplates.TabIndex = 0;
-            this._NO_TRANSLATE_comboBoxCommitTemplates.SelectedIndexChanged += new System.EventHandler(this.comboBoxCommitTemplates_SelectedIndexChanged);
+            this.labelSecondLineEmpty.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.labelSecondLineEmpty.AutoSize = true;
+            this.labelSecondLineEmpty.Location = new System.Drawing.Point(3, 121);
+            this.labelSecondLineEmpty.Name = "labelSecondLineEmpty";
+            this.labelSecondLineEmpty.Size = new System.Drawing.Size(137, 13);
+            this.labelSecondLineEmpty.TabIndex = 6;
+            this.labelSecondLineEmpty.Text = "Second line must be empty:";
             // 
             // labelAutoWrap
             // 
             this.labelAutoWrap.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.labelAutoWrap.AutoSize = true;
-            this.labelAutoWrap.Location = new System.Drawing.Point(3, 60);
+            this.labelAutoWrap.Location = new System.Drawing.Point(3, 55);
             this.labelAutoWrap.Name = "labelAutoWrap";
-            this.labelAutoWrap.Size = new System.Drawing.Size(266, 15);
+            this.labelAutoWrap.Size = new System.Drawing.Size(233, 13);
             this.labelAutoWrap.TabIndex = 13;
             this.labelAutoWrap.Text = "Auto-wrap commit message (except subject line)";
             // 
             // checkBoxSecondLineEmpty
             // 
-            this.checkBoxSecondLineEmpty.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.checkBoxSecondLineEmpty.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.checkBoxSecondLineEmpty.AutoSize = true;
-            this.checkBoxSecondLineEmpty.Location = new System.Drawing.Point(668, 132);
+            this.checkBoxSecondLineEmpty.Location = new System.Drawing.Point(319, 121);
             this.checkBoxSecondLineEmpty.Name = "checkBoxSecondLineEmpty";
             this.checkBoxSecondLineEmpty.Size = new System.Drawing.Size(15, 14);
             this.checkBoxSecondLineEmpty.TabIndex = 5;
@@ -366,9 +370,9 @@
             // 
             // checkBoxAutoWrap
             // 
-            this.checkBoxAutoWrap.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.checkBoxAutoWrap.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.checkBoxAutoWrap.AutoSize = true;
-            this.checkBoxAutoWrap.Location = new System.Drawing.Point(668, 61);
+            this.checkBoxAutoWrap.Location = new System.Drawing.Point(319, 55);
             this.checkBoxAutoWrap.Name = "checkBoxAutoWrap";
             this.checkBoxAutoWrap.Size = new System.Drawing.Size(15, 14);
             this.checkBoxAutoWrap.TabIndex = 14;
@@ -382,19 +386,20 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.MinimumSize = new System.Drawing.Size(550, 400);
             this.Name = "FormCommitTemplateSettings";
-            this.Text = "Commit template settings";
+            this.Text = "Commit message settings";
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
-            this.groupBoxCommitValidation.ResumeLayout(false);
+            this.tabControl1.ResumeLayout(false);
+            this.tabPage1.ResumeLayout(false);
+            this.tableLayoutPanel5.ResumeLayout(false);
+            this.tableLayoutPanel5.PerformLayout();
+            this.tabPage2.ResumeLayout(false);
+            this.tabPage2.PerformLayout();
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_numericMaxLineLength)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_numericMaxFirstLineLength)).EndInit();
-            this.groupBoxCommitTemplates.ResumeLayout(false);
-            this.tableLayoutPanel4.ResumeLayout(false);
-            this.tableLayoutPanel5.ResumeLayout(false);
-            this.tableLayoutPanel5.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -406,7 +411,6 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.Button buttonOk;
         private System.Windows.Forms.Button buttonCancel;
-        private System.Windows.Forms.GroupBox groupBoxCommitValidation;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.NumericUpDown _NO_TRANSLATE_numericMaxLineLength;
         private System.Windows.Forms.Label labelMaxFirstLineLength;
@@ -414,8 +418,6 @@
         private System.Windows.Forms.Label labelMaxLineLength;
         private System.Windows.Forms.Label labelSecondLineEmpty;
         private System.Windows.Forms.CheckBox checkBoxSecondLineEmpty;
-        private System.Windows.Forms.GroupBox groupBoxCommitTemplates;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
         private System.Windows.Forms.Label labelCommitTemplate;
         private System.Windows.Forms.TextBox _NO_TRANSLATE_textCommitTemplateText;
@@ -428,5 +430,8 @@
         private System.Windows.Forms.CheckBox checkBoxUseIndent;
         private System.Windows.Forms.Label labelAutoWrap;
         private System.Windows.Forms.CheckBox checkBoxAutoWrap;
+        private System.Windows.Forms.TabControl tabControl1;
+        private System.Windows.Forms.TabPage tabPage1;
+        private System.Windows.Forms.TabPage tabPage2;
     }
 }

--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
@@ -12,7 +12,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
         private CommitTemplateItem[] _commitTemplates;
 
         private const int _maxCommitTemplates = 5;
-        private const int _maxShownCharsForName = 15;
+        private const int _maxShownCharsForName = 50;
         private const int _maxUsedCharsForName = 80;
 
         public FormCommitTemplateSettings()
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
                 comboBoxText = "<" + _emptyTemplate.Text + ">";
             }
 
-            _NO_TRANSLATE_comboBoxCommitTemplates.Items[line] = string.Format("{0} : {1}", line + 1, comboBoxText);
+            _NO_TRANSLATE_comboBoxCommitTemplates.Items[line] = $"{line + 1} : {comboBoxText}";
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -123,7 +123,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _commitValidationCaption = new TranslationString("Commit validation");
 
-        private readonly TranslationString _commitTemplateSettings = new TranslationString("Settings");
+        private readonly TranslationString _commitMessageSettings = new TranslationString("Edit commit message templates and settings...");
 
         private readonly TranslationString _commitAuthorInfo = new TranslationString("Author");
         private readonly TranslationString _commitCommitterInfo = new TranslationString("Committer");
@@ -3144,7 +3144,7 @@ namespace GitUI.CommandsDialogs
 
                 void AddSettingsItem()
                 {
-                    var settingsItem = new ToolStripMenuItem(_commitTemplateSettings.Text);
+                    var settingsItem = new ToolStripMenuItem(_commitMessageSettings.Text);
                     settingsItem.Click += delegate
                     {
                         using (var frm = new FormCommitTemplateSettings())

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3248,6 +3248,10 @@ Git will never check if the file has changed that will improve status check perf
         <source>Commit Message is requested during commit</source>
         <target />
       </trans-unit>
+      <trans-unit id="_commitMessageSettings.Text">
+        <source>Edit commit message templates and settings...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_commitMsgFirstLineInvalid.Text">
         <source>First line of commit message contains too many characters.
 Do you want to continue?</source>
@@ -3269,10 +3273,6 @@ Do you want to continue?</source>
       <trans-unit id="_commitMsgSecondLineNotEmpty.Text">
         <source>Second line of commit message is not empty.
 Do you want to continue?</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_commitTemplateSettings.Text">
-        <source>Settings</source>
         <target />
       </trans-unit>
       <trans-unit id="_commitValidationCaption.Text">
@@ -3753,7 +3753,7 @@ You can unset the template:
   <file datatype="plaintext" original="FormCommitTemplateSettings" source-language="en">
     <body>
       <trans-unit id="$this.Text">
-        <source>Commit template settings</source>
+        <source>Commit message settings</source>
         <target />
       </trans-unit>
       <trans-unit id="_emptyTemplate.Text">
@@ -3766,14 +3766,6 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="buttonOk.Text">
         <source>OK</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="groupBoxCommitTemplates.Text">
-        <source>Commit templates</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="groupBoxCommitValidation.Text">
-        <source>Commit validation</source>
         <target />
       </trans-unit>
       <trans-unit id="labelAutoWrap.Text">
@@ -3806,6 +3798,14 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="labelUseIndent.Text">
         <source>Indent lines after first line:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tabPage1.Text">
+        <source>Commit templates</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tabPage2.Text">
+        <source>Commit validation</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes bad display of "Form commit template settings"


## Proposed changes

Redesign form commit template settings: 
- Use tabs to separate the 2 different kinds of settings
- Fix bad display due to dpi scaling
- More size for the Regex textbox
- rename the menu entry label to give more information

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/460196/60591272-6a942c80-9d9e-11e9-8983-810ac457ee19.png)

### After

![image](https://user-images.githubusercontent.com/460196/60591522-f0b07300-9d9e-11e9-8c63-7bd254063120.png)

### Before

By default when opened:

![image](https://user-images.githubusercontent.com/460196/60591224-4b959a80-9d9e-11e9-8549-e11baaa3dc2e.png)

When resized:
![image](https://user-images.githubusercontent.com/460196/60591763-6d435180-9d9f-11e9-864d-54ba2d42dd3c.png)


### After

![image](https://user-images.githubusercontent.com/460196/60591558-0160e900-9d9f-11e9-8b2f-89ae54bf2aac.png)

![image](https://user-images.githubusercontent.com/460196/60591578-0c1b7e00-9d9f-11e9-97e9-30ae7361d9d4.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual 


## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 3.2.0
- Build 0877b85d6bb0417d567c29e6eea557ad7edbe0fb
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)
