### PR TITLE
Fix 7364: "Fetch and Prune All" confirmation modal has weird focus behavior

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -245,7 +245,7 @@ namespace GitUI.CommandsDialogs
 
                 bool isActionConfirmed = AppSettings.DontConfirmFetchAndPruneAll
                                          || MessageBox.Show(
-                                             this,
+                                             owner,
                                              _pullFetchPruneAllConfirmation.Text,
                                              messageBoxTitle,
                                              MessageBoxButtons.YesNo) == DialogResult.Yes;


### PR DESCRIPTION
- use the proper window owner when showing the "fetch and prune all" confirmation dialog (to fix focus issues)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7364 


## Proposed changes

- use the correct owner window to fix focus issues 


## Screenshots <!-- Remove this section if PR does not change UI -->

**N/A**

## Test methodology <!-- How did you ensure quality? -->

- built and interactively tested the fix


## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
