### PR TITLE
correctly call hMSBuild batch file

### DIFF
--- a/Setup/Build.cmd
+++ b/Setup/Build.cmd
@@ -15,5 +15,5 @@ set msbuildparams=/p:Configuration=%Configuration% /t:Rebuild /nologo /v:m
 call BuildGitExtNative.cmd %Configuration% Rebuild
 IF ERRORLEVEL 1 EXIT /B 1
 
-%msbuild32% %solution% /p:Platform="Any CPU" %msbuildparams%
+call %msbuild32% %solution% /p:Platform="Any CPU" %msbuildparams%
 IF ERRORLEVEL 1 EXIT /B 1

--- a/Setup/BuildGitExtNative.cmd
+++ b/Setup/BuildGitExtNative.cmd
@@ -14,11 +14,9 @@ set projectSshAskPass=..\GitExtSshAskPass\GitExtSshAskPass.sln
 set SkipShellExtRegistration=1
 set msbuildparams=/p:Configuration=%Configuration% /t:%BuildType% /nologo /v:m
 
-%msbuild32% %projectShellEx% /p:Platform=Win32 %msbuildparams%
+call %msbuild32% %projectShellEx% /p:Platform=Win32 %msbuildparams%
 IF ERRORLEVEL 1 EXIT /B 1
-%msbuild32% %projectShellEx% /p:Platform=x64 %msbuildparams%
+call %msbuild32% %projectShellEx% /p:Platform=x64 %msbuildparams%
 IF ERRORLEVEL 1 EXIT /B 1
-%msbuild32% %projectSshAskPass% /p:Platform=Win32 %msbuildparams%
+call %msbuild32% %projectSshAskPass% /p:Platform=Win32 %msbuildparams%
 IF ERRORLEVEL 1 EXIT /B 1
-
-

--- a/Setup/MakeInstallers.cmd
+++ b/Setup/MakeInstallers.cmd
@@ -26,7 +26,7 @@ REM HACK: for some reason when we build the full solution the VSIX contains too 
 rmdir ..\GitExtensionsVSIX\bin\Release /s /q
 pushd ..\GitExtensionsVSIX
 set msbuild32=..\Setup\hMSBuild -notamd64
-%msbuild32% /t:%BuildType% /p:Configuration=%Configuration% /nologo /v:m
+call %msbuild32% /t:%BuildType% /p:Configuration=%Configuration% /nologo /v:m
 popd
 
 echo Creating installers for Git Extensions %version%
@@ -37,7 +37,7 @@ del %normal% 2> nul
 
 echo.
 
-%msbuild% Setup.wixproj /t:%BuildType% /p:Version=%version% /p:NumericVersion=%numericVersion% /p:Configuration=%Configuration% /nologo /v:m
+call %msbuild% Setup.wixproj /t:%BuildType% /p:Version=%version% /p:NumericVersion=%numericVersion% /p:Configuration=%Configuration% /nologo /v:m
 IF ERRORLEVEL 1 EXIT /B 1
 copy %output% %normal%
 IF ERRORLEVEL 1 EXIT /B 1


### PR DESCRIPTION
Fixes a problem where a call to hMSBuild would be the last thing executed in a batch file

## Proposed changes / problem description

- From what I gather from reading about executing nested batch files is if you simply call a batch from withing another batch file then it's executed inline and if there is an `exit` in the nested file the root batch exits as it's as if there was just one big batch file. To properly executed a nested batch files one needs to:
- Use `call` to execute `hMSBuild`

more on this: https://stackoverflow.com/questions/1103994/how-to-run-multiple-bat-files-within-a-bat-file

This raises another question... are these batch files used at all? Without this fix `MakeInstallers.cmd` would not produce an installer for me.