### PR TITLE
Make plugin settings development easier

### DIFF
--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -1157,10 +1157,6 @@ Do you want to reset the configured path?</source>
         <source>Jira hint plugin enabled</source>
         <target />
       </trans-unit>
-      <trans-unit id="_jiraFields.Caption">
-        <source>Jira fields</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_jqlQuerySettings.Caption">
         <source>JQL Query</source>
         <target />

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Settings\ChoiceSetting.cs" />
     <Compile Include="Settings\CredentialsSetting.cs" />
     <Compile Include="Settings\PasswordSetting.cs" />
+    <Compile Include="Settings\PseudoSetting.cs" />
     <Compile Include="Settings\StringSetting.cs" />
     <Compile Include="UserControls\CredentialsControl.cs">
       <SubType>UserControl</SubType>

--- a/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
@@ -48,7 +48,8 @@ namespace GitUIPluginInterfaces
 
             public override CheckBox CreateControl()
             {
-                return new CheckBox { ThreeState = true };
+                Setting.CustomControl = new CheckBox { ThreeState = true };
+                return Setting.CustomControl;
             }
 
             public override void LoadSetting(ISettingsSource settings, CheckBox control)

--- a/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
@@ -43,9 +43,9 @@ namespace GitUIPluginInterfaces
 
             public override ComboBox CreateControl()
             {
-                var comboBox = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList };
-                comboBox.Items.AddRange(Setting.Values.ToArray());
-                return comboBox;
+                Setting.CustomControl = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList };
+                Setting.CustomControl.Items.AddRange(Setting.Values.ToArray());
+                return Setting.CustomControl;
             }
 
             public override void LoadSetting(ISettingsSource settings, ComboBox control)

--- a/Plugins/GitUIPluginInterfaces/Settings/CredentialsSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/CredentialsSetting.cs
@@ -54,7 +54,8 @@ namespace GitUIPluginInterfaces
 
             public override CredentialsControl CreateControl()
             {
-                return new CredentialsControl();
+                Setting.CustomControl = new CredentialsControl();
+                return Setting.CustomControl;
             }
 
             public override void LoadSetting(ISettingsSource settings, CredentialsControl control)

--- a/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
@@ -36,7 +36,8 @@ namespace GitUIPluginInterfaces
 
             public override TextBox CreateControl()
             {
-                return new TextBox();
+                Setting.CustomControl = new TextBox();
+                return Setting.CustomControl;
             }
 
             public override void LoadSetting(ISettingsSource settings, TextBox control)

--- a/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
@@ -35,7 +35,8 @@ namespace GitUIPluginInterfaces
 
             public override TextBox CreateControl()
             {
-                return new TextBox { PasswordChar = '\u25CF' };
+                Setting.CustomControl = new TextBox { PasswordChar = '\u25CF' };
+                return Setting.CustomControl;
             }
 
             public override void LoadSetting(ISettingsSource settings, TextBox control)

