### PR TITLE
Apply timeouts to JoinTillEmptyAsync

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableVisualStudioThreading)' != 'false'">
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.132" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.33" />
   </ItemGroup>
 
 </Project>

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.Threading;
@@ -112,9 +113,9 @@ namespace GitUI
                 });
         }
 
-        public static async Task JoinPendingOperationsAsync()
+        public static async Task JoinPendingOperationsAsync(CancellationToken cancellationToken)
         {
-            await _joinableTaskCollection.JoinTillEmptyAsync();
+            await _joinableTaskCollection.JoinTillEmptyAsync(cancellationToken);
         }
 
         public static T CompletedResult<T>(this Task<T> task)

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -16,7 +16,7 @@ namespace CommonTestUtils
                 noBranchText: string.Empty,
                 updateStatus: updateStatus);
 
-            AsyncTestHelper.WaitForPendingOperations();
+            AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
             provider.StatusUpdated -= Provider_StatusUpdated;
 
@@ -37,7 +37,7 @@ namespace CommonTestUtils
                 workingDirectory: module.WorkingDir,
                 gitStatus: gitStatus);
 
-            AsyncTestHelper.WaitForPendingOperations();
+            AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
             provider.StatusUpdated -= Provider_StatusUpdated;
 

--- a/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormCommitTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using CommonTestUtils;
 using FluentAssertions;
 using GitUI;
 using GitUI.CommandsDialogs;
@@ -88,7 +89,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             _referenceRepository.CheckoutMaster();
             RunFormTest(async form =>
             {
-                await ThreadHelper.JoinPendingOperationsAsync();
+                using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
+                {
+                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
+                }
 
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
@@ -104,7 +108,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             _referenceRepository.CheckoutRevision();
             RunFormTest(async form =>
             {
-                await ThreadHelper.JoinPendingOperationsAsync();
+                using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
+                {
+                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
+                }
 
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
@@ -120,7 +127,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
             _referenceRepository.CreateRemoteForMasterBranch();
             RunFormTest(async form =>
             {
-                await ThreadHelper.JoinPendingOperationsAsync();
+                using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
+                {
+                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
+                }
 
                 var currentBranchNameLabelStatus = form.GetTestAccessor().CurrentBranchNameLabelStatus;
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
@@ -253,7 +263,10 @@ namespace GitUITests.CommandsDialogs.CommitDialog
         {
             RunFormTest(async form =>
             {
-                await ThreadHelper.JoinPendingOperationsAsync();
+                using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
+                {
+                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
+                }
 
                 form.GetTestAccessor().UnstagedList.ClearSelected();
 

--- a/UnitTests/GitUITests/ThreadHelperTests.cs
+++ b/UnitTests/GitUITests/ThreadHelperTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using CommonTestUtils;
 using GitUI;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
@@ -241,7 +242,10 @@ namespace GitUITests
             // Note that ThreadHelper.JoinableTaskContext.Factory must be used to bypass the default behavior of
             // ThreadHelper.JoinableTaskFactory since the latter adds new tasks to the collection and would therefore
             // never complete.
-            ThreadHelper.JoinableTaskContext?.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync());
+            using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
+            {
+                ThreadHelper.JoinableTaskContext?.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(cts.Token));
+            }
         }
 
         private sealed class ThreadExceptionHelper : IDisposable


### PR DESCRIPTION
Applies a 60-second timeout to `JoinTillEmptyAsync`. When a debugger is attached, the timeout is extended to an hour.