### PR TITLE
Filter branches: display a placeholder when no branches found

### DIFF
--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -18,6 +18,8 @@ namespace GitUI
         private readonly ToolStripMenuItem _remoteToolStripMenuItem;
         private GitModule Module => _NO_TRANSLATE_RevisionGrid.Module;
 
+        private static readonly string[] _noResultsFound = { Strings.NoResultsFound };
+
         public FilterBranchHelper()
         {
             _localToolStripMenuItem = new ToolStripMenuItem();
@@ -171,6 +173,12 @@ namespace GitUI
             try
             {
                 string filter = _NO_TRANSLATE_toolStripBranches.Items.Count > 0 ? _NO_TRANSLATE_toolStripBranches.Text : string.Empty;
+
+                if (filter == Strings.NoResultsFound)
+                {
+                    filter = string.Empty;
+                }
+
                 bool success = _NO_TRANSLATE_RevisionGrid.SetAndApplyBranchFilter(filter);
                 if (success && refresh)
                 {
@@ -188,6 +196,11 @@ namespace GitUI
             string filter = _NO_TRANSLATE_toolStripBranches.Items.Count > 0 ? _NO_TRANSLATE_toolStripBranches.Text : string.Empty;
             var branches = GetBranchAndTagRefs(_localToolStripMenuItem.Checked, _tagsToolStripMenuItem.Checked, _remoteToolStripMenuItem.Checked);
             var matches = branches.Where(branch => branch.IndexOf(filter, StringComparison.InvariantCultureIgnoreCase) >= 0).ToArray();
+
+            if (matches.Length == 0)
+            {
+                matches = _noResultsFound;
+            }
 
             var index = _NO_TRANSLATE_toolStripBranches.SelectionStart;
             _NO_TRANSLATE_toolStripBranches.Items.Clear();

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -32,14 +32,14 @@ namespace GitUI
             _localToolStripMenuItem.Checked = true;
             _localToolStripMenuItem.CheckOnClick = true;
             _localToolStripMenuItem.Name = "localToolStripMenuItem";
-            _localToolStripMenuItem.Text = "Local";
+            _localToolStripMenuItem.Text = Strings.Local;
 
             //
             // tagsToolStripMenuItem
             //
             _tagsToolStripMenuItem.CheckOnClick = true;
             _tagsToolStripMenuItem.Name = "tagToolStripMenuItem";
-            _tagsToolStripMenuItem.Text = "Tag";
+            _tagsToolStripMenuItem.Text = Strings.Tag;
 
             //
             // remoteToolStripMenuItem
@@ -47,7 +47,7 @@ namespace GitUI
             _remoteToolStripMenuItem.CheckOnClick = true;
             _remoteToolStripMenuItem.Name = "remoteToolStripMenuItem";
             _remoteToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            _remoteToolStripMenuItem.Text = "Remote";
+            _remoteToolStripMenuItem.Text = Strings.Remote;
         }
 
         public FilterBranchHelper(ToolStripComboBox toolStripBranches, ToolStripDropDownButton toolStripDropDownButton2, RevisionGridControl revisionGrid)

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -18,6 +18,7 @@ namespace GitUI
         private readonly TranslationString _searchingFor = new TranslationString("Searching for: ");
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
+        private readonly TranslationString _noResultsFound = new TranslationString("<No results found>");
 
         // public only because of FormTranslate
         public Strings()
@@ -50,5 +51,6 @@ namespace GitUI
 
         public static string LoadingData => _instance.Value._loadingDataText.Text;
         public static string UninterestingDiffOmitted => _instance.Value._uninterestingDiffOmitted.Text;
+        public static string NoResultsFound => _instance.Value._noResultsFound.Text;
     }
 }

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -19,6 +19,9 @@ namespace GitUI
         private readonly TranslationString _loadingDataText = new TranslationString("Loading data...");
         private readonly TranslationString _uninterestingDiffOmitted = new TranslationString("Uninteresting diff hunks are omitted.");
         private readonly TranslationString _noResultsFound = new TranslationString("<No results found>");
+        private readonly TranslationString _local = new TranslationString("Local");
+        private readonly TranslationString _tag = new TranslationString("Tag");
+        private readonly TranslationString _remote = new TranslationString("Remote");
 
         // public only because of FormTranslate
         public Strings()
@@ -52,5 +55,8 @@ namespace GitUI
         public static string LoadingData => _instance.Value._loadingDataText.Text;
         public static string UninterestingDiffOmitted => _instance.Value._uninterestingDiffOmitted.Text;
         public static string NoResultsFound => _instance.Value._noResultsFound.Text;
+        public static string Local => _instance.Value._local.Text;
+        public static string Tag => _instance.Value._tag.Text;
+        public static string Remote => _instance.Value._remote.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9273,6 +9273,10 @@ Select this commit to populate the full message.</source>
         <source>{0} {1:month|months} ago</source>
         <target />
       </trans-unit>
+      <trans-unit id="_noResultsFound.Text">
+        <source>&lt;No results found&gt;</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_parentsText.Text">
         <source>{0:Parent|Parents}</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9261,6 +9261,10 @@ Select this commit to populate the full message.</source>
         <source>Loading data...</source>
         <target />
       </trans-unit>
+      <trans-unit id="_local.Text">
+        <source>Local</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_messageText.Text">
         <source>{0:Message|Messages}</source>
         <target />
@@ -9281,6 +9285,10 @@ Select this commit to populate the full message.</source>
         <source>{0:Parent|Parents}</source>
         <target />
       </trans-unit>
+      <trans-unit id="_remote.Text">
+        <source>Remote</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_remotesText.Text">
         <source>Remotes</source>
         <target />
@@ -9295,6 +9303,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_submodulesText.Text">
         <source>Submodules</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_tag.Text">
+        <source>Tag</source>
         <target />
       </trans-unit>
       <trans-unit id="_tagsText.Text">


### PR DESCRIPTION
to prevent an exception when the combobox is empty

Fixes #6680, #6931, #6964, #6988, #7177, #7204

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 6cbbd91a7221cde0678773fb4a6b96583f076dac (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4010.0
- DPI 192dpi (200% scaling)
