### PR TITLE
Fix: Build error due to duplicate NSubstitue entry in csproj

### DIFF
--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegrationTests/AppVeyorIntegrationTests.csproj
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegrationTests/AppVeyorIntegrationTests.csproj
@@ -37,9 +37,6 @@
     <DocumentationFile>bin\Release\AppVeyorIntegrationTests.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NSubstitute">
-      <HintPath>..\..\..\..\..\..\..\.nuget\packages\nsubstitute\3.1.0\lib\net46\NSubstitute.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>


### PR DESCRIPTION
Fixes build issue when building from scratch. Didn't create an issue for this pull request, because it is just a build issue, not user facing, not production code either.

## Proposed changes

- Remove the duplicate NSubstitue reference from the csproj

## Test methodology <!-- How did you ensure quality? -->

- Build the project to make sure can build successfully

## Test environment(s) <!-- Remove any that don't apply -->

- VS2019

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
