### PR TITLE
Align location of System.Collections.Immutable.dll between MSI and Portable builds

### DIFF
--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -25,6 +25,8 @@ xcopy /y /i ..\GitExtensions\bin\%Configuration%\System.Collections.Concurrent.d
 IF ERRORLEVEL 1 EXIT /B 1 
 xcopy /y /i ..\GitExtensions\bin\%Configuration%\System.Collections.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1 
+xcopy /y /i ..\GitExtensions\bin\%Configuration%\System.Collections.Immutable.dll GitExtensions\
+IF ERRORLEVEL 1 EXIT /B 1 
 xcopy /y /i ..\GitExtensions\bin\%Configuration%\System.Collections.NonGeneric.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1 
 xcopy /y /i ..\GitExtensions\bin\%Configuration%\System.Collections.Specialized.dll GitExtensions\
@@ -529,8 +531,6 @@ IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\Plugins\JiraCommitHintPlugin\bin\%Configuration%\JiraCommitHintPlugin.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\Plugins\JiraCommitHintPlugin\bin\%Configuration%\NString.dll GitExtensions\Plugins\
-IF ERRORLEVEL 1 EXIT /B 1
-xcopy /y /i ..\Plugins\JiraCommitHintPlugin\bin\%Configuration%\System.Collections.Immutable.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\Plugins\ProxySwitcher\bin\%Configuration%\ProxySwitcher.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7155


## Proposed changes

- move `System.Collections.Immutable.dll` from /plugins dir to root dir for portable builds, since this is the location of the DLL in the installed version


## Test methodology <!-- How did you ensure quality? -->

- made portable build and verified correct location of DLL
- manual tests 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
