### PR TITLE
Add an option to sort commits by author date in the revision grid

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -178,6 +178,7 @@ namespace GitCommands
                     new ArgumentBuilder
                     {
                         { AppSettings.ShowReflogReferences, "--reflog" },
+                        { AppSettings.SortByAuthorDate, "--author-date-order" },
                         {
                             refFilterOptions.HasFlag(RefFilterOptions.All),
                             "--all",

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -430,6 +430,12 @@ namespace GitCommands
             set => SetBool("showgitstatusforartificialcommits", value);
         }
 
+        public static bool SortByAuthorDate
+        {
+            get => GetBool("sortbyauthordate", false);
+            set => SetBool("sortbyauthordate", value);
+        }
+
         public static bool CommitInfoShowContainedInBranches => CommitInfoShowContainedInBranchesLocal ||
                                                                 CommitInfoShowContainedInBranchesRemote ||
                                                                 CommitInfoShowContainedInBranchesRemoteIfNoLocal;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -31,6 +31,7 @@
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
             this.gbGeneral = new System.Windows.Forms.GroupBox();
             this.tlpnlGeneral = new System.Windows.Forms.TableLayoutPanel();
+            this.chkSortByAuthorDate = new System.Windows.Forms.CheckBox();
             this.chkShowRelativeDate = new System.Windows.Forms.CheckBox();
             this.truncatePathMethod = new System.Windows.Forms.ComboBox();
             this.truncateLongFilenames = new System.Windows.Forms.Label();
@@ -112,6 +113,7 @@
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlGeneral.Controls.Add(this.chkSortByAuthorDate, 0, 4);
             this.tlpnlGeneral.Controls.Add(this.chkShowRelativeDate, 0, 0);
             this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 3);
             this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 3);
@@ -120,13 +122,23 @@
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlGeneral.Location = new System.Drawing.Point(8, 21);
             this.tlpnlGeneral.Name = "tlpnlGeneral";
-            this.tlpnlGeneral.RowCount = 4;
+            this.tlpnlGeneral.RowCount = 5;
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlGeneral.Size = new System.Drawing.Size(1520, 96);
+            this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlGeneral.Size = new System.Drawing.Size(1035, 119);
             this.tlpnlGeneral.TabIndex = 0;
+            // 
+            // chkSortByAuthorDate
+            // 
+            this.chkSortByAuthorDate.AutoSize = true;
+            this.chkSortByAuthorDate.Location = new System.Drawing.Point(3, 99);
+            this.chkSortByAuthorDate.Name = "chkSortByAuthorDate";
+            this.chkSortByAuthorDate.Size = new System.Drawing.Size(116, 17);
+            this.chkSortByAuthorDate.TabIndex = 12;
+            this.chkSortByAuthorDate.Text = "Sort by author date";
             // 
             // chkShowRelativeDate
             // 
@@ -538,5 +550,6 @@
         private System.Windows.Forms.PictureBox pictureAvatarHelp;
         private System.Windows.Forms.Label lblAvatarProvider;
         private System.Windows.Forms.ComboBox AvatarProvider;
+        private System.Windows.Forms.CheckBox chkSortByAuthorDate;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -16,6 +16,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _noDictFile = new TranslationString("None");
         private readonly TranslationString _noDictFilesFound = new TranslationString("No dictionary files found in: {0}");
         private readonly TranslationString _noImageServiceTooltip = new TranslationString("A default image, if an email address has no matching Gravatar image.\r\nSee http://en.gravatar.com/site/implement/images#default-image for more details.");
