### PR TITLE
Features/only my messages

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3514,7 +3514,7 @@ namespace GitCommands
             }
         }
 
-        public IEnumerable<string> GetPreviousCommitMessages(int count, string revision = "HEAD")
+        public IEnumerable<string> GetPreviousCommitMessages(int count, string revision = "HEAD", string authorPattern = "")
         {
             var args = new GitArgumentBuilder("log")
             {
@@ -3523,6 +3523,12 @@ namespace GitCommands
                 revision,
                 "--pretty=format:%e%n%s%n%n%b"
             };
+
+            if (!string.IsNullOrEmpty(authorPattern))
+            {
+                args.Add($"--author=\"{authorPattern}\"");
+            }
+
             var messages = _gitExecutable.GetOutput(
                 args,
                 outputEncoding: LosslessEncoding).Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -368,6 +368,12 @@ namespace GitCommands
             set => SetInt("commitDialogNumberOfPreviousMessages", value);
         }
 
+        public static bool CommitDialogShowOnlyMyMessages
+        {
+            get => GetBool("commitDialogShowOnlyMyMessages", false);
+            set => SetBool("commitDialogShowOnlyMyMessages", value);
+        }
+
         public static bool ShowCommitAndPush
         {
             get => GetBool("showcommitandpush", true);

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -127,6 +127,7 @@ namespace GitUI.CommandsDialogs
             this.ResetUnStaged = new System.Windows.Forms.Button();
             this.toolbarCommit = new GitUI.ToolStripEx();
             this.commitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripDropDownButton();
+            this.ShowOnlyMyMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.generateListOfChangesInSubmodulesChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripDropDownButton();
@@ -1225,7 +1226,8 @@ namespace GitUI.CommandsDialogs
             this.commitMessageToolStripMenuItem.AutoToolTip = false;
             this.commitMessageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem1,
-            this.generateListOfChangesInSubmodulesChangesToolStripMenuItem});
+            this.generateListOfChangesInSubmodulesChangesToolStripMenuItem,
+            this.ShowOnlyMyMessagesToolStripMenuItem});
             this.commitMessageToolStripMenuItem.Image = global::GitUI.Properties.Images.WorkingDirChanges;
             this.commitMessageToolStripMenuItem.Name = "commitMessageToolStripMenuItem";
             this.commitMessageToolStripMenuItem.RightToLeft = System.Windows.Forms.RightToLeft.No;
@@ -1234,6 +1236,15 @@ namespace GitUI.CommandsDialogs
             this.commitMessageToolStripMenuItem.DropDownOpening += new System.EventHandler(this.CommitMessageToolStripMenuItemDropDownOpening);
             this.commitMessageToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.CommitMessageToolStripMenuItemDropDownItemClicked);
             //
+            // ShowOnlyMyMessagesToolStripMenuItem
+            // 
+            this.ShowOnlyMyMessagesToolStripMenuItem.Checked = true;
+            this.ShowOnlyMyMessagesToolStripMenuItem.CheckOnClick = true;
+            this.ShowOnlyMyMessagesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ShowOnlyMyMessagesToolStripMenuItem.Name = "ShowOnlyMyMessagesToolStripMenuItem";
+            this.ShowOnlyMyMessagesToolStripMenuItem.Size = new System.Drawing.Size(290, 22);
+            this.ShowOnlyMyMessagesToolStripMenuItem.Text = "Show only my messages";
+            // 
             // toolStripMenuItem1
             //
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
@@ -1678,5 +1689,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripComboBox gpgSignCommitToolStripComboBox;
         private ToolStripMenuItem stopTrackingThisFileToolStripMenuItem;
         private Button modifyCommitMessageButton;
+        private ToolStripMenuItem ShowOnlyMyMessagesToolStripMenuItem;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3183,6 +3183,10 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <source>Reset u&amp;nstaged changes</source>
         <target />
       </trans-unit>
+      <trans-unit id="ShowOnlyMyMessagesToolStripMenuItem.Text">
+        <source>Show only my messages</source>
+        <target />
+      </trans-unit>
       <trans-unit id="SolveMergeconflicts.Text">
         <source>There are unresolved merge conflicts
 </source>

--- a/contributors.txt
+++ b/contributors.txt
@@ -103,3 +103,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/10/14, FabMan08, Fabrizio Mancin, fabman08(at)gmail.com
 2019/10/15, manishkungwani, Manish Kungwani, manishkungwani{at]yahoo.com
 2019/10/18, lhiginbotham, Logan Higinbotham, logan.higinbotham(at)gmail.com
+2019/10/18, idealist1508, none, none(at)none.de


### PR DESCRIPTION
Fixes #7326 


## Proposed changes

- GitCommands 
  - GetPreviousCommitMessages allows filter by author
- GitUi
  - Commit dialog: New option to show only my messages.


## Screenshots 

### Before

![image](https://user-images.githubusercontent.com/4608274/67093220-6c4cf900-f1b1-11e9-9eec-717c7077d7a5.png)

### After
![image](https://user-images.githubusercontent.com/4608274/67094514-4f65f500-f1b4-11e9-8ebe-9dcfecfc614f.png)


## Test methodology 

- Manual test 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
