### PR TITLE
Incorrect placement of  update submodules on checkout  setting #7290

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -944,6 +944,12 @@ namespace GitCommands
             set => SetBool("updateSubmodulesOnCheckout", value);
         }
 
+        public static bool? DontConfirmUpdateSubmodulesOnCheckout
+        {
+            get => GetBool("dontConfirmUpdateSubmodulesOnCheckout");
+            set => SetBool("dontConfirmUpdateSubmodulesOnCheckout", value);
+        }
+
         public static string Dictionary
         {
             get => SettingsContainer.Dictionary;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -31,13 +31,6 @@
             this.tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             this.gbConfirmations = new System.Windows.Forms.GroupBox();
             this.tlpnlConfirmations = new System.Windows.Forms.TableLayoutPanel();
-            this.chkFetchAndPruneAllConfirmation = new System.Windows.Forms.CheckBox();
-            this.chkSwitchWorktree = new System.Windows.Forms.CheckBox();
-            this.chkUndoLastCommitConfirmation = new System.Windows.Forms.CheckBox();
-            this.chkRebaseOnTopOfSelectedCommit = new System.Windows.Forms.CheckBox();
-            this.chkSecondAbortConfirmation = new System.Windows.Forms.CheckBox();
-            this.chkCommitAfterConflictsResolved = new System.Windows.Forms.CheckBox();
-            this.chkResolveConflicts = new System.Windows.Forms.CheckBox();
             this.chkAmend = new System.Windows.Forms.CheckBox();
             this.chkCommitIfNoBranch = new System.Windows.Forms.CheckBox();
             this.chkAutoPopStashAfterPull = new System.Windows.Forms.CheckBox();
@@ -46,6 +39,13 @@
             this.chkAddTrackingRef = new System.Windows.Forms.CheckBox();
             this.chkPushNewBranch = new System.Windows.Forms.CheckBox();
             this.chkUpdateModules = new System.Windows.Forms.CheckBox();
+            this.chkResolveConflicts = new System.Windows.Forms.CheckBox();
+            this.chkCommitAfterConflictsResolved = new System.Windows.Forms.CheckBox();
+            this.chkSecondAbortConfirmation = new System.Windows.Forms.CheckBox();
+            this.chkRebaseOnTopOfSelectedCommit = new System.Windows.Forms.CheckBox();
+            this.chkUndoLastCommitConfirmation = new System.Windows.Forms.CheckBox();
+            this.chkFetchAndPruneAllConfirmation = new System.Windows.Forms.CheckBox();
+            this.chkSwitchWorktree = new System.Windows.Forms.CheckBox();
             this.tlpnlMain.SuspendLayout();
             this.gbConfirmations.SuspendLayout();
             this.tlpnlConfirmations.SuspendLayout();
@@ -56,14 +56,14 @@
             this.tlpnlMain.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tlpnlMain.ColumnCount = 1;
             this.tlpnlMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tlpnlMain.Location = new System.Drawing.Point(3, 3);
             this.tlpnlMain.Controls.Add(this.gbConfirmations, 0, 0);
             this.tlpnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tlpnlMain.Location = new System.Drawing.Point(8, 8);
             this.tlpnlMain.Name = "tlpnlMain";
             this.tlpnlMain.RowCount = 2;
             this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlMain.Size = new System.Drawing.Size(500, 372);
+            this.tlpnlMain.Size = new System.Drawing.Size(1359, 441);
             this.tlpnlMain.TabIndex = 2;
             // 
             // gbConfirmations
@@ -75,7 +75,7 @@
             this.gbConfirmations.Location = new System.Drawing.Point(3, 3);
             this.gbConfirmations.Name = "gbConfirmations";
             this.gbConfirmations.Padding = new System.Windows.Forms.Padding(8);
-            this.gbConfirmations.Size = new System.Drawing.Size(494, 366);
+            this.gbConfirmations.Size = new System.Drawing.Size(1353, 371);
             this.gbConfirmations.TabIndex = 0;
             this.gbConfirmations.TabStop = false;
             this.gbConfirmations.Text = "Don\'t ask to confirm to (use with caution)";
@@ -102,7 +102,7 @@
             this.tlpnlConfirmations.Controls.Add(this.chkFetchAndPruneAllConfirmation, 0, 13);
             this.tlpnlConfirmations.Controls.Add(this.chkSwitchWorktree, 0, 14);
             this.tlpnlConfirmations.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlConfirmations.Location = new System.Drawing.Point(5, 19);
+            this.tlpnlConfirmations.Location = new System.Drawing.Point(8, 21);
             this.tlpnlConfirmations.Name = "tlpnlConfirmations";
             this.tlpnlConfirmations.RowCount = 14;
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -119,90 +119,16 @@
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.Size = new System.Drawing.Size(483, 325);
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tlpnlConfirmations.Size = new System.Drawing.Size(1337, 342);
             this.tlpnlConfirmations.TabIndex = 1;
-            // 
-            // chkSwitchWorktree
-            // 
-            this.chkSwitchWorktree.AutoSize = true;
-            this.chkSwitchWorktree.Location = new System.Drawing.Point(3, 278);
-            this.chkSwitchWorktree.Name = "chkSwitchWorktree";
-            this.chkSwitchWorktree.Size = new System.Drawing.Size(121, 19);
-            this.chkSwitchWorktree.TabIndex = 15;
-            this.chkSwitchWorktree.Text = "Switch Worktree";
-            this.chkSwitchWorktree.UseVisualStyleBackColor = true;
-            // 
-            // chkFetchAndPruneAllConfirmation
-            // 
-            this.chkFetchAndPruneAllConfirmation.AutoSize = true;
-            this.chkFetchAndPruneAllConfirmation.Location = new System.Drawing.Point(3, 303);
-            this.chkFetchAndPruneAllConfirmation.Name = "chkFetchAndPruneAllConfirmation";
-            this.chkFetchAndPruneAllConfirmation.Size = new System.Drawing.Size(127, 19);
-            this.chkFetchAndPruneAllConfirmation.TabIndex = 14;
-            this.chkFetchAndPruneAllConfirmation.Text = "Fetch and prune branches";
-            this.chkFetchAndPruneAllConfirmation.UseVisualStyleBackColor = true;
-            // 
-            // chkUndoLastCommitConfirmation
-            // 
-            this.chkUndoLastCommitConfirmation.AutoSize = true;
-            this.chkUndoLastCommitConfirmation.Location = new System.Drawing.Point(3, 278);
-            this.chkUndoLastCommitConfirmation.Name = "chkUndoLastCommitConfirmation";
-            this.chkUndoLastCommitConfirmation.Size = new System.Drawing.Size(121, 19);
-            this.chkUndoLastCommitConfirmation.TabIndex = 13;
-            this.chkUndoLastCommitConfirmation.Text = "Undo last commit";
-            this.chkUndoLastCommitConfirmation.ThreeState = true;
-            this.chkUndoLastCommitConfirmation.UseVisualStyleBackColor = true;
-            // 
-            // chkRebaseOnTopOfSelectedCommit
-            // 
-            this.chkRebaseOnTopOfSelectedCommit.AutoSize = true;
-            this.chkRebaseOnTopOfSelectedCommit.Location = new System.Drawing.Point(3, 253);
-            this.chkRebaseOnTopOfSelectedCommit.Name = "chkRebaseOnTopOfSelectedCommit";
-            this.chkRebaseOnTopOfSelectedCommit.Size = new System.Drawing.Size(206, 19);
-            this.chkRebaseOnTopOfSelectedCommit.TabIndex = 12;
-            this.chkRebaseOnTopOfSelectedCommit.Text = "Rebase on top of selected commit";
-            this.chkRebaseOnTopOfSelectedCommit.ThreeState = true;
-            this.chkRebaseOnTopOfSelectedCommit.UseVisualStyleBackColor = true;
-            // 
-            // chkSecondAbortConfirmation
-            // 
-            this.chkSecondAbortConfirmation.AutoSize = true;
-            this.chkSecondAbortConfirmation.Location = new System.Drawing.Point(3, 228);
-            this.chkSecondAbortConfirmation.Name = "chkSecondAbortConfirmation";
-            this.chkSecondAbortConfirmation.Size = new System.Drawing.Size(267, 19);
-            this.chkSecondAbortConfirmation.TabIndex = 11;
-            this.chkSecondAbortConfirmation.Text = "Confirm for the second time to abort a merge";
-            this.chkSecondAbortConfirmation.ThreeState = true;
-            this.chkSecondAbortConfirmation.UseVisualStyleBackColor = true;
-            // 
-            // chkCommitAfterConflictsResolved
-            // 
-            this.chkCommitAfterConflictsResolved.AutoSize = true;
-            this.chkCommitAfterConflictsResolved.Location = new System.Drawing.Point(3, 203);
-            this.chkCommitAfterConflictsResolved.Name = "chkCommitAfterConflictsResolved";
-            this.chkCommitAfterConflictsResolved.Size = new System.Drawing.Size(296, 19);
-            this.chkCommitAfterConflictsResolved.TabIndex = 10;
-            this.chkCommitAfterConflictsResolved.Text = "Commit changes after conflicts have been resolved";
-            this.chkCommitAfterConflictsResolved.ThreeState = true;
-            this.chkCommitAfterConflictsResolved.UseVisualStyleBackColor = true;
-            // 
-            // chkResolveConflicts
-            // 
-            this.chkResolveConflicts.AutoSize = true;
-            this.chkResolveConflicts.Location = new System.Drawing.Point(3, 178);
-            this.chkResolveConflicts.Name = "chkResolveConflicts";
-            this.chkResolveConflicts.Size = new System.Drawing.Size(114, 19);
-            this.chkResolveConflicts.TabIndex = 9;
-            this.chkResolveConflicts.Text = "Resolve conflicts";
-            this.chkResolveConflicts.ThreeState = true;
-            this.chkResolveConflicts.UseVisualStyleBackColor = true;
             // 
             // chkAmend
             // 
             this.chkAmend.AutoSize = true;
             this.chkAmend.Location = new System.Drawing.Point(3, 3);
             this.chkAmend.Name = "chkAmend";
-            this.chkAmend.Size = new System.Drawing.Size(131, 19);
+            this.chkAmend.Size = new System.Drawing.Size(114, 17);
             this.chkAmend.TabIndex = 1;
             this.chkAmend.Text = "Amend last commit";
             this.chkAmend.UseVisualStyleBackColor = true;
@@ -210,9 +136,9 @@
             // chkCommitIfNoBranch
             // 
             this.chkCommitIfNoBranch.AutoSize = true;
-            this.chkCommitIfNoBranch.Location = new System.Drawing.Point(3, 28);
+            this.chkCommitIfNoBranch.Location = new System.Drawing.Point(3, 26);
             this.chkCommitIfNoBranch.Name = "chkCommitIfNoBranch";
-            this.chkCommitIfNoBranch.Size = new System.Drawing.Size(372, 19);
+            this.chkCommitIfNoBranch.Size = new System.Drawing.Size(333, 17);
             this.chkCommitIfNoBranch.TabIndex = 2;
             this.chkCommitIfNoBranch.Text = "Commit when no branch is currently checked out (headless state)";
             this.chkCommitIfNoBranch.UseVisualStyleBackColor = true;
@@ -220,9 +146,9 @@
             // chkAutoPopStashAfterPull
             // 
             this.chkAutoPopStashAfterPull.AutoSize = true;
-            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 53);
+            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 49);
             this.chkAutoPopStashAfterPull.Name = "chkAutoPopStashAfterPull";
