### PR TITLE
Limit removable for "Contained in branches/tags"

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2597,6 +2597,9 @@ namespace GitUI.CommandsDialogs
                 case "navigateforward":
                     RevisionGrid.NavigateForward();
                     break;
+                case "showall":
+                    RevisionInfo.ShowAll(e.Data);
+                    break;
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -53,7 +53,6 @@ namespace GitUI.CommitInfo
         private static readonly TranslationString _plusCommits = new TranslationString("commits");
         private static readonly TranslationString _repoFailure = new TranslationString("Repository failure");
 
-        private const int MaximumDisplayedRefs = 20;
         private readonly ILinkFactory _linkFactory = new LinkFactory();
         private readonly ICommitDataManager _commitDataManager;
         private readonly ICommitDataBodyRenderer _commitDataBodyRenderer;
@@ -537,27 +536,13 @@ namespace GitUI.CommitInfo
                 if (_tags != null && string.IsNullOrEmpty(_tagInfo))
                 {
                     _tags.Sort(new ItemTpComparer(_refsOrderDict, "refs/tags/"));
-                    if (_tags.Count > MaximumDisplayedRefs)
-                    {
-                        _tags[MaximumDisplayedRefs - 2] = "…";
-                        _tags[MaximumDisplayedRefs - 1] = _tags[_tags.Count - 1];
-                        _tags.RemoveRange(MaximumDisplayedRefs, _tags.Count - MaximumDisplayedRefs);
-                    }
-
-                    _tagInfo = _refsFormatter.FormatTags(_tags, ShowBranchesAsLinks);
+                    _tagInfo = _refsFormatter.FormatTags(_tags, ShowBranchesAsLinks, limit: true);
                 }
 
                 if (_branches != null && string.IsNullOrEmpty(_branchInfo))
                 {
                     _branches.Sort(new ItemTpComparer(_refsOrderDict, "refs/heads/"));
-                    if (_branches.Count > MaximumDisplayedRefs)
-                    {
-                        _branches[MaximumDisplayedRefs - 2] = "…";
-                        _branches[MaximumDisplayedRefs - 1] = _branches[_branches.Count - 1];
-                        _branches.RemoveRange(MaximumDisplayedRefs, _branches.Count - MaximumDisplayedRefs);
-                    }
-
-                    _branchInfo = _refsFormatter.FormatBranches(_branches, ShowBranchesAsLinks);
+                    _branchInfo = _refsFormatter.FormatBranches(_branches, ShowBranchesAsLinks, limit: true);
                 }
             }
 

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using GitCommands;
+using JetBrains.Annotations;
+using ResourceManager;
+
+namespace GitUI.CommitInfo
+{
+    public sealed class RefsFormatter
+    {
+        [NotNull]
+        private readonly ILinkFactory _linkFactory;
+
+        public RefsFormatter([NotNull] ILinkFactory linkFactory)
+        {
+            _linkFactory = linkFactory ?? throw new ArgumentNullException("RefsFormatter requires an ILinkFactory instance");
+        }
+
+        public string FormatBranches(IEnumerable<string> branches, bool showAsLinks)
+        {
+            const string remotesPrefix = "remotes/";
+
+            // Include local branches if explicitly requested or when needed to decide whether to show remotes
+            bool getLocal = AppSettings.CommitInfoShowContainedInBranchesLocal ||
+                            AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
+
+            // Include remote branches if requested
+            bool getRemote = AppSettings.CommitInfoShowContainedInBranchesRemote ||
+                             AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
+            var links = new List<string>();
+            bool allowLocal = AppSettings.CommitInfoShowContainedInBranchesLocal;
+            bool allowRemote = getRemote;
+
+            foreach (var branch in branches)
+            {
+                string noPrefixBranch = branch;
+                bool branchIsLocal;
+                if (getLocal && getRemote)
+                {
+                    // "git branch -a" prefixes remote branches with "remotes/"
+                    // It is possible to create a local branch named "remotes/origin/something"
+                    // so this check is not 100% reliable.
+                    // This shouldn't be a big problem if we're only displaying information.
+                    // This could be solved by listing local and remote branches separately.
+                    branchIsLocal = !branch.StartsWith(remotesPrefix);
+                    if (!branchIsLocal)
+                    {
+                        noPrefixBranch = branch.Substring(remotesPrefix.Length);
+                    }
+                }
+                else
+                {
+                    branchIsLocal = !getRemote;
+                }
+
+                if ((branchIsLocal && allowLocal) || (!branchIsLocal && allowRemote))
+                {
+                    var branchText = showAsLinks
+                        ? _linkFactory.CreateBranchLink(noPrefixBranch)
+                        : WebUtility.HtmlEncode(noPrefixBranch);
+
+                    links.Add(branchText);
+                }
+
+                if (branchIsLocal && AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal)
+                {
+                    allowRemote = false;
+                }
+            }
+
+            if (links.Any())
+            {
+                return WebUtility.HtmlEncode(Strings.ContainedInBranches) + " " + links.Join(", ");
+            }
+
+            return WebUtility.HtmlEncode(Strings.ContainedInNoBranch);
+        }
+
+        public string FormatTags(IEnumerable<string> tags, bool showAsLinks)
+        {
+            var tagString = tags
+                .Select(s => showAsLinks ? _linkFactory.CreateTagLink(s) : WebUtility.HtmlEncode(s)).Join(", ");
+
+            if (!string.IsNullOrEmpty(tagString))
+            {
+                return WebUtility.HtmlEncode(Strings.ContainedInTags) + " " + tagString;
+            }
+
+            return WebUtility.HtmlEncode(Strings.ContainedInNoTag);
+        }
+    }
+}

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -40,6 +40,29 @@ namespace GitUI.CommitInfo
                 return string.Empty;
             }
 
