### PR TITLE
FormReflog : fix crash when switching from reference

### DIFF
--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -80,6 +80,7 @@ namespace GitUI.CommandsDialogs
                 var output = UICommands.GitModule.GitExecutable.GetOutput(arguments);
                 var refLines = ConvertReflogOutput().ToList();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                _lastHitRowIndex = 0;
                 gridReflog.DataSource = refLines;
 
                 IEnumerable<RefLine> ConvertReflogOutput()
@@ -174,7 +175,11 @@ namespace GitUI.CommandsDialogs
 
             if (hit.Type == DataGridViewHitTestType.Cell && _lastHitRowIndex != hit.RowIndex)
             {
-                gridReflog.Rows[_lastHitRowIndex].Selected = false;
+                if (_lastHitRowIndex < gridReflog.Rows.Count)
+                {
+                    gridReflog.Rows[_lastHitRowIndex].Selected = false;
+                }
+
                 _lastHitRowIndex = hit.RowIndex;
                 gridReflog.Rows[_lastHitRowIndex].Selected = true;
             }


### PR DESCRIPTION
`_lastHitRowIndex` contained a bad value after the switch
and could be higher than the number of rows.

This commit:

 * reset the value when reference selected is changed
 * add a control to prevent it to occur again if it contains a bad value

Fixes #7410

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 3b399511bbbc2cb6c1e65e13850a456c7a1ffdb8
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4042.0
- DPI 192dpi (200% scaling)
