### PR TITLE
Remove use of possessive in "Cherry pick file's changes"

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -260,7 +260,7 @@ namespace GitUI.CommandsDialogs
             this.cherryPickSelectedDiffFileToolStripMenuItem.Image = global::GitUI.Properties.Images.CherryPick;
             this.cherryPickSelectedDiffFileToolStripMenuItem.Name = "cherryPickSelectedDiffFileToolStripMenuItem";
             this.cherryPickSelectedDiffFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Text = "Cherry pick file\'s changes";
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Text = "Cherry pick changes";
             this.cherryPickSelectedDiffFileToolStripMenuItem.Click += new System.EventHandler(this.cherryPickSelectedDiffFileToolStripMenuItem_Click);
             // 
             // toolStripSeparator32

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8099,7 +8099,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="cherryPickSelectedDiffFileToolStripMenuItem.Text">
-        <source>Cherry pick file's changes</source>
+        <source>Cherry pick changes</source>
         <target />
       </trans-unit>
       <trans-unit id="copyFilenameToClipboardToolStripMenuItem1.Text">


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/6907#discussion_r301898228


## Proposed changes

- Remove use of possessive in "Cherry pick file's changes"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/60982453-70f34d00-a338-11e9-900f-f1b1126dcf56.png)


### After

![image](https://user-images.githubusercontent.com/460196/60982416-5faa4080-a338-11e9-9866-4bc52b679b0c.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build ff0e8eed0b4b577c62bbcd8469d62b31b29a6e4d
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)


:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