+            var (formattedBranches, truncated) = FilterAndFormatBranches(branches, showAsLinks, limit);
+            return ToString(formattedBranches, Strings.ContainedInBranches, Strings.ContainedInNoBranch, "branches", truncated);
+        }
+
+        public string FormatTags(IReadOnlyList<string> tags, bool showAsLinks, bool limit)
+        {
+            if (tags == null)
+            {
+                return string.Empty;
+            }
+
+            bool truncate = limit && tags.Count > MaximumDisplayedLinesIfLimited;
+            var formattedTags = FormatTags(truncate ? tags.Take(MaximumDisplayedRefsIfLimited) : tags);
+            return ToString(formattedTags, Strings.ContainedInTags, Strings.ContainedInNoTag, "tags", truncate);
+
+            IEnumerable<string> FormatTags(IEnumerable<string> selectedTags)
+            {
+                return selectedTags.Select(s => showAsLinks ? _linkFactory.CreateTagLink(s) : WebUtility.HtmlEncode(s));
+            }
+        }
+
+        private (IEnumerable<string> formattedBranches, bool truncated) FilterAndFormatBranches(IEnumerable<string> branches, bool showAsLinks, bool limit)
+        {
             var formattedBranches = new List<string>();
             bool truncated = false;
 
@@ -99,24 +122,7 @@ namespace GitUI.CommitInfo
                 }
             }
 
