### PR TITLE
Incorrect tab order on multiple settings pages #7301

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
@@ -97,7 +97,6 @@
             this.label56.TabIndex = 0;
             this.label56.Text = "Code font";
             this.label56.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
             // commitFontChangeButton
             // 
             this.commitFontChangeButton.AutoSize = true;
@@ -106,7 +105,7 @@
             this.commitFontChangeButton.Location = new System.Drawing.Point(91, 61);
             this.commitFontChangeButton.Name = "commitFontChangeButton";
             this.commitFontChangeButton.Size = new System.Drawing.Size(66, 23);
-            this.commitFontChangeButton.TabIndex = 5;
+            this.commitFontChangeButton.TabIndex = 2;
             this.commitFontChangeButton.Text = "font name";
             this.commitFontChangeButton.UseVisualStyleBackColor = true;
             this.commitFontChangeButton.Click += new System.EventHandler(this.commitFontChangeButton_Click);
@@ -119,7 +118,7 @@
             this.diffFontChangeButton.Location = new System.Drawing.Point(91, 3);
             this.diffFontChangeButton.Name = "diffFontChangeButton";
             this.diffFontChangeButton.Size = new System.Drawing.Size(66, 23);
-            this.diffFontChangeButton.TabIndex = 1;
+            this.diffFontChangeButton.TabIndex = 0;
             this.diffFontChangeButton.Text = "font name";
             this.diffFontChangeButton.UseVisualStyleBackColor = true;
             this.diffFontChangeButton.Click += new System.EventHandler(this.diffFontChangeButton_Click);
@@ -132,7 +131,7 @@
             this.applicationFontChangeButton.Location = new System.Drawing.Point(91, 32);
             this.applicationFontChangeButton.Name = "applicationFontChangeButton";
             this.applicationFontChangeButton.Size = new System.Drawing.Size(66, 23);
-            this.applicationFontChangeButton.TabIndex = 3;
+            this.applicationFontChangeButton.TabIndex = 1;
             this.applicationFontChangeButton.Text = "font name";
             this.applicationFontChangeButton.UseVisualStyleBackColor = true;
             this.applicationFontChangeButton.Click += new System.EventHandler(this.applicationFontChangeButton_Click);
@@ -178,10 +177,10 @@
             this.monospaceFontChangeButton.Location = new System.Drawing.Point(91, 61);
             this.monospaceFontChangeButton.Name = "monospaceFontChangeButton";
             this.monospaceFontChangeButton.Size = new System.Drawing.Size(66, 23);
-            this.monospaceFontChangeButton.TabIndex = 6;
             this.monospaceFontChangeButton.Text = "font name";
             this.monospaceFontChangeButton.UseVisualStyleBackColor = true;
             this.monospaceFontChangeButton.Click += new System.EventHandler(this.monospaceFontChangeButton_Click);
+            this.monospaceFontChangeButton.TabIndex = 3;
             // 
             // diffFontDialog
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -266,7 +266,7 @@
             this.AvatarProvider.Location = new System.Drawing.Point(164, 75);
             this.AvatarProvider.Name = "AvatarProvider";
             this.AvatarProvider.Size = new System.Drawing.Size(183, 21);
-            this.AvatarProvider.TabIndex = 10;
+            this.AvatarProvider.TabIndex = 3;
             this.AvatarProvider.SelectedIndexChanged += new System.EventHandler(this.AvatarProvider_SelectedIndexChanged);
             // 
             // ShowAuthorAvatarInCommitGraph
@@ -352,7 +352,7 @@
             this.Dictionary.Location = new System.Drawing.Point(158, 30);
             this.Dictionary.Name = "Dictionary";
             this.Dictionary.Size = new System.Drawing.Size(86, 21);
-            this.Dictionary.TabIndex = 4;
+            this.Dictionary.TabIndex = 3;
             this.Dictionary.DropDown += new System.EventHandler(this.Dictionary_DropDown);
             // 
             // downloadDictionary
@@ -363,7 +363,7 @@
             this.downloadDictionary.Location = new System.Drawing.Point(250, 27);
             this.downloadDictionary.Name = "downloadDictionary";
             this.downloadDictionary.Size = new System.Drawing.Size(103, 27);
