### PR TITLE
Commit messages menu: Fix (sometimes) broken display

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2330,26 +2330,19 @@ namespace GitUI.CommandsDialogs
 
             void AddCommitMessageToMenu(string commitMessage)
             {
-                const int maxLabelLength = 50;
+                const int maxLabelLength = 72;
 
-                string label;
+                string label = commitMessage;
+                var newlineIndex = label.IndexOf('\n');
 
-                if (commitMessage.Length <= maxLabelLength)
+                if (newlineIndex != -1)
                 {
-                    label = commitMessage;
+                    label = label.Substring(0, newlineIndex);
                 }
-                else
-                {
-                    var newlineIndex = commitMessage.IndexOf('\n');
 
-                    if (newlineIndex != -1 && newlineIndex <= maxLabelLength)
-                    {
-                        label = commitMessage.Substring(0, newlineIndex);
-                    }
-                    else
-                    {
-                        label = commitMessage.ShortenTo(maxLabelLength);
-                    }
+                if (label.Length > maxLabelLength)
+                {
+                    label = label.ShortenTo(maxLabelLength);
                 }
 
                 commitMessageToolStripMenuItem.DropDownItems.Add(new ToolStripMenuItem

--- a/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
@@ -185,6 +185,22 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             });
         }
 
+        [Test]
+        public void Should_handle_well_commit_message_in_commit_message_menu()
+        {
+            _referenceRepository.CreateCommit("Only first line\n\nof a multi-line commit message\nmust be displayed in the menu");
+            _referenceRepository.CreateCommit("Too long commit message that should be shorten because first line of a commit message is only 50 chars long");
+            RunFormTest(form =>
+            {
+                var commitMessageToolStripMenuItem = form.GetTestAccessor().CommitMessageToolStripMenuItem;
+
+                // Verify the message appears correctly
+                commitMessageToolStripMenuItem.ShowDropDown();
+                Assert.AreEqual("Too long commit message that should be shorten because first line of ...", commitMessageToolStripMenuItem.DropDownItems[0].Text);
+                Assert.AreEqual("Only first line", commitMessageToolStripMenuItem.DropDownItems[1].Text);
+            });
+        }
+
         [Test, TestCaseSource(typeof(FormatCommitMessageTestData), "TestCases")]
         public void FormatCommitMessageFromTextBox(
             string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty, string expectedMessage)

--- a/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/ReferenceRepository.cs
@@ -15,23 +15,32 @@ namespace GitUITests.CommandsDialogs
         {
             _moduleTestHelper = new GitModuleTestHelper();
 
-            using (var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir))
-            {
-                _moduleTestHelper.CreateRepoFile("A.txt", "A");
-                repository.Index.Add("A.txt");
-
-                var message = "A commit message";
-                var author = new LibGit2Sharp.Signature("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
-                var committer = author;
-                var options = new LibGit2Sharp.CommitOptions();
-                var commit = repository.Commit(message, author, committer, options);
-                _commitHash = commit.Id.Sha;
-            }
+            CreateCommit("A commit message", "A");
         }
 
         public GitModule Module => _moduleTestHelper.Module;
 
         public string CommitHash => _commitHash;
+
+        private string Commit(Repository repository, string commitMessage)
+        {
+            var author = new LibGit2Sharp.Signature("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
+            var committer = author;
+            var options = new LibGit2Sharp.CommitOptions() { PrettifyMessage = false };
+            var commit = repository.Commit(commitMessage, author, committer, options);
+            return commit.Id.Sha;
+        }
+
+        public void CreateCommit(string commitMessage, string content = null)
+        {
+            using (var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir))
+            {
+                _moduleTestHelper.CreateRepoFile("A.txt", content ?? commitMessage);
+                repository.Index.Add("A.txt");
+
+                _commitHash = Commit(repository, commitMessage);
+            }
+        }
 
         public void CheckoutRevision()
         {


### PR DESCRIPTION
Fixes #5115

## Proposed changes

When building the commit message history to display in the dropdown menu,
and the commit message is shorter than the maximum length allowed
but is a multi line commit message,
then the display is broken for all the menus items.

=> add a check that the commit message is multi line and must be shorten.

+ increase the length of text in the menu items because 50 char is too short

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See the first menu item which is display onto 2 lines and so increase the height of all menu items:
 
![image](https://user-images.githubusercontent.com/460196/67680064-ce181a80-f98a-11e9-8329-6a5bc5797b37.png)

### After

![image](https://user-images.githubusercontent.com/460196/67680247-2a7b3a00-f98b-11e9-9f33-8105ae0795da.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build bffb060100bbe3ab838b00d2a37810cb34e1638a (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4042.0
- DPI 192dpi (200% scaling)