-            return ToString(formattedBranches, Strings.ContainedInBranches, Strings.ContainedInNoBranch, "branches", truncated);
-        }
-
-        public string FormatTags(IReadOnlyList<string> tags, bool showAsLinks, bool limit)
-        {
-            if (tags == null)
-            {
-                return string.Empty;
-            }
-
-            bool truncate = limit && tags.Count > MaximumDisplayedLinesIfLimited;
-            var formattedTags = FormatTags(truncate ? tags.Take(MaximumDisplayedRefsIfLimited) : tags);
-            return ToString(formattedTags, Strings.ContainedInTags, Strings.ContainedInNoTag, "tags", truncate);
-
-            IEnumerable<string> FormatTags(IEnumerable<string> selectedTags)
-            {
-                return selectedTags.Select(s => showAsLinks ? _linkFactory.CreateTagLink(s) : WebUtility.HtmlEncode(s));
-            }
+            return (formattedBranches, truncated);
         }
 
         private string ToString(IEnumerable<string> formattedRefs, string prefix, string textIfEmpty, string refsType, bool truncated)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -327,6 +327,7 @@
     <Compile Include="CommandsDialogs\ToolStripPushButton.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="CommitInfo\RefsFormatter.cs" />
     <Compile Include="CommitInfo\CommitInfoHeader.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -6,6 +6,10 @@ namespace GitUI
 {
     internal sealed class Strings : Translate
     {
+        private readonly TranslationString _containedInBranchesText = new TranslationString("Contained in branches:");
+        private readonly TranslationString _containedInNoBranchText = new TranslationString("Contained in no branch");
+        private readonly TranslationString _containedInTagsText = new TranslationString("Contained in tags:");
+        private readonly TranslationString _containedInNoTagText = new TranslationString("Contained in no tag");
         private readonly TranslationString _viewPullRequest = new TranslationString("View pull requests");
         private readonly TranslationString _createPullRequest = new TranslationString("Create pull request");
         private readonly TranslationString _forkCloneRepo = new TranslationString("Fork or clone a repository");
@@ -39,6 +43,11 @@ namespace GitUI
                 _instance = new Lazy<Strings>();
             }
         }
+
+        public static string ContainedInBranches => _instance.Value._containedInBranchesText.Text;
+        public static string ContainedInNoBranch => _instance.Value._containedInNoBranchText.Text;
+        public static string ContainedInTags => _instance.Value._containedInTagsText.Text;
+        public static string ContainedInNoTag => _instance.Value._containedInNoTagText.Text;
 
         public static string CreatePullRequest => _instance.Value._createPullRequest.Text;
         public static string ForkCloneRepo => _instance.Value._forkCloneRepo.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -812,22 +812,6 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>The repository refs seem to be broken:</source>
         <target />
       </trans-unit>
-      <trans-unit id="_containedInBranches.Text">
-        <source>Contained in branches:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_containedInNoBranch.Text">
-        <source>Contained in no branch</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_containedInNoTag.Text">
-        <source>Contained in no tag</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_containedInTags.Text">
-        <source>Contained in tags:</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_copyLink.Text">
         <source>Copy &amp;link ({0})</source>
         <target />
@@ -9243,6 +9227,22 @@ Select this commit to populate the full message.</source>
         <source>Committer</source>
         <target />
       </trans-unit>
+      <trans-unit id="_containedInBranchesText.Text">
+        <source>Contained in branches:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_containedInNoBranchText.Text">
+        <source>Contained in no branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_containedInNoTagText.Text">
+        <source>Contained in no tag</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_containedInTagsText.Text">
+        <source>Contained in tags:</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_createPullRequest.Text">
         <source>Create pull request</source>
         <target />
@@ -9325,6 +9325,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_secondsAgo.Text">
         <source>{0} {1:second|seconds} ago</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_showAllText.Text">
+        <source>Show all</source>
         <target />
       </trans-unit>
       <trans-unit id="_submodulesText.Text">

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -12,6 +12,7 @@ namespace ResourceManager
         string CreateTagLink(string tag);
         string CreateBranchLink(string noPrefixBranch);
         string CreateCommitLink(ObjectId objectId, string linkText = null, bool preserveGuidInLinkText = false);
+        string CreateShowAllLink(string what);
         string ParseLink(string linkText);
     }
 
@@ -83,6 +84,9 @@ namespace ResourceManager
 
             return AddLink(linkText, "gitext://gotocommit/" + objectId);
         }
