### PR TITLE
Pr/logfilelogging

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GitExtUtils;
+using GitExtUtils.FileLogging;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -14,35 +14,35 @@ namespace GitCommands.Logging
 
     public sealed class ProcessOperation
     {
-        private readonly CommandLogEntry _entry;
+        internal readonly CommandLogEntry Entry;
         private readonly Stopwatch _stopwatch;
         private readonly Action _raiseCommandsChanged;
 
         internal ProcessOperation(CommandLogEntry entry, Stopwatch stopwatch, Action raiseCommandsChanged)
         {
-            _entry = entry;
+            Entry = entry;
             _stopwatch = stopwatch;
             _raiseCommandsChanged = raiseCommandsChanged;
         }
 
         public void LogProcessEnd(int? exitCode = null)
         {
-            _entry.Duration = _stopwatch.Elapsed;
-            _entry.ExitCode = exitCode;
+            Entry.Duration = _stopwatch.Elapsed;
+            Entry.ExitCode = exitCode;
             _raiseCommandsChanged();
         }
 
         public void SetProcessId(int processId)
         {
-            _entry.ProcessId = processId;
+            Entry.ProcessId = processId;
             _raiseCommandsChanged();
         }
 
         public void NotifyDisposed()
         {
-            if (_entry.Duration == null)
+            if (Entry.Duration == null)
             {
-                _entry.Duration = _stopwatch.Elapsed;
+                Entry.Duration = _stopwatch.Elapsed;
                 _raiseCommandsChanged();
             }
         }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands.Settings;
+using GitExtUtils.FileLogging;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using Microsoft.Win32;
@@ -1404,8 +1405,9 @@ namespace GitCommands
                     SettingsContainer.Save();
                 });
             }
-            catch
+            catch (Exception e)
             {
+                Logger.LogError("Error while saving settings", e);
             }
         }
 
@@ -1417,8 +1419,9 @@ namespace GitCommands
             {
                 GitCommandHelpers.SetSsh(SshPath);
             }
-            catch
+            catch (Exception e)
             {
+                Logger.LogError("Error while loading settings", e);
             }
         }
 

--- a/GitExtUtils/FileLogging/GitCommandLogFormatter.cs
+++ b/GitExtUtils/FileLogging/GitCommandLogFormatter.cs
@@ -11,8 +11,6 @@ namespace GitExtUtils.FileLogging
 
     public class GitCommandLogFormatter : ILogFormatter
     {
-        private static string pid = Process.GetCurrentProcess().Id.ToString();
-
         public string Format(LogEntry entry)
         {
             try
@@ -24,7 +22,7 @@ namespace GitExtUtils.FileLogging
                     var stack = entry.ExtraInfo["CallStack"];
                     var stackFormatted = stack == null ? "" : $" stack: {stack}";
 
-                    return $"{entry.Time:yyyy-MM-dd HH:mm:ss} {pid,5} {entry.Severity,-5} {entry.ExtraInfo["Duration"],9} {entry.ExtraInfo["ProcessId"],6} {entry.ExtraInfo["IsOnMainThread"],2} {entry.ExtraInfo["ExitCode"],4} {entry.Message} {entry.ExtraInfo["Arguments"]} {entry.ExtraInfo["WorkingDir"]}{stackFormatted} metatype: {metatype}";
+                    return $"{entry.Time:yyyy-MM-dd HH:mm:ss} {entry.Severity,-5} {entry.ExtraInfo["Duration"],9} {entry.ExtraInfo["ProcessId"],6} {entry.ExtraInfo["IsOnMainThread"],2} {entry.ExtraInfo["ExitCode"],4} {entry.Message} {entry.ExtraInfo["Arguments"]} {entry.ExtraInfo["WorkingDir"]}{stackFormatted} metatype: {metatype}";
                 }
                 else
                 {
@@ -33,7 +31,7 @@ namespace GitExtUtils.FileLogging
                         .OrderBy(x => x.Key)
                         .Select(x => $"{x.Key}: {x.Value}");
 
-                    return $"{entry.Time:yyyy-MM-dd HH:mm:ss} {pid,5} {entry.Severity,-5}                          {entry.Message} {string.Join(" ", extra)} metatype: {metatype}";
+                    return $"{entry.Time:yyyy-MM-dd HH:mm:ss} {entry.Severity,-5}                          {entry.Message} {string.Join(" ", extra)} metatype: {metatype}";
                 }
             }
             catch (Exception e)

