### PR TITLE
Sort branches alphabethical/lastAccess (#6310)

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Remotes\RemoteParser.cs" />
     <Compile Include="Remotes\RepoNameExtractor.cs" />
     <Compile Include="Settings\AvatarProvider.cs" />
+    <Compile Include="Settings\BranchOrdering.cs" />
     <Compile Include="Settings\GravatarFallbackAvatarType.cs" />
     <Compile Include="Settings\IgnoreWhitespaceKind.cs" />
     <Compile Include="Submodules\DetailedSubmoduleInfo.cs" />

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1620,6 +1620,12 @@ namespace GitCommands
             set => SetBool("UseConsoleEmulatorForCommands", value);
         }
 
+        public static BranchOrdering BranchOrderingCriteria
+        {
+            get { return GetEnum("BranchOrderingCriteria", BranchOrdering.ByLastAccessDate); }
+            set { SetEnum("BranchOrderingCriteria", value); }
+        }
+
         public static DiffListSortType DiffListSorting
         {
             get => GetEnum("DiffListSortType", DiffListSortType.FilePath);

--- a/GitCommands/Settings/BranchOrdering.cs
+++ b/GitCommands/Settings/BranchOrdering.cs
@@ -1,0 +1,8 @@
+﻿namespace GitCommands
+{
+    public enum BranchOrdering
+    {
+        ByLastAccessDate = 0,
+        Alphabetically = 1,
+    }
+}

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -5,12 +5,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitCommands;
 using GitCommands.Git;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.Properties;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
-using ResourceManager;
 
 namespace GitUI.BranchTreePanel
 {
@@ -245,6 +245,12 @@ namespace GitUI.BranchTreePanel
                 token.ThrowIfCancellationRequested();
 
                 var branchNames = Module.GetRefs(tags: false, branches: true, noLocks: true).Select(b => b.Name);
+
+                if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
+                {
+                    branchNames = branchNames.OrderBy(b => b);
+                }
+
                 return FillBranchTree(branchNames, token);
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2078,12 +2078,16 @@ namespace GitUI.CommandsDialogs
 
                 IEnumerable<string> GetBranchNames()
                 {
+                    var branchNames = Module.GetRefs(tags: false, branches: true, noLocks: true).Select(b => b.Name);
+
+                    if (AppSettings.BranchOrderingCriteria == BranchOrdering.Alphabetically)
+                    {
+                        branchNames = branchNames.OrderBy(b => b);
+                    }
+
                     // Make sure there are never more than a 100 branches added to the menu
                     // Git Extensions will hang when the drop down is too large...
-                    return Module
-                        .GetRefs(tags: false, branches: true, noLocks: true)
-                        .Select(b => b.Name)
-                        .Take(100);
+                    return branchNames.Take(100);
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -94,6 +94,7 @@ namespace GitUI.CommandsDialogs
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this), detailedSettingsPage, Images.BranchFolder);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<CommitDialogSettingsPage>(this), detailedSettingsPage, Images.CommitSummary);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DiffViewerSettingsPage>(this), detailedSettingsPage, Images.Diff);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BranchesSettingsPage>(this), detailedSettingsPage, Images.Branch);
 
             var sshSettingsPage = SettingsPageBase.Create<SshSettingsPage>(this);
             settingsTreeView.AddSettingsPage(sshSettingsPage, gitExtPageRef, Images.Key);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BranchesSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BranchesSettingsPage.cs
