### PR TITLE
fix: Illegal characters in path

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1355,6 +1355,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
+      <trans-unit id="_error.Text">
+        <source>Error</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_largeFileSizeWarning.Text">
         <source>This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.</source>
         <target />


### PR DESCRIPTION

Closes #6982



## Proposed changes

- Do not crash the app if a repository contains illegal characters.



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/62410143-1e4e3d80-b625-11e9-978f-15e668784bf4.png)


### After

![image](https://user-images.githubusercontent.com/4403806/62410125-d7f8de80-b624-11e9-9590-d8214319279b.png)



## Test methodology <!-- How did you ensure quality? -->

- clone the reported repo and reproduce the issue
- apply the fix and confirm the app no longer crashes


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
