### PR TITLE
Dev: Improve dev experience in plugins projects

### DIFF
--- a/Plugins/Directory.Build.targets
+++ b/Plugins/Directory.Build.targets
@@ -1,0 +1,20 @@
+<Project>
+
+  <!-- Import content of parent file otherwise the content is masked -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(SolutionDir)'))" />
+  <!--
+      Direct plugins artifacts to be placed under GitExtensions/Plugins folder
+    -->
+  <Target Name="CopyPlugin"
+          BeforeTargets="GetTargetPath"
+          Condition=" '$(Configuration)' == 'Debug' And '$(ProjectName)' != 'GitUIPluginInterfaces'">
+
+    <PropertyGroup>
+      <OutDir>$(SolutionDir)GitExtensions\$(OutDir)Plugins\</OutDir>
+    </PropertyGroup>
+
+    <!-- Fail if we don't have 'SolutionDir' variable is not set -->
+    <Error Condition="'$(SolutionDir)' == ''" Text="'SolutionDir' is unset" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
by copying the output dll directly in GitExtensions folder.
That way, you avoid having to rebuild GitExtensions project (which is very slow)
that do the copy in a PostEvent.

Just launching the debug in Visual Studio is now enough

Requires to update all the csproj to support `Directory.Build.targets`
