### PR TITLE
Fix #3280: Optimize unstage/reset performance by git reset/unstage batch files

### DIFF
--- a/GitCommands/BatchArgumentItem.cs
+++ b/GitCommands/BatchArgumentItem.cs
@@ -1,0 +1,24 @@
+﻿namespace GitCommands
+{
+    /// <summary>
+    /// Result model for batch processing arguments and count of items for batch progress
+    /// </summary>
+    public sealed class BatchArgumentItem
+    {
+        public BatchArgumentItem(ArgumentString argument, int count)
+        {
+            Argument = argument;
+            BatchItemsCount = count;
+        }
+
+        /// <summary>
+        /// Batch command line argument
+        /// </summary>
+        public ArgumentString Argument { get; }
+
+        /// <summary>
+        /// Count of items in batch, used for batch progress update
+        /// </summary>
+        public int BatchItemsCount { get; }
+    }
+}

--- a/GitCommands/Git/BatchProgressEventArgs.cs
+++ b/GitCommands/Git/BatchProgressEventArgs.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Event arguments for batch progress updating
+    /// </summary>
+    public sealed class BatchProgressEventArgs : EventArgs
+    {
+        public BatchProgressEventArgs(int batchItemsProcessed, bool executionResult)
+        {
+            ProcessedCount = batchItemsProcessed;
+            ExecutionResult = executionResult;
+        }
+
+        /// <summary>
+        /// Number of items processed in this batch event
+        /// </summary>
+        public int ProcessedCount { get; }
+
+        /// <summary>
+        /// Batch execution result
+        /// </summary>
+        public bool ExecutionResult { get; }
+    }
+}

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -64,6 +64,7 @@
     <Compile Include="AppTitleGenerator.cs" />
     <Compile Include="ArgumentBuilderExtensions.cs" />
     <Compile Include="AsyncLoader.cs" />
+    <Compile Include="BatchArgumentItem.cs" />
     <Compile Include="CommandStatus.cs" />
     <Compile Include="CommitData.cs" />
     <Compile Include="CommitDataManager.cs" />
@@ -90,6 +91,7 @@
     <Compile Include="GitRevisionInfoProvider.cs" />
     <Compile Include="Git\AheadBehindData.cs" />
     <Compile Include="Git\AheadBehindDataProvider.cs" />
+    <Compile Include="Git\BatchProgressEventArgs.cs" />
     <Compile Include="Git\ConflictData.cs" />
     <Compile Include="Git\ConflictedFileData.cs" />
     <Compile Include="Git\ExecutableExtensions.cs" />

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -504,25 +504,7 @@ namespace GitUI.CommandsDialogs
 
         private void UnstageFileToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var files = new List<GitItemStatus>();
-            foreach (var item in DiffFiles.SelectedItems.Where(item => item.Staged == StagedStatus.Index))
-            {
-                if (!item.IsNew)
-                {
-                    Module.UnstageFileToRemove(item.Name);
-
-                    if (item.IsRenamed)
-                    {
-                        Module.UnstageFileToRemove(item.OldName);
-                    }
-                }
-                else
-                {
-                    files.Add(item);
-                }
-            }
-
-            Module.UnstageFiles(files);
+            Module.BatchUnstageFiles(DiffFiles.SelectedItems.Where(item => item.Staged == StagedStatus.Index));
             RefreshArtificial();
         }
 
@@ -819,26 +801,7 @@ namespace GitUI.CommandsDialogs
                 var selectedItems = DiffFiles.SelectedItems;
 
                 // If any file is staged, it must be unstaged
-                var files = new List<GitItemStatus>();
-                var stagedItems = selectedItems.Where(item => item.Staged == StagedStatus.Index);
-                foreach (var item in stagedItems)
-                {
-                    if (!item.IsNew)
-                    {
-                        Module.UnstageFileToRemove(item.Name);
-
-                        if (item.IsRenamed)
-                        {
-                            Module.UnstageFileToRemove(item.OldName);
-                        }
-                    }
-                    else
-                    {
-                        files.Add(item);
-                    }
-                }
-
-                Module.UnstageFiles(files);
+                Module.BatchUnstageFiles(selectedItems.Where(item => item.Staged == StagedStatus.Index));
 
                 DiffFiles.StoreNextIndexToSelect();
                 var items = DiffFiles.SelectedItems.Where(item => !item.IsSubmodule);

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -177,8 +177,13 @@ namespace CommonTestUtils
                 Assert.AreEqual(StandardOutput.BaseStream.Length, StandardOutput.BaseStream.Position);
                 Assert.AreEqual(StandardError.BaseStream.Length, StandardError.BaseStream.Position);
 
-                // no input should have been written (yet)
-                Assert.AreEqual(0, StandardInput.BaseStream.Length);
+                // Only verify if std input is not closed.
+                // ExecutableExtensions.ExecuteAsync will close std input when writeInput action is specified
+                if (StandardInput.BaseStream != null)
+                {
+                    // no input should have been written (yet)
+                    Assert.AreEqual(0, StandardInput.BaseStream.Length);
+                }
             }
         }
 