-            this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(448, 19);
+            this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(401, 17);
             this.chkAutoPopStashAfterPull.TabIndex = 3;
             this.chkAutoPopStashAfterPull.Text = "Apply stashed changes after successful pull (stash will be popped automatically)";
             this.chkAutoPopStashAfterPull.ThreeState = true;
@@ -231,9 +157,9 @@
             // chkAutoPopStashAfterCheckout
             // 
             this.chkAutoPopStashAfterCheckout.AutoSize = true;
-            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 78);
+            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 72);
             this.chkAutoPopStashAfterCheckout.Name = "chkAutoPopStashAfterCheckout";
-            this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(477, 19);
+            this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(430, 17);
             this.chkAutoPopStashAfterCheckout.TabIndex = 4;
             this.chkAutoPopStashAfterCheckout.Text = "Apply stashed changes after successful checkout (stash will be popped automatical" +
     "ly)";
@@ -243,9 +169,9 @@
             // chkConfirmStashDrop
             // 
             this.chkConfirmStashDrop.AutoSize = true;
-            this.chkConfirmStashDrop.Location = new System.Drawing.Point(3, 78);
+            this.chkConfirmStashDrop.Location = new System.Drawing.Point(3, 95);
             this.chkConfirmStashDrop.Name = "chkConfirmStashDrop";
-            this.chkConfirmStashDrop.Size = new System.Drawing.Size(477, 19);
+            this.chkConfirmStashDrop.Size = new System.Drawing.Size(77, 17);
             this.chkConfirmStashDrop.TabIndex = 5;
             this.chkConfirmStashDrop.Text = "Drop stash";
             this.chkConfirmStashDrop.UseVisualStyleBackColor = true;
@@ -253,9 +179,9 @@
             // chkAddTrackingRef
             // 
             this.chkAddTrackingRef.AutoSize = true;
-            this.chkAddTrackingRef.Location = new System.Drawing.Point(3, 103);
+            this.chkAddTrackingRef.Location = new System.Drawing.Point(3, 118);
             this.chkAddTrackingRef.Name = "chkAddTrackingRef";
