### PR TITLE
fix: Commit message incorrect height at 150% scale factor

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -14,6 +14,7 @@ using GitCommands.ExternalLinks;
 using GitCommands.Git;
 using GitCommands.Remotes;
 using GitExtUtils;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.Editor.RichTextBoxExtension;
 using GitUI.Hotkey;
@@ -751,6 +752,17 @@ namespace GitUI.CommitInfo
         private void CommitMessage_ContentsResized(ContentsResizedEventArgs e)
         {
             _commitMessageHeight = e.NewRectangle.Height;
+
+            // at scale factor of 150% there is rendering artifact - the last line is almost lost
+            // at all other scaling factors from 100% to 350% everything is rendered as expected
+            // see https://github.com/gitextensions/gitextensions/issues/6898 for more details
+            //
+            // absent of an obvious way to fix it, hardcode the fix - add an extra space at the bottom
+            if (DpiUtil.ScaleX - 1.5f < float.Epsilon)
+            {
+                _commitMessageHeight += 16;
+            }
+
             PerformLayout();
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -758,7 +758,7 @@ namespace GitUI.CommitInfo
             // see https://github.com/gitextensions/gitextensions/issues/6898 for more details
             //
             // absent of an obvious way to fix it, hardcode the fix - add an extra space at the bottom
-            if (DpiUtil.ScaleX - 1.5f < float.Epsilon)
+            if (Math.Abs(DpiUtil.ScaleX - 1.5f) <= 0.01f)
             {
                 _commitMessageHeight += 16;
             }


### PR DESCRIPTION
Closes #6898



## Proposed changes

-  Absent of an obvious way to fix it, hardcode the fix - add an extra space at the bottom


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/60768585-e678d680-a108-11e9-98a6-12f37d120d47.png)

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/61047821-b2acf200-a423-11e9-901a-3e9d2b5fefb2.png)



## Test methodology <!-- How did you ensure quality? -->

- manual testing at various scale factors


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
