### PR TITLE
Fix #6593: GitExtension Exception resetting 1500 files in Diff tab.

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -142,6 +142,30 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Launches a process for the executable per batch item, and returns <c>true</c> if all process exit codes were zero.
+        /// </summary>
+        /// <remarks>
+        /// This method uses <see cref="RunCommand"/> to execute multiple commands in batch, used in accordance with
+        /// <see cref="ArgumentBuilderExtensions.BuildBatchArguments(ArgumentBuilder, IEnumerable{string}, int, int)"/>
+        /// to work around Windows command line length 32767 character limitation
+        /// <see href="https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa"/>.
+        /// </remarks>
+        /// <param name="executable">The executable from which to launch processes.</param>
+        /// <param name="batchArguments">The array of batch arguments to pass to the executable</param>
+        /// <param name="input">Bytes to be written to each process's standard input stream, or <c>null</c> if no input is required.</param>
+        /// <param name="createWindow">A flag indicating whether a console window should be created and bound to each process.</param>
+        /// <returns><c>true</c> if all process exit codes were zero, otherwise <c>false</c>.</returns>
+        [MustUseReturnValue("Callers should verify that " + nameof(RunBatchCommand) + " returned true")]
+        public static bool RunBatchCommand(
+            this IExecutable executable,
+            ArgumentString[] batchArguments,
+            byte[] input = null,
+            bool createWindow = false)
+        {
+            return batchArguments.Aggregate(true, (result, arguments) => executable.RunCommand(arguments, input, createWindow) && result);
+        }
+
+        /// <summary>
         /// Launches a process for the executable and returns <c>true</c> if its exit code is zero.
         /// </summary>
         /// <param name="executable">The executable from which to launch a process.</param>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1392,14 +1392,16 @@ namespace GitCommands
                 revision = null;
             }
 
-            _gitExecutable.RunCommand(
-                new GitArgumentBuilder("checkout")
+            // Run batch arguments to work around max command line length on Windows. Fix #6593
+            // 3: double quotes + ' '
+            // See https://referencesource.microsoft.com/#system/services/monitoring/system/diagnosticts/Process.cs,1952
+            _gitExecutable.RunBatchCommand(new GitArgumentBuilder("checkout")
                 {
                     { force, "--force" },
                     revision,
-                    "--",
-                    files.Select(f => f.ToPosixPath().Quote())
-                });
+                    "--"
+                }
+                .BuildBatchArguments(files.Select(f => f.ToPosixPath().Quote()), AppSettings.GitCommand.Length + 3));
         }
 
         public string RemoveFiles(IReadOnlyList<string> files, bool force)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -354,7 +354,8 @@ namespace GitUI
         public IEnumerable<GitRevision> SelectedItemParents
             => FileStatusListView.SelectedItems()
                 .Select(i => i.Group?.Tag<GitRevision>())
-                .Where(r => r != null);
+                .Where(r => r != null)
+                .Distinct(); // Parents should be distinct to avoid iterating same items
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]

--- a/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
@@ -320,5 +320,48 @@ namespace GitCommandsTests
                 };
             }
         }
+
+        // 14: 'checkout name1'
+        // 20: 'checkout name1 name2'
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 15, new string[] { "checkout name1", "checkout name2", "checkout name3" })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 16, new string[] { "checkout name1", "checkout name2", "checkout name3" })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 20, new string[] { "checkout name1", "checkout name2", "checkout name3" })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 21, new string[] { "checkout name1 name2", "checkout name3" })]
+
+        // With base length
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 31, new string[] { "checkout name1 name2", "checkout name3" }, 10)]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 26, new string[] { "checkout name1", "checkout name2", "checkout name3" }, 10)]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 30, new string[] { "checkout name1", "checkout name2", "checkout name3" }, 10)]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 31, new string[] { "checkout name1 name2", "checkout name3" }, 10)]
+        public void BuildBatchArguments_builder_work_as_expected(string command, string[] arguments, int maxLength, string[] expected,
+            int baseLength = 0)
+        {
+            var batch = new GitArgumentBuilder(command)
+                .BuildBatchArguments(arguments, baseLength, maxLength)
+                .Select(item => item.ToString())
+                .ToArray();
+
+            Assert.AreEqual(expected, batch);
+        }
+
+        // 8: 'checkout'
+        // 14: 'checkout name1'
+        [TestCase("checkout", new string[] { "a", "b", "c" }, 7)]
+        [TestCase("checkout", new string[] { "a", "b", "c" }, 8)]
+        [TestCase("checkout", new string[] { "a", "b", "c" }, 9)]
+        [TestCase("checkout", new string[] { "a", "b", "name1" }, 14)]
+        [TestCase("checkout", new string[] { "name1", "b", "a" }, 14)]
+
+        // With base length
+        [TestCase("checkout", new string[] { "a", "b", "c" }, 17, 10)]
+        [TestCase("checkout", new string[] { "a", "b", "c" }, 18, 10)]
+        [TestCase("checkout", new string[] { "a", "b", "c" }, 19, 10)]
+        [TestCase("checkout", new string[] { "a", "b", "name1" }, 24, 10)]
+        [TestCase("checkout", new string[] { "name1", "b", "a" }, 24, 10)]
+        public void BuildBatchArguments_builder_throw_invalid_argument_exception(string command, string[] arguments, int maxLength,
+            int baseLength = 0)
+        {
+            Assert.Throws(typeof(ArgumentException), () => new GitArgumentBuilder(command).BuildBatchArguments(arguments, baseLength, maxLength));
+        }
     }
 }

