### PR TITLE
Add scripts for BeforeFetch and AfterFetch

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2221,7 +2221,11 @@ namespace GitUI.CommandsDialogs
         private void QuickFetch()
         {
             ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
-            FormProcess.ShowDialog(this, Module.FetchCmd(string.Empty, string.Empty, string.Empty));
+            var success = FormProcess.ShowDialog(this, Module.FetchCmd(string.Empty, string.Empty, string.Empty));
+            if (!success) 
+            {
+                return;
+            }
             ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
             UICommands.RepoChangedNotifier.Notify();
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2220,7 +2220,9 @@ namespace GitUI.CommandsDialogs
 
         private void QuickFetch()
         {
+            ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
             FormProcess.ShowDialog(this, Module.FetchCmd(string.Empty, string.Empty, string.Empty));
+            ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
             UICommands.RepoChangedNotifier.Notify();
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2222,10 +2222,11 @@ namespace GitUI.CommandsDialogs
         {
             ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
             var success = FormProcess.ShowDialog(this, Module.FetchCmd(string.Empty, string.Empty, string.Empty));
-            if (!success) 
+            if (!success)
             {
                 return;
             }
+
             ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
             UICommands.RepoChangedNotifier.Notify();
         }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -398,7 +398,7 @@ namespace GitUI.CommandsDialogs
                 return DialogResult.No;
             }
 
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforePull);
+            executeBeforeScripts();
 
             var stashed = CalculateStashedValue(owner);
 
@@ -437,7 +437,7 @@ namespace GitUI.CommandsDialogs
                         PopStash();
                     }
 
-                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterPull);
+                    executeAfterScripts();
                 }
             }
 
@@ -555,6 +555,32 @@ namespace GitUI.CommandsDialogs
                 if ((bool)messageBoxResult)
                 {
                     UICommands.StashPop(owner);
+                }
+            }
+
+            void executeBeforeScripts()
+            {
+                if (Fetch.Checked)
+                {
+                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
+                }
+                else
+                {
+                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforePull);
+                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
+                }
+            }
+
+            void executeAfterScripts()
+            {
+                if (Fetch.Checked)
+                {
+                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
+                }
+                else
+                {
+                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
+                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterPull);
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -560,6 +560,7 @@ namespace GitUI.CommandsDialogs
 
             void executeBeforeScripts()
             {
+                // Request to pull/merge in addition to the fetch
                 if (!Fetch.Checked)
                 {
                     ScriptManager.RunEventScripts(this, ScriptEvent.BeforePull);
@@ -572,6 +573,7 @@ namespace GitUI.CommandsDialogs
             {
                 ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
 
+                // Request to pull/merge in addition to the fetch
                 if (!Fetch.Checked)
                 {
                     ScriptManager.RunEventScripts(this, ScriptEvent.AfterPull);

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -560,26 +560,20 @@ namespace GitUI.CommandsDialogs
 
             void executeBeforeScripts()
             {
-                if (Fetch.Checked)
-                {
-                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
-                }
-                else
+                if (!Fetch.Checked)
                 {
                     ScriptManager.RunEventScripts(this, ScriptEvent.BeforePull);
-                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
                 }
+
+                ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
             }
 
             void executeAfterScripts()
             {
-                if (Fetch.Checked)
+                ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
+
+                if (!Fetch.Checked)
                 {
-                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
-                }
-                else
-                {
-                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterFetch);
                     ScriptManager.RunEventScripts(this, ScriptEvent.AfterPull);
                 }
             }

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -14,6 +14,8 @@ namespace GitUI.Script
         ShowInUserMenuBar,
         BeforeCheckout,
         AfterCheckout,
+        BeforeFetch,
+        AfterFetch,
         BeforeMerge,
         AfterMerge
     }

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -14,10 +14,10 @@ namespace GitUI.Script
         ShowInUserMenuBar,
         BeforeCheckout,
         AfterCheckout,
-        BeforeFetch,
-        AfterFetch,
         BeforeMerge,
-        AfterMerge
+        AfterMerge,
+        BeforeFetch,
+        AfterFetch
     }
 
     public class ScriptInfo


### PR DESCRIPTION
Fixes #4909


## Proposed changes
Additional scripts that should be executed before/after fetch can be added.

## Test methodology <!-- How did you ensure quality? -->
Manual


## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 3.2.0
- Build bace57f405cdd2f5675278f88ba2947e8d5bb852
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
