### PR TITLE
fix: Crash on Missing Settings Directory

### DIFF
--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -141,12 +141,6 @@ namespace GitCommands.Settings
                     return;
                 }
 
-                int currentProcessId;
-                using (var currentProcess = Process.GetCurrentProcess())
-                {
-                    currentProcessId = currentProcess.Id;
-                }
-
                 var tmpFile = Path.GetTempFileName();
                 WriteSettings(tmpFile);
 
@@ -161,6 +155,13 @@ namespace GitCommands.Settings
                     {
                         // Ignore errors for the backup file
                     }
+                }
+
+                // ensure the directory structure exists
+                var parentFolder = Path.GetDirectoryName(SettingsFilePath);
+                if (!Directory.Exists(parentFolder))
+                {
+                    Directory.CreateDirectory(parentFolder);
                 }
 
                 File.Copy(tmpFile, SettingsFilePath, true);

--- a/UnitTests/GitCommandsTests/Settings/FileSettingsCacheTests.cs
+++ b/UnitTests/GitCommandsTests/Settings/FileSettingsCacheTests.cs
@@ -60,6 +60,39 @@ namespace GitCommandsTests.Settings
             ((Action)(() => cache.SaveImpl())).Should().Throw<Exception>();
         }
 
+        [Test]
+        public void SaveImpl_should_create_folder_if_absent()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var settingsFilePath = Path.Combine(tempPath, "GitExtensions.settings");
+
+            try
+            {
+                var cache = new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor();
+                cache.SetLastModificationDate(DateTime.Now);
+
+                Directory.Exists(tempPath).Should().BeFalse();
+                File.Exists(settingsFilePath).Should().BeFalse();
+
+                cache.SaveImpl();
+
+                Directory.Exists(tempPath).Should().BeTrue();
+                File.Exists(settingsFilePath).Should().BeTrue();
+            }
+            finally
+            {
+                // clean up
+                try
+                {
+                    Directory.Delete(tempPath, true);
+                }
+                catch
+                {
+                    // no-op
+                }
+            }
+        }
+
         private class MockFileSettingsCache : FileSettingsCache
         {
             public MockFileSettingsCache(string settingsFilePath, bool autoSave = true)


### PR DESCRIPTION
Fixes #7376
Fixes #7395


<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- A settings file could not be created and the app would crash, if a user's settings directory is missing.
Ensure the directory is created, before writing the file in it.


## Test methodology <!-- How did you ensure quality? -->

- manual
- unit test


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