--- a/UnitTests/GitCommandsTests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ExecutableExtensionsTests.cs
@@ -1,6 +1,14 @@
 ﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using CommonTestUtils;
 using GitCommands;
+using GitCommands.Settings;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Git
@@ -9,11 +17,27 @@ namespace GitCommandsTests.Git
     public sealed class ExecutableExtensionsTests
     {
         private MockExecutable _executable;
+        private Executable _gitExecutable;
+        private string _appPath;
 
         [SetUp]
         public void SetUp()
         {
             _executable = new MockExecutable();
+
+            // Work around: When running unittest, Application.UserAppDataPath always points to
+            // %APPDATA%Roaming\Microsoft Corporation\Microsoft.TestHost.x86
+            // We need to correct it to %APPDATA%\GitExtensions\GitExtensions for v3 at least
+            var userAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var settingPath = Path.Combine(userAppDataPath, "GitExtensions\\GitExtensions\\GitExtensions.settings");
+            var settingContainer = new RepoDistSettings(null, GitExtSettingsCache.FromCache(settingPath), SettingLevel.Unknown);
+            _appPath = Path.Combine(settingContainer.GetString("gitbindir", ""), "git.exe");
+
+            // Execute process in GitExtension working directory, so that git will return success exit-code
+            // git always return non-zero exit code when run git reset outside of git repository
+            // NUnit working directory always default to MS test host
+            var workingDir = Path.GetDirectoryName(Assembly.GetAssembly(typeof(ExecutableExtensionsTests)).Location);
+            _gitExecutable = new Executable(_appPath, workingDir);
         }
 
         [TearDown]
@@ -63,6 +87,55 @@ namespace GitCommandsTests.Git
             Assert.IsTrue(cache.TryGet(arguments, out var outputBytes, out var errorBytes));
             Assert.AreEqual(GitModule.SystemEncoding.GetBytes(commandOutput), outputBytes);
             Assert.IsEmpty(errorBytes);
+        }
+
+        // Process argument upper bound is actually (short.MaxValue - 1)
+        [TestCase(32766, 32766, 32767, 2, true)]
+        [TestCase(32764, 1, 32767, 1, true)]
+        public void RunBatchCommand_can_handle_max_length_arguments(int arg1Len, int arg2Len,
+            int maxLength, int argCount, bool expectedResult)
+        {
+            // 3: double quotes + ' '
+            // 9: 'reset -- '
+            // 1: ' ' added after second Add in ArgumentBuilder
+            var appLength = _appPath.Length + 3;
+            var builder = new ArgumentBuilder() { "reset --" };
+            var len = builder.ToString().Length;
+            var args = builder.BuildBatchArguments(new string[]
+            {
+                GenerateStringByLength(Math.Max(1, arg1Len - appLength - len - 1)),
+                GenerateStringByLength(Math.Max(1, arg2Len - appLength - len - 1))
+            }, appLength, maxLength);
+
+            Assert.AreEqual(argCount, args.Length);
+            Assert.AreEqual(expectedResult, _gitExecutable.RunBatchCommand(args));
+        }
+
+        [TestCase(32766 - 8, 32766 - 8, int.MaxValue)]
+        [TestCase(32766 - 9, 1, int.MaxValue)]
+        public void RunBatchCommand_throw_when_cmd_exceed_max_length(int arg1Len, int arg2Len,
+            int maxLength)
+        {
+            var args = new ArgumentBuilder() { "reset --" }
+                .BuildBatchArguments(new string[]
+                {
+                    GenerateStringByLength(Math.Max(1, arg1Len - _appPath.Length - 4)),
+                    GenerateStringByLength(Math.Max(1, arg2Len - _appPath.Length - 4))
+                }, _appPath.Length + 3, maxLength);
+
+            Assert.Throws(typeof(Win32Exception), () => _gitExecutable.RunBatchCommand(args));
+        }
+
+        private string GenerateStringByLength(int length)
+        {
+            var sb = new StringBuilder(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                sb.Append((char)((i % 26) + 97));
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/contributors.txt
+++ b/contributors.txt
@@ -97,3 +97,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/02, MelnikovIG, Igor Melnikov, zero_88(at)bk.ru
 2019/09/24, lekhmanrus, Ruslan Lekhman, lekhman112(at)gmail.com
 2019/09/27, kbilsted, Kasper B. Graversen, redbeard1945redbeard(at)gmail.com
+2019/09/30, hieuxlu, Hieu Do, xlu.untitled(at)gmail.com


### PR DESCRIPTION
Work around for Windows command line length 32767 characters limitation

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fix #6593: GitExtension Exception resetting 1500 files in Diff tab.


## Proposed changes

- Work around for Windows command line length 32767 characters limitation
- Add GitArgumentBuilderExtensions.BuildBatchArguments to wrap long commands in to multiple child commands
- Add RunBatchCommand to run commands in batch 


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/11418231/65906540-f98c0180-e3ec-11e9-9a22-7d7e9049cd55.png)

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/11418231/65906581-04df2d00-e3ed-11e9-9bd4-2b6be313d9c2.png)

## Test methodology <!-- How did you ensure quality? -->

- Add GitArgumentBuilderTest fixture
- Manual test


## Test environment(s) <!-- Remove any that don't apply -->

- GIT: 3.2
- Windows 10 64bit

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
