### PR TITLE
Ignore difftool for CombinedDiff

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -609,6 +609,13 @@ namespace GitUI.CommandsDialogs
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
+                if (itemWithParent.ParentRevision.Guid == GitRevision.CombinedDiffGuid)
+                {
+                    // CombinedDiff cannot be viewed in a difftool
+                    // Disabled in menues but can be activated from shortcuts, just ignore
+                    continue;
+                }
+
                 var revs = new[] { DiffFiles.Revision, itemWithParent.ParentRevision };
                 UICommands.OpenWithDifftool(this, revs, itemWithParent.Item.Name, itemWithParent.Item.OldName, diffKind, itemWithParent.Item.IsTracked);
             }


### PR DESCRIPTION
Fixes #7087


## Proposed changes

- Ignore difftool for combined diff

## Test methodology <!-- How did you ensure quality? -->

- Select GE b33a12e3af16cc1164ebfa2562f06b485421fbcf
- Rightclick a file in CombinedDiff
- Verifiy that diff in menu is disabled
- Verify that nothing happens (no error or difftool) when pressing F3, Shift-F3, Shift-Alt-F3

- Select both a file in CombinedDiff and normal commit, rightclick
- Verifiy that diff in menu is disabled
- Verify that the  when pressing F3, Shift-F3, Shift-Alt-F3, that the normal diftool is shown only

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
