### PR TITLE
Don't assume e.Node is nullable

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -390,7 +390,7 @@ See the changes in the commit form.");
                 return;
             }
 
-            if (e.Node?.Tag is GitItem gitItem)
+            if (e.Node.Tag is GitItem gitItem)
             {
                 e.Node.Nodes.Clear();
                 _revisionFileTreeController.LoadChildren(gitItem, e.Node.Nodes, tvGitTree.ImageList.Images);


### PR DESCRIPTION
## Proposed changes

-  ~Assume that `e.Node` may be null in first `if` like it's done in the second `if`~
- Don't assume e.Node is nullable

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
