### PR TITLE
Fix scrolling for committers label in statistics plugin

### DIFF
--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.Designer.cs
@@ -152,6 +152,7 @@ namespace GitStatistics
             // 
             // splitContainer4.Panel1
             // 
+            this.splitContainer4.Panel1.AutoScroll = true;
             this.splitContainer4.Panel1.Controls.Add(this.CommitStatistics);
             this.splitContainer4.Panel1MinSize = 250;
             // 

--- a/contributors.txt
+++ b/contributors.txt
@@ -94,4 +94,5 @@ YYYY/MM/DD, github id, Full name, email
 2019/08/18, manuc66, Emmanuel Counasse, manuc66(at)gmail.com
 2019/08/25, kvanttt, Ivan Kochurkin, kvanttt(at)gmail.com
 2019/08/27, palver123, Levente Koncz, palver123@gmail.com
+2019/09/02, MelnikovIG, Igor Melnikov, zero_88@bk.ru
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Fixed scrolling of commiters in statistics plugin


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![statistics_before](https://user-images.githubusercontent.com/6163811/64132708-60140480-cdda-11e9-9767-83b3f33bb1f1.png)

### After

![statistics_after](https://user-images.githubusercontent.com/6163811/64132712-63a78b80-cdda-11e9-8abe-b256e3e0db3c.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.20.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