--- a/GitExtUtils/FileLogging/GitCommandLogFormatter.cs
+++ b/GitExtUtils/FileLogging/GitCommandLogFormatter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace GitExtUtils.FileLogging
+{
+    public interface ILogFormatter
+    {
+        string Format(LogEntry entry);
+    }
+
+    public class GitCommandLogFormatter : ILogFormatter
+    {
+        private static string pid = Process.GetCurrentProcess().Id.ToString();
+
+        public string Format(LogEntry entry)
+        {
+            try
+            {
+                entry.ExtraInfo.TryGetValue(Logger.MetaTypeKeyName, out var metatype);
+
+                if (metatype == "GitExeCommand")
+                {
+                    var stack = entry.ExtraInfo["CallStack"];
+                    var stackFormatted = stack == null ? "" : $" stack: {stack}";
+
+                    return $"{entry.Time:yyyy-MM-dd HH:mm:ss} {pid,5} {entry.Severity,-5} {entry.ExtraInfo["Duration"],9} {entry.ExtraInfo["ProcessId"],6} {entry.ExtraInfo["IsOnMainThread"],2} {entry.ExtraInfo["ExitCode"],4} {entry.Message} {entry.ExtraInfo["Arguments"]} {entry.ExtraInfo["WorkingDir"]}{stackFormatted} metatype: {metatype}";
+                }
+                else
+                {
+                    var extra = entry.ExtraInfo
+                        .Where(x => x.Key != Logger.MetaTypeKeyName)
+                        .OrderBy(x => x.Key)
+                        .Select(x => $"{x.Key}: {x.Value}");
+
+                    return $"{entry.Time:yyyy-MM-dd HH:mm:ss} {pid,5} {entry.Severity,-5}                          {entry.Message} {string.Join(" ", extra)} metatype: {metatype}";
+                }
+            }
+            catch (Exception e)
+            {
+                return e.ToString();
+            }
+        }
+    }
+}

--- a/GitExtUtils/FileLogging/ILogger.cs
+++ b/GitExtUtils/FileLogging/ILogger.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace GitExtUtils.FileLogging
+{
+    public interface ILogger
+    {
+        void WaitShutdown();
+
+        void Log(LogSeverity severity, string message, Dictionary<string, string> extra = null);
+
+        void Info(string message, Dictionary<string, string> extra = null);
+
+        void Error(string message, Dictionary<string, string> extra = null);
+
+        void Error(string message, Exception e, Dictionary<string, string> extra = null);
+
+        void LogGitCommandExecution(
+            string message,
+            string fileName,
+            string arguments,
+            string workingDir,
+            int? processId,
+            bool isOnMainThread,
+            TimeSpan? duration,
+            int? exitCode,
+            StackTrace callStack);
+    }
+}

--- a/GitExtUtils/FileLogging/LogEntry.cs
+++ b/GitExtUtils/FileLogging/LogEntry.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GitExtUtils.FileLogging
+{
+    /// <summary>
+    /// Tiniest definition for now
+    /// </summary>
+    public class LogEntry
+    {
+        public DateTime Time { get; set; }
+        public LogSeverity Severity { get; set; }
+        public string Message { get; set; }
+
+        public Dictionary<string, string> ExtraInfo { get; set; }
+    }
+}

--- a/GitExtUtils/FileLogging/LogEntryCreator.cs
+++ b/GitExtUtils/FileLogging/LogEntryCreator.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace GitExtUtils.FileLogging
+{
+    internal class LogEntryCreator
+    {
+        public static LogEntry Create(LogSeverity severity, string message, Dictionary<string, string> extra = null)
+        {
+            extra = extra ?? new Dictionary<string, string>();
+            if (!extra.ContainsKey(Logger.MetaTypeKeyName))
+            {
+                extra.Add(Logger.MetaTypeKeyName, "Application");
+            }
+
+            var entry = new LogEntry()
+            {
+                Severity = severity,
+                Time = DateTime.Now,
+                Message = message,
+                ExtraInfo = extra,
+            };
+
+            return entry;
+        }
+
+        public static LogEntry Create(LogSeverity severity, string message, Exception e, Dictionary<string, string> extra = null)
+        {
+            extra = extra ?? new Dictionary<string, string>();
+
+            if (e != null && !extra.ContainsKey("Stacktrace"))
+            {
+                extra.Add("Stacktrace", e.ToStringDemystified());
+            }
+
+            return Create(LogSeverity.Error, message, extra);
+        }
+
+        public static LogEntry Create(
+            string message,
+            string fileName,
+            string arguments,
+            string workingDir,
+            int? processId,
+            bool isOnMainThread,
+            TimeSpan? duration,
+            int? exitCode,
+            StackTrace callStack)
+        {
+            var extra = new Dictionary<string, string>()
+            {
+                { Logger.MetaTypeKeyName, "GitExeCommand" },
+                { "Filename", fileName },
+                { "Arguments", arguments },
+                { "WorkingDir", workingDir },
+                { "ProcessId", processId?.ToString() },
+                { "IsOnMainThread", isOnMainThread ? "UI" : "  " },
+                { "Duration", duration == null ? "" : $"{(int)duration.Value.TotalMilliseconds:##,#} ms" },
+                { "ExitCode", exitCode == null ? "" : exitCode.ToString() },
+                { "CallStack", callStack?.ToString() },
+            };
+
+            return Create(LogSeverity.Info, message, extra);
+        }
+    }
+}

