### PR TITLE
exename not set for tortoisemerge

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -122,6 +122,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 case "semanticdiff":
                     return "semanticmergetool.exe";
                 case "tmerge":
+                case "tortoisemerge":
                     return "TortoiseGitMerge.exe";
                 case "winmerge":
                     return "winmergeu.exe";


### PR DESCRIPTION
Fixes #7169 

## Proposed changes
Set TortoiseGitMerge.exe

Should be cherry picked to 3.2

## Test methodology <!-- How did you ensure quality? -->
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
