### PR TITLE
Replace git-diff patience with histogram

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2266,7 +2266,7 @@ namespace GitCommands
             {
                 "--no-color",
                 extraDiffArguments,
-                { AppSettings.UsePatienceDiffAlgorithm, "--patience" },
+                { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                 "-M -C",
                 diffOptions
             };
@@ -2577,7 +2577,7 @@ namespace GitCommands
                     "--no-color",
                     { staged, "-M -C --cached" },
                     extraDiffArguments,
-                    { AppSettings.UsePatienceDiffAlgorithm, "--patience" },
+                    { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                     "--",
                     fileName.ToPosixPath().Quote(),
                     { staged, oldFileName?.ToPosixPath().Quote() }
@@ -3914,7 +3914,7 @@ namespace GitCommands
                 "--no-commit-id",
                 extraArgs,
                 revisionOfMergeCommit.Guid,
-                { AppSettings.UsePatienceDiffAlgorithm, "--patience" },
+                { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                 "--",
                 filePath.ToPosixPath().Quote()
             };

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -337,8 +337,9 @@ namespace GitCommands
             set => SetBool("applypatchignorewhitespace", value);
         }
 
-        public static bool UsePatienceDiffAlgorithm
+        public static bool UseHistogramDiffAlgorithm
         {
+            // The settings key has patience in the name for historical reasons
             get => GetBool("usepatiencediffalgorithm", false);
             set => SetBool("usepatiencediffalgorithm", value);
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -50,7 +50,7 @@
             this.cbDefaultCloneDestination = new System.Windows.Forms.ComboBox();
             this.chkShowGitCommandLine = new System.Windows.Forms.CheckBox();
             this.lblDefaultCloneDestination = new System.Windows.Forms.Label();
-            this.chkUsePatienceDiffAlgorithm = new System.Windows.Forms.CheckBox();
+            this.chkUseHistogramDiffAlgorithm = new System.Windows.Forms.CheckBox();
             this.chkStashUntrackedFiles = new System.Windows.Forms.CheckBox();
             this.chkStartWithRecentWorkingDir = new System.Windows.Forms.CheckBox();
             this.chkFollowRenamesInFileHistory = new System.Windows.Forms.CheckBox();
@@ -283,7 +283,7 @@
             this.tlpnlBehaviour.Controls.Add(this.cbDefaultCloneDestination, 1, 6);
             this.tlpnlBehaviour.Controls.Add(this.chkShowGitCommandLine, 0, 1);
             this.tlpnlBehaviour.Controls.Add(this.lblDefaultCloneDestination, 0, 6);
-            this.tlpnlBehaviour.Controls.Add(this.chkUsePatienceDiffAlgorithm, 0, 2);
+            this.tlpnlBehaviour.Controls.Add(this.chkUseHistogramDiffAlgorithm, 0, 2);
             this.tlpnlBehaviour.Controls.Add(this.chkStashUntrackedFiles, 0, 3);
             this.tlpnlBehaviour.Controls.Add(this.chkStartWithRecentWorkingDir, 0, 5);
             this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistory, 0, 4);
@@ -412,16 +412,16 @@
             this.lblDefaultCloneDestination.Text = "Default clone destination";
             this.lblDefaultCloneDestination.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // chkUsePatienceDiffAlgorithm
+            // chkUseHistogramDiffAlgorithm
             // 
-            this.chkUsePatienceDiffAlgorithm.AutoSize = true;
-            this.chkUsePatienceDiffAlgorithm.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkUsePatienceDiffAlgorithm.Location = new System.Drawing.Point(3, 49);
-            this.chkUsePatienceDiffAlgorithm.Name = "chkUsePatienceDiffAlgorithm";
-            this.chkUsePatienceDiffAlgorithm.Size = new System.Drawing.Size(264, 17);
-            this.chkUsePatienceDiffAlgorithm.TabIndex = 2;
-            this.chkUsePatienceDiffAlgorithm.Text = "Use patience diff algorithm";
-            this.chkUsePatienceDiffAlgorithm.UseVisualStyleBackColor = true;
+            this.chkUseHistogramDiffAlgorithm.AutoSize = true;
+            this.chkUseHistogramDiffAlgorithm.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkUseHistogramDiffAlgorithm.Location = new System.Drawing.Point(3, 49);
+            this.chkUseHistogramDiffAlgorithm.Name = "chkUseHistogramDiffAlgorithm";
+            this.chkUseHistogramDiffAlgorithm.Size = new System.Drawing.Size(264, 17);
+            this.chkUseHistogramDiffAlgorithm.TabIndex = 2;
+            this.chkUseHistogramDiffAlgorithm.Text = "Use histogram diff algorithm";
+            this.chkUseHistogramDiffAlgorithm.UseVisualStyleBackColor = true;
             // 
             // chkStashUntrackedFiles
             // 
@@ -567,7 +567,7 @@
         private System.Windows.Forms.NumericUpDown RevisionGridQuickSearchTimeout;
         private System.Windows.Forms.CheckBox chkStashUntrackedFiles;
         private System.Windows.Forms.Label lblQuickSearchTimeout;
-        private System.Windows.Forms.CheckBox chkUsePatienceDiffAlgorithm;
+        private System.Windows.Forms.CheckBox chkUseHistogramDiffAlgorithm;
         private System.Windows.Forms.CheckBox chkFollowRenamesInFileHistory;
         private System.Windows.Forms.GroupBox groupBoxPerformance;
         private System.Windows.Forms.CheckBox chkCheckForUncommittedChangesInCheckoutBranch;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -80,7 +80,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             chkCheckForUncommittedChangesInCheckoutBranch.Checked = AppSettings.CheckForUncommittedChangesInCheckoutBranch;
             chkStartWithRecentWorkingDir.Checked = AppSettings.StartWithRecentWorkingDir;
-            chkUsePatienceDiffAlgorithm.Checked = AppSettings.UsePatienceDiffAlgorithm;
+            chkUseHistogramDiffAlgorithm.Checked = AppSettings.UseHistogramDiffAlgorithm;
             RevisionGridQuickSearchTimeout.Value = AppSettings.RevisionGridQuickSearchTimeout;
             chkFollowRenamesInFileHistory.Checked = AppSettings.FollowRenamesInFileHistory;
             chkStashUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInAutoStash;
@@ -108,7 +108,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             AppSettings.CheckForUncommittedChangesInCheckoutBranch = chkCheckForUncommittedChangesInCheckoutBranch.Checked;
             AppSettings.StartWithRecentWorkingDir = chkStartWithRecentWorkingDir.Checked;
-            AppSettings.UsePatienceDiffAlgorithm = chkUsePatienceDiffAlgorithm.Checked;
+            AppSettings.UseHistogramDiffAlgorithm = chkUseHistogramDiffAlgorithm.Checked;
             AppSettings.IncludeUntrackedFilesInAutoStash = chkStashUntrackedFiles.Checked;
             AppSettings.FollowRenamesInFileHistory = chkFollowRenamesInFileHistory.Checked;
             AppSettings.ShowGitStatusInBrowseToolbar = chkShowGitStatusInToolbar.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7209,8 +7209,8 @@ Context menu for additional operations</source>
         <source>Use FileSystemWatcher to check if index is changed</source>
         <target />
       </trans-unit>
-      <trans-unit id="chkUsePatienceDiffAlgorithm.Text">
-        <source>Use patience diff algorithm</source>
+      <trans-unit id="chkUseHistogramDiffAlgorithm.Text">
+        <source>Use histogram diff algorithm</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBoxBehaviour.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6991 

## Proposed changes

Use --histogram instead of --patience for the setting.
See issue for motivation.

TBD Is a setting tooltip required?
If so, a proposal
```
Use --histogram for git-diff, replacing the default algorithm as well as the git config diff.algorithm option.
```

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/62715423-c2a6fa00-ba00-11e9-9ac6-348c41f61b9b.png)

### After

![image](https://user-images.githubusercontent.com/6248932/62715466-da7e7e00-ba00-11e9-87d9-5cea4fc667f2.png)

## Test methodology <!-- How did you ensure quality? -->
Check the Git Command log that --histogram is used instead of --patience.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
