### PR TITLE
Remove KDiff3 hardcoding

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -558,33 +558,21 @@ namespace GitUI.CommandsDialogs
                 _mergetoolCmd = Module.GetEffectiveSetting($"mergetool.{_mergetool}.cmd");
                 _mergetoolPath = Module.GetEffectiveSetting($"mergetool.{_mergetool}.path");
 
-                if (_mergetool == "kdiff3")
+                if (string.IsNullOrWhiteSpace(_mergetoolCmd) && string.IsNullOrWhiteSpace(_mergetoolPath))
                 {
-                    if (string.IsNullOrEmpty(_mergetoolPath))
-                    {
-                        _mergetoolPath = "kdiff3";
-                    }
-
-                    _mergetoolCmd = "\"$BASE\" \"$LOCAL\" \"$REMOTE\" -o \"$MERGED\"";
+                    MessageBox.Show(this, _noMergeToolConfigured.Text, _errorCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return false;
                 }
-                else
-                {
-                    if (string.IsNullOrWhiteSpace(_mergetoolCmd) && string.IsNullOrWhiteSpace(_mergetoolPath))
-                    {
-                        MessageBox.Show(this, _noMergeToolConfigured.Text, _errorCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        return false;
-                    }
 
-                    if (EnvUtils.RunningOnWindows())
+                if (EnvUtils.RunningOnWindows())
+                {
+                    // This only works when on Windows....
+                    const string executablePattern = ".exe";
+                    int idx = _mergetoolCmd.IndexOf(executablePattern);
+                    if (idx >= 0)
                     {
-                        // This only works when on Windows....
-                        const string executablePattern = ".exe";
-                        int idx = _mergetoolCmd.IndexOf(executablePattern);
-                        if (idx >= 0)
-                        {
-                            _mergetoolPath = _mergetoolCmd.Substring(0, idx + executablePattern.Length + 1).Trim('\"', ' ');
-                            _mergetoolCmd = _mergetoolCmd.Substring(idx + executablePattern.Length + 1);
-                        }
+                        _mergetoolPath = _mergetoolCmd.Substring(0, idx + executablePattern.Length + 1).Trim('\"', ' ');
+                        _mergetoolCmd = _mergetoolCmd.Substring(idx + executablePattern.Length + 1);
                     }
                 }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -29,8 +29,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             bool valid = SolveGitCommand();
             valid = SolveLinuxToolsDir() && valid;
-            valid = SolveMergeToolForKDiff() && valid;
-            valid = SolveDiffToolForKDiff() && valid;
             valid = SolveGitExtensionsDir() && valid;
             valid = SolveEditor() && valid;
 
@@ -234,40 +232,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             return PathUtil.TryFindFullPath(fileName, out _);
         }
 
-        public bool SolveMergeToolForKDiff()
-        {
-            string mergeTool = CommonLogic.GetGlobalMergeTool();
-            if (string.IsNullOrEmpty(mergeTool))
-            {
-                mergeTool = "kdiff3";
-                GlobalConfigFileSettings.SetValue("merge.tool", mergeTool);
-            }
-
-            if (mergeTool.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase))
-            {
-                return SolveMergeToolPathForKDiff();
-            }
-
-            return true;
-        }
-
-        public bool SolveDiffToolForKDiff()
-        {
-            string diffTool = GetDiffToolFromConfig(GlobalConfigFileSettings);
-            if (string.IsNullOrEmpty(diffTool))
-            {
-                diffTool = "kdiff3";
-                SetDiffToolToConfig(GlobalConfigFileSettings, diffTool);
-            }
-
-            if (diffTool.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase))
-            {
-                return SolveDiffToolPathForKDiff();
-            }
-
-            return true;
-        }
-
         public static string GetDiffToolFromConfig(ConfigFileSettings settings)
         {
             return settings.GetValue("diff.guitool");
@@ -276,30 +240,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public static void SetDiffToolToConfig(ConfigFileSettings settings, string diffTool)
         {
             settings.SetValue("diff.guitool", diffTool);
-        }
-
-        public bool SolveDiffToolPathForKDiff()
-        {
-            string kdiff3path = MergeToolsHelper.FindPathForKDiff(GlobalConfigFileSettings.GetValue("difftool.kdiff3.path"));
-            if (string.IsNullOrEmpty(kdiff3path))
-            {
-                return false;
-            }
-
-            GlobalConfigFileSettings.SetPathValue("difftool.kdiff3.path", kdiff3path);
-            return true;
-        }
-
-        public bool SolveMergeToolPathForKDiff()
-        {
-            string kdiff3path = MergeToolsHelper.FindPathForKDiff(GlobalConfigFileSettings.GetValue("mergetool.kdiff3.path"));
-            if (string.IsNullOrEmpty(kdiff3path))
-            {
-                return false;
-            }
-
-            GlobalConfigFileSettings.SetPathValue("mergetool.kdiff3.path", kdiff3path);
-            return true;
         }
 
         public bool CanFindGitCmd()

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -100,42 +100,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         }
 
         [CanBeNull]