--- a/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/ArgumentBuilderExtensionsTests.cs
@@ -324,25 +324,27 @@ namespace GitCommandsTests
 
         // 14: 'checkout name1'
         // 20: 'checkout name1 name2'
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 15, new string[] { "checkout name1", "checkout name2", "checkout name3" })]
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 16, new string[] { "checkout name1", "checkout name2", "checkout name3" })]
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 20, new string[] { "checkout name1", "checkout name2", "checkout name3" })]
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 21, new string[] { "checkout name1 name2", "checkout name3" })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 15, new string[] { "checkout name1", "checkout name2", "checkout name3" }, new int[] { 1, 1, 1 })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 16, new string[] { "checkout name1", "checkout name2", "checkout name3" }, new int[] { 1, 1, 1 })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 20, new string[] { "checkout name1", "checkout name2", "checkout name3" }, new int[] { 1, 1, 1 })]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 21, new string[] { "checkout name1 name2", "checkout name3" }, new int[] { 2, 1 })]
 
         // With base length
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 31, new string[] { "checkout name1 name2", "checkout name3" }, 10)]
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 26, new string[] { "checkout name1", "checkout name2", "checkout name3" }, 10)]
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 30, new string[] { "checkout name1", "checkout name2", "checkout name3" }, 10)]
-        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 31, new string[] { "checkout name1 name2", "checkout name3" }, 10)]
-        public void BuildBatchArguments_builder_work_as_expected(string command, string[] arguments, int maxLength, string[] expected,
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 25, new string[] { "checkout name1", "checkout name2", "checkout name3" }, new int[] { 1, 1, 1 }, 10)]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 26, new string[] { "checkout name1", "checkout name2", "checkout name3" }, new int[] { 1, 1, 1 }, 10)]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 30, new string[] { "checkout name1", "checkout name2", "checkout name3" }, new int[] { 1, 1, 1 }, 10)]
+        [TestCase("checkout", new string[] { "name1", "name2", "name3" }, 31, new string[] { "checkout name1 name2", "checkout name3" }, new int[] { 2, 1 }, 10)]
+        public void BuildBatchArguments_builder_work_as_expected(string command, string[] arguments, int maxLength, string[] expected, int[] expectedCounts,
             int baseLength = 0)
         {
             var batch = new GitArgumentBuilder(command)
-                .BuildBatchArguments(arguments, baseLength, maxLength)
-                .Select(item => item.ToString())
-                .ToArray();
+                .BuildBatchArguments(arguments, baseLength, maxLength);
 
-            Assert.AreEqual(expected, batch);
+            var args = batch.Select(item => item.Argument.ToString()).ToArray();
+            var counts = batch.Select(item => item.BatchItemsCount).ToArray();
+
+            Assert.AreEqual(expected, args);
+            Assert.AreEqual(expectedCounts, counts);
         }
 
         // 8: 'checkout'

--- a/UnitTests/GitCommandsTests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommandsTests/Git/ExecutableExtensionsTests.cs
@@ -89,10 +89,10 @@ namespace GitCommandsTests.Git
         }
 
         // Process argument upper bound is actually (short.MaxValue - 1)
-        [TestCase(32766, 32766, 32767, 2, true)]
-        [TestCase(32764, 1, 32767, 1, true)]
+        [TestCase(32766, 32766, 32767, 2, true, new int[] { 1, 1 })]
+        [TestCase(32764, 1, 32767, 1, true, new int[] { 2 })]
         public void RunBatchCommand_can_handle_max_length_arguments(int arg1Len, int arg2Len,
-            int maxLength, int argCount, bool expectedResult)
+            int maxLength, int argCount, bool expectedResult, int[] expectedProcessedCounts)
         {
             // 3: double quotes + ' '
             // 9: 'reset -- '
@@ -106,8 +106,14 @@ namespace GitCommandsTests.Git
                 GenerateStringByLength(Math.Max(1, arg2Len - appLength - len - 1))
             }, appLength, maxLength);
 
-            Assert.AreEqual(argCount, args.Length);
-            Assert.AreEqual(expectedResult, _gitExecutable.RunBatchCommand(args));
+            Assert.AreEqual(argCount, args.Count);
+            var index = 0;
+            Assert.AreEqual(expectedResult, _gitExecutable.RunBatchCommand(args, (eventArgs) =>
+            {
+                Assert.IsTrue(eventArgs.ExecutionResult);
+                Assert.AreEqual(expectedProcessedCounts[index], eventArgs.ProcessedCount);
+                index++;
+            }));
         }
 
         [TestCase(32766 - 8, 32766 - 8, int.MaxValue)]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fix #3280: Optimize unstage/reset performance by git reset/unstage batch files (continue from batch processing in #6593)

## Proposed changes
Use RunBatchCommand & BuildBatchArguments from #7218 to fix performance issue with git reset/unstage individual files consequentially.


## Test methodology <!-- How did you ensure quality? -->

- Manual test
- Unit test cases


## Test environment(s) <!-- Remove any that don't apply -->

- GIT: 2.23.0.windows.1
- Windows: 10 x64

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
