### PR TITLE
Fix #7077: Hide push checkbox cells when there's no local branches

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -390,6 +390,8 @@
             this.BranchGrid.Size = new System.Drawing.Size(546, 117);
             this.BranchGrid.TabIndex = 0;
             this.BranchGrid.CurrentCellDirtyStateChanged += new System.EventHandler(this.BranchGrid_CurrentCellDirtyStateChanged);
+            this.BranchGrid.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.BranchGrid_DataBindingComplete);
+            this.BranchGrid.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.BranchGrid_CellPainting);
             // 
             // LocalColumn
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -977,6 +977,8 @@ namespace GitUI.CommandsDialogs
                 var localHeads = GetLocalBranches().ToList();
                 var remoteBranches = remoteHeads.ToHashSet(h => h.LocalName);
 
+                _branchTable.BeginLoadData();
+
                 // Add all the local branches.
                 foreach (var head in localHeads)
                 {
@@ -1015,6 +1017,7 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
+                _branchTable.EndLoadData();
                 BranchGrid.Enabled = true;
             }
         }
@@ -1082,6 +1085,32 @@ namespace GitUI.CommandsDialogs
             {
                 BranchGrid.EndEdit();
                 ((BindingSource)BranchGrid.DataSource).EndEdit();
+            }
+        }
+
+        private void BranchGrid_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
+        {
+            foreach (DataGridViewRow row in BranchGrid.Rows)
+            {
+                if (row.Cells[0].Value == DBNull.Value)
+                {
+                    row.Cells[3].ReadOnly = true;
+                    row.Cells[4].ReadOnly = true;
+                }
+            }
+        }
+
+        private void BranchGrid_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
+        {
+            if (e.RowIndex < 0)
+            {
+                return;
+            }
+
+            if ((e.ColumnIndex == 3 || e.ColumnIndex == 4) && BranchGrid.Rows[e.RowIndex].Cells[0].Value == DBNull.Value)
+            {
+                e.PaintBackground(e.ClipBounds, true);
+                e.Handled = true;
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7077


## Proposed changes

- Hide push checkbox cells when there's no local branches

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/11418231/67475241-06181880-f680-11e9-8375-0b0d51f4adae.png)


### After

![image](https://user-images.githubusercontent.com/11418231/67475252-0c0df980-f680-11e9-999e-7b5ffbcc79fd.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 81fe6435db607ed42c197390d34e085f3f658e33
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.8.4018.0
- DPI 144dpi (150% scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
