### PR TITLE
Blame: Fix missing commit metadata on some commits

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3234,19 +3234,45 @@ namespace GitCommands
                     GitBlameCommit commit;
                     if (hasCommitHeader)
                     {
-                        commit = new GitBlameCommit(
-                            objectId,
-                            author,
-                            authorMail,
-                            authorTime,
-                            authorTimeZone,
-                            committer,
-                            committerMail,
-                            committerTime,
-                            committerTimeZone,
-                            summary,
-                            filename);
-                        commitByObjectId[objectId] = commit;
+                        if (!commitByObjectId.ContainsKey(objectId))
+                        {
+                            commit = new GitBlameCommit(
+                                objectId,
+                                author,
+                                authorMail,
+                                authorTime,
+                                authorTimeZone,
+                                committer,
+                                committerMail,
+                                committerTime,
+                                committerTimeZone,
+                                summary,
+                                filename);
+                            commitByObjectId[objectId] = commit;
+                        }
+                        else
+                        {
+                            var commitData = commitByObjectId[objectId];
+                            if (filename == commitData.FileName)
+                            {
+                                commit = commitData;
+                            }
+                            else
+                            {
+                                commit = new GitBlameCommit(
+                                    commitData.ObjectId,
+                                    commitData.Author,
+                                    commitData.AuthorMail,
+                                    commitData.AuthorTime,
+                                    commitData.AuthorTimeZone,
+                                    commitData.Committer,
+                                    commitData.CommitterMail,
+                                    commitData.CommitterTime,
+                                    commitData.CommitterTimeZone,
+                                    commitData.Summary,
+                                    filename);
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
due to "orphan" filename lines that has for effect to overwrite good commit data
by incomplete ones **when "Detect move and copy in all files" is enabled**.

For example, command:

`git blame --porcelain -M -C -w -l "18fcca6d89c2d38ac1830697b5da3f78630b226e" -- "GitUI/Translation/English.Plugins.xlf"`

returns (part of the file):

```
8f8393c283e7ad60c02805182d6778e5fc0c8b28 180 13
	      <trans-unit id="MsBuildEnabled.Caption">
b1d567eb22570bd2f278d779695f4556a27fb2ce 7506 14 3
filename GitUI/Translation/English.xlf       <= orphan line that breaks the blame
	        <source>Enabled</source>
b1d567eb22570bd2f278d779695f4556a27fb2ce 7507 15
	        <target />
b1d567eb22570bd2f278d779695f4556a27fb2ce 7508 16
	      </trans-unit>
8f8393c283e7ad60c02805182d6778e5fc0c8b28 184 17 12
	      <trans-unit id="MsBuildPath.Caption">
```

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/65950965-67f9af80-e43f-11e9-9a98-c565216705f1.png)


### After

![image](https://user-images.githubusercontent.com/460196/65951034-83fd5100-e43f-11e9-950b-9b61f5841f95.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 17857e871544d418a544248a8cc0b1a9a2f64a48 (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3460.0
- DPI 192dpi (200% scaling)

