### PR TITLE
Add "default pull action" config in setting dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1459,6 +1459,8 @@ namespace GitUI.CommandsDialogs
             _dashboard?.RefreshContent();
 
             _gitStatusMonitor.Active = NeedsGitStatusMonitor() && Module.IsValidGitWorkingDir();
+
+            RefreshDefaultPullAction();
         }
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -58,6 +58,8 @@
             this.tlpnlTelemetry = new System.Windows.Forms.TableLayoutPanel();
             this.chkTelemetry = new System.Windows.Forms.CheckBox();
             this.llblTelemetryPrivacyLink = new System.Windows.Forms.LinkLabel();
+            this.lblDefaultPullAction = new System.Windows.Forms.Label();
+            this.cboDefaultPullAction = new System.Windows.Forms.ComboBox();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             tlpnlMain.SuspendLayout();
             this.groupBoxPerformance.SuspendLayout();
@@ -260,7 +262,7 @@
             this.groupBoxBehaviour.Location = new System.Drawing.Point(3, 248);
             this.groupBoxBehaviour.Name = "groupBoxBehaviour";
             this.groupBoxBehaviour.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxBehaviour.Size = new System.Drawing.Size(1318, 222);
+            this.groupBoxBehaviour.Size = new System.Drawing.Size(1188, 249);
             this.groupBoxBehaviour.TabIndex = 1;
             this.groupBoxBehaviour.TabStop = false;
             this.groupBoxBehaviour.Text = "Behaviour";
@@ -274,9 +276,9 @@
             this.tlpnlBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpnlBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistoryExact, 1, 4);
-            this.tlpnlBehaviour.Controls.Add(this.RevisionGridQuickSearchTimeout, 1, 7);
+            this.tlpnlBehaviour.Controls.Add(this.RevisionGridQuickSearchTimeout, 1, 8);
             this.tlpnlBehaviour.Controls.Add(this.btnDefaultDestinationBrowse, 2, 6);
-            this.tlpnlBehaviour.Controls.Add(this.lblQuickSearchTimeout, 0, 7);
+            this.tlpnlBehaviour.Controls.Add(this.lblQuickSearchTimeout, 0, 8);
             this.tlpnlBehaviour.Controls.Add(this.chkCloseProcessDialog, 0, 0);
             this.tlpnlBehaviour.Controls.Add(this.cbDefaultCloneDestination, 1, 6);
             this.tlpnlBehaviour.Controls.Add(this.chkShowGitCommandLine, 0, 1);
@@ -285,10 +287,12 @@
             this.tlpnlBehaviour.Controls.Add(this.chkStashUntrackedFiles, 0, 3);
             this.tlpnlBehaviour.Controls.Add(this.chkStartWithRecentWorkingDir, 0, 5);
             this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistory, 0, 4);
+            this.tlpnlBehaviour.Controls.Add(this.lblDefaultPullAction, 0, 7);
+            this.tlpnlBehaviour.Controls.Add(this.cboDefaultPullAction, 1, 7);
             this.tlpnlBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
             this.tlpnlBehaviour.Location = new System.Drawing.Point(8, 21);
             this.tlpnlBehaviour.Name = "tlpnlBehaviour";
-            this.tlpnlBehaviour.RowCount = 8;
+            this.tlpnlBehaviour.RowCount = 9;
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -297,7 +301,8 @@
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlBehaviour.Size = new System.Drawing.Size(1302, 193);
+            this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlBehaviour.Size = new System.Drawing.Size(1172, 220);
             this.tlpnlBehaviour.TabIndex = 0;
             // 
             // chkFollowRenamesInFileHistoryExact
@@ -504,6 +509,25 @@
             this.llblTelemetryPrivacyLink.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.llblTelemetryPrivacyLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlblTelemetryPrivacyLink_LinkClicked);
             // 
+            // lblDefaultPullAction
+            // 
+            this.lblDefaultPullAction.AutoSize = true;
+            this.lblDefaultPullAction.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblDefaultPullAction.Location = new System.Drawing.Point(3, 167);
+            this.lblDefaultPullAction.Name = "lblDefaultPullAction";
+            this.lblDefaultPullAction.Size = new System.Drawing.Size(264, 27);
+            this.lblDefaultPullAction.TabIndex = 13;
+            this.lblDefaultPullAction.Text = "Default pull action";
+            this.lblDefaultPullAction.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // cboDefaultPullAction
+            // 
+            this.cboDefaultPullAction.FormattingEnabled = true;
+            this.cboDefaultPullAction.Location = new System.Drawing.Point(273, 170);
+            this.cboDefaultPullAction.Name = "cboDefaultPullAction";
+            this.cboDefaultPullAction.Size = new System.Drawing.Size(121, 21);
+            this.cboDefaultPullAction.TabIndex = 14;
+            // 
             // GeneralSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -565,5 +589,7 @@
         private System.Windows.Forms.TableLayoutPanel tlpnlTelemetry;
         private System.Windows.Forms.CheckBox chkTelemetry;
         private System.Windows.Forms.LinkLabel llblTelemetryPrivacyLink;
