### PR TITLE
improved validation on create new repository dialog

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/FormInitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormInitTests.cs
@@ -67,6 +67,38 @@ namespace GitUITests.CommandsDialogs.CommitDialog
                 null);
         }
 
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("    ")]
+        [TestCase(@"c:\foo*\bar?\")]
+        [TestCase(@"foo\bar")]
+        public void IsRootedDirectoryPath_should_detect_invalid_paths(string input)
+        {
+            var currentDir = "bla";
+            RunFormTest(
+                form =>
+                {
+                    Assert.IsFalse(form.GetTestAccessor().IsRootedDirectoryPath(input));
+                },
+                currentDir);
+        }
+
+        [TestCase(@"c:\foo\bar")]
+        [TestCase(@"c:\foo\bar\")]
+        [TestCase(@"c:")]
+        [TestCase(@"c:\foo\bar")]
+        [TestCase(@"  c:\foo\bar  ")]
+        public void IsRootedDirectoryPath_returns_true_on_valid_paths(string input)
+        {
+            var currentDir = "bla";
+            RunFormTest(
+                form =>
+                {
+                    Assert.IsTrue(form.GetTestAccessor().IsRootedDirectoryPath(input));
+                },
+                currentDir);
+        }
+
         private void RunFormTest(Action<FormInit> testDriver, string path)
         {
             RunFormTest(


### PR DESCRIPTION
Fixes #6955


## Proposed changes

- on the create new repository dialog I've improved the directory textbox validation in order to prevent the crash described in #6955 

## Test methodology 

- Manual tests
- Added some unit tests for the path validator

## Test environment(s) 

- Git Extensions 3.1.1.6049
- Build 2f872105b4eb42421d9fdafd68e90a9e27d20d96
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.7.3416.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
