### PR TITLE
TortoiseGitMerge.exe old default name

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -158,7 +158,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 case "semanticdiff":
                     return "semanticmergetool.exe";
                 case "tmerge":
-                    return "TortoiseMerge.exe";
+                    return "TortoiseGitMerge.exe";
                 case "winmerge":
                     return "winmergeu.exe";
                 case "vsdiffmerge":
@@ -199,10 +199,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     folder = Path.Combine(folder, @"PlasticSCM4\semanticmerge\");
                     return FindFileInFolders(exeName, folder);
                 case "tmerge":
-                    exeName = "TortoiseGitMerge.exe"; // TortoiseGit 1.8 use new names
                     string difftoolPath = FindFileInFolders(exeName, @"TortoiseGit\bin\");
                     if (string.IsNullOrEmpty(difftoolPath))
                     {
+                        // TortoiseGit <1.8 (2013), TortoiseSVN
                         exeName = "TortoiseMerge.exe";
                         difftoolPath = FindFileInFolders(exeName, @"TortoiseGit\bin\", @"TortoiseSVN\bin\");
                     }
@@ -266,19 +266,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             string mergeTool = mergeToolText.ToLowerInvariant();
             var exeName = GetDiffToolExeFile(mergeTool);
-            if (exeName != null)
-            {
-                return exeName;
-            }
 
-            switch (mergeTool)
-            {
-                case "tortoisemerge":
-                    return "TortoiseMerge.exe";
-            }
-
-            return null;
-        }
+            return exeName;
+         }
 
         public static string FindMergeToolFullPath(ConfigFileSettingsSet settings, string mergeToolText, out string exeName)
         {
@@ -319,10 +309,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     folder = Path.Combine(folder, @"PlasticSCM4\semanticmerge\");
                     return FindFileInFolders(exeName, folder);
                 case "tortoisemerge":
-                    exeName = "TortoiseGitMerge.exe"; // TortoiseGit 1.8 use new names
                     string path = FindFileInFolders(exeName, @"TortoiseGit\bin\");
                     if (string.IsNullOrEmpty(path))
                     {
+                        // TortoiseGit <1.8 (2013), TortoiseSVN
                         exeName = "TortoiseMerge.exe";
                         path = FindFileInFolders(exeName, @"TortoiseGit\bin\", @"TortoiseSVN\bin\");
                     }


### PR DESCRIPTION

## Proposed changes

TortoiseGit changed the name of the Git/Merge executable in v1.8 (2013).
TortoiseMerge.exe -> TortoiseGitMerge.exe

When selecting tmerge as difftool (or TortoiseMerge as mergetool) and clicking Browse, GE searced for the old executable name, changed in 2013.
Using Suggest was OK.

Note: There is still compatibility when selecting Suggest to select tgit <1.8 or TortoiseSVN if no TortoiseGit >=1.8. This could be removed. I added a comment, this could be removed.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/62821141-53e8ae80-bb70-11e9-9de6-54b9ab6bf829.png)

### After

![image](https://user-images.githubusercontent.com/6248932/62821155-97dbb380-bb70-11e9-8657-3ef525d47846.png)

## Test methodology 
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
