### PR TITLE
Fix installer when PS is in ConstrainedLanguage mode

### DIFF
--- a/Bin/set-telemetry.ps1
+++ b/Bin/set-telemetry.ps1
@@ -5,6 +5,11 @@ Param(
 
 [bool]$telemetryEnabled = -not [string]::IsNullOrEmpty($Enabled);
 
+if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage")
+{
+    exit 0
+}
+
 [string]$userAppDataPath = Join-Path -Path $env:APPDATA -ChildPath 'GitExtensions\GitExtensions\GitExtensions.settings'
 if (-not (Test-Path -Path $userAppDataPath)) {
     [string]$userAppDataFolder = Split-Path $userAppDataPath -Parent

--- a/Bin/set-telemetry.ps1
+++ b/Bin/set-telemetry.ps1
@@ -7,7 +7,12 @@ Param(
 
 [string]$userAppDataPath = Join-Path -Path $env:APPDATA -ChildPath 'GitExtensions\GitExtensions\GitExtensions.settings'
 if (-not (Test-Path -Path $userAppDataPath)) {
-   '<?xml version="1.0" encoding="utf-8"?><dictionary />' | Out-File $userAppDataPath -Encoding utf8
+    [string]$userAppDataFolder = Split-Path $userAppDataPath -Parent
+    if (-not (Test-Path -Path $userAppDataFolder)) {
+        New-Item -ItemType Directory -Path $userAppDataFolder | Out-Null
+    }
+
+    '<?xml version="1.0" encoding="utf-8"?><dictionary />' | Out-File $userAppDataPath -Encoding utf8
 }
 
 [xml]$doc = Get-Content $userAppDataPath

--- a/Bin/set-telemetry.ps1
+++ b/Bin/set-telemetry.ps1
@@ -37,6 +37,3 @@ $node = $doc.CreateElement('item');
 $node.InnerXml = "<key><string>TelemetryEnabled</string></key><value><string>$telemetryEnabled</string></value>";
 $_ = $topNode.AppendChild($node);
 $doc.Save($userAppDataPath)
-
-# this script now deletes itself
-Remove-Item $MyINvocation.InvocationName

--- a/Setup/UI/TelemetryDlg.wxs
+++ b/Setup/UI/TelemetryDlg.wxs
@@ -14,11 +14,10 @@
       <![CDATA[Installed OR POWERSHELLEXE]]>
     </Condition>
 
-    <!-- Windows 7SP1 supports only PowerShell 2.0 -->
     <SetProperty Id="ConfigureTelemetry"
         Before ="ConfigureTelemetry"
         Sequence="execute"
-        Value="&quot;[POWERSHELLEXE]&quot; -Version 2.0 -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED] ; exit $$($Error.Count)&quot;" />
+        Value="&quot;[POWERSHELLEXE]&quot; -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED]; exit $$($Error.Count)&quot;" />
 
     <CustomAction Id="ConfigureTelemetry" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="yes" />
 


### PR DESCRIPTION
Fixes #7308


## Proposed changes

- cherry-picked abac1b4564a5166f0453fa3ee459769e8a199b6f & cedb5886f722349df047d87d90434e8326d8f4a2. These are the commits between v.3.2.0 and v3.2.1. They haven't been ported back into master branch yet.
- Add a check at the beginning of `set-telemetry.ps1` to verify the LanguageMode. In case it is anything different from `FullLanguage`, exit immediately with code 0. This means that the element `telemetryEnabled` **will not be written** to `GitExtensions.settings` during installation in that case.
- At first startup after installation, since the element `telemetryEnabled` is still missing in `GitExtensions.settings`, GE will act like the portable build and show the popup for telemetry. This was already implemented and I didn't change it.


## Test methodology <!-- How did you ensure quality? -->

- manual tests


## Test environment(s) <!-- Remove any that don't apply -->

- not relevant

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).