### PR TITLE
Ignore all potential errors from PowerShell during installation

### DIFF
--- a/Setup/UI/TelemetryDlg.wxs
+++ b/Setup/UI/TelemetryDlg.wxs
@@ -19,7 +19,7 @@
         Sequence="execute"
         Value="&quot;[POWERSHELLEXE]&quot; -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -Command &quot;&amp; '[INSTALLDIR]set-telemetry.ps1' [TELEMETRY_ENABLED]; exit $$($Error.Count)&quot;" />
 
-    <CustomAction Id="ConfigureTelemetry" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="yes" />
+    <CustomAction Id="ConfigureTelemetry" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="ignore" Impersonate="yes" />
 
     <InstallExecuteSequence>
       <Custom Action="ConfigureTelemetry" Before="InstallFinalize"><![CDATA[NOT Installed]]></Custom>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7379 


## Proposed changes

- Ignore all errors that might be thrown from script `set-telemetry.ps1` during installation. This will avoid rollback of the installation in case the script cannot be executed for whatever reason.
- The user will get a popup on the first start asking whether they want to opt in or out of telemetry. This was already implemented for portable builds and can be used without modifications.


## Test methodology <!-- How did you ensure quality? -->

- Manual tests:
  - Made the installer fail due to a modification in calling the script `set-telemetry.ps1`. I forced the PowerShell version to 7, which did obviously fail, since PS version 7 doesn't even exist.
  ->This led to the expected rollback of the installation.
  - Added the change proposed in this PR and rebuilt installer.
  ->The call to `set-telemetry.ps1` still fails, but the installer now finishes successfully.
  -> At the first start on a clean system, the user gets the following popup:
![60513985-d84b4480-9d1b-11e9-9077-0bf5cf88f5d2](https://user-images.githubusercontent.com/46861028/69286747-61441900-0bf4-11ea-8ec9-473611f99086.png)



## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.24.0
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