-            this.chkAddTrackingRef.Size = new System.Drawing.Size(289, 19);
+            this.chkAddTrackingRef.Size = new System.Drawing.Size(262, 17);
             this.chkAddTrackingRef.TabIndex = 6;
             this.chkAddTrackingRef.Text = "Add a tracking reference for newly pushed branch";
             this.chkAddTrackingRef.UseVisualStyleBackColor = true;
@@ -263,9 +189,9 @@
             // chkPushNewBranch
             // 
             this.chkPushNewBranch.AutoSize = true;
-            this.chkPushNewBranch.Location = new System.Drawing.Point(3, 128);
+            this.chkPushNewBranch.Location = new System.Drawing.Point(3, 141);
             this.chkPushNewBranch.Name = "chkPushNewBranch";
-            this.chkPushNewBranch.Size = new System.Drawing.Size(205, 19);
+            this.chkPushNewBranch.Size = new System.Drawing.Size(186, 17);
             this.chkPushNewBranch.TabIndex = 7;
             this.chkPushNewBranch.Text = "Push a new branch for the remote";
             this.chkPushNewBranch.UseVisualStyleBackColor = true;
@@ -273,13 +199,88 @@
             // chkUpdateModules
             // 
             this.chkUpdateModules.AutoSize = true;
-            this.chkUpdateModules.Location = new System.Drawing.Point(3, 153);
+            this.chkUpdateModules.Location = new System.Drawing.Point(3, 164);
             this.chkUpdateModules.Name = "chkUpdateModules";
-            this.chkUpdateModules.Size = new System.Drawing.Size(201, 19);
+            this.chkUpdateModules.Size = new System.Drawing.Size(183, 17);
             this.chkUpdateModules.TabIndex = 8;
             this.chkUpdateModules.Text = "Update submodules on checkout";
             this.chkUpdateModules.ThreeState = true;
             this.chkUpdateModules.UseVisualStyleBackColor = true;
+            // 
+            // chkResolveConflicts
+            // 
+            this.chkResolveConflicts.AutoSize = true;
+            this.chkResolveConflicts.Location = new System.Drawing.Point(3, 187);
+            this.chkResolveConflicts.Name = "chkResolveConflicts";
+            this.chkResolveConflicts.Size = new System.Drawing.Size(107, 17);
+            this.chkResolveConflicts.TabIndex = 9;
+            this.chkResolveConflicts.Text = "Resolve conflicts";
+            this.chkResolveConflicts.ThreeState = true;
+            this.chkResolveConflicts.UseVisualStyleBackColor = true;
+            // 
+            // chkCommitAfterConflictsResolved
+            // 
+            this.chkCommitAfterConflictsResolved.AutoSize = true;
+            this.chkCommitAfterConflictsResolved.Location = new System.Drawing.Point(3, 210);
+            this.chkCommitAfterConflictsResolved.Name = "chkCommitAfterConflictsResolved";
+            this.chkCommitAfterConflictsResolved.Size = new System.Drawing.Size(267, 17);
+            this.chkCommitAfterConflictsResolved.TabIndex = 10;
+            this.chkCommitAfterConflictsResolved.Text = "Commit changes after conflicts have been resolved";
+            this.chkCommitAfterConflictsResolved.ThreeState = true;
+            this.chkCommitAfterConflictsResolved.UseVisualStyleBackColor = true;
+            // 
+            // chkSecondAbortConfirmation
+            // 
+            this.chkSecondAbortConfirmation.AutoSize = true;
+            this.chkSecondAbortConfirmation.Location = new System.Drawing.Point(3, 233);
+            this.chkSecondAbortConfirmation.Name = "chkSecondAbortConfirmation";
+            this.chkSecondAbortConfirmation.Size = new System.Drawing.Size(234, 17);
+            this.chkSecondAbortConfirmation.TabIndex = 11;
+            this.chkSecondAbortConfirmation.Text = "Confirm for the second time to abort a merge";
+            this.chkSecondAbortConfirmation.ThreeState = true;
+            this.chkSecondAbortConfirmation.UseVisualStyleBackColor = true;
+            // 
+            // chkRebaseOnTopOfSelectedCommit
+            // 
+            this.chkRebaseOnTopOfSelectedCommit.AutoSize = true;
+            this.chkRebaseOnTopOfSelectedCommit.Location = new System.Drawing.Point(3, 256);
+            this.chkRebaseOnTopOfSelectedCommit.Name = "chkRebaseOnTopOfSelectedCommit";
+            this.chkRebaseOnTopOfSelectedCommit.Size = new System.Drawing.Size(187, 17);
+            this.chkRebaseOnTopOfSelectedCommit.TabIndex = 12;
+            this.chkRebaseOnTopOfSelectedCommit.Text = "Rebase on top of selected commit";
+            this.chkRebaseOnTopOfSelectedCommit.ThreeState = true;
+            this.chkRebaseOnTopOfSelectedCommit.UseVisualStyleBackColor = true;
+            // 
+            // chkUndoLastCommitConfirmation
+            // 
+            this.chkUndoLastCommitConfirmation.AutoSize = true;
+            this.chkUndoLastCommitConfirmation.Location = new System.Drawing.Point(3, 279);
+            this.chkUndoLastCommitConfirmation.Name = "chkUndoLastCommitConfirmation";
+            this.chkUndoLastCommitConfirmation.Size = new System.Drawing.Size(107, 17);
+            this.chkUndoLastCommitConfirmation.TabIndex = 13;
+            this.chkUndoLastCommitConfirmation.Text = "Undo last commit";
+            this.chkUndoLastCommitConfirmation.ThreeState = true;
+            this.chkUndoLastCommitConfirmation.UseVisualStyleBackColor = true;
+            // 
+            // chkFetchAndPruneAllConfirmation
+            // 
+            this.chkFetchAndPruneAllConfirmation.AutoSize = true;
+            this.chkFetchAndPruneAllConfirmation.Location = new System.Drawing.Point(3, 302);
+            this.chkFetchAndPruneAllConfirmation.Name = "chkFetchAndPruneAllConfirmation";
+            this.chkFetchAndPruneAllConfirmation.Size = new System.Drawing.Size(151, 17);
+            this.chkFetchAndPruneAllConfirmation.TabIndex = 14;
+            this.chkFetchAndPruneAllConfirmation.Text = "Fetch and prune branches";
+            this.chkFetchAndPruneAllConfirmation.UseVisualStyleBackColor = true;
+            // 
+            // chkSwitchWorktree
+            // 
+            this.chkSwitchWorktree.AutoSize = true;
+            this.chkSwitchWorktree.Location = new System.Drawing.Point(3, 325);
+            this.chkSwitchWorktree.Name = "chkSwitchWorktree";
+            this.chkSwitchWorktree.Size = new System.Drawing.Size(105, 14);
+            this.chkSwitchWorktree.TabIndex = 15;
+            this.chkSwitchWorktree.Text = "Switch Worktree";
+            this.chkSwitchWorktree.UseVisualStyleBackColor = true;
             // 
             // ConfirmationsSettingsPage
             // 