--- a/GitExtUtils/FileLogging/LogFileCleaner.cs
+++ b/GitExtUtils/FileLogging/LogFileCleaner.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace GitExtUtils.FileLogging
+{
+    public class LogFileCleaner
+    {
+        private readonly ILogger _logger;
+        private readonly LogPathGenerator _logPathGenerator;
+        private readonly TimeSpan _maxLogAge;
+
+        public LogFileCleaner(ILogger logger, LogPathGenerator logPathGenerator, TimeSpan maxLogAge)
+        {
+            _logger = logger;
+            _logPathGenerator = logPathGenerator;
+            _maxLogAge = maxLogAge;
+        }
+
+        public void Run()
+        {
+            try
+            {
+                WaitToPreventAddedStartupTime();
+
+                var deleteThreshold = DateTime.Now - _maxLogAge;
+
+                new DirectoryInfo(_logPathGenerator.LogPath)
+                    .GetFileSystemInfos(_logPathGenerator.GetFilenamePattern())
+                    .Where(x => x.CreationTime < deleteThreshold)
+                    .ForEach(x => x.Delete());
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e.Message, e);
+            }
+        }
+
+        private static void WaitToPreventAddedStartupTime()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+        }
+    }
+}

--- a/GitExtUtils/FileLogging/LogPathGenerator.cs
+++ b/GitExtUtils/FileLogging/LogPathGenerator.cs
@@ -12,11 +12,13 @@ namespace GitExtUtils.FileLogging
 
         private Tuple<DateTime, string> _fileNameCache = new Tuple<DateTime, string>(DateTime.MinValue, null);
         private readonly string _logName;
+        private readonly int _processId;
 
-        public LogPathGenerator(string logPath, string logName)
+        public LogPathGenerator(string logPath, string logName, int processId)
         {
             LogPath = logPath;
             _logName = logName;
+            _processId = processId;
         }
 
         public string GenerateFullPath(DateTime now)
@@ -31,13 +33,13 @@ namespace GitExtUtils.FileLogging
 
         public string GetFilenamePattern()
         {
-            return $"{_logName}-*.log";
+            return $"{_logName}-*-*.log";
         }
 
         private Tuple<DateTime, string> Renew(DateTime now)
         {
             var today = now.Date;
-            var fullPath = Path.Combine(LogPath, $"{_logName}-{today:yyyy-MM-dd}.log");
+            var fullPath = Path.Combine(LogPath, $"{_logName}-{today:yyyyMMdd}-{_processId}.log");
             return Tuple.Create(today, fullPath);
         }
     }

--- a/GitExtUtils/FileLogging/LogPathGenerator.cs
+++ b/GitExtUtils/FileLogging/LogPathGenerator.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+
+namespace GitExtUtils.FileLogging
+{
+    public class LogPathGenerator
+    {
+        /// <summary>
+        /// The folder for log files
+        /// </summary>
+        public readonly string LogPath;
+
+        private Tuple<DateTime, string> _fileNameCache = new Tuple<DateTime, string>(DateTime.MinValue, null);
+        private readonly string _logName;
+
+        public LogPathGenerator(string logPath, string logName)
+        {
+            LogPath = logPath;
+            _logName = logName;
+        }
+
+        public string GenerateFullPath(DateTime now)
+        {
+            if (now.Date != _fileNameCache.Item1)
+            {
+                _fileNameCache = Renew(now);
+            }
+
+            return _fileNameCache.Item2;
+        }
+
+        public string GetFilenamePattern()
+        {
+            return $"{_logName}-*.log";
+        }
+
+        private Tuple<DateTime, string> Renew(DateTime now)
+        {
+            var today = now.Date;
+            var fullPath = Path.Combine(LogPath, $"{_logName}-{today:yyyy-MM-dd}.log");
+            return Tuple.Create(today, fullPath);
+        }
+    }
+}

--- a/GitExtUtils/FileLogging/LogSeverity.cs
+++ b/GitExtUtils/FileLogging/LogSeverity.cs
@@ -1,0 +1,8 @@
+﻿namespace GitExtUtils.FileLogging
+{
+    public enum LogSeverity
+    {
+        Info,
+        Error,
+    }
+}

--- a/GitExtUtils/FileLogging/LogWriter.cs
+++ b/GitExtUtils/FileLogging/LogWriter.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.SymbolStore;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace GitExtUtils.FileLogging
+{
+    public interface ILogWriter
+    {
+        void Enqueue(LogEntry entry);
+    }
+
+    public class LogWriter : ILogWriter
+    {
+        private readonly LogPathGenerator _logPathGenerator;
+        private readonly ILogFormatter _formatter;
+        private readonly TimeSpan _flushInterval;
+        private readonly ConcurrentQueue<LogEntry> _unsaved = new ConcurrentQueue<LogEntry>();
+
+        public LogWriter(
+            LogPathGenerator logPathGenerator,
+            ILogFormatter formatter,
+            TimeSpan flushInterval)
+        {
+            _logPathGenerator = logPathGenerator;
+            _formatter = formatter;
+            _flushInterval = flushInterval;
+        }
+
+        public void Enqueue(LogEntry entry)
+        {
+            _unsaved.Enqueue(entry);
+        }
+
+        public void Run(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (!Directory.Exists(_logPathGenerator.LogPath))
+                {
+                    Directory.CreateDirectory(_logPathGenerator.LogPath);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception(message: $"Cannot create folder for log files", e);
+            }
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    cancellationToken.WaitHandle.WaitOne(_flushInterval);
+
+                    WriteUnsaved();
+                }
+                catch (Exception e)
+                {
+                    throw new Exception($"Cannot save entries to disc.", e);
+                }
+            }
+        }
+
+        private void WriteUnsaved()
+        {
+            int max = _unsaved.Count;
+            if (max <= 0)
+            {
+                return;
+            }
+
+            var sb = new StringBuilder(max * 1000);
+            int i = 0;
+            while (i++ < max && _unsaved.TryDequeue(out var entry))
+            {
+                sb.AppendLine(_formatter.Format(entry));
+            }
+
+            using (var file = new FileStream(_logPathGenerator.GenerateFullPath(DateTime.Now), FileMode.Append, FileAccess.Write, FileShare.Read))
+            using (var writer = new StreamWriter(file, Encoding.Unicode))
+            {
+                writer.Write(sb.ToString());
+            }
+        }
+    }
+}

