### PR TITLE
Skip duplicate ref entries when building the Sorted Refs Dictionary

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -225,6 +225,11 @@ namespace GitUI.CommitInfo
             var dict = new Dictionary<string, int>();
             foreach (var entry in tree.Split('\n'))
             {
+                if (dict.ContainsKey(entry))
+                {
+                    continue;
+                }
+
                 dict.Add(entry, i);
                 i++;
             }

--- a/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
@@ -141,5 +141,25 @@ namespace GitUITests.CommitInfo
             refs.Count.Should().Be(5);
             refs.Should().BeEquivalentTo(expected);
         }
+
+        [Test]
+        public void GetSortedRefs_should_remove_duplicate_refs()
+        {
+            _gitExecutable.StageOutput("for-each-ref --sort=-committerdate --sort=-taggerdate --format=\"%(refname)\" refs/",
+                "refs/remotes/origin/master\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/bar\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/last"); // exact duplicates
+
+            var expected = new Dictionary<string, int>
+            {
+                ["refs/remotes/origin/master"] = 0,
+                ["refs/remotes/foo/duplicate"] = 1,
+                ["refs/remotes/foo/bar"] = 2,
+                ["refs/remotes/foo/last"] = 3,
+            };
+
+            var refs = _commitInfo.GetTestAccessor().GetSortedRefs();
+
+            refs.Count.Should().Be(4);
+            refs.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/contributors.txt
+++ b/contributors.txt
@@ -106,3 +106,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/10/18, lhiginbotham, Logan Higinbotham, logan.higinbotham(at)gmail.com
 2019/10/18, RalphJSmart, Ralph J Smart, id1508-gitextensions_github(at)yahoo.com
 2019/10/24, jvitkauskas, Julius Vitkauskas, zadintuvas(at)gmail.com
+2019/10/31, rickaas, Ricky Lindeman, saakcir(at)gmail.com


### PR DESCRIPTION
Fixes #7372


## Proposed changes

- Don't put duplicate keys in a dictory when building `CommitInfo.GetSortedRefs()`
- Add TestCase for duplicate refs in `CommitInfoTests.GetSortedRefs_should_remove_duplicate_refs()`

## Test methodology <!-- How did you ensure quality? -->

- There is a testcase in `CommitInfoTests`. It test a git output that contains duplicate refs


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