@@ -288,7 +289,7 @@
             this.Controls.Add(this.tlpnlMain);
             this.Name = "ConfirmationsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1001, 614);
+            this.Size = new System.Drawing.Size(1375, 457);
             this.tlpnlMain.ResumeLayout(false);
             this.tlpnlMain.PerformLayout();
             this.gbConfirmations.ResumeLayout(false);
@@ -296,7 +297,6 @@
             this.tlpnlConfirmations.ResumeLayout(false);
             this.tlpnlConfirmations.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -21,7 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkConfirmStashDrop.Checked = !AppSettings.StashConfirmDropShow;
             chkPushNewBranch.Checked = AppSettings.DontConfirmPushNewBranch;
             chkAddTrackingRef.Checked = AppSettings.DontConfirmAddTrackingRef;
-            chkUpdateModules.CheckState = AppSettings.UpdateSubmodulesOnCheckout.ToCheckboxState();
+            chkUpdateModules.CheckState = AppSettings.DontConfirmUpdateSubmodulesOnCheckout.ToCheckboxState();
             chkResolveConflicts.Checked = AppSettings.DontConfirmResolveConflicts;
             chkCommitAfterConflictsResolved.Checked = AppSettings.DontConfirmCommitAfterConflictsResolved;
             chkSecondAbortConfirmation.Checked = AppSettings.DontConfirmSecondAbortConfirmation;
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.StashConfirmDropShow = !chkConfirmStashDrop.Checked;
             AppSettings.DontConfirmPushNewBranch = chkPushNewBranch.Checked;
             AppSettings.DontConfirmAddTrackingRef = chkAddTrackingRef.Checked;
-            AppSettings.UpdateSubmodulesOnCheckout = chkUpdateModules.CheckState.ToBoolean();
+            AppSettings.DontConfirmUpdateSubmodulesOnCheckout = chkUpdateModules.CheckState.ToBoolean();
             AppSettings.DontConfirmResolveConflicts = chkResolveConflicts.Checked;
             AppSettings.DontConfirmCommitAfterConflictsResolved = chkCommitAfterConflictsResolved.Checked;
             AppSettings.DontConfirmSecondAbortConfirmation = chkSecondAbortConfirmation.Checked;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -29,6 +29,10 @@
         private void InitializeComponent()
         {
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
+            this.groupBoxTelemetry = new System.Windows.Forms.GroupBox();
+            this.tlpnlTelemetry = new System.Windows.Forms.TableLayoutPanel();
+            this.chkTelemetry = new System.Windows.Forms.CheckBox();
+            this.llblTelemetryPrivacyLink = new System.Windows.Forms.LinkLabel();
             this.groupBoxPerformance = new System.Windows.Forms.GroupBox();
             this.tlpnlPerformance = new System.Windows.Forms.TableLayoutPanel();
             this.chkShowAheadBehindDataInBrowseWindow = new System.Windows.Forms.CheckBox();
@@ -54,22 +58,19 @@
             this.chkStashUntrackedFiles = new System.Windows.Forms.CheckBox();
             this.chkStartWithRecentWorkingDir = new System.Windows.Forms.CheckBox();
             this.chkFollowRenamesInFileHistory = new System.Windows.Forms.CheckBox();
-            this.groupBoxTelemetry = new System.Windows.Forms.GroupBox();
-            this.tlpnlTelemetry = new System.Windows.Forms.TableLayoutPanel();
-            this.chkTelemetry = new System.Windows.Forms.CheckBox();
-            this.llblTelemetryPrivacyLink = new System.Windows.Forms.LinkLabel();
             this.lblDefaultPullAction = new System.Windows.Forms.Label();
             this.cboDefaultPullAction = new System.Windows.Forms.ComboBox();
+            this.chkUpdateModules = new System.Windows.Forms.CheckBox();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             tlpnlMain.SuspendLayout();
+            this.groupBoxTelemetry.SuspendLayout();
+            this.tlpnlTelemetry.SuspendLayout();
             this.groupBoxPerformance.SuspendLayout();
             this.tlpnlPerformance.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_MaxCommits)).BeginInit();
             this.groupBoxBehaviour.SuspendLayout();
             this.tlpnlBehaviour.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.RevisionGridQuickSearchTimeout)).BeginInit();
-            this.groupBoxTelemetry.SuspendLayout();
-            this.tlpnlTelemetry.SuspendLayout();
             this.SuspendLayout();
             // 
             // tlpnlMain
@@ -89,8 +90,61 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tlpnlMain.Size = new System.Drawing.Size(1324, 873);
+            tlpnlMain.Size = new System.Drawing.Size(1494, 621);
             tlpnlMain.TabIndex = 0;
+            // 
+            // groupBoxTelemetry
+            // 
+            this.groupBoxTelemetry.AutoSize = true;
+            this.groupBoxTelemetry.Controls.Add(this.tlpnlTelemetry);
+            this.groupBoxTelemetry.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBoxTelemetry.Location = new System.Drawing.Point(3, 503);
+            this.groupBoxTelemetry.Name = "groupBoxTelemetry";
+            this.groupBoxTelemetry.Padding = new System.Windows.Forms.Padding(8);
+            this.groupBoxTelemetry.Size = new System.Drawing.Size(1488, 52);
+            this.groupBoxTelemetry.TabIndex = 3;
+            this.groupBoxTelemetry.TabStop = false;
+            this.groupBoxTelemetry.Text = "Telemetry";
+            // 
+            // tlpnlTelemetry
+            // 
+            this.tlpnlTelemetry.AutoSize = true;
+            this.tlpnlTelemetry.ColumnCount = 2;
+            this.tlpnlTelemetry.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlTelemetry.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlTelemetry.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tlpnlTelemetry.Controls.Add(this.chkTelemetry, 0, 0);
+            this.tlpnlTelemetry.Controls.Add(this.llblTelemetryPrivacyLink, 1, 0);
+            this.tlpnlTelemetry.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tlpnlTelemetry.Location = new System.Drawing.Point(8, 21);
+            this.tlpnlTelemetry.Name = "tlpnlTelemetry";
+            this.tlpnlTelemetry.RowCount = 1;
+            this.tlpnlTelemetry.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlTelemetry.Size = new System.Drawing.Size(1472, 23);
+            this.tlpnlTelemetry.TabIndex = 0;
+            // 
+            // chkTelemetry
+            // 
+            this.chkTelemetry.AutoSize = true;
+            this.chkTelemetry.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkTelemetry.Location = new System.Drawing.Point(3, 3);
+            this.chkTelemetry.Name = "chkTelemetry";
+            this.chkTelemetry.Size = new System.Drawing.Size(128, 17);
+            this.chkTelemetry.TabIndex = 0;
+            this.chkTelemetry.Text = "Yes, I allow telemetry!";
+            this.chkTelemetry.UseVisualStyleBackColor = true;
+            // 
+            // llblTelemetryPrivacyLink
+            // 
+            this.llblTelemetryPrivacyLink.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.llblTelemetryPrivacyLink.Location = new System.Drawing.Point(137, 0);
+            this.llblTelemetryPrivacyLink.Name = "llblTelemetryPrivacyLink";
+            this.llblTelemetryPrivacyLink.Size = new System.Drawing.Size(1357, 23);
+            this.llblTelemetryPrivacyLink.TabIndex = 1;
+            this.llblTelemetryPrivacyLink.TabStop = true;
+            this.llblTelemetryPrivacyLink.Text = "Why and what is captured?";
+            this.llblTelemetryPrivacyLink.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.llblTelemetryPrivacyLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlblTelemetryPrivacyLink_LinkClicked);
             // 
             // groupBoxPerformance
             // 
