### PR TITLE
Fix installer for Win7

### DIFF
--- a/Bin/set-telemetry.ps1
+++ b/Bin/set-telemetry.ps1
@@ -3,7 +3,7 @@ Param(
     [string] $Enabled = ''
 )
 
-[bool]$telemetryEnabled = -not [string]::IsNullOrWhiteSpace($Enabled);
+[bool]$telemetryEnabled = -not [string]::IsNullOrEmpty($Enabled);
 
 [string]$userAppDataPath = Join-Path -Path $env:APPDATA -ChildPath 'GitExtensions\GitExtensions\GitExtensions.settings'
 if (-not (Test-Path -Path $userAppDataPath)) {

--- a/Setup/UI/TelemetryDlg.wxs
+++ b/Setup/UI/TelemetryDlg.wxs
@@ -14,10 +14,11 @@
       <![CDATA[Installed OR POWERSHELLEXE]]>
     </Condition>
 
+    <!-- Windows 7SP1 supports only PowerShell 2.0 -->
     <SetProperty Id="ConfigureTelemetry"
         Before ="ConfigureTelemetry"
         Sequence="execute"
-        Value="&quot;[POWERSHELLEXE]&quot; -Version 3.0 -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED] ; exit $$($Error.Count)&quot;" />
+        Value="&quot;[POWERSHELLEXE]&quot; -Version 2.0 -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED] ; exit $$($Error.Count)&quot;" />
 
     <CustomAction Id="ConfigureTelemetry" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="yes" />
 

--- a/Setup/UI/WixUI.wxs
+++ b/Setup/UI/WixUI.wxs
@@ -61,7 +61,7 @@
       <Publish Dialog="GitEx_TelemetryDlg" Control="Back" Event="NewDialog" Value="GitEx_SSHClientDlg">1</Publish>
       <Publish Dialog="GitEx_TelemetryDlg" Control="Next" Event="NewDialog" Value="GitEx_VerifyReadyDlg">1</Publish>
 
-      <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_SSHClientDlg" Order="1">
+      <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_TelemetryDlg" Order="1">
         NOT Installed
       </Publish>
       <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_MaintenanceTypeDlg" Order="3">


### PR DESCRIPTION
Fixes #7079


## Proposed changes

* Make installer compatible with PowerShell 2.0 (needed on Win7 SP1)
* General: correct dialog order when using "back" button.  Clicking "back" in  `GitEx_VerifyReadyDlg`  jumped back by 2 dialogs to `GitEx_SSHClientDlg`.
The correct sequence is: `GitEx_SSHClientDlg` <-> `GitEx_TelemetryDlg` <-> `GitEx_VerifyReadyDlg`.


## Test methodology

- Built MSI and verified correct installation on both Win7 and Win10 


## Test environment (Win10)
- Git Extensions 3.2.0.67
- Build cd95abe635787a35f3574adf9d012436d0cfe950
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.8.3928.0
- DPI 96dpi (no scaling)

## Test environment (Win7)
- Git Extensions 3.2.0.67
- Build cd95abe635787a35f3574adf9d012436d0cfe950
- Git 2.20.1.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 6.1.7601 Service Pack 1
- .NET Framework 4.7.3416.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
