### PR TITLE
Allow remote repositories with local disk path to be saved in recents

### DIFF
--- a/GitCommands/UserRepositoryHistory/RemoteRepositoryManager.cs
+++ b/GitCommands/UserRepositoryHistory/RemoteRepositoryManager.cs
@@ -32,19 +32,12 @@ namespace GitCommands.UserRepositoryHistory
         /// <param name="repositoryPathUrl">A repository URL to be save as "most recent".</param>
         /// <returns>The current version of the list of recently used git repositories after the update.</returns>
         /// <exception cref="ArgumentException"><paramref name="repositoryPathUrl"/> is <see langword="null"/> or <see cref="string.Empty"/>.</exception>
-        /// <exception cref="NotSupportedException"><paramref name="repositoryPathUrl"/> is not a URL.</exception>
         [ContractAnnotation("repositoryPathUrl:null=>halt")]
         public async Task<IList<Repository>> AddAsMostRecentAsync(string repositoryPathUrl)
         {
             if (string.IsNullOrWhiteSpace(repositoryPathUrl))
             {
                 throw new ArgumentException(nameof(repositoryPathUrl));
-            }
-
-            if (!PathUtil.IsUrl(repositoryPathUrl))
-            {
-                // TODO: throw a specific exception
-                throw new NotSupportedException();
             }
 
             return await AddAsMostRecentRepositoryAsync(repositoryPathUrl);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7260 


## Proposed changes

Allow saving remote repositories with non-URL paths (e.g. local disk path) in the recent repositories list.

## Test methodology <!-- How did you ensure quality? -->

Tested manually to match the expected behavior in #7260 

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.14.1
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