@@ -100,7 +154,7 @@
             this.groupBoxPerformance.Location = new System.Drawing.Point(3, 3);
             this.groupBoxPerformance.Name = "groupBoxPerformance";
             this.groupBoxPerformance.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxPerformance.Size = new System.Drawing.Size(1318, 239);
+            this.groupBoxPerformance.Size = new System.Drawing.Size(1488, 216);
             this.groupBoxPerformance.TabIndex = 0;
             this.groupBoxPerformance.TabStop = false;
             this.groupBoxPerformance.Text = "Performance";
@@ -135,14 +189,14 @@
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlPerformance.Size = new System.Drawing.Size(1302, 210);
+            this.tlpnlPerformance.Size = new System.Drawing.Size(1472, 187);
             this.tlpnlPerformance.TabIndex = 0;
             // 
             // chkShowAheadBehindDataInBrowseWindow
             // 
             this.chkShowAheadBehindDataInBrowseWindow.AutoSize = true;
             this.chkShowAheadBehindDataInBrowseWindow.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkShowAheadBehindDataInBrowseWindow.Location = new System.Drawing.Point(3, 141);
+            this.chkShowAheadBehindDataInBrowseWindow.Location = new System.Drawing.Point(3, 118);
             this.chkShowAheadBehindDataInBrowseWindow.Name = "chkShowAheadBehindDataInBrowseWindow";
             this.chkShowAheadBehindDataInBrowseWindow.Size = new System.Drawing.Size(347, 17);
             this.chkShowAheadBehindDataInBrowseWindow.TabIndex = 6;
@@ -153,7 +207,7 @@
             // 
             this.chkCheckForUncommittedChangesInCheckoutBranch.AutoSize = true;
             this.chkCheckForUncommittedChangesInCheckoutBranch.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkCheckForUncommittedChangesInCheckoutBranch.Location = new System.Drawing.Point(3, 164);
+            this.chkCheckForUncommittedChangesInCheckoutBranch.Location = new System.Drawing.Point(3, 141);
             this.chkCheckForUncommittedChangesInCheckoutBranch.Name = "chkCheckForUncommittedChangesInCheckoutBranch";
             this.chkCheckForUncommittedChangesInCheckoutBranch.Size = new System.Drawing.Size(347, 17);
             this.chkCheckForUncommittedChangesInCheckoutBranch.TabIndex = 7;
@@ -167,7 +221,7 @@
             this.chkShowGitStatusInToolbar.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowGitStatusInToolbar.Location = new System.Drawing.Point(3, 3);
             this.chkShowGitStatusInToolbar.Name = "chkShowGitStatusInToolbar";
-            this.chkShowGitStatusInToolbar.Size = new System.Drawing.Size(1296, 17);
+            this.chkShowGitStatusInToolbar.Size = new System.Drawing.Size(1466, 17);
             this.chkShowGitStatusInToolbar.TabIndex = 0;
             this.chkShowGitStatusInToolbar.Text = "Show number of changed files on commit button";
             this.chkShowGitStatusInToolbar.UseVisualStyleBackColor = true;
@@ -180,7 +234,7 @@
             this.chkShowGitStatusForArtificialCommits.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowGitStatusForArtificialCommits.Location = new System.Drawing.Point(3, 26);
             this.chkShowGitStatusForArtificialCommits.Name = "chkShowGitStatusForArtificialCommits";
-            this.chkShowGitStatusForArtificialCommits.Size = new System.Drawing.Size(1296, 17);
+            this.chkShowGitStatusForArtificialCommits.Size = new System.Drawing.Size(1466, 17);
             this.chkShowGitStatusForArtificialCommits.TabIndex = 1;
             this.chkShowGitStatusForArtificialCommits.Text = "Show number of changed files for artificial commits";
             this.chkShowGitStatusForArtificialCommits.UseVisualStyleBackColor = true;
@@ -190,7 +244,7 @@
             // 
             this.chkShowStashCountInBrowseWindow.AutoSize = true;
             this.chkShowStashCountInBrowseWindow.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkShowStashCountInBrowseWindow.Location = new System.Drawing.Point(3, 118);
+            this.chkShowStashCountInBrowseWindow.Location = new System.Drawing.Point(3, 95);
             this.chkShowStashCountInBrowseWindow.Name = "chkShowStashCountInBrowseWindow";
             this.chkShowStashCountInBrowseWindow.Size = new System.Drawing.Size(347, 17);
             this.chkShowStashCountInBrowseWindow.TabIndex = 5;
@@ -212,7 +266,7 @@
             // 
             this.chkUseFastChecks.AutoSize = true;
             this.chkUseFastChecks.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkUseFastChecks.Location = new System.Drawing.Point(3, 95);
+            this.chkUseFastChecks.Location = new System.Drawing.Point(3, 72);
             this.chkUseFastChecks.Name = "chkUseFastChecks";
             this.chkUseFastChecks.Size = new System.Drawing.Size(347, 17);
             this.chkUseFastChecks.TabIndex = 4;
@@ -223,7 +277,7 @@
             // 
             this.lblCommitsLimit.AutoSize = true;
             this.lblCommitsLimit.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblCommitsLimit.Location = new System.Drawing.Point(3, 184);
+            this.lblCommitsLimit.Location = new System.Drawing.Point(3, 161);
             this.lblCommitsLimit.Name = "lblCommitsLimit";
             this.lblCommitsLimit.Size = new System.Drawing.Size(347, 26);
             this.lblCommitsLimit.TabIndex = 7;
@@ -237,7 +291,7 @@
             0,
             0,
             0});
