### PR TITLE
Add icon to all MessageBox that don't have one

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -245,7 +245,7 @@ namespace GitExtensions
                                 Directory.Delete(localSettingsPath, true); // deletes all application settings not just for this instance - but should work
 
                                 // Restart Git Extensions with the same arguments after old config is deleted?
-                                if (DialogResult.OK.Equals(MessageBox.Show(string.Format("Files have been deleted.{0}{0}Would you like to attempt to restart Git Extensions?", Environment.NewLine), "Configuration Error", MessageBoxButtons.OKCancel, MessageBoxIcon.Information)))
+                                if (DialogResult.OK.Equals(MessageBox.Show(string.Format("Files have been deleted.{0}{0}Would you like to attempt to restart Git Extensions?", Environment.NewLine), "Configuration Error", MessageBoxButtons.OKCancel, MessageBoxIcon.Question)))
                                 {
                                     var args = Environment.GetCommandLineArgs();
                                     var p = new System.Diagnostics.Process { StartInfo = { FileName = args[0] } };

--- a/GitExtensionsVSIX/Git/GitCommands.cs
+++ b/GitExtensionsVSIX/Git/GitCommands.cs
@@ -25,7 +25,7 @@ namespace GitExtensionsVSIX.Git
             }
             catch (UnauthorizedAccessException)
             {
-                MessageBox.Show("Git Extensions has insufficient permissions to check the registry.");
+                MessageBox.Show("Git Extensions has insufficient permissions to check the registry.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return "";
@@ -92,7 +92,7 @@ namespace GitExtensionsVSIX.Git
             {
                 if (!File.Exists(Path.Combine(path, "GitExtensions.exe")))
                 {
-                    MessageBox.Show("This plugin requires Git Extensions to be installed. This application can be downloaded from http://gitextensions.github.io/");
+                    MessageBox.Show("This plugin requires Git Extensions to be installed. This application can be downloaded from http://gitextensions.github.io/", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 return null;

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -750,7 +750,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message);
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -47,7 +47,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 }
                 else
                 {
-                    MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.");
+                    MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             };
 

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -96,7 +96,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.ToString());
+                MessageBox.Show(this, ex.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             Close();

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -160,7 +160,7 @@ namespace GitUI.CommandsDialogs
 
             if (string.IsNullOrEmpty(patchFile) && string.IsNullOrEmpty(dirText))
             {
-                MessageBox.Show(this, _noFileSelectedText.Text);
+                MessageBox.Show(this, _noFileSelectedText.Text, "Error", MessageBoxButtons.OK,  MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1519,7 +1519,7 @@ namespace GitUI.CommandsDialogs
             var revisions = RevisionGrid.GetSelectedRevisions();
             if (revisions.Count < 1 || revisions.Count > 2)
             {
-                MessageBox.Show(this, @"Select only one or two revisions. Abort.", @"Archive revision");
+                MessageBox.Show(this, @"Select only one or two revisions. Abort.", @"Archive revision", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -1990,7 +1990,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message);
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2040,7 +2040,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (FileDeleteException ex)
             {
-                MessageBox.Show(this, $@"{_indexLockCantDelete.Text}: {ex.FileName}{Environment.NewLine}{ex.Message}");
+                MessageBox.Show(this, $@"{_indexLockCantDelete.Text}: {ex.FileName}{Environment.NewLine}{ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -294,14 +294,14 @@ namespace GitUI.CommandsDialogs
                     newBranchMode = CheckoutNewBranchMode.Create;
                     if (newBranchName.IsNullOrWhiteSpace())
                     {
-                        MessageBox.Show(_customBranchNameIsEmpty.Text, Text);
+                        MessageBox.Show(_customBranchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         DialogResult = DialogResult.None;
                         return DialogResult.None;
                     }
 
                     if (!Module.CheckBranchFormat(newBranchName))
                     {
-                        MessageBox.Show(string.Format(_customBranchNameIsNotValid.Text, newBranchName), Text);
+                        MessageBox.Show(string.Format(_customBranchNameIsNotValid.Text, newBranchName), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         DialogResult = DialogResult.None;
                         return DialogResult.None;
                     }

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs
 
                 if (selectedObjectId == null)
                 {
-                    MessageBox.Show(this, _noRevisionSelectedMsgBox.Text, _noRevisionSelectedMsgBoxCaption.Text);
+                    MessageBox.Show(this, _noRevisionSelectedMsgBox.Text, _noRevisionSelectedMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -899,7 +899,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!string.IsNullOrEmpty(output))
             {
-                MessageBox.Show(this, output + "\n\n" + SelectedDiff.Encoding.GetString(patch));
+                MessageBox.Show(this, output + "\n\n" + SelectedDiff.Encoding.GetString(patch), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
 
             if (_currentItemStaged)
@@ -1454,7 +1454,7 @@ namespace GitUI.CommandsDialogs
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show(this, $"Exception: {e.Message}");
+                    MessageBox.Show(this, $"Exception: {e.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 return;
@@ -2090,12 +2090,12 @@ namespace GitUI.CommandsDialogs
 
                 if (filesInUse.Count > 0)
                 {
-                    MessageBox.Show(this, "The following files are currently in use and will not be reset:" + Environment.NewLine + "\u2022 " + string.Join(Environment.NewLine + "\u2022 ", filesInUse), "Files In Use");
+                    MessageBox.Show(this, "The following files are currently in use and will not be reset:" + Environment.NewLine + "\u2022 " + string.Join(Environment.NewLine + "\u2022 ", filesInUse), "Files In Use", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 if (!string.IsNullOrEmpty(output.ToString()))
                 {
-                    MessageBox.Show(this, output.ToString(), _resetChangesCaption.Text);
+                    MessageBox.Show(this, output.ToString(), _resetChangesCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }
             finally
@@ -2111,7 +2111,7 @@ namespace GitUI.CommandsDialogs
             try
             {
                 if (Unstaged.SelectedItem == null ||
-                    MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
+                    MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
                     DialogResult.Yes)
                 {
                     return;
@@ -2129,7 +2129,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message);
+                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2143,7 +2143,7 @@ namespace GitUI.CommandsDialogs
 
         private void DeleteSelectedFilesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
+            if (MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
                 DialogResult.Yes)
             {
                 return;
@@ -2158,7 +2158,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex);
+                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             Initialize();
@@ -2166,7 +2166,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResetSelectedFilesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, _resetSelectedChangesText.Text, _resetChangesCaption.Text, MessageBoxButtons.YesNo) !=
+            if (MessageBox.Show(this, _resetSelectedChangesText.Text, _resetChangesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
                 DialogResult.Yes)
             {
                 return;
@@ -2263,7 +2263,8 @@ namespace GitUI.CommandsDialogs
             if (MessageBox.Show(this,
                 _deleteUntrackedFiles.Text,
                 _deleteUntrackedFilesCaption.Text,
-                MessageBoxButtons.YesNo) !=
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question) !=
                 DialogResult.Yes)
             {
                 return;
@@ -2591,7 +2592,7 @@ namespace GitUI.CommandsDialogs
                 string output = Module.OpenWithDifftool(item.Name, null, firstRevision, secondRevision, "", item.IsTracked);
                 if (!string.IsNullOrEmpty(output))
                 {
-                    MessageBox.Show(this, output);
+                    MessageBox.Show(this, output, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }
         }
@@ -2607,7 +2608,7 @@ namespace GitUI.CommandsDialogs
 
             if (items.Count != 1)
             {
-                MessageBox.Show(this, _onlyStageChunkOfSingleFileError.Text, _resetStageChunkOfFileCaption.Text);
+                MessageBox.Show(this, _onlyStageChunkOfSingleFileError.Text, _resetStageChunkOfFileCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2726,7 +2727,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(this, _selectOnlyOneFile.Text, _error.Text);
+                MessageBox.Show(this, _selectOnlyOneFile.Text, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -930,7 +930,7 @@ namespace GitUI.CommandsDialogs
             }
 
             if (MessageBox.Show(this, _resetSelectedLinesConfirmation.Text, _resetChangesCaption.Text,
-                MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+                MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
                 return;
             }
@@ -1287,7 +1287,7 @@ namespace GitUI.CommandsDialogs
                     // commit, because amend may be used just to change the commit message or timestamp.
                     if (!AppSettings.DontConfirmAmend)
                     {
-                        if (MessageBox.Show(this, _amendCommit.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo) != DialogResult.Yes)
+                        if (MessageBox.Show(this, _amendCommit.Text, _amendCommitCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
                         {
                             return false;
                         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -899,7 +899,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!string.IsNullOrEmpty(output))
             {
-                MessageBox.Show(this, output + "\n\n" + SelectedDiff.Encoding.GetString(patch), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(this, output + "\n\n" + SelectedDiff.Encoding.GetString(patch), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             if (_currentItemStaged)
@@ -2090,12 +2090,12 @@ namespace GitUI.CommandsDialogs
 
                 if (filesInUse.Count > 0)
                 {
-                    MessageBox.Show(this, "The following files are currently in use and will not be reset:" + Environment.NewLine + "\u2022 " + string.Join(Environment.NewLine + "\u2022 ", filesInUse), "Files In Use", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBox.Show(this, "The following files are currently in use and will not be reset:" + Environment.NewLine + "\u2022 " + string.Join(Environment.NewLine + "\u2022 ", filesInUse), "Files In Use", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
 
                 if (!string.IsNullOrEmpty(output.ToString()))
                 {
-                    MessageBox.Show(this, output.ToString(), _resetChangesCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBox.Show(this, output.ToString(), _resetChangesCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
             finally
@@ -2592,7 +2592,7 @@ namespace GitUI.CommandsDialogs
                 string output = Module.OpenWithDifftool(item.Name, null, firstRevision, secondRevision, "", item.IsTracked);
                 if (!string.IsNullOrEmpty(output))
                 {
-                    MessageBox.Show(this, output, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBox.Show(this, output, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -90,7 +90,7 @@ namespace GitUI.CommandsDialogs
             var objectId = commitPickerSmallControl1.SelectedObjectId;
             if (objectId == null)
             {
-                MessageBox.Show(this, _noRevisionSelected.Text, Text);
+                MessageBox.Show(this, _noRevisionSelected.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.None;
                 return;
             }
@@ -98,14 +98,14 @@ namespace GitUI.CommandsDialogs
             var branchName = BranchNameTextBox.Text.Trim();
             if (branchName.IsNullOrWhiteSpace())
             {
-                MessageBox.Show(_branchNameIsEmpty.Text, Text);
+                MessageBox.Show(_branchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.None;
                 return;
             }
 
             if (!Module.CheckBranchFormat(branchName))
             {
-                MessageBox.Show(string.Format(_branchNameIsNotValid.Text, branchName), Text);
+                MessageBox.Show(string.Format(_branchNameIsNotValid.Text, branchName), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.None;
                 return;
             }

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -79,7 +79,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message);
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -89,7 +89,7 @@ namespace GitUI.CommandsDialogs
 
             if (objectId == null)
             {
-                MessageBox.Show(this, _noRevisionSelected.Text, _messageCaption.Text);
+                MessageBox.Show(this, _noRevisionSelected.Text, _messageCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return "";
             }
 

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs
 
                 if (_currentBranch != null && selectedBranches.Any(branch => branch.Name == _currentBranch))
                 {
-                    MessageBox.Show(this, string.Format(_cannotDeleteCurrentBranchMessage.Text, _currentBranch), _deleteBranchCaption.Text);
+                    MessageBox.Show(this, string.Format(_cannotDeleteCurrentBranchMessage.Text, _currentBranch), _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -82,14 +82,14 @@ namespace GitUI.CommandsDialogs
                 // we could show yes/no dialog and set forcing checkbox automatically, but more safe way is asking user to do it himself
                 if (hasUnmergedBranches && !ForceDelete.Checked)
                 {
-                    MessageBox.Show(this, _deleteUnmergedBranchForcingSuggestion.Text, _deleteBranchCaption.Text);
+                    MessageBox.Show(this, _deleteUnmergedBranchForcingSuggestion.Text, _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
                 // ask for confirmation to delete unmerged branch that may cause loosing commits
                 // (actually we could check if there are another branches pointing to that commit)
                 if (hasUnmergedBranches
-                    && MessageBox.Show(this, _deleteBranchQuestion.Text, _deleteBranchCaption.Text, MessageBoxButtons.YesNo) != DialogResult.Yes)
+                    && MessageBox.Show(this, _deleteBranchQuestion.Text, _deleteBranchCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
                 {
                     return;
                 }

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -64,7 +64,7 @@ namespace GitUI.CommandsDialogs
 
                 if (hasUnmergedBranches)
                 {
-                    if (MessageBox.Show(this, _confirmDeleteUnmergedRemoteBranchMessage.Text, _deleteRemoteBranchesCaption.Text, MessageBoxButtons.YesNo) != DialogResult.Yes)
+                    if (MessageBox.Show(this, _confirmDeleteUnmergedRemoteBranchMessage.Text, _deleteRemoteBranchesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
                     {
                         return;
                     }

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, _error.Text);
+                MessageBox.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Close();
             }
         }

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -86,25 +86,25 @@ namespace GitUI.CommandsDialogs
         {
             if (SaveToDir.Checked && string.IsNullOrEmpty(OutputPath.Text))
             {
-                MessageBox.Show(this, _noOutputPathEnteredText.Text);
+                MessageBox.Show(this, _noOutputPathEnteredText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!SaveToDir.Checked && string.IsNullOrEmpty(MailTo.Text))
             {
-                MessageBox.Show(this, _noEmailEnteredText.Text);
+                MessageBox.Show(this, _noEmailEnteredText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!SaveToDir.Checked && string.IsNullOrEmpty(MailSubject.Text))
             {
-                MessageBox.Show(this, _noSubjectEnteredText.Text);
+                MessageBox.Show(this, _noSubjectEnteredText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!SaveToDir.Checked && string.IsNullOrEmpty(AppSettings.SmtpServer))
             {
-                MessageBox.Show(this, _wrongSmtpSettingsText.Text);
+                MessageBox.Show(this, _wrongSmtpSettingsText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(this, _revisionsNeededText.Text, _revisionsNeededCaption.Text);
+                MessageBox.Show(this, _revisionsNeededText.Text, _revisionsNeededCaption.Text,  MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -194,7 +194,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(this, result, _patchResultCaption.Text);
+                MessageBox.Show(this, result, _patchResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Close();
             }
         }
@@ -207,7 +207,7 @@ namespace GitUI.CommandsDialogs
 
                 if (string.IsNullOrEmpty(from))
                 {
-                    MessageBox.Show(this, _noGitMailConfigured.Text);
+                    MessageBox.Show(this, _noGitMailConfigured.Text, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
 
                 string to = MailTo.Text;
@@ -242,7 +242,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message);
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -93,7 +93,7 @@ namespace GitUI.CommandsDialogs
             catch (Exception ex)
             {
                 MessageBox.Show(this, _cannotAccessGitattributes.Text + Environment.NewLine + ex.Message,
-                    _cannotAccessGitattributesCaption.Text);
+                    _cannotAccessGitattributesCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
         }
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            MessageBox.Show(this, _noWorkingDir.Text, _noWorkingDirCaption.Text);
+            MessageBox.Show(this, _noWorkingDir.Text, _noWorkingDirCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             Close();
         }
 

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            MessageBox.Show(this, _noWorkingDir.Text, _noWorkingDirCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show(this, _noWorkingDir.Text, _noWorkingDirCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
         }
 

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -161,7 +161,7 @@ namespace GitUI.CommandsDialogs
             catch (Exception ex)
             {
                 MessageBox.Show(this, _dialogModel.CannotAccessFile + Environment.NewLine + ex.Message,
-                    _dialogModel.CannotAccessFileCaption);
+                    _dialogModel.CannotAccessFileCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
         }
@@ -194,7 +194,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            MessageBox.Show(this, _dialogModel.FileOnlyInWorkingDirSupported, _gitignoreOnlyInWorkingDirSupportedCaption.Text);
+            MessageBox.Show(this, _dialogModel.FileOnlyInWorkingDirSupported, _gitignoreOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
         }
 

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -53,13 +53,13 @@ namespace GitUI.CommandsDialogs
 
             if (!IsRootedDirectoryPath(directoryPath))
             {
-                MessageBox.Show(this, _chooseDirectory.Text, _chooseDirectoryCaption.Text);
+                MessageBox.Show(this, _chooseDirectory.Text, _chooseDirectoryCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (File.Exists(directoryPath))
             {
-                MessageBox.Show(this, _chooseDirectoryNotFile.Text, _chooseDirectoryNotFileCaption.Text);
+                MessageBox.Show(this, _chooseDirectoryNotFile.Text, _chooseDirectoryNotFileCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -70,7 +70,7 @@ namespace GitUI.CommandsDialogs
                 System.IO.Directory.CreateDirectory(module.WorkingDir);
             }
 
-            MessageBox.Show(this, module.Init(Central.Checked, Central.Checked), _initMsgBoxCaption.Text);
+            MessageBox.Show(this, module.Init(Central.Checked, Central.Checked), _initMsgBoxCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
             _gitModuleChanged?.Invoke(this, new GitModuleEventArgs(module));
 

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -95,7 +95,7 @@ namespace GitUI.CommandsDialogs
             catch (Exception ex)
             {
                 MessageBox.Show(this, _cannotAccessMailmap.Text + Environment.NewLine + ex.Message,
-                    _cannotAccessMailmapCaption.Text);
+                    _cannotAccessMailmapCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
         }
@@ -138,7 +138,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            MessageBox.Show(this, _mailmapOnlyInWorkingDirSupported.Text, _mailmapOnlyInWorkingDirSupportedCaption.Text);
+            MessageBox.Show(this, _mailmapOnlyInWorkingDirSupported.Text, _mailmapOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             Close();
         }
 

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -138,7 +138,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            MessageBox.Show(this, _mailmapOnlyInWorkingDirSupported.Text, _mailmapOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show(this, _mailmapOnlyInWorkingDirSupported.Text, _mailmapOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
         }
 

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -276,7 +276,7 @@ namespace GitUI.CommandsDialogs
             Module.RunMergeTool();
 
             if (MessageBox.Show(this, _allMergeConflictSolvedQuestion.Text, _allMergeConflictSolvedQuestionCaption.Text,
-                                MessageBoxButtons.YesNo) != DialogResult.Yes)
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
             {
                 return;
             }
@@ -455,19 +455,19 @@ namespace GitUI.CommandsDialogs
             {
                 if (PullFromUrl.Checked && string.IsNullOrEmpty(comboBoxPullSource.Text))
                 {
-                    MessageBox.Show(this, _selectSourceDirectory.Text);
+                    MessageBox.Show(this, _selectSourceDirectory.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
 
                 if (PullFromRemote.Checked && string.IsNullOrEmpty(_NO_TRANSLATE_Remotes.Text) && !IsPullAll())
                 {
-                    MessageBox.Show(this, _selectRemoteRepository.Text);
+                    MessageBox.Show(this, _selectRemoteRepository.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
 
                 if (!Fetch.Checked && Branches.Text == "*")
                 {
-                    MessageBox.Show(this, _fetchAllBranchesCanOnlyWithFetch.Text);
+                    MessageBox.Show(this, _fetchAllBranchesCanOnlyWithFetch.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
 
@@ -610,7 +610,9 @@ namespace GitUI.CommandsDialogs
             {
                 dialogResult = MessageBox.Show(this, _areYouSureYouWantToRebaseMerge.Text,
                                                   _areYouSureYouWantToRebaseMergeCaption.Text,
-                                                  MessageBoxButtons.YesNoCancel);
+                                                  MessageBoxButtons.YesNoCancel,
+                                                  MessageBoxIcon.Warning,
+                                                  MessageBoxDefaultButton.Button2);
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -268,7 +268,7 @@ namespace GitUI.CommandsDialogs
             ErrorOccurred = false;
             if (PushToUrl.Checked && !PathUtil.IsUrl(PushDestination.Text))
             {
-                MessageBox.Show(owner, _selectDestinationDirectory.Text);
+                MessageBox.Show(owner, _selectDestinationDirectory.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -280,7 +280,7 @@ namespace GitUI.CommandsDialogs
             var selectedRemoteName = _selectedRemote.Name;
             if (TabControlTagBranch.SelectedTab == TagTab && string.IsNullOrEmpty(TagComboBox.Text))
             {
-                MessageBox.Show(owner, _selectTag.Text);
+                MessageBox.Show(owner, _selectTag.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -298,7 +298,7 @@ namespace GitUI.CommandsDialogs
                 {
                     // Ask if this is really what the user wants
                     if (!AppSettings.DontConfirmPushNewBranch &&
-                        MessageBox.Show(owner, _branchNewForRemote.Text, _pushCaption.Text, MessageBoxButtons.YesNo) == DialogResult.No)
+                        MessageBox.Show(owner, _branchNewForRemote.Text, _pushCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
                     {
                         return false;
                     }
@@ -347,7 +347,9 @@ namespace GitUI.CommandsDialogs
                         var result = MessageBox.Show(owner,
                                                      string.Format(_updateTrackingReference.Text, selectedLocalBranch.Name, RemoteBranch.Text),
                                                      _pushCaption.Text,
-                                                     MessageBoxButtons.YesNoCancel);
+                                                     MessageBoxButtons.YesNoCancel,
+                                                     MessageBoxIcon.Question,
+                                                     MessageBoxDefaultButton.Button1);
                         if (result == DialogResult.Cancel)
                         {
                             return false;
@@ -363,7 +365,7 @@ namespace GitUI.CommandsDialogs
                     {
                         var choice = MessageBox.Show(owner,
                                                      _useForceWithLeaseInstead.Text,
-                                                     "", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question,
+                                                     "Question", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question,
                                                      MessageBoxDefaultButton.Button1);
                         switch (choice)
                         {

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -247,7 +247,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (string.IsNullOrEmpty(Branches.Text))
                 {
-                    MessageBox.Show(this, _noBranchSelectedText.Text);
+                    MessageBox.Show(this, _noBranchSelectedText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -270,7 +270,7 @@ namespace GitUI.CommandsDialogs
                 var dialogResult = FormProcess.ReadDialog(this, rebaseCmd);
                 if (dialogResult.Trim() == "Current branch a is up to date.")
                 {
-                    MessageBox.Show(this, _branchUpToDateText.Text, _branchUpToDateCaption.Text);
+                    MessageBox.Show(this, _branchUpToDateText.Text, _branchUpToDateCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 if (!Module.InTheMiddleOfAction() &&

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -137,7 +137,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (MessageBox.Show(this, _continueResetCurrentBranchEvenWithChangesText.Text,
                         _continueResetCurrentBranchCaptionText.Text,
-                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
+                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) == DialogResult.No)
                 {
                     return;
                 }

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -49,7 +49,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _sshKeyOpenCaption =
             new TranslationString("Select ssh key file");
 
-        private readonly TranslationString _warningNoKeyEntered =
+        private readonly TranslationString _errorNoKeyEntered =
             new TranslationString("No SSH key file entered");
 
         private readonly TranslationString _labelUrlAsFetch =
@@ -459,7 +459,8 @@ Inactive remote is completely invisible to git.");
                     MessageBox.Show(this,
                         _questionAutoPullBehaviour.Text,
                         _questionAutoPullBehaviourCaption.Text,
-                        MessageBoxButtons.YesNo) == DialogResult.Yes)
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     UICommands.StartPullDialogAndPullImmediately(
                         remote: remote,
@@ -492,12 +493,14 @@ Inactive remote is completely invisible to git.");
             if (MessageBox.Show(this,
                                 _questionDeleteRemote.Text,
                                 _questionDeleteRemoteCaption.Text,
-                                MessageBoxButtons.YesNo) == DialogResult.Yes)
+                                MessageBoxButtons.YesNo,
+                                MessageBoxIcon.Warning,
+                                MessageBoxDefaultButton.Button2) == DialogResult.Yes)
             {
                 var output = _remotesManager.RemoveRemote(_selectedRemote);
                 if (!string.IsNullOrEmpty(output))
                 {
-                    MessageBox.Show(this, output, _gitMessage.Text);
+                    MessageBox.Show(this, output, _gitMessage.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 // Deleting a remote from the history list may be undesirable as
@@ -528,7 +531,7 @@ Inactive remote is completely invisible to git.");
         {
             if (string.IsNullOrEmpty(PuttySshKey.Text))
             {
-                MessageBox.Show(this, _warningNoKeyEntered.Text);
+                MessageBox.Show(this, _errorNoKeyEntered.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
@@ -548,7 +551,8 @@ Inactive remote is completely invisible to git.");
         private void RemoteBranchesDataError(object sender, DataGridViewDataErrorEventArgs e)
         {
             MessageBox.Show(this,
-                            string.Format(_remoteBranchDataError.Text, RemoteBranches.Rows[e.RowIndex].Cells[0].Value, RemoteBranches.Columns[e.ColumnIndex].HeaderText));
+                            string.Format(_remoteBranchDataError.Text, RemoteBranches.Rows[e.RowIndex].Cells[0].Value, RemoteBranches.Columns[e.ColumnIndex].HeaderText),
+                            "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             RemoteBranches.Rows[e.RowIndex].Cells[e.ColumnIndex].Value = "";
         }
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -314,7 +314,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, "Merge using script failed.\n" + ex);
+                MessageBox.Show(this, "Merge using script failed.\n" + ex, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return false;
@@ -353,7 +353,7 @@ namespace GitUI.CommandsDialogs
                 // The file is not modified, do not stage file and present warning
                 if (lastWriteTimeBeforeMerge == lastWriteTimeAfterMerge)
                 {
-                    MessageBox.Show(this, _fileUnchangedAfterMerge.Text);
+                    MessageBox.Show(this, _fileUnchangedAfterMerge.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 else
                 {
@@ -494,7 +494,7 @@ namespace GitUI.CommandsDialogs
                     {
                         var text = string.Format(_noBaseRevision.Text, item.Filename);
                         DialogResult result = MessageBox.Show(this, text, _noBaseFileMergeCaption.Text,
-                            MessageBoxButtons.YesNoCancel);
+                            MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
                         if (result == DialogResult.Yes)
                         {
                             Use2WayMerge(ref arguments);
@@ -527,7 +527,7 @@ namespace GitUI.CommandsDialogs
                     {
                         var text = string.Format(_errorStartingMergetool.Text, _mergetoolPath);
                         MessageBox.Show(this, text, _noBaseFileMergeCaption.Text,
-                            MessageBoxButtons.OK);
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }
 
@@ -800,7 +800,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.HandleConflictSelectSide(fileName, "BASE"))
             {
-                MessageBox.Show(this, _chooseBaseFileFailedText.Text);
+                MessageBox.Show(this, _chooseBaseFileFailedText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -829,7 +829,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.HandleConflictSelectSide(fileName, "LOCAL"))
             {
-                MessageBox.Show(this, _chooseLocalFileFailedText.Text);
+                MessageBox.Show(this, _chooseLocalFileFailedText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -858,7 +858,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.HandleConflictSelectSide(fileName, "REMOTE"))
             {
-                MessageBox.Show(this, _chooseRemoteFileFailedText.Text);
+                MessageBox.Show(this, _chooseRemoteFileFailedText.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -1084,7 +1084,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!Module.HandleConflictsSaveSide(conflictData.Filename, fileName, side))
                 {
-                    MessageBox.Show(this, _failureWhileOpenFile.Text);
+                    MessageBox.Show(this, _failureWhileOpenFile.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 OsShellUtil.OpenAs(fileName);
@@ -1142,7 +1142,7 @@ namespace GitUI.CommandsDialogs
                     {
                         if (!Module.HandleConflictsSaveSide(conflictData.Filename, fileDialog.FileName, side))
                         {
-                            MessageBox.Show(this, _failureWhileSaveFile.Text);
+                            MessageBox.Show(this, _failureWhileSaveFile.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                 }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -244,10 +244,8 @@ namespace GitUI.CommandsDialogs
         {
             if (chkIncludeUntrackedFiles.Checked && !GitVersion.Current.StashUntrackedFilesSupported)
             {
-                if (MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == DialogResult.Cancel)
-                {
-                    return;
-                }
+                MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
             }
 
             using (WaitCursorScope.Enter())
@@ -262,10 +260,8 @@ namespace GitUI.CommandsDialogs
         {
             if (chkIncludeUntrackedFiles.Checked && !GitVersion.Current.StashUntrackedFilesSupported)
             {
-                if (MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OKCancel) == DialogResult.Cancel)
-                {
-                    return;
-                }
+                MessageBox.Show(_stashUntrackedFilesNotSupported.Text, _stashUntrackedFilesNotSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
             }
 
             using (WaitCursorScope.Enter())

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
         {
             if (Submodules.SelectedRows.Count != 1 ||
                 MessageBox.Show(this, _removeSelectedSubmodule.Text, _removeSelectedSubmoduleCaption.Text,
-                                MessageBoxButtons.YesNo) !=
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Warning) !=
                 DialogResult.Yes)
             {
                 return;

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -87,7 +87,8 @@ namespace GitUI.CommandsDialogs
             if (MessageBox.Show(this,
                 _removeDanglingObjectsQuestion.Text,
                 _removeDanglingObjectsCaption.Text,
-                MessageBoxButtons.YesNo) != DialogResult.Yes)
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question) != DialogResult.Yes)
             {
                 return;
             }

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -183,7 +183,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             var body = _bodyTB.Text.Trim();
             if (title.Length == 0)
             {
-                MessageBox.Show(this, _strYouMustSpecifyATitle.Text, _strError.Text);
+                MessageBox.Show(this, _strYouMustSpecifyATitle.Text, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -192,7 +192,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 var hostedRepo = _currentHostedRemote.GetHostedRepository();
 
                 hostedRepo.CreatePullRequest(_yourBranchesCB.Text, _remoteBranchesCB.Text, title, body);
-                MessageBox.Show(this, _strDone.Text, _strPullRequest.Text);
+                MessageBox.Show(this, _strDone.Text, _strPullRequest.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Close();
             }
             catch (Exception ex)

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -181,7 +181,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     {
                         await this.SwitchToMainThreadAsync();
 
-                        MessageBox.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, _strError.Text);
+                        MessageBox.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         searchBtn.Enabled = true;
                     }
                 })
@@ -217,12 +217,12 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         if (ex.Message.Contains("404"))
                         {
-                            MessageBox.Show(this, _strUserNotFound.Text, _strError.Text);
+                            MessageBox.Show(this, _strUserNotFound.Text, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                         else
                         {
                             MessageBox.Show(this, _strCouldNotFetchReposOfUser.Text + Environment.NewLine +
-                                                  ex.Message, _strError.Text);
+                                                  ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
 
                         searchBtn.Enabled = true;
@@ -268,7 +268,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             if (searchResultsLV.SelectedItems.Count != 1)
             {
-                MessageBox.Show(this, _strSelectOneItem.Text, _strError.Text);
+                MessageBox.Show(this, _strSelectOneItem.Text, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -279,7 +279,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _strFailedToFork.Text + Environment.NewLine + ex.Message, _strError.Text);
+                MessageBox.Show(this, _strFailedToFork.Text + Environment.NewLine + ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             tabControl.SelectedTab = myReposPage;
@@ -338,7 +338,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             string hp = CurrentySelectedGitRepo.Homepage;
             if (string.IsNullOrEmpty(hp) || (!hp.StartsWith("http://") && !hp.StartsWith("https://")))
             {
-                MessageBox.Show(this, _strNoHomepageDefined.Text, _strError.Text);
+                MessageBox.Show(this, _strNoHomepageDefined.Text, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
@@ -412,7 +412,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 var error = module.AddRemote(addUpstreamRemoteAsCB.Text.Trim(), repo.ParentReadOnlyUrl);
                 if (!string.IsNullOrEmpty(error))
                 {
-                    MessageBox.Show(this, error, _strCouldNotAddRemote.Text);
+                    MessageBox.Show(this, error, _strCouldNotAddRemote.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
 
@@ -523,7 +523,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             string targetDir = destinationTB.Text.Trim();
             if (targetDir.Length == 0)
             {
-                MessageBox.Show(this, _strCloneFolderCanNotBeEmpty.Text, _strError.Text);
+                MessageBox.Show(this, _strCloneFolderCanNotBeEmpty.Text, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return null;
             }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -123,7 +123,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                     catch (Exception ex) when (!(ex is OperationCanceledException))
                     {
-                        MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, _strError.Text);
+                        MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 })
                 .FileAndForget();
@@ -294,7 +294,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                     catch (Exception ex) when (!(ex is OperationCanceledException))
                     {
-                        MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, _strError.Text);
+                        MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         LoadDiscussion(null);
                     }
                 })
@@ -333,7 +333,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                     catch (Exception ex) when (!(ex is OperationCanceledException))
                     {
-                        MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, _strError.Text);
+                        MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 })
                 .FileAndForget();
@@ -351,7 +351,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 var match = Regex.Match(part, @"^a/([^\n]+) b/([^\n]+)\s*(.*)$", RegexOptions.Singleline);
                 if (!match.Success)
                 {
-                    MessageBox.Show(this, _strUnableUnderstandPatch.Text, _strError.Text);
+                    MessageBox.Show(this, _strUnableUnderstandPatch.Text, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -415,7 +415,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     if (hostedRepository.CloneReadOnlyUrl != remoteUrl)
                     {
                         MessageBox.Show(this, string.Format(_strRemoteAlreadyExist.Text,
-                                            remoteName, hostedRepository.CloneReadOnlyUrl, remoteUrl));
+                                            remoteName, hostedRepository.CloneReadOnlyUrl, remoteUrl),
+                                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }
                 }
@@ -424,7 +425,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     var error = Module.AddRemote(remoteName, remoteUrl);
                     if (!string.IsNullOrEmpty(error))
                     {
-                        MessageBox.Show(this, error, string.Format(_strCouldNotAddRemote.Text, remoteName, remoteUrl));
+                        MessageBox.Show(this, error, string.Format(_strCouldNotAddRemote.Text, remoteName, remoteUrl), MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }
 
@@ -481,7 +482,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _strFailedToClosePullRequest.Text + Environment.NewLine + ex.Message, _strError.Text);
+                MessageBox.Show(this, _strFailedToClosePullRequest.Text + Environment.NewLine + ex.Message, _strError.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -801,7 +801,8 @@ namespace GitUI.CommandsDialogs
             try
             {
                 if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null || !DiffFiles.Revision.IsArtificial ||
-                    MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo) !=
+                    MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo,
+                                    MessageBoxIcon.Warning) !=
                     DialogResult.Yes)
                 {
                     return false;
@@ -832,7 +833,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message);
+                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -115,7 +115,7 @@ See the changes in the commit form.");
             {
                 if (isIncompleteMatch)
                 {
-                    MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text);
+                    MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 tvGitTree.SelectedNode = foundNode;
@@ -123,7 +123,7 @@ See the changes in the commit form.");
             }
             else
             {
-                MessageBox.Show(_nodeNotFoundSelectionNotChanged.Text);
+                MessageBox.Show(_nodeNotFoundSelectionNotChanged.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -624,7 +624,7 @@ See the changes in the commit form.");
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message);
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -654,7 +654,7 @@ See the changes in the commit form.");
         {
             if (tvGitTree.SelectedNode?.Tag is GitItem gitItem && _revision != null)
             {
-                if (MessageBox.Show(_resetFileText.Text, _resetFileCaption.Text, MessageBoxButtons.OKCancel) == DialogResult.OK)
+                if (MessageBox.Show(_resetFileText.Text, _resetFileCaption.Text, MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.OK)
                 {
                     Module.CheckoutFiles(new[] { gitItem.FileName }, _revision.ObjectId, false);
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -76,7 +76,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             }
             catch (UnauthorizedAccessException)
             {
-                MessageBox.Show(_cantReadRegistry.Text);
+                MessageBox.Show(_cantReadRegistry.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return value ?? "";

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             catch
             {
-                MessageBox.Show(this, string.Format(_noDictFilesFound.Text, AppSettings.GetDictionaryDir()));
+                MessageBox.Show(this, string.Format(_noDictFilesFound.Text, AppSettings.GetDictionaryDir()), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -188,7 +188,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 if (SshSettingsPage.AutoFindPuttyPaths())
                 {
-                    MessageBox.Show(this, _puttyFoundAuto.Text, _putty);
+                    MessageBox.Show(this, _puttyFoundAuto.Text, _putty, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 else
                 {
@@ -207,12 +207,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             if (!CheckSettingsLogic.SolveLinuxToolsDir())
             {
-                MessageBox.Show(this, _linuxToolsShNotFound.Text, _linuxToolsShNotFoundCaption.Text);
+                MessageBox.Show(this, _linuxToolsShNotFound.Text, _linuxToolsShNotFoundCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 PageHost.GotoPage(GitSettingsPage.GetPageReference());
                 return;
             }
 
-            MessageBox.Show(this, string.Format(_shCanBeRun.Text, AppSettings.GitBinDir), _shCanBeRunCaption.Text);
+            MessageBox.Show(this, string.Format(_shCanBeRun.Text, AppSettings.GitBinDir), _shCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             ////GitBinPath.Text = Settings.GitBinDir;
             PageHost.LoadAll(); // apply settings to dialog controls (otherwise the later called SaveAndRescan_Click would overwrite settings again)
             SaveAndRescan_Click(null, null);
@@ -256,7 +256,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                         }
                         else
                         {
-                            MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx64Name));
+                            MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx64Name), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                 }
@@ -267,7 +267,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             else
             {
-                MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx32Name));
+                MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx32Name), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             CheckSettings();
@@ -313,13 +313,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             if (!CheckSettingsLogic.SolveGitCommand())
             {
-                MessageBox.Show(this, _solveGitCommandFailed.Text, _solveGitCommandFailedCaption.Text);
+                MessageBox.Show(this, _solveGitCommandFailed.Text, _solveGitCommandFailedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                 PageHost.GotoPage(GitSettingsPage.GetPageReference());
                 return;
             }
 
-            MessageBox.Show(this, string.Format(_gitCanBeRun.Text, AppSettings.GitCommandValue), _gitCanBeRunCaption.Text);
+            MessageBox.Show(this, string.Format(_gitCanBeRun.Text, AppSettings.GitCommandValue), _gitCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
             PageHost.GotoPage(GitSettingsPage.GetPageReference());
             SaveAndRescan_Click(null, null);
@@ -359,7 +359,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     }
                     catch (Exception e)
                     {
-                        MessageBox.Show(this, e.Message);
+                        MessageBox.Show(this, e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -88,7 +88,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public void ShowIfUserWant()
         {
             if (MessageBox.Show(string.Format(_gitGlobalConfigNotFound.Text, Environment.GetEnvironmentVariable("HOME")),
-                     _gitGlobalConfigNotFoundCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
+                     _gitGlobalConfigNotFoundCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Error) == DialogResult.Yes)
             {
                 ShowDialog();
             }
@@ -139,7 +139,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 string userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
                 if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Combine(userHomeDir, ".gitconfig")))
                 {
-                    MessageBox.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir));
+                    MessageBox.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     defaultHome.Checked = true;
                     return;
                 }
@@ -157,7 +157,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                            Environment.GetEnvironmentVariable("HOMEPATH");
                 if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
-                    MessageBox.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path));
+                    MessageBox.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     defaultHome.Checked = true;
                     return;
                 }
@@ -174,7 +174,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 var path = Environment.GetEnvironmentVariable("USERPROFILE");
                 if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
-                    MessageBox.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path));
+                    MessageBox.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     userprofileHome.Checked = true;
                     return;
                 }
@@ -191,7 +191,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 var path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
-                    MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)));
+                    MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
+                        "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     otherHome.Checked = true;
                     otherHomeDir.Text = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 }
@@ -210,7 +211,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 if (string.IsNullOrEmpty(otherHomeDir.Text))
                 {
-                    MessageBox.Show(this, _noHomeDirectorySpecified.Text);
+                    MessageBox.Show(this, _noHomeDirectorySpecified.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -227,7 +228,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             string path = Environment.GetEnvironmentVariable("HOME");
             if (!Directory.Exists(path) || string.IsNullOrEmpty(path))
             {
-                MessageBox.Show(this, string.Format(_homeNotAccessible.Text, path));
+                MessageBox.Show(this, string.Format(_homeNotAccessible.Text, path), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                 return;
             }

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
         {
             if (string.IsNullOrEmpty(Directory.Text) || string.IsNullOrEmpty(LocalPath.Text))
             {
-                MessageBox.Show(this, _remoteAndLocalPathRequired.Text, Text);
+                MessageBox.Show(this, _remoteAndLocalPathRequired.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             if (e.ColumnIndex == 5)
             {
                 if (AppSettings.DontConfirmSwitchWorktree || MessageBox.Show(this,
-                        _switchWorktreeText.Text, _switchWorktreeTitle.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
+                        _switchWorktreeText.Text, _switchWorktreeTitle.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     if (Directory.Exists(workTree.Path))
                     {
@@ -233,7 +233,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 }
 
                 if (MessageBox.Show(this, _deleteWorktreeText.Text, _deleteWorktreeTitle.Text,
-                        MessageBoxButtons.YesNo) == DialogResult.Yes)
+                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
                 {
                     if (Directory.Exists(workTree.Path))
                     {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1462,7 +1462,7 @@ namespace GitUI.Editor
                 {
                     if (!MergeConflictHandler.HandleMergeConflicts(UICommands, this, false, false))
                     {
-                        MessageBox.Show(this, output + "\n\n" + Encoding.GetString(patch));
+                        MessageBox.Show(this, output + "\n\n" + Encoding.GetString(patch), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
             }

--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -344,11 +344,11 @@ namespace GitUI
 
             if (count == 0)
             {
-                MessageBox.Show(this, _noOccurrencesFoundString.Text);
+                MessageBox.Show(this, _noOccurrencesFoundString.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             else
             {
-                MessageBox.Show(this, string.Format(_replacedOccurrencesString.Text, count));
+                MessageBox.Show(this, string.Format(_replacedOccurrencesString.Text, count), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 Close();
             }
         }

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -710,7 +710,7 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
             catch (Exception /*ex*/)
             {
-                ////MessageBox.Show(ex.Message);
+                ////MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
             {
@@ -1086,7 +1086,7 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
             catch (Exception /*ex*/)
             {
-                ////MessageBox.Show(ex.Message);
+                ////MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
             {

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -710,7 +710,6 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
             catch (Exception /*ex*/)
             {
-                ////MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
             {
@@ -1086,7 +1085,6 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
             catch (Exception /*ex*/)
             {
-                ////MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
             {

--- a/GitUI/FilterRevisionsHelper.cs
+++ b/GitUI/FilterRevisionsHelper.cs
@@ -127,7 +127,7 @@ namespace GitUI
             }
             catch (InvalidOperationException ex)
             {
-                MessageBox.Show(_NO_TRANSLATE_form, ex.Message, "Filter error");
+                MessageBox.Show(_NO_TRANSLATE_form, ex.Message, "Filter error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 _NO_TRANSLATE_textBox.Text = "";
                 return;
             }

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -15,7 +15,11 @@ namespace GitUI
     {
         #region Translation
         private readonly TranslationString _fingerprintNotRegistredText =
-            new TranslationString("The fingerprint of this host is not registered by PuTTY." + Environment.NewLine + "This causes this process to hang, and that why it is automatically stopped." + Environment.NewLine + Environment.NewLine + "When the connection is opened detached from Git and Git Extensions, the host's fingerprint can be registered." + Environment.NewLine + "You could also manually add the host's fingerprint or run Test Connection from the remotes dialog." + Environment.NewLine + Environment.NewLine + "Do you want to register the host's fingerprint and restart the process?");
+            new TranslationString("The fingerprint of this host is not registered by PuTTY." + Environment.NewLine +
+                "This causes this process to hang, and that why it is automatically stopped." + Environment.NewLine + Environment.NewLine +
+                "When the connection is opened detached from Git and Git Extensions, the host's fingerprint can be registered." + Environment.NewLine +
+                "You could also manually add the host's fingerprint or run Test Connection from the remotes dialog." + Environment.NewLine + Environment.NewLine +
+                "Do you want to register the host's fingerprint and restart the process?");
         private readonly TranslationString _fingerprintNotRegistredTextCaption =
             new TranslationString("Host Fingerprint not registered");
         #endregion
@@ -156,7 +160,7 @@ namespace GitUI
         {
             if (Plink && e.Text.Contains("If you trust this host, enter \"y\" to add the key to"))
             {
-                if (MessageBox.Show(this, _fingerprintNotRegistredText.Text, _fingerprintNotRegistredTextCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
+                if (MessageBox.Show(this, _fingerprintNotRegistredText.Text, _fingerprintNotRegistredTextCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
                 {
                     string remoteUrl;
                     if (string.IsNullOrEmpty(_urlTryingToConnect))

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -15,11 +15,13 @@ namespace GitUI
     {
         #region Translation
         private readonly TranslationString _fingerprintNotRegistredText =
-            new TranslationString("The fingerprint of this host is not registered by PuTTY." + Environment.NewLine +
-                "This causes this process to hang, and that why it is automatically stopped." + Environment.NewLine + Environment.NewLine +
-                "When the connection is opened detached from Git and Git Extensions, the host's fingerprint can be registered." + Environment.NewLine +
-                "You could also manually add the host's fingerprint or run Test Connection from the remotes dialog." + Environment.NewLine + Environment.NewLine +
-                "Do you want to register the host's fingerprint and restart the process?");
+            new TranslationString(@"The fingerprint of this host is not registered by PuTTY.
+This causes this process to hang, and that why it is automatically stopped.
+
+When the connection is opened detached from Git and Git Extensions, the host's fingerprint can be registered.
+You could also manually add the host's fingerprint or run Test Connection from the remotes dialog.
+
+Do you want to register the host's fingerprint and restart the process?");
         private readonly TranslationString _fingerprintNotRegistredTextCaption =
             new TranslationString("Host Fingerprint not registered");
         #endregion

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -180,7 +180,7 @@ namespace GitUI
             var objectId = Module.RevParse(branch);
             if (objectId == null)
             {
-                MessageBox.Show($"Branch \"{branch}\" could not be resolved.");
+                MessageBox.Show($"Branch \"{branch}\" could not be resolved.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -386,7 +386,7 @@ namespace GitUI
             var objectId = Module.RevParse(branch);
             if (objectId == null)
             {
-                MessageBox.Show($"Branch \"{branch}\" could not be resolved.");
+                MessageBox.Show($"Branch \"{branch}\" could not be resolved.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -1183,14 +1183,14 @@ namespace GitUI
 
             if (!RevisionDiffInfoProvider.TryGet(revisions, diffKind, out var extraDiffArgs, out var firstRevision, out var secondRevision, out var error))
             {
-                MessageBox.Show(owner, error);
+                MessageBox.Show(owner, error, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
                 string output = Module.OpenWithDifftool(fileName, oldFileName, firstRevision, secondRevision, extraDiffArgs, isTracked);
                 if (!string.IsNullOrEmpty(output))
                 {
-                    MessageBox.Show(owner, output);
+                    MessageBox.Show(owner, output, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
@@ -1292,7 +1292,7 @@ namespace GitUI
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Exception");
+                MessageBox.Show(ex.Message, "Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return true;
@@ -1325,7 +1325,7 @@ namespace GitUI
                 {
                     MessageBox.Show(
                         string.Format("ERROR: {0} failed. Message: {1}\r\n\r\n{2}", name, ex.Message, ex.StackTrace),
-                        "Error! :(");
+                        "Error! :(", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
@@ -1358,7 +1358,7 @@ namespace GitUI
 
             if (relevantHosts.Count == 0)
             {
-                MessageBox.Show(owner, "Could not find any repo hosts for current working directory");
+                MessageBox.Show(owner, "Could not find any repo hosts for current working directory", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else if (relevantHosts.Count == 1)
             {
@@ -1366,7 +1366,7 @@ namespace GitUI
             }
             else
             {
-                MessageBox.Show("StartCreatePullRequest:Selection not implemented!");
+                MessageBox.Show("StartCreatePullRequest:Selection not implemented!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -1399,31 +1399,31 @@ namespace GitUI
 
             if (command == "blame" && args.Count <= 2)
             {
-                MessageBox.Show("Cannot open blame, there is no file selected.", "Blame");
+                MessageBox.Show("Cannot open blame, there is no file selected.", "Blame", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (command == "difftool" && args.Count <= 2)
             {
-                MessageBox.Show("Cannot open difftool, there is no file selected.", "Difftool");
+                MessageBox.Show("Cannot open difftool, there is no file selected.", "Difftool", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (command == "filehistory" && args.Count <= 2)
             {
-                MessageBox.Show("Cannot open file history, there is no file selected.", "File history");
+                MessageBox.Show("Cannot open file history, there is no file selected.", "File history", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (command == "fileeditor" && args.Count <= 2)
             {
-                MessageBox.Show("Cannot open file editor, there is no file selected.", "File editor");
+                MessageBox.Show("Cannot open file editor, there is no file selected.", "File editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (command == "revert" && args.Count <= 2)
             {
-                MessageBox.Show("Cannot open revert, there is no file selected.", "Revert");
+                MessageBox.Show("Cannot open revert, there is no file selected.", "Revert", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -48,22 +48,22 @@ namespace GitUI
 
         public static bool UnresolvedMergeConflicts(IWin32Window owner)
         {
-            return MessageBox.Show(owner, Instance._unresolvedMergeConflicts.Text, Instance._unresolvedMergeConflictsCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes;
+            return MessageBox.Show(owner, Instance._unresolvedMergeConflicts.Text, Instance._unresolvedMergeConflictsCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
         }
 
         public static bool MiddleOfRebase(IWin32Window owner)
         {
-            return MessageBox.Show(owner, Instance._middleOfRebase.Text, Instance._middleOfRebaseCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes;
+            return MessageBox.Show(owner, Instance._middleOfRebase.Text, Instance._middleOfRebaseCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
         }
 
         public static bool MiddleOfPatchApply(IWin32Window owner)
         {
-            return MessageBox.Show(owner, Instance._middleOfPatchApply.Text, Instance._middleOfPatchApplyCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes;
+            return MessageBox.Show(owner, Instance._middleOfPatchApply.Text, Instance._middleOfPatchApplyCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
         }
 
         public static void PAgentNotFound(IWin32Window owner)
         {
-            MessageBox.Show(owner, Instance._pageantNotFound.Text, _putty);
+            MessageBox.Show(owner, Instance._pageantNotFound.Text, _putty, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         public static bool CacheHostkey(IWin32Window owner)

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -185,7 +185,7 @@ namespace GitUI
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message);
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -50,7 +50,7 @@ namespace GitUI
                 var gitHead = _branchesToSelect.FirstOrDefault(g => g.Name == branch);
                 if (gitHead == null)
                 {
-                    MessageBox.Show(string.Format(_branchCheckoutError.Text, branch));
+                    MessageBox.Show(string.Format(_branchCheckoutError.Text, branch), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
                 else
                 {

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -35,7 +35,7 @@ namespace GitUI.UserControls
             if (SelectedObjectId == null && !commitHash.IsNullOrWhiteSpace())
             {
                 SelectedObjectId = oldCommitHash;
-                MessageBox.Show("The given commit hash is not valid for this repository and was therefore discarded.");
+                MessageBox.Show("The given commit hash is not valid for this repository and was therefore discarded.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             var isArtificialCommitForEmptyRepo = commitHash == "HEAD";

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -90,7 +90,7 @@ namespace GitUI
 
             if (string.IsNullOrEmpty(patchFile.FullName))
             {
-                MessageBox.Show(_unableToShowPatchDetails.Text);
+                MessageBox.Show(_unableToShowPatchDetails.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1830,7 +1830,7 @@ namespace GitUI
             var selectedRevisions = GetSelectedRevisions();
             if (selectedRevisions.Count > 2)
             {
-                MessageBox.Show(this, "Select only one or two revisions. Abort.", "Archive revision");
+                MessageBox.Show(this, "Select only one or two revisions. Abort.", "Archive revision", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2249,7 +2249,7 @@ namespace GitUI
         {
             if (_revisionReader != null)
             {
-                MessageBox.Show(_cannotHighlightSelectedBranch.Text);
+                MessageBox.Show(_cannotHighlightSelectedBranch.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2321,7 +2321,7 @@ namespace GitUI
             var mergeBaseCommitId = UICommands.GitModule.GitExecutable.GetOutput(args).TrimEnd('\n');
             if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
             {
-                MessageBox.Show(_noMergeBaseCommit.Text);
+                MessageBox.Show(_noMergeBaseCommit.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2364,7 +2364,7 @@ namespace GitUI
             }
             else if (showNoRevisionMsg)
             {
-                MessageBox.Show(ParentForm as IWin32Window ?? this, _noRevisionFoundError.Text);
+                MessageBox.Show(ParentForm as IWin32Window ?? this, _noRevisionFoundError.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2412,7 +2412,7 @@ namespace GitUI
             var headBranch = Module.GetSelectedBranch(setDefaultIfEmpty: false);
             if (headBranch.IsNullOrWhiteSpace())
             {
-                MessageBox.Show(this, "No branch is currently selected");
+                MessageBox.Show(this, "No branch is currently selected", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2459,7 +2459,7 @@ namespace GitUI
 
             if (baseCommit.ObjectId == ObjectId.WorkTreeId)
             {
-                MessageBox.Show(this, "Cannot diff working directory to itself");
+                MessageBox.Show(this, "Cannot diff working directory to itself", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2474,7 +2474,7 @@ namespace GitUI
                 .FirstOrDefault();
             if (headCommit == null || baseCommit == null)
             {
-                MessageBox.Show(this, "You must have two commits selected to compare");
+                MessageBox.Show(this, "You must have two commits selected to compare", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2628,7 +2628,7 @@ namespace GitUI
                 if (fileNameArray.Length > 10)
                 {
                     // Some users need to be protected against themselves!
-                    MessageBox.Show(this, _droppingFilesBlocked.Text);
+                    MessageBox.Show(this, _droppingFilesBlocked.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -138,7 +138,7 @@ namespace GitUI.UserControls.RevisionGrid
                     Name = "QuickSearch",
                     Text = "Quick search",
                     ToolTipText = _quickSearchQuickHelp.Text,
-                    ExecuteAction = () => MessageBox.Show(_quickSearchQuickHelp.Text)
+                    ExecuteAction = () => MessageBox.Show(_quickSearchQuickHelp.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information)
                 },
                 new MenuCommand
                 {
@@ -417,7 +417,7 @@ namespace GitUI.UserControls.RevisionGrid
                 }
                 else
                 {
-                    MessageBox.Show(_revisionGrid, _noRevisionFoundError.Text);
+                    MessageBox.Show(_revisionGrid, _noRevisionFoundError.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
@@ -79,7 +79,8 @@ namespace AutoCompileSubmodules
                                       solutionFile.Name,
                                       SolutionFilesToString(solutionFiles)),
                         "Build",
-                        MessageBoxButtons.YesNoCancel);
+                        MessageBoxButtons.YesNoCancel,
+                        MessageBoxIcon.Question);
 
                 if (result == DialogResult.Cancel)
                 {
@@ -93,7 +94,7 @@ namespace AutoCompileSubmodules
 
                 if (string.IsNullOrEmpty(msbuildPath) || !File.Exists(msbuildPath))
                 {
-                    MessageBox.Show(args.OwnerForm, _enterCorrectMsBuildPath.Text);
+                    MessageBox.Show(args.OwnerForm, _enterCorrectMsBuildPath.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
                 else
                 {

--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -33,7 +33,7 @@ namespace Bitbucket
                                 _yourRepositoryIsNotInBitbucket.Text,
                                 string.Empty,
                                 MessageBoxButtons.OK,
-                                MessageBoxIcon.Exclamation);
+                                MessageBoxIcon.Error);
                 return false;
             }
 

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -158,7 +158,7 @@ namespace Bitbucket
                 await this.SwitchToMainThreadAsync();
                 if (response.Success)
                 {
-                    MessageBox.Show(_success.Text);
+                    MessageBox.Show(_success.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     ReloadPullRequests();
                 }
                 else
@@ -355,7 +355,7 @@ namespace Bitbucket
                 var response = ThreadHelper.JoinableTaskFactory.Run(() => mergeRequest.SendAsync());
                 if (response.Success)
                 {
-                    MessageBox.Show(_success.Text);
+                    MessageBox.Show(_success.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     ReloadPullRequests();
                 }
                 else
@@ -384,7 +384,7 @@ namespace Bitbucket
                 var response = ThreadHelper.JoinableTaskFactory.Run(() => approveRequest.SendAsync());
                 if (response.Success)
                 {
-                    MessageBox.Show(_success.Text);
+                    MessageBox.Show(_success.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     ReloadPullRequests();
                 }
                 else

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -143,14 +143,14 @@ namespace AzureDevOpsIntegration.Settings
                     }
                     catch (Exception)
                     {
-                        MessageBox.Show(_failToLoadBuildDefinitionInfoMessage.Text, _failToExtractDataFromClipboardCaption.Text);
+                        MessageBox.Show(_failToLoadBuildDefinitionInfoMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }
                 }
                 else
                 {
                     buildDefinitionName = "";
-                    MessageBox.Show(_infoNoApiTokenMessage.Text, _failToExtractDataFromClipboardCaption.Text);
+                    MessageBox.Show(_infoNoApiTokenMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
 
                 _currentSettings.ProjectUrl = projectUrl;
@@ -159,7 +159,7 @@ namespace AzureDevOpsIntegration.Settings
             }
             else
             {
-                MessageBox.Show(_failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text);
+                MessageBox.Show(_failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
     }

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
@@ -26,7 +26,7 @@ namespace CreateLocalBranches
 
             if (references.Length == 0)
             {
-                MessageBox.Show(this, "No remote branches found.");
+                MessageBox.Show(this, "No remote branches found.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.Cancel;
                 return;
             }
@@ -53,8 +53,8 @@ namespace CreateLocalBranches
                 }
             }
 
-            MessageBox.Show(this, string.Format("{0} local tracking branches have been created/updated.",
-                                          references.Length));
+            MessageBox.Show(this, string.Format("{0} local tracking branches have been created/updated.", references.Length),
+                "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
             Close();
         }
     }

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -153,11 +153,11 @@ namespace DeleteUnusedBranches
             var selectedBranches = _branches.Where(branch => branch.Delete).ToList();
             if (selectedBranches.Count == 0)
             {
-                MessageBox.Show(string.Format(_selectBranchesToDelete.Text, _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderText), _deleteCaption.Text);
+                MessageBox.Show(string.Format(_selectBranchesToDelete.Text, _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderText), _deleteCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            if (MessageBox.Show(this, string.Format(_areYouSureToDelete.Text, selectedBranches.Count), _deleteCaption.Text, MessageBoxButtons.YesNo) != DialogResult.Yes)
+            if (MessageBox.Show(this, string.Format(_areYouSureToDelete.Text, selectedBranches.Count), _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
             {
                 return;
             }
@@ -172,7 +172,7 @@ namespace DeleteUnusedBranches
             if (remoteBranches.Count > 0)
             {
                 var message = string.Format(_dangerousAction.Text, remoteName);
-                if (MessageBox.Show(this, message, _deleteCaption.Text, MessageBoxButtons.YesNo) != DialogResult.Yes)
+                if (MessageBox.Show(this, message, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
                 {
                     return;
                 }
@@ -231,7 +231,7 @@ namespace DeleteUnusedBranches
 
             if (includeUnmergedBranches.Checked)
             {
-                MessageBox.Show(this, _deletingUnmergedBranches.Text, _deleteCaption.Text, MessageBoxButtons.OK);
+                MessageBox.Show(this, _deletingUnmergedBranches.Text, _deleteCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -204,7 +204,7 @@ namespace FindLargeFiles
 
         private void Delete_Click(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, _areYouSureToDelete.Text, _deleteCaption.Text, MessageBoxButtons.YesNo) == DialogResult.Yes)
+            if (MessageBox.Show(this, _areYouSureToDelete.Text, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
                 var sb = new StringBuilder();
                 foreach (GitObject gitObject in _gitObjects.Where(gitObject => gitObject.Delete))

--- a/Plugins/Gerrit/FormGerritDownload.cs
+++ b/Plugins/Gerrit/FormGerritDownload.cs
@@ -48,13 +48,13 @@ namespace Gerrit
 
             if (string.IsNullOrEmpty(_NO_TRANSLATE_Remotes.Text))
             {
-                MessageBox.Show(owner, _selectRemote.Text);
+                MessageBox.Show(owner, _selectRemote.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
             if (string.IsNullOrEmpty(change))
             {
-                MessageBox.Show(owner, _selectChange.Text);
+                MessageBox.Show(owner, _selectChange.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -65,7 +65,7 @@ namespace Gerrit
 
             if (reviewInfo?["id"] == null)
             {
-                MessageBox.Show(owner, _cannotGetChangeDetails.Text);
+                MessageBox.Show(owner, _cannotGetChangeDetails.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -70,13 +70,13 @@ namespace Gerrit
 
             if (string.IsNullOrEmpty(_NO_TRANSLATE_Remotes.Text))
             {
-                MessageBox.Show(owner, _selectRemote.Text);
+                MessageBox.Show(owner, _selectRemote.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
             if (string.IsNullOrEmpty(branch))
             {
-                MessageBox.Show(owner, _selectBranch.Text);
+                MessageBox.Show(owner, _selectBranch.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/Plugins/Gerrit/FormGitReview.cs
+++ b/Plugins/Gerrit/FormGitReview.cs
@@ -106,7 +106,7 @@ namespace Gerrit
             catch (Exception ex)
             {
                 MessageBox.Show(this, _cannotAccessGitreview.Text + Environment.NewLine + ex.Message,
-                    _cannotAccessGitreviewCaption.Text);
+                    _cannotAccessGitreviewCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
         }
@@ -139,7 +139,7 @@ namespace Gerrit
                 return;
             }
 
-            MessageBox.Show(this, _gitreviewOnlyInWorkingDirSupported.Text, _gitreviewOnlyInWorkingDirSupportedCaption.Text);
+            MessageBox.Show(this, _gitreviewOnlyInWorkingDirSupported.Text, _gitreviewOnlyInWorkingDirSupportedCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
         }
 

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -39,7 +39,6 @@ namespace GitHub3
                     if (user != null)
                     {
                         _username = user.Login;
-                        ////MessageBox.Show("GitHub username: " + _username);
                         return _username;
                     }
                     else
@@ -127,7 +126,7 @@ namespace GitHub3
             }
             else
             {
-                MessageBox.Show(args.OwnerForm, _tokenAlreadyExist.Text);
+                MessageBox.Show(args.OwnerForm, _tokenAlreadyExist.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return false;

--- a/Plugins/GitHub3/GitHubCredentialsPrompt.cs
+++ b/Plugins/GitHub3/GitHubCredentialsPrompt.cs
@@ -40,7 +40,7 @@ namespace GitHub3
             {
                 GitHubLoginInfo.OAuthToken = token;
 
-                MessageBox.Show(this, _generationSucceed.Text, Text);
+                MessageBox.Show(this, _generationSucceed.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 DialogResult = DialogResult.OK;
                 Close();
             }

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -56,7 +56,7 @@ namespace Gource
         {
             if (!args.GitModule.IsValidGitWorkingDir())
             {
-                MessageBox.Show(args.OwnerForm, _currentDirectoryIsNotValidGit.Text);
+                MessageBox.Show(args.OwnerForm, _currentDirectoryIsNotValidGit.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -66,7 +66,7 @@ namespace Gource
             {
                 var result = MessageBox.Show(
                     args.OwnerForm,
-                    string.Format(_resetConfigPath.Text, pathToGource), _gource.Text, MessageBoxButtons.YesNo);
+                    string.Format(_resetConfigPath.Text, pathToGource), _gource.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
                 if (result == DialogResult.Yes)
                 {
@@ -79,13 +79,13 @@ namespace Gource
             {
                 if (MessageBox.Show(
                         args.OwnerForm, _doYouWantDownloadGource.Text, _download.Text,
-                        MessageBoxButtons.YesNo) == DialogResult.Yes)
+                        MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
                 {
                     var gourceUrl = SearchForGourceUrl();
 
                     if (string.IsNullOrEmpty(gourceUrl))
                     {
-                        MessageBox.Show(args.OwnerForm, _cannotFindGource.Text);
+                        MessageBox.Show(args.OwnerForm, _cannotFindGource.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return false;
                     }
 
@@ -94,20 +94,20 @@ namespace Gource
                     var downloadSize = DownloadFile(gourceUrl, fileName);
                     if (downloadSize > 0)
                     {
-                        MessageBox.Show(string.Format(_bytesDownloaded.Text, downloadSize));
+                        MessageBox.Show(string.Format(_bytesDownloaded.Text, downloadSize), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         Directory.CreateDirectory(Path.Combine(downloadDir, "gource"));
                         UnZipFiles(fileName, Path.Combine(downloadDir, "gource"), true);
 
                         var newGourcePath = Path.Combine(downloadDir, "gource\\gource.exe");
                         if (File.Exists(newGourcePath))
                         {
-                            MessageBox.Show(args.OwnerForm, _gourceDownloadedAndUnzipped.Text);
+                            MessageBox.Show(args.OwnerForm, _gourceDownloadedAndUnzipped.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                             pathToGource = newGourcePath;
                         }
                     }
                     else
                     {
-                        MessageBox.Show(args.OwnerForm, _downloadingFailed.Text);
+                        MessageBox.Show(args.OwnerForm, _downloadingFailed.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
             }
@@ -173,7 +173,7 @@ namespace Gource
             }
             catch (Exception e)
             {
-                MessageBox.Show(e.Message);
+                MessageBox.Show(e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -222,7 +222,7 @@ namespace Gource
             }
             catch (Exception e)
             {
-                MessageBox.Show(e.Message);
+                MessageBox.Show(e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
             {
@@ -272,7 +272,7 @@ namespace Gource
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Exception");
+                MessageBox.Show(ex.Message, "Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return string.Empty;
             }
         }

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -50,7 +50,7 @@ namespace Gource
             }
             catch (Exception e)
             {
-                MessageBox.Show(this, e.Message);
+                MessageBox.Show(this, e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -58,7 +58,7 @@ namespace Gource
         {
             if (!File.Exists(GourcePath.Text))
             {
-                MessageBox.Show(this, "Cannot find Gource.\nPlease download Gource and set the correct path.");
+                MessageBox.Show(this, "Cannot find Gource.\nPlease download Gource and set the correct path.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -71,7 +71,7 @@ namespace JiraCommitHintPlugin
                 {
                     var message = await GetMessageToCommitAsync(_jira, _query, _stringTemplate);
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    MessageBox.Show(string.Join(Environment.NewLine, message.Select(jt => jt.Text).ToArray()));
+                    MessageBox.Show(string.Join(Environment.NewLine, message.Select(jt => jt.Text).ToArray()), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 });
 
             return false;
@@ -152,14 +152,14 @@ namespace JiraCommitHintPlugin
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         var preview = message.FirstOrDefault();
 
-                        MessageBox.Show(null, preview == null ? EmptyQueryResultMessage.Text : preview.Text, EmptyQueryResultCaption.Text);
+                        MessageBox.Show(null, preview == null ? EmptyQueryResultMessage.Text : preview.Text, EmptyQueryResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                         _btnPreview.Enabled = true;
                     });
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.ToString());
+                MessageBox.Show(ex.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 _btnPreview.Enabled = true;
             }
         }

--- a/Plugins/ProxySwitcher/ProxySwitcherForm.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherForm.cs
@@ -45,7 +45,7 @@ namespace ProxySwitcher
         {
             if (string.IsNullOrEmpty(_plugin.HttpProxy.ValueOrDefault(_settings)))
             {
-                MessageBox.Show(this, _pleaseSetProxy.Text, Text, MessageBoxButtons.OK);
+                MessageBox.Show(this, _pleaseSetProxy.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Close();
             }
             else

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -48,14 +48,14 @@ namespace ReleaseNotesGenerator
 
             if (string.IsNullOrWhiteSpace(textBoxRevFrom.Text))
             {
-                MessageBox.Show(this, _fromCommitNotSpecified.Text, _caption.Text);
+                MessageBox.Show(this, _fromCommitNotSpecified.Text, _caption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 textBoxRevFrom.Focus();
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_textBoxRevTo.Text))
             {
-                MessageBox.Show(this, _toCommitNotSpecified.Text, _caption.Text);
+                MessageBox.Show(this, _toCommitNotSpecified.Text, _caption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 _NO_TRANSLATE_textBoxRevTo.Focus();
                 return;
             }


### PR DESCRIPTION
Fixes #7312

## Proposed changes

- Add icon to all MessageBox that miss icon
- When MessageBox has button Yes/No/Cancel, it's always a question even if the message appears in case of error
- To add icon, I need to add a title to MessageBox. This new title is not translated and is "Error" or "Information"
- There's some MessageBox that just show return string from external application. The message could be normal message or error message. Because I don't know if it's an error or a normal message, I put a Information icon.
- I really tried MessageBox only on two cases where I doubt if it should be Information or Error. For the other 99% MessageBox, I decided Icon message only by reading source code.

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
