### PR TITLE
Improve some mnemonics of commit dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -384,7 +384,7 @@ namespace GitUI.CommandsDialogs
             this.StageInSuperproject.Name = "StageInSuperproject";
             this.StageInSuperproject.Size = new System.Drawing.Size(130, 17);
             this.StageInSuperproject.TabIndex = 13;
-            this.StageInSuperproject.Text = "Stage in Superproject";
+            this.StageInSuperproject.Text = "Stage &in Superproject";
             this.fileTooltip.SetToolTip(this.StageInSuperproject, "Stage current submodule in superproject after commit");
             this.StageInSuperproject.UseVisualStyleBackColor = true;
             this.StageInSuperproject.CheckedChanged += new System.EventHandler(this.StageInSuperproject_CheckedChanged);
@@ -763,7 +763,7 @@ namespace GitUI.CommandsDialogs
             this.workingToolStripMenuItem.Image = global::GitUI.Properties.Images.WorkingDirChanges;
             this.workingToolStripMenuItem.Name = "workingToolStripMenuItem";
             this.workingToolStripMenuItem.Size = new System.Drawing.Size(178, 20);
-            this.workingToolStripMenuItem.Text = "Working directory changes";
+            this.workingToolStripMenuItem.Text = "&Working directory changes";
             //
             // showIgnoredFilesToolStripMenuItem
             //
@@ -1140,7 +1140,7 @@ namespace GitUI.CommandsDialogs
             this.CommitAndPush.Size = new System.Drawing.Size(171, 26);
             this.CommitAndPush.TabIndex = 9;
             this.CommitAndPush.TabStop = false;
-            this.CommitAndPush.Text = "C&ommit && push";
+            this.CommitAndPush.Text = "Commit && &push";
             this.CommitAndPush.UseVisualStyleBackColor = true;
             this.CommitAndPush.Click += new System.EventHandler(this.CommitAndPush_Click);
             //
@@ -1166,7 +1166,7 @@ namespace GitUI.CommandsDialogs
             this.Reset.Size = new System.Drawing.Size(171, 26);
             this.Reset.TabIndex = 11;
             this.Reset.TabStop = false;
-            this.Reset.Text = "Reset all changes";
+            this.Reset.Text = "&Reset all changes";
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.ResetClick);
             //
@@ -1180,7 +1180,7 @@ namespace GitUI.CommandsDialogs
             this.ResetUnStaged.Size = new System.Drawing.Size(171, 26);
             this.ResetUnStaged.TabIndex = 14;
             this.ResetUnStaged.TabStop = false;
-            this.ResetUnStaged.Text = "Reset unstaged changes";
+            this.ResetUnStaged.Text = "Reset u&nstaged changes";
             this.ResetUnStaged.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.ResetUnStaged.UseVisualStyleBackColor = true;
             this.ResetUnStaged.Click += new System.EventHandler(this.ResetUnStagedClick);
@@ -1249,7 +1249,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
             this.toolStripMenuItem3.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.toolStripMenuItem3.Size = new System.Drawing.Size(62, 23);
-            this.toolStripMenuItem3.Text = "Options";
+            this.toolStripMenuItem3.Text = "&Options";
             //
             // closeDialogAfterEachCommitToolStripMenuItem
             //
@@ -1348,7 +1348,7 @@ namespace GitUI.CommandsDialogs
             this.createBranchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.createBranchToolStripButton.Name = "createBranchToolStripButton";
             this.createBranchToolStripButton.Size = new System.Drawing.Size(101, 20);
-            this.createBranchToolStripButton.Text = "Create branch";
+            this.createBranchToolStripButton.Text = "Create &branch";
             this.createBranchToolStripButton.Click += new System.EventHandler(this.createBranchToolStripButton_Click);
             //
             // commitStatusStrip

--- a/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
@@ -53,7 +53,7 @@
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(95, 25);
             this.btnReset.TabIndex = 1;
-            this.btnReset.Text = "Reset";
+            this.btnReset.Text = "&Reset";
             this.btnReset.UseVisualStyleBackColor = true;
             this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
             // 
@@ -65,7 +65,7 @@
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(95, 25);
             this.btnCancel.TabIndex = 2;
-            this.btnCancel.Text = "Cancel";
+            this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3164,7 +3164,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="CommitAndPush.Text">
-        <source>C&amp;ommit &amp;&amp; push</source>
+        <source>Commit &amp;&amp; &amp;push</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
@@ -3172,11 +3172,11 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="Reset.Text">
-        <source>Reset all changes</source>
+        <source>&amp;Reset all changes</source>
         <target />
       </trans-unit>
       <trans-unit id="ResetUnStaged.Text">
-        <source>Reset unstaged changes</source>
+        <source>Reset u&amp;nstaged changes</source>
         <target />
       </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
@@ -3185,7 +3185,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="StageInSuperproject.Text">
-        <source>Stage in Superproject</source>
+        <source>Stage &amp;in Superproject</source>
         <target />
       </trans-unit>
       <trans-unit id="_addSelectionToCommitMessage.Text">
@@ -3486,7 +3486,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="createBranchToolStripButton.Text">
-        <source>Create branch</source>
+        <source>Create &amp;branch</source>
         <target />
       </trans-unit>
       <trans-unit id="deleteAllUntrackedFilesToolStripMenuItem.Text">
@@ -3690,7 +3690,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="toolStripMenuItem3.Text">
-        <source>Options</source>
+        <source>&amp;Options</source>
         <target />
       </trans-unit>
       <trans-unit id="toolUnstageAllItem.Text">
@@ -3714,7 +3714,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="workingToolStripMenuItem.Text">
-        <source>Working directory changes</source>
+        <source>&amp;Working directory changes</source>
         <target />
       </trans-unit>
     </body>
@@ -6113,11 +6113,11 @@ Value has been reset to empty value.</source>
         <target />
       </trans-unit>
       <trans-unit id="btnCancel.Text">
-        <source>Cancel</source>
+        <source>&amp;Cancel</source>
         <target />
       </trans-unit>
       <trans-unit id="btnReset.Text">
-        <source>Reset</source>
+        <source>&amp;Reset</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDeleteNewFilesAndDirectories.Text">


### PR DESCRIPTION
## Proposed changes

- turn mnemonic of button `Commit & push` form `Alt+O` into `Alt+P`
- add mnemonics for all labeled buttons

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/65390029-bcc06a80-dd5b-11e9-8b4b-d57dbe762e2f.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/65390001-67845900-dd5b-11e9-9d1f-71ecc0ee1334.png)

### Before

![grafik](https://user-images.githubusercontent.com/36601201/64907947-bac23000-d6f9-11e9-94b5-374f1e79bf28.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/64907856-5f437280-d6f8-11e9-987d-f98ebc2db8bc.png)

## Test methodology <!-- How did you ensure quality? -->

- manual test

## Test environment(s)

- Git Extensions 3.3.0
- Build 3e02aadd0814cd712929d70ef741c6b7bc95aa4d
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4010.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