-            this._NO_TRANSLATE_MaxCommits.Location = new System.Drawing.Point(356, 187);
+            this._NO_TRANSLATE_MaxCommits.Location = new System.Drawing.Point(356, 164);
             this._NO_TRANSLATE_MaxCommits.Maximum = new decimal(new int[] {
             1000000,
             0,
@@ -259,10 +313,10 @@
             this.groupBoxBehaviour.AutoSize = true;
             this.groupBoxBehaviour.Controls.Add(this.tlpnlBehaviour);
             this.groupBoxBehaviour.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxBehaviour.Location = new System.Drawing.Point(3, 248);
+            this.groupBoxBehaviour.Location = new System.Drawing.Point(3, 225);
             this.groupBoxBehaviour.Name = "groupBoxBehaviour";
             this.groupBoxBehaviour.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxBehaviour.Size = new System.Drawing.Size(1188, 249);
+            this.groupBoxBehaviour.Size = new System.Drawing.Size(1488, 272);
             this.groupBoxBehaviour.TabIndex = 1;
             this.groupBoxBehaviour.TabStop = false;
             this.groupBoxBehaviour.Text = "Behaviour";
@@ -275,24 +329,25 @@
             this.tlpnlBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpnlBehaviour.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistoryExact, 1, 4);
-            this.tlpnlBehaviour.Controls.Add(this.RevisionGridQuickSearchTimeout, 1, 8);
-            this.tlpnlBehaviour.Controls.Add(this.btnDefaultDestinationBrowse, 2, 6);
-            this.tlpnlBehaviour.Controls.Add(this.lblQuickSearchTimeout, 0, 8);
+            this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistoryExact, 1, 5);
+            this.tlpnlBehaviour.Controls.Add(this.RevisionGridQuickSearchTimeout, 1, 9);
+            this.tlpnlBehaviour.Controls.Add(this.btnDefaultDestinationBrowse, 2, 7);
+            this.tlpnlBehaviour.Controls.Add(this.lblQuickSearchTimeout, 0, 9);
             this.tlpnlBehaviour.Controls.Add(this.chkCloseProcessDialog, 0, 0);
-            this.tlpnlBehaviour.Controls.Add(this.cbDefaultCloneDestination, 1, 6);
+            this.tlpnlBehaviour.Controls.Add(this.cbDefaultCloneDestination, 1, 7);
             this.tlpnlBehaviour.Controls.Add(this.chkShowGitCommandLine, 0, 1);
-            this.tlpnlBehaviour.Controls.Add(this.lblDefaultCloneDestination, 0, 6);
+            this.tlpnlBehaviour.Controls.Add(this.lblDefaultCloneDestination, 0, 7);
             this.tlpnlBehaviour.Controls.Add(this.chkUseHistogramDiffAlgorithm, 0, 2);
             this.tlpnlBehaviour.Controls.Add(this.chkStashUntrackedFiles, 0, 3);
-            this.tlpnlBehaviour.Controls.Add(this.chkStartWithRecentWorkingDir, 0, 5);
-            this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistory, 0, 4);
-            this.tlpnlBehaviour.Controls.Add(this.lblDefaultPullAction, 0, 7);
-            this.tlpnlBehaviour.Controls.Add(this.cboDefaultPullAction, 1, 7);
+            this.tlpnlBehaviour.Controls.Add(this.chkStartWithRecentWorkingDir, 0, 6);
+            this.tlpnlBehaviour.Controls.Add(this.chkFollowRenamesInFileHistory, 0, 5);
+            this.tlpnlBehaviour.Controls.Add(this.lblDefaultPullAction, 0, 8);
+            this.tlpnlBehaviour.Controls.Add(this.cboDefaultPullAction, 1, 8);
+            this.tlpnlBehaviour.Controls.Add(this.chkUpdateModules, 0, 4);
             this.tlpnlBehaviour.Dock = System.Windows.Forms.DockStyle.Top;
             this.tlpnlBehaviour.Location = new System.Drawing.Point(8, 21);
             this.tlpnlBehaviour.Name = "tlpnlBehaviour";
-            this.tlpnlBehaviour.RowCount = 9;
+            this.tlpnlBehaviour.RowCount = 10;
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -302,17 +357,18 @@
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlBehaviour.Size = new System.Drawing.Size(1172, 220);
+            this.tlpnlBehaviour.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlBehaviour.Size = new System.Drawing.Size(1472, 243);
             this.tlpnlBehaviour.TabIndex = 0;
             // 
             // chkFollowRenamesInFileHistoryExact
             // 
             this.chkFollowRenamesInFileHistoryExact.AutoSize = true;
             this.chkFollowRenamesInFileHistoryExact.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkFollowRenamesInFileHistoryExact.Location = new System.Drawing.Point(273, 95);
+            this.chkFollowRenamesInFileHistoryExact.Location = new System.Drawing.Point(273, 118);
             this.chkFollowRenamesInFileHistoryExact.Name = "chkFollowRenamesInFileHistoryExact";
-            this.chkFollowRenamesInFileHistoryExact.Size = new System.Drawing.Size(968, 17);
-            this.chkFollowRenamesInFileHistoryExact.TabIndex = 5;
+            this.chkFollowRenamesInFileHistoryExact.Size = new System.Drawing.Size(1138, 17);
+            this.chkFollowRenamesInFileHistoryExact.TabIndex = 6;
             this.chkFollowRenamesInFileHistoryExact.Text = "Follow exact renames and copies only";
             this.chkFollowRenamesInFileHistoryExact.UseVisualStyleBackColor = true;
             // 
@@ -323,7 +379,7 @@
             0,
             0,
             0});
-            this.RevisionGridQuickSearchTimeout.Location = new System.Drawing.Point(273, 170);
+            this.RevisionGridQuickSearchTimeout.Location = new System.Drawing.Point(273, 220);
             this.RevisionGridQuickSearchTimeout.Maximum = new decimal(new int[] {
             1000000,
             0,
@@ -336,7 +392,7 @@
             0});
             this.RevisionGridQuickSearchTimeout.Name = "RevisionGridQuickSearchTimeout";
             this.RevisionGridQuickSearchTimeout.Size = new System.Drawing.Size(85, 20);
