### PR TITLE
Fix: Keep push dialog open on failure (#6367)

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -204,7 +204,7 @@ namespace GitUI.CommandsDialogs
 
         private void PushClick(object sender, EventArgs e)
         {
-            DialogResult = PushChanges(this) ? DialogResult.OK : DialogResult.Abort;
+            DialogResult = PushChanges(this) ? DialogResult.OK : DialogResult.None;
         }
 
         private void BindRemotesDropDown(string selectedRemoteName)


### PR DESCRIPTION
Fixes #6367 


## Proposed changes
When the Push-Dialog is open and an error occured after clicking "Push", the Push-Dialog will stay open to allow the user to take changes that may lead to a succesfull push. Only a succesfull push will make the dialog close.

## Test methodology
- Manual

## Test environment(s)
- Git Extensions 3.2.0
- Build fafe69557b0f9e79603b7f42bb1448fb3dc8d9a0 (Dirty)
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