--- a/GitExtUtils/FileLogging/LogWriter.cs
+++ b/GitExtUtils/FileLogging/LogWriter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Diagnostics.SymbolStore;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -10,6 +9,7 @@ namespace GitExtUtils.FileLogging
     public interface ILogWriter
     {
         void Enqueue(LogEntry entry);
+        void Run(CancellationToken cancellationToken);
     }
 
     public class LogWriter : ILogWriter

--- a/GitExtUtils/FileLogging/Logger.cs
+++ b/GitExtUtils/FileLogging/Logger.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitExtUtils.FileLogging
+{
+    /// <summary>
+    /// For unit testing
+    /// </summary>
+    public class LoggerStub : ILogger
+    {
+        public List<LogEntry> LogEntries = new List<LogEntry>();
+
+        public void WaitShutdown()
+        {
+        }
+
+        public void Log(LogSeverity severity, string message, Dictionary<string, string> extra = null)
+        {
+            LogEntries.Add(LogEntryCreator.Create(severity, message, extra));
+        }
+
+        public void Info(string message, Dictionary<string, string> extra = null)
+        {
+            LogEntries.Add(LogEntryCreator.Create(LogSeverity.Info, message, extra));
+        }
+
+        public void Error(string message, Dictionary<string, string> extra = null)
+        {
+            LogEntries.Add(LogEntryCreator.Create(LogSeverity.Error, message, extra));
+        }
+
+        public void Error(string message, Exception e, Dictionary<string, string> extra = null)
+        {
+            LogEntries.Add(LogEntryCreator.Create(LogSeverity.Error, message, e, extra));
+        }
+
+        public void LogGitCommandExecution(string message, string fileName, string arguments, string workingDir, int? processId,
+            bool isOnMainThread, TimeSpan? duration, int? exitCode, StackTrace callStack)
+        {
+            LogEntries.Add(LogEntryCreator.Create(message, fileName, arguments, workingDir, processId, isOnMainThread, duration,
+                exitCode, callStack));
+        }
+    }
+
+    public class Logger : ILogger
+    {
+        private readonly LogWriter _writer;
+
+        private readonly Task _writerTask;
+
+        public const string MetaTypeKeyName = "_MetaType";
+
+        private static ILogger _instance;
+
+        public Logger(
+            string gitExtensionsPath,
+            ILogFormatter formatter,
+            TimeSpan flushInterval,
+            TimeSpan maxLogAge,
+            CancellationToken cancellationToken)
+        {
+            if (!Directory.Exists(gitExtensionsPath))
+            {
+                throw new ArgumentException($"Non-existing folder '{gitExtensionsPath}'", nameof(gitExtensionsPath));
+            }
+
+            var logPath = Path.Combine(gitExtensionsPath, "logs");
+            var creator = new LogPathGenerator(logPath, "gitextensions");
+            _writer = new LogWriter(creator, formatter, flushInterval);
+
+            Task.Run(new LogFileCleaner(this, creator, maxLogAge).Run);
+
+            _writerTask = Task.Run(() => _writer.Run(cancellationToken));
+
+            _instance = this;
+        }
+
+        public void WaitShutdown()
+        {
+            _writerTask?.Wait(TimeSpan.FromSeconds(2));
+        }
+
+        public void Log(LogSeverity severity, string message, Dictionary<string, string> extra = null)
+        {
+            _writer?.Enqueue(LogEntryCreator.Create(severity, message, extra));
+        }
+
+        public void Info(string message, Dictionary<string, string> extra = null)
+        {
+            _writer?.Enqueue(LogEntryCreator.Create(LogSeverity.Info, message, extra));
+        }
+
+        public void Error(string message, Dictionary<string, string> extra = null)
+        {
+            _writer?.Enqueue(LogEntryCreator.Create(LogSeverity.Error, message, extra));
+        }
+
+        public void Error(string message, Exception e, Dictionary<string, string> extra = null)
+        {
+            _writer?.Enqueue(LogEntryCreator.Create(LogSeverity.Error, message, e, extra));
+        }
+
+        /// <summary>
+        /// shortcut specifically for logging git commands executions
+        /// </summary>
+        public void LogGitCommandExecution(
+            string message,
+            string fileName,
+            string arguments,
+            string workingDir,
+            int? processId,
+            bool isOnMainThread,
+            TimeSpan? duration,
+            int? exitCode,
+            StackTrace callStack)
+        {
+            _writer?.Enqueue(LogEntryCreator.Create(message, fileName, arguments, workingDir, processId, isOnMainThread, duration, exitCode, callStack));
+        }
+
+        public static void LogEntry(LogSeverity severity, string message, Dictionary<string, string> extra = null)
+        {
+            _instance.Log(severity, message, extra);
+        }
+
+        public static void LogInfo(string message, Dictionary<string, string> extra = null)
+        {
+            _instance.Info(message, extra);
+        }
+
+        public static void LogError(string message, Dictionary<string, string> extra = null)
+        {
+            _instance.Error(message, extra);
+        }
+
+        public static void LogError(string message, Exception e, Dictionary<string, string> extra = null)
+        {
+            _instance.Error(message, e, extra);
+        }
+
+        /// <summary>
+        /// shortcut specifically for logging git commands executions
+        /// </summary>
+        public static void LogAGitCommandExecution(
+            string message,
+            string fileName,
+            string arguments,
+            string workingDir,
+            int? processId,
+            bool isOnMainThread,
+            TimeSpan? duration,
+            int? exitCode,
+            StackTrace callStack)
+        {
+            _instance.LogGitCommandExecution(message, fileName, arguments, workingDir, processId, isOnMainThread, duration, exitCode, callStack);
+        }
+    }
+}

