### PR TITLE
Set repo workingdir from env only if cmd line arguments

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -191,7 +191,7 @@ namespace GitExtensions
                 }
             }
 
-            if (workingDir == null)
+            if (args.Length > 1 && workingDir == null)
             {
                 // If no working dir is yet found, try to find one relative to the current working directory.
                 // This allows the `fileeditor` command to discover repository configuration which is


### PR DESCRIPTION
This will allow starting with the dashboard in the debugger
This was changed in #4740 (see the discussion there for further information), changed in #4870 (for #4809) and regressed in #5722.

## Proposed changes
This change still allows commands with arguments to find the current Git dir but starts dashboard if configured so without arguments.

In some sense, this will break command line start without arguments assuming that "browse" will start (probably not so before 3.0 though).
The workaround is not too difficult, add "browse" as an argument (and current dir will be used if in a repo).

## Test methodology <!-- How did you ensure quality? -->
Manual
By default "browse" is an argument for the Debugger.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
