### PR TITLE
Fix FileHistory/Blame for files not existing in the working directory

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -210,9 +210,9 @@ namespace GitUI.CommandsDialogs
                 // we will need this later to look up proper casing for the file
                 var fullFilePath = _fullPathResolver.Resolve(fileName);
 
-                if (_controller.TryGetExactPath(fullFilePath, out fileName))
+                if (_controller.TryGetExactPath(fullFilePath, out var exactFileName))
                 {
-                    fileName = fileName.Substring(Module.WorkingDir.Length);
+                    fileName = exactFileName.Substring(Module.WorkingDir.Length);
                 }
 
                 // Replace windows path separator to Linux path separator.

--- a/GitUI/CommandsDialogs/FormFileHistoryController.cs
+++ b/GitUI/CommandsDialogs/FormFileHistoryController.cs
@@ -1,12 +1,34 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
 using System.Text;
+using GitCommands;
 using GitCommands.Utils;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.CommandsDialogs
 {
     public sealed class FormFileHistoryController
     {
+        private readonly Func<IGitModule> _getModule;
+        private readonly IFullPathResolver _fullPathResolver;
+        private readonly IFileSystem _fileSystem;
+
+        public FormFileHistoryController(Func<IGitModule> getModule, IFullPathResolver fullPathResolver, IFileSystem fileSystem)
+        {
+            _getModule = getModule;
+            _fullPathResolver = fullPathResolver;
+            _fileSystem = fileSystem;
+        }
+
+        public FormFileHistoryController(Func<IGitModule> getModule, IFullPathResolver fullPathResolver)
+            : this(getModule, fullPathResolver, new FileSystem())
+        {
+        }
+
         /// <summary>
         /// Gets the exact case used on the file system for an existing file or directory.
         /// </summary>
@@ -49,6 +71,98 @@ namespace GitUI.CommandsDialogs
 
             exactPath = path;
             return true;
+        }
+
+        public string SanitiseRelativeFilePath(string relativeFilePath, string fullFilePath)
+        {
+            if (TryGetExactPath(fullFilePath, out var exactFileName))
+            {
+                var module = GetModule();
+                relativeFilePath = exactFileName.Substring(module.WorkingDir.Length);
+            }
+
+            // Replace windows path separator to Linux path separator.
+            // This is needed to keep the file history working when started from file tree in
+            // browse dialog.
+            return relativeFilePath.ToPosixPath();
+        }
+
+        public (string revision, string path) BuildFilter(string relativeFilePath, string fullFilePath)
+        {
+            var res = (revision: (string)null, path: $" \"{relativeFilePath}\"");
+
+            if (AppSettings.FollowRenamesInFileHistory && !Directory.Exists(fullFilePath))
+            {
+                // git log --follow is not working as expected (see  http://kerneltrap.org/mailarchive/git/2009/1/30/4856404/thread)
+                //
+                // But we can take a more complicated path to get reasonable results:
+                //  1. use git log --follow to get all previous filenames of the file we are interested in
+                //  2. use git log "list of files names" to get the history graph
+                //
+                // note: This implementation is quite a quick hack (by someone who does not speak C# fluently).
+                //
+
+                var args = new GitArgumentBuilder("log")
+                    {
+                        "--format=\"%n\"",
+                        "--name-only",
+                        "--follow",
+                        GitCommandHelpers.FindRenamesAndCopiesOpts(),
+                        "--",
+                        relativeFilePath.Quote()
+                    };
+
+                var listOfFileNames = new StringBuilder(relativeFilePath.Quote());
+
+                // keep a set of the file names already seen
+                var setOfFileNames = new HashSet<string> { relativeFilePath };
+
+                var module = GetModule();
+                var lines = module.GitExecutable.GetOutputLines(args, outputEncoding: GitModule.LosslessEncoding);
+
+                foreach (var line in lines.Select(GitModule.ReEncodeFileNameFromLossless))
+                {
+                    if (!string.IsNullOrEmpty(line) && setOfFileNames.Add(line))
+                    {
+                        listOfFileNames.Append(" \"");
+                        listOfFileNames.Append(line);
+                        listOfFileNames.Append('\"');
+                    }
+                }
+
+                // here we need --name-only to get the previous filenames in the revision graph
+                res.path = listOfFileNames.ToString();
+                res.revision += " --name-only --parents" + GitCommandHelpers.FindRenamesAndCopiesOpts();
+            }
+            else if (AppSettings.FollowRenamesInFileHistory)
+            {
+                // history of a directory
+                // --parents doesn't work with --follow enabled, but needed to graph a filtered log
+                res.revision = " " + GitCommandHelpers.FindRenamesOpt() + " --follow --parents";
+            }
+            else
+            {
+                // rename following disabled
+                res.revision = " --parents";
+            }
+
+            if (AppSettings.FullHistoryInFileHistory)
+            {
+                res.revision = string.Concat(" --full-history ", AppSettings.SimplifyMergesInFileHistory ? "--simplify-merges " : string.Empty, res.revision);
+            }
+
+            return res;
+        }
+
+        private IGitModule GetModule()
+        {
+            var module = _getModule();
+            if (module == null)
+            {
+                throw new ArgumentException($"Require a valid instance of {nameof(IGitModule)}");
+            }
+
+            return module;
         }
     }
 }