+        private System.Windows.Forms.Label lblDefaultPullAction;
+        private System.Windows.Forms.ComboBox cboDefaultPullAction;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -5,11 +5,19 @@ using System.IO;
 using System.Linq;
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class GeneralSettingsPage : SettingsPageWithHeader
     {
+        private readonly TranslationString _openPullDialog = new TranslationString("Open pull dialog");
+        private readonly TranslationString _pullMerge = new TranslationString("Pull - merge");
+        private readonly TranslationString _pullRebase = new TranslationString("Pull - rebase");
+        private readonly TranslationString _fetch = new TranslationString("Fetch");
+        private readonly TranslationString _fetchAll = new TranslationString("Fetch all");
+        private readonly TranslationString _fetchAndPruneAll = new TranslationString("Fetch and prune all");
+
         public GeneralSettingsPage()
         {
             InitializeComponent();
@@ -32,6 +40,20 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                                                      .ToArray();
                 cbDefaultCloneDestination.Items.AddRange(historicPaths);
             });
+
+            var pullActions = new[]
+            {
+                new { Key = _openPullDialog, Value = AppSettings.PullAction.None },
+                new { Key = _pullMerge, Value = AppSettings.PullAction.Merge },
+                new { Key = _pullRebase, Value = AppSettings.PullAction.Rebase },
+                new { Key = _fetch, Value = AppSettings.PullAction.Fetch },
+                new { Key = _fetchAll, Value = AppSettings.PullAction.FetchAll },
+                new { Key = _fetchAndPruneAll, Value = AppSettings.PullAction.FetchPruneAll },
+            };
+            cboDefaultPullAction.DisplayMember = "Key";
+            cboDefaultPullAction.ValueMember = "Value";
+            cboDefaultPullAction.DataSource = pullActions;
+            cboDefaultPullAction.SelectedIndex = 0;
         }
 
         public static SettingsPageReference GetPageReference()
@@ -73,6 +95,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowGitCommandLine.Checked = AppSettings.ShowGitCommandLine;
             chkUseFastChecks.Checked = AppSettings.UseFastChecks;
             cbDefaultCloneDestination.Text = AppSettings.DefaultCloneDestinationPath;
+            cboDefaultPullAction.SelectedValue
+                = AppSettings.DefaultPullAction != AppSettings.PullAction.Default ?
+                  AppSettings.DefaultPullAction : AppSettings.PullAction.None;
             chkFollowRenamesInFileHistoryExact.Checked = AppSettings.FollowRenamesInFileHistoryExactOnly;
             SetSubmoduleStatus();
 
@@ -98,6 +123,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowSubmoduleStatus = chkShowSubmoduleStatusInBrowse.Checked;
 
             AppSettings.DefaultCloneDestinationPath = cbDefaultCloneDestination.Text;
+            AppSettings.DefaultPullAction = (AppSettings.PullAction)cboDefaultPullAction.SelectedValue;
             AppSettings.FollowRenamesInFileHistoryExactOnly = chkFollowRenamesInFileHistoryExact.Checked;
 
             AppSettings.TelemetryEnabled = chkTelemetry.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7125,6 +7125,30 @@ Context menu for additional operations</source>
         <source>General</source>
         <target />
       </trans-unit>
+      <trans-unit id="_fetch.Text">
+        <source>Fetch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_fetchAll.Text">
+        <source>Fetch all</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_fetchAndPruneAll.Text">
+        <source>Fetch and prune all</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_openPullDialog.Text">
+        <source>Open pull dialog</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_pullMerge.Text">
+        <source>Pull - merge</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_pullRebase.Text">
+        <source>Pull - rebase</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnDefaultDestinationBrowse.Text">
         <source>Browse</source>
         <target />
@@ -7207,6 +7231,10 @@ Context menu for additional operations</source>
       </trans-unit>
       <trans-unit id="lblDefaultCloneDestination.Text">
         <source>Default clone destination</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblDefaultPullAction.Text">
+        <source>Default pull action</source>
         <target />
       </trans-unit>
       <trans-unit id="lblQuickSearchTimeout.Text">


### PR DESCRIPTION
Fixes #6443 


## Proposed changes

- Add "default pull action" config in setting dialog


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![before](https://user-images.githubusercontent.com/11786151/61998527-2158a380-b0e4-11e9-9996-dc9aa2f0758f.png)

### After
![after](https://user-images.githubusercontent.com/11786151/61998632-67facd80-b0e5-11e9-94e0-9e3277012e68.png)

## Test methodology <!-- How did you ensure quality? -->

- Use the new combo box to set a pull action and back to the main window to check if the pull button on toolbar shows the correct action icon. And then click the button to see if the action we set is triggered.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.22.0.windows.1
- Windows 10 build 18362.239

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
