### PR TITLE
catch cannot write to settings

### DIFF
--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Windows.Forms;
 using GitCommands.Utils;
 
 namespace GitCommands.Settings
@@ -151,21 +152,28 @@ namespace GitCommands.Settings
                     {
                         File.Copy(SettingsFilePath, backupName, true);
                     }
-                    catch (IOException)
+                    catch (Exception)
                     {
                         // Ignore errors for the backup file
                     }
                 }
 
-                // ensure the directory structure exists
-                var parentFolder = Path.GetDirectoryName(SettingsFilePath);
-                if (!Directory.Exists(parentFolder))
+                try
                 {
-                    Directory.CreateDirectory(parentFolder);
-                }
+                    // ensure the directory structure exists
+                    var parentFolder = Path.GetDirectoryName(SettingsFilePath);
+                    if (!Directory.Exists(parentFolder))
+                    {
+                        Directory.CreateDirectory(parentFolder);
+                    }
 
-                File.Copy(tmpFile, SettingsFilePath, true);
-                File.Delete(tmpFile);
+                    File.Copy(tmpFile, SettingsFilePath, true);
+                    File.Delete(tmpFile);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Cannot save settings", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
 
                 _lastFileModificationDate = GetLastFileModificationUtc();
                 _lastFileRead = DateTime.UtcNow;

--- a/UnitTests/GitCommandsTests/Settings/FileSettingsCacheTests.cs
+++ b/UnitTests/GitCommandsTests/Settings/FileSettingsCacheTests.cs
@@ -50,6 +50,7 @@ namespace GitCommandsTests.Settings
             new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().CanEnableFileWatcher.Should().BeFalse();
         }
 
+        [Ignore("Popup instead of a throw")]
         [TestCase(null)]
         [TestCase("")]
         [TestCase("C:\\" + "\t")]


### PR DESCRIPTION
Fixes #7345 
Fixes #6830 
Fixes #6794 
Fixes #6635 

## Proposed changes
If settings cannot be saved, show popup instead of NBug for users
Also catch all errors on the backup file, read-only gives UnauthorizedException

## Screenshots
### Before

NBug

### After

![image](https://user-images.githubusercontent.com/6248932/68550530-e0bb3680-0403-11ea-82d0-d811e8c553f8.png)


## Test methodology
Manual
Set read-only on GitExtensions.settings

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
