### PR TITLE
increase FormCheckoutBranch Ok button size

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
@@ -84,7 +84,8 @@ namespace GitUI.CommandsDialogs
             this.Ok.Location = new System.Drawing.Point(480, 20);
             this.Ok.Margin = new System.Windows.Forms.Padding(0, 20, 6, 6);
             this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(62, 23);
+            this.Ok.MinimumSize = new System.Drawing.Size(72, 23);
+            this.Ok.Size = new System.Drawing.Size(72, 23);
             this.Ok.TabIndex = 1;
             this.Ok.Text = "Checkout";
             this.Ok.UseVisualStyleBackColor = true;


### PR DESCRIPTION
## Proposed changes

- Increase width of `Checkout` button slightly as it gets its last char clipped at 225% dpi

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/483659/67586845-3e405980-f75b-11e9-9c7c-59cf46a4382a.png)

### After
![image](https://user-images.githubusercontent.com/483659/67586833-397ba580-f75b-11e9-804d-e0f7100f7134.png)

## Test methodology

- Manual testing


## Test environment(s)

- Windows 10
- DPI 225%
