### PR TITLE
prevent flickering when selecting files in staged/unstaged FileStatusList

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -705,7 +705,7 @@ namespace GitUI.CommandsDialogs
             this.Unstaged.SelectedIndexChanged += new System.EventHandler(this.UnstagedSelectionChanged);
             this.Unstaged.DataSourceChanged += new System.EventHandler(this.Staged_DataSourceChanged);
             this.Unstaged.DoubleClick += new System.EventHandler(this.Unstaged_DoubleClick);
-            this.Unstaged.Enter += new System.EventHandler(this.Unstaged_Enter);
+            this.Unstaged.Enter += new FileStatusList.EnterEventHandler(this.Unstaged_Enter);
             //
             // toolbarUnstaged
             //
@@ -933,7 +933,7 @@ namespace GitUI.CommandsDialogs
             this.Staged.SelectedIndexChanged += new System.EventHandler(this.StagedSelectionChanged);
             this.Staged.DataSourceChanged += new System.EventHandler(this.Staged_DataSourceChanged);
             this.Staged.DoubleClick += new System.EventHandler(this.Staged_DoubleClick);
-            this.Staged.Enter += new System.EventHandler(this.Staged_Enter);
+            this.Staged.Enter += new FileStatusList.EnterEventHandler(this.Staged_Enter);
             //
             // toolbarStaged
             //
@@ -1080,7 +1080,7 @@ namespace GitUI.CommandsDialogs
             this.SelectedDiff.TabIndex = 0;
             this.SelectedDiff.TabStop = false;
             this.SelectedDiff.ContextMenuOpening += new System.ComponentModel.CancelEventHandler(this.SelectedDiff_ContextMenuOpening);
-            this.SelectedDiff.TextLoaded += new System.EventHandler(this.SelectedDiff_TextLoaded); 
+            this.SelectedDiff.TextLoaded += new System.EventHandler(this.SelectedDiff_TextLoaded);
             //
             // tableLayoutPanel1
             //
@@ -1099,9 +1099,9 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(517, 192);
             this.tableLayoutPanel1.TabIndex = 8;
-            // 
+            //
             // Message
-            // 
+            //
             this.Message.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Message.Location = new System.Drawing.Point(177, 28);
             this.Message.Margin = new System.Windows.Forms.Padding(0);
@@ -1161,7 +1161,7 @@ namespace GitUI.CommandsDialogs
             this.CommitAndPush.Click += new System.EventHandler(this.CommitAndPush_Click);
             //
             // Amend
-            // 
+            //
             this.Amend.AutoSize = true;
             this.Amend.Location = new System.Drawing.Point(0, 93);
             this.Amend.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
@@ -1171,9 +1171,9 @@ namespace GitUI.CommandsDialogs
             this.Amend.Text = "&Amend Commit";
             this.Amend.UseVisualStyleBackColor = true;
             this.Amend.CheckedChanged += new System.EventHandler(this.Amend_CheckedChanged);
-            // 
+            //
             // Reset
-            // 
+            //
             this.Reset.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.Reset.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.Reset.Location = new System.Drawing.Point(0, 122);
@@ -1324,12 +1324,12 @@ namespace GitUI.CommandsDialogs
             this.noVerifyToolStripMenuItem.Text = "No verify";
             //
             // toolStripSeparator14
-            // 
+            //
             this.toolStripSeparator14.Name = "toolStripSeparator14";
             this.toolStripSeparator14.Size = new System.Drawing.Size(311, 6);
-            // 
+            //
             // gpgSignCommitToolStripComboBox
