### PR TITLE
fix incorect use of TestAccessor struct

### DIFF
--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -49,7 +49,7 @@ namespace GitCommands
         {
         }
 
-        private CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string overriddenCommitMessage = null)
+        internal CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string overriddenCommitMessage = null)
         {
             _fileSystem = fileSystem;
             _commitEncoding = commitEncoding;
@@ -130,12 +130,6 @@ namespace GitCommands
             }
 
             return (_commitMessagePath, _fileSystem.File.Exists(_commitMessagePath));
-        }
-
-        internal class TestAccessor
-        {
-            internal static CommitMessageManager Construct(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string overriddenCommitMessage)
-                => new CommitMessageManager(workingDirGitDir, commitEncoding, fileSystem, overriddenCommitMessage);
         }
     }
 }

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -103,7 +103,7 @@ namespace GitCommands.Git
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly AheadBehindDataProvider _provider;
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -473,7 +473,7 @@ namespace GitUI.BranchTreePanel
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly RepoObjectsTree _repoObjectsTree;
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -169,7 +169,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly FormOpenDirectory _form;
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3219,7 +3219,7 @@ namespace GitUI.CommandsDialogs
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly FormBrowse _form;
 

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -112,7 +112,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
                         .ToImmutableList();
         }
 
-        public static class TestAccessor
+        internal readonly struct TestAccessor
         {
             public static IEnumerable<string> LoadRemoteRepoBranches(IExecutable gitExecutable, string url)
                 => FormAddSubmodule.LoadRemoteRepoBranches(gitExecutable, url);

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -83,7 +83,7 @@ namespace GitUI.CommandsDialogs
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly ToolStripPushButton _button;
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -870,7 +870,7 @@ namespace GitUI.CommitInfo
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly CommitInfo _commitInfo;
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -592,7 +592,7 @@ namespace GitUI.Editor
                 }
             }
 