--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -77,5 +77,26 @@ namespace GitUITests.CommandsDialogs
                 Assert.AreEqual(doesMatch, exactPath == expected);
             }
         }
+
+        [TestCase(@"System32\cmd.exe", @"c:\Windows\System32\cmd.exe")]
+        [TestCase(@"system32\cmd.exe", @"c:\Windows\system32\cmd.exe")]
+        public void SanitiseRelativeFilePath_When_File_Exists_Should_return_relative_path_with_posix_format(string relativeFilePath, string fullFilePath)
+        {
+            var gitModule = Substitute.For<IGitModule>();
+            gitModule.WorkingDir.Returns(@"c:\Windows\");
+
+            var controller = new FormFileHistoryController(() => gitModule, Substitute.For<IFullPathResolver>());
+            var exactPath = controller.SanitiseRelativeFilePath(relativeFilePath, fullFilePath);
+
+            Assert.AreEqual(@"System32/cmd.exe", exactPath);
+        }
+
+        [Test]
+        public void SanitiseRelativeFilePath_When_File_Not_Existing_Should_return_INPUTED_relative_path_with_posix_format()
+        {
+            var exactPath = _controller.SanitiseRelativeFilePath(@"directory\file.txt", @"c:\directory\file.txt");
+
+            Assert.AreEqual(@"directory/file.txt", exactPath);
+        }
     }
 }

--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -17,42 +17,44 @@ namespace GitUITests.CommandsDialogs
             _controller = new FormFileHistoryController();
         }
 
-        [Test]
-        public void TryGetExactPathName()
+        [TestCase(@"Does not exist")]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void TryGetExactPathName_Should_return_null_on_not_existing_file(string path)
         {
-            // TODO: needs rework/refactor
+            var lowercasePath = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
 
-            var paths = new[]
-            {
-                @"C:\Users\Public\desktop.ini",
-                @"C:\pagefile.sys",
-                @"C:\Windows\System32\cmd.exe",
-                @"C:\Users\Default\NTUSER.DAT",
-                @"C:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies",
-                @"C:\Program Files (x86)",
-                @"Does not exist",
-                @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32",
-                "",
-                " "
-            };
+            Assert.IsFalse(isExistingOnFileSystem);
+            Assert.IsNull(exactPath);
+        }
 
-            foreach (var path in paths)
-            {
-                var lowercasePath = path.ToLower();
-                var expected = File.Exists(lowercasePath) || Directory.Exists(lowercasePath);
-                var actual = _controller.TryGetExactPath(lowercasePath, out string exactPath);
+        [TestCase(@"c:\Users\Public\desktop.ini")]
+        [TestCase(@"c:\pagefile.sys")]
+        [TestCase(@"c:\Windows\System32\cmd.exe")]
+        [TestCase(@"c:\Users\Default\NTUSER.DAT")]
+        [TestCase(@"c:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies")]
+        [TestCase(@"c:\Program Files (x86)")]
+        public void TryGetExactPathName_Should_output_path_with_exact_casing(string path)
+        {
+            var lowercasePath = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
 
-                Assert.AreEqual(expected, actual);
+            Assert.IsTrue(isExistingOnFileSystem);
+            Assert.AreEqual(path, exactPath);
+        }
 
-                if (actual)
-                {
-                    Assert.AreEqual(path.ToLower(), exactPath.ToLower());
-                }
-                else
-                {
-                    Assert.IsNull(exactPath);
-                }
-            }
+        [Test]
+        public void TryGetExactPathName_Should_handle_network_path()
+        {
+            var path = @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32";
+
+            var lowercasePath = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
+
+            Assert.IsTrue(isExistingOnFileSystem);
+
+            Assert.AreEqual(path, exactPath);
         }
 
         [TestCase("Folder1\\file1.txt", true, true)]

--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.IO;
 using CommonTestUtils;
+using GitCommands;
 using GitUI.CommandsDialogs;
+using GitUIPluginInterfaces;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace GitUITests.CommandsDialogs
@@ -14,7 +17,7 @@ namespace GitUITests.CommandsDialogs
         [SetUp]
         public void Setup()
         {
-            _controller = new FormFileHistoryController();
+            _controller = new FormFileHistoryController(() => Substitute.For<IGitModule>(), Substitute.For<IFullPathResolver>());
         }
 
         [TestCase(@"Does not exist")]


### PR DESCRIPTION


Fixes #6458 and #6892

## Proposed changes

The bad behavior comes from the fact that `TryGetExactPath()`
overwrite the out variable `fileName` with null
when return is false.
We should use another temporary variable.

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 8fee24f359f4422a9b038775fce2e13d4f748d0d (Dirty)
- Git 2.21.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