-            // 
+            //
             this.gpgSignCommitToolStripComboBox.BackColor = System.Drawing.SystemColors.Control;
             this.gpgSignCommitToolStripComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.gpgSignCommitToolStripComboBox.Items.AddRange(new object[] {
@@ -1340,15 +1340,15 @@ namespace GitUI.CommandsDialogs
             this.gpgSignCommitToolStripComboBox.Name = "gpgSignCommitToolStripComboBox";
             this.gpgSignCommitToolStripComboBox.Size = new System.Drawing.Size(230, 23);
             this.gpgSignCommitToolStripComboBox.SelectedIndexChanged += new System.EventHandler(this.gpgSignCommitChanged);
-            // 
+            //
             // toolStripGpgKeyTextBox
-            // 
+            //
             this.toolStripGpgKeyTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.toolStripGpgKeyTextBox.MaxLength = 8;
             this.toolStripGpgKeyTextBox.Name = "toolStripGpgKeyTextBox";
             this.toolStripGpgKeyTextBox.Size = new System.Drawing.Size(230, 23);
             this.toolStripGpgKeyTextBox.Visible = false;
-            // 
+            //
             // commitTemplatesToolStripMenuItem
             //
             this.commitTemplatesToolStripMenuItem.Image = global::GitUI.Properties.Images.CommitTemplates;
@@ -1400,27 +1400,27 @@ namespace GitUI.CommandsDialogs
             this.commitAuthorStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.commitAuthorStatus.ToolTipText = "Click to change author information.";
             this.commitAuthorStatus.Click += new System.EventHandler(this.commitCommitter_Click);
-            // 
+            //
             // toolStripStatusBranchIcon
-            // 
+            //
             this.toolStripStatusBranchIcon.AutoSize = false;
             this.toolStripStatusBranchIcon.Image = global::GitUI.Properties.Images.Branch;
             this.toolStripStatusBranchIcon.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.toolStripStatusBranchIcon.Name = "toolStripStatusBranchIcon";
             this.toolStripStatusBranchIcon.Size = new System.Drawing.Size(17, 17);
             this.toolStripStatusBranchIcon.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
+            //
             // branchNameLabel
-            // 
+            //
             this.branchNameLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.branchNameLabel.Margin = new System.Windows.Forms.Padding(0, 3, 0, 2);
             this.branchNameLabel.Name = "branchNameLabel";
             this.branchNameLabel.Size = new System.Drawing.Size(85, 17);
             this.branchNameLabel.Text = "(Branch name)";
             this.branchNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
+            //
             // remoteNameLabel
-            // 
+            //
             this.remoteNameLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.remoteNameLabel.IsLink = true;
             this.remoteNameLabel.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
@@ -1429,7 +1429,7 @@ namespace GitUI.CommandsDialogs
             this.remoteNameLabel.Size = new System.Drawing.Size(85, 17);
             this.remoteNameLabel.Text = "(Remote name)";
             this.remoteNameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
             // commitStagedCountLabel
             //
             this.commitStagedCountLabel.Name = "commitStagedCountLabel";

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1638,13 +1638,13 @@ namespace GitUI.CommandsDialogs
             stagedOpenDifftoolToolStripMenuItem9.Enabled = !isNewSelected;
         }
 
-        private void Unstaged_Enter(object sender, EventArgs e)
+        private void Unstaged_Enter(object sender, EnterEventArgs e)
         {
             if (_currentFilesList != Unstaged)
             {
                 _currentFilesList = Unstaged;
                 _skipUpdate = false;
-                if (Unstaged.AllItems.Count() != 0 && Unstaged.SelectedIndex == -1)
+                if (!e.ByMouse && Unstaged.AllItems.Count() != 0 && Unstaged.SelectedIndex == -1)
                 {
                     Unstaged.SelectedIndex = 0;
                 }
@@ -1874,13 +1874,13 @@ namespace GitUI.CommandsDialogs
             commitStagedCount.Text = stagedCount + "/" + totalFilesCount;
         }
 
-        private void Staged_Enter(object sender, EventArgs e)
+        private void Staged_Enter(object sender, EnterEventArgs e)
         {
             if (_currentFilesList != Staged)
             {
                 _currentFilesList = Staged;
                 _skipUpdate = false;
-                if (Staged.AllItems.Count() != 0 && Staged.SelectedIndex == -1)
+                if (!e.ByMouse && Staged.AllItems.Count() != 0 && Staged.SelectedIndex == -1)
                 {
                     Staged.SelectedIndex = 0;
                 }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Strings.cs" />
     <Compile Include="TaskbarProgress.cs" />
     <Compile Include="UserControls\GitItemStatusWithParent.cs" />
+    <Compile Include="UserControls\EnterEventArgs.cs" />
     <Compile Include="UserControls\NativeTreeViewDoubleClickDecorator.cs" />
     <Compile Include="UserControls\NativeTreeViewExplorerNavigationDecorator.cs" />
     <Compile Include="UserControls\RevisionGrid\CellStyle.cs" />

--- a/GitUI/UserControls/EnterEventArgs.cs
+++ b/GitUI/UserControls/EnterEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace GitUI
+{
+    public class EnterEventArgs : EventArgs
+    {
+        public bool ByMouse { get; }
+
+        public EnterEventArgs(bool byMouse)
+        {
+            ByMouse = byMouse;
+        }
+    }
+}

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -36,6 +36,7 @@ namespace GitUI
         private int _nextIndexToSelect = -1;
         private bool _groupByRevision;
         private bool _enableSelectedIndexChangeEvent = true;
+        private bool _mouseEntered;
         private ToolStripItem _openSubmoduleMenuItem;
         private Rectangle _dragBoxFromMouseDown;
         private IReadOnlyList<(GitRevision revision, IReadOnlyList<GitItemStatus> statuses)> _itemsWithParent = Array.Empty<(GitRevision, IReadOnlyList<GitItemStatus>)>();
@@ -44,11 +45,14 @@ namespace GitUI
 
         private bool _updatingColumnWidth;
 
+        public delegate void EnterEventHandler(object sender, EnterEventArgs e);
+
         public event EventHandler SelectedIndexChanged;
         public event EventHandler DataSourceChanged;
 
         public new event EventHandler DoubleClick;
         public new event KeyEventHandler KeyDown;
+        public new event EnterEventHandler Enter;
 
         public FileStatusList()
         {
@@ -76,6 +80,8 @@ namespace GitUI
 
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _revisionTester = new GitRevisionTester(_fullPathResolver);
+
+            base.Enter += FileStatusList_Enter;
 
             return;
 
@@ -780,6 +786,16 @@ namespace GitUI
             _diffListSortSubscription?.Dispose();
         }
 
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == NativeConstants.WM_MOUSEACTIVATE)
+            {
+                _mouseEntered = !Focused;
+            }
+
+            base.WndProc(ref m);
+        }
+
         // Private methods
 
         private void CreateOpenSubmoduleMenuItem()
@@ -1333,6 +1349,12 @@ namespace GitUI
             }
 
             UpdateColumnWidth();
+        }
+
+        private void FileStatusList_Enter(object sender, EventArgs e)
+        {
+            Enter?.Invoke(this, new EnterEventArgs(_mouseEntered));
+            _mouseEntered = false;
         }
 
         #region Filtering


### PR DESCRIPTION
Fixes #7266

## Proposed changes

- It appears that first item in staged/unstaged file status list should be selected only if `Entering` the control by keyboard as when using the mouse you either click on specific item to select it or on an empty space to deselect everything
- Add overridden `Enter` event to `FileStatusList` which would provide extra details as to how control was entered
- Only select first item if control wasn't entered by mouse

## Test methodology

- Manual testing