### PR TITLE
Popup when error staring mergetool

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -29,6 +29,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _askMergeConflictSolvedCaption = new TranslationString("Conflict solved?");
         private readonly TranslationString _noMergeTool = new TranslationString("There is no mergetool configured." + Environment.NewLine + "Please go to settings and set a mergetool!");
         private readonly TranslationString _noMergeToolConfigured = new TranslationString("The mergetool is not correctly configured." + Environment.NewLine + "Please go to settings and configure the mergetool!");
+        private readonly TranslationString _errorStartingMergetool = new TranslationString("Error starting mergetool: {0}");
         private readonly TranslationString _stageFilename = new TranslationString("Stage {0}");
 
         private readonly TranslationString _noBaseRevision = new TranslationString("There is no base revision for {0}." + Environment.NewLine + "Fall back to 2-way merge?");
@@ -498,7 +499,18 @@ namespace GitUI.CommandsDialogs
                         lastWriteTimeBeforeMerge = File.GetLastWriteTime(_fullPathResolver.Resolve(item.Filename));
                     }
 
-                    var res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments);
+                    GitUIPluginInterfaces.ExecutionResult res;
+                    try
+                    {
+                        res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments);
+                    }
+                    catch (Exception)
+                    {
+                        var text = string.Format(_errorStartingMergetool.Text, _mergetoolPath);
+                        MessageBox.Show(this, text, _noBaseFileMergeCaption.Text,
+                            MessageBoxButtons.OK);
+                        return;
+                    }
 
                     DateTime lastWriteTimeAfterMerge = lastWriteTimeBeforeMerge;
                     if (File.Exists(_fullPathResolver.Resolve(item.Filename)))

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6359,6 +6359,10 @@ Is the merge conflict solved?</source>
         <source>Error</source>
         <target />
       </trans-unit>
+      <trans-unit id="_errorStartingMergetool.Text">
+        <source>Error starting mergetool: {0}</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_failureWhileOpenFile.Text">
         <source>Open temporary file failed.</source>
         <target />


### PR DESCRIPTION
Fixes #6687
(part 3)

## Proposed changes
#6687 was partly fixed in #6869 (3.2) but occasionally still occurs.
When testing this change, I found that the remaining problems are mostly caused by kdiff3 hardcoding and more or less resolved by #7009 
Still, I believe this PR makes sense.

GE creates exceptions when failing to run processes, for instance when the mergetool does not exist.
As the executable may not have full path, it is not possible to make a generic check in Executable()
Each call to Executable().Execute() has to be checked separately

## Screenshots 
### Before
NBug

### After

![image](https://user-images.githubusercontent.com/6248932/65823375-33c29b00-e255-11e9-895f-01a71b3e2294.png)

## Test methodology
Manual

Due to #7009 and #6869 you have to force the problem:

 * Make sure you have a mergeconflict
 * Start merge and let MergeConflict open
 * Rename the mergetool
 * Click Merge button (the other buttons were already handled)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
