### PR TITLE
Fix: Commit Dialog Spell Checker

### DIFF
--- a/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/GitUI/SpellChecker/TextBoxHelper.cs
@@ -23,7 +23,7 @@ namespace GitUI.SpellChecker
 
             var lineNumber = rtb.GetLineFromCharIndex(index);
             var lineIndex = NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINEINDEX, new IntPtr(lineNumber), IntPtr.Zero).ToInt32();
-            var lineLength = NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINELENGTH, new IntPtr(lineNumber), IntPtr.Zero).ToInt32();
+            var lineLength = NativeMethods.SendMessageInt(rtb.Handle, NativeMethods.EM_LINELENGTH, new IntPtr(index), IntPtr.Zero).ToInt32();
 
             var charRange = new NativeMethods.CHARRANGE
             {


### PR DESCRIPTION
Fixes #6895


## Proposed changes
- "EM_LINELENGTH message" expects a character index and not a line index: https://docs.microsoft.com/en-us/windows/win32/controls/em-linelength
- This messed up the highlighting in the commit window


## Screenshots
### Before
![before](https://user-images.githubusercontent.com/26045339/62821017-c5732d80-bb6d-11e9-8cc1-2a3cc90584ae.png)

### After
![after](https://user-images.githubusercontent.com/26045339/62821009-9d83ca00-bb6d-11e9-8ab7-b7c66687ff3d.png)


## Test methodology 
- Manual


## Test environment(s) 
- Git Extensions 3.2.0
- Build 79324b84f01fd3ba5dd0276228dee6e38372c0f7 (Dirty)
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
