### PR TITLE
fix: Unable to intstall new version

### DIFF
--- a/Bin/set-telemetry.ps1
+++ b/Bin/set-telemetry.ps1
@@ -37,6 +37,3 @@ $node = $doc.CreateElement('item');
 $node.InnerXml = "<key><string>TelemetryEnabled</string></key><value><string>$telemetryEnabled</string></value>";
 $_ = $topNode.AppendChild($node);
 $doc.Save($userAppDataPath)
-
-# this script now deletes itself
-Remove-Item $MyINvocation.InvocationName

--- a/Setup/UI/TelemetryDlg.wxs
+++ b/Setup/UI/TelemetryDlg.wxs
@@ -14,11 +14,10 @@
       <![CDATA[Installed OR POWERSHELLEXE]]>
     </Condition>
 
-    <!-- Windows 7SP1 supports only PowerShell 2.0 -->
     <SetProperty Id="ConfigureTelemetry"
         Before ="ConfigureTelemetry"
         Sequence="execute"
-        Value="&quot;[POWERSHELLEXE]&quot; -Version 2.0 -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED] ; exit $$($Error.Count)&quot;" />
+        Value="&quot;[POWERSHELLEXE]&quot; -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED]; exit $$($Error.Count)&quot;" />
 
     <CustomAction Id="ConfigureTelemetry" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="yes" />
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.2.0.{build}
+version: 3.2.1.{build}
 
 os: Visual Studio 2017
 


### PR DESCRIPTION
Resolves #7120

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

* There are few issues with the install script related to configuring the telemetry settings.

    1. On W7 there is only PowerShell 2.0 (that is what ships with .NET 2.0). On the later versions of OS there are different versions of PowerShell and thus requiring a specific version would lead to failures.

    2. A problem related to the logic responsible for self-removal

       * First `$MyINvocation.InvocationName` returned different and unexpected         values when a script is run not from a command line but invoked as a     script-block. In the latter case, `$MyINvocation.InvocationName` is     set to `&`.

       * Secondly the installer somehow would fail to remove the script     (permissions?)

  The self-removal logic is removed.

* Bump the version to 3.2.1 to ensure the new fix flows through to all distribution channels correctly.
 


## Test methodology <!-- How did you ensure quality? -->

- Manual execution of the script
- Verification reports from users

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
