### PR TITLE
Settings: Display label to the top to make UI more readable on multiline controls

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
+using GitExtUtils.GitUI;
 using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
@@ -126,7 +127,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 {
                     Text = controlBinding.Caption(),
                     AutoSize = true,
-                    Anchor = AnchorStyles.Left
+                    Anchor = AnchorStyles.Left | AnchorStyles.Top,
+                    Margin = new Padding(0, DpiUtil.Scale(2), 0, 0)
                 };
 
                 tableLayout.Controls.Add(label, 0, _currentRow);


### PR DESCRIPTION
## Changes

- Align labels to the top because labels on multiline text fields are misleading...

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/63441316-7fea1680-c431-11e9-9aaa-a5367ffae1a0.png)


### After

![image](https://user-images.githubusercontent.com/460196/63442018-a65c8180-c432-11e9-87c3-550fa24e9d73.png)




## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build eb91b7b1e0643f9bd19ac8f44bbcb8eb797e65d3 (Dirty)
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)