-            this.downloadDictionary.TabIndex = 5;
+            this.downloadDictionary.TabIndex = 4;
             this.downloadDictionary.TabStop = true;
             this.downloadDictionary.Text = "Download dictionary";
             this.downloadDictionary.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -399,7 +399,7 @@
             this.Language.Location = new System.Drawing.Point(158, 3);
             this.Language.Name = "Language";
             this.Language.Size = new System.Drawing.Size(86, 21);
-            this.Language.TabIndex = 1;
+            this.Language.TabIndex = 0;
             // 
             // helpTranslate
             // 
@@ -409,7 +409,7 @@
             this.helpTranslate.Location = new System.Drawing.Point(250, 0);
             this.helpTranslate.Name = "helpTranslate";
             this.helpTranslate.Size = new System.Drawing.Size(103, 27);
-            this.helpTranslate.TabIndex = 2;
+            this.helpTranslate.TabIndex = 1;
             this.helpTranslate.TabStop = true;
             this.helpTranslate.Text = "Help translate";
             this.helpTranslate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -423,7 +423,7 @@
             this._NO_TRANSLATE_NoImageService.Location = new System.Drawing.Point(164, 102);
             this._NO_TRANSLATE_NoImageService.Name = "_NO_TRANSLATE_NoImageService";
             this._NO_TRANSLATE_NoImageService.Size = new System.Drawing.Size(183, 21);
-            this._NO_TRANSLATE_NoImageService.TabIndex = 5;
+            this._NO_TRANSLATE_NoImageService.TabIndex = 4;
             // 
             // lblCacheDays
             // 
@@ -457,7 +457,7 @@
             0});
             this._NO_TRANSLATE_DaysToCacheImages.Name = "_NO_TRANSLATE_DaysToCacheImages";
             this._NO_TRANSLATE_DaysToCacheImages.Size = new System.Drawing.Size(38, 20);
-            this._NO_TRANSLATE_DaysToCacheImages.TabIndex = 3;
+            this._NO_TRANSLATE_DaysToCacheImages.TabIndex = 2;
             this._NO_TRANSLATE_DaysToCacheImages.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // pictureAvatarHelp
@@ -468,7 +468,7 @@
             this.pictureAvatarHelp.Name = "pictureAvatarHelp";
             this.pictureAvatarHelp.Size = new System.Drawing.Size(16, 16);
             this.pictureAvatarHelp.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
-            this.pictureAvatarHelp.TabIndex = 8;
+            this.pictureAvatarHelp.TabIndex = 3;
             this.pictureAvatarHelp.TabStop = false;
             this.pictureAvatarHelp.Click += new System.EventHandler(this.pictureAvatarHelp_Click);
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.BuildServerType.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.BuildServerType.Name = "BuildServerType";
             this.BuildServerType.Size = new System.Drawing.Size(1455, 21);
-            this.BuildServerType.TabIndex = 4;
+            this.BuildServerType.TabIndex = 3;
             this.BuildServerType.SelectedIndexChanged += new System.EventHandler(this.BuildServerType_SelectedIndexChanged);
             // 
             // labelBuildServerType

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -154,7 +154,7 @@
             this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Location = new System.Drawing.Point(176, 138);
             this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Name = "_NO_TRANSLATE_ColorHighlightAuthoredLabel";
             this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Size = new System.Drawing.Size(27, 19);
-            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.TabIndex = 8;
+            this._NO_TRANSLATE_ColorHighlightAuthoredLabel.TabIndex = 7;
             this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Text = "Red";
             this._NO_TRANSLATE_ColorHighlightAuthoredLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorHighlightAuthoredLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -168,7 +168,7 @@
             this.lblColorHighlightAuthored.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorHighlightAuthored.Name = "lblColorHighlightAuthored";
             this.lblColorHighlightAuthored.Size = new System.Drawing.Size(167, 13);