+        private readonly TranslationString _authorDateSortWarningTooltip = new TranslationString("Sorting by author date may delay rendering of the revision graph.");
 
         public AppearanceSettingsPage()
         {
@@ -41,6 +42,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             ToolTip.SetToolTip(_NO_TRANSLATE_NoImageService, _noImageServiceTooltip.Text);
             ToolTip.SetToolTip(pictureAvatarHelp, _noImageServiceTooltip.Text);
+            ToolTip.SetToolTip(chkSortByAuthorDate, _authorDateSortWarningTooltip.Text);
             pictureAvatarHelp.Size = DpiUtil.Scale(pictureAvatarHelp.Size);
 
             // align 1st columns across all tables
@@ -69,6 +71,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
             ShowAuthorAvatarInCommitInfo.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
             ShowAuthorAvatarInCommitGraph.Checked = AppSettings.ShowAuthorAvatarColumn;
+            chkSortByAuthorDate.Checked = AppSettings.SortByAuthorDate;
             AvatarProvider.SelectedValue = AppSettings.AvatarProvider;
             _NO_TRANSLATE_NoImageService.SelectedValue = AppSettings.GravatarFallbackAvatarType;
             ManageGravatarOptionsDisplay();
@@ -128,6 +131,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowAuthorAvatarColumn = ShowAuthorAvatarInCommitGraph.Checked;
             AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatarInCommitInfo.Checked;
             AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
+            AppSettings.SortByAuthorDate = chkSortByAuthorDate.Checked;
 
             AppSettings.Translation = Language.Text;
             ResourceManager.Strings.Reinitialize();

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -131,6 +131,10 @@ This action will be performed without warning while checking out branch.</source
         <source>Show author's avatar in the commit info view</source>
         <target />
       </trans-unit>
+      <trans-unit id="_authorDateSortWarningTooltip.Text">
+        <source>Sorting by author date may delay rendering of the revision graph.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_noDictFile.Text">
         <source>None</source>
         <target />
@@ -154,6 +158,10 @@ See http://en.gravatar.com/site/implement/images#default-image for more details.
       </trans-unit>
       <trans-unit id="chkShowRelativeDate.Text">
         <source>Show relative date instead of full date</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="chkSortByAuthorDate.Text">
+        <source>Sort by author date</source>
         <target />
       </trans-unit>
       <trans-unit id="downloadDictionary.Text">
@@ -8342,6 +8350,10 @@ See the changes in the commit form.</source>
   </file>
   <file datatype="plaintext" original="RevisionGrid" source-language="en">
     <body>
+      <trans-unit id="AuthorDateSort.Text">
+        <source>Sort commits by author date</source>
+        <target />
+      </trans-unit>
       <trans-unit id="GotoChildCommit.Text">
         <source>Go to child commit</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1836,6 +1836,12 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
+        internal void ToggleAuthorDateSort()
+        {
+            AppSettings.SortByAuthorDate = !AppSettings.SortByAuthorDate;
+            ForceRefreshRevisions();
+        }
+
         internal void ToggleShowReflogReferences()
         {
             AppSettings.ShowReflogReferences = !AppSettings.ShowReflogReferences;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -303,6 +303,13 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
+                    Name = "AuthorDateSort",
+                    Text = "Sort commits by author date",
+                    ExecuteAction = () => _revisionGrid.ToggleAuthorDateSort(),
+                    IsCheckedFunc = () => AppSettings.SortByAuthorDate
+                },
+                new MenuCommand
+                {
                     Name = "showAuthorDateToolStripMenuItem",
                     Text = "Show author date",
                     ExecuteAction = () => _revisionGrid.ToggleShowAuthorDate(),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6826

Replace #6854


## Proposed changes
Add option to sort commits by author date in the revision grid. Add menu-option and Settings checkbox to access setting. Added tool-tip in Settings to warn of potential performance impact.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
<img src="https://camo.githubusercontent.com/3c0443d6c994764bf0e0c34c8bc38b9baa904592/68747470733a2f2f692e696d6775722e636f6d2f486d6752446b6d2e706e67"/>

### After
<img src="https://camo.githubusercontent.com/c95ab46d3818b2dd69303858f253601655b8408b/68747470733a2f2f692e696d6775722e636f6d2f356f39536743532e706e67"/>


## Test methodology <!-- How did you ensure quality? -->
Tested on repo where commit-dates were not the same as author-dates. Appearance was as-expected. Tested enabling and disabling option; the commit sorting responded as expected.


## Test environment(s) <!-- Remove any that don't apply -->

GIT 2.17.1.windows.2
Windows NT 10.0.17763.0
.NET 4.7.3416.0

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
