### PR TITLE
Fix 7097: Invalid escape character in .gitmodule leads to crash

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -33,8 +33,7 @@ namespace GitCommands.Config
             }
             catch (Exception ex)
             {
-                ex.Data.Add(GetType().Name + ".Load", "Could not load config file: " + FileName);
-                throw;
+                throw new GitCommands.Config.GitConfigurationException(fileName, ex);
             }
         }
 
@@ -415,7 +414,6 @@ namespace GitCommands.Config
             {
                 if (_escapedValue)
                 {
-                    // TODO: case 'b' is valid, according to https://git-scm.com/docs/git-config#_syntax
                     switch (c)
                     {
                         case '\\':

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -415,6 +415,7 @@ namespace GitCommands.Config
             {
                 if (_escapedValue)
                 {
+                    // TODO: case 'b' is valid, according to https://git-scm.com/docs/git-config#_syntax
                     switch (c)
                     {
                         case '\\':

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -33,7 +33,7 @@ namespace GitCommands.Config
             }
             catch (Exception ex)
             {
-                throw new GitCommands.Config.GitConfigurationException(fileName, ex);
+                throw new GitConfigurationException(fileName, ex);
             }
         }
 

--- a/GitCommands/Config/GitConfigurationException.cs
+++ b/GitCommands/Config/GitConfigurationException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace GitCommands.Config
+{
+    public class GitConfigurationException : Exception
+    {
+        public GitConfigurationException(string configPath, Exception inner) : base(null, inner)
+        {
+            if (string.IsNullOrWhiteSpace(configPath))
+            {
+                throw new ArgumentException("ConfigPath is required", nameof(configPath));
+            }
+
+            ConfigPath = configPath;
+        }
+
+        public string ConfigPath { get; }
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -454,6 +454,10 @@ namespace GitCommands
             List<string> GetSubmodulePaths(GitModule module)
             {
                 var configFile = module.GetSubmoduleConfigFile();
+                if (configFile == null)
+                {
+                    return new List<string>();
+                }
 
                 return configFile.ConfigSections
                     .Select(section => section.GetValue("path").Trim())
@@ -1208,9 +1212,19 @@ namespace GitCommands
             }
         }
 
+        [CanBeNull]
         public ConfigFile GetSubmoduleConfigFile()
         {
-            return new ConfigFile(WorkingDir + ".gitmodules", true);
+            try
+            {
+                return new ConfigFile(WorkingDir + ".gitmodules", true);
+            }
+            catch (Exception ex)
+            {
+                ExceptionUtils.ShowException(ex, false);
+            }
+
+            return null;
         }
 
         [CanBeNull]
@@ -1257,6 +1271,10 @@ namespace GitCommands
             string lastLine = null;
 
             var configFile = GetSubmoduleConfigFile();
+            if (configFile == null)
+            {
+                yield break;
+            }
 
             foreach (var line in lines)
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -451,17 +451,12 @@ namespace GitCommands
                 }
             }
 
-            List<string> GetSubmodulePaths(GitModule module)
+            IEnumerable<string> GetSubmodulePaths(GitModule module)
             {
-                var configFile = module.GetSubmoduleConfigFile();
-                if (configFile == null)
-                {
-                    return new List<string>();
-                }
+                ConfigFile configFile = module.GetSubmoduleConfigFile();
 
                 return configFile.ConfigSections
-                    .Select(section => section.GetValue("path").Trim())
-                    .ToList();
+                    .Select(section => section.GetValue("path").Trim());
             }
         }
 
@@ -1212,19 +1207,9 @@ namespace GitCommands
             }
         }
 
-        [CanBeNull]
         public ConfigFile GetSubmoduleConfigFile()
         {
-            try
-            {
-                return new ConfigFile(WorkingDir + ".gitmodules", true);
-            }
-            catch (Exception ex)
-            {
-                ExceptionUtils.ShowException(ex, false);
-            }
-
-            return null;
+            return new ConfigFile(WorkingDir + ".gitmodules", true);
         }
 
         [CanBeNull]

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -71,6 +71,7 @@
     <Compile Include="CommitDataManager.cs" />
     <Compile Include="CommitTemplateItem.cs" />
     <Compile Include="CommitTemplateManager.cs" />
