### PR TITLE
Add Squash feature on GitFlow Plugin Form

### DIFF
--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -941,6 +941,10 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
         <source>Push after finish</source>
         <target />
       </trans-unit>
+      <trans-unit id="cbSquashFeature.Text">
+        <source>Squash feature</source>
+        <target />
+      </trans-unit>
       <trans-unit id="gbManage.Text">
         <source>Manage existing branches:</source>
         <target />

--- a/Plugins/GitFlow/GitFlowForm.Designer.cs
+++ b/Plugins/GitFlow/GitFlowForm.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GitFlowForm));
             this.btnInit = new System.Windows.Forms.Button();
             this.txtBranchName = new System.Windows.Forms.TextBox();
             this.btnCreateBranch = new System.Windows.Forms.Button();
@@ -68,6 +67,7 @@
             this.panel3 = new System.Windows.Forms.GroupBox();
             this.txtResult = new System.Windows.Forms.TextBox();
             this.lblRunCommand = new System.Windows.Forms.Label();
+            this.cbSquashFeature = new System.Windows.Forms.CheckBox();
             this.gbManage.SuspendLayout();
             this.pnlManageBranch.SuspendLayout();
             this.pnlPull.SuspendLayout();
@@ -91,7 +91,7 @@
             // 
             this.txtBranchName.Location = new System.Drawing.Point(163, 25);
             this.txtBranchName.Name = "txtBranchName";
-            this.txtBranchName.Size = new System.Drawing.Size(374, 21);
+            this.txtBranchName.Size = new System.Drawing.Size(374, 20);
             this.txtBranchName.TabIndex = 2;
             // 
             // btnCreateBranch
@@ -136,6 +136,7 @@
             // 
             // pnlManageBranch
             // 
+            this.pnlManageBranch.Controls.Add(this.cbSquashFeature);
             this.pnlManageBranch.Controls.Add(this.cbPushAfterFinish);
             this.pnlManageBranch.Controls.Add(this.panel2);
             this.pnlManageBranch.Controls.Add(this.pnlPull);
@@ -155,7 +156,7 @@
             this.cbPushAfterFinish.AutoSize = true;
             this.cbPushAfterFinish.Location = new System.Drawing.Point(492, 97);
             this.cbPushAfterFinish.Name = "cbPushAfterFinish";
-            this.cbPushAfterFinish.Size = new System.Drawing.Size(104, 17);
+            this.cbPushAfterFinish.Size = new System.Drawing.Size(101, 17);
             this.cbPushAfterFinish.TabIndex = 8;
             this.cbPushAfterFinish.Text = "Push after finish";
             this.cbPushAfterFinish.UseVisualStyleBackColor = true;
@@ -192,7 +193,7 @@
             this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(80, 9);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(108, 13);
+            this.label9.Size = new System.Drawing.Size(104, 13);
             this.label9.TabIndex = 1;
             this.label9.Text = "Remote to pull from :";
             // 
@@ -220,7 +221,7 @@
             this.lblPrefixManage.AutoSize = true;
             this.lblPrefixManage.Location = new System.Drawing.Point(104, 11);
             this.lblPrefixManage.Name = "lblPrefixManage";
-            this.lblPrefixManage.Size = new System.Drawing.Size(47, 13);
+            this.lblPrefixManage.Size = new System.Drawing.Size(43, 13);
             this.lblPrefixManage.TabIndex = 1;
             this.lblPrefixManage.Text = "[prefix]/";
             this.lblPrefixManage.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -230,7 +231,7 @@
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(38, 11);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(44, 13);
+            this.label1.Size = new System.Drawing.Size(43, 13);
             this.label1.TabIndex = 1;
             this.label1.Text = "branch:";
             // 
@@ -279,7 +280,7 @@
             this.label10.AutoSize = true;
             this.label10.Location = new System.Drawing.Point(9, 28);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(85, 13);
+            this.label10.Size = new System.Drawing.Size(84, 13);
             this.label10.TabIndex = 1;
             this.label10.Text = "Expected name:";
             // 
@@ -288,7 +289,7 @@
             this.lblPrefixName.AutoSize = true;
             this.lblPrefixName.Location = new System.Drawing.Point(119, 28);
             this.lblPrefixName.Name = "lblPrefixName";
-            this.lblPrefixName.Size = new System.Drawing.Size(47, 13);
+            this.lblPrefixName.Size = new System.Drawing.Size(43, 13);
             this.lblPrefixName.TabIndex = 1;
             this.lblPrefixName.Text = "[prefix]/";
             this.lblPrefixName.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -331,7 +332,7 @@
             this.cbBasedOn.AutoSize = true;
             this.cbBasedOn.Location = new System.Drawing.Point(3, 11);
             this.cbBasedOn.Name = "cbBasedOn";
-            this.cbBasedOn.Size = new System.Drawing.Size(74, 17);
+            this.cbBasedOn.Size = new System.Drawing.Size(73, 17);
             this.cbBasedOn.TabIndex = 0;
             this.cbBasedOn.Text = "based on:";
             this.cbBasedOn.UseVisualStyleBackColor = true;
