### PR TITLE
Add support for "--rebase-merges" for newest version of git

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -403,7 +403,7 @@ namespace GitCommands
                 { interactive, "-i" },
                 { interactive && autosquash, "--autosquash" },
                 { interactive && !autosquash, "--no-autosquash" },
-                { preserveMerges, "--preserve-merges" },
+                { preserveMerges, GitVersion.Current.SupportRebaseMerges ? "--rebase-merges" : "--preserve-merges" },
                 { autoStash, "--autostash" },
                 from.QuoteNE(),
                 branch.Quote(),

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -19,6 +19,7 @@ namespace GitCommands
         private static readonly GitVersion v2_11_0 = new GitVersion("2.11.0");
         private static readonly GitVersion v2_15_0 = new GitVersion("2.15.0");
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
+        private static readonly GitVersion v2_19_0 = new GitVersion("2.19.0");
 
         public static readonly GitVersion LastSupportedVersion = v2_11_0;
         public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.22.0");
@@ -123,6 +124,8 @@ namespace GitCommands
         public bool DepreciatedLfsClone => this >= v2_15_0;
 
         public bool SupportNoOptionalLocks => this >= v2_15_2;
+
+        public bool SupportRebaseMerges => this >= v2_19_0;
 
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 

--- a/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommandsTests/Git/GitCommandHelpersTest.cs
@@ -605,7 +605,7 @@ namespace GitCommandsTests.Git
                 "-c rebase.autoSquash=false rebase -i --no-autosquash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: false, autosquash: false, autoStash: false).Arguments);
             Assert.AreEqual(
-                "-c rebase.autoSquash=false rebase --preserve-merges \"branch\"",
+                GitVersion.Current.SupportRebaseMerges ? "-c rebase.autoSquash=false rebase --rebase-merges \"branch\"" : "-c rebase.autoSquash=false rebase --preserve-merges \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: true, autosquash: false, autoStash: false).Arguments);
             Assert.AreEqual(
                 "-c rebase.autoSquash=false rebase \"branch\"",
@@ -617,7 +617,7 @@ namespace GitCommandsTests.Git
                 "-c rebase.autoSquash=false rebase -i --autosquash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: false, autosquash: true, autoStash: false).Arguments);
             Assert.AreEqual(
-                "-c rebase.autoSquash=false rebase -i --autosquash --preserve-merges --autostash \"branch\"",
+                GitVersion.Current.SupportRebaseMerges ? "-c rebase.autoSquash=false rebase -i --autosquash --rebase-merges --autostash \"branch\"" : "-c rebase.autoSquash=false rebase -i --autosquash --preserve-merges --autostash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: true, autosquash: true, autoStash: true).Arguments);
 
             // TODO quote 'onto'?


### PR DESCRIPTION
now that we recommend v2.22 (#6769) that deprecate "--preserve-merges"

See:
* for option deprection: https://github.com/git/git/commit/fa1b86e45743fd5895c33adcd3769782e608bb40#diff-c7361e406139e8cd3a300b80b8f8cc8dR1220
* for some doc: https://stackoverflow.com/questions/15915430/what-exactly-does-gits-rebase-preserve-merges-do-and-why/50555740#50555740

## Test methodology <!-- How did you ensure quality? -->

- Manual (not heavily)
- Updated unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 8ee3620d3fa4b960b24240cb5ccf1822c01a33f7
- Git 2.20.1.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

