### PR TITLE
Add Submodule: Fill combobox with branches regardless of the repo URL type

### DIFF
--- a/UnitTests/GitUITests/CommandsDialogs/FormAddSubmoduleTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormAddSubmoduleTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using GitExtUtils;
+using GitUI.CommandsDialogs.SubmodulesDialog;
+using GitUI.CommitInfo;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs
+{
+    public class FormAddSubmoduleTests
+    {
+        private const string DummyUrl = "URL";
+        private const string DummyUrlEncoded = "\"URL\"";
+        private const string Heads = "1234567890123456789012345678901234567890 /refs/heads/master\n"
+                                   + "/refs/heads/branch\n"
+                                   + "abc /refs/heads/\n"
+                                   + "123/refs/heads/b123\n"
+                                   + "456\t/refs/heads/b456\n"
+                                   + "789  /refs/heads/b789";
+
+        private readonly string[] _branches = { "master", "branch", "", "b123", "b456", "b789" };
+
+        // Created once for each test
+        private IExecutable _gitExecutable;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gitExecutable = Substitute.For<IExecutable>();
+        }
+
+        [Test]
+        public void LoadRemoteRepoBranches_NoUrl([Values(null, "", " ")] string url)
+        {
+            FormAddSubmodule.TestAccessor.LoadRemoteRepoBranches(_gitExecutable, url)
+                .Should().BeEmpty();
+        }
+
+        [TestCase("git@github.com:gitextensions/gitextensions.git", "\"git@github.com:gitextensions/gitextensions.git\"")]
+        [TestCase("https://github.com/gitextensions/gitextensions.git", "\"https://github.com/gitextensions/gitextensions.git\"")]
+        [TestCase("C:\\Repo", "\"C:/Repo\"")]
+        public void LoadRemoteRepoBranches_Url(string url, string encodedUrl)
+        {
+            MockupGitOutput(Heads, encodedUrl);
+            FormAddSubmodule.TestAccessor.LoadRemoteRepoBranches(_gitExecutable, url)
+                .Should().BeEquivalentTo(_branches);
+        }
+
+        [Test]
+        public void LoadRemoteRepoBranches_GitWarnings()
+        {
+            MockupGitOutput($"warning: this\n{Heads}\nwarning: or that");
+            FormAddSubmodule.TestAccessor.LoadRemoteRepoBranches(_gitExecutable, DummyUrl)
+                .Should().BeEquivalentTo(_branches);
+        }
+
+        [Test]
+        public void LoadRemoteRepoBranches_GitError()
+        {
+            MockupGitOutput("error: no such repo");
+            FormAddSubmodule.TestAccessor.LoadRemoteRepoBranches(_gitExecutable, DummyUrl)
+                .Should().BeEmpty();
+        }
+
+        private void MockupGitOutput(string output, string encodedUrl = DummyUrlEncoded)
+        {
+            var gitArguments = new GitArgumentBuilder("ls-remote") { "--heads", encodedUrl };
+            _gitExecutable.GetOutput(gitArguments).Returns(_ => output);
+        }
+    }
+}

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="BranchTreePanel\GitRefMenuItemsTest.cs" />
     <Compile Include="NBugReports\BugReportFormTests.cs" />
     <Compile Include="CancellationTokenSequenceTests.cs" />
+    <Compile Include="CommandsDialogs\FormAddSubmoduleTests.cs" />
     <Compile Include="CommandsDialogs\FormBrowseTests.LeftPanel.ReorderNodes.cs" />
     <Compile Include="CommandsDialogs\FormBrowseTests.LeftPanel.Submodules.cs" />
     <Compile Include="CommandsDialogs\FormBrowseTests.LeftPanel.Remotes.cs" />


### PR DESCRIPTION
Fixes #6556

## Proposed changes

- use "git ls-remote" to get possible submodule branches

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/67817033-47f3f500-faac-11e9-81e5-816f0d4a353f.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/67817073-7540a300-faac-11e9-89f5-95c84ac76af1.png)

## Test methodology <!-- How did you ensure quality? -->

- manual testing
- add a NUnit test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build db1c36b00e745692448ef8b877dd0b3b858ad3b6
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4018.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
