### PR TITLE
Remove test assuming local file paths

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -29,21 +29,6 @@ namespace GitUITests.CommandsDialogs
             Assert.IsNull(exactPath);
         }
 
-        [TestCase(@"c:\Users\Public\desktop.ini")]
-        [TestCase(@"c:\pagefile.sys")]
-        [TestCase(@"c:\Windows\System32\cmd.exe")]
-        [TestCase(@"c:\Users\Default\NTUSER.DAT")]
-        [TestCase(@"c:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies")]
-        [TestCase(@"c:\Program Files (x86)")]
-        public void TryGetExactPathName_Should_output_path_with_exact_casing(string path)
-        {
-            var lowercasePath = path.ToLower();
-            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
-
-            Assert.IsTrue(isExistingOnFileSystem);
-            Assert.AreEqual(path, exactPath);
-        }
-
         [Test]
         public void TryGetExactPathName_Should_handle_network_path()
         {


### PR DESCRIPTION
Test case TryGetExactPathName_Should_output_path_with_exact_casing() uses the local file system for comparisons.
The test for "c:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies" occasionally fails for me for unknown reason (when debugging it is OK), similar in #7049). (An alternative to this PR would be to remove this specific test only.
It is possible to install to other paths, the test assumes that the PC uses standard paths.
 Similar tests are already done in TryGetExactPathName_should_check_if_path_matches_case()

Note that TryGetExactPathName_Should_handle_network_path() could fail too, but there are no tests replacing that, so it is kept in this PR.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
