### PR TITLE
Increase stability of test execution

### DIFF
--- a/Build/Run-Tests.ps1
+++ b/Build/Run-Tests.ps1
@@ -13,7 +13,9 @@ $opencover_console = "packages\OpenCover.$opencover_version\tools\OpenCover.Cons
     -output:"OpenCover.GitExtensions.xml" `
     -target:"nunit3-console.exe" `
     -targetargs:"$testAssemblies --workers=1 --timeout=90000"
-if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+$testExitCode = $LastExitCode
+Push-AppveyorArtifact "TestResult.xml"
+if ($testExitCode -ne 0) { $host.SetShouldExit($testExitCode) }
 
 $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
 $codecov = "packages\Codecov.$codecov_version\tools\codecov.exe"

--- a/Build/Run-Tests.ps1
+++ b/Build/Run-Tests.ps1
@@ -12,7 +12,7 @@ $opencover_console = "packages\OpenCover.$opencover_version\tools\OpenCover.Cons
     -excludebyfile:*\*Designer.cs `
     -output:"OpenCover.GitExtensions.xml" `
     -target:"nunit3-console.exe" `
-    -targetargs:"$testAssemblies"
+    -targetargs:"$testAssemblies --workers=1 --timeout=90000"
 if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -41,7 +41,7 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.Add(revision, RevisionNodeFlags.CheckedOut);
         }
 
-        [Test]
+        [Test, Timeout(10 /*min*/ * 60 /*s*/ * 1000 /*ms*/)]
         public void ShouldReorderInTopoOrder()
         {
             for (int i = 0; i < _numberOfRepeats; i++)


### PR DESCRIPTION
Improves #7382

## Proposed changes

- do not run tests in parallel: `--workers=1`
  in order to avoid race conditions with singletons like the `AppSettings` and the clipboard
  (applies only to the tests of the same test assembly)
- set a default timeout of 90 seconds for every single test, and to 10 minutes for the only long running test (the maximum runtime seen was almost 40 seconds / 5 minutes) 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- trigger AppVeyor builds

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build e6dad27982e96ccfc37a81b6ba99f80fb062d9b9
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4018.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
