### PR TITLE
Fix different problems around FileHistory/Blame

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -207,20 +207,13 @@ namespace GitUI.CommandsDialogs
             {
                 var fileName = FileName;
 
-                // we will need this later to look up proper casing for the file
-                var fullFilePath = _fullPathResolver.Resolve(fileName);
-
-                if (_controller.TryGetExactPath(fullFilePath, out fileName))
-                {
-                    fileName = fileName.Substring(Module.WorkingDir.Length);
-                }
-
                 // Replace windows path separator to Linux path separator.
                 // This is needed to keep the file history working when started from file tree in
                 // browse dialog.
                 FileName = fileName.ToPosixPath();
 
                 var res = (revision: (string)null, path: $" \"{fileName}\"");
+                var fullFilePath = _fullPathResolver.Resolve(fileName);
 
                 if (AppSettings.FollowRenamesInFileHistory && !Directory.Exists(fullFilePath))
                 {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1703,6 +1703,11 @@ namespace GitUI
             // long while there is room left when the workingdir was not in the path.
             string fileHistoryFileName = string.IsNullOrEmpty(Module.WorkingDir) ? args[2] :
                 args[2].Replace(Module.WorkingDir, "").ToPosixPath();
+            var fullFilePath = _fullPathResolver.Resolve(fileHistoryFileName);
+            if (new FormFileHistoryController().TryGetExactPath(fullFilePath, out var exactFileName))
+            {
+                fileHistoryFileName = exactFileName.Substring(Module.WorkingDir.Length);
+            }
 
             StartFileHistoryDialog(null, fileHistoryFileName);
         }

--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -17,42 +17,44 @@ namespace GitUITests.CommandsDialogs
             _controller = new FormFileHistoryController();
         }
 
-        [Test]
-        public void TryGetExactPathName()
+        [TestCase(@"Does not exist")]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void TryGetExactPathName_Should_return_null_on_not_existing_file(string path)
         {
-            // TODO: needs rework/refactor
+            var lowercasePath = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
 
-            var paths = new[]
-            {
-                @"C:\Users\Public\desktop.ini",
-                @"C:\pagefile.sys",
-                @"C:\Windows\System32\cmd.exe",
-                @"C:\Users\Default\NTUSER.DAT",
-                @"C:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies",
-                @"C:\Program Files (x86)",
-                @"Does not exist",
-                @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32",
-                "",
-                " "
-            };
+            Assert.IsFalse(isExistingOnFileSystem);
+            Assert.IsNull(exactPath);
+        }
 
-            foreach (var path in paths)
-            {
-                var lowercasePath = path.ToLower();
-                var expected = File.Exists(lowercasePath) || Directory.Exists(lowercasePath);
-                var actual = _controller.TryGetExactPath(lowercasePath, out string exactPath);
+        [TestCase(@"c:\Users\Public\desktop.ini")]
+        [TestCase(@"c:\pagefile.sys")]
+        [TestCase(@"c:\Windows\System32\cmd.exe")]
+        [TestCase(@"c:\Users\Default\NTUSER.DAT")]
+        [TestCase(@"c:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies")]
+        [TestCase(@"c:\Program Files (x86)")]
+        public void TryGetExactPathName_Should_output_path_with_exact_casing(string path)
+        {
+            var lowercasePath = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
 
-                Assert.AreEqual(expected, actual);
+            Assert.IsTrue(isExistingOnFileSystem);
+            Assert.AreEqual(path, exactPath);
+        }
 
-                if (actual)
-                {
-                    Assert.AreEqual(path.ToLower(), exactPath.ToLower());
-                }
-                else
-                {
-                    Assert.IsNull(exactPath);
-                }
-            }
+        [Test]
+        public void TryGetExactPathName_Should_handle_network_path()
+        {
+            var path = @"\\" + Environment.MachineName.ToLower() + @"\c$\Windows\System32";
+
+            var lowercasePath = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
+
+            Assert.IsTrue(isExistingOnFileSystem);
+
+            Assert.AreEqual(path, exactPath);
         }
 
         [TestCase("Folder1\\file1.txt", true, true)]


### PR DESCRIPTION
Fixes #6458, #6892 and #6815

Alternative for #6893 (like discussed in https://github.com/gitextensions/gitextensions/pull/6893#issuecomment-509390885 )

## Proposed changes

- Fix FileHistory/Blame for files not existing in the working directory

The bad behavior comes from the fact that `TryGetExactPath()`
changes the path to the file system path (if not existing, the path is cleared)
- Improve readability of unit tests on `TryGetExactPath()`

/cc @gerhardol  @RussKie 