### PR TITLE
Stash: Add cherry pick of file's changes

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -48,6 +48,8 @@ namespace GitUI.CommandsDialogs
             this.panel1 = new System.Windows.Forms.Panel();
             this.Loading = new LoadingControl();
             this.Stashed = new GitUI.FileStatusList();
+            this.contextMenuStripStashedFiles = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.cherryPickFileChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStrip1 = new GitUI.ToolStripEx();
             this.showToolStripLabel = new System.Windows.Forms.ToolStripLabel();
             this.Stashes = new System.Windows.Forms.ToolStripComboBox();
@@ -65,6 +67,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.SuspendLayout();
             this.panel1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
+            this.contextMenuStripStashedFiles.SuspendLayout();
             this.SuspendLayout();
             // 
             // gitStashBindingSource
@@ -250,6 +253,7 @@ namespace GitUI.CommandsDialogs
             this.Loading.BackColor = System.Drawing.SystemColors.Control;
             this.Loading.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
             this.Loading.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Loading.IsAnimating = true;
             this.Loading.Location = new System.Drawing.Point(0, 0);
             this.Loading.Margin = new System.Windows.Forms.Padding(0);
             this.Loading.Name = "Loading";
@@ -260,14 +264,33 @@ namespace GitUI.CommandsDialogs
             // 
             // Stashed
             // 
+            this.Stashed.ContextMenuStrip = this.contextMenuStripStashedFiles;
             this.Stashed.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Stashed.FilterVisible = false;
+            this.Stashed.GroupByRevision = false;
             this.Stashed.Location = new System.Drawing.Point(0, 0);
             this.Stashed.Margin = new System.Windows.Forms.Padding(0);
+            this.Stashed.MultiSelect = false;
             this.Stashed.Name = "Stashed";
             this.Stashed.Size = new System.Drawing.Size(280, 553);
             this.Stashed.TabIndex = 2;
             this.Stashed.SelectedIndexChanged += new System.EventHandler(this.StashedSelectedIndexChanged);
+            // 
+            // contextMenuStripStashedFiles
+            // 
+            this.contextMenuStripStashedFiles.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cherryPickFileChangesToolStripMenuItem});
+            this.contextMenuStripStashedFiles.Name = "contextMenuStripStashedFiles";
+            this.contextMenuStripStashedFiles.Size = new System.Drawing.Size(209, 76);
+            this.contextMenuStripStashedFiles.Opening += new System.ComponentModel.CancelEventHandler(this.ContextMenuStripStashedFiles_Opening);
+            // 
+            // cherryPickFileChangesToolStripMenuItem
+            // 
+            this.cherryPickFileChangesToolStripMenuItem.Image = global::GitUI.Properties.Resources.CherryPick;
+            this.cherryPickFileChangesToolStripMenuItem.Name = "cherryPickFileChangesToolStripMenuItem";
+            this.cherryPickFileChangesToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
+            this.cherryPickFileChangesToolStripMenuItem.Text = "Cherry pick file changes";
+            this.cherryPickFileChangesToolStripMenuItem.Click += new System.EventHandler(this.CherryPickFileChangesToolStripMenuItem_Click);
             // 
             // toolStrip1
             // 
@@ -377,6 +400,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.panel1.ResumeLayout(false);
+            this.contextMenuStripStashedFiles.ResumeLayout(false);
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();
             this.ResumeLayout(false);
@@ -407,5 +431,7 @@ namespace GitUI.CommandsDialogs
         private Panel panel1;
         private ToolTip toolTip;
         private Button StashSelectedFiles;
+        private ContextMenuStrip contextMenuStripStashedFiles;
+        private ToolStripMenuItem cherryPickFileChangesToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -438,5 +438,15 @@ namespace GitUI.CommandsDialogs
                 Close();
             }
         }
+
+        private void CherryPickFileChangesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            View.CherryPickAllChanges();
+        }
+
+        private void ContextMenuStripStashedFiles_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            cherryPickFileChangesToolStripMenuItem.Enabled = Stashed.SelectedItems.Count() == 1;
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormStash.resx
+++ b/GitUI/CommandsDialogs/FormStash.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -120,17 +120,14 @@
   <metadata name="gitStashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>179, 17</value>
-  </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>284, 17</value>
   </metadata>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>179, 17</value>
   </metadata>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>284, 17</value>
+  <metadata name="contextMenuStripStashedFiles.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>374, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>46</value>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1886,6 +1886,9 @@
   <ItemGroup>
     <None Include="Resources\Icons\FileStatusRemoved.png" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\Icons\CherryPick.png" />
+  </ItemGroup>
   <Target Name="CopyTranslations" AfterTargets="AfterBuild">
     <ItemGroup>
       <Translations Include="$(ProjectDir)Translation\*.xlf;$(ProjectDir)Translation\*.gif" />

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -122,6 +122,16 @@ namespace GitUI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap CherryPick {
+            get {
+                object obj = ResourceManager.GetObject("CherryPick", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Steffen Forkmann, Jacob Stanley, Nick Mayer, Kevin Moore, Davide,
         ///Dominique Plante, Grzegorz Pachocki, Seth Behunin, bleis-tift, Chris Meaney, Nathanael Schmied, Adrian Codrington,
         ///Troels Thomsen, Wilbert van Dolleweerd, Tobias Bieniek, Radoslaw Miazio, Stan Angeloff, Matt McCormick,

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -216,4 +216,7 @@ Alexander Eifler, Marcelo Ghelman, ghanique, olshevskiy87</value>
   <data name="Blame" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Icons\Blame.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="CherryPick" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\CherryPick.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6774,6 +6774,10 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <source>Stash untracked files</source>
         <target />
       </trans-unit>
+      <trans-unit id="cherryPickFileChangesToolStripMenuItem.Text">
+        <source>Cherry pick file changes</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkIncludeUntrackedFiles.Text">
         <source>Include untracked files</source>
         <target />

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -266,6 +266,13 @@ namespace GitUI
             set => _groupByRevision = value;
         }
 
+        [DefaultValue(true)]
+        public bool MultiSelect
+        {
+            get => FileStatusListView.MultiSelect;
+            set => FileStatusListView.MultiSelect = value;
+        }
+
         [Browsable(false)]
         [DefaultValue(true)]
         public bool IsEmpty => GitItemStatuses == null || !GitItemStatuses.Any();


### PR DESCRIPTION
Fixes #6902

## Proposed changes

- In the file list of a stash, add a contextual menu that allows the cherry pick of a file's changes.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

nothing

### After

![image](https://user-images.githubusercontent.com/460196/60873203-3ef9c200-a236-11e9-9f1e-f8149d1678c6.png)

PS: I don't know why but that also add a 'Sort by' menu item... but that options works, so I didn't investigated on that subject.


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 12ee015dbb06e3fbff2752d3bc12fc2ceea5f87b (Dirty)
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)


