### PR TITLE
Move tsmiTelemetryEnabled behind donateToolStripMenuItem

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -23,7 +23,6 @@ namespace GitUI.CommandsDialogs
             System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
             System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
             System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
-            System.Windows.Forms.ToolStripSeparator toolStripMenuItem3;
             this.ToolStrip = new GitUI.ToolStripEx();
             this.RefreshButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator0 = new System.Windows.Forms.ToolStripSeparator();
@@ -195,7 +194,6 @@ namespace GitUI.CommandsDialogs
             toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
             this.ToolStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MainSplitContainer)).BeginInit();
             this.MainSplitContainer.Panel1.SuspendLayout();
@@ -238,11 +236,6 @@ namespace GitUI.CommandsDialogs
             // 
             toolStripSeparator14.Name = "toolStripSeparator14";
             toolStripSeparator14.Size = new System.Drawing.Size(236, 6);
-            // 
-            // toolStripMenuItem3
-            // 
-            toolStripMenuItem3.Name = "toolStripMenuItem3";
-            toolStripMenuItem3.Size = new System.Drawing.Size(275, 6);
             // 
             // ToolStrip
             // 
@@ -1595,11 +1588,10 @@ namespace GitUI.CommandsDialogs
             this.translateToolStripMenuItem,
             this.toolStripSeparator16,
             this.donateToolStripMenuItem,
+            this.tsmiTelemetryEnabled,
             this.reportAnIssueToolStripMenuItem,
             this.checkForUpdatesToolStripMenuItem,
-            this.aboutToolStripMenuItem,
-            toolStripMenuItem3,
-            this.tsmiTelemetryEnabled});
+            this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "&Help";


### PR DESCRIPTION
Fixes #7130

## Proposed changes

- make `About` the last `Help` menu item again

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![GitExtensions](https://user-images.githubusercontent.com/3006525/64832068-5462e200-d613-11e9-91ca-c0301fde4851.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/66867263-37675900-ef9b-11e9-9c7e-452996aaa998.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 63b6d216a875d1f51b240ca64e141a7409441656
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4018.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
