### PR TITLE
fix: FormResolveConflicts incorrect row selection

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -159,7 +159,7 @@ namespace GitUI.CommandsDialogs
                 ConflictedFiles.Columns[0].DataPropertyName = nameof(ConflictData.Filename);
 
                 // if the last row was previously selected, select the last row again
-                if (isLastRow && ConflictedFiles.Rows.Count >= oldSelectedRow)
+                if (isLastRow && oldSelectedRow >= ConflictedFiles.Rows.Count)
                 {
                     oldSelectedRow = ConflictedFiles.Rows.Count - 1;
                 }


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

 If a user selected a different row from the top, upon rescan/refresh of the dialog there would be 2 rows selected - the top and the one that the user wanted.
This would lead to a situation where an incorrect file would be shown, or worse, no file would be shown due to multiple selection.

Fix the selection by resetting the initial selection after databind and selecting the user's choice.
Also if the user selected the last row, and a conflict was resolved, retain the selection and select the new last row upon refresh.


## Screenshots <!-- Remove this section if PR does not change UI -->

## Test methodology <!-- How did you ensure quality? -->

- manual



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
