### PR TITLE
Clarify Settings-Stash label

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -431,7 +431,7 @@
             this.chkStashUntrackedFiles.Name = "chkStashUntrackedFiles";
             this.chkStashUntrackedFiles.Size = new System.Drawing.Size(264, 17);
             this.chkStashUntrackedFiles.TabIndex = 3;
-            this.chkStashUntrackedFiles.Text = "Include untracked files in stash";
+            this.chkStashUntrackedFiles.Text = "Include untracked files in autostash";
             this.chkStashUntrackedFiles.UseVisualStyleBackColor = true;
             // 
             // chkStartWithRecentWorkingDir

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7198,7 +7198,7 @@ Context menu for additional operations</source>
         <target />
       </trans-unit>
       <trans-unit id="chkStashUntrackedFiles.Text">
-        <source>Include untracked files in stash</source>
+        <source>Include untracked files in autostash</source>
         <target />
       </trans-unit>
       <trans-unit id="chkTelemetry.Text">


### PR DESCRIPTION
## Proposed changes

"Include untracked files in stash" is only used in autostash, not in the stash dialog.
It setting this in Settings, creating a stash manually will not stash changes
(can be done in the menu or ctrl-alt-up so do not even see the stash form)

## Screenshots 

### Before
![image](https://user-images.githubusercontent.com/6248932/63887637-86eac900-c9dd-11e9-8665-1c236f5a56a2.png)
![image](https://user-images.githubusercontent.com/6248932/63887661-8fdb9a80-c9dd-11e9-9ff3-218c93e51ab4.png)

### After

stash -> autostash

## Test methodology <!-- How did you ensure quality? -->

Manual


## Test environment(s) <!-- Remove any that don't apply -->

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
