### PR TITLE
Regression: #7408 exception if no files are conflicted

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -161,19 +161,18 @@ namespace GitUI.CommandsDialogs
                 // if the last row was previously selected, select the last row again
                 if (isLastRow && oldSelectedRow >= ConflictedFiles.Rows.Count)
                 {
-                    oldSelectedRow = ConflictedFiles.Rows.Count - 1;
+                    oldSelectedRow = Math.Max(0, ConflictedFiles.Rows.Count - 1);
                 }
 
                 if (ConflictedFiles.Rows.Count > oldSelectedRow)
                 {
-                    if (oldSelectedRow != 0)
+                    // as part of the databinding event, the fist row is selected automatically
+                    // if previously another row was selected, we need to reset the selection,
+                    // and select the desired row
+                    if (oldSelectedRow > 0)
                     {
                         if (ConflictedFiles.SelectedRows.Count > 0)
                         {
-                            // as part of the databinding event, the fist row is selected automatically
-                            // if previously another row was selected, we need to reset the selection,
-                            // and select the desired row
-
                             ConflictedFiles.SelectionChanged -= ConflictedFiles_SelectionChanged;
                             ConflictedFiles.SelectedRows[0].Selected = false;
                             ConflictedFiles.SelectionChanged += ConflictedFiles_SelectionChanged;


### PR DESCRIPTION
Fixes regression in #7408 

Not to be included in release notes

If no files are conflicted after resolve (at least by selecting localfiles), the selected index is set to -1 which causes an exception 
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
   at System.Collections.ArrayList.get_Item(Int32 index)
   at System.Windows.Forms.DataGridViewRowCollection.SharedRow(Int32 rowIndex)
   at System.Windows.Forms.DataGridViewRowCollection.get_Item(Int32 index)
   at GitUI.CommandsDialogs.FormResolveConflicts.Initialize() in F:\dev\gc\gitextensions_3\GitUI\CommandsDialogs\FormResolveConflicts.cs:line 183
   at GitUI.CommandsDialogs.FormResolveConflicts.ContextChooseLocal_Click(Object sender, EventArgs e) in F:\dev\gc\gitextensions_3\GitUI\CommandsDialogs\FormResolveConflicts.cs:line 816
   at System.Windows.Forms.ToolStripItem.RaiseEvent(Object key, EventArgs e)
   at System.Windows.Forms.ToolStripMenuItem.OnClick(EventArgs e)
   at System.Windows.Forms.ToolStripItem.HandleClick(EventArgs e)
   at System.Windows.Forms.ToolStripItem.HandleMouseUp(MouseEventArgs e)
   at System.Windows.Forms.ToolStripItem.FireEventInteractive(EventArgs e, ToolStripItemEventType met)
   at System.Windows.Forms.ToolStripItem.FireEvent(EventArgs e, ToolStripItemEventType met)
   at System.Windows.Forms.ToolStrip.OnMouseUp(MouseEventArgs mea)
   at System.Windows.Forms.ToolStripDropDown.OnMouseUp(MouseEventArgs mea)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ScrollableControl.WndProc(Message& m)
   at System.Windows.Forms.ToolStrip.WndProc(Message& m)
   at System.Windows.Forms.ToolStripDropDown.WndProc(Message& m)
   at System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m)
   at System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

## Proposed changes

Set the selected index to 0
(there are alternative implementations, I choose the minimal solution).

## Test methodology <!-- How did you ensure quality? -->
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
