### PR TITLE
Remove background thread from RevisionDataGridView

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils;
@@ -13,6 +14,7 @@ using GitUI.UserControls.RevisionGrid.Columns;
 using GitUI.UserControls.RevisionGrid.Graph;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitUI.UserControls.RevisionGrid
 {
@@ -33,9 +35,11 @@ namespace GitUI.UserControls.RevisionGrid
         internal RevisionGraph _revisionGraph = new RevisionGraph();
 
         private readonly List<ColumnProvider> _columnProviders = new List<ColumnProvider>();
-        private readonly AutoResetEvent _backgroundEvent = new AutoResetEvent(false);
-        private Thread _backgroundThread;
-        private volatile bool _shouldRun = LicenseManager.UsageMode != LicenseUsageMode.Designtime;
+        private readonly CancellationTokenSequence _backgroundCancellationSequence;
+        private readonly AsyncQueue<(Func<CancellationToken, Task> backgroundOperation, CancellationToken cancellationToken)> _backgroundQueue =
+            new AsyncQueue<(Func<CancellationToken, Task> backgroundOperation, CancellationToken cancellationToken)>();
+        private CancellationToken _backgroundCancellationToken;
+        private JoinableTask _backgroundProcessingTask;
         private int _backgroundScrollTo;
 
         private int _rowHeight; // Height of elements in the cache. Is equal to the control's row height.
@@ -49,12 +53,9 @@ namespace GitUI.UserControls.RevisionGrid
 
         public RevisionDataGridView()
         {
-            _backgroundThread = new Thread(BackgroundThreadEntry)
-            {
-                IsBackground = true,
-                Name = "RevisionDataGridView.backgroundThread"
-            };
-            _backgroundThread.Start();
+            _backgroundCancellationSequence = new CancellationTokenSequence();
+            _backgroundCancellationToken = _backgroundCancellationSequence.Next();
+            StartBackgroundProcessingTask(_backgroundCancellationToken);
 
             NormalFont = AppSettings.Font;
             _monospaceFont = AppSettings.MonospaceFont;
@@ -156,11 +157,12 @@ namespace GitUI.UserControls.RevisionGrid
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Justification = "It looks like such lock was made intentionally but it is better to rewrite this")]
         protected override void Dispose(bool disposing)
         {
-            _shouldRun = false;
-
             if (disposing)
             {
-                _backgroundEvent?.Dispose();
+                // Make sure to mark the background queue as complete before disposing the cancellation token sequence.
+                _backgroundQueue.Complete();
+                _backgroundCancellationSequence.Dispose();
+                _backgroundProcessingTask.Join();
             }
 
             base.Dispose(disposing);
@@ -319,8 +321,9 @@ namespace GitUI.UserControls.RevisionGrid
         {
             _backgroundScrollTo = 0;
 
-            // Force the background thread to be killed, we need to be sure no background processes are running. Not the best practice, but safe.
-            _backgroundThread.Abort();
+            // Cancel all outstanding background operations, and provide a new cancellation token for future work.
+            var cancellationToken = _backgroundCancellationToken = _backgroundCancellationSequence.Next();
+            _backgroundProcessingTask.Join();
 
             // Set rowcount to 0 first, to ensure it is not possible to select or redraw, since we are about te delete the data
             SetRowCount(0);
@@ -337,12 +340,14 @@ namespace GitUI.UserControls.RevisionGrid
             UpdateVisibleRowRange();
             Invalidate(invalidateChildren: true);
 
-            _backgroundThread = new Thread(BackgroundThreadEntry)
-            {
-                IsBackground = true,
-                Name = "RevisionDataGridView.backgroundThread"
-            };
-            _backgroundThread.Start();
+            StartBackgroundProcessingTask(cancellationToken);
+        }
+
+        private void StartBackgroundProcessingTask(CancellationToken cancellationToken)
+        {
+            // Start the background processing via JoinableTaskContext.Factory to avoid tracking the long-running
+            // operation in JoinPendingOperationsAsync.
+            _backgroundProcessingTask = ThreadHelper.JoinableTaskContext.Factory.RunAsync(() => RunBackgroundAsync(cancellationToken));
         }
 
         public bool RowIsRelative(int rowIndex)
@@ -434,69 +439,75 @@ namespace GitUI.UserControls.RevisionGrid
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Justification = "It looks like such lock was made intentionally but it is better to rewrite this")]
-        private void BackgroundThreadEntry()
+        private async Task RunBackgroundAsync(CancellationToken cancellationToken)
         {
-            bool keepRunning = false;
-            while (_shouldRun)
+            if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
             {
-                if (!_shouldRun)
-                {
-                    return;
-                }
+                // Don't run background operations in the designer.
+                return;
+            }
 
-                if (keepRunning || _backgroundEvent.WaitOne(200))
-                {
-                    keepRunning = false;
+            await TaskScheduler.Default;
 
-                    if (!_shouldRun)
+            while (true)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    // The background thread is requesting shutdown. Return immediately unless the work queue is marked
+                    // as completed (meaning the background thread will not be restarted) and still contains work items.
+                    if (!_backgroundQueue.IsCompleted || _backgroundQueue.IsEmpty)
                     {
                         return;
                     }
+                }
 
-                    if (AppSettings.ShowRevisionGridGraphColumn)
+                try
+                {
+                    CancellationToken timeoutToken;
+                    Func<CancellationToken, Task> backgroundOperation;
+                    CancellationToken backgroundOperationCancellation;
+                    try
                     {
-                        int scrollTo = _backgroundScrollTo;
-
-                        int curCount = _revisionGraph.GetCachedCount();
-
-                        UpdateGraph(curCount, scrollTo);
-                        keepRunning = curCount < scrollTo;
+                        using (var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+                        {
+                            timeoutToken = timeoutTokenSource.Token;
+                            (backgroundOperation, backgroundOperationCancellation) = await _backgroundQueue.DequeueAsync(timeoutToken);
+                        }
                     }
-                    else
+                    catch (OperationCanceledException) when (timeoutToken.IsCancellationRequested)
                     {
-                        UpdateGraph(_revisionGraph.Count, _revisionGraph.Count);
+                        // No work was received from the queue within the timeout.
+                        if (RowCount < _revisionGraph.Count)
+                        {
+                            this.InvokeAsync(() => { SetRowCountAndSelectRowsIfReady(_revisionGraph.Count); }).FileAndForget();
+                        }
+
+                        continue;
                     }
 
-                    if (!keepRunning)
+                    if (backgroundOperationCancellation.IsCancellationRequested)
                     {
-                        this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
+                        continue;
+                    }
+
+                    try
+                    {
+                        await backgroundOperation(backgroundOperationCancellation);
+                    }
+                    catch (OperationCanceledException) when (backgroundOperationCancellation.IsCancellationRequested)
+                    {
+                        // Normal cancellation of background work
                     }
                 }
-                else
+                catch (OperationCanceledException) when (_backgroundQueue.IsCompleted && _backgroundQueue.IsEmpty)
                 {
-                    if (RowCount < _revisionGraph.Count)
-                    {
-                        this.InvokeAsync(() => { SetRowCountAndSelectRowsIfReady(_revisionGraph.Count); }).FileAndForget();
-                    }
+                    // Normal completion of background work
+                    return;
                 }
-            }
-
-            void UpdateGraph(int fromIndex, in int toIndex)
-            {
-                // Cache the next item
-                _revisionGraph.CacheTo(toIndex, Math.Min(fromIndex + 1500, toIndex));
-
-                var rowIndex = _revisionGraph.GetCachedCount();
-
-                this.InvokeAsync(UpdateRowCount, toIndex).FileAndForget();
-                return;
-
-                void UpdateRowCount(int row)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    if (RowCount < _revisionGraph.Count)
-                    {
-                        SetRowCountAndSelectRowsIfReady(_revisionGraph.Count);
-                    }
+                    // Normal cancellation of background queue during clear
+                    return;
                 }
             }
         }
