### PR TITLE
fix: Overflow error in Commit Dialog

### DIFF
--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -31,7 +31,7 @@ namespace GitUI.Editor.Diff
             {
                 if (_visible && _diffLines.Any())
                 {
-                    int maxDigits = (int)Math.Log10(MaxLineNumber) + 1;
+                    int maxDigits = MaxLineNumber > 0 ? ((int)Math.Log10(MaxLineNumber) + 1) : 0;
                     return TextHorizontalMargin + (textArea.TextView.WideSpaceWidth * ((2 * maxDigits) + /* a space behind each number */ 2));
                 }
 


### PR DESCRIPTION
`DiffViewerLineNumberControl` did not handle when `MaxLineNumber `was 0. Either an empty file can cause this (in this case `_diffLines `is empty so no problem) or a file where diff hunks were lost due to encoding errors.

Fixes #7023

## Proposed changes

Change the current getter:

``` csharp
if (_visible && _diffLines.Any())
{
    int maxDigits = (int)Math.Log10(MaxLineNumber) + 1;
    return ...;
}
```

to

``` csharp
if (_visible && _diffLines.Any())
{
    int maxDigits = MaxLineNumber > 0 ?  ((int)Math.Log10(MaxLineNumber) + 1) : 0;
    return ...;
}
```


## Test methodology <!-- How did you ensure quality? -->

Tested manually.

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
