### PR TITLE
Display icons in commit templates menu items

### DIFF
--- a/GitCommands/CommitTemplateItem.cs
+++ b/GitCommands/CommitTemplateItem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -12,17 +13,20 @@ namespace GitCommands
     {
         public string Name { get; set; }
         public string Text { get; set; }
+        public Image Icon { get; set; }
 
-        public CommitTemplateItem(string name, string text)
+        public CommitTemplateItem(string name, string text, Image icon)
         {
             Name = name;
             Text = text;
+            Icon = icon;
         }
 
         public CommitTemplateItem()
         {
             Name = string.Empty;
             Text = string.Empty;
+            Icon = null;
         }
 
         private CommitTemplateItem(SerializationInfo info, StreamingContext context)

--- a/GitCommands/CommitTemplateManager.cs
+++ b/GitCommands/CommitTemplateManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
@@ -31,7 +32,7 @@ namespace GitCommands
         /// </summary>
         /// <param name="templateName">The name of the template.</param>
         /// <param name="templateText">The body of the template.</param>
-        void Register(string templateName, Func<string> templateText);
+        void Register(string templateName, Func<string> templateText, Image icon);
 
         /// <summary>
         /// Allows a plugin to unregister a commit template.
@@ -47,11 +48,13 @@ namespace GitCommands
             public readonly string Name;
 
             public readonly Func<string> Text;
+            public readonly Image Icon;
 
-            public RegisteredCommitTemplateItem(string name, Func<string> text)
+            public RegisteredCommitTemplateItem(string name, Func<string> text, Image icon)
             {
                 Name = name;
                 Text = text;
+                Icon = icon;
             }
         }
 
@@ -81,7 +84,7 @@ namespace GitCommands
             {
                 lock (RegisteredTemplatesStorage)
                 {
-                    return RegisteredTemplatesStorage.Select(item => new CommitTemplateItem(item.Name, item.Text())).AsReadOnlyList();
+                    return RegisteredTemplatesStorage.Select(item => new CommitTemplateItem(item.Name, item.Text(), item.Icon)).AsReadOnlyList();
                 }
             }
         }
@@ -119,13 +122,13 @@ namespace GitCommands
         /// </summary>
         /// <param name="templateName">The name of the template.</param>
         /// <param name="templateText">The body of the template.</param>
-        public void Register(string templateName, Func<string> templateText)
+        public void Register(string templateName, Func<string> templateText, Image icon)
         {
             lock (RegisteredTemplatesStorage)
             {
                 if (RegisteredTemplatesStorage.All(item => item.Name != templateName))
                 {
-                    RegisteredTemplatesStorage.Add(new RegisteredCommitTemplateItem(templateName, templateText));
+                    RegisteredTemplatesStorage.Add(new RegisteredCommitTemplateItem(templateName, templateText, icon));
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -258,7 +258,7 @@ namespace GitUI.CommandsDialogs
                 gpgSignCommitToolStripComboBox.SelectedIndex = 0;
             }
 
-            ((ToolStripDropDownMenu)commitTemplatesToolStripMenuItem.DropDown).ShowImageMargin = false;
+            ((ToolStripDropDownMenu)commitTemplatesToolStripMenuItem.DropDown).ShowImageMargin = true;
             ((ToolStripDropDownMenu)commitTemplatesToolStripMenuItem.DropDown).ShowCheckMargin = false;
 
             ((ToolStripDropDownMenu)commitMessageToolStripMenuItem.DropDown).ShowImageMargin = false;
@@ -3119,7 +3119,7 @@ namespace GitUI.CommandsDialogs
                         return;
                     }
 
-                    var toolStripItem = new ToolStripMenuItem(item.Name);
+                    var toolStripItem = new ToolStripMenuItem(item.Name, item.Icon);
                     toolStripItem.Click += delegate
                     {
                         try
@@ -3144,7 +3144,7 @@ namespace GitUI.CommandsDialogs
 
                 void AddSettingsItem()
                 {
-                    var settingsItem = new ToolStripMenuItem(_commitMessageSettings.Text);
+                    var settingsItem = new ToolStripMenuItem(_commitMessageSettings.Text, Images.Settings);
                     settingsItem.Click += delegate
                     {
                         using (var frm = new FormCommitTemplateSettings())

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -623,9 +624,9 @@ namespace GitUI
             return DoActionOnRepo(owner, true, false, null, null, Action);
         }
 
-        public void AddCommitTemplate(string key, Func<string> addingText)
+        public void AddCommitTemplate(string key, Func<string> addingText, Image icon)
         {
-            _commitTemplateManager.Register(key, addingText);
+            _commitTemplateManager.Register(key, addingText, icon);
         }
 
         public void RemoveCommitTemplate(string key)

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using JetBrains.Annotations;
@@ -31,7 +32,7 @@ namespace GitUIPluginInterfaces
 
         bool StartRemotesDialog();
         bool StartSettingsDialog(IGitPlugin gitPlugin);
-        void AddCommitTemplate(string key, Func<string> addingText);
+        void AddCommitTemplate(string key, Func<string> addingText, Image icon);
         void RemoveCommitTemplate(string key);
     }
 }

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -257,7 +257,7 @@ namespace JiraCommitHintPlugin
                 _currentMessages = currentMessages;
                 foreach (var message in _currentMessages)
                 {
-                    e.GitUICommands.AddCommitTemplate(message.Title, () => message.Text);
+                    e.GitUICommands.AddCommitTemplate(message.Title, () => message.Text, Icon);
                 }
             });
         }