-            public readonly struct TestAccessor
+            internal readonly struct TestAccessor
             {
                 private readonly CurrentViewPositionCache _viewPositionCache;
 

--- a/GitUI/NBugReports/BugReportForm.cs
+++ b/GitUI/NBugReports/BugReportForm.cs
@@ -160,7 +160,7 @@ Send report anyway?");
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             private readonly BugReportForm _form;
 

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -510,7 +510,7 @@ namespace GitUI.Script
 
         internal static TestAccessor GetTestAccessor() => new TestAccessor();
 
-        public readonly struct TestAccessor
+        internal readonly struct TestAccessor
         {
             public string ParseScriptArguments(string arguments, string option, IWin32Window owner, RevisionGridControl revisionGrid, IGitModule module, IReadOnlyList<GitRevision> allSelectedRevisions, List<IGitRef> selectedTags, List<IGitRef> selectedBranches, List<IGitRef> selectedLocalBranches, List<IGitRef> selectedRemoteBranches, List<string> selectedRemotes, GitRevision selectedRevision, List<IGitRef> currentTags, List<IGitRef> currentBranches, List<IGitRef> currentLocalBranches, List<IGitRef> currentRemoteBranches, GitRevision currentRevision, string currentRemote) =>
                 ScriptOptionsParser.ParseScriptArguments(arguments, option, owner, revisionGrid, module, allSelectedRevisions, selectedTags, selectedBranches, selectedLocalBranches, selectedRemoteBranches, selectedRemotes, selectedRevision, currentTags, currentBranches, currentLocalBranches, currentRemoteBranches, currentRevision, currentRemote);

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -185,7 +185,7 @@ namespace GitUI
             TextFormatFlags.VerticalCenter |
             TextFormatFlags.TextBoxControl;
 
-        internal class TestAccessor
+        internal readonly struct TestAccessor
         {
             internal static string FormatOldName(string oldName) => PathFormatter.FormatOldName(oldName);
             internal static (string Path, string FileName) SplitPathName(string name) => PathFormatter.SplitPathName(name);

--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="AsyncTestHelper.cs" />
     <Compile Include="MockExecutable.cs" />
+    <Compile Include="NoAssertContext.cs" />
     <Compile Include="SubmoduleTestHelpers.cs" />
     <Compile Include="ConfigureJoinableTaskFactoryAttribute.cs" />
     <Compile Include="EmbeddedResourceLoader.cs" />

--- a/UnitTests/CommonTestUtils/NoAssertContext.cs
+++ b/UnitTests/CommonTestUtils/NoAssertContext.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System
+{
+    /// <summary>
+    ///  Use (within a using) to eat asserts.
+    /// </summary>
+    public sealed class NoAssertContext : IDisposable
+    {
+        // For any given thread we don't need to lock to decide how to route messages, as any messages for that
+        // given thread will not happen while we're in the constructor or dispose method on that thread. That
+        // means we can safely check to see if we've hooked our thread without locking (outside of using a
+        // concurrent collection to make sure the collection is in a known state).
+        //
+        // We do, however need to lock around hooking/unhooking our custom listener to make sure that we
+        // are rerouting correctly if multiple threads are creating/disposing this class concurrently.
+
+#pragma warning disable SA1308 // Variable names should not be prefixed
+        private static readonly object s_lock = new object();
+        private static bool s_hooked;
+
+        private static readonly ConcurrentDictionary<int, int> s_suppressedThreads = new ConcurrentDictionary<int, int>();
+
+        // "Default" is the listener that terminates the process when debug assertions fail.
+        private static readonly TraceListener s_defaultListener = Trace.Listeners["Default"];
+        private static readonly NoAssertListener s_noAssertListener = new NoAssertListener();
+#pragma warning restore SA1308 // Variable names should not be prefixed
+
+        public NoAssertContext()
+        {
+            s_suppressedThreads.AddOrUpdate(Thread.CurrentThread.ManagedThreadId, 1, (key, oldValue) => oldValue + 1);
+
+            // Lock to make sure we are hooked properly if two threads come into the constructor/dispose at the same time.
+            lock (s_lock)
+            {
+                if (!s_hooked)
+                {
+                    // Hook our custom listener first so we don't lose assertions from other threads when
+                    // we disconnect the default listener.
+                    Trace.Listeners.Add(s_noAssertListener);
+                    Trace.Listeners.Remove(s_defaultListener);
+                    s_hooked = true;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            int currentThread = Thread.CurrentThread.ManagedThreadId;
+            if (s_suppressedThreads.TryRemove(currentThread, out int count))
+            {
+                if (count > 1)
+                {
+                    // We're in a nested assert context on a given thread, re-add with a decremented count.
+                    // This doesn't need to be atomic as we're currently on the thread that would care about
+                    // being rerouted.
+                    s_suppressedThreads.TryAdd(currentThread, --count);
+                }
+            }
+
+            lock (s_lock)
+            {
+                if (s_hooked && s_suppressedThreads.Count == 0)
+                {
+                    // We're the first to hit the need to unhook. Add the default listener back first to
+                    // ensure we don't lose any asserts from other threads.
+                    Trace.Listeners.Add(s_defaultListener);
+                    Trace.Listeners.Remove(s_noAssertListener);
+                    s_hooked = false;
+                }
+            }
+        }
+
+        ~NoAssertContext()
+        {
+            // We need this class to be used in a using to effectively rationalize about a test.
+            throw new InvalidOperationException($"Did not dispose {nameof(NoAssertContext)}");
+        }
+
+        private class NoAssertListener : TraceListener
+        {
+            public NoAssertListener()
+                : base(typeof(NoAssertListener).FullName)
+            {
+            }
+
+            public override void Fail(string message)
+            {
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
+                {
+                    s_defaultListener.Fail(message);
+                }
+            }
+
+            public override void Fail(string message, string detailMessage)
+            {
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
+                {
+                    s_defaultListener.Fail(message, detailMessage);
+                }
+            }
+
+            // Write and WriteLine are virtual
+
+            public override void Write(string message)
+            {
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
+                {
+                    s_defaultListener.Write(message);
+                }
+            }
+
+            public override void WriteLine(string message)
+            {
+                if (!s_suppressedThreads.TryGetValue(Thread.CurrentThread.ManagedThreadId, out _))
+                {
+                    s_defaultListener.WriteLine(message);
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/CommitMessageManagerTests.cs
+++ b/UnitTests/GitCommandsTests/CommitMessageManagerTests.cs
@@ -51,12 +51,12 @@ namespace GitCommandsTests
             _fileSystem.File.Returns(_file);
             _fileSystem.Path.Returns(path);
 
-            _manager = CommitMessageManager.TestAccessor.Construct(_workingDirGitDir, _encoding, _fileSystem, overriddenCommitMessage: null);
+            _manager = new CommitMessageManager(_workingDirGitDir, _encoding, _fileSystem, overriddenCommitMessage: null);
         }
 
         public void SetupExtra(string overriddenCommitMessage)
         {
-            _manager = CommitMessageManager.TestAccessor.Construct(_workingDirGitDir, _encoding, _fileSystem, overriddenCommitMessage);
+            _manager = new CommitMessageManager(_workingDirGitDir, _encoding, _fileSystem, overriddenCommitMessage);
         }
 
         [TearDown]

--- a/UnitTests/GitCommandsTests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommandsTests/RevisionReaderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using FluentAssertions;
 using GitCommands;
 using NUnit.Framework;
@@ -147,8 +148,11 @@ namespace GitCommandsTests
         [TestCase("subject", "subject\nl2")]
         public void ParseCommitBody_should_return_null_if_no_EndOfBody(string subject, string encodedBody)
         {
-            var reader = RevisionReader.TestAccessor.MakeReader(encodedBody);
-            RevisionReader.TestAccessor.ParseCommitBody(reader, subject).Should().Be((null, null));
+            using (new NoAssertContext())
+            {
+                var reader = RevisionReader.TestAccessor.MakeReader(encodedBody);
+                RevisionReader.TestAccessor.ParseCommitBody(reader, subject).Should().Be((null, null));
+            }
         }
     }
 }


### PR DESCRIPTION
Also add `NoAssertContext` class to prevent tests deadlocking or failing on `Debug.Fail` statements in production code.
The implementation is copied from https://github.com/dotnet/winforms/pull/2191