-            this.RevisionGridQuickSearchTimeout.TabIndex = 10;
+            this.RevisionGridQuickSearchTimeout.TabIndex = 11;
             this.RevisionGridQuickSearchTimeout.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.RevisionGridQuickSearchTimeout.ThousandsSeparator = true;
             this.RevisionGridQuickSearchTimeout.Value = new decimal(new int[] {
@@ -349,10 +405,10 @@
             // 
             this.btnDefaultDestinationBrowse.AutoSize = true;
             this.btnDefaultDestinationBrowse.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.btnDefaultDestinationBrowse.Location = new System.Drawing.Point(1247, 141);
+            this.btnDefaultDestinationBrowse.Location = new System.Drawing.Point(1417, 164);
             this.btnDefaultDestinationBrowse.Name = "btnDefaultDestinationBrowse";
             this.btnDefaultDestinationBrowse.Size = new System.Drawing.Size(52, 23);
-            this.btnDefaultDestinationBrowse.TabIndex = 8;
+            this.btnDefaultDestinationBrowse.TabIndex = 9;
             this.btnDefaultDestinationBrowse.Text = "Browse";
             this.btnDefaultDestinationBrowse.UseVisualStyleBackColor = true;
             this.btnDefaultDestinationBrowse.Click += new System.EventHandler(this.DefaultCloneDestinationBrowseClick);
@@ -361,7 +417,7 @@
             // 
             this.lblQuickSearchTimeout.AutoSize = true;
             this.lblQuickSearchTimeout.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblQuickSearchTimeout.Location = new System.Drawing.Point(3, 167);
+            this.lblQuickSearchTimeout.Location = new System.Drawing.Point(3, 217);
             this.lblQuickSearchTimeout.Name = "lblQuickSearchTimeout";
             this.lblQuickSearchTimeout.Size = new System.Drawing.Size(264, 26);
             this.lblQuickSearchTimeout.TabIndex = 11;
@@ -385,10 +441,10 @@
             this.cbDefaultCloneDestination.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystemDirectories;
             this.cbDefaultCloneDestination.Dock = System.Windows.Forms.DockStyle.Fill;
             this.cbDefaultCloneDestination.FormattingEnabled = true;
-            this.cbDefaultCloneDestination.Location = new System.Drawing.Point(273, 141);
+            this.cbDefaultCloneDestination.Location = new System.Drawing.Point(273, 164);
             this.cbDefaultCloneDestination.Name = "cbDefaultCloneDestination";
-            this.cbDefaultCloneDestination.Size = new System.Drawing.Size(968, 21);
-            this.cbDefaultCloneDestination.TabIndex = 7;
+            this.cbDefaultCloneDestination.Size = new System.Drawing.Size(1138, 21);
+            this.cbDefaultCloneDestination.TabIndex = 8;
             // 
             // chkShowGitCommandLine
             // 
@@ -405,7 +461,7 @@
             // 
             this.lblDefaultCloneDestination.AutoSize = true;
             this.lblDefaultCloneDestination.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblDefaultCloneDestination.Location = new System.Drawing.Point(3, 138);
+            this.lblDefaultCloneDestination.Location = new System.Drawing.Point(3, 161);
             this.lblDefaultCloneDestination.Name = "lblDefaultCloneDestination";
             this.lblDefaultCloneDestination.Size = new System.Drawing.Size(264, 29);
             this.lblDefaultCloneDestination.TabIndex = 8;
@@ -438,10 +494,10 @@
             // 
             this.chkStartWithRecentWorkingDir.AutoSize = true;
             this.chkStartWithRecentWorkingDir.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkStartWithRecentWorkingDir.Location = new System.Drawing.Point(3, 118);
+            this.chkStartWithRecentWorkingDir.Location = new System.Drawing.Point(3, 141);
             this.chkStartWithRecentWorkingDir.Name = "chkStartWithRecentWorkingDir";
             this.chkStartWithRecentWorkingDir.Size = new System.Drawing.Size(264, 17);
-            this.chkStartWithRecentWorkingDir.TabIndex = 6;
+            this.chkStartWithRecentWorkingDir.TabIndex = 7;
             this.chkStartWithRecentWorkingDir.Text = "Open last working directory on startup";
             this.chkStartWithRecentWorkingDir.UseVisualStyleBackColor = true;
             // 
@@ -449,84 +505,42 @@
             // 
             this.chkFollowRenamesInFileHistory.AutoSize = true;
             this.chkFollowRenamesInFileHistory.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkFollowRenamesInFileHistory.Location = new System.Drawing.Point(3, 95);
+            this.chkFollowRenamesInFileHistory.Location = new System.Drawing.Point(3, 118);
             this.chkFollowRenamesInFileHistory.Name = "chkFollowRenamesInFileHistory";
             this.chkFollowRenamesInFileHistory.Size = new System.Drawing.Size(264, 17);
-            this.chkFollowRenamesInFileHistory.TabIndex = 4;
+            this.chkFollowRenamesInFileHistory.TabIndex = 5;
             this.chkFollowRenamesInFileHistory.Text = "Follow renames in file history (experimental)";
             this.chkFollowRenamesInFileHistory.UseVisualStyleBackColor = true;
-            // 
-            // groupBoxTelemetry
-            // 
-            this.groupBoxTelemetry.AutoSize = true;
-            this.groupBoxTelemetry.Controls.Add(this.tlpnlTelemetry);
-            this.groupBoxTelemetry.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBoxTelemetry.Location = new System.Drawing.Point(3, 476);
-            this.groupBoxTelemetry.Name = "groupBoxTelemetry";
-            this.groupBoxTelemetry.Padding = new System.Windows.Forms.Padding(8);
-            this.groupBoxTelemetry.Size = new System.Drawing.Size(1318, 52);
-            this.groupBoxTelemetry.TabIndex = 3;
-            this.groupBoxTelemetry.TabStop = false;
-            this.groupBoxTelemetry.Text = "Telemetry";
-            // 
-            // tlpnlTelemetry
-            // 
-            this.tlpnlTelemetry.AutoSize = true;
-            this.tlpnlTelemetry.ColumnCount = 2;
-            this.tlpnlTelemetry.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlTelemetry.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlTelemetry.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tlpnlTelemetry.Controls.Add(this.chkTelemetry, 0, 0);
-            this.tlpnlTelemetry.Controls.Add(this.llblTelemetryPrivacyLink, 1, 0);
-            this.tlpnlTelemetry.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tlpnlTelemetry.Location = new System.Drawing.Point(8, 21);
-            this.tlpnlTelemetry.Name = "tlpnlTelemetry";
-            this.tlpnlTelemetry.RowCount = 1;
-            this.tlpnlTelemetry.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlTelemetry.Size = new System.Drawing.Size(1302, 23);
-            this.tlpnlTelemetry.TabIndex = 0;
-            // 
-            // chkTelemetry
-            // 
-            this.chkTelemetry.AutoSize = true;
-            this.chkTelemetry.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkTelemetry.Location = new System.Drawing.Point(3, 3);
-            this.chkTelemetry.Name = "chkTelemetry";
-            this.chkTelemetry.Size = new System.Drawing.Size(128, 17);
-            this.chkTelemetry.TabIndex = 0;
-            this.chkTelemetry.Text = "Yes, I allow telemetry!";
-            this.chkTelemetry.UseVisualStyleBackColor = true;
-            // 
-            // llblTelemetryPrivacyLink
-            // 
-            this.llblTelemetryPrivacyLink.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.llblTelemetryPrivacyLink.Location = new System.Drawing.Point(137, 0);
-            this.llblTelemetryPrivacyLink.Name = "llblTelemetryPrivacyLink";
-            this.llblTelemetryPrivacyLink.Size = new System.Drawing.Size(1162, 23);
-            this.llblTelemetryPrivacyLink.TabIndex = 1;
-            this.llblTelemetryPrivacyLink.TabStop = true;
-            this.llblTelemetryPrivacyLink.Text = "Why and what is captured?";
-            this.llblTelemetryPrivacyLink.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.llblTelemetryPrivacyLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlblTelemetryPrivacyLink_LinkClicked);
             // 
             // lblDefaultPullAction
             // 
             this.lblDefaultPullAction.AutoSize = true;
             this.lblDefaultPullAction.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblDefaultPullAction.Location = new System.Drawing.Point(3, 167);
+            this.lblDefaultPullAction.Location = new System.Drawing.Point(3, 190);
             this.lblDefaultPullAction.Name = "lblDefaultPullAction";
             this.lblDefaultPullAction.Size = new System.Drawing.Size(264, 27);
-            this.lblDefaultPullAction.TabIndex = 13;
+            this.lblDefaultPullAction.TabIndex = 14;
             this.lblDefaultPullAction.Text = "Default pull action";
             this.lblDefaultPullAction.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // cboDefaultPullAction
             // 
             this.cboDefaultPullAction.FormattingEnabled = true;
-            this.cboDefaultPullAction.Location = new System.Drawing.Point(273, 170);
+            this.cboDefaultPullAction.Location = new System.Drawing.Point(273, 193);
             this.cboDefaultPullAction.Name = "cboDefaultPullAction";
             this.cboDefaultPullAction.Size = new System.Drawing.Size(121, 21);
-            this.cboDefaultPullAction.TabIndex = 9;
+            this.cboDefaultPullAction.TabIndex = 10;
+            // 
+            // chkUpdateModules
+            // 
+            this.chkUpdateModules.AutoSize = true;
+            this.chkUpdateModules.Location = new System.Drawing.Point(3, 95);
+            this.chkUpdateModules.Name = "chkUpdateModules";
+            this.chkUpdateModules.Size = new System.Drawing.Size(183, 17);
+            this.chkUpdateModules.TabIndex = 4;
+            this.chkUpdateModules.Text = "Update submodules on checkout";
+            this.chkUpdateModules.ThreeState = true;
+            this.chkUpdateModules.UseVisualStyleBackColor = true;
             // 
             // GeneralSettingsPage
             // 
@@ -536,9 +550,13 @@
             this.Controls.Add(tlpnlMain);
             this.Name = "GeneralSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1340, 889);
+            this.Size = new System.Drawing.Size(1510, 637);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
+            this.groupBoxTelemetry.ResumeLayout(false);
+            this.groupBoxTelemetry.PerformLayout();
+            this.tlpnlTelemetry.ResumeLayout(false);
+            this.tlpnlTelemetry.PerformLayout();
             this.groupBoxPerformance.ResumeLayout(false);
             this.groupBoxPerformance.PerformLayout();
             this.tlpnlPerformance.ResumeLayout(false);
@@ -549,10 +567,6 @@
             this.tlpnlBehaviour.ResumeLayout(false);
             this.tlpnlBehaviour.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.RevisionGridQuickSearchTimeout)).EndInit();
