### PR TITLE
Branch list could contain '+'

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2961,7 +2961,7 @@ namespace GitCommands
                 return Array.Empty<string>();
             }
 
-            var result = output.Split(new[] { '\r', '\n', '*' }, StringSplitOptions.RemoveEmptyEntries);
+            var result = output.Split(new[] { '\r', '\n', '*', '+' }, StringSplitOptions.RemoveEmptyEntries);
 
             // Remove symlink targets as in "origin/HEAD -> origin/master"
             for (var i = 0; i < result.Length; i++)

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -316,6 +316,48 @@ namespace GitCommandsTests
             Assert.AreSame(_gitModule, refs[3].Module);
         }
 
+        [TestCase("branch -a --contains",
+            true,
+            true,
+            "  aaa\n* current\n+ feature/worktree\n  feature/zzz_another\n  remotes/origin/master\n  remotes/origin/current\n  remotes/upstream/master\n",
+            new string[] { "aaa", "current", "feature/worktree", "feature/zzz_another", "remotes/origin/master", "remotes/origin/current", "remotes/upstream/master" })]
+        [TestCase("branch --contains",
+            true,
+            false,
+            "  aaa\n* current\n+ feature/worktree\n  feature/zzz_another\n",
+            new string[] { "aaa", "current", "feature/worktree", "feature/zzz_another" })]
+        [TestCase("branch -r --contains",
+            false,
+            true,
+            "remotes/origin/master\n  remotes/origin/current\n  remotes/upstream/master\n",
+            new string[] { "remotes/origin/master", "remotes/origin/current", "remotes/upstream/master" })]
+        public void GetAllBranchesWhichContainGivenCommit_wellformed(
+            string cmd,
+            bool getLocal,
+            bool getRemote,
+            string output,
+            string[] expected)
+        {
+            using (_executable.StageOutput(cmd + " " + Sha1.ToString(), output))
+            {
+                var result = _gitModule.GetAllBranchesWhichContainGivenCommit(Sha1, getLocal, getRemote);
+                Assert.AreEqual(result, expected);
+            }
+        }
+
+        [TestCase(
+            false,
+            false,
+            new string[] { })]
+        public void GetAllBranchesWhichContainGivenCommit_empty(
+            bool getLocal,
+            bool getRemote,
+            string[] expected)
+        {
+            var result = _gitModule.GetAllBranchesWhichContainGivenCommit(Sha1, getLocal, getRemote);
+            Assert.AreEqual(result, expected);
+        }
+
         [TestCase(null)]
         [TestCase("")]
         [TestCase("\t")]


### PR DESCRIPTION
Seen in CommitInfo

See https://github.com/gitextensions/gitextensions/pull/7186#issuecomment-535709962

## Proposed changes
Remove + in front of branches that are checked out in other worktrees

## Screenshots
See #7186 

## Test methodology
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
