### PR TITLE
Display multiple pushurl in the Remote sidepanel tooltip

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -313,8 +313,8 @@ namespace GitUI.BranchTreePanel
             {
                 base.ApplyStyle();
 
-                TreeViewNode.ToolTipText = _remote.FetchUrl != _remote.PushUrls[0]
-                    ? $"Push: {_remote.PushUrls[0]}\nFetch: {_remote.FetchUrl}"
+                TreeViewNode.ToolTipText = _remote.PushUrls.Count != 1 && _remote.FetchUrl != _remote.PushUrls[0]
+                    ? $"Fetch: {_remote.FetchUrl}\nPush: {string.Join("\n", _remote.PushUrls.ToArray())}"
                     : _remote.FetchUrl;
 
                 string imageKey;


### PR DESCRIPTION
Part 2 of #7255 
(previously included in #7256)


## Proposed changes

Show multiple pushurl in the sidepanel
Follow up from #7214


## Screenshots
### Before

![image](https://user-images.githubusercontent.com/6248932/66714695-23183600-edba-11e9-955f-0b8275e70c9a.png)


### After

![image](https://user-images.githubusercontent.com/6248932/66682062-5c468e00-ec74-11e9-87f1-307b6e0c15b1.png)

## Test methodology 

GUI change only

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
