### PR TITLE
Commit dialog, FileStatusList: Fix up/down selects unexpected file

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/FileStatusListTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FileStatusListTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
 using FluentAssertions;
+using GitCommands;
 using GitUI;
 using NUnit.Framework;
 
@@ -31,6 +33,186 @@ namespace GitUITests.CommandsDialogs
             _fileStatusList = null;
             _form?.Dispose();
             _form = null;
+        }
+
+        [Test]
+        public void ItemSelections()
+        {
+            var accessor = _fileStatusList.GetTestAccessor();
+
+            var itemNotInList = new GitItemStatus { Name = "not in list" };
+            var item0 = new GitItemStatus { Name = "z.0" };
+            var item1 = new GitItemStatus { Name = "x.1" };
+            var item2 = new GitItemStatus { Name = "y.2" };
+            var items = new List<GitItemStatus> { item0, item1, item2 };
+
+            // alphabetical order
+            var itemAt0 = item1;
+            var itemAt1 = item2;
+            var itemAt2 = item0;
+            _fileStatusList.SetDiffs(items: items);
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
+            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt0);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
+
+            // SelectedIndex
+
+            _fileStatusList.SelectedIndex = 1;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+
+            _fileStatusList.SelectedIndex = -1;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedIndex = 42; // clears the selection
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedIndex = 1;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+
+            // SelectedItem
+
+            _fileStatusList.SelectedItem = itemAt1;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+
+            _fileStatusList.SelectedItem = null;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedItem = itemAt2;
+            _fileStatusList.SelectedItem = itemNotInList; // clears the selection
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedItem = itemAt1;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+
+            // SelectedItems (up to one item)
+
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { itemAt1 };
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+
+            _fileStatusList.SelectedItems = null;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { };
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { itemAt2 };
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { itemNotInList }; // clears the selection
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
+            _fileStatusList.SelectedIndex.Should().Be(-1);
+            _fileStatusList.SelectedItem.Should().BeNull();
+            _fileStatusList.SelectedItems.Should().BeEmpty();
+
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { itemAt1 };
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1);
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+
+            // SelectedItems (multiple items)
+
+            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { itemAt2, itemAt0, itemNotInList };
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
+            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt0); // focused item
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
+
+            accessor.FileStatusListView.Items[1].Focused = true;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt2); // LastSelectedItem
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
+
+            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectedItems = new List<GitItemStatus> { itemAt2, itemAt1, itemNotInList };
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt1); // focused item
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
+
+            accessor.FileStatusListView.Items[0].Focused = true;
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
+            _fileStatusList.SelectedIndex.Should().Be(1);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt2); // LastSelectedItem
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
+
+            // SelectAll
+
+            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectAll();
+
+            foreach (var item in accessor.FileStatusListView.Items())
+            {
+                item.Selected.Should().BeTrue();
+            }
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
+            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt0); // focused item
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt1, itemAt2 });
+
+            // SelectFirstVisibleItem
+
+            _fileStatusList.SelectedIndex = 2;
+            _fileStatusList.SelectFirstVisibleItem();
+
+            accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
+            _fileStatusList.SelectedIndex.Should().Be(0);
+            _fileStatusList.SelectedItem.Should().BeSameAs(itemAt0); // focused item
+            _fileStatusList.SelectedItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
         }
 
         [Test]


### PR DESCRIPTION
Fixes #7246 
Fixes #6212

## Proposed changes

- Set FileStatusListView.FocusedItem, too

## Test methodology <!-- How did you ensure quality? -->

- manual test (see STR in #7246)
- added NUnit test

## Test environment(s)

- Git Extensions 3.3.0
- Build 420bcdfe3fab4baef6a69b62698151b3170c2b35
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4010.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