-        public static string FindPathForKDiff(string pathFromConfig)
-        {
-            if (string.IsNullOrEmpty(pathFromConfig) || !File.Exists(pathFromConfig))
-            {
-                string kdiff3path = pathFromConfig;
-                if (EnvUtils.RunningOnUnix())
-                {
-                    // Maybe command -v is better, but didn't work
-                    kdiff3path = new Executable("which").GetOutput("kdiff3").Replace("\n", "");
-                    if (string.IsNullOrEmpty(kdiff3path))
-                    {
-                        return null;
-                    }
-                }
-                else if (EnvUtils.RunningOnWindows())
-                {
-                    string regkdiff3path = GetRegistryValue(Registry.LocalMachine, "SOFTWARE\\KDiff3", "");
-                    if (regkdiff3path != "")
-                    {
-                        regkdiff3path += "\\kdiff3.exe";
-                    }
-
-                    kdiff3path = FindFileInFolders("kdiff3.exe", @"KDiff3\", regkdiff3path);
-                    if (string.IsNullOrEmpty(kdiff3path))
-                    {
-                        return null;
-                    }
-                }
-
-                return kdiff3path;
-            }
-
-            return null;
-        }
-
-        [CanBeNull]
         public static string GetDiffToolExeFile(string difftoolText)
         {
             string diffTool = difftoolText.ToLowerInvariant();
@@ -229,6 +193,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             return FindFileInFolders(exeName, paths);
         }
 
+        /// <summary>
+        /// Get the suggested parameters for known difftools
+        /// This should probably be replaced with the built in Git handling instead
+        /// </summary>
+        /// <param name="diffToolText">The difftool</param>
+        /// <param name="exeFile">The executable</param>
+        /// <returns>The suggested parameters</returns>
         public static string DiffToolCmdSuggest(string diffToolText, string exeFile)
         {
             string diffTool = diffToolText.ToLowerInvariant();
@@ -333,11 +304,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         public static string MergeToolcmdSuggest(string mergeToolText, string exeFile)
         {
             string mergeTool = mergeToolText.ToLowerInvariant();
-            switch (mergeTool)
-            {
-                case "kdiff3":
-                    return "";
-            }
 
             return AutoConfigMergeToolCmd(mergeToolText, exeFile);
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -50,7 +50,7 @@
             this.label19 = new System.Windows.Forms.Label();
             this.BrowseMergeTool = new System.Windows.Forms.Button();
             this._NO_TRANSLATE_GlobalMergeTool = new System.Windows.Forms.ComboBox();
-            this.PathToKDiff3 = new System.Windows.Forms.Label();
+            this.MergeToolPathLabel = new System.Windows.Forms.Label();
             this.MergetoolPath = new System.Windows.Forms.TextBox();
             this.GlobalKeepMergeBackup = new System.Windows.Forms.CheckBox();
             this.label7 = new System.Windows.Forms.Label();
@@ -360,16 +360,16 @@
             this._NO_TRANSLATE_GlobalMergeTool.TabIndex = 3;
             this._NO_TRANSLATE_GlobalMergeTool.TextChanged += new System.EventHandler(this.GlobalMergeTool_TextChanged);
             // 
-            // PathToKDiff3
+            // MergeToolPathLabel
             // 
-            this.PathToKDiff3.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.PathToKDiff3.AutoSize = true;
-            this.PathToKDiff3.Location = new System.Drawing.Point(4, 153);
-            this.PathToKDiff3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.PathToKDiff3.Name = "PathToKDiff3";
-            this.PathToKDiff3.Size = new System.Drawing.Size(135, 19);
-            this.PathToKDiff3.TabIndex = 59;
-            this.PathToKDiff3.Text = "Path to mergetool";
+            this.MergeToolPathLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.MergeToolPathLabel.AutoSize = true;
+            this.MergeToolPathLabel.Location = new System.Drawing.Point(4, 153);
+            this.MergeToolPathLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.MergeToolPathLabel.Name = "MergeToolPathLabel";
+            this.MergeToolPathLabel.Size = new System.Drawing.Size(135, 19);
+            this.MergeToolPathLabel.TabIndex = 59;
+            this.MergeToolPathLabel.Text = "Path to mergetool";
             // 
             // MergetoolPath
             // 
@@ -570,7 +570,7 @@
             this.tableLayoutPanelGitConfig.Controls.Add(this.DifftoolCmd, 1, 9);
             this.tableLayoutPanelGitConfig.Controls.Add(this._NO_TRANSLATE_GlobalMergeTool, 1, 3);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label48, 0, 9);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.PathToKDiff3, 0, 4);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.MergeToolPathLabel, 0, 4);
             this.tableLayoutPanelGitConfig.Controls.Add(this.MergetoolPath, 1, 4);
             this.tableLayoutPanelGitConfig.Controls.Add(this.DifftoolPath, 1, 8);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label42, 0, 8);
