### PR TITLE
Open jira settings when not configured

### DIFF
--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -62,7 +62,7 @@ namespace JiraCommitHintPlugin
 
         public override bool Execute(GitUIEventArgs args)
         {
-            if (_enabledSettings.ValueOrDefault(Settings))
+            if (!_enabledSettings.ValueOrDefault(Settings))
             {
                 return false;
             }

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -64,6 +64,7 @@ namespace JiraCommitHintPlugin
         {
             if (!_enabledSettings.ValueOrDefault(Settings))
             {
+                args.GitUICommands.StartSettingsDialog(this);
                 return false;
             }
 


### PR DESCRIPTION
## Proposed changes

- Fix a bad check if settings exists
- open the settings if not configured


## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) 

- Git Extensions 3.2.0
- Build 885dbb88d9ed3e02e77b1291df54a634ac159e0e
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