+    <Compile Include="Config\GitConfigurationException.cs" />
     <Compile Include="Config\SettingKeyString.cs" />
     <Compile Include="DateTimeExtensions.cs" />
     <Compile Include="DateTimeUtils.cs" />

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -116,8 +115,8 @@ namespace GitCommands.Submodules
 
                 if (_gitStatusWhileUpdatingStructure != null)
                 {
-                    // Current module must be updated separetly (not in _submoduleInfos)
-                    await UpdateSubmodulesStatusInternalAsync(currentModule, _gitStatusWhileUpdatingStructure, cancelToken);
+                    // Current module must be updated separately (not in _submoduleInfos)
+                    await UpdateSubmodulesStatusAsync(currentModule, _gitStatusWhileUpdatingStructure, cancelToken);
                 }
 
                 OnStatusUpdated(result, cancelToken);
@@ -148,7 +147,7 @@ namespace GitCommands.Submodules
             await TaskScheduler.Default;
 
             var currentModule = new GitModule(workingDirectory);
-            await UpdateSubmodulesStatusInternalAsync(currentModule, gitStatus, cancelToken);
+            await UpdateSubmodulesStatusAsync(currentModule, gitStatus, cancelToken);
 
             OnStatusUpdated(_submoduleInfoResult, cancelToken);
         }
@@ -223,7 +222,7 @@ namespace GitCommands.Submodules
             {
                 var localPath = superprojectModule.WorkingDir.Substring(topProject.WorkingDir.Length);
                 name = Path.GetDirectoryName(localPath).ToPosixPath();
-             }
+            }
 
             string path = superprojectModule.WorkingDir;
             name += GetBranchNameSuffix(path, noBranchText);
@@ -300,7 +299,7 @@ namespace GitCommands.Submodules
         /// <param name="gitStatus">git status</param>
         /// <param name="cancelToken">Cancellation token</param>
         /// <returns>The task</returns>
