### PR TITLE
GitIndexWatcher: check that directory exists before enabling

### DIFF
--- a/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -93,7 +93,8 @@ namespace GitUI.UserControls.RevisionGrid
             set
             {
                 _indexChanged = value;
-                GitIndexWatcher.EnableRaisingEvents = !IndexChanged;
+                GitIndexWatcher.EnableRaisingEvents = !IndexChanged
+                    && Directory.Exists(GitIndexWatcher.Path);
 
                 Changed?.Invoke(this, new IndexChangedEventArgs(IndexChanged));
             }


### PR DESCRIPTION
Fixes #7235

## Proposed changes
Only enable GitIndexWatcher when directory exists
Similar changes already done in 3.2 (do not know how this was missed)

## Test methodology <!-- How did you ensure quality? -->
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
