### PR TITLE
ReleaseNotesGenerator plugin To defaults to "HEAD"

### DIFF
--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.Designer.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.textBoxRevTo = new System.Windows.Forms.TextBox();
+            this._NO_TRANSLATE_textBoxRevTo = new System.Windows.Forms.TextBox();
             this.textBoxRevFrom = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_textBoxGitLogArguments = new System.Windows.Forms.TextBox();
@@ -87,10 +87,11 @@
             // 
             // textBoxRevTo
             // 
-            this.textBoxRevTo.Location = new System.Drawing.Point(214, 38);
-            this.textBoxRevTo.Name = "textBoxRevTo";
-            this.textBoxRevTo.Size = new System.Drawing.Size(162, 21);
-            this.textBoxRevTo.TabIndex = 1;
+            this._NO_TRANSLATE_textBoxRevTo.Location = new System.Drawing.Point(214, 38);
+            this._NO_TRANSLATE_textBoxRevTo.Name = "textBoxRevTo";
+            this._NO_TRANSLATE_textBoxRevTo.Size = new System.Drawing.Size(162, 21);
+            this._NO_TRANSLATE_textBoxRevTo.TabIndex = 1;
+            this._NO_TRANSLATE_textBoxRevTo.Text = "HEAD";
             // 
             // textBoxRevFrom
             // 
@@ -376,7 +377,7 @@
             this.Controls.Add(this._NO_TRANSLATE_textBoxGitLogArguments);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.textBoxRevFrom);
-            this.Controls.Add(this.textBoxRevTo);
+            this.Controls.Add(this._NO_TRANSLATE_textBoxRevTo);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.label1);
             this.MinimizeBox = false;
@@ -407,7 +408,7 @@
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.TextBox textBoxRevTo;
+        private System.Windows.Forms.TextBox _NO_TRANSLATE_textBoxRevTo;
         private System.Windows.Forms.TextBox textBoxRevFrom;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TextBox _NO_TRANSLATE_textBoxGitLogArguments;

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -53,16 +53,16 @@ namespace ReleaseNotesGenerator
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(textBoxRevTo.Text))
+            if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_textBoxRevTo.Text))
             {
                 MessageBox.Show(this, _toCommitNotSpecified.Text, _caption.Text);
-                textBoxRevTo.Focus();
+                _NO_TRANSLATE_textBoxRevTo.Focus();
                 return;
             }
 
             var args = new GitArgumentBuilder("log")
             {
-                string.Format(_NO_TRANSLATE_textBoxGitLogArguments.Text, textBoxRevFrom.Text, textBoxRevTo.Text)
+                string.Format(_NO_TRANSLATE_textBoxGitLogArguments.Text, textBoxRevFrom.Text, _NO_TRANSLATE_textBoxRevTo.Text)
             };
 
             string result = _gitUiCommands.GitModule.GitExecutable.GetOutput(args);
@@ -110,7 +110,7 @@ namespace ReleaseNotesGenerator
 
         private void buttonCopyAsHtml_Click(object sender, EventArgs e)
         {
-            string headerHtml = string.Format("<p>Commit log from '{0}' to '{1}' ({2}):</p>", textBoxRevFrom.Text, textBoxRevTo.Text, MostRecentHint);
+            string headerHtml = string.Format("<p>Commit log from '{0}' to '{1}' ({2}):</p>", textBoxRevFrom.Text, _NO_TRANSLATE_textBoxRevTo.Text, MostRecentHint);
             string tableHtml = CreateHtmlTable(_lastGeneratedLogLines);
             HtmlFragment.CopyToClipboard(headerHtml + tableHtml);
         }
@@ -118,7 +118,7 @@ namespace ReleaseNotesGenerator
         private string CreateTextTable(IEnumerable<LogLine> logLines, bool suppressEmptyLines = true, bool separateColumnWithTabInsteadOfSpaces = true)
         {
             string headerText = string.Format(_commitLogFrom.Text,
-                textBoxRevFrom.Text, textBoxRevTo.Text, MostRecentHint);
+                textBoxRevFrom.Text, _NO_TRANSLATE_textBoxRevTo.Text, MostRecentHint);
 
             string colSeparatorFirstLine = separateColumnWithTabInsteadOfSpaces ? "\t" : " ";
             string colSeparatorRestLines = separateColumnWithTabInsteadOfSpaces ? "\t" : "        ";

--- a/contributors.txt
+++ b/contributors.txt
@@ -87,3 +87,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/06/05, AOrlov, Andrei Orlov, gooshift(at)gmail.com
 2019/06/07, veremenko-y, Yaroslav Veremenko, yaroslav(at)veremenko.info
 2019/07/28, FisherTsai, Fisher Tsai, fishy0903(at)gmail.com
+2019/07/28, manuelspezzani, Manuel Spezzani, manuel.spezzani(at)gmail.com


### PR DESCRIPTION
Fixes #4444


## Proposed changes

The ReleaseNotesGenerator is initialized with a default "HEAD" text for the To field.
Another option could have been to completely remove the To field validation (blank is an "alias" for HEAD) but IMHO having an explicit default value provides a more clear/usable experience.

## Test methodology 

- Manual


## Test environment(s) 

- Git Extensions 3.1.1.6049
- Build 2f872105b4eb42421d9fdafd68e90a9e27d20d96
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
