### PR TITLE
Implement quotePath-like codepoint escaping

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1781,7 +1781,7 @@ namespace GitCommands
                     {
                         foreach (var file in nonNewFiles)
                         {
-                            inputWriter.WriteLine($"0 0000000000000000000000000000000000000000\t\"{file.Name.ToPosixPath()}\"");
+                            inputWriter.WriteLine($"0 0000000000000000000000000000000000000000\t\"{EscapeOctalCodePoints(file.Name.ToPosixPath())}\"");
                         }
                     },
                     SystemEncoding);
@@ -3741,6 +3741,46 @@ namespace GitCommands
                         return match.Value;
                     }
                 });
+        }
+
+        /// <summary>
+        /// Escapes a UTF8 string <paramref name="s"/> into octal code points.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="s"/> is <c>null</c> then an empty string is returned.
+        /// </remarks>
+        /// <example>
+        /// <code>EscapeOctalCodePoints("두다") == @"\353\221\220\353\213\244"</code>
+        /// </example>
+        /// <param name="s">The string to escape.</param>
+        /// <returns>The escaped string, or <c>""</c> if <paramref name="s"/> is <c>null</c>.</returns>
+        public static string EscapeOctalCodePoints([CanBeNull] string s)
+        {
+            if (s == null)
+            {
+                return null;
+            }
+
+            var resultBuilder = new StringBuilder(s.Length);
+
+            for (int i = 0; i < s.Length; i++)
+            {
+                var charSubstring = s.Substring(i, 1);
+                var charBytes = Encoding.UTF8.GetBytes(charSubstring);
+                if (charBytes.Length == 1)
+                {
+                    resultBuilder.Append(charSubstring);
+                }
+                else
+                {
+                    foreach (var charByte in charBytes)
+                    {
+                        resultBuilder.AppendFormat(@"\{0}", Convert.ToString(charByte, toBase: 8));
+                    }
+                }
+            }
+
+            return resultBuilder.ToString();
         }
 
         [ContractAnnotation("fileName:null=>null")]

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -113,6 +113,24 @@ namespace GitCommandsTests
             Assert.AreSame(s, GitModule.UnescapeOctalCodePoints(s));
         }
 
+        [TestCase(null, null)]
+        [TestCase("", "")]
+        [TestCase(" ", " ")]
+        [TestCase("Hello, World!", "Hello, World!")]
+        [TestCase("두다.txt", @"\353\221\220\353\213\244.txt")] // escaped octal code points (Korean Hangul in this case)
+        [TestCase(@"Привет, World!", @"\320\237\321\200\320\270\320\262\320\265\321\202, World!")] // escaped and not escaped in the same string
+        public void EscapeOctalCodePoints_handles_text(string input, string expected)
+        {
+            Assert.AreEqual(expected, GitModule.EscapeOctalCodePoints(input));
+        }
+
+        [TestCase("Hello, World!")]
+        [TestCase("두다.txt")]
+        public void UnescapeOctalCodePoints_reverses_EscapeOctalCodePoints(string input)
+        {
+            Assert.AreEqual(input, GitModule.UnescapeOctalCodePoints(GitModule.EscapeOctalCodePoints(input)));
+        }
+
         [Test]
         public void FetchCmd()
         {

--- a/contributors.txt
+++ b/contributors.txt
@@ -98,3 +98,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/24, lekhmanrus, Ruslan Lekhman, lekhman112(at)gmail.com
 2019/09/27, kbilsted, Kasper B. Graversen, redbeard1945redbeard(at)gmail.com
 2019/09/30, hieuxlu, Hieu Do, xlu.untitled(at)gmail.com
+2019/10/13, R0nd, Roland Gneev, rgneev(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7207 


## Proposed changes
- Implement codepoint-escaping function similar to git's `quote_c_style` 
- Pass escaped filenames to `git-update-index`

## Test methodology <!-- How did you ensure quality? -->

- Tested manually to ensure expected behavior from #7207 using filenames containing both unicode and ASCII characters
- Added tests similar to existing tests for UnescapeOctalCodePoints

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.23.0
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
