### PR TITLE
Use latest Windows SDK

### DIFF
--- a/GitExtSshAskPass/SshAskPass.vcxproj
+++ b/GitExtSshAskPass/SshAskPass.vcxproj
@@ -23,7 +23,7 @@
     <RootNamespace>SshAskPass</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>GitExtSshAskPass</ProjectName>
-	<WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+	<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.vcxproj
@@ -23,7 +23,7 @@
     <RootNamespace>GitExtensionsShellEx</RootNamespace>
     <Keyword>AtlProj</Keyword>
     <ProjectName>GitExtensionsShellEx</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -30,10 +30,9 @@ namespace GitUITests.CommandsDialogs
         }
 
         [TestCase(@"c:\Users\Public\desktop.ini")]
-        [TestCase(@"c:\pagefile.sys")]
         [TestCase(@"c:\Windows\System32\cmd.exe")]
         [TestCase(@"c:\Users\Default\NTUSER.DAT")]
-        [TestCase(@"c:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies")]
+        [TestCase(@"c:\Program Files (x86)\microsoft.net\primary interop assemblies")]
         [TestCase(@"c:\Program Files (x86)")]
         public void TryGetExactPathName_Should_output_path_with_exact_casing(string path)
         {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 3.2.0.{build}
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 
 branches:
   except:
@@ -9,7 +9,7 @@ branches:
 
 environment:
   matrix:
-  - IdeVersion: VS2017
+  - IdeVersion: VS2019
   SKIP_PAUSE: TRUE
   ARCHIVE_WITH_PDB: TRUE
 


### PR DESCRIPTION
VS2019 has a simple way to compile with latest SDK.
https://developercommunity.visualstudio.com/content/problem/140294/windowstargetplatformversion-makes-it-impossible-t.html#reply-548052

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