+
+        public string CreateShowAllLink(string what)
+            => AddLink($"[ {Strings.ShowAll} ]", $"gitext://showall/{what}");
 
         public string ParseLink(string linkText)
         {

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -36,6 +36,7 @@ Yes, I allow telemetry!");
         private readonly TranslationString _commitDateText = new TranslationString("{0:Commit date|Commits dates}");
         private readonly TranslationString _commitHashText = new TranslationString("{0:Commit hash|Commits hashes}");
         private readonly TranslationString _messageText = new TranslationString("{0:Message|Messages}");
+        private readonly TranslationString _showAllText = new TranslationString("Show all");
         private readonly TranslationString _workspaceText = new TranslationString("Working directory");
         private readonly TranslationString _indexText = new TranslationString("Commit index");
 
@@ -71,6 +72,7 @@ Yes, I allow telemetry!");
         public static string Committer => _instance.Value._committerText.Text;
         public static string CommitDate => GetCommitDate(1);
         public static string CommitHash => GetCommitHash(1);
+        public static string ShowAll => _instance.Value._showAllText.Text;
         public static string Workspace => _instance.Value._workspaceText.Text;
         public static string Index => _instance.Value._indexText.Text;
 

--- a/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
@@ -51,7 +51,7 @@ namespace GitUITests.CommitInfo
             uiCommandsSource.UICommands.Returns(x => _commands);
 
             // the following assignment of _commitInfo.UICommandsSource will already call this command
-            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/", "");
+            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/", "");
 
             _commitInfo = new GitUI.CommitInfo.CommitInfo
             {
@@ -151,18 +151,18 @@ namespace GitUITests.CommitInfo
         }
 
         [Test]
-        public void GetSortedRefs_should_throw_on_git_warning()
+        public void GetSortedTags_should_throw_on_git_warning()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                 "refs/heads/master\nwarning: message");
 
-            ((Action)(() => _commitInfo.GetTestAccessor().GetSortedRefs())).Should().Throw<RefsWarningException>();
+            ((Action)(() => _commitInfo.GetTestAccessor().GetSortedTags())).Should().Throw<RefsWarningException>();
         }
 
         [Test]
-        public void GetSortedRefs_should_split_output_if_no_warning()
+        public void GetSortedTags_should_split_output_if_no_warning()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                 "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"); // does not contain "warning:"
 
             var expected = new Dictionary<string, int>
@@ -172,16 +172,16 @@ namespace GitUITests.CommitInfo
                 ["refs/heads/warning"] = 2
             };
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
 
             refs.Count.Should().Be(3);
             refs.Should().BeEquivalentTo(expected);
         }
 
         [Test]
-        public void GetSortedRefs_should_load_ref_different_in_case()
+        public void GetSortedTags_should_load_ref_different_in_case()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                 "refs/remotes/origin/master\nrefs/heads/master\nrefs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375\nrefs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"); // case sensitive duplicates
 
             var expected = new Dictionary<string, int>
@@ -192,16 +192,16 @@ namespace GitUITests.CommitInfo
                 ["refs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"] = 3
             };
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
 
             refs.Count.Should().Be(4);
             refs.Should().BeEquivalentTo(expected);
         }
 
         [Test]
-        public void GetSortedRefs_should_load_ref_with_extra_spaces()
+        public void GetSortedTags_should_load_ref_with_extra_spaces()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                 "refs/remotes/origin/master\nrefs/heads/master\nrefs/tags/v3.1\nrefs/tags/v3.1 \n refs/tags/v3.1"); // have leading and trailing spaces
 
             var expected = new Dictionary<string, int>
@@ -213,16 +213,16 @@ namespace GitUITests.CommitInfo
                 [" refs/tags/v3.1"] = 4
             };
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
 
             refs.Count.Should().Be(5);
             refs.Should().BeEquivalentTo(expected);
         }
 
         [Test]
-        public void GetSortedRefs_should_remove_duplicate_refs()
+        public void GetSortedTags_should_remove_duplicate_refs()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                 "refs/remotes/origin/master\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/bar\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/last"); // exact duplicates
 
             var expected = new Dictionary<string, int>
