### PR TITLE
PathUtil.GetDirectoryName did not accept root dirs

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -477,7 +477,7 @@ namespace GitCommands
                     return dir.EnsureTrailingPathSeparator();
                 }
 
-                dir = PathUtil.GetDirectoryName(dir);
+                dir = Path.GetDirectoryName(dir);
             }
 
             return null;
@@ -1222,8 +1222,8 @@ namespace GitCommands
 
             Debug.Assert(WorkingDir.StartsWith(SuperprojectModule.WorkingDir), "Submodule working dir should start with super-project's working dir");
 
-            return PathUtil.GetDirectoryName(
-                WorkingDir.Substring(SuperprojectModule.WorkingDir.Length).ToPosixPath());
+            return Path.GetDirectoryName(
+                WorkingDir.Substring(SuperprojectModule.WorkingDir.Length)).ToPosixPath();
         }
 
         public string GetSubmoduleFullPath(string localPath)

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -101,29 +101,6 @@ namespace GitCommands
         }
 
         [NotNull]
-        public static string GetDirectoryName([NotNull] string fileName)
-        {
-            var pathSeparators = new[] { NativeDirectorySeparatorChar, PosixDirectorySeparatorChar };
-            var pos = fileName.LastIndexOfAny(pathSeparators);
-            if (pos != -1)
-            {
-                if (pos == 0 && fileName[0] == PosixDirectorySeparatorChar)
-                {
-                    return fileName.Length == 1 ? "" : PosixDirectorySeparatorChar.ToString();
-                }
-
-                fileName = fileName.Substring(0, pos);
-            }
-
-            if (fileName.Length == 2 && char.IsLetter(fileName[0]) && fileName[1] == Path.VolumeSeparatorChar)
-            {
-                return "";
-            }
-
-            return fileName;
-        }
-
-        [NotNull]
         public static string NormalizePath([NotNull] this string path)
         {
             if (string.IsNullOrWhiteSpace(path))

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -226,7 +226,7 @@ namespace GitCommands.Submodules
             else
             {
                 var localPath = superprojectModule.WorkingDir.Substring(topProject.WorkingDir.Length);
-                name = PathUtil.GetDirectoryName(localPath.ToPosixPath());
+                name = Path.GetDirectoryName(localPath).ToPosixPath();
              }
 
             string path = superprojectModule.WorkingDir;
@@ -260,7 +260,7 @@ namespace GitCommands.Submodules
             if (submodules.Any())
             {
                 string localPath = result.Module.WorkingDir.Substring(topProject.WorkingDir.Length);
-                localPath = PathUtil.GetDirectoryName(localPath.ToPosixPath());
+                localPath = Path.GetDirectoryName(localPath).ToPosixPath();
 
                 foreach (var submodule in submodules)
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -317,7 +318,7 @@ namespace GitUI.BranchTreePanel
                 foreach (var submoduleInfo in submodules)
                 {
                     string superPath = GetSubmoduleSuperPath(submoduleInfo.Path);
-                    string localPath = PathUtil.GetDirectoryName(submoduleInfo.Path.Substring(superPath.Length).ToPosixPath());
+                    string localPath = Path.GetDirectoryName(submoduleInfo.Path.Substring(superPath.Length)).ToPosixPath();
 
                     var isCurrent = submoduleInfo.Bold;
                     nodes.Add(new SubmoduleNode(this, submoduleInfo, isCurrent, localPath, superPath));

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1097,7 +1097,7 @@ namespace GitUI.CommandsDialogs
                 using (var fileDialog = new SaveFileDialog
                 {
                     FileName = fileName,
-                    InitialDirectory = _fullPathResolver.Resolve(PathUtil.GetDirectoryName(conflictData.Filename)),
+                    InitialDirectory = _fullPathResolver.Resolve(Path.GetDirectoryName(conflictData.Filename)),
                     AddExtension = true
                 })
                 {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1705,12 +1705,16 @@ namespace GitUI
             string fileHistoryFileName = string.IsNullOrEmpty(Module.WorkingDir) ? args[2] :
                 args[2].Replace(Module.WorkingDir, "").ToPosixPath();
             var fullFilePath = _fullPathResolver.Resolve(fileHistoryFileName);
-            if (new FormFileHistoryController().TryGetExactPath(fullFilePath, out var exactFileName))
+            if (new FormFileHistoryController().TryGetExactPath(fullFilePath, out var exactFileName) &&
+                exactFileName.Length > Module.WorkingDir.Length)
             {
                 fileHistoryFileName = exactFileName.Substring(Module.WorkingDir.Length);
             }
 
-            StartFileHistoryDialog(null, fileHistoryFileName);
+            if (fileHistoryFileName.IsNotNullOrWhitespace())
+            {
+                StartFileHistoryDialog(null, fileHistoryFileName);
+            }
         }
 
         private void RunCloneCommand(IReadOnlyList<string> args)

--- a/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommandsTests/Helpers/PathUtilTest.cs
@@ -131,29 +131,6 @@ namespace GitCommandsTests.Helpers
         }
 
         [Test]
-        public void GetDirectoryNameTest()
-        {
-            if (Path.DirectorySeparatorChar == '\\')
-            {
-                Assert.AreEqual(PathUtil.GetDirectoryName("\\\\my-pc\\Work\\GitExtensions\\"), "\\\\my-pc\\Work\\GitExtensions");
-                Assert.AreEqual(PathUtil.GetDirectoryName("C:\\Work\\GitExtensions\\"), "C:\\Work\\GitExtensions");
-                Assert.AreEqual(PathUtil.GetDirectoryName("C:\\Work\\GitExtensions"), "C:\\Work");
-                Assert.AreEqual(PathUtil.GetDirectoryName("C:\\Work\\"), "C:\\Work");
-                Assert.AreEqual(PathUtil.GetDirectoryName("C:\\Work"), "");
-                Assert.AreEqual(PathUtil.GetDirectoryName("C:\\"), "");
-                Assert.AreEqual(PathUtil.GetDirectoryName("C:"), "");
-                Assert.AreEqual(PathUtil.GetDirectoryName(""), "");
-            }
-
-            Assert.AreEqual(PathUtil.GetDirectoryName("//my-pc/Work/GitExtensions/"), "//my-pc/Work/GitExtensions");
-            Assert.AreEqual(PathUtil.GetDirectoryName("/Work/GitExtensions/"), "/Work/GitExtensions");
-            Assert.AreEqual(PathUtil.GetDirectoryName("/Work/GitExtensions"), "/Work");
-            Assert.AreEqual(PathUtil.GetDirectoryName("/Work/"), "/Work");
-            Assert.AreEqual(PathUtil.GetDirectoryName("/"), "");
-            Assert.AreEqual("/", PathUtil.GetDirectoryName("/Work"), "/Work");
-        }
-
-        [Test]
         public void GetRepositoryNameTest()
         {
             Assert.AreEqual(PathUtil.GetRepositoryName("https://github.com/gitextensions/gitextensions.git"), "gitextensions");


### PR DESCRIPTION
Fixes #7086

## Proposed changes
 * Use .NET Path.GetDirectoryName instead of PathUtil to also detect root directories

The existing function could have been adapted (by removing a few lines), but the standard function should be used. 

## Test methodology <!-- How did you ensure quality? -->
Manual

## Test environment(s) <!-- Remove any that don't apply -->

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
