### PR TITLE
Dont confirm switch worktree option

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -884,6 +884,12 @@ namespace GitCommands
             set => SetBool("DontConfirmFetchAndPruneAll", value);
         }
 
+        public static bool DontConfirmSwitchWorktree
+        {
+            get => GetBool("DontConfirmSwitchWorktree", false);
+            set => SetBool("DontConfirmSwitchWorktree", value);
+        }
+
         public static bool IncludeUntrackedFilesInAutoStash
         {
             get => GetBool("includeUntrackedFilesInAutoStash", false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -32,6 +32,7 @@
             this.gbConfirmations = new System.Windows.Forms.GroupBox();
             this.tlpnlConfirmations = new System.Windows.Forms.TableLayoutPanel();
             this.chkFetchAndPruneAllConfirmation = new System.Windows.Forms.CheckBox();
+            this.chkSwitchWorktree = new System.Windows.Forms.CheckBox();
             this.chkUndoLastCommitConfirmation = new System.Windows.Forms.CheckBox();
             this.chkRebaseOnTopOfSelectedCommit = new System.Windows.Forms.CheckBox();
             this.chkSecondAbortConfirmation = new System.Windows.Forms.CheckBox();
@@ -99,6 +100,7 @@
             this.tlpnlConfirmations.Controls.Add(this.chkRebaseOnTopOfSelectedCommit, 0, 11);
             this.tlpnlConfirmations.Controls.Add(this.chkUndoLastCommitConfirmation, 0, 12);
             this.tlpnlConfirmations.Controls.Add(this.chkFetchAndPruneAllConfirmation, 0, 13);
+            this.tlpnlConfirmations.Controls.Add(this.chkSwitchWorktree, 0, 14);
             this.tlpnlConfirmations.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlConfirmations.Location = new System.Drawing.Point(5, 19);
             this.tlpnlConfirmations.Name = "tlpnlConfirmations";
@@ -119,6 +121,16 @@
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.Size = new System.Drawing.Size(483, 325);
             this.tlpnlConfirmations.TabIndex = 1;
+            // 
+            // chkSwitchWorktree
+            // 
+            this.chkSwitchWorktree.AutoSize = true;
+            this.chkSwitchWorktree.Location = new System.Drawing.Point(3, 278);
+            this.chkSwitchWorktree.Name = "chkSwitchWorktree";
+            this.chkSwitchWorktree.Size = new System.Drawing.Size(121, 19);
+            this.chkSwitchWorktree.TabIndex = 15;
+            this.chkSwitchWorktree.Text = "Switch Worktree";
+            this.chkSwitchWorktree.UseVisualStyleBackColor = true;
             // 
             // chkFetchAndPruneAllConfirmation
             // 
@@ -307,5 +319,6 @@
         private System.Windows.Forms.CheckBox chkRebaseOnTopOfSelectedCommit;
         private System.Windows.Forms.CheckBox chkUndoLastCommitConfirmation;
         private System.Windows.Forms.CheckBox chkFetchAndPruneAllConfirmation;
+        private System.Windows.Forms.CheckBox chkSwitchWorktree;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -28,6 +28,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkRebaseOnTopOfSelectedCommit.Checked = AppSettings.DontConfirmRebase;
             chkUndoLastCommitConfirmation.Checked = AppSettings.DontConfirmUndoLastCommit;
             chkFetchAndPruneAllConfirmation.Checked = AppSettings.DontConfirmFetchAndPruneAll;
+            chkSwitchWorktree.Checked = AppSettings.DontConfirmSwitchWorktree;
         }
 
         protected override void PageToSettings()
@@ -46,6 +47,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.DontConfirmRebase = chkRebaseOnTopOfSelectedCommit.Checked;
             AppSettings.DontConfirmUndoLastCommit = chkUndoLastCommitConfirmation.Checked;
             AppSettings.DontConfirmFetchAndPruneAll = chkFetchAndPruneAllConfirmation.Checked;
+            AppSettings.DontConfirmSwitchWorktree = chkSwitchWorktree.Checked;
         }
 
         public static SettingsPageReference GetPageReference()

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -6,11 +6,17 @@ using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
 using GitUI.Properties;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.WorktreeDialog
 {
     public partial class FormManageWorktree : GitModuleForm
     {
+        private readonly TranslationString _switchWorktreeText = new TranslationString("Are you sure you want to switch to this worktree?");
+        private readonly TranslationString _switchWorktreeTitle = new TranslationString("Open a worktree");
+        private readonly TranslationString _deleteWorktreeText = new TranslationString("Are you sure you want to delete this worktree?");
+        private readonly TranslationString _deleteWorktreeTitle = new TranslationString("Delete a worktree");
+
         private List<WorkTree> _worktrees;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
@@ -207,8 +213,8 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             if (e.ColumnIndex == 5)
             {
-                if (MessageBox.Show(this, "Are you sure you want to switch to this worktree?", "Open a worktree",
-                    MessageBoxButtons.YesNo) == DialogResult.Yes)
+                if (AppSettings.DontConfirmSwitchWorktree || MessageBox.Show(this,
+                        _switchWorktreeText.Text, _switchWorktreeTitle.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
                 {
                     if (Directory.Exists(workTree.Path))
                     {
@@ -227,7 +233,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                     return;
                 }
 
-                if (MessageBox.Show(this, "Are you sure you want to delete this worktree?", "Delete a worktree",
+                if (MessageBox.Show(this, _deleteWorktreeText.Text, _deleteWorktreeTitle.Text,
                         MessageBoxButtons.YesNo) == DialogResult.Yes)
                 {
                     if (Directory.Exists(workTree.Path))

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -980,6 +980,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Confirm for the second time to abort a merge</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkSwitchWorktree.Text">
+        <source>Switch Worktree</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkUndoLastCommitConfirmation.Text">
         <source>Undo last commit</source>
         <target />
@@ -4931,6 +4935,22 @@ command "git help shortlog"</source>
       </trans-unit>
       <trans-unit id="Type.HeaderText">
         <source>Type</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_deleteWorktreeText.Text">
+        <source>Are you sure you want to delete this worktree?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_deleteWorktreeTitle.Text">
+        <source>Delete a worktree</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_switchWorktreeText.Text">
+        <source>Are you sure you want to switch to this worktree?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_switchWorktreeTitle.Text">
+        <source>Open a worktree</source>
         <target />
       </trans-unit>
       <trans-unit id="buttonClose.Text">


### PR DESCRIPTION
Fixes #6864


## Proposed changes

- Option in the confirmations setting menu to not ask for a confirmation when switching the worktree


## Screenshots
![switchWorktree](https://user-images.githubusercontent.com/26045339/66057783-96f44c00-e539-11e9-8ad7-6e4bfcaf95f0.PNG)



## Test methodology <!-- How did you ensure quality? -->

Manual


## Test environment(s)
- Git Extensions 3.3.0
- Build 429a4f06e30478c41bdfaf1f501de175b82b8126 (Dirty)
- Git 2.22.0.windows.1 (recommended: 2.23.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.7.3460.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
