### PR TITLE
Add ability to specify commit message on the command line

### DIFF
--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -37,10 +37,12 @@ namespace GitCommands
         private readonly string _amendSaveStatePath;
         private readonly string _commitMessagePath;
         private readonly string _mergeMessagePath;
-        [CanBeNull]
-        private string _overriddenCommitMessage;
+
         private Encoding _commitEncoding;
         private IFileSystem _fileSystem;
+
+        [CanBeNull]
+        private string _overriddenCommitMessage;
 
         public CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, string overriddenCommitMessage = null)
             : this(workingDirGitDir, commitEncoding, new FileSystem(), overriddenCommitMessage)

--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO.Abstractions;
 using System.Text;
+using JetBrains.Annotations;
 
 namespace GitCommands
 {
@@ -36,22 +37,24 @@ namespace GitCommands
         private readonly string _amendSaveStatePath;
         private readonly string _commitMessagePath;
         private readonly string _mergeMessagePath;
-
+        [CanBeNull]
+        private string _overriddenCommitMessage;
         private Encoding _commitEncoding;
         private IFileSystem _fileSystem;
 
-        public CommitMessageManager(string workingDirGitDir, Encoding commitEncoding)
-            : this(workingDirGitDir, commitEncoding, new FileSystem())
+        public CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, string overriddenCommitMessage = null)
+            : this(workingDirGitDir, commitEncoding, new FileSystem(), overriddenCommitMessage)
         {
         }
 
-        private CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem)
+        private CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string overriddenCommitMessage = null)
         {
             _fileSystem = fileSystem;
             _commitEncoding = commitEncoding;
             _amendSaveStatePath = GetFilePath(workingDirGitDir, "GitExtensions.amend");
             _commitMessagePath = GetFilePath(workingDirGitDir, "COMMITMESSAGE");
             _mergeMessagePath = GetFilePath(workingDirGitDir, "MERGE_MSG");
+            _overriddenCommitMessage = overriddenCommitMessage;
         }
 
         public bool AmendState
@@ -88,17 +91,29 @@ namespace GitCommands
         {
             get
             {
+                if (_overriddenCommitMessage != null)
+                {
+                    return _overriddenCommitMessage;
+                }
+
                 var (file, exists) = GetMergeOrCommitMessagePath();
                 return exists ? _fileSystem.File.ReadAllText(file, _commitEncoding) : string.Empty;
             }
             set
             {
-                _fileSystem.File.WriteAllText(GetMergeOrCommitMessagePath().FilePath, value ?? string.Empty, _commitEncoding);
+                var content = value ?? string.Empty;
+
+                // do not remember commit message when they have been specified by the command line
+                if (content != _overriddenCommitMessage)
+                {
+                    _fileSystem.File.WriteAllText(GetMergeOrCommitMessagePath().FilePath, content, _commitEncoding);
+                }
             }
         }
 
         public void ResetCommitMessage()
         {
+            _overriddenCommitMessage = null;
             _fileSystem.File.Delete(_commitMessagePath);
             _fileSystem.File.Delete(_amendSaveStatePath);
         }
@@ -117,8 +132,8 @@ namespace GitCommands
 
         internal class TestAccessor
         {
-            internal static CommitMessageManager Construct(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem)
-                => new CommitMessageManager(workingDirGitDir, commitEncoding, fileSystem);
+            internal static CommitMessageManager Construct(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string overriddenCommitMessage)
+                => new CommitMessageManager(workingDirGitDir, commitEncoding, fileSystem, overriddenCommitMessage);
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormCommandlineHelp.resx
+++ b/GitUI/CommandsDialogs/FormCommandlineHelp.resx
@@ -132,7 +132,7 @@ checkoutrevision
 cherry
 cleanup
 clone [path]
-commit [--quiet]
+commit [--quiet] [--message commitmessage]
 difftool filename
 filehistory filename
 fileeditor filename

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -205,7 +205,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
         }
 
-        public FormCommit([NotNull] GitUICommands commands, CommitKind commitKind = CommitKind.Normal, GitRevision editedCommit = null)
+        public FormCommit([NotNull] GitUICommands commands, CommitKind commitKind = CommitKind.Normal, GitRevision editedCommit = null, string commitMessage = null)
             : base(commands)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -216,7 +216,7 @@ namespace GitUI.CommandsDialogs
 
             splitRight.Panel2MinSize = DpiUtil.Scale(100);
 
-            _commitMessageManager = new CommitMessageManager(Module.WorkingDirGitDir, Module.CommitEncoding);
+            _commitMessageManager = new CommitMessageManager(Module.WorkingDirGitDir, Module.CommitEncoding, commitMessage);
 
             Message.TextChanged += Message_TextChanged;
             Message.TextAssigned += Message_TextAssigned;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -464,7 +464,7 @@ namespace GitUI
             return DoActionOnRepo(Action);
         }
 