@@ -233,7 +233,7 @@ namespace GitUITests.CommitInfo
                 ["refs/remotes/foo/last"] = 3,
             };
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
 
             refs.Count.Should().Be(4);
             refs.Should().BeEquivalentTo(expected);

--- a/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Threading;
 using CommonTestUtils;
@@ -71,6 +72,82 @@ namespace GitUITests.CommitInfo
         public void OneTimeTearDown()
         {
             _referenceRepository.Dispose();
+        }
+
+        [Test]
+        public void BranchComparer([Values(null, "current")] string currentBranch)
+        {
+            var expectedBranches = new List<string>
+            {
+                currentBranch,
+
+                // local important
+                "master",
+                "master2",
+
+                // remote important, important repos
+                "remotes/origin/master",
+                "remotes/upstream/master",
+
+                // remote important, other repos
+                "remotes/myrepo/master",
+                "remotes/myrepo/master2",
+                "remotes/other/master",
+                "remotes/z_other/master",
+
+                // local branches
+                "1234_issue",
+                "current/2",
+                "current_2",
+                "feature/1234_issue",
+                "fix/master",
+                "mastr",
+                "repro/issue",
+
+                // important repos
+                "remotes/origin/b1",
+                "remotes/origin/b2",
+                "remotes/upstream/b1",
+                "remotes/upstream/b2",
+
+                // other repos
+                "remotes/myrepo/b1",
+                "remotes/myrepo/b2",
+                "remotes/other/b1",
+                "remotes/other/b2",
+                "remotes/z_other/b1",
+                "remotes/z_other/b2",
+            };
+
+            if (currentBranch == null)
+            {
+                expectedBranches.RemoveAt(0);
+            }
+
+            var branches = new List<string>(expectedBranches);
+
+            SortAndCheckListsForEquality();
+
+            branches.Sort();
+
+            SortAndCheckListsForEquality();
+
+            branches.Reverse();
+
+            SortAndCheckListsForEquality();
+
+            return;
+
+            void SortAndCheckListsForEquality()
+            {
+                branches.Sort(new GitUI.CommitInfo.CommitInfo.BranchComparer(currentBranch));
+
+                branches.Count.Should().Be(expectedBranches.Count);
+                for (int index = 0; index < branches.Count; ++index)
+                {
+                    branches[index].Should().BeSameAs(expectedBranches[index]);
+                }
+            }
         }
 
         [Test]