@@ -520,10 +531,52 @@ namespace GitUI.UserControls.RevisionGrid
                     if (_backgroundScrollTo != newBackgroundScrollTo)
                     {
                         _backgroundScrollTo = newBackgroundScrollTo;
-                        _backgroundEvent.Set();
+                        _backgroundQueue.Enqueue((BackgroundUpdateAsync, _backgroundCancellationToken));
                     }
 
                     this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
+                }
+            }
+        }
+
+        private Task BackgroundUpdateAsync(CancellationToken cancellationToken)
+        {
+            if (AppSettings.ShowRevisionGridGraphColumn)
+            {
+                int scrollTo;
+                int curCount;
+                do
+                {
+                    scrollTo = _backgroundScrollTo;
+                    curCount = _revisionGraph.GetCachedCount();
+                    UpdateGraph(curCount, scrollTo);
+                }
+                while (curCount < scrollTo);
+            }
+            else
+            {
+                UpdateGraph(_revisionGraph.Count, _revisionGraph.Count);
+            }
+
+            this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged).FileAndForget();
+            return Task.CompletedTask;
+
+            void UpdateGraph(int fromIndex, int toIndex)
+            {
+                // Cache the next item
+                _revisionGraph.CacheTo(toIndex, Math.Min(fromIndex + 1500, toIndex));
+
+                var rowIndex = _revisionGraph.GetCachedCount();
+
+                this.InvokeAsync(UpdateRowCount, toIndex).FileAndForget();
+                return;
+
+                void UpdateRowCount(int row)
+                {
+                    if (RowCount < _revisionGraph.Count)
+                    {
+                        SetRowCountAndSelectRowsIfReady(_revisionGraph.Count);
+                    }
                 }
             }
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -235,6 +235,12 @@ namespace GitUI
                 }
 
                 components?.Dispose();
+
+                if (!Controls.Contains(_gridView))
+                {
+                    // Dispose _gridView explicitly since it won't be disposed automatically
+                    _gridView.Dispose();
+                }
             }
 
             base.Dispose(disposing);


### PR DESCRIPTION
This is a work-in-progress to eliminate the use of a background processing thread in `RevisionDataGridView`.

* [x] Switch from `Thread` to `AsyncQueue<T>`
* [x] ~~Add helpers to wait for background updates to complete before proceeding with tests~~ (follow-up #7573)