-            this.lblColorHighlightAuthored.TabIndex = 7;
+            this.lblColorHighlightAuthored.TabIndex = 6;
             this.lblColorHighlightAuthored.Text = "Color authored revisions";
             // 
             // chkHighlightAuthored
@@ -178,7 +178,7 @@
             this.chkHighlightAuthored.Location = new System.Drawing.Point(3, 118);
             this.chkHighlightAuthored.Name = "chkHighlightAuthored";
             this.chkHighlightAuthored.Size = new System.Drawing.Size(167, 17);
-            this.chkHighlightAuthored.TabIndex = 6;
+            this.chkHighlightAuthored.TabIndex = 5;
             this.chkHighlightAuthored.Text = "Highlight authored revisions";
             this.chkHighlightAuthored.UseVisualStyleBackColor = true;
             this.chkHighlightAuthored.CheckedChanged += new System.EventHandler(this.chkHighlightAuthored_CheckedChanged);
@@ -204,7 +204,7 @@
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Location = new System.Drawing.Point(176, 195);
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Name = "_NO_TRANSLATE_ColorRemoteBranchLabel";
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Size = new System.Drawing.Size(27, 19);
-            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 14;
+            this._NO_TRANSLATE_ColorRemoteBranchLabel.TabIndex = 13;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorRemoteBranchLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorRemoteBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -217,7 +217,7 @@
             this.lblColorBranchRemote.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorBranchRemote.Name = "lblColorBranchRemote";
             this.lblColorBranchRemote.Size = new System.Drawing.Size(167, 13);
-            this.lblColorBranchRemote.TabIndex = 13;
+            this.lblColorBranchRemote.TabIndex = 12;
             this.lblColorBranchRemote.Text = "Color remote branch";
             // 
             // _NO_TRANSLATE_ColorOtherLabel
@@ -229,7 +229,7 @@
             this._NO_TRANSLATE_ColorOtherLabel.Location = new System.Drawing.Point(176, 214);
             this._NO_TRANSLATE_ColorOtherLabel.Name = "_NO_TRANSLATE_ColorOtherLabel";
             this._NO_TRANSLATE_ColorOtherLabel.Size = new System.Drawing.Size(27, 19);
-            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 16;
+            this._NO_TRANSLATE_ColorOtherLabel.TabIndex = 15;
             this._NO_TRANSLATE_ColorOtherLabel.Text = "Red";
             this._NO_TRANSLATE_ColorOtherLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorOtherLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -242,7 +242,7 @@
             this.lblColorLabel.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorLabel.Name = "lblColorLabel";
             this.lblColorLabel.Size = new System.Drawing.Size(167, 13);
-            this.lblColorLabel.TabIndex = 15;
+            this.lblColorLabel.TabIndex = 14;
             this.lblColorLabel.Text = "Color other label";
             // 
             // chkDrawAlternateBackColor
@@ -252,7 +252,7 @@
             this.chkDrawAlternateBackColor.Location = new System.Drawing.Point(3, 49);
             this.chkDrawAlternateBackColor.Name = "chkDrawAlternateBackColor";
             this.chkDrawAlternateBackColor.Size = new System.Drawing.Size(167, 17);
-            this.chkDrawAlternateBackColor.TabIndex = 3;
+            this.chkDrawAlternateBackColor.TabIndex = 2;
             this.chkDrawAlternateBackColor.Text = "Draw alternate background";
             this.chkDrawAlternateBackColor.UseVisualStyleBackColor = true;
             // 
@@ -263,7 +263,7 @@
             this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(3, 95);
             this.DrawNonRelativesTextGray.Name = "DrawNonRelativesTextGray";
             this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(167, 17);
-            this.DrawNonRelativesTextGray.TabIndex = 5;
+            this.DrawNonRelativesTextGray.TabIndex = 4;
             this.DrawNonRelativesTextGray.Text = "Draw non relatives text gray";
             this.DrawNonRelativesTextGray.UseVisualStyleBackColor = true;
             // 
@@ -288,7 +288,7 @@
             this.DrawNonRelativesGray.Location = new System.Drawing.Point(3, 72);
             this.DrawNonRelativesGray.Name = "DrawNonRelativesGray";
             this.DrawNonRelativesGray.Size = new System.Drawing.Size(167, 17);