--- a/UnitTests/GitUITests/CommitInfo/RefsFormatterTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/RefsFormatterTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using GitUI.CommitInfo;
+using NUnit.Framework;
+using ResourceManager;
+
+namespace GitUITests.CommitInfo
+{
+    public class RefsFormatterTests
+    {
+        private readonly IReadOnlyList<string> _refs
+            = new List<string> { "r1", null, "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "r13" };
+
+        // Created once for each test
+        private ILinkFactory _linkFactory;
+        private RefsFormatter _refsFormatter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _linkFactory = new LinkFactory();
+            _refsFormatter = new RefsFormatter(_linkFactory);
+        }
+
+        [Test]
+        public void LinkFactoryNull()
+        {
+            ((Action)(() => new RefsFormatter(null))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void RefsNull()
+        {
+            _refsFormatter.FormatBranches(branches: null, showAsLinks: true, limit: true)
+                .Should().Be(string.Empty);
+
+            _refsFormatter.FormatTags(tags: null, showAsLinks: true, limit: true)
+                .Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void Empty([Values(true, false)] bool showAsLinks, [Values(true, false)] bool limit)
+        {
+            IReadOnlyList<string> refs = new List<string>();
+
+            _refsFormatter.FormatBranches(refs, showAsLinks, limit)
+                .Should().Be(GitUI.Strings.ContainedInNoBranch);
+
+            _refsFormatter.FormatTags(refs, showAsLinks, limit)
+                .Should().Be(GitUI.Strings.ContainedInNoTag);
+        }
+
+        [Test]
+        public void LimitNotExceededOrNotLimited([Values(1, 2, 3, 9, 10, 11, 12, 13)] int count, [Values(true, false)] bool showAsLinks)
+        {
+            bool limit = count <= 12;
+            IReadOnlyList<string> refs = _refs.Take(count).ToList();
+            IEnumerable<string> formattedBranches = refs.Select(r => FormatRef(r, "branch", showAsLinks));
+            IEnumerable<string> formattedTags = refs.Select(r => FormatRef(r, "tag", showAsLinks));
+
+            _refsFormatter.FormatBranches(refs, showAsLinks, limit)
+                .Should().Be(GitUI.Strings.ContainedInBranches
+                             + Environment.NewLine
+                             + formattedBranches.Join(Environment.NewLine));
+
+            _refsFormatter.FormatTags(refs, showAsLinks, limit)
+                .Should().Be(GitUI.Strings.ContainedInTags
+                             + Environment.NewLine
+                             + formattedTags.Join(Environment.NewLine));
+        }
+
+        [Test]
+        public void LimitExceeded([Values(true, false)] bool showAsLinks)
+        {
+            IEnumerable<string> formattedBranches = _refs.Take(10).Select(r => FormatRef(r, "branch", showAsLinks));
+            IEnumerable<string> formattedTags = _refs.Take(10).Select(r => FormatRef(r, "tag", showAsLinks));
+
+            _refsFormatter.FormatBranches(_refs, showAsLinks, limit: true)
+                .Should().Be(GitUI.Strings.ContainedInBranches
+                             + Environment.NewLine
+                             + formattedBranches.Join(Environment.NewLine)
+                             + GetShowAllLink("branches"));
+
+            _refsFormatter.FormatTags(_refs, showAsLinks, limit: true)
+                .Should().Be(GitUI.Strings.ContainedInTags
+                             + Environment.NewLine
+                             + formattedTags.Join(Environment.NewLine)
+                             + GetShowAllLink("tags"));
+        }
+
+        private string FormatRef(string r, string type, bool showAsLinks)
+        {
+            return showAsLinks ? $"<a href='gitext://goto{type}/{r}'>{r}</a>" : r;
+        }
+
+        private string GetShowAllLink(string type)
+        {
+            return $"{Environment.NewLine}<a href='gitext://showall/{type}'>[ {Strings.ShowAll} ]</a>{Environment.NewLine}";
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="CommandsDialogs\Settings\GitHubExternalLinkDefinitionExtractorTests.cs" />
     <Compile Include="CommandsDialogs\Settings\AzureDevOpsExternalLinkDefinitionExtractorTests.cs" />
     <Compile Include="CommitInfo\CommitInfoTests.cs" />
+    <Compile Include="CommitInfo\RefsFormatterTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
     <Compile Include="UserEnvironmentInformationTests.cs" />
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />


### PR DESCRIPTION
Fixes #5966 (part 2 of 2).

## Proposed changes

- [x] Show up to 12 lines for "Contained in branches/tags", one branch/tag per line
- [x] Add link to show all "Contained in branches/tags"
- [x] Show relevant branches (current & masters) first
- [x] As long as GetSortedRefs() doesn't return the branches sorted by date (#7181), sort other branches alphabetically.
- [x] Add `TranslationString`s from helper classes to translation
- [x] Turn GetSortedRefs into GetSortedTags (no more need to load sorted branches)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/65379942-10d23d00-dcd1-11e9-91d4-ca7bcdc5b36f.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/65379948-2c3d4800-dcd1-11e9-95ea-049257d16ff1.png)![grafik](https://user-images.githubusercontent.com/36601201/65379953-39f2cd80-dcd1-11e9-9a0b-974413c463ca.png)
![grafik](https://user-images.githubusercontent.com/36601201/65379973-b84f6f80-dcd1-11e9-8363-b729fa53d4e2.png)

## Test methodology <!-- How did you ensure quality? -->

- added NUnit tests

## Test environment(s)- Git Extensions 3.3.0
- Build 7ff0c27138154120d4e886b8169119250af7fd5b
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4010.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