--- a/GitExtUtils/FileLogging/Logger.cs
+++ b/GitExtUtils/FileLogging/Logger.cs
@@ -54,7 +54,7 @@ namespace GitExtUtils.FileLogging
 
         public const string MetaTypeKeyName = "_MetaType";
 
-        private static ILogger _instance;
+        private static ILogger _instance = new LoggerStub();
 
         public Logger(
             string gitExtensionsPath,

--- a/GitExtUtils/FileLogging/Logger.cs
+++ b/GitExtUtils/FileLogging/Logger.cs
@@ -7,9 +7,6 @@ using System.Threading.Tasks;
 
 namespace GitExtUtils.FileLogging
 {
-    /// <summary>
-    /// For unit testing
-    /// </summary>
     public class LoggerStub : ILogger
     {
         public List<LogEntry> LogEntries = new List<LogEntry>();
@@ -48,7 +45,7 @@ namespace GitExtUtils.FileLogging
 
     public class Logger : ILogger
     {
-        private readonly LogWriter _writer;
+        private readonly ILogWriter _writer;
 
         private readonly Task _writerTask;
 
@@ -99,22 +96,22 @@ namespace GitExtUtils.FileLogging
 
         public void Log(LogSeverity severity, string message, Dictionary<string, string> extra = null)
         {
-            _writer?.Enqueue(LogEntryCreator.Create(severity, message, extra));
+            _writer.Enqueue(LogEntryCreator.Create(severity, message, extra));
         }
 
         public void Info(string message, Dictionary<string, string> extra = null)
         {
-            _writer?.Enqueue(LogEntryCreator.Create(LogSeverity.Info, message, extra));
+            _writer.Enqueue(LogEntryCreator.Create(LogSeverity.Info, message, extra));
         }
 
         public void Error(string message, Dictionary<string, string> extra = null)
         {
-            _writer?.Enqueue(LogEntryCreator.Create(LogSeverity.Error, message, extra));
+            _writer.Enqueue(LogEntryCreator.Create(LogSeverity.Error, message, extra));
         }
 
         public void Error(string message, Exception e, Dictionary<string, string> extra = null)
         {
-            _writer?.Enqueue(LogEntryCreator.Create(LogSeverity.Error, message, e, extra));
+            _writer.Enqueue(LogEntryCreator.Create(LogSeverity.Error, message, e, extra));
         }
 
         /// <summary>
@@ -131,7 +128,7 @@ namespace GitExtUtils.FileLogging
             int? exitCode,
             StackTrace callStack)
         {
-            _writer?.Enqueue(LogEntryCreator.Create(message, fileName, arguments, workingDir, processId, isOnMainThread, duration, exitCode, callStack));
+            _writer.Enqueue(LogEntryCreator.Create(message, fileName, arguments, workingDir, processId, isOnMainThread, duration, exitCode, callStack));
         }
 
         public static void LogEntry(LogSeverity severity, string message, Dictionary<string, string> extra = null)

--- a/GitExtUtils/FileLogging/Logger.cs
+++ b/GitExtUtils/FileLogging/Logger.cs
@@ -61,6 +61,7 @@ namespace GitExtUtils.FileLogging
             ILogFormatter formatter,
             TimeSpan flushInterval,
             TimeSpan maxLogAge,
+            int processId,
             CancellationToken cancellationToken)
         {
             if (!Directory.Exists(gitExtensionsPath))
@@ -69,7 +70,7 @@ namespace GitExtUtils.FileLogging
             }
 
             var logPath = Path.Combine(gitExtensionsPath, "logs");
-            var creator = new LogPathGenerator(logPath, "gitextensions");
+            var creator = new LogPathGenerator(logPath, "gitextensions", processId);
             _writer = new LogWriter(creator, formatter, flushInterval);
 
             Task.Run(new LogFileCleaner(this, creator, maxLogAge).Run);

--- a/GitExtUtils/FileLogging/Logger.cs
+++ b/GitExtUtils/FileLogging/Logger.cs
@@ -69,7 +69,7 @@ namespace GitExtUtils.FileLogging
                 throw new ArgumentException($"Non-existing folder '{gitExtensionsPath}'", nameof(gitExtensionsPath));
             }
 
-            var logPath = Path.Combine(gitExtensionsPath, "logs");
+            var logPath = Path.Combine(gitExtensionsPath, "gitextensions");
             var creator = new LogPathGenerator(logPath, "gitextensions", processId);
             _writer = new LogWriter(creator, formatter, flushInterval);
 

--- a/GitExtUtils/FileLogging/Logger.cs
+++ b/GitExtUtils/FileLogging/Logger.cs
@@ -54,7 +54,13 @@ namespace GitExtUtils.FileLogging
 
         public const string MetaTypeKeyName = "_MetaType";
 
+        /// <summary>
+        /// We hold a static logger for as long as the static interface of the logger exist.
+        /// When all the code has an <see cref="ILogger"/> injected, this field is no longer needed.
+        /// </summary>
         private static ILogger _instance = new LoggerStub();
+
+        private static readonly object LockObject = new object();
 
         public Logger(
             string gitExtensionsPath,
@@ -77,7 +83,13 @@ namespace GitExtUtils.FileLogging
 
             _writerTask = Task.Run(() => _writer.Run(cancellationToken));
 
-            _instance = this;
+            lock (LockObject)
+            {
+                if (_instance.GetType() == typeof(LoggerStub))
+                {
+                    _instance = this;
+                }
+            }
         }
 
         public void WaitShutdown()

--- a/GitExtUtils/GitExtUtils.csproj
+++ b/GitExtUtils/GitExtUtils.csproj
@@ -52,6 +52,15 @@
     <Compile Include="ArrayExtensions.cs" />
     <Compile Include="BinarySearch.cs" />
     <Compile Include="ClipboardUtil.cs" />
+    <Compile Include="FileLogging\ILogger.cs" />
+    <Compile Include="FileLogging\LogEntryCreator.cs" />
+    <Compile Include="FileLogging\LogSeverity.cs" />
+    <Compile Include="FileLogging\LogWriter.cs" />
+    <Compile Include="FileLogging\GitCommandLogFormatter.cs" />
+    <Compile Include="FileLogging\LogEntry.cs" />
+    <Compile Include="FileLogging\LogFileCleaner.cs" />
+    <Compile Include="FileLogging\LogPathGenerator.cs" />
+    <Compile Include="FileLogging\Logger.cs" />
     <Compile Include="GitArgumentBuilder.cs" />
     <Compile Include="GitCommandConfiguration.cs" />
     <Compile Include="GitConfigItem.cs" />
@@ -95,5 +104,6 @@
       <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -46,6 +46,7 @@ namespace GitExtensions
                     new GitCommandLogFormatter(),
                     TimeSpan.FromSeconds(1.01),
                     TimeSpan.FromDays(7),
+                    Process.GetCurrentProcess().Id,
                     source.Token);
 
                 logger.Info($"Application starting - version {AppSettings.ProductVersion} - {AppSettings.AppVersion}");

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -41,7 +41,7 @@ namespace GitExtensions
             {
                 DiagnosticsClient.Initialize(ThisAssembly.Git.IsDirty);
 
-                var logLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                var logLocation = Path.GetTempPath();
                 logger = new Logger(logLocation,
                     new GitCommandLogFormatter(),
                     TimeSpan.FromSeconds(1.01),

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.FileLogging;
 using GitUI.Infrastructure.Telemetry;
 using GitUI.Script;
 using JetBrains.Annotations;
@@ -65,7 +66,10 @@ namespace GitUI
             : base(enablePositionRestore: true)
         {
             _uiCommands = commands;
-            DiagnosticsClient.TrackPageView(GetType().FullName);
+
+            var name = GetType().FullName;
+            DiagnosticsClient.TrackPageView(name);
+            Logger.LogInfo($"Opening {name}");
         }
 
         protected override CommandStatus ExecuteCommand(int command)
@@ -78,6 +82,13 @@ namespace GitUI
             }
 
             return result;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Logger.LogInfo($"Disposing {GetType().FullName}");
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -8,6 +8,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Settings;
 using GitExtUtils;
+using GitExtUtils.FileLogging;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.RepoHosting;
 using GitUI.CommandsDialogs.SettingsDialog;
@@ -1143,6 +1144,8 @@ namespace GitUI
         public bool StartBrowseDialog(IWin32Window owner = null, string filter = "", ObjectId selectedCommit = null)
         {
             var form = new FormBrowse(this, filter, selectedCommit);
+
+            Logger.LogInfo("Application displaying window");
 
             if (Application.MessageLoop)
             {

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using GitCommands;
 using JetBrains.Annotations;
@@ -35,5 +36,9 @@ namespace GitUIPluginInterfaces
         [NotNull]
         [MustUseReturnValue]
         string GetOutput(ArgumentString arguments);
+
+        string WorkingDir { get; }
+
+        Func<string> FileNameProvider { get; }
     }
 }

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -118,6 +118,9 @@ namespace CommonTestUtils
             throw new Exception("Unexpected arguments: " + arguments);
         }
 