--- a/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitTemplateManagerTests.cs
@@ -77,21 +77,21 @@ namespace GitCommandsTests
         {
             const string templateName = "template1";
             var count = _manager.RegisteredTemplates.Count();
-            _manager.Register(templateName, () => "text1");
-            _manager.Register(templateName, () => "text2");
+            _manager.Register(templateName, () => "text1", null);
+            _manager.Register(templateName, () => "text2", null);
             _manager.RegisteredTemplates.Count().Should().Be(count + 1);
         }
 
         [Test]
         public void RegisteredTemplates_should_be_threadsafe()
         {
-            _manager.Register("template1", () => "text1");
-            _manager.Register("template2", () => "text2");
+            _manager.Register("template1", () => "text1", null);
+            _manager.Register("template2", () => "text2", null);
             var i = _manager.RegisteredTemplates.Count() + 1;
             foreach (var managerRegisteredTemplate in _manager.RegisteredTemplates)
             {
                 _manager.Unregister(managerRegisteredTemplate.Name);
-                _manager.Register($"template{i}", () => "text");
+                _manager.Register($"template{i}", () => "text", null);
                 i++;
             }
         }
@@ -99,7 +99,7 @@ namespace GitCommandsTests
         [Test]
         public void RegisteredTemplates_should_be_immutable()
         {
-            _manager.Register("template1", () => "text1");
+            _manager.Register("template1", () => "text1", null);
             var expectedCount = _manager.RegisteredTemplates.Count();
             expectedCount.Should().BeGreaterThan(0);
             ((IList)_manager.RegisteredTemplates).Clear();


### PR DESCRIPTION
## Proposed changes

- Display icons (especially the one of the **Jira** commit hint plugin) in commit templates menu items

PS: I have created because I'm mostly interested by the api change that it introduce (most of the code is common, there is just one line to update in the commit hint plugin).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/63446203-128eb380-c43a-11e9-9164-88953f3b1754.png)

### After

With provider:
![image](https://user-images.githubusercontent.com/460196/63445870-749ae900-c439-11e9-9fd6-32b9efc8c34e.png)

Without provider (don't block on the Azure DevOps icon, this PR add Jira icon but I only can test it with the AzureDevOps plugin I'm developping...):

![image](https://user-images.githubusercontent.com/460196/63445948-9f853d00-c439-11e9-829c-24761fa73b6d.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 4bb4263d32fd2787bb14c191fe27f69166e88393
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

 