### PR TITLE
Add System.Reactive to installer

### DIFF
--- a/Setup/MakePortableArchive.cmd
+++ b/Setup/MakePortableArchive.cmd
@@ -486,6 +486,8 @@ xcopy /y /i ..\Plugins\AutoCompileSubmodules\bin\%Configuration%\AutoCompileSubm
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\Plugins\BackgroundFetch\bin\%Configuration%\BackgroundFetch.dll GitExtensions\Plugins\
 IF ERRORLEVEL 1 EXIT /B 1
+xcopy /y /i ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.dll GitExtensions\
+IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.Interfaces.dll GitExtensions\
 IF ERRORLEVEL 1 EXIT /B 1
 xcopy /y /i ..\Plugins\BackgroundFetch\bin\%Configuration%\System.Reactive.Linq.dll GitExtensions\

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -182,6 +182,9 @@
       <Component Id="Ben.Demystifier.dll" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\Ben.Demystifier.dll" />
       </Component>
+      <Component Id="System.Reactive.dll" Guid="*">
+        <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.dll" />
+      </Component>
       <Component Id="System.Reactive.Interfaces.dll" Guid="*">
         <File Source="..\GitExtensions\bin\$(var.Configuration)\System.Reactive.Interfaces.dll" />
       </Component>
@@ -1540,6 +1543,7 @@
       <ComponentRef Id="Microsoft.WindowsAPICodePack.dll" />
       <ComponentRef Id="Microsoft.WindowsAPICodePack.Shell.dll" />
       <ComponentRef Id="System.IO.Abstractions.dll" />
+      <ComponentRef Id="System.Reactive.dll" />
       <ComponentRef Id="System.Reactive.Interfaces.dll" />
       <ComponentRef Id="System.Reactive.Linq.dll" />
       <ComponentRef Id="System.ValueTuple.dll" />


### PR DESCRIPTION
Fixes installer


## Proposed changes

- `System.Reactive.dll` is missing from an installer. We should include it to prevent crashing on startup.

## Test methodology

- Manual testing