### PR TITLE
Unblock special commit message

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -118,6 +118,7 @@ namespace GitUI.CommandsDialogs
             this.SelectedDiff = new GitUI.Editor.FileViewer();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.Message = new GitUI.SpellChecker.EditNetSpell();
+            this.modifyCommitMessageButton = new System.Windows.Forms.Button();
             this.flowCommitButtons = new System.Windows.Forms.FlowLayoutPanel();
             this.Commit = new System.Windows.Forms.Button();
             this.CommitAndPush = new System.Windows.Forms.Button();
@@ -318,7 +319,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(229, 6);
             //
-            // addFileTogitignoreToolStripMenuItem
+            // addFileToGitIgnoreToolStripMenuItem
             //
             this.addFileToGitIgnoreToolStripMenuItem.Image = global::GitUI.Properties.Images.AddToGitIgnore;
             this.addFileToGitIgnoreToolStripMenuItem.Name = "addFileToGitIgnoreToolStripMenuItem";
@@ -326,7 +327,7 @@ namespace GitUI.CommandsDialogs
             this.addFileToGitIgnoreToolStripMenuItem.Text = "Add file to .gitignore";
             this.addFileToGitIgnoreToolStripMenuItem.Click += new System.EventHandler(this.AddFileToGitIgnoreToolStripMenuItemClick);
             //
-            // addFileTogitinfoexcludeExcludeLocallyToolStripMenuItem
+            // addFileToGitInfoExcludeLocallyToolStripMenuItem
             //
             this.addFileToGitInfoExcludeLocallyToolStripMenuItem.Image = global::GitUI.Properties.Images.AddToGitIgnore;
             this.addFileToGitInfoExcludeLocallyToolStripMenuItem.Name = "addFileToGitInfoExcludeLocallyToolStripMenuItem";
@@ -369,7 +370,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(229, 6);
             //
-            // interactiveAddtoolStripMenuItem
+            // interactiveAddToolStripMenuItem
             //
             this.interactiveAddToolStripMenuItem.Name = "interactiveAddToolStripMenuItem";
             this.interactiveAddToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
@@ -822,7 +823,7 @@ namespace GitUI.CommandsDialogs
             this.resetUnstagedChangesToolStripMenuItem.Text = "Reset unstaged changes";
             this.resetUnstagedChangesToolStripMenuItem.Click += new System.EventHandler(this.resetUnstagedChangesToolStripMenuItem_Click);
             //
-            // resetAlltrackedChangesToolStripMenuItem
+            // resetAllTrackedChangesToolStripMenuItem
             //
             this.resetAllTrackedChangesToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.resetAllTrackedChangesToolStripMenuItem.Name = "resetAllTrackedChangesToolStripMenuItem";
@@ -1033,11 +1034,26 @@ namespace GitUI.CommandsDialogs
             //
             // splitRight.Panel2
             //
+            this.splitRight.Panel2.Controls.Add(this.modifyCommitMessageButton);
             this.splitRight.Panel2.Controls.Add(this.tableLayoutPanel1);
             this.splitRight.Size = new System.Drawing.Size(517, 622);
             this.splitRight.SplitterDistance = 426;
             this.splitRight.TabIndex = 0;
             this.splitRight.TabStop = false;
+            //
+            // modifyCommitMessageButton
+            //
+            this.modifyCommitMessageButton.AutoSize = true;
+            this.modifyCommitMessageButton.BackColor = System.Drawing.SystemColors.ButtonFace;
+            this.modifyCommitMessageButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.modifyCommitMessageButton.ForeColor = System.Drawing.SystemColors.HotTrack;
+            this.modifyCommitMessageButton.Location = new System.Drawing.Point(185, 55);
+            this.modifyCommitMessageButton.Name = "modifyCommitMessageButton";
+            this.modifyCommitMessageButton.Size = new System.Drawing.Size(149, 25);
+            this.modifyCommitMessageButton.TabIndex = 9;
+            this.modifyCommitMessageButton.Text = "Modify the commit m&essage";
+            this.modifyCommitMessageButton.UseVisualStyleBackColor = false;
+            this.modifyCommitMessageButton.Click += new System.EventHandler(this.modifyCommitMessageButton_Click);
             //
             // SolveMergeconflicts
             //
