### PR TITLE
fix: SetRevisionFunc produce empty dropdown

### DIFF
--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -23,25 +23,14 @@ namespace GitUI.UserControls.RevisionGrid
             Text = _copyToClipboardText.Text;
 
             DropDownOpening += OnDropDownOpening;
-
-            // Don't show the menu as long as no revision function is set
-            HideDropDown();
         }
 
         public void SetRevisionFunc(Func<IReadOnlyList<GitRevision>> revisionFunc)
         {
             _revisionFunc = revisionFunc;
 
-            if (_revisionFunc?.Invoke() != null)
-            {
-                // Add dummy item for the menu entry to appear expandable (triangle on the right)
-                DropDownItems.Add(new ToolStripMenuItem());
-                ShowDropDown();
-            }
-            else
-            {
-                HideDropDown();
-            }
+            // Add dummy item for the menu entry to appear expandable (triangle on the right)
+            DropDownItems.Add(new ToolStripMenuItem());
         }
 
         private void AddItem(string displayText, Func<GitRevision, string> extractRevisionText, Image image, char? hotkey)

--- a/UnitTests/GitUITests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
+++ b/UnitTests/GitUITests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
@@ -37,13 +37,13 @@ namespace GitUITests.UserControls.RevisionGrid
         }
 
         [Test]
-        public void Should_should_show_nothing_if_no_revision_supplied()
+        public void Should_should_contain_single_item_if_no_revision_supplied()
         {
             _copyContextMenuItem.SetRevisionFunc(() => null);
 
             _copyContextMenuItem.ShowDropDown();
 
-            _copyContextMenuItem.DropDownItems.Count.Should().Be(0);
+            _copyContextMenuItem.DropDownItems.Count.Should().Be(1);
         }
 
         [TestCaseSource(nameof(GetArtificialCommits))]


### PR DESCRIPTION


Fixes #7357
Partial revert of a regression introduced in #7084.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

- `ShowDropDown` call would cause an dummy dropdown item shown on a screen while app was loading.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![gitextensions_start](https://user-images.githubusercontent.com/4608274/67549266-25588980-f704-11e9-85f3-62ceb38e049d.gif)


### After

No ghost dropdown item


## Test methodology <!-- How did you ensure quality? -->

- manual


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
