### PR TITLE
Jira commit hint plugin: fix some string not translated

### DIFF
--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.2.0">
+<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.3.0">
   <file datatype="plaintext" original="AppVeyorSettingsUserControl" source-language="en">
     <body>
       <trans-unit id="cbLoadTestResults.Text">
@@ -1155,6 +1155,38 @@ Do you want to reset the configured path?</source>
     <body>
       <trans-unit id="Description.Text">
         <source>Jira Commit Hint</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="EmptyQueryResultCaption.Text">
+        <source>First Task Preview</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="EmptyQueryResultMessage.Text">
+        <source>[Empty Jira Query Result]</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="InvalidUrlCaption.Text">
+        <source>Invalid Jira url</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="InvalidUrlMessage.Text">
+        <source>A valid url is required to launch the Jira query helper</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="JiraFieldsLabel.Text">
+        <source>Jira fields</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="PreviewButtonText.Text">
+        <source>Preview</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="QueryHelperLinkText.Text">
+        <source>Open the query helper inside Jira</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="QueryHelperOpenErrorText.Text">
+        <source>Unable to open Jira query helper</source>
         <target />
       </trans-unit>
       <trans-unit id="_credentialsSettings.Caption">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.2.0">
+<xliff xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" GitExVersion="3.3.0">
   <file datatype="plaintext" original="AdvancedSettingsPage" source-language="en">
     <body>
       <trans-unit id="$this.Text">

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -19,32 +19,26 @@ namespace JiraCommitHintPlugin
     [Export(typeof(IGitPlugin))]
     public class JiraCommitHintPlugin : GitPluginBase, IGitPluginForRepository
     {
-        private static readonly string EnablePluginLabel = new TranslationString("Jira hint plugin enabled").Text;
-        private static readonly string JiraUrlLabel = new TranslationString("Jira URL").Text;
-        private static readonly string JiraCredentialsLabel = new TranslationString("Jira credentials").Text;
-        private static readonly string JiraQueryLabel = new TranslationString("JQL Query").Text;
-        private static readonly string MessageTemplateLabel = new TranslationString("Message Template").Text;
-        private static readonly string JiraFieldsLabel = new TranslationString("Jira fields").Text;
-        private static readonly string QueryHelperLinkText = new TranslationString("Open the query helper inside Jira").Text;
-        private static readonly string InvalidUrlMessage = new TranslationString("A valid url is required to launch the Jira query helper").Text;
-        private static readonly string InvalidUrlCaption = new TranslationString("Invalid Jira url").Text;
-        private static readonly string PreviewButtonText = new TranslationString("Preview").Text;
-        private static readonly string QueryHelperOpenErrorText = new TranslationString("Unable to open Jira query helper").Text;
-        private static readonly string EmptyQueryResultMessage = new TranslationString("[Empty Jira Query Result]").Text;
-        private static readonly string EmptyQueryResultCaption = new TranslationString("First Task Preview").Text;
+        private static readonly TranslationString JiraFieldsLabel = new TranslationString("Jira fields");
+        private static readonly TranslationString QueryHelperLinkText = new TranslationString("Open the query helper inside Jira");
+        private static readonly TranslationString InvalidUrlMessage = new TranslationString("A valid url is required to launch the Jira query helper");
+        private static readonly TranslationString InvalidUrlCaption = new TranslationString("Invalid Jira url");
+        private static readonly TranslationString PreviewButtonText = new TranslationString("Preview");
+        private static readonly TranslationString QueryHelperOpenErrorText = new TranslationString("Unable to open Jira query helper");
+        private static readonly TranslationString EmptyQueryResultMessage = new TranslationString("[Empty Jira Query Result]");
+        private static readonly TranslationString EmptyQueryResultCaption = new TranslationString("First Task Preview");
 
-        private const string description = "Jira Commit Hint";
-        private const string defaultFormat = "{Key} {Summary}";
+        private const string DefaultFormat = "{Key} {Summary}";
         private Jira _jira;
         private string _query;
-        private string _stringTemplate = defaultFormat;
-        private readonly BoolSetting _enabledSettings = new BoolSetting("Jira hint plugin enabled", EnablePluginLabel, false);
-        private readonly StringSetting _urlSettings = new StringSetting("Jira URL", JiraUrlLabel, @"https://jira.atlassian.com");
+        private string _stringTemplate = DefaultFormat;
+        private readonly BoolSetting _enabledSettings = new BoolSetting("Jira hint plugin enabled", false);
+        private readonly StringSetting _urlSettings = new StringSetting("Jira URL", @"https://jira.atlassian.com");
         private readonly CredentialsSetting _credentialsSettings;
 
         // For compatibility reason, the setting key is kept to "JDL Query" even if the label is, rightly, "JQL Query" (for "Jira Query Language")
-        private readonly StringSetting _jqlQuerySettings = new StringSetting("JDL Query", JiraQueryLabel, "assignee = currentUser() and resolution is EMPTY ORDER BY updatedDate DESC", true);
-        private readonly StringSetting _stringTemplateSetting = new StringSetting("Jira Message Template", MessageTemplateLabel, defaultFormat, true);
+        private readonly StringSetting _jqlQuerySettings = new StringSetting("JDL Query", "JQL Query", "assignee = currentUser() and resolution is EMPTY ORDER BY updatedDate DESC", true);
+        private readonly StringSetting _stringTemplateSetting = new StringSetting("Jira Message Template", "Message Template", DefaultFormat, true);
         private readonly string _jiraFields = $"{{{string.Join("} {", typeof(Issue).GetProperties().Where(i => i.CanRead).Select(i => i.Name).OrderBy(i => i).ToArray())}}}";
         private IGitModule _gitModule;
         private JiraTaskDTO[] _currentMessages;
@@ -52,11 +46,11 @@ namespace JiraCommitHintPlugin
 
         public JiraCommitHintPlugin()
         {
-            SetNameAndDescription(description);
+            SetNameAndDescription("Jira Commit Hint");
             Translate();
             Icon = Resources.IconJira;
 
-            _credentialsSettings = new CredentialsSetting("JiraCredentials", JiraCredentialsLabel, () => _gitModule?.WorkingDir);
+            _credentialsSettings = new CredentialsSetting("JiraCredentials", "Jira credentials", () => _gitModule?.WorkingDir);
         }
 
         public override bool Execute(GitUIEventArgs args)
@@ -96,11 +90,11 @@ namespace JiraCommitHintPlugin
             _jqlQuerySettings.CustomControl = new TextBox();
             yield return _jqlQuerySettings;
 
-            var queryHelperLink = new LinkLabel { Text = QueryHelperLinkText };
+            var queryHelperLink = new LinkLabel { Text = QueryHelperLinkText.Text };
             queryHelperLink.Click += QueryHelperLink_Click;
             yield return new PseudoSetting(queryHelperLink);
 
-            yield return new PseudoSetting(_jiraFields, JiraFieldsLabel, DpiUtil.Scale(55));
+            yield return new PseudoSetting(_jiraFields, JiraFieldsLabel.Text, DpiUtil.Scale(55));
 
             var txtTemplate = new TextBox
             {
@@ -114,7 +108,7 @@ namespace JiraCommitHintPlugin
             };
             _btnPreview = new Button
             {
-                Text = PreviewButtonText,
+                Text = PreviewButtonText.Text,
                 Top = DpiUtil.Scale(45),
                 Anchor = AnchorStyles.Right
             };
@@ -129,7 +123,7 @@ namespace JiraCommitHintPlugin
         {
             if (string.IsNullOrWhiteSpace(_urlSettings.CustomControl.Text))
             {
-                MessageBox.Show(null, InvalidUrlMessage, InvalidUrlCaption, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show(null, InvalidUrlMessage.Text, InvalidUrlCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
@@ -139,7 +133,7 @@ namespace JiraCommitHintPlugin
             }
             catch (Exception ex)
             {
-                MessageBox.Show(null, ex.Message, QueryHelperOpenErrorText, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(null, ex.Message, QueryHelperOpenErrorText.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -161,7 +155,7 @@ namespace JiraCommitHintPlugin
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         var preview = message.FirstOrDefault();
 
-                        MessageBox.Show(null, preview == null ? EmptyQueryResultMessage : preview.Text, EmptyQueryResultCaption);
+                        MessageBox.Show(null, preview == null ? EmptyQueryResultMessage.Text : preview.Text, EmptyQueryResultCaption.Text);
 
                         _btnPreview.Enabled = true;
                     });
@@ -271,7 +265,7 @@ namespace JiraCommitHintPlugin
             _currentMessages = null;
         }
 
-        private static async Task<JiraTaskDTO[]> GetMessageToCommitAsync(Jira jira, string query, string stringTemplate)
+        private async Task<JiraTaskDTO[]> GetMessageToCommitAsync(Jira jira, string query, string stringTemplate)
         {
             try
             {
@@ -282,7 +276,7 @@ namespace JiraCommitHintPlugin
             }
             catch (Exception ex)
             {
-                return new[] { new JiraTaskDTO($"{description} error", ex.ToString()) };
+                return new[] { new JiraTaskDTO($"{Description} error", ex.ToString()) };
             }
         }
 


### PR DESCRIPTION
To be merged after #7039 will be (just the last commit is specific to this PR).

## Proposed changes

JiraPlugin: Fix way to define TranslationString that prevent translation

+ remove TranslationString redundant with settings caption
(which is translated when defined in a private field!)

## Test methodology <!-- How did you ensure quality? -->

- Some more strings appears in `English.Plugins.xlf`