-        private async Task UpdateSubmodulesStatusInternalAsync(GitModule module, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus, CancellationToken cancelToken)
+        private async Task UpdateSubmodulesStatusAsync(GitModule module, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus, CancellationToken cancelToken)
         {
             _previousSubmoduleUpdateTime = DateTime.Now;
             await TaskScheduler.Default;

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -37,8 +37,11 @@ namespace GitExtensions
             {
                 DiagnosticsClient.Initialize(ThisAssembly.Git.IsDirty);
 
-                AppDomain.CurrentDomain.UnhandledException += (s, e) => UncaughtExceptionHandler((Exception)e.ExceptionObject);
-                Application.ThreadException += (s, e) => UncaughtExceptionHandler(e.Exception);
+                if (!Debugger.IsAttached)
+                {
+                    AppDomain.CurrentDomain.UnhandledException += (s, e) => ReportBug((Exception)e.ExceptionObject);
+                    Application.ThreadException += (s, e) => ReportBug(e.Exception);
+                }
             }
             catch (TypeInitializationException tie)
             {
@@ -320,22 +323,6 @@ namespace GitExtensions
                     {
                         return false;
                     }
-            }
-        }
-
-        private static void UncaughtExceptionHandler(Exception ex)
-        {
-            if (ex is GitCommands.Config.GitConfigurationException)
-            {
-                var configEx = (GitCommands.Config.GitConfigurationException)ex;
-                string message = string.Format(Strings.GeneralGitConfigExceptionMessage, configEx.ConfigPath, Environment.NewLine, configEx.InnerException.Message);
-                MessageBox.Show(message, Strings.GeneralGitConfigExceptionCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Environment.Exit(-1);
-            }
-
-            if (!Debugger.IsAttached)
-            {
-                ReportBug(ex);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2372,6 +2372,10 @@ namespace GitUI.CommandsDialogs
             var stagedFiles = Staged.AllItems;
 
             var configFile = Module.GetSubmoduleConfigFile();
+            if (configFile == null)
+            {
+                return;
+            }
 
             Dictionary<string, string> modules = stagedFiles
                 .Where(item => item.IsSubmodule)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2371,9 +2371,14 @@ namespace GitUI.CommandsDialogs
         {
             var stagedFiles = Staged.AllItems;
 
-            var configFile = Module.GetSubmoduleConfigFile();
-            if (configFile == null)
+            ConfigFile configFile;
+            try
             {
+                configFile = Module.GetSubmoduleConfigFile();
+            }
+            catch (GitConfigurationException ex)
+            {
+                MessageBox.Show(this, ex.Message, "Failed to parse " + ex.ConfigPath, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -147,6 +147,11 @@ namespace GitUI.CommandsDialogs
                 Module.UnstageFile(SubModuleLocalPath.Text);
 
                 var modules = Module.GetSubmoduleConfigFile();
+                if (modules == null)
+                {
+                    return;
+                }
+
                 modules.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
                 if (modules.ConfigSections.Count > 0)
                 {

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs.SubmodulesDialog;
@@ -146,16 +147,21 @@ namespace GitUI.CommandsDialogs
             {
                 Module.UnstageFile(SubModuleLocalPath.Text);
 
-                var modules = Module.GetSubmoduleConfigFile();
-                if (modules == null)
+                ConfigFile configFile;
+                try
                 {
+                    configFile = Module.GetSubmoduleConfigFile();
+                }
+                catch (GitConfigurationException ex)
+                {
+                    MessageBox.Show(this, ex.Message, "Failed to parse " + ex.ConfigPath, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return;
                 }
 
-                modules.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
-                if (modules.ConfigSections.Count > 0)
+                configFile.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
+                if (configFile.ConfigSections.Count > 0)
                 {
-                    modules.Save();
+                    configFile.Save();
                     Module.StageFile(".gitmodules");
                 }
                 else
@@ -163,9 +169,9 @@ namespace GitUI.CommandsDialogs
                     Module.UnstageFile(".gitmodules");
                 }
 
-                var configFile = Module.LocalConfigFile;
-                configFile.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
-                configFile.Save();
+                var configFileSettings = Module.LocalConfigFile;
+                configFileSettings.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
+                configFileSettings.Save();
 
                 Initialize();
             }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9284,11 +9284,11 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_generalGitConfigExceptionCaption.Text">
-        <source>Error in Git configuration file</source>
+        <source>Configuration Error</source>
         <target />
       </trans-unit>
       <trans-unit id="_generalGitConfigExceptionMessage.Text">
-        <source>GitExtensions failed to read the Git configuration file "{0}" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and must be closed.  Please correct this issue and re-open GitExtensions.</source>
+        <source>Failed to read "{0}" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and must be closed.  Please correct this issue and re-open GitExtensions.</source>
         <target />
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9283,6 +9283,14 @@ Select this commit to populate the full message.</source>
         <source>Fork or clone a repository</source>
         <target />
       </trans-unit>
+      <trans-unit id="_generalGitConfigExceptionCaption.Text">
+        <source>Error in Git configuration file</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_generalGitConfigExceptionMessage.Text">
+        <source>GitExtensions failed to read the Git configuration file "{0}" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and must be closed.  Please correct this issue and re-open GitExtensions.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
         <source>The Git executable could not be located on your system.</source>
         <target />

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -43,8 +43,8 @@ Yes, I allow telemetry!");
         private readonly TranslationString _parentsText = new TranslationString("{0:Parent|Parents}");
         private readonly TranslationString _childrenText = new TranslationString("{0:Child|Children}");
 
-        private readonly TranslationString _generalGitConfigExceptionMessage = new TranslationString("GitExtensions failed to read the Git configuration file \"{0}\" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and must be closed.  Please correct this issue and re-open GitExtensions.");
-        private readonly TranslationString _generalGitConfigExceptionCaption = new TranslationString("Error in Git configuration file");
+        private readonly TranslationString _generalGitConfigExceptionMessage = new TranslationString("Failed to read \"{0}\" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and must be closed.  Please correct this issue and re-open GitExtensions.");
+        private readonly TranslationString _generalGitConfigExceptionCaption = new TranslationString("Configuration Error");
 
         // public only because of FormTranslate
         public Strings()

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -43,6 +43,9 @@ Yes, I allow telemetry!");
         private readonly TranslationString _parentsText = new TranslationString("{0:Parent|Parents}");
         private readonly TranslationString _childrenText = new TranslationString("{0:Child|Children}");
 
+        private readonly TranslationString _generalGitConfigExceptionMessage = new TranslationString("GitExtensions failed to read the Git configuration file \"{0}\" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and must be closed.  Please correct this issue and re-open GitExtensions.");
+        private readonly TranslationString _generalGitConfigExceptionCaption = new TranslationString("Error in Git configuration file");
+
         // public only because of FormTranslate
         public Strings()
         {
@@ -75,6 +78,9 @@ Yes, I allow telemetry!");
         public static string ShowAll => _instance.Value._showAllText.Text;
         public static string Workspace => _instance.Value._workspaceText.Text;
         public static string Index => _instance.Value._indexText.Text;
+
+        public static string GeneralGitConfigExceptionMessage => _instance.Value._generalGitConfigExceptionMessage.Text;
+        public static string GeneralGitConfigExceptionCaption => _instance.Value._generalGitConfigExceptionCaption.Text;
 
         public static string GetParents(int value)
         {

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using GitCommands;
 using GitCommands.Submodules;
 
@@ -6,12 +7,12 @@ namespace CommonTestUtils
 {
     public class SubmoduleTestHelpers
     {
-        public static SubmoduleInfoResult UpdateSubmoduleStructureAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        public static async Task<SubmoduleInfoResult> UpdateSubmoduleStructureAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
         {
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStructure(
+            await provider.UpdateSubmodulesStructureAsync(
                 workingDirectory: module.WorkingDir,
                 noBranchText: string.Empty,
                 updateStatus: updateStatus);
@@ -33,15 +34,13 @@ namespace CommonTestUtils
             List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStatus(
+            provider.UpdateSubmodulesStatusAsync(
                 workingDirectory: module.WorkingDir,
                 gitStatus: gitStatus);
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
             provider.StatusUpdated -= Provider_StatusUpdated;
-
-            return;
 
             void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
             {

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
 using GitCommands;
 using GitCommands.Submodules;
 
@@ -7,12 +6,12 @@ namespace CommonTestUtils
 {
     public class SubmoduleTestHelpers
     {
-        public static async Task<SubmoduleInfoResult> UpdateSubmoduleStructureAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        public static SubmoduleInfoResult UpdateSubmoduleStructureAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
         {
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            await provider.UpdateSubmodulesStructureAsync(
+            provider.UpdateSubmodulesStructure(
                 workingDirectory: module.WorkingDir,
                 noBranchText: string.Empty,
                 updateStatus: updateStatus);
@@ -34,13 +33,15 @@ namespace CommonTestUtils
             List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStatusAsync(
+            provider.UpdateSubmodulesStatus(
                 workingDirectory: module.WorkingDir,
                 gitStatus: gitStatus);
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
             provider.StatusUpdated -= Provider_StatusUpdated;
+
+            return;
 
             void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
             {

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GitCommands;
 using GitCommands.Submodules;
 using GitUI;
@@ -8,25 +9,15 @@ namespace CommonTestUtils
 {
     public class SubmoduleTestHelpers
     {
-        public static SubmoduleInfoResult UpdateSubmoduleStructureAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        public static async Task<SubmoduleInfoResult> UpdateSubmoduleStructureAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
         {
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            try
-            {
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-                {
-                    await provider.UpdateSubmodulesStructureAsync(
-                        workingDirectory: module.WorkingDir,
-                        noBranchText: string.Empty,
-                        updateStatus: updateStatus);
-                });
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            await provider.UpdateSubmodulesStructureAsync(
+                    workingDirectory: module.WorkingDir,
+                    noBranchText: string.Empty,
+                    updateStatus: updateStatus).ConfigureAwait(false);
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
@@ -40,24 +31,14 @@ namespace CommonTestUtils
             }
         }
 
-        public static void UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
+        public static async void UpdateSubmoduleStatusAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
         {
             List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            try
-            {
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-                {
-                    await provider.UpdateSubmodulesStatusAsync(
-                        workingDirectory: module.WorkingDir,
-                        gitStatus: gitStatus);
-                });
-            }
-            catch (Exception)
-            {
-                return;
-            }
+            await provider.UpdateSubmodulesStatusAsync(
+                    workingDirectory: module.WorkingDir,
+                    gitStatus: gitStatus);
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GitCommands;
 using GitCommands.Submodules;
+using GitUI;
 
 namespace CommonTestUtils
 {
@@ -11,10 +13,20 @@ namespace CommonTestUtils
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStructure(
-                workingDirectory: module.WorkingDir,
-                noBranchText: string.Empty,
-                updateStatus: updateStatus);
+            try
+            {
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await provider.UpdateSubmodulesStructureAsync(
+                        workingDirectory: module.WorkingDir,
+                        noBranchText: string.Empty,
+                        updateStatus: updateStatus);
+                });
+            }
+            catch (Exception)
+            {
+                return null;
+            }
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
@@ -33,9 +45,19 @@ namespace CommonTestUtils
             List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
             provider.StatusUpdated += Provider_StatusUpdated;
 
-            provider.UpdateSubmodulesStatus(
-                workingDirectory: module.WorkingDir,
-                gitStatus: gitStatus);
+            try
+            {
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await provider.UpdateSubmodulesStatusAsync(
+                        workingDirectory: module.WorkingDir,
+                        gitStatus: gitStatus);
+                });
+            }
+            catch (Exception)
+            {
+                return;
+            }
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -31,7 +31,7 @@ namespace CommonTestUtils
             }
         }
 
-        public static async void UpdateSubmoduleStatusAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
+        public static async Task UpdateSubmoduleStatusAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
         {
             List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
             provider.StatusUpdated += Provider_StatusUpdated;

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -65,6 +65,7 @@ namespace GitCommandsTests.Submodules
             public void UpdateSubmoduleStructure_valid_result_for_top_module()
             {
                 var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
+                result.Should().NotBeNull();
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(null);
@@ -78,6 +79,7 @@ namespace GitCommandsTests.Submodules
             public void UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
             {
                 var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo2Module, true);
+                result.Should().NotBeNull();
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(result.TopProject);
@@ -91,6 +93,7 @@ namespace GitCommandsTests.Submodules
             public void UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
             {
                 var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo3Module, true);
+                result.Should().NotBeNull();
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Path.Should().Be(_repo2Module.WorkingDir);
@@ -105,6 +108,7 @@ namespace GitCommandsTests.Submodules
             {
                 var currentModule = _repo1Module;
                 var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
+                result.Should().NotBeNull();
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
@@ -135,6 +139,7 @@ namespace GitCommandsTests.Submodules
             {
                 var currentModule = _repo2Module;
                 var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
+                result.Should().NotBeNull();
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -62,9 +62,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStructure_valid_result_for_top_module()
+            public async Task UpdateSubmoduleStructure_valid_result_for_top_module()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module).ConfigureAwait(false);
                 result.Should().NotBeNull();
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
@@ -76,9 +76,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
+            public async Task UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo2Module, true);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo2Module, true).ConfigureAwait(false);
                 result.Should().NotBeNull();
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
@@ -90,9 +90,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
+            public async Task UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo3Module, true);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo3Module, true).ConfigureAwait(false);
                 result.Should().NotBeNull();
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
@@ -104,23 +104,23 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void Submodule_status_changes_for_top_module()
+            public async Task Submodule_status_changes_for_top_module()
             {
                 var currentModule = _repo1Module;
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule).ConfigureAwait(false);
                 result.Should().NotBeNull();
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Make a change in repo2
                 _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(1);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
 
                 // Disabled test as the test case does not await async retrieval of submodule status
                 ////result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
@@ -130,42 +130,42 @@ namespace GitCommandsTests.Submodules
                 File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
             }
 
             [Test]
-            public void Submodule_status_changes_for_first_nested_module()
+            public async Task Submodule_status_changes_for_first_nested_module()
             {
                 var currentModule = _repo2Module;
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule).ConfigureAwait(false);
                 result.Should().NotBeNull();
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Make a change in repo1
                 _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Revert the change
                 File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Make a change in repo3
                 _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(1);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
 
                 // Fails, for same reason as previous test
                 ////result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
@@ -174,7 +174,7 @@ namespace GitCommandsTests.Submodules
                 File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
+                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
             }
 

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -62,9 +62,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public async Task UpdateSubmoduleStructure_valid_result_for_top_module()
+            public void UpdateSubmoduleStructure_valid_result_for_top_module()
             {
-                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(null);
@@ -75,9 +75,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public async Task UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
+            public void UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
             {
-                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo2Module, true);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo2Module, true);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(result.TopProject);
@@ -88,9 +88,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public async Task UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
+            public void UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
             {
-                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo3Module, true);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo3Module, true);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Path.Should().Be(_repo2Module.WorkingDir);
@@ -101,10 +101,10 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public async Task Submodule_status_changes_for_top_module()
+            public void Submodule_status_changes_for_top_module()
             {
                 var currentModule = _repo1Module;
-                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
@@ -131,10 +131,10 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public async Task Submodule_status_changes_for_first_nested_module()
+            public void Submodule_status_changes_for_first_nested_module()
             {
                 var currentModule = _repo2Module;
-                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -62,9 +62,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStructure_valid_result_for_top_module()
+            public async Task UpdateSubmoduleStructure_valid_result_for_top_module()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(null);
@@ -75,9 +75,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
+            public async Task UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo2Module, true);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo2Module, true);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Should().Be(result.TopProject);
@@ -88,9 +88,9 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
+            public async Task UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
             {
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo3Module, true);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo3Module, true);
 
                 result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
                 result.SuperProject.Path.Should().Be(_repo2Module.WorkingDir);
@@ -101,10 +101,10 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void Submodule_status_changes_for_top_module()
+            public async Task Submodule_status_changes_for_top_module()
             {
                 var currentModule = _repo1Module;
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
@@ -131,10 +131,10 @@ namespace GitCommandsTests.Submodules
             }
 
             [Test]
-            public void Submodule_status_changes_for_first_nested_module()
+            public async Task Submodule_status_changes_for_first_nested_module()
             {
                 var currentModule = _repo2Module;
-                var result = SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, currentModule);
+                var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
 
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -113,14 +113,14 @@ namespace GitCommandsTests.Submodules
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Make a change in repo2
                 _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(1);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
 
                 // Disabled test as the test case does not await async retrieval of submodule status
                 ////result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
@@ -130,7 +130,7 @@ namespace GitCommandsTests.Submodules
                 File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
             }
 
@@ -144,28 +144,28 @@ namespace GitCommandsTests.Submodules
                 // No changes in repo
                 var changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles).ConfigureAwait(false);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Make a change in repo1
                 _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles).ConfigureAwait(false);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Revert the change
                 File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles).ConfigureAwait(false);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
 
                 // Make a change in repo3
                 _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(1);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles).ConfigureAwait(false);
 
                 // Fails, for same reason as previous test
                 ////result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
@@ -174,7 +174,7 @@ namespace GitCommandsTests.Submodules
                 File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
                 changedFiles = GetStatusChangedFiles(currentModule);
                 changedFiles.Should().HaveCount(0);
-                SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+                await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles).ConfigureAwait(false);
                 result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
             }
 

--- a/UnitTests/GitUITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
@@ -83,10 +83,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void RepoObjectTree_should_show_all_submodules()
         {
             RunFormTest(
-                async (form) =>
+                form =>
                 {
                     // act
-                    await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module);
+                    SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
 
                     // assert
                     var submodulesNode = GetSubmoduleNode(form);

--- a/UnitTests/GitUITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
@@ -83,10 +83,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void RepoObjectTree_should_show_all_submodules()
         {
             RunFormTest(
-                form =>
+                async (form) =>
                 {
                     // act
-                    SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
+                    await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module);
 
                     // assert
                     var submodulesNode = GetSubmoduleNode(form);

--- a/UnitTests/GitUITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
@@ -83,10 +83,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         public void RepoObjectTree_should_show_all_submodules()
         {
             RunFormTest(
-                form =>
+                async form =>
                 {
                     // act
-                    SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResult(_provider, _repo1Module);
+                    await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module);
 
                     // assert
                     var submodulesNode = GetSubmoduleNode(form);


### PR DESCRIPTION
	- catch exceptions from the ConfigFileParser and display it using ExceptionUtils to prevent crashes

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7097


## Proposed changes

- catch exceptions from ConfigFileParser and use ExceptionUtils to display it
- return null ConfigFile reference to client code that relies on GetSubmoduleConfigFile


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before


![image](https://user-images.githubusercontent.com/14078392/67165850-f3d46c80-f357-11e9-9c51-663231543d8b.png)


### After

![image](https://user-images.githubusercontent.com/14078392/67165787-26ca3080-f357-11e9-85cc-236138981bde.png)



## Test methodology <!-- How did you ensure quality? -->

- built in Release
- interactive testing to ensure the error message would display to the user and not result in a crash
- reproduced the error pop-up in several worflows, such as the 'commit/staging' window, hitting the refresh button on the main branch-view/commit-log browsing window, and by hitting the diff tab on a commit that updated a submodule


## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.23.0.windows.1
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->
Sadly, the exceptions displayed do not have any translation capabilities at the moment.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
