### PR TITLE
Refactor FormClone.ToTextUpdate()

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -23,13 +23,13 @@ namespace GitUI.CommandsDialogs
             this.Personal = new System.Windows.Forms.RadioButton();
             this.Ok = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.label1 = new System.Windows.Forms.Label();
+            this.repositoryLabel = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_From = new System.Windows.Forms.ComboBox();
             this.FromBrowse = new System.Windows.Forms.Button();
-            this.label2 = new System.Windows.Forms.Label();
+            this.destinationLabel = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_To = new System.Windows.Forms.ComboBox();
             this.ToBrowse = new System.Windows.Forms.Button();
-            this.label3 = new System.Windows.Forms.Label();
+            this.subdirectoryLabel = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_NewDirectory = new System.Windows.Forms.TextBox();
             this.brachLabel = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_Branches = new System.Windows.Forms.ComboBox();
@@ -91,13 +91,13 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.repositoryLabel, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_From, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.FromBrowse, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.destinationLabel, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_To, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.ToBrowse, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.subdirectoryLabel, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_NewDirectory, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.brachLabel, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_Branches, 1, 3);
@@ -112,26 +112,26 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel1.Size = new System.Drawing.Size(610, 122);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
-            // label1
+            // repositoryLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Dock = System.Windows.Forms.DockStyle.Left;
-            this.label1.Location = new System.Drawing.Point(3, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(104, 30);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Repository to &clone:";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.repositoryLabel.AutoSize = true;
+            this.repositoryLabel.Dock = System.Windows.Forms.DockStyle.Left;
+            this.repositoryLabel.Location = new System.Drawing.Point(3, 0);
+            this.repositoryLabel.Name = "repositoryLabel";
+            this.repositoryLabel.Size = new System.Drawing.Size(101, 30);
+            this.repositoryLabel.TabIndex = 0;
+            this.repositoryLabel.Text = "Repository to &clone:";
+            this.repositoryLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_From
             // 
-            this._NO_TRANSLATE_From.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this._NO_TRANSLATE_From.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this._NO_TRANSLATE_From.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this._NO_TRANSLATE_From.FormattingEnabled = true;
-            this._NO_TRANSLATE_From.Location = new System.Drawing.Point(128, 3);
+            this._NO_TRANSLATE_From.Location = new System.Drawing.Point(123, 3);
             this._NO_TRANSLATE_From.Name = "_NO_TRANSLATE_From";
-            this._NO_TRANSLATE_From.Size = new System.Drawing.Size(379, 21);
+            this._NO_TRANSLATE_From.Size = new System.Drawing.Size(384, 21);
             this._NO_TRANSLATE_From.TabIndex = 1;
             this._NO_TRANSLATE_From.SelectedIndexChanged += new System.EventHandler(this.FromSelectedIndexChanged);
             this._NO_TRANSLATE_From.TextUpdate += new System.EventHandler(this.FromTextUpdate);
@@ -147,27 +147,27 @@ namespace GitUI.CommandsDialogs
             this.FromBrowse.UseVisualStyleBackColor = true;
             this.FromBrowse.Click += new System.EventHandler(this.FromBrowseClick);
             // 
-            // label2
+            // destinationLabel
             // 
-            this.label2.AutoSize = true;
-            this.label2.Dock = System.Windows.Forms.DockStyle.Left;
-            this.label2.Location = new System.Drawing.Point(3, 30);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(65, 30);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "&Destination:";
-            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.destinationLabel.AutoSize = true;
+            this.destinationLabel.Dock = System.Windows.Forms.DockStyle.Left;
+            this.destinationLabel.Location = new System.Drawing.Point(3, 30);
+            this.destinationLabel.Name = "destinationLabel";
+            this.destinationLabel.Size = new System.Drawing.Size(63, 30);
+            this.destinationLabel.TabIndex = 3;
+            this.destinationLabel.Text = "&Destination:";
+            this.destinationLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_To
             // 
-            this._NO_TRANSLATE_To.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this._NO_TRANSLATE_To.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this._NO_TRANSLATE_To.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this._NO_TRANSLATE_To.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.FileSystemDirectories;
             this._NO_TRANSLATE_To.FormattingEnabled = true;
-            this._NO_TRANSLATE_To.Location = new System.Drawing.Point(128, 33);
+            this._NO_TRANSLATE_To.Location = new System.Drawing.Point(123, 33);
             this._NO_TRANSLATE_To.Name = "_NO_TRANSLATE_To";
-            this._NO_TRANSLATE_To.Size = new System.Drawing.Size(379, 21);
+            this._NO_TRANSLATE_To.Size = new System.Drawing.Size(384, 21);
             this._NO_TRANSLATE_To.TabIndex = 4;
             this._NO_TRANSLATE_To.SelectedIndexChanged += new System.EventHandler(this.ToSelectedIndexChanged);
             this._NO_TRANSLATE_To.TextUpdate += new System.EventHandler(this.ToTextUpdate);
@@ -183,24 +183,24 @@ namespace GitUI.CommandsDialogs
             this.ToBrowse.UseVisualStyleBackColor = true;
             this.ToBrowse.Click += new System.EventHandler(this.ToBrowseClick);
             // 
-            // label3
+            // subdirectoryLabel
             // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Left;
-            this.label3.Location = new System.Drawing.Point(3, 60);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(119, 30);
-            this.label3.TabIndex = 6;
-            this.label3.Text = "&Subdirectory to create:";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.subdirectoryLabel.AutoSize = true;
+            this.subdirectoryLabel.Dock = System.Windows.Forms.DockStyle.Left;
+            this.subdirectoryLabel.Location = new System.Drawing.Point(3, 60);
+            this.subdirectoryLabel.Name = "subdirectoryLabel";
+            this.subdirectoryLabel.Size = new System.Drawing.Size(114, 30);
+            this.subdirectoryLabel.TabIndex = 6;
+            this.subdirectoryLabel.Text = "&Subdirectory to create:";
+            this.subdirectoryLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_NewDirectory
             // 
-            this._NO_TRANSLATE_NewDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this._NO_TRANSLATE_NewDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._NO_TRANSLATE_NewDirectory.Location = new System.Drawing.Point(128, 63);
+            this._NO_TRANSLATE_NewDirectory.Location = new System.Drawing.Point(123, 63);
             this._NO_TRANSLATE_NewDirectory.Name = "_NO_TRANSLATE_NewDirectory";
-            this._NO_TRANSLATE_NewDirectory.Size = new System.Drawing.Size(379, 21);
+            this._NO_TRANSLATE_NewDirectory.Size = new System.Drawing.Size(384, 20);
             this._NO_TRANSLATE_NewDirectory.TabIndex = 7;
             this._NO_TRANSLATE_NewDirectory.TextChanged += new System.EventHandler(this.NewDirectoryTextChanged);
             // 
@@ -217,12 +217,12 @@ namespace GitUI.CommandsDialogs
             // 
             // _NO_TRANSLATE_Branches
             // 
-            this._NO_TRANSLATE_Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this._NO_TRANSLATE_Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this._NO_TRANSLATE_Branches.FormattingEnabled = true;
-            this._NO_TRANSLATE_Branches.Location = new System.Drawing.Point(128, 93);
+            this._NO_TRANSLATE_Branches.Location = new System.Drawing.Point(123, 93);
             this._NO_TRANSLATE_Branches.Name = "_NO_TRANSLATE_Branches";
-            this._NO_TRANSLATE_Branches.Size = new System.Drawing.Size(379, 21);
+            this._NO_TRANSLATE_Branches.Size = new System.Drawing.Size(384, 21);
             this._NO_TRANSLATE_Branches.TabIndex = 9;
             this._NO_TRANSLATE_Branches.DropDown += new System.EventHandler(this.Branches_DropDown);
             // 
@@ -234,7 +234,7 @@ namespace GitUI.CommandsDialogs
             this.cbIntializeAllSubmodules.Location = new System.Drawing.Point(15, 3);
             this.cbIntializeAllSubmodules.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbIntializeAllSubmodules.Name = "cbIntializeAllSubmodules";
-            this.cbIntializeAllSubmodules.Size = new System.Drawing.Size(137, 17);
+            this.cbIntializeAllSubmodules.Size = new System.Drawing.Size(135, 17);
             this.cbIntializeAllSubmodules.TabIndex = 3;
             this.cbIntializeAllSubmodules.Text = "Initialize all submodules";
             this.cbIntializeAllSubmodules.UseVisualStyleBackColor = true;
@@ -244,17 +244,17 @@ namespace GitUI.CommandsDialogs
             this.cbDownloadFullHistory.AutoSize = true;
             this.cbDownloadFullHistory.Checked = true;
             this.cbDownloadFullHistory.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbDownloadFullHistory.Location = new System.Drawing.Point(176, 3);
+            this.cbDownloadFullHistory.Location = new System.Drawing.Point(174, 3);
             this.cbDownloadFullHistory.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbDownloadFullHistory.Name = "cbDownloadFullHistory";
-            this.cbDownloadFullHistory.Size = new System.Drawing.Size(126, 17);
+            this.cbDownloadFullHistory.Size = new System.Drawing.Size(123, 17);
             this.cbDownloadFullHistory.TabIndex = 4;
             this.cbDownloadFullHistory.Text = "Download full &history";
             this.ttHints.SetToolTip(this.cbDownloadFullHistory, resources.GetString("cbDownloadFullHistory.ToolTip"));
             // 
             // Info
             // 
-            this.Info.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.Info.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.Info.BackColor = System.Drawing.SystemColors.Info;
             this.Info.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -267,7 +267,7 @@ namespace GitUI.CommandsDialogs
             // 
             // groupBox1
             // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.CentralRepository);
             this.groupBox1.Controls.Add(this.PersonalRepository);
@@ -284,7 +284,7 @@ namespace GitUI.CommandsDialogs
             this.CentralRepository.AutoSize = true;
             this.CentralRepository.Location = new System.Drawing.Point(6, 42);
             this.CentralRepository.Name = "CentralRepository";
-            this.CentralRepository.Size = new System.Drawing.Size(253, 17);
+            this.CentralRepository.Size = new System.Drawing.Size(242, 17);
             this.CentralRepository.TabIndex = 0;
             this.CentralRepository.Text = "P&ublic repository, no working directory  (--bare)";
             this.CentralRepository.UseVisualStyleBackColor = true;
@@ -295,7 +295,7 @@ namespace GitUI.CommandsDialogs
             this.PersonalRepository.Checked = true;
             this.PersonalRepository.Location = new System.Drawing.Point(6, 19);
             this.PersonalRepository.Name = "PersonalRepository";
-            this.PersonalRepository.Size = new System.Drawing.Size(118, 17);
+            this.PersonalRepository.Size = new System.Drawing.Size(114, 17);
             this.PersonalRepository.TabIndex = 1;
             this.PersonalRepository.TabStop = true;
             this.PersonalRepository.Text = "&Personal repository";
@@ -352,10 +352,10 @@ namespace GitUI.CommandsDialogs
             // cbLfs
             // 
             this.cbLfs.AutoSize = true;
-            this.cbLfs.Location = new System.Drawing.Point(326, 3);
+            this.cbLfs.Location = new System.Drawing.Point(321, 3);
             this.cbLfs.Margin = new System.Windows.Forms.Padding(15, 3, 9, 3);
             this.cbLfs.Name = "cbLfs";
-            this.cbLfs.Size = new System.Drawing.Size(114, 17);
+            this.cbLfs.Size = new System.Drawing.Size(115, 17);
             this.cbLfs.TabIndex = 5;
             this.cbLfs.Text = "Use LFS extension";
             this.ttHints.SetToolTip(this.cbLfs, resources.GetString("cbLfs.ToolTip"));
@@ -423,11 +423,11 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.CheckBox cbIntializeAllSubmodules;
         private System.Windows.Forms.CheckBox cbDownloadFullHistory;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label repositoryLabel;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_From;
         private System.Windows.Forms.Label brachLabel;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label destinationLabel;
+        private System.Windows.Forms.Label subdirectoryLabel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private ToolTip ttHints;

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -368,53 +368,32 @@ namespace GitUI.CommandsDialogs
 
         private void ToTextUpdate(object sender, EventArgs e)
         {
-            string destinationPath = string.Empty;
+            bool destinationUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_To.Text);
+            bool subDirectoryUnfilled = string.IsNullOrEmpty(_NO_TRANSLATE_NewDirectory.Text);
 
-            if (string.IsNullOrEmpty(_NO_TRANSLATE_To.Text))
-            {
-                destinationPath += "[" + label2.Text + "]";
-            }
-            else
-            {
-                destinationPath += _NO_TRANSLATE_To.Text.TrimEnd('\\', '/');
-            }
+            string destinationDirectory = destinationUnfilled ? $@"[{destinationLabel.Text}]" : _NO_TRANSLATE_To.Text;
+            string destinationSubDirectory = subDirectoryUnfilled ? $@"[{subdirectoryLabel.Text}]" : _NO_TRANSLATE_NewDirectory.Text;
 
-            destinationPath += "\\";
+            string destinationPath = Path.Combine(destinationDirectory, destinationSubDirectory);
 
-            if (string.IsNullOrEmpty(_NO_TRANSLATE_NewDirectory.Text))
-            {
-                destinationPath += "[" + label3.Text + "]";
-            }
-            else
-            {
-                destinationPath += _NO_TRANSLATE_NewDirectory.Text;
-            }
+            string newRepositoryLocationInfo = string.Format(_infoNewRepositoryLocation.Text, destinationPath);
 
-            Info.Text = string.Format(_infoNewRepositoryLocation.Text, destinationPath);
-
-            if (destinationPath.Contains("[") || destinationPath.Contains("]"))
+            if (destinationUnfilled || subDirectoryUnfilled)
             {
+                Info.Text = newRepositoryLocationInfo;
                 Info.ForeColor = Color.Red;
                 return;
             }
 
-            if (Directory.Exists(destinationPath))
+            if (Directory.Exists(destinationPath) && Directory.EnumerateFileSystemEntries(destinationPath).Any())
             {
-                if (Directory.GetDirectories(destinationPath).Length > 0 || Directory.GetFiles(destinationPath).Length > 0)
-                {
-                    Info.Text += " " + _infoDirectoryExists.Text;
-                    Info.ForeColor = Color.Red;
-                }
-                else
-                {
-                    Info.ForeColor = SystemColors.ControlText;
-                }
+                Info.Text = $@"{newRepositoryLocationInfo} {_infoDirectoryExists.Text}";
+                Info.ForeColor = Color.Red;
+                return;
             }
-            else
-            {
-                Info.Text += " " + _infoDirectoryNew.Text;
-                Info.ForeColor = SystemColors.ControlText;
-            }
+
+            Info.Text = $@"{newRepositoryLocationInfo} {_infoDirectoryNew.Text}";
+            Info.ForeColor = SystemColors.ControlText;
         }
 
         private void NewDirectoryTextChanged(object sender, EventArgs e)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3122,19 +3122,19 @@ Do you want to open the new repository "{0}" now?</source>
         <source>Use LFS extension</source>
         <target />
       </trans-unit>
+      <trans-unit id="destinationLabel.Text">
+        <source>&amp;Destination:</source>
+        <target />
+      </trans-unit>
       <trans-unit id="groupBox1.Text">
         <source>Repository type</source>
         <target />
       </trans-unit>
-      <trans-unit id="label1.Text">
+      <trans-unit id="repositoryLabel.Text">
         <source>Repository to &amp;clone:</source>
         <target />
       </trans-unit>
-      <trans-unit id="label2.Text">
-        <source>&amp;Destination:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label3.Text">
+      <trans-unit id="subdirectoryLabel.Text">
         <source>&amp;Subdirectory to create:</source>
         <target />
       </trans-unit>


### PR DESCRIPTION
## Proposed changes

- Refactor convoluted FormClone.ToTextUpdate() method
- Fix: text is no longer colored in red when cloning to a path containing "[" or "]" symbols


## Screenshots

### Before

![image](https://user-images.githubusercontent.com/9928675/67982009-81eb0580-fc2a-11e9-85e2-c11afb82b23f.png)


### After

![image](https://user-images.githubusercontent.com/9928675/67982068-a34bf180-fc2a-11e9-9d51-9cb950f4c476.png)



## Test methodology

-  Manual testing


## Test environment(s)

- GIT 2.23
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
