### PR TITLE
Remove unnecessary null coalescing

### DIFF
--- a/UnitTests/GitCommandsTests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommandsTests/RevisionReaderTests.cs
@@ -134,7 +134,7 @@ namespace GitCommandsTests
         [TestCase("subject", "sub\n1DEA7CC4-FB39-450A-8DDF-762FCEA28B05\nject")]
         public void ParseCommitBody_should_return_subject_ignoring_contents(string subject, string encodedMessage, string expectedAdditionalData = null)
         {
-            var reader = RevisionReader.TestAccessor.MakeReader(encodedMessage + (expectedAdditionalData ?? ""));
+            var reader = RevisionReader.TestAccessor.MakeReader(encodedMessage + expectedAdditionalData);
 
             var (body, additionalData) = RevisionReader.TestAccessor.ParseCommitBody(reader, subject);
 

--- a/UnitTests/GitCommandsTests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommandsTests/RevisionReaderTests.cs
@@ -134,7 +134,7 @@ namespace GitCommandsTests
         [TestCase("subject", "sub\n1DEA7CC4-FB39-450A-8DDF-762FCEA28B05\nject")]
         public void ParseCommitBody_should_return_subject_ignoring_contents(string subject, string encodedMessage, string expectedAdditionalData = null)
         {
-            var reader = RevisionReader.TestAccessor.MakeReader(encodedMessage + expectedAdditionalData ?? "");
+            var reader = RevisionReader.TestAccessor.MakeReader(encodedMessage + (expectedAdditionalData ?? ""));
 
             var (body, additionalData) = RevisionReader.TestAccessor.ParseCommitBody(reader, subject);
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -105,3 +105,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/10/15, manishkungwani, Manish Kungwani, manishkungwani{at]yahoo.com
 2019/10/18, lhiginbotham, Logan Higinbotham, logan.higinbotham(at)gmail.com
 2019/10/18, RalphJSmart, Ralph J Smart, id1508-gitextensions_github(at)yahoo.com
+2019/10/24, jvitkauskas, Julius Vitkauskas, zadintuvas(at)gmail.com


### PR DESCRIPTION
## Proposed changes

- ~Add parenthesis for correct expectedAdditionalData string null coalescing~
- Remove unnecessary null coalescing as concatenating null is allowed and does not produce a different string

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