-            this.DrawNonRelativesGray.TabIndex = 4;
+            this.DrawNonRelativesGray.TabIndex = 3;
             this.DrawNonRelativesGray.Text = "Draw non relatives graph gray";
             this.DrawNonRelativesGray.UseVisualStyleBackColor = true;
             // 
@@ -300,7 +300,7 @@
             this.lblColorBranchLocal.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorBranchLocal.Name = "lblColorBranchLocal";
             this.lblColorBranchLocal.Size = new System.Drawing.Size(167, 13);
-            this.lblColorBranchLocal.TabIndex = 11;
+            this.lblColorBranchLocal.TabIndex = 10;
             this.lblColorBranchLocal.Text = "Color branch";
             // 
             // _NO_TRANSLATE_ColorBranchLabel
@@ -312,7 +312,7 @@
             this._NO_TRANSLATE_ColorBranchLabel.Location = new System.Drawing.Point(176, 176);
             this._NO_TRANSLATE_ColorBranchLabel.Name = "_NO_TRANSLATE_ColorBranchLabel";
             this._NO_TRANSLATE_ColorBranchLabel.Size = new System.Drawing.Size(27, 19);
-            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 12;
+            this._NO_TRANSLATE_ColorBranchLabel.TabIndex = 11;
             this._NO_TRANSLATE_ColorBranchLabel.Text = "Red";
             this._NO_TRANSLATE_ColorBranchLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorBranchLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -326,7 +326,7 @@
             this._NO_TRANSLATE_ColorTagLabel.Location = new System.Drawing.Point(176, 157);
             this._NO_TRANSLATE_ColorTagLabel.Name = "_NO_TRANSLATE_ColorTagLabel";
             this._NO_TRANSLATE_ColorTagLabel.Size = new System.Drawing.Size(27, 19);
-            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 10;
+            this._NO_TRANSLATE_ColorTagLabel.TabIndex = 9;
             this._NO_TRANSLATE_ColorTagLabel.Text = "Red";
             this._NO_TRANSLATE_ColorTagLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this._NO_TRANSLATE_ColorTagLabel.Click += new System.EventHandler(this.ColorLabel_Click);
@@ -339,7 +339,7 @@
             this.lblColorTag.Margin = new System.Windows.Forms.Padding(3);
             this.lblColorTag.Name = "lblColorTag";
             this.lblColorTag.Size = new System.Drawing.Size(167, 13);
-            this.lblColorTag.TabIndex = 9;
+            this.lblColorTag.TabIndex = 8;
             this.lblColorTag.Text = "Color tag";
             // 
             // gbDiffView

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -145,7 +145,7 @@
             this.chkShowAheadBehindDataInBrowseWindow.Location = new System.Drawing.Point(3, 141);
             this.chkShowAheadBehindDataInBrowseWindow.Name = "chkShowAheadBehindDataInBrowseWindow";
             this.chkShowAheadBehindDataInBrowseWindow.Size = new System.Drawing.Size(347, 17);
-            this.chkShowAheadBehindDataInBrowseWindow.TabIndex = 10;
+            this.chkShowAheadBehindDataInBrowseWindow.TabIndex = 6;
             this.chkShowAheadBehindDataInBrowseWindow.Text = "Show ahead and behind information on status bar in browse window";
             this.chkShowAheadBehindDataInBrowseWindow.UseVisualStyleBackColor = true;
             // 
@@ -156,7 +156,7 @@
             this.chkCheckForUncommittedChangesInCheckoutBranch.Location = new System.Drawing.Point(3, 164);
             this.chkCheckForUncommittedChangesInCheckoutBranch.Name = "chkCheckForUncommittedChangesInCheckoutBranch";
             this.chkCheckForUncommittedChangesInCheckoutBranch.Size = new System.Drawing.Size(347, 17);
