### PR TITLE
Fix potential bad end of line replacement

### DIFF
--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -61,8 +61,9 @@ namespace GitUIPluginInterfaces
                     settingVal = Setting.ValueOrDefault(settings);
                 }
 
+                // for multiline control, transform "\n" in "\r\n" but prevent "\r\n" to be transformed in "\r\r\n"
                 control.Text = control.Multiline
-                    ? settingVal?.Replace("\n", Environment.NewLine)
+                    ? settingVal?.Replace(Environment.NewLine, "\n").Replace("\n", Environment.NewLine)
                     : settingVal;
             }
 


### PR DESCRIPTION
If the value contains a `\r\n`, the result will contain `\r\r\n`
which duplicate blank lines (in multi-line controls) at the loading and each time a settings is changed and saved...


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 3.2.0
- Build 885dbb88d9ed3e02e77b1291df54a634ac159e0e
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

