### PR TITLE
Truncate large hexdumps

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -619,9 +619,13 @@ namespace GitUI.Editor
                 return "";
             }
 
+            // Do not freeze GE when selecting large binary files
+            // Show only the header of the binary file to indicate contents and files incorrectly handled
+            // Use a dedicated editor to view the complete file
+            var limit = Math.Min(bytes.Length, columnWidth * columnCount * 256);
             var i = 0;
 
-            while (i < bytes.Length)
+            while (i < limit)
             {
                 var baseIndex = i;
 
@@ -683,6 +687,12 @@ namespace GitUI.Editor
                         i++;
                     }
                 }
+           }
+
+            if (bytes.Length > limit)
+            {
+                str.AppendLine();
+                str.Append("[Truncated]");
             }
 
             return str.ToString();


### PR DESCRIPTION
Part of #7322

## Proposed changes
Displaying hexdumps when viewing binary files (as well as when editing them...) is a nice touch to give an indication to the contents of a file in the repo that is not in text format. (In general though git-lfs should be used for binary files, do not store them in Git.)
However, the complete file is not interesting.
If you select a larger file like .nuget/NuGet.exe (5MB), it takes over 40s to display the file for me, with the spinner running. It seems like GE freezes.

This PR limits the display to the first 16384 bytes (1024 lines), which should be sufficient to display relevant information.
No configuration, save the file and use a dedicated hexeditor to see the complete file.

This cannot be an important feature as hexdump display has not been working properly (ever?), #6434, #7330 
This will conflict with #7330, will rebase after #7330 is merged and merge 24 after approval.

## Screenshots 
### After
![image](https://user-images.githubusercontent.com/6248932/67144426-6cfb9300-f276-11e9-905f-38c62c16b0a6.png)

## Test methodology 

View for instance .nuget/Nuget

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