-        public bool StartCommitDialog(IWin32Window owner, bool showOnlyWhenChanges = false)
+        public bool StartCommitDialog(IWin32Window owner, string commitMessage = null, bool showOnlyWhenChanges = false)
         {
             if (Module.IsBareRepository())
             {
@@ -493,7 +493,7 @@ namespace GitUI
                         });
                     }
 
-                    using (var form = new FormCommit(this))
+                    using (var form = new FormCommit(this, commitMessage: commitMessage))
                     {
                         if (showOnlyWhenChanges)
                         {
@@ -1791,7 +1791,9 @@ namespace GitUI
 
         private void Commit(IReadOnlyDictionary<string, string> arguments)
         {
-            StartCommitDialog(null, arguments.ContainsKey("quiet"));
+            arguments.TryGetValue("message", out string overridingMessage);
+            var showOnlyWhenChanges = arguments.ContainsKey("quiet");
+            StartCommitDialog(null, overridingMessage, showOnlyWhenChanges);
         }
 
         private void Push(IReadOnlyDictionary<string, string> arguments)

--- a/UnitTests/GitCommandsTests/CommitMessageManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitMessageManagerTests.cs
@@ -15,6 +15,7 @@ namespace GitCommandsTests
         private const string _commitMessage = "commit message";
         private const string _mergeMessage = "merge message";
         private const string _newMessage = "new message";
+        private const string _overriddenCommitMessage = "commandline message";
 
         private readonly string _workingDirGitDir = @"c:\dev\repo\.git";
         private readonly Encoding _encoding = Encoding.UTF8;
@@ -50,7 +51,12 @@ namespace GitCommandsTests
             _fileSystem.File.Returns(_file);
             _fileSystem.Path.Returns(path);
 
-            _manager = CommitMessageManager.TestAccessor.Construct(_workingDirGitDir, _encoding, _fileSystem);
+            _manager = CommitMessageManager.TestAccessor.Construct(_workingDirGitDir, _encoding, _fileSystem, overriddenCommitMessage: null);
+        }
+
+        public void SetupExtra(string overriddenCommitMessage)
+        {
+            _manager = CommitMessageManager.TestAccessor.Construct(_workingDirGitDir, _encoding, _fileSystem, overriddenCommitMessage);
         }
 
         [TearDown]
@@ -180,6 +186,18 @@ namespace GitCommandsTests
         }
 
         [Test]
+        public void MergeOrCommitMessage_should_return_overridden_message_if_set()
+        {
+            SetupExtra(overriddenCommitMessage: _overriddenCommitMessage);
+            _file.Exists(_commitMessagePath).Returns(true);
+            _file.Exists(_mergeMessagePath).Returns(true);
+
+            _manager.MergeOrCommitMessage.Should().Be(_overriddenCommitMessage);
+
+            _manager.IsMergeCommit.Should().BeTrue();
+        }
+
+        [Test]
         public void MergeOrCommitMessage_should_return_commit_message_if_exists_and_no_merge_message()
         {
             _file.Exists(_commitMessagePath).Returns(true);
@@ -202,6 +220,18 @@ namespace GitCommandsTests
         }
 
         [Test]
+        public void MergeOrCommitMessage_should_return_overridden_if_exist_and_if_no_file_exists()
+        {
+            SetupExtra(_overriddenCommitMessage);
+            _file.Exists(_commitMessagePath).Returns(false);
+            _file.Exists(_mergeMessagePath).Returns(false);
+
+            _manager.MergeOrCommitMessage.Should().Be(_overriddenCommitMessage);
+
+            _manager.IsMergeCommit.Should().BeFalse();
+        }
+
+        [Test]
         public void MergeOrCommitMessage_should_write_merge_message_if_exists()
         {
             bool correctlyWritten = false;
@@ -212,6 +242,20 @@ namespace GitCommandsTests
             _manager.MergeOrCommitMessage = _newMessage;
 
             Assert.That(correctlyWritten);
+        }
+
+        [Test]
+        public void MergeOrCommitMessage_should_not_write_merge_message_if_exist_if_it_is_the_overridding_commitmessage_exists()
+        {
+            SetupExtra(_overriddenCommitMessage);
+            bool hasBeenWritten = false;
+            _file.When(x => x.WriteAllText(_mergeMessagePath, _newMessage, _encoding)).Do(_ => hasBeenWritten = true);
+            _file.Exists(_commitMessagePath).Returns(true);
+            _file.Exists(_mergeMessagePath).Returns(true);
+
+            _manager.MergeOrCommitMessage = _overriddenCommitMessage;
+
+            hasBeenWritten.Should().BeFalse();
         }
 
         [Test]


### PR DESCRIPTION
This PR extends the command line commit command to enable a commit message. 

I was a bit in doubt whether we should include a new field in `FormCommit.cs` as I have done, or simply modify the `MergeOrCommitMessage` on the `_commitMessageManager`. The later will save the message to disc though and this is why I opted out of the idea

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