@@ -1469,7 +1485,7 @@ namespace GitUI.CommandsDialogs
             this.stopTrackingThisFileToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
             this.stopTrackingThisFileToolStripMenuItem.Text = "Stop tracking this file";
             this.stopTrackingThisFileToolStripMenuItem.Click += new System.EventHandler(this.stopTrackingThisFileToolStripMenuItem_Click);
-            // 
+            //
             // FormCommit
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1661,5 +1677,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripTextBox toolStripGpgKeyTextBox;
         private ToolStripComboBox gpgSignCommitToolStripComboBox;
         private ToolStripMenuItem stopTrackingThisFileToolStripMenuItem;
+        private Button modifyCommitMessageButton;
     }
 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -337,8 +337,6 @@ namespace GitUI.CommandsDialogs
 
             void ConfigureMessageBox()
             {
-                Amend.Enabled = _commitKind == CommitKind.Normal;
-
                 bool messageCanBeChanged = _useFormCommitMessage && _commitKind == CommitKind.Normal;
 
                 Message.Enabled = messageCanBeChanged;
@@ -1086,7 +1084,7 @@ namespace GitUI.CommandsDialogs
             LoadingStaged.Visible = false;
             Commit.Enabled = true;
             CommitAndPush.Enabled = true;
-            Amend.Enabled = _commitKind == CommitKind.Normal;
+            Amend.Enabled = true;
             Reset.Enabled = doChangesExist;
 
             EnableStageButtons(true);
@@ -1981,7 +1979,7 @@ namespace GitUI.CommandsDialogs
                 EnableStageButtons(true);
 
                 Commit.Enabled = true;
-                Amend.Enabled = _commitKind == CommitKind.Normal;
+                Amend.Enabled = true;
             }
 
             if (AppSettings.RevisionGraphShowWorkingDirChanges)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3304,6 +3304,11 @@ Do you want to continue?</source>
         <source>Merge conflicts</source>
         <target />
       </trans-unit>
+      <trans-unit id="_modifyCommitMessageButtonToolTip.Text">
+        <source>If you change the first line of the commit message, git will treat this commit as an ordinary commit,
+i.e. it may no longer be a fixup or an autosquash commit.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_noFilesStagedAndConfirmAnEmptyMergeCommit.Text">
         <source>There are no files staged for this commit.
 Are you sure you want to commit?</source>
@@ -3531,6 +3536,10 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="interactiveAddToolStripMenuItem.Text">
         <source>Interactive Add</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="modifyCommitMessageButton.Text">
+        <source>Modify the commit m&amp;essage</source>
         <target />
       </trans-unit>
       <trans-unit id="noVerifyToolStripMenuItem.Text">


### PR DESCRIPTION
Fixes #7104
Fixes #6993

## Proposed changes

- add button to enable editing the special commit message of `fixup!` and `squash!` commits
- add/adapt hotkeys for buttons
- allow `Amend commit'` for any `CommitKind`
- reset `CommitKind` after commiting without closing `FormCommit`
- slightly off topic: add more test cases for empty lines in commit messages (addendum to #6877)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/64907930-8a7a9180-d6f9-11e9-8967-9bfa7188424b.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/65071727-ad25d800-d98f-11e9-9fb2-705a7c1d874f.png)
(different message font due to different font settings vs. portable build)
![grafik](https://user-images.githubusercontent.com/36601201/65071885-fb3adb80-d98f-11e9-9f23-a35647e8b475.png)

### (Intermediate with ToolStripItemButton)
![grafik](https://user-images.githubusercontent.com/36601201/64907893-ff010080-d6f8-11e9-9e82-18f539ed377e.png)

### Before

![grafik](https://user-images.githubusercontent.com/36601201/64907947-bac23000-d6f9-11e9-94b5-374f1e79bf28.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/64907856-5f437280-d6f8-11e9-987d-f98ebc2db8bc.png)


## Test methodology <!-- How did you ensure quality? -->

- manual tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 79dee30803b7eb1ae0ff5999ff3bb962a9cacff7
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.3815.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