--- a/Plugins/GitUIPluginInterfaces/Settings/PseudoSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/PseudoSetting.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace GitUIPluginInterfaces
+{
+    /// <summary>
+    /// Not a real setting (as it save no setting value). It is used to display a control that is not a setting (linklabel, text,...)
+    /// </summary>
+    public class PseudoSetting : ISetting
+    {
+        private readonly Func<TextBox> _textBoxCreator;
+
+        public PseudoSetting(Control control, string caption = "")
+        {
+            Caption = caption;
+            CustomControl = control;
+        }
+
+        public PseudoSetting(string text, string caption = "    ", int? height = null,  Action<TextBox> textboxSettings = null)
+        {
+            Caption = caption;
+
+            _textBoxCreator = () =>
+            {
+                var textbox = new TextBox { ReadOnly = true, BorderStyle = BorderStyle.None, Text = text };
+
+                if (height.HasValue)
+                {
+                    textbox.Multiline = true;
+                    textbox.Height = height.Value;
+                }
+
+                textboxSettings?.Invoke(textbox);
+                return textbox;
+            };
+
+            CustomControl = _textBoxCreator();
+        }
+
+        public string Name { get; } = "PseusoSetting";
+        public string Caption { get; }
+        public Control CustomControl { get; set; }
+
+        public ISettingControlBinding CreateControlBinding()
+        {
+            return new PseudoBinding(this, CustomControl, _textBoxCreator);
+        }
+
+        private class PseudoBinding : SettingControlBinding<PseudoSetting, Control>
+        {
+            private readonly Func<TextBox> _textBoxCreator;
+            public PseudoBinding(PseudoSetting setting, Control customControl, Func<TextBox> textBoxCreator)
+                : base(setting, customControl)
+            {
+                _textBoxCreator = textBoxCreator;
+            }
+
+            public override Control CreateControl()
+            {
+                Setting.CustomControl = _textBoxCreator();
+                return Setting.CustomControl;
+            }
+
+            public override void LoadSetting(ISettingsSource settings, Control control)
+            {
+            }
+
+            public override void SaveSetting(ISettingsSource settings, Control control)
+            {
+            }
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -41,7 +41,8 @@ namespace GitUIPluginInterfaces
 
             public override TextBox CreateControl()
             {
-                return new TextBox();
+                Setting.CustomControl = new TextBox();
+                return Setting.CustomControl;
             }
 
             public override void LoadSetting(ISettingsSource settings, TextBox control)

--- a/Plugins/GitUIPluginInterfaces/UserControls/CredentialsControl.cs
+++ b/Plugins/GitUIPluginInterfaces/UserControls/CredentialsControl.cs
@@ -5,9 +5,19 @@ namespace GitUIPluginInterfaces.UserControls
 {
     public partial class CredentialsControl : UserControl
     {
-        public CredentialsControl()
+        public CredentialsControl(string userNameLabelText = null, string passwordLabelText = null)
         {
             InitializeComponent();
+
+            if (!string.IsNullOrWhiteSpace(userNameLabelText))
+            {
+                userNameLabel.Text = userNameLabelText;
+            }
+
+            if (!string.IsNullOrWhiteSpace(passwordLabelText))
+            {
+                passwordLabel.Text = passwordLabelText;
+            }
         }
 
         public string UserName

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -45,8 +45,7 @@ namespace JiraCommitHintPlugin
         // For compatibility reason, the setting key is kept to "JDL Query" even if the label is, rightly, "JQL Query" (for "Jira Query Language")
         private readonly StringSetting _jqlQuerySettings = new StringSetting("JDL Query", JiraQueryLabel, "assignee = currentUser() and resolution is EMPTY ORDER BY updatedDate DESC", true);
         private readonly StringSetting _stringTemplateSetting = new StringSetting("Jira Message Template", MessageTemplateLabel, defaultFormat, true);
-        private readonly StringSetting _jiraFields = new StringSetting("Jira fields", JiraFieldsLabel, $"{{{string.Join("} {", typeof(Issue).GetProperties().Where(i => i.CanRead).Select(i => i.Name).OrderBy(i => i).ToArray())}}}");
-        private readonly StringSetting _jiraQueryHelpLink = new StringSetting("    ", "");
+        private readonly string _jiraFields = $"{{{string.Join("} {", typeof(Issue).GetProperties().Where(i => i.CanRead).Select(i => i.Name).OrderBy(i => i).ToArray())}}}";
         private IGitModule _gitModule;
         private JiraTaskDTO[] _currentMessages;
         private Button _btnPreview;
@@ -97,22 +96,11 @@ namespace JiraCommitHintPlugin
             _jqlQuerySettings.CustomControl = new TextBox();
             yield return _jqlQuerySettings;
 
-            var queryHelperLink = new LinkLabel { Text = QueryHelperLinkText, Width = DpiUtil.Scale(300) };
+            var queryHelperLink = new LinkLabel { Text = QueryHelperLinkText };
             queryHelperLink.Click += QueryHelperLink_Click;
-            var txtJiraQueryHelpLink = new TextBox { ReadOnly = true, BorderStyle = BorderStyle.None, Width = DpiUtil.Scale(300) };
-            txtJiraQueryHelpLink.Controls.Add(queryHelperLink);
-            _jiraQueryHelpLink.CustomControl = txtJiraQueryHelpLink;
-            yield return _jiraQueryHelpLink;
+            yield return new PseudoSetting(queryHelperLink);
 
-            _jiraFields.CustomControl = new TextBox
-            {
-                ReadOnly = true,
-                Multiline = true,
-                Height = DpiUtil.Scale(55),
-                BorderStyle = BorderStyle.None,
-                Text = _jiraFields.DefaultValue
-            };
-            yield return _jiraFields;
+            yield return new PseudoSetting(_jiraFields, JiraFieldsLabel, DpiUtil.Scale(55));
 
             var txtTemplate = new TextBox
             {


### PR DESCRIPTION
Fixes some paper cuts felt when developing a plugin (so I hope that you won't ask we to do one PR for each... 😉 but review is easier commit by commit).

## Proposed changes

### Settings: Ensure that `CustomControl` is set

if we let the Setting(s) classes create the controls.
Otherwise, it could will trow a NRE if we access it to get the current value

### Add a `PseudoSetting` to display controls that are not settings

i.e. that don't save a value in the settings files.
It is used to easily display a control that is not a setting (linklabel, text,...)

PS: Also, solve problem linklabels truncated horizontally of vertically if the good size is not set
(because the size no more have to be set)

 => and apply it to the "Jira Commit Hint" plugin

PS: I'm not fond of the name of the class. If someone have a better idea (`DisplayOnlySetting` ?)

### Being able to change CredentialsControl labels

to specify other things than the currently "User name" / "Password".

For example: "email" / "Token"

PS: not used at the moment. Except in my, still in development, AzureDevops plugin. But could help if someone want to develop a new plugin

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Link label truncated vertically (because the height must be set by the dev and has been done badly)
![image](https://user-images.githubusercontent.com/460196/63589053-5e5f6b00-c5a8-11e9-9545-9674280d2019.png)


### After

Link label not truncated vertically (because no more needed to set the height) and the linklabel and the Jira Fields are still displayed (that prove that the `PseudoClass` is working)

![image](https://user-images.githubusercontent.com/460196/63589234-e2b1ee00-c5a8-11e9-9cb4-7c2ea2a4b7b6.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.2.0
- Build 1c94e2894362a1576a85aa19fc224b250d619d2d
- Git 2.21.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 192dpi (200% scaling)