@@ -351,7 +352,7 @@
             this.lnkGitFlow.AutoSize = true;
             this.lnkGitFlow.Location = new System.Drawing.Point(570, 17);
             this.lnkGitFlow.Name = "lnkGitFlow";
-            this.lnkGitFlow.Size = new System.Drawing.Size(74, 13);
+            this.lnkGitFlow.Size = new System.Drawing.Size(73, 13);
             this.lnkGitFlow.TabIndex = 9;
             this.lnkGitFlow.TabStop = true;
             this.lnkGitFlow.Text = "About GitFlow";
@@ -391,7 +392,7 @@
             this.lblCaptionHead.AutoSize = true;
             this.lblCaptionHead.Location = new System.Drawing.Point(176, 17);
             this.lblCaptionHead.Name = "lblCaptionHead";
-            this.lblCaptionHead.Size = new System.Drawing.Size(38, 13);
+            this.lblCaptionHead.Size = new System.Drawing.Size(40, 13);
             this.lblCaptionHead.TabIndex = 1;
             this.lblCaptionHead.Text = "HEAD:";
             // 
@@ -400,7 +401,7 @@
             this.lblHead.AutoSize = true;
             this.lblHead.Location = new System.Drawing.Point(217, 17);
             this.lblHead.Name = "lblHead";
-            this.lblHead.Size = new System.Drawing.Size(37, 13);
+            this.lblHead.Size = new System.Drawing.Size(33, 13);
             this.lblHead.TabIndex = 1;
             this.lblHead.Text = "ref/...";
             this.lblHead.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -444,9 +445,19 @@
             this.lblRunCommand.AutoSize = true;
             this.lblRunCommand.Location = new System.Drawing.Point(60, 14);
             this.lblRunCommand.Name = "lblRunCommand";
-            this.lblRunCommand.Size = new System.Drawing.Size(11, 13);
+            this.lblRunCommand.Size = new System.Drawing.Size(10, 13);
             this.lblRunCommand.TabIndex = 1;
             this.lblRunCommand.Text = "-";
+            // 
+            // cbSquashFeature
+            // 
+            this.cbSquashFeature.AutoSize = true;
+            this.cbSquashFeature.Location = new System.Drawing.Point(492, 113);
+            this.cbSquashFeature.Name = "cbSquashFeature";
+            this.cbSquashFeature.Size = new System.Drawing.Size(98, 17);
+            this.cbSquashFeature.TabIndex = 9;
+            this.cbSquashFeature.Text = "Squash feature";
+            this.cbSquashFeature.UseVisualStyleBackColor = true;
             // 
             // GitFlowForm
             // 
@@ -524,5 +535,6 @@
         private System.Windows.Forms.Label lblRunCommand;
         private System.Windows.Forms.TextBox txtResult;
         private System.Windows.Forms.CheckBox cbPushAfterFinish;
+        private System.Windows.Forms.CheckBox cbSquashFeature;
     }
 }

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -95,6 +95,10 @@ namespace GitFlow
 
                 cbBasedOn.Checked = false;
                 cbBaseBranch.Enabled = false;
+
+                cbPushAfterFinish.Enabled = false;
+                cbSquashFeature.Enabled = false;
+
                 LoadBaseBranches();
 
                 DisplayHead();
@@ -171,6 +175,7 @@ namespace GitFlow
 
             btnFinish.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
             cbPushAfterFinish.Enabled = isThereABranch && (branchType == Branch.hotfix.ToString("G") || branchType == Branch.release.ToString("G"));
+            cbSquashFeature.Enabled = isThereABranch && branchType == Branch.feature.ToString("G");
             btnPublish.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
             btnPull.Enabled = isThereABranch && (branchType != Branch.support.ToString("G"));
             pnlPull.Enabled = branchType != Branch.support.ToString("G");
@@ -289,6 +294,7 @@ namespace GitFlow
                 cbManageType.SelectedValue.ToString(),
                 "finish",
                 { cbPushAfterFinish.Checked, "-p" },
+                { cbSquashFeature.Checked, "-S" },
                 cbBranches.SelectedValue.ToString()
             };
             RunCommand(args);

--- a/contributors.txt
+++ b/contributors.txt
@@ -100,4 +100,5 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/30, hieuxlu, Hieu Do, xlu.untitled(at)gmail.com
 2019/10/13, R0nd, Roland Gneev, rgneev(at)gmail.com
 2019/10/13, bansan85, Le Garrec Vincent, legarrec.vincent{at]gmail.com
+2019/10/14, FabMan08, Fabrizio Mancin, fabman08(at)gmail.com
 2019/10/15, manishkungwani, Manish Kungwani, manishkungwani{at]yahoo.com


### PR DESCRIPTION
## Proposed changes
Add new checkbox on GitFlow plugin: "Squash feature"
This checkbox enables the user to squash the merge commit form one feature to develop branch.
Simply adds the -S parameter to the git flow feature finish command

I think it can be userful :)

## Screenshots 
![image](https://user-images.githubusercontent.com/6802895/66466500-170f3a00-ea83-11e9-8340-8150a509c603.png)

## Test environment(s) 

- GIT 3.2.1.6628
- Windows 10

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