@@ -665,7 +665,7 @@
         private System.Windows.Forms.Label label19;
         private System.Windows.Forms.Button BrowseMergeTool;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_GlobalMergeTool;
-        private System.Windows.Forms.Label PathToKDiff3;
+        private System.Windows.Forms.Label MergeToolPathLabel;
         private System.Windows.Forms.TextBox MergetoolPath;
         private System.Windows.Forms.CheckBox GlobalKeepMergeBackup;
         private System.Windows.Forms.Label label7;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -51,9 +51,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             GlobalKeepMergeBackup.Enabled = canFindGitCmd;
             InvalidGitPathGlobal.Visible = !canFindGitCmd;
 
-            var isKdiff3 = _NO_TRANSLATE_GlobalMergeTool.Text.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase);
-
-            MergeToolCmd.Enabled = !isKdiff3 || !string.IsNullOrEmpty(MergeToolCmd.Text);
+            MergeToolCmd.Enabled = !string.IsNullOrEmpty(MergeToolCmd.Text);
         }
 
         protected override void SettingsToPage()
@@ -146,9 +144,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             MergetoolPath.Text = CurrentSettings.GetValue($"mergetool.{mergeTool}.path");
             MergeToolCmd.Text = CurrentSettings.GetValue($"mergetool.{mergeTool}.cmd");
 
-            var isKdiff3 = mergeTool.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase);
-
-            MergeToolCmd.Enabled = !isKdiff3 || !string.IsNullOrEmpty(MergeToolCmd.Text);
+            MergeToolCmd.Enabled = !string.IsNullOrEmpty(MergeToolCmd.Text);
 
             MergeToolCmdSuggest_Click(null, null);
         }
@@ -194,23 +190,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             MergetoolPath.SelectedText = exeFile;
             MergeToolCmd.SelectAll();
             MergeToolCmd.SelectedText = MergeToolsHelper.MergeToolcmdSuggest(_NO_TRANSLATE_GlobalMergeTool.Text, exeFile);
-        }
-
-        private void ResolveDiffToolPath()
-        {
-            string kdiff3Path = MergeToolsHelper.FindPathForKDiff(CurrentSettings.GetValue("difftool.kdiff3.path"));
-            if (string.IsNullOrEmpty(kdiff3Path))
-            {
-                return;
-            }
-
-            kdiff3Path = MergeToolsHelper.FindFileInFolders("kdiff3.exe", MergetoolPath.Text);
-            if (string.IsNullOrEmpty(kdiff3Path))
-            {
-                return;
-            }
-
-            DifftoolPath.Text = kdiff3Path;
         }
 
         private void DiffToolCmdSuggest_Click(object sender, EventArgs e)
@@ -278,11 +257,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             string diffTool = _NO_TRANSLATE_GlobalDiffTool.Text.Trim();
             DifftoolPath.Text = CurrentSettings.GetValue($"difftool.{diffTool}.path");
             DifftoolCmd.Text = CurrentSettings.GetValue($"difftool.{diffTool}.cmd");
-
-            if (diffTool.Equals("kdiff3", StringComparison.CurrentCultureIgnoreCase))
-            {
-                ResolveDiffToolPath();
-            }
 
             DiffToolCmdSuggest_Click(null, null);
         }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -510,7 +510,7 @@ A valid GitHub account is required</source>
         <target />
       </trans-unit>
       <trans-unit id="_adviceDiffToolConfiguration.Text">
