### PR TITLE
AzureDevOps CI: prevent call if settings invalid

### DIFF
--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -53,6 +53,12 @@ namespace AzureDevOpsIntegration
             }
 
             var projectUrl = _buildServerWatcher.ReplaceVariables(_settings.ProjectUrl);
+
+            if (!Uri.IsWellFormedUriString(projectUrl, UriKind.Absolute) || string.IsNullOrWhiteSpace(_settings.ApiToken))
+            {
+                return;
+            }
+
             _apiClient = new ApiClient(projectUrl, _settings.ApiToken);
         }
 
@@ -78,6 +84,12 @@ namespace AzureDevOpsIntegration
 
         private async Task ObserveBuildsAsync(DateTime? sinceDate, bool? running, IObserver<BuildInfo> observer, CancellationToken cancellationToken)
         {
+            if (_apiClient == null)
+            {
+                observer.OnCompleted();
+                return;
+            }
+
             try
             {
                 var builds = await _apiClient.QueryBuildsAsync(_settings.BuildDefinitionFilter, sinceDate, running);


### PR DESCRIPTION


Fixes #7390

## Proposed changes

- Prevent http calls to be made (and fail) when the settings are invalid
(if project url is missing)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 6fb065325b568c8f9dc1a12fc9500094fc75fe56
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4042.0
- DPI 192dpi (200% scaling)
