### PR TITLE
Add hotkeys for continue rebase, resolve merge conflicts etc.

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -42,11 +42,11 @@ namespace GitUI.CommandsDialogs
     {
         #region Translation
 
-        private readonly TranslationString _warningMiddleOfBisect = new TranslationString("You are in the middle of a bisect");
-        private readonly TranslationString _warningMiddleOfRebase = new TranslationString("You are in the middle of a rebase");
-        private readonly TranslationString _warningMiddleOfPatchApply = new TranslationString("You are in the middle of a patch apply");
+        private readonly TranslationString _warningMiddleOfBisect = new TranslationString("You are in the middle of a bisect. C&ontinue...");
+        private readonly TranslationString _warningMiddleOfRebase = new TranslationString("You are in the middle of a rebase. C&ontinue...");
+        private readonly TranslationString _warningMiddleOfPatchApply = new TranslationString("You are in the middle of a patch apply. C&ontinue...");
 
-        private readonly TranslationString _hintUnresolvedMergeConflicts = new TranslationString("There are unresolved merge conflicts!");
+        private readonly TranslationString _hintUnresolvedMergeConflicts = new TranslationString("There are unresolved merge conflicts. Res&olve...");
 
         private readonly TranslationString _noBranchTitle = new TranslationString("no branch");
         private readonly TranslationString _noSubmodulesPresent = new TranslationString("No submodules");

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2189,7 +2189,7 @@ compare with first:</source>
         <target />
       </trans-unit>
       <trans-unit id="_hintUnresolvedMergeConflicts.Text">
-        <source>There are unresolved merge conflicts!</source>
+        <source>There are unresolved merge conflicts. Res&amp;olve...</source>
         <target />
       </trans-unit>
       <trans-unit id="_indexLockCantDelete.Text">
@@ -2275,15 +2275,15 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="_warningMiddleOfBisect.Text">
-        <source>You are in the middle of a bisect</source>
+        <source>You are in the middle of a bisect. C&amp;ontinue...</source>
         <target />
       </trans-unit>
       <trans-unit id="_warningMiddleOfPatchApply.Text">
-        <source>You are in the middle of a patch apply</source>
+        <source>You are in the middle of a patch apply. C&amp;ontinue...</source>
         <target />
       </trans-unit>
       <trans-unit id="_warningMiddleOfRebase.Text">
-        <source>You are in the middle of a rebase</source>
+        <source>You are in the middle of a rebase. C&amp;ontinue...</source>
         <target />
       </trans-unit>
       <trans-unit id="aboutToolStripMenuItem.Text">

--- a/GitUI/UserControls/WarningToolStripItem.cs
+++ b/GitUI/UserControls/WarningToolStripItem.cs
@@ -14,6 +14,7 @@ namespace GitUI
             _counter = 0;
             Width = 200;
             Height = 20;
+            RightToLeft = RightToLeft.No;
             _blinkTimer = new Timer { Interval = 150, Enabled = true };
             _blinkTimer.Tick += _blinkTimer_Tick;
             _blinkTimer.Start();


### PR DESCRIPTION
Fixes #7110

## Proposed changes

- extent `WarningToolStripItem.Text` with action what will happen on click, i.e.
  - "continue" rebase, bisect or patch apply
  - "resolve" merge conflicts
- add hotkey `Alt+O` to these `WarningToolStripItem`s

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/64926732-378c0180-d801-11e9-8400-6f5b0f71c48c.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/64926486-5a68e680-d7fe-11e9-94db-531dd1e9ad65.png)

## Test methodology <!-- How did you ensure quality? -->

- manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 54b165d0ecfc2161f034d2c6aee1aee50df03bef
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4010.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
