### PR TITLE
Fix 3934 add force push with lease to the push dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -69,7 +69,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _pullRepository =
             new TranslationString("The push was rejected because the tip of your current branch is behind its remote counterpart. " +
                 "Merge the remote changes before pushing again.");
-        private readonly TranslationString _pullRepositoryButtons = new TranslationString("Pull with the default pull action ({0})|Pull with rebase|Pull with merge|Force push|Cancel");
+        private readonly TranslationString _pullRepositoryButtons = new TranslationString("Pull with the default pull action ({0})|Pull with rebase|Pull with merge|Force push with lease|Cancel");
         private readonly TranslationString _pullActionNone = new TranslationString("none");
         private readonly TranslationString _pullActionFetch = new TranslationString("fetch");
         private readonly TranslationString _pullActionRebase = new TranslationString("rebase");

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5532,7 +5532,7 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="_pullRepositoryButtons.Text">
-        <source>Pull with the default pull action ({0})|Pull with rebase|Pull with merge|Force push|Cancel</source>
+        <source>Pull with the default pull action ({0})|Pull with rebase|Pull with merge|Force push with lease|Cancel</source>
         <target />
       </trans-unit>
       <trans-unit id="_pullRepositoryCaption.Text">


### PR DESCRIPTION
Fixes #3934

## Proposed changes

Changed `Force push` to `Force push with lease` in `Push was rejected` dialog (including Russian translation).

## Screenshots

### Before

![Force push](https://user-images.githubusercontent.com/1150330/63650668-c1423500-c755-11e9-956d-6cba74884f5e.png)

### After

![Force push with lease](https://user-images.githubusercontent.com/1150330/63650661-ac65a180-c755-11e9-9ffb-4e2f00f90f0e.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
