### PR TITLE
Settings: Regenerate the Controls when previous instance was disposed

### DIFF
--- a/Plugins/GitUIPluginInterfaces/ISettingControlBinding.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingControlBinding.cs
@@ -44,7 +44,7 @@ namespace GitUIPluginInterfaces
         {
             get
             {
-                if (_control == null)
+                if (_control == null || _control.IsDisposed)
                 {
                     _control = CreateControl();
                 }


### PR DESCRIPTION
because we don't control the controls lifecycle
and the settings controls are disposed when settings are closed.

It depends on how the settings control is defined but could prevent exceptions
(and make plugins easier to write)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build cacce7f5baa67af9f3863bc033eeee6b3b2bbef5 (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.3928.0
- DPI 192dpi (200% scaling)
