### PR TITLE
fix: Crash when suggest merge/diff tool paths

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -160,12 +160,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return;
             }
 
-            CurrentSettings.SetPathValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()), MergetoolPath.Text?.Trim() ?? "");
+            var mergeToolPath = MergetoolPath.Text.Trim().Trim('"', '\'');
+
+            CurrentSettings.SetPathValue(string.Format("mergetool.{0}.path", _NO_TRANSLATE_GlobalMergeTool.Text.Trim()), mergeToolPath ?? "");
             string exeName;
             string exeFile;
-            if (!string.IsNullOrEmpty(MergetoolPath.Text))
+            if (!string.IsNullOrEmpty(mergeToolPath))
             {
-                exeFile = MergetoolPath.Text;
+                exeFile = mergeToolPath;
                 exeName = Path.GetFileName(exeFile);
             }
             else
@@ -218,12 +220,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return;
             }
 
-            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text.Trim()), DifftoolPath.Text?.Trim() ?? "");
+            var diffToolPath = DifftoolPath.Text.Trim().Trim('"', '\'');
+
+            CurrentSettings.SetPathValue(string.Format("difftool.{0}.path", _NO_TRANSLATE_GlobalDiffTool.Text.Trim()), diffToolPath ?? "");
             string exeName;
             string exeFile;
-            if (!string.IsNullOrEmpty(DifftoolPath.Text))
+            if (!string.IsNullOrEmpty(diffToolPath))
             {
-                exeFile = DifftoolPath.Text;
+                exeFile = diffToolPath;
                 exeName = Path.GetFileName(exeFile);
             }
             else


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

If merge/diff tool paths enclosed in quotes, clicking on "Suggest" button would crash the app.



Fixes #7000



## Proposed changes

- Strip quotes from paths before attempting to suggest.




## Test methodology <!-- How did you ensure quality? -->

- manual entering paths enclosed in `'` and `"`



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
