### PR TITLE
Fix #7257 ConEmu is missing

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2976,7 +2976,18 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory);
+                try
+                {
+                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory);
+                }
+                catch (InvalidOperationException)
+                {
+#if DEBUG
+                    MessageBox.Show(@"ConEmu appears to be missing. Please perform a full rebuild and try again.", @"Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+#else
+                    throw;
+#endif
+                }
             };
         }
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -99,3 +99,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/27, kbilsted, Kasper B. Graversen, redbeard1945redbeard(at)gmail.com
 2019/09/30, hieuxlu, Hieu Do, xlu.untitled(at)gmail.com
 2019/10/13, R0nd, Roland Gneev, rgneev(at)gmail.com
+2019/10/13, bansan85, Le Garrec Vincent, legarrec.vincent{at]gmail.com


### PR DESCRIPTION
Fixes #7257 

## Proposed changes

- Add an error message if ConEmu is missing instead of having a unhandled exception.

### Before

If ComEmu.exe is missing,Git Extensions shows the crash report window.

### After

Now Git Extensions shows an error message that ask to reinstall application.


## Test methodology

- Run the application with ComEmu.exe missing and click on the Console tab.
- An error message shall be shown.

## Test environment(s)

- GIT git version 2.23.0.windows.1
- Windows 10 v 1903 18362.356

The message will need to be translated.


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