+        public string WorkingDir { get; }
+        public Func<string> FileNameProvider { get; }
+
         private sealed class MockProcess : IProcess
         {
             public MockProcess([CanBeNull] string output, int? exitCode = 0)

--- a/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
+++ b/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ArrayExtensionsTests.cs" />
     <Compile Include="ComboBoxExtensionsTests.cs" />
     <Compile Include="GitArgumentBuilderTests.cs" />
+    <Compile Include="LogPathGeneratorTests.cs" />
     <Compile Include="MruCacheTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TableLayoutPanelExtensionsTests.cs" />

--- a/UnitTests/GitExtUtils/LogPathGeneratorTests.cs
+++ b/UnitTests/GitExtUtils/LogPathGeneratorTests.cs
@@ -8,7 +8,7 @@ namespace FileLoggingTests
     [TestFixture]
     public sealed class LogPathGeneratorTests
     {
-        private const string LogPath = "c:\\temp\\logs";
+        private const string LogPath = "c:\\temp\\gitextensions";
 
         [Test]
         public void Logpath_is_unmodified()
@@ -31,8 +31,8 @@ namespace FileLoggingTests
             var t1 = new DateTime(2019, 10, 9, 8, 7, 6);
             var t2 = t1.AddDays(1);
 
-            generator.GenerateFullPath(t1).Should().Be(@"c:\temp\logs\mylogname-20191009-666.log");
-            generator.GenerateFullPath(t2).Should().Be(@"c:\temp\logs\mylogname-20191010-666.log");
+            generator.GenerateFullPath(t1).Should().Be(@"c:\temp\gitextensions\mylogname-20191009-666.log");
+            generator.GenerateFullPath(t2).Should().Be(@"c:\temp\gitextensions\mylogname-20191010-666.log");
         }
 
         private static LogPathGenerator CreateGenerator()

--- a/UnitTests/GitExtUtils/LogPathGeneratorTests.cs
+++ b/UnitTests/GitExtUtils/LogPathGeneratorTests.cs
@@ -21,7 +21,7 @@ namespace FileLoggingTests
         public void GetFilenamePattern_returns_pattern_to_delete_logfiles()
         {
             var generator = CreateGenerator();
-            generator.GetFilenamePattern().Should().Be("mylogname-*.log");
+            generator.GetFilenamePattern().Should().Be("mylogname-*-*.log");
         }
 
         [Test]
@@ -31,13 +31,13 @@ namespace FileLoggingTests
             var t1 = new DateTime(2019, 10, 9, 8, 7, 6);
             var t2 = t1.AddDays(1);
 
-            generator.GenerateFullPath(t1).Should().Be(@"c:\temp\logs\mylogname-2019-10-09.log");
-            generator.GenerateFullPath(t2).Should().Be(@"c:\temp\logs\mylogname-2019-10-10.log");
+            generator.GenerateFullPath(t1).Should().Be(@"c:\temp\logs\mylogname-20191009-666.log");
+            generator.GenerateFullPath(t2).Should().Be(@"c:\temp\logs\mylogname-20191010-666.log");
         }
 
         private static LogPathGenerator CreateGenerator()
         {
-            return new LogPathGenerator(LogPath, "mylogname");
+            return new LogPathGenerator(LogPath, "mylogname", 666);
         }
     }
 }