@@ -1,0 +1,29 @@
+﻿using GitCommands;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    public partial class BranchesSettingsPage : SettingsPageWithHeader
+    {
+        public BranchesSettingsPage()
+        {
+            InitializeComponent();
+            Text = "Branches";
+            InitializeComplete();
+        }
+
+        protected override void SettingsToPage()
+        {
+            cbBranchOrderingCriteria.SelectedIndex = (int)AppSettings.BranchOrderingCriteria;
+        }
+
+        protected override void PageToSettings()
+        {
+            AppSettings.BranchOrderingCriteria = (BranchOrdering)cbBranchOrderingCriteria.SelectedIndex;
+        }
+
+        public static SettingsPageReference GetPageReference()
+        {
+            return new SettingsPageReferenceByType(typeof(BranchesSettingsPage));
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BranchesSettingsPage.designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BranchesSettingsPage.designer.cs
@@ -1,0 +1,111 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    partial class BranchesSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.tableLayoutPanelForToolbar = new System.Windows.Forms.TableLayoutPanel();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cbBranchOrderingCriteria = new System.Windows.Forms.ComboBox();
+            this.tooltip = new System.Windows.Forms.ToolTip(this.components);
+            this.tableLayoutPanelForToolbar.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanelForToolbar
+            // 
+            this.tableLayoutPanelForToolbar.AutoSize = true;
+            this.tableLayoutPanelForToolbar.ColumnCount = 2;
+            this.tableLayoutPanelForToolbar.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelForToolbar.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelForToolbar.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanelForToolbar.Controls.Add(this.cbBranchOrderingCriteria, 1, 0);
+            this.tableLayoutPanelForToolbar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelForToolbar.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanelForToolbar.Name = "tableLayoutPanelForToolbar";
+            this.tableLayoutPanelForToolbar.RowCount = 9;
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelForToolbar.Size = new System.Drawing.Size(2046, 575);
+            this.tableLayoutPanelForToolbar.TabIndex = 1;
+            // 
+            // label2
+            // 
+            this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 7);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(310, 32);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Branch ordering criteria";
+            // 
+            // cbBranchOrderingCriteria
+            // 
+            this.cbBranchOrderingCriteria.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbBranchOrderingCriteria.FormattingEnabled = true;
+            this.cbBranchOrderingCriteria.Items.AddRange(new object[] {
+            "Last access date",
+            "Alphabetically"});
+            this.cbBranchOrderingCriteria.Location = new System.Drawing.Point(319, 3);
+            this.cbBranchOrderingCriteria.Name = "cbBranchOrderingCriteria";
+            this.cbBranchOrderingCriteria.Size = new System.Drawing.Size(337, 39);
+            this.cbBranchOrderingCriteria.TabIndex = 3;
+            // 
+            // tooltip
+            // 
+            this.tooltip.AutoPopDelay = 30000;
+            this.tooltip.InitialDelay = 500;
+            this.tooltip.ReshowDelay = 100;
+            // 
+            // BranchesSettingsPage
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.tableLayoutPanelForToolbar);
+            this.Name = "BranchesSettingsPage";
+            this.Size = new System.Drawing.Size(2046, 575);
+            this.tableLayoutPanelForToolbar.ResumeLayout(false);
+            this.tableLayoutPanelForToolbar.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelForToolbar;
+        private System.Windows.Forms.ToolTip tooltip;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ComboBox cbBranchOrderingCriteria;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BranchesSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BranchesSettingsPage.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="tooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -317,6 +317,12 @@
     <Compile Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.Designer.cs">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
     </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\Pages\BranchesSettingsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CommandsDialogs\SettingsDialog\Pages\BranchesSettingsPage.designer.cs">
+      <DependentUpon>BranchesSettingsPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\AzureDevopsExternalLinkDefinitionExtractor.cs" />
     <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\CloudProviderExternalLinkDefinitionExtractorFactory.cs" />
     <Compile Include="CommandsDialogs\SettingsDialog\RevisionLinks\CloudProviderKind.cs" />
@@ -1324,6 +1330,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\FormBrowseRepoSettingsPage.resx">
       <DependentUpon>FormBrowseRepoSettingsPage.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CommandsDialogs\SettingsDialog\Pages\BranchesSettingsPage.resx">
+      <DependentUpon>BranchesSettingsPage.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CommandsDialogs\SettingsDialog\RepoDistSettingsPage.resx">
       <DependentUpon>RepoDistSettingsPage.cs</DependentUpon>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -286,6 +286,26 @@ See http://en.gravatar.com/site/implement/images#default-image for more details.
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="BranchesSettingsPage" source-language="en">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbBranchOrderingCriteria.Item0">
+        <source>Last access date</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbBranchOrderingCriteria.Item1">
+        <source>Alphabetically</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="label2.Text">
+        <source>Branch ordering criteria</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="BranchMenuItemsStrings" source-language="en">
     <body>
       <trans-unit id="CheckoutTooltip.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6310

Note: These changes are mostly copied from a previous PR #4124 which has been merged and the changes removed later.

## Proposed changes
- Add a configuration setting to choose the ordering criteria of the branches in the dropdown: by date (default) or alphabetically. It affects the branch list in the top bar menu and the repo objects side panel.

## Screenshots <!-- Remove this section if PR does not change UI -->

### New settings sub-menu

![image](https://user-images.githubusercontent.com/1075032/69654737-937ecc00-1075-11ea-9def-09922e3dd5db.png)

## Test methodology <!-- How did you ensure quality? -->
Manually tested:
- Check the branches are shown in date order by default in the top bar menu
- Check the branches are shown in date order by default in the repo objects side panel
- Change the setting to alphabetical
- Check the branches are shown in alphabetical order in the top bar menu
- Check the branches are shown in alphabetical order in the repo objects side panel
- Change the setting to last access date
- Check the branches are shown in date order in the top bar menu
- Check the branches are shown in date order in the repo objects side panel

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.24
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
