### PR TITLE
Fix unit tests on `TryGetExactPathName()` (for AppVeyor VS2019 image)

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -30,18 +30,18 @@ namespace GitUITests.CommandsDialogs
         }
 
         [TestCase(@"c:\Users\Public\desktop.ini")]
-        [TestCase(@"c:\pagefile.sys")]
         [TestCase(@"c:\Windows\System32\cmd.exe")]
         [TestCase(@"c:\Users\Default\NTUSER.DAT")]
         [TestCase(@"c:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies")]
         [TestCase(@"c:\Program Files (x86)")]
         public void TryGetExactPathName_Should_output_path_with_exact_casing(string path)
         {
-            var lowercasePath = path.ToLower();
-            var isExistingOnFileSystem = _controller.TryGetExactPath(lowercasePath, out string exactPath);
+            var pathLowered = path.ToLower();
+            var isExistingOnFileSystem = _controller.TryGetExactPath(pathLowered, out string exactPath);
 
             Assert.IsTrue(isExistingOnFileSystem);
-            Assert.AreEqual(path, exactPath);
+            Assert.AreEqual(pathLowered, exactPath.ToLower(), "The path should be still equivalent");
+            Assert.AreNotEqual(pathLowered, exactPath, "The path case has been changed");
         }
 
         [Test]


### PR DESCRIPTION
A little less punitive try to fix a failing test than #7112.
A per-requisite at the use of the VS2019 AppVeyor image.

The test that fails is partly due to a refactoring made in 1246b50 where I raise a little the bar with the expectations.

Indeed, before that, when the files existing, the unit test was verifying... nothing!

I made a change to verify that the paths cases was the ones of the real paths. I was thinking that the windows paths would have always the same cases for system files. It seems not to be the case :( as the AppVeyor VS2019 image has a different one...

I can propose is to find a in-between between testing nothing (like before the refactoring) and having the expected casing (after the refactoring).

I.e:

    We start with the paths without the good casing (lower case)
    We check that the result is still equivalent (by lowering the result)
    We check that the path has been changed (expecting that it is the good case)

PS: The test on @"C:\pagefile.sys" has been removed because I discovered that the call to the native api are not working with files at the root of the drive 👿 😭

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Test methodology <!-- How did you ensure quality? -->

- Unit test ;) 