-            this.groupBoxTelemetry.ResumeLayout(false);
-            this.groupBoxTelemetry.PerformLayout();
-            this.tlpnlTelemetry.ResumeLayout(false);
-            this.tlpnlTelemetry.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -591,5 +605,6 @@
         private System.Windows.Forms.LinkLabel llblTelemetryPrivacyLink;
         private System.Windows.Forms.Label lblDefaultPullAction;
         private System.Windows.Forms.ComboBox cboDefaultPullAction;
+        private System.Windows.Forms.CheckBox chkUpdateModules;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -84,6 +84,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             RevisionGridQuickSearchTimeout.Value = AppSettings.RevisionGridQuickSearchTimeout;
             chkFollowRenamesInFileHistory.Checked = AppSettings.FollowRenamesInFileHistory;
             chkStashUntrackedFiles.Checked = AppSettings.IncludeUntrackedFilesInAutoStash;
+            chkUpdateModules.CheckState = AppSettings.UpdateSubmodulesOnCheckout.ToCheckboxState();
             chkShowStashCountInBrowseWindow.Checked = AppSettings.ShowStashCount;
             chkShowAheadBehindDataInBrowseWindow.Checked = AppSettings.ShowAheadBehindData;
             chkShowAheadBehindDataInBrowseWindow.Enabled = GitVersion.Current.SupportAheadBehindData;
@@ -110,6 +111,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.StartWithRecentWorkingDir = chkStartWithRecentWorkingDir.Checked;
             AppSettings.UseHistogramDiffAlgorithm = chkUseHistogramDiffAlgorithm.Checked;
             AppSettings.IncludeUntrackedFilesInAutoStash = chkStashUntrackedFiles.Checked;
+            AppSettings.UpdateSubmodulesOnCheckout = chkUpdateModules.CheckState.ToBoolean();
             AppSettings.FollowRenamesInFileHistory = chkFollowRenamesInFileHistory.Checked;
             AppSettings.ShowGitStatusInBrowseToolbar = chkShowGitStatusInToolbar.Checked;
             AppSettings.ShowGitStatusForArtificialCommits = chkShowGitStatusForArtificialCommits.Checked;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1117,7 +1117,7 @@ namespace GitUI
                 return;
             }
 
-            var updateSubmodules = AppSettings.UpdateSubmodulesOnCheckout ?? MessageBoxes.ConfirmUpdateSubmodules(win);
+            var updateSubmodules = AppSettings.UpdateSubmodulesOnCheckout ?? (AppSettings.DontConfirmUpdateSubmodulesOnCheckout ?? MessageBoxes.ConfirmUpdateSubmodules(win));
 
             if (updateSubmodules)
             {

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -89,6 +89,7 @@ namespace GitUI
 
             if (PSTaskDialog.cTaskDialog.VerificationChecked)
             {
+                AppSettings.DontConfirmUpdateSubmodulesOnCheckout = result;
                 AppSettings.UpdateSubmodulesOnCheckout = result;
             }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7211,6 +7211,10 @@ Context menu for additional operations</source>
         <source>Yes, I allow telemetry!</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkUpdateModules.Text">
+        <source>Update submodules on checkout</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkUseFastChecks.Text">
         <source>Use FileSystemWatcher to check if index is changed</source>
         <target />


### PR DESCRIPTION
Fixes #7290
- Moved the "Update submodules on checkout" setting from Confirmation page to General page (Behaviour group).

## Proposed changes

- [x] Added the control to General page
- [x] Added the logic to General page
- [x] Removed the control to Confirmations page
- [x] Removed the logic from Confirmations page
- [x] Ensured that TabOrder is correct

## Screenshots

![image](https://user-images.githubusercontent.com/673367/66756850-7670ae00-eeb8-11e9-9f57-49c4afa2f0e8.png)

![image](https://user-images.githubusercontent.com/673367/66756876-84263380-eeb8-11e9-929c-8aace27e0615.png)

## Test methodology <!-- How did you ensure quality? -->

- Verified the UI
- Tested the settings are not adversely affected by the change in UI.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).