-            this.chkCheckForUncommittedChangesInCheckoutBranch.TabIndex = 6;
+            this.chkCheckForUncommittedChangesInCheckoutBranch.TabIndex = 7;
             this.chkCheckForUncommittedChangesInCheckoutBranch.Text = "Check for uncommitted changes in checkout branch dialog";
             this.chkCheckForUncommittedChangesInCheckoutBranch.UseVisualStyleBackColor = true;
             // 
@@ -336,7 +336,7 @@
             0});
             this.RevisionGridQuickSearchTimeout.Name = "RevisionGridQuickSearchTimeout";
             this.RevisionGridQuickSearchTimeout.Size = new System.Drawing.Size(85, 20);
-            this.RevisionGridQuickSearchTimeout.TabIndex = 12;
+            this.RevisionGridQuickSearchTimeout.TabIndex = 10;
             this.RevisionGridQuickSearchTimeout.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.RevisionGridQuickSearchTimeout.ThousandsSeparator = true;
             this.RevisionGridQuickSearchTimeout.Value = new decimal(new int[] {
@@ -352,7 +352,7 @@
             this.btnDefaultDestinationBrowse.Location = new System.Drawing.Point(1247, 141);
             this.btnDefaultDestinationBrowse.Name = "btnDefaultDestinationBrowse";
             this.btnDefaultDestinationBrowse.Size = new System.Drawing.Size(52, 23);
-            this.btnDefaultDestinationBrowse.TabIndex = 10;
+            this.btnDefaultDestinationBrowse.TabIndex = 8;
             this.btnDefaultDestinationBrowse.Text = "Browse";
             this.btnDefaultDestinationBrowse.UseVisualStyleBackColor = true;
             this.btnDefaultDestinationBrowse.Click += new System.EventHandler(this.DefaultCloneDestinationBrowseClick);
@@ -388,7 +388,7 @@
             this.cbDefaultCloneDestination.Location = new System.Drawing.Point(273, 141);
             this.cbDefaultCloneDestination.Name = "cbDefaultCloneDestination";
             this.cbDefaultCloneDestination.Size = new System.Drawing.Size(968, 21);
-            this.cbDefaultCloneDestination.TabIndex = 9;
+            this.cbDefaultCloneDestination.TabIndex = 7;
             // 
             // chkShowGitCommandLine
             // 
@@ -526,7 +526,7 @@
             this.cboDefaultPullAction.Location = new System.Drawing.Point(273, 170);
             this.cboDefaultPullAction.Name = "cboDefaultPullAction";
             this.cboDefaultPullAction.Size = new System.Drawing.Size(121, 21);
-            this.cboDefaultPullAction.TabIndex = 14;
+            this.cboDefaultPullAction.TabIndex = 9;
             // 
             // GeneralSettingsPage
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
@@ -39,7 +39,7 @@
             this.checkBoxRebaseAutostash.Location = new System.Drawing.Point(19, 80);
             this.checkBoxRebaseAutostash.Name = "checkBoxRebaseAutostash";
             this.checkBoxRebaseAutostash.Size = new System.Drawing.Size(228, 17);
-            this.checkBoxRebaseAutostash.TabIndex = 1;
+            this.checkBoxRebaseAutostash.TabIndex = 3;
             this.checkBoxRebaseAutostash.Text = "Automatically stash before doing a rebase";
             this.checkBoxRebaseAutostash.UseVisualStyleBackColor = true;
             // 
@@ -59,7 +59,7 @@
             this.checkBoxPullRebase.Location = new System.Drawing.Point(19, 14);
             this.checkBoxPullRebase.Name = "checkBoxPullRebase";
             this.checkBoxPullRebase.Size = new System.Drawing.Size(276, 17);
-            this.checkBoxPullRebase.TabIndex = 3;
+            this.checkBoxPullRebase.TabIndex = 1;
             this.checkBoxPullRebase.Text = "Rebase local branch when pulling (instead of merge)";
             this.checkBoxPullRebase.UseVisualStyleBackColor = true;
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -246,7 +246,7 @@
             this.scriptEvent.Location = new System.Drawing.Point(3, 4);
             this.scriptEvent.Name = "scriptEvent";
             this.scriptEvent.Size = new System.Drawing.Size(208, 23);
-            this.scriptEvent.TabIndex = 21;
+            this.scriptEvent.TabIndex = 15;
             this.scriptEvent.SelectedIndexChanged += new System.EventHandler(this.scriptEvent_SelectedIndexChanged);
             this.scriptEvent.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
             // 
@@ -272,7 +272,7 @@
             this.sbtn_icon.Name = "sbtn_icon";
             this.sbtn_icon.Size = new System.Drawing.Size(92, 25);
             this.sbtn_icon.SplitMenuStrip = this.contextMenuStrip_SplitButton;
-            this.sbtn_icon.TabIndex = 23;
+            this.sbtn_icon.TabIndex = 16;
             this.sbtn_icon.Text = "Select icon";
             this.sbtn_icon.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.sbtn_icon.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -387,7 +387,7 @@
             this.argumentsTextBox.Location = new System.Drawing.Point(90, 114);
             this.argumentsTextBox.Name = "argumentsTextBox";
             this.argumentsTextBox.Size = new System.Drawing.Size(938, 52);
-            this.argumentsTextBox.TabIndex = 16;
+            this.argumentsTextBox.TabIndex = 14;
             this.argumentsTextBox.Text = "";
             this.argumentsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.argumentsTextBox_KeyDown);
             this.argumentsTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
@@ -399,7 +399,6 @@
             this.labelOnEvent.Location = new System.Drawing.Point(3, 180);
             this.labelOnEvent.Name = "labelOnEvent";
             this.labelOnEvent.Size = new System.Drawing.Size(58, 15);
-            this.labelOnEvent.TabIndex = 20;
             this.labelOnEvent.Text = "On event:";
             // 
             // flowLayoutPanel4
@@ -420,7 +419,6 @@
             this.argumentsLabel.Location = new System.Drawing.Point(3, 0);
             this.argumentsLabel.Name = "argumentsLabel";
             this.argumentsLabel.Size = new System.Drawing.Size(69, 15);
-            this.argumentsLabel.TabIndex = 14;
             this.argumentsLabel.Text = "Arguments:";
             // 
             // buttonShowArgumentsHelp
@@ -428,7 +426,7 @@
             this.buttonShowArgumentsHelp.Location = new System.Drawing.Point(3, 18);
             this.buttonShowArgumentsHelp.Name = "buttonShowArgumentsHelp";
             this.buttonShowArgumentsHelp.Size = new System.Drawing.Size(75, 23);
-            this.buttonShowArgumentsHelp.TabIndex = 15;
+            this.buttonShowArgumentsHelp.TabIndex = 13;
             this.buttonShowArgumentsHelp.Text = "Help";
             this.buttonShowArgumentsHelp.UseVisualStyleBackColor = true;
             this.buttonShowArgumentsHelp.Click += new System.EventHandler(this.buttonShowArgumentsHelp_Click);

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.Designer.cs
@@ -108,7 +108,7 @@ namespace AzureDevOpsIntegration.Settings
             this.TfsServer.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.TfsServer.Name = "TfsServer";
             this.TfsServer.Size = new System.Drawing.Size(1100, 20);
-            this.TfsServer.TabIndex = 0;
+            this.TfsServer.TabIndex = 2;
             this.TfsServer.TextChanged += new System.EventHandler(this.TextBox_TextChanged);
             // 
             // TfsBuildDefinitionNameFilter
@@ -176,7 +176,7 @@ namespace AzureDevOpsIntegration.Settings
             this.ExtractLink.Location = new System.Drawing.Point(126, 0);
             this.ExtractLink.Name = "ExtractLink";
             this.ExtractLink.Size = new System.Drawing.Size(1100, 13);
-            this.ExtractLink.TabIndex = 15;
+            this.ExtractLink.TabIndex = 1;
             this.ExtractLink.TabStop = true;
             this.ExtractLink.Text = "Extract data from a build result url copied in the clipboard";
             this.ExtractLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.ExtractLink_LinkClicked);
