### PR TITLE
Let the copy menu entry appear expandable at startup

### DIFF
--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -22,15 +22,26 @@ namespace GitUI.UserControls.RevisionGrid
             Image = Images.CopyToClipboard;
             Text = _copyToClipboardText.Text;
 
-            // Create a dummy menu, so that the shortcut keys work.
-            OnDropDownOpening(null, null);
-
             DropDownOpening += OnDropDownOpening;
+
+            // Don't show the menu as long as no revision function is set
+            HideDropDown();
         }
 
         public void SetRevisionFunc(Func<IReadOnlyList<GitRevision>> revisionFunc)
         {
             _revisionFunc = revisionFunc;
+
+            if (_revisionFunc?.Invoke() != null)
+            {
+                // Add dummy item for the menu entry to appear expandable (triangle on the right)
+                DropDownItems.Add(new ToolStripMenuItem());
+                ShowDropDown();
+            }
+            else
+            {
+                HideDropDown();
+            }
         }
 
         private void AddItem(string displayText, Func<GitRevision, string> extractRevisionText, Image image, char? hotkey)
@@ -96,16 +107,8 @@ namespace GitUI.UserControls.RevisionGrid
             var revisions = _revisionFunc?.Invoke();
             if (revisions == null || revisions.Count == 0)
             {
-                if (sender == null)
-                {
-                    // create the initial dummy menu on a dummy revision
-                    revisions = new List<GitRevision> { new GitRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId) };
-                }
-                else
-                {
-                    HideDropDown();
-                    return;
-                }
+                HideDropDown();
+                return;
             }
 
             DropDownItems.Clear();


### PR DESCRIPTION
Fixes #7046


## Proposed changes
Since the copy to clipboard menu is filled on the `DropDownOpening` event, it appears empty (has no triangle/arrow at the right) at startup. By adding a dummy element in the constructor, the triangle is present at startup indicating it as a drop down submenu.
I removed the adding of a dummy revision (according to the comment to allow shortkeys, see #5422 and #5444) since it does not seem to do anything anymore as `_revisionFunc` is not set. Shortkeys (Ctrl+C) are working nonetheless.


## Screenshots
See #7046 

## Test methodology
Manually

## Test environment(s)
- Git Extensions 3.1.1.6049
- Build 2f872105b4eb42421d9fdafd68e90a9e27d20d96
- Git 2.22.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3416.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
