### PR TITLE
fix: Fail attempting an empty path

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -164,23 +164,25 @@ namespace GitExtensions
                 // while parsing command line arguments, it unescapes " incorrectly
                 // https://github.com/gitextensions/gitextensions/issues/3489
                 string dirArg = args[2].TrimEnd('"');
-
-                if (!Directory.Exists(dirArg))
+                if (!string.IsNullOrWhiteSpace(dirArg))
                 {
-                    dirArg = Path.GetDirectoryName(dirArg);
+                    if (!Directory.Exists(dirArg))
+                    {
+                        dirArg = Path.GetDirectoryName(dirArg);
+                    }
+
+                    workingDir = GitModule.TryFindGitWorkingDir(dirArg);
+
+                    if (Directory.Exists(workingDir))
+                    {
+                        workingDir = Path.GetFullPath(workingDir);
+                    }
+
+                    // Do not add this working directory to the recent repositories. It is a nice feature, but it
+                    // also increases the startup time
+                    ////if (Module.ValidWorkingDir())
+                    ////   Repositories.RepositoryHistory.AddMostRecentRepository(Module.WorkingDir);
                 }
-
-                workingDir = GitModule.TryFindGitWorkingDir(dirArg);
-
-                if (Directory.Exists(workingDir))
-                {
-                    workingDir = Path.GetFullPath(workingDir);
-                }
-
-                // Do not add this working directory to the recent repositories. It is a nice feature, but it
-                // also increases the startup time
-                ////if (Module.ValidWorkingDir())
-                ////   Repositories.RepositoryHistory.AddMostRecentRepository(Module.WorkingDir);
             }
 
             if (args.Length <= 1 && workingDir == null && AppSettings.StartWithRecentWorkingDir)


### PR DESCRIPTION

Fixes #7381

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

- Ignore empty paths.
The app would fail if a user passed an invalid repo path such as:
`"C:\portable\GitExtensions\GitExtensions.exe" openrepo ""`.


## Test methodology <!-- How did you ensure quality? -->

- reproduced the issue locally, fixed, manual testing

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
