### PR TITLE
Removes extra dot from Save as revfiletree dialog

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -677,7 +677,7 @@ See the changes in the commit form.");
                 {
                     var extension = Path.GetExtension(fileDialog.FileName);
 
-                    fileDialog.Filter = $@"{_saveFileFilterCurrentFormat.Text}(*.{extension})|*.{extension}| {_saveFileFilterAllFiles.Text} (*.*)|*.*";
+                    fileDialog.Filter = $@"{_saveFileFilterCurrentFormat.Text}(*{extension})|*{extension}| {_saveFileFilterAllFiles.Text} (*.*)|*.*";
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)
                     {
                         Module.SaveBlobAs(fileDialog.FileName, gitItem.Guid);

--- a/contributors.txt
+++ b/contributors.txt
@@ -107,3 +107,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/10/18, RalphJSmart, Ralph J Smart, id1508-gitextensions_github(at)yahoo.com
 2019/10/24, jvitkauskas, Julius Vitkauskas, zadintuvas(at)gmail.com
 2019/10/31, rickaas, Ricky Lindeman, saakcir(at)gmail.com
+2019/11/27, andrewcartwright1, Andrew Cartwright, kickme93(at)hotmail.co.uk


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7444

## Proposed changes

- Use file extension as filter and as save type

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/10059155/69704280-01b1a600-10eb-11ea-8a6e-c46fdce67aea.png)

### After

![Save as Dialog](https://user-images.githubusercontent.com/10059155/69703991-83550400-10ea-11ea-9c76-691e90ae87e2.png)

![Output saved file](https://user-images.githubusercontent.com/10059155/69704047-9e277880-10ea-11ea-8351-e51bf0d86e65.png)


## Test methodology <!-- How did you ensure quality? -->

- I saved a file without the extra dot and verified that the file type was correct.

## Test environment(s)

- GIT version 2.24.0.windows.2
- Windows Version 10.0.18363 Build 18363

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
