### PR TITLE
Allow multiple push url for git-remote

### DIFF
--- a/GitCommands/Remotes/ConfigFileRemote.cs
+++ b/GitCommands/Remotes/ConfigFileRemote.cs
@@ -22,7 +22,7 @@ namespace GitCommands.Remotes
         public IReadOnlyList<string> Push { get; set; }
 
         /// <summary>
-        /// Gets or sets value stored in .git/config via <see cref="SettingKeyString.RemotePushUrl"/> key.
+        /// Gets or sets the last pushurl stored in .git/config via <see cref="SettingKeyString.RemotePushUrl"/> key.
         /// </summary>
         public string PushUrl { get; set; }
 

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -167,7 +167,7 @@ namespace GitCommands.Remotes
         {
             var disabledRemotes = GetModule().LocalConfigFile.GetConfigSections()
                 .Where(s => s.SectionName == $"{DisabledSectionPrefix}remote")
-                .Select(s => new Remote(s.SubSection, s.GetValue("pushurl", s.GetValue("url")), s.GetValue("url")))
+                .Select(s => new Remote(s.SubSection, s.GetValue("url"), s.GetValue("pushurl", s.GetValue("url"))))
                 .ToList();
 
             return disabledRemotes;
@@ -427,6 +427,8 @@ namespace GitCommands.Remotes
                     Name = remote,
                     Url = module.GetSetting(GetSettingKey(SettingKeyString.RemoteUrl, remote, enabled)),
                     Push = module.GetSettings(GetSettingKey(SettingKeyString.RemotePush, remote, enabled)).ToList(),
+
+                    // Note: This only gets the last pushurl
                     PushUrl = module.GetSetting(GetSettingKey(SettingKeyString.RemotePushUrl, remote, enabled)),
                     PuttySshKey = module.GetSetting(GetSettingKey(SettingKeyString.RemotePuttySshKey, remote, enabled)),
                 }));

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -313,20 +313,20 @@ namespace GitUI.BranchTreePanel
             {
                 base.ApplyStyle();
 
-                TreeViewNode.ToolTipText = _remote.FetchUrl != _remote.PushUrl
-                    ? $"Push: {_remote.PushUrl}\nFetch: {_remote.FetchUrl}"
+                TreeViewNode.ToolTipText = _remote.FetchUrl != _remote.PushUrls[0]
+                    ? $"Push: {_remote.PushUrls[0]}\nFetch: {_remote.FetchUrl}"
                     : _remote.FetchUrl;
 
                 string imageKey;
-                if (_remote.PushUrl.Contains("github.com") || _remote.FetchUrl.Contains("github.com"))
+                if (_remote.FetchUrl.Contains("github.com"))
                 {
                     imageKey = nameof(Images.GitHub);
                 }
-                else if (_remote.PushUrl.Contains("bitbucket.") || _remote.FetchUrl.Contains("bitbucket."))
+                else if (_remote.FetchUrl.Contains("bitbucket."))
                 {
                     imageKey = nameof(Images.BitBucket);
                 }
-                else if (_remote.PushUrl.Contains("visualstudio.com") || _remote.FetchUrl.Contains("visualstudio.com"))
+                else if (_remote.FetchUrl.Contains("visualstudio.com") || _remote.FetchUrl.Contains("dev.azure.com"))
                 {
                     imageKey = nameof(Images.VisualStudioTeamServices);
                 }

--- a/Plugins/GitUIPluginInterfaces/Remote.cs
+++ b/Plugins/GitUIPluginInterfaces/Remote.cs
@@ -1,18 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace GitUIPluginInterfaces
 {
     public readonly struct Remote
     {
         public string Name { get; }
-        public string PushUrl { get; }
         public string FetchUrl { get; }
+        public List<string> PushUrls { get; }
 
-        public Remote(string name, string pushUrl, string fetchUrl)
+        public Remote(string name, string fetchUrl, string firstPushUrl)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            PushUrl = pushUrl ?? throw new ArgumentNullException(nameof(pushUrl));
             FetchUrl = fetchUrl ?? throw new ArgumentNullException(nameof(fetchUrl));
+
+            // At least one push URL must be added
+            PushUrls = firstPushUrl != null ? new List<string>() { firstPushUrl } : throw new ArgumentNullException(nameof(firstPushUrl));
         }
     }
 }


### PR DESCRIPTION
Fixes #6922

## Proposed changes
Allow multiple push url in git-remote
The pushurl are not really used (can be used to display the GitHub/BitBucket icon in sidepanel, updated that logic to only use fetchurl).

## Test methodology
Manual (test is updated)
See issue with how to reproduce (like add a repo on gitlab).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
