### PR TITLE
Catch ConEmu exception for Done()

### DIFF
--- a/GitUI/FormStatus.cs
+++ b/GitUI/FormStatus.cs
@@ -147,6 +147,10 @@ namespace GitUI
                     Close();
                 }
             }
+            catch (ConEmu.WinForms.GuiMacroExecutor.GuiMacroException)
+            {
+                // Do nothing
+            }
             finally
             {
                 _modalController?.EndModal(isSuccess);


### PR DESCRIPTION
Fixes #6675

## Proposed changes
ConEmu raises exceptions in some situation, see many duplicates to #6675 (and a milestone)
All the #6675 exceptions occurs in Done(), when the Git command has already executed.
I have tried to recreated but not succeeded, but saw a coworker getting this problem once when quickly dismissing the popup. It should not be very unsafe assume that this is the core problem, no real action occurs after the form is dismissed.
Therefore, it should be OK to catch and ignore the ConEmu exception.


## Test methodology <!-- How did you ensure quality? -->
Code review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
