### PR TITLE
Build Report: Open the report in the user browser

### DIFF
--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -47,17 +47,7 @@ namespace GitUI.CommandsDialogs
 
         public void FillBuildReport([CanBeNull] GitRevision revision)
         {
-            if (_selectedGitRevision != null)
-            {
-                _selectedGitRevision.PropertyChanged -= RevisionPropertyChanged;
-            }
-
-            _selectedGitRevision = revision;
-
-            if (_selectedGitRevision != null)
-            {
-                _selectedGitRevision.PropertyChanged += RevisionPropertyChanged;
-            }
+            SetSelectedRevision(revision);
 
             _tabControl.SuspendLayout();
 
@@ -75,43 +65,13 @@ namespace GitUI.CommandsDialogs
 
                     _buildReportTabPage.Controls.Clear();
 
-                    if (revision.BuildStatus.ShowInBuildReportTab)
-                    {
-                        Control = _buildReportWebBrowser;
-                        _buildReportTabPage.Controls.Add(_buildReportWebBrowser);
-                    }
-                    else
-                    {
-                        _buildReportTabPage.Cursor = Cursors.Hand;
-                        Control = _openReportLink;
-                        _buildReportTabPage.Controls.Add(_openReportLink);
-                    }
+                    SetTabPageContent(revision);
 
                     var isFavIconMissing = _buildReportTabPage.ImageIndex < 0;
 
                     if (isFavIconMissing || _tabControl.SelectedTab == _buildReportTabPage)
                     {
-                        try
-                        {
-                            if (revision.BuildStatus.ShowInBuildReportTab)
-                            {
-                                _url = null;
-                                _buildReportWebBrowser.Navigate(revision.BuildStatus.Url);
-                            }
-                            else
-                            {
-                                _url = revision.BuildStatus.Url;
-                            }
-
-                            if (isFavIconMissing)
-                            {
-                                _buildReportWebBrowser.Navigated += BuildReportWebBrowserOnNavigated;
-                            }
-                        }
-                        catch
-                        {
-                            // No propagation to the user if the report fails
-                        }
+                        LoadReportContent(revision, isFavIconMissing);
                     }
 
                     if (!_tabControl.Controls.Contains(_buildReportTabPage))
@@ -132,6 +92,58 @@ namespace GitUI.CommandsDialogs
             finally
             {
                 _tabControl.ResumeLayout();
+            }
+        }
+
+        private void LoadReportContent(GitRevision revision, bool isFavIconMissing)
+        {
+            try
+            {
+                if (revision.BuildStatus.ShowInBuildReportTab)
+                {
+                    _buildReportWebBrowser.Navigate(revision.BuildStatus.Url);
+                }
+
+                if (isFavIconMissing)
+                {
+                    _buildReportWebBrowser.Navigated += BuildReportWebBrowserOnNavigated;
+                }
+            }
+            catch
+            {
+                // No propagation to the user if the report fails
+            }
+        }
+
+        private void SetTabPageContent(GitRevision revision)
+        {
+            if (revision.BuildStatus.ShowInBuildReportTab)
+            {
+                _url = null;
+                Control = _buildReportWebBrowser;
+                _buildReportTabPage.Controls.Add(_buildReportWebBrowser);
+            }
+            else
+            {
+                _url = revision.BuildStatus.Url;
+                _buildReportTabPage.Cursor = Cursors.Hand;
+                Control = _openReportLink;
+                _buildReportTabPage.Controls.Add(_openReportLink);
+            }
+        }
+
+        private void SetSelectedRevision(GitRevision revision)
+        {
+            if (_selectedGitRevision != null)
+            {
+                _selectedGitRevision.PropertyChanged -= RevisionPropertyChanged;
+            }
+
+            _selectedGitRevision = revision;
+
+            if (_selectedGitRevision != null)
+            {
+                _selectedGitRevision.PropertyChanged += RevisionPropertyChanged;
             }
         }
 

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -18,6 +18,7 @@ namespace GitUI
         private readonly TranslationString _searchingFor = new TranslationString("Searching for: ");
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
+        private readonly TranslationString _openReport = new TranslationString("Open report");
         private readonly TranslationString _noResultsFound = new TranslationString("<No results found>");
         private readonly TranslationString _local = new TranslationString("Local");
         private readonly TranslationString _tag = new TranslationString("Tag");
@@ -58,5 +59,7 @@ namespace GitUI
         public static string Local => _instance.Value._local.Text;
         public static string Tag => _instance.Value._tag.Text;
         public static string Remote => _instance.Value._remote.Text;
+
+        public static string OpenReport => _instance.Value._openReport.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9285,6 +9285,10 @@ Select this commit to populate the full message.</source>
         <source>&lt;No results found&gt;</source>
         <target />
       </trans-unit>
+      <trans-unit id="_openReport.Text">
+        <source>Open report</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_parentsText.Text">
         <source>{0:Parent|Parents}</source>
         <target />


### PR DESCRIPTION
## Proposed changes

by replacing html link by a link label 
(and not in an old version of Internet Explorer that have no credential stored)

+ link centered
+ open report wherever the user click on the tab page
+ translate the "Open report" string

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/65955068-9bd8d300-e447-11e9-95fb-3db937af693e.png)


### After

![image](https://user-images.githubusercontent.com/460196/65955110-b448ed80-e447-11e9-8a6c-26d9a8e72e9f.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build cacce7f5baa67af9f3863bc033eeee6b3b2bbef5 (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3460.0
- DPI 192dpi (200% scaling)