--- a/UnitTests/GitExtUtils/LogPathGeneratorTests.cs
+++ b/UnitTests/GitExtUtils/LogPathGeneratorTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using FluentAssertions;
+using GitExtUtils.FileLogging;
+using NUnit.Framework;
+
+namespace FileLoggingTests
+{
+    [TestFixture]
+    public sealed class LogPathGeneratorTests
+    {
+        private const string LogPath = "c:\\temp\\logs";
+
+        [Test]
+        public void Logpath_is_unmodified()
+        {
+            var generator = CreateGenerator();
+            generator.LogPath.Should().Be(LogPath);
+        }
+
+        [Test]
+        public void GetFilenamePattern_returns_pattern_to_delete_logfiles()
+        {
+            var generator = CreateGenerator();
+            generator.GetFilenamePattern().Should().Be("mylogname-*.log");
+        }
+
+        [Test]
+        public void GenerateFullPath_returns_a_full_path_of_the_day_and_changes_file_name_on_new_date()
+        {
+            var generator = CreateGenerator();
+            var t1 = new DateTime(2019, 10, 9, 8, 7, 6);
+            var t2 = t1.AddDays(1);
+
+            generator.GenerateFullPath(t1).Should().Be(@"c:\temp\logs\mylogname-2019-10-09.log");
+            generator.GenerateFullPath(t2).Should().Be(@"c:\temp\logs\mylogname-2019-10-10.log");
+        }
+
+        private static LogPathGenerator CreateGenerator()
+        {
+            return new LogPathGenerator(LogPath, "mylogname");
+        }
+    }
+}


### PR DESCRIPTION
Here is a PR for issue #7244 

The PR adds 
* a file logging capability 
* logs a few application events such as startup and some error scenarios - not everything is covered
* logs command execution (and logs more than the existing gui logger)

When several instances are running they log with different PID (2nd column)