@@ -198,7 +198,7 @@ namespace AzureDevOpsIntegration.Settings
             this.TokenManagementLink.Location = new System.Drawing.Point(126, 220);
             this.TokenManagementLink.Name = "TokenManagementLink";
             this.TokenManagementLink.Size = new System.Drawing.Size(1100, 13);
-            this.TokenManagementLink.TabIndex = 1;
+            this.TokenManagementLink.TabIndex = 5;
             this.TokenManagementLink.TabStop = true;
             this.TokenManagementLink.Text = "Go to token management page";
             this.TokenManagementLink.Click += new System.EventHandler(this.RestApiTokenLink_Click);

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.Designer.cs
@@ -111,7 +111,7 @@ namespace TeamCityIntegration.Settings
             this.TeamCityServerUrl.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.TeamCityServerUrl.Name = "TeamCityServerUrl";
             this.TeamCityServerUrl.Size = new System.Drawing.Size(437, 21);
-            this.TeamCityServerUrl.TabIndex = 1;
+            this.TeamCityServerUrl.TabIndex = 2;
             this.TeamCityServerUrl.TextChanged += new System.EventHandler(this.TeamCityServerUrl_TextChanged);
             // 
             // TeamCityProjectName
@@ -153,7 +153,7 @@ namespace TeamCityIntegration.Settings
             this.CheckBoxLogAsGuest.Margin = new System.Windows.Forms.Padding(3, 6, 3, 2);
             this.CheckBoxLogAsGuest.Name = "CheckBoxLogAsGuest";
             this.CheckBoxLogAsGuest.Size = new System.Drawing.Size(213, 17);
