### PR TITLE
fix: missing method ResourceManager.GitPluginBase..ctor

### DIFF
--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -14,9 +14,15 @@ namespace ResourceManager
         public string Name { get; protected set; }
         public Image Icon { get; protected set; }
 
-        public GitPluginBase(bool hasSettings)
+        protected GitPluginBase(bool hasSettings)
         {
             HasSettings = hasSettings;
+        }
+
+        // requried for the TranslationApp to work
+        private GitPluginBase()
+            : this(false)
+        {
         }
 
         protected void SetNameAndDescription(string name)

--- a/TranslationApp/TranslationHelpers.cs
+++ b/TranslationApp/TranslationHelpers.cs
@@ -25,13 +25,20 @@ namespace TranslationApp
                     {
                         foreach (Type type in types)
                         {
-                            if (TranslationUtil.CreateInstanceOfClass(type) is ITranslate obj)
+                            try
                             {
-                                obj.AddTranslationItems(translation);
-                                if (obj is IDisposable disposable)
+                                if (TranslationUtil.CreateInstanceOfClass(type) is ITranslate obj)
                                 {
-                                    disposable.Dispose();
+                                    obj.AddTranslationItems(translation);
+                                    if (obj is IDisposable disposable)
+                                    {
+                                        disposable.Dispose();
+                                    }
                                 }
+                            }
+                            catch
+                            {
+                                // no-op
                             }
                         }
                     }


### PR DESCRIPTION



Closes #7286

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

- Fix a refactor regression - the translation app requires a parameterless constructor.
- Also add safe guards to the type iteration routine that ignore any failures.
Locally a lot of contributors would have custom plugins installed (e.g. `GitExtensions.PluginManager`) that does not belong to the main codebase and, thus, does not need to be translated.
The translation app would previously fail on these external types, and fail to update the translations as a result.




----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