**Two issues for debate**
1. can we accept a static logger class and later change it into an instance-based. I've actually implemented **both** so people can either use the static or the `ILogger`. Going through the entire code base and injecting an `ILogger` is a lot of work that I'd rather postpone untill the logging turns out to be a success (i.e. useful)
2. What is the logfiles life expectency? Currently it is set to 7 days. Personally I'd prefer a much longer time span. Simply due to the potential debug-value in them.
If we can agree on X days, we can later make it a configuration setting.


The following is logged when I start the application, see the list of recent repositories and closing the application again. The logformat is enriched with a `metatype` making it easier to color different kinds of log lines eg using notepad++ and analyse plugin (https://sourceforge.net/projects/analyseplugin/) 

Stacktraces are also written to the log when they are selected in the logwindow (F12)


	2019-10-10 16.15.38 16208 Info                           Application starting - version 3.3.0 - 3.3.0.0  metatype: Application
	2019-10-10 16.15.38 16208 Info             16152 UI      Starting git config --get ą  metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info      70 ms  16152 UI    1 Ended    git config --get ą  metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info      65 ms              0 Command executed config --get ą  metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info      70 ms  16152 UI    1 Disposed git config --get ą  metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info             15836 UI      Starting git   metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info      56 ms  15836 UI    1 Ended    git   metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info      55 ms              0 Command executed   metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info      56 ms  15836 UI    1 Disposed git   metatype: GitExeCommand
	2019-10-10 16.15.38 16208 Info             10356 UI      Starting git --version  metatype: GitExeCommand
	2019-10-10 16.15.39 16208 Info      70 ms  10356 UI    0 Ended    git --version  metatype: GitExeCommand
	2019-10-10 16.15.39 16208 Info      68 ms              0 Command executed --version  metatype: GitExeCommand
	2019-10-10 16.15.39 16208 Info      70 ms  10356 UI    0 Disposed git --version  metatype: GitExeCommand
	2019-10-10 16.15.39 16208 Info                           Opening GitUI.CommandsDialogs.FormBrowse  metatype: Application
	2019-10-10 16.15.40 16208 Info              7188         Starting git --no-optional-locks for-each-ref --sort=-committerdate refs/heads/ --format="%(objectname) %(refname)"  metatype: GitExeCommand
	2019-10-10 16.15.40 16208 Info              2820 UI      Starting git rev-parse --git-common-dir  metatype: GitExeCommand
	2019-10-10 16.15.40 16208 Info     104 ms   7188       0 Ended    git --no-optional-locks for-each-ref --sort=-committerdate refs/heads/ --format="%(objectname) %(refname)"  metatype: GitExeCommand
	2019-10-10 16.15.40 16208 Info      89 ms   2820 UI    0 Ended    git rev-parse --git-common-dir  metatype: GitExeCommand
	2019-10-10 16.15.40 16208 Info              4488         Starting git --no-optional-locks show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.42 16208 Info   2.880 ms              0 Command executed rev-parse --git-common-dir  metatype: GitExeCommand
	2019-10-10 16.15.42 16208 Info      89 ms   2820 UI    0 Disposed git rev-parse --git-common-dir  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info                           Application displaying window  metatype: Application
	2019-10-10 16.15.43 16208 Info   3.677 ms              0 Command executed --no-optional-locks for-each-ref --sort=-committerdate refs/heads/ --format="%(objectname) %(refname)"  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     104 ms   7188       0 Disposed git --no-optional-locks for-each-ref --sort=-committerdate refs/heads/ --format="%(objectname) %(refname)"  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info   2.748 ms   4488       0 Ended    git --no-optional-locks show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info   2.746 ms              0 Command executed --no-optional-locks show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info   2.748 ms   4488       0 Disposed git --no-optional-locks show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info              5552         Starting git remote -v  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info             15164         Starting git for-each-ref --format="%(push:track)::%(upstream:track)::%(refname:short)" refs/heads/  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     131 ms  15164       0 Ended    git for-each-ref --format="%(push:track)::%(upstream:track)::%(refname:short)" refs/heads/  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     129 ms              0 Command executed for-each-ref --format="%(push:track)::%(upstream:track)::%(refname:short)" refs/heads/  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     131 ms  15164       0 Disposed git for-each-ref --format="%(push:track)::%(upstream:track)::%(refname:short)" refs/heads/  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     156 ms   5552       0 Ended    git remote -v  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     155 ms              0 Command executed remote -v  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info     156 ms   5552       0 Disposed git remote -v  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info             14552         Starting git show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.43 16208 Info             10128         Starting git symbolic-ref HEAD  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info      87 ms  10128       0 Ended    git symbolic-ref HEAD  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info      94 ms              0 Command executed symbolic-ref HEAD  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info      87 ms  10128       0 Disposed git symbolic-ref HEAD  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info     154 ms  14552       0 Ended    git show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info     153 ms              0 Command executed show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info     154 ms  14552       0 Disposed git show-ref --dereference  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info             10888         Starting git remote  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info     140 ms  10888       0 Ended    git remote  metatype: GitExeCommand
	2019-10-10 16.15.44 16208 Info     140 ms  10888       0 Disposed git remote  metatype: GitExeCommand
	2019-10-10 16.16.37 16208 Info                           Disposing GitUI.CommandsDialogs.FormBrowse  metatype: Application
	2019-10-10 16.16.37 16208 Info                           Application stopped  metatype: Application

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