-            this.CheckBoxLogAsGuest.TabIndex = 11;
+            this.CheckBoxLogAsGuest.TabIndex = 6;
             this.CheckBoxLogAsGuest.Text = "Log as guest to display the build report";
             this.CheckBoxLogAsGuest.UseVisualStyleBackColor = true;
             // 
@@ -164,7 +164,7 @@ namespace TeamCityIntegration.Settings
             this.buttonProjectChooser.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.buttonProjectChooser.Name = "buttonProjectChooser";
             this.buttonProjectChooser.Size = new System.Drawing.Size(24, 20);
-            this.buttonProjectChooser.TabIndex = 12;
+            this.buttonProjectChooser.TabIndex = 4;
             this.buttonProjectChooser.Text = "...";
             this.buttonProjectChooser.UseVisualStyleBackColor = true;
             this.buttonProjectChooser.Click += new System.EventHandler(this.buttonProjectChooser_Click);
@@ -176,7 +176,7 @@ namespace TeamCityIntegration.Settings
             this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Margin = new System.Windows.Forms.Padding(3, 0, 3, 6);
             this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Name = "lnkExtractDataFromBuildUrlCopiedInTheClipboard";
             this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Size = new System.Drawing.Size(280, 13);
-            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.TabIndex = 13;
+            this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.TabIndex = 1;
             this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.TabStop = true;
             this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.Text = "Extract the data from the build url copied in the clipboard";
             this.lnkExtractDataFromBuildUrlCopiedInTheClipboard.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkExtractDataFromBuildUrlCopiedInTheClipboard_LinkClicked);


### PR DESCRIPTION
Fixes #7301


## Proposed changes

Corrected and verified that the TabOrder should be correct on the following pages
- "Git extensions"
-  General
-  Appearance
-  Appearance > Color
-  Appearance > Fonts
-  Revision Links
-  Build server integration
-  Scripts
-  Hotkeys
-  Shell extensions
-  Advanced
-  Advanced > Confirmations
-  Detailed
-  Detailed > Browse repository window
-  Detailed > Commit dialog
-  Detailed > Diff Viewer
-  SSH
-  Git
-  Git > Paths
-  Git > Config
-  Git > Advanced
-  Plugins

## Test methodology

- Go to the "Tools" menu, then "Settings"
- Visit the General page, and hit the TAB key multiple times
- Control should move sequentially through all the settings


## Test environment(s)

- Git Extensions 3.2.1.6628
- Build bc07663c3c893f1d896520e0bdcfbe35cfe4b729
- Git 2.18.0.windows.1 (recommended: 2.22.0 or later)
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4018.0
- DPI 120dpi (125% scaling)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
