### PR TITLE
Document that PowerShell scripts are run detached

### DIFF
--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -94,7 +94,10 @@ namespace GitUI.Script
             if (scriptInfo.IsPowerShell)
             {
                 PowerShellHelper.RunPowerShell(command, argument, module.WorkingDir, scriptInfo.RunInBackground);
-                return new CommandStatus(true, false);
+
+                // 'RunPowerShell' always runs the script detached (yet).
+                // Hence currently, it does not make sense to set 'needsGridRefresh' to '!scriptInfo.RunInBackground'.
+                return new CommandStatus(executed: true, needsGridRefresh: false);
             }
 
             if (command.StartsWith(PluginPrefix))
@@ -105,7 +108,7 @@ namespace GitUI.Script
                     if (plugin.Description.ToLower().Equals(command, StringComparison.CurrentCultureIgnoreCase))
                     {
                         var eventArgs = new GitUIEventArgs(owner, uiCommands);
-                        return new CommandStatus(true, plugin.Execute(eventArgs));
+                        return new CommandStatus(executed: true, needsGridRefresh: plugin.Execute(eventArgs));
                     }
                 }
 
@@ -130,7 +133,7 @@ namespace GitUI.Script
                     }
                 }
 
-                return new CommandStatus(true, false);
+                return new CommandStatus(executed: true, needsGridRefresh: false);
             }
 
             if (!scriptInfo.RunInBackground)
@@ -149,7 +152,7 @@ namespace GitUI.Script
                 }
             }
 
-            return new CommandStatus(true, !scriptInfo.RunInBackground);
+            return new CommandStatus(executed: true, needsGridRefresh: !scriptInfo.RunInBackground);
         }
 
         private static string ExpandCommandVariables(string originalCommand, IGitModule module)

--- a/Plugins/GitUIPluginInterfaces/IGitPlugin.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitPlugin.cs
@@ -23,6 +23,9 @@ namespace GitUIPluginInterfaces
 
         void Unregister(IGitUICommands gitUiCommands);
 
+        /// <summary>
+        /// Runs the plugin and returns whether the RevisionGrid should be refreshed.
+        /// </summary>
         bool Execute(GitUIEventArgs args);
     }
 }


### PR DESCRIPTION
## Proposed changes

- add comment why the RevisionGrid cannot be refreshed for PowerShell scripts
- improve code readability

## Test methodology <!-- How did you ensure quality? -->

- no functional change

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 697478fd79be9d4b7d4518c1a8bf3583008d2f5f
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4018.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