-        <source>You should configure a diff tool to show file diff in external program (kdiff3 for example).</source>
+        <source>You should configure a diff tool to show file diff in external program.</source>
         <target />
       </trans-unit>
       <trans-unit id="_cantRegisterShellExtension.Text">
@@ -518,7 +518,7 @@ A valid GitHub account is required</source>
         <target />
       </trans-unit>
       <trans-unit id="_configureMergeTool.Text">
-        <source>You need to configure merge tool in order to solve merge conflicts (kdiff3 for example).</source>
+        <source>You need to configure merge tool in order to solve merge conflicts.</source>
         <target />
       </trans-unit>
       <trans-unit id="_customMergeToolXConfigured.Text">
@@ -553,27 +553,6 @@ A valid GitHub account is required</source>
         <source>Git {0} is found on your computer.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_kdiff3NotFoundAuto.Text">
-        <source>Path to kdiff3 could not be found automatically.
-Please make sure KDiff3 is installed or set path manually.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_kdiffAsDiffConfigured.Text">
-        <source>KDiff3 is configured as difftool.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_kdiffAsDiffConfiguredButNotFound.Text">
-        <source>KDiff3 is configured as difftool, but the path to kdiff.exe is not configured.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_kdiffAsMergeConfigured.Text">
-        <source>KDiff3 is configured as mergetool.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_kdiffAsMergeConfiguredButNotFound.Text">
-        <source>KDiff3 is configured as mergetool, but the path to kdiff.exe is not configured.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_languageConfigured.Text">
         <source>The configured language is {0}.</source>
         <target />
@@ -603,11 +582,6 @@ Please make sure there are linux tools installed (through Git for Windows or cyg
         <source>{0} is configured as mergetool, this is a custom mergetool and needs a custom cmd to be configured.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_noDiffToolConfigured.Text">
-        <source>There is no difftool configured. Do you want to configure kdiff3 as your difftool?
-Select no if you want to configure a different difftool yourself.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_noDiffToolConfiguredCaption.Text">
         <source>Difftool</source>
         <target />
@@ -618,15 +592,6 @@ Select no if you want to configure a different difftool yourself.</source>
       </trans-unit>
       <trans-unit id="_noLanguageConfigured.Text">
         <source>There is no language configured for Git Extensions.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_noMergeToolConfigured.Text">
-        <source>There is no mergetool configured. Do you want to configure kdiff3 as your mergetool?
-Select no if you want to configure a different mergetool yourself.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_noMergeToolConfiguredCaption.Text">
-        <source>Mergetool</source>
         <target />
       </trans-unit>
       <trans-unit id="_notRecommendedGitVersion.Text">
@@ -7297,7 +7262,7 @@ Context menu for additional operations</source>
         <source>Suggest</source>
         <target />
       </trans-unit>
-      <trans-unit id="PathToKDiff3.Text">
+      <trans-unit id="MergeToolPathLabel.Text">
         <source>Path to mergetool</source>
         <target />
       </trans-unit>


### PR DESCRIPTION
Refactoring
Somehow related to #5919

GE has a lot of hardcoded support for KDiff3. That made sense when kdiff was bundled with GE but has really no effect now and is just confusing and makes other changes harder.
There is also some duplication of code.

At startup and in the settings form, GE tries to set kdiff3 if no diif or mergetool is set.
(The situation that kdiff3 is a configured tool and that no tool is set is not a use case to optimize for.)

To let Git handle the tools supported (the list in GE is not same as in Git, also diff like tmerge -> tortoisemerge) and to cleanup is another MR.
(as well as better handle custom tools)

This is WIP as it should not be merged before 3.2
Other changes may be added to the PR

## Proposed changes

If no diff or mergetool, send users to the Git config settings form and let the user select manually.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/62839050-32c5b200-bc85-11e9-8120-a888cdd7f2f1.png)

### After

Directly to:

![image](https://user-images.githubusercontent.com/6248932/62839055-48d37280-bc85-11e9-8668-38414f5c48d4.png)


## Test methodology <!-- How did you ensure quality? -->

Remove diff.tool, diff.guitool and merge.tool in .gitconfig.


## Test environment(s) <!-- Remove any that don't apply -->

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
