### PR TITLE
FormCommit: Add a menu item to easily convert eol of a file

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -157,6 +157,9 @@ namespace GitUI.CommandsDialogs
             this.commitCursorColumn = new System.Windows.Forms.ToolStripStatusLabel();
             this.commitEndPadding = new System.Windows.Forms.ToolStripStatusLabel();
             this.stopTrackingThisFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.convertEndOfLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toWindowsCRLFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toUnixLFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.UnstagedFileContext.SuspendLayout();
             this.StagedFileContext.SuspendLayout();
             this.UnstagedSubmoduleContext.SuspendLayout();
@@ -201,6 +204,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator8,
             this.viewFileHistoryToolStripItem,
             this.toolStripSeparator7,
+            this.convertEndOfLinesToolStripMenuItem,
             this.editFileToolStripMenuItem,
             this.deleteFileToolStripMenuItem,
             this.toolStripSeparator5,
@@ -1497,7 +1501,30 @@ namespace GitUI.CommandsDialogs
             this.stopTrackingThisFileToolStripMenuItem.Size = new System.Drawing.Size(428, 38);
             this.stopTrackingThisFileToolStripMenuItem.Text = "Stop tracking this file";
             this.stopTrackingThisFileToolStripMenuItem.Click += new System.EventHandler(this.stopTrackingThisFileToolStripMenuItem_Click);
-            //
+            // 
+            // convertEndOfLinesToolStripMenuItem
+            // 
+            this.convertEndOfLinesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toWindowsCRLFToolStripMenuItem,
+            this.toUnixLFToolStripMenuItem});
+            this.convertEndOfLinesToolStripMenuItem.Name = "convertEndOfLinesToolStripMenuItem";
+            this.convertEndOfLinesToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.convertEndOfLinesToolStripMenuItem.Text = "Convert End of lines";
+            // 
+            // toWindowsCRLFToolStripMenuItem
+            // 
+            this.toWindowsCRLFToolStripMenuItem.Name = "toWindowsCRLFToolStripMenuItem";
+            this.toWindowsCRLFToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.toWindowsCRLFToolStripMenuItem.Text = "To Windows (CRLF)";
+            this.toWindowsCRLFToolStripMenuItem.Click += new System.EventHandler(this.toWindowsCRLFToolStripMenuItem_Click);
+            // 
+            // toUnixLFToolStripMenuItem
+            // 
+            this.toUnixLFToolStripMenuItem.Name = "toUnixLFToolStripMenuItem";
+            this.toUnixLFToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.toUnixLFToolStripMenuItem.Text = "To Unix (LF)";
+            this.toUnixLFToolStripMenuItem.Click += new System.EventHandler(this.toUnixLFToolStripMenuItem_Click);
+            // 
             // FormCommit
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -1689,6 +1716,9 @@ namespace GitUI.CommandsDialogs
         private ToolStripTextBox toolStripGpgKeyTextBox;
         private ToolStripComboBox gpgSignCommitToolStripComboBox;
         private ToolStripMenuItem stopTrackingThisFileToolStripMenuItem;
+        private ToolStripMenuItem convertEndOfLinesToolStripMenuItem;
+        private ToolStripMenuItem toWindowsCRLFToolStripMenuItem;
+        private ToolStripMenuItem toUnixLFToolStripMenuItem;
         private Button modifyCommitMessageButton;
         private ToolStripMenuItem ShowOnlyMyMessagesToolStripMenuItem;
     }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -3330,6 +3330,42 @@ namespace GitUI.CommandsDialogs
                 string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
                     => FormCommit.FormatCommitMessageFromTextBox(commitMessageText, usingCommitTemplate, ensureCommitMessageSecondLineEmpty);
         }
+
+        private void toWindowsCRLFToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ConvertEndOfLines(Environment.NewLine);
+        }
+
+        private void ConvertEndOfLines(string eol)
+        {
+            if (Unstaged.SelectedItem == null || !Unstaged.SelectedItem.IsTracked)
+            {
+                return;
+            }
+
+            var filePath = Path.Combine(Module.WorkingDir, Unstaged.SelectedItem.Name);
+
+            if (!File.Exists(filePath))
+            {
+                return;
+            }
+
+            try
+            {
+                var allLines = File.ReadAllLines(filePath);
+
+                File.WriteAllText(filePath, string.Join(eol, allLines));
+                ShowChanges(Unstaged.SelectedItem, false);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        private void toUnixLFToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ConvertEndOfLines("\n");
+        }
     }
 
     /// <summary>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3490,6 +3490,10 @@ You can unset the template:
         <source>Commit &amp;templates</source>
         <target />
       </trans-unit>
+      <trans-unit id="convertEndOfLinesToolStripMenuItem.Text">
+        <source>Convert End of lines</source>
+        <target />
+      </trans-unit>
       <trans-unit id="copyFolderNameMenuItem.Text">
         <source>Copy folder name</source>
         <target />
@@ -3680,6 +3684,14 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="submoduleSummaryMenuItem.Text">
         <source>View summary</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toUnixLFToolStripMenuItem.Text">
+        <source>To Unix (LF)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toWindowsCRLFToolStripMenuItem.Text">
+        <source>To Windows (CRLF)</source>
         <target />
       </trans-unit>
       <trans-unit id="toolAuthorLabelItem.Text">


### PR DESCRIPTION
## Proposed changes

- Add an option in the commit form to convert the end of lines of a file. Because that's really boring to be obliged to open an editor to convert the file when a repository don't provide a `.gitattributes`file...


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

None

### After

![image](https://user-images.githubusercontent.com/460196/68628612-62cd5d00-04e1-11ea-86cb-2d63dd00f8fa.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build ed46c2ee58d0b62f968028302b822b5440b2f72a
- Git 2.20.1.windows.1 (recommended: 2.23.0 or later)
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.3815.0
- DPI 96dpi (no scaling)

