### PR TITLE
Azure devops ci: reduce calls to api when revision grid is refreshed 

### DIFF
--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -19,9 +19,6 @@ namespace AzureDevOpsIntegration
         private const string BuildDefinitionsUrl = "build/definitions?api-version=2.0";
         private readonly HttpClient _httpClient;
 
-        private string _buildDefinitionsToQuery;
-        private string _lastBuildDefinitionFilter;
-
         /// <summary>
         /// Creates a new API client instance for the given Azure DevOps / TFS project, that uses the given authentication token.
         /// </summary>
@@ -68,7 +65,7 @@ namespace AzureDevOpsIntegration
         }
 
         [ItemCanBeNull]
-        private async Task<string> GetBuildDefinitionsAsync(string buildDefinitionNameFilter)
+        public async Task<string> GetBuildDefinitionsAsync(string buildDefinitionNameFilter)
         {
             var isNotFiltered = string.IsNullOrWhiteSpace(buildDefinitionNameFilter);
             var buildDefinitionUriFilter = isNotFiltered ? string.Empty : "&name=" + buildDefinitionNameFilter;
@@ -112,20 +109,14 @@ namespace AzureDevOpsIntegration
             return build.Definition.Name;
         }
 
-        public async Task<IEnumerable<Build>> QueryBuildsAsync(string buildDefinitionFilter, DateTime? sinceDate, bool? running)
+        public async Task<IEnumerable<Build>> QueryBuildsAsync(string buildDefinitionsToQuery, DateTime? sinceDate, bool? running)
         {
-            if (_buildDefinitionsToQuery == null || !string.Equals(_lastBuildDefinitionFilter, buildDefinitionFilter, StringComparison.OrdinalIgnoreCase))
-            {
-                _buildDefinitionsToQuery = await GetBuildDefinitionsAsync(buildDefinitionFilter);
-                _lastBuildDefinitionFilter = buildDefinitionFilter;
-            }
-
-            if (_buildDefinitionsToQuery == null)
+            if (buildDefinitionsToQuery == null)
             {
                 return Enumerable.Empty<Build>();
             }
 
-            var builds = (await HttpGetAsync<ListWrapper<Build>>($"build/builds?api-version=2.0&definitions={_buildDefinitionsToQuery}")).Value;
+            var builds = (await HttpGetAsync<ListWrapper<Build>>($"build/builds?api-version=2.0&definitions={buildDefinitionsToQuery}")).Value;
 
             return builds
                 .Where(b => !running.HasValue || running.Value == b.IsInProgress)

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -77,7 +77,7 @@ namespace AzureDevOpsIntegration
             return GetBuilds(scheduler, null, true);
         }
 
-        public IObservable<BuildInfo> GetBuilds(IScheduler scheduler, DateTime? sinceDate = null, bool? running = null)
+        private IObservable<BuildInfo> GetBuilds(IScheduler scheduler, DateTime? sinceDate = null, bool? running = null)
         {
             return Observable.Create<BuildInfo>((observer, cancellationToken) => ObserveBuildsAsync(sinceDate, running, observer, cancellationToken));
         }
@@ -94,7 +94,10 @@ namespace AzureDevOpsIntegration
             {
                 var builds = await _apiClient.QueryBuildsAsync(_settings.BuildDefinitionFilter, sinceDate, running);
 
-                Parallel.ForEach(builds, detail => { observer.OnNext(CreateBuildInfo(detail)); });
+                foreach (var build in builds)
+                {
+                    observer.OnNext(CreateBuildInfo(build));
+                }
             }
             catch (OperationCanceledException)
             {

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -3,7 +3,6 @@ using System.ComponentModel.Composition;
 using System.Globalization;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AzureDevOpsIntegration.Settings;
@@ -37,6 +36,14 @@ namespace AzureDevOpsIntegration
         private ApiClient _apiClient;
         private static readonly IBuildDurationFormatter _buildDurationFormatter = new BuildDurationFormatter();
         private Task<string> _buildDefinitionsTask;
+        private string _projectUrl;
+        private string _buildDefinitions;
+
+        // Static variable used to convey the data between the different instances of the class but that doesn't necessarily require synchronisation because:
+        // * there is only one instance at every given time (link to the revision grid and recreated on revision grid refresh)
+        // * data is created by the first instance and used in readonly by the later instances
+        private static CacheAzureDevOps CacheAzureDevOps = null;
+        private string CacheKey => _projectUrl + "|" + _settings.BuildDefinitionFilter;
 
         public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
@@ -53,15 +60,23 @@ namespace AzureDevOpsIntegration
                 return;
             }
 
-            var projectUrl = _buildServerWatcher.ReplaceVariables(_settings.ProjectUrl);
+            _projectUrl = _buildServerWatcher.ReplaceVariables(_settings.ProjectUrl);
 
-            if (!Uri.IsWellFormedUriString(projectUrl, UriKind.Absolute) || string.IsNullOrWhiteSpace(_settings.ApiToken))
+            if (!Uri.IsWellFormedUriString(_projectUrl, UriKind.Absolute) || string.IsNullOrWhiteSpace(_settings.ApiToken))
             {
                 return;
             }
 
-            _apiClient = new ApiClient(projectUrl, _settings.ApiToken);
-            _buildDefinitionsTask = _apiClient.GetBuildDefinitionsAsync(_settings.BuildDefinitionFilter);
+            _apiClient = new ApiClient(_projectUrl, _settings.ApiToken);
+            if (CacheAzureDevOps == null || CacheAzureDevOps.Id != CacheKey)
+            {
+                CacheAzureDevOps = null;
+                _buildDefinitionsTask = _apiClient.GetBuildDefinitionsAsync(_settings.BuildDefinitionFilter);
+            }
+            else
+            {
+                _buildDefinitions = CacheAzureDevOps.BuildDefinitions;
+            }
         }
 
         /// <summary>
@@ -94,15 +109,20 @@ namespace AzureDevOpsIntegration
 
             try
             {
-                var buildDefinitions = await _buildDefinitionsTask;
-
-                if (buildDefinitions == null)
+                if (_buildDefinitions == null)
                 {
-                    observer.OnCompleted();
-                    return;
+                    _buildDefinitions = await _buildDefinitionsTask;
+
+                    if (_buildDefinitions == null)
+                    {
+                        observer.OnCompleted();
+                        return;
+                    }
+
+                    CacheAzureDevOps = new CacheAzureDevOps { Id = CacheKey, BuildDefinitions = _buildDefinitions };
                 }
 
-                var builds = await _apiClient.QueryBuildsAsync(buildDefinitions, sinceDate, running);
+                var builds = await _apiClient.QueryBuildsAsync(_buildDefinitions, sinceDate, running);
 
                 foreach (var build in builds)
                 {

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="CacheAzureDevOps.cs" />
     <Compile Include="Settings\SettingsUserControl.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/CacheAzureDevOps.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/CacheAzureDevOps.cs
@@ -1,0 +1,8 @@
+namespace AzureDevOpsIntegration
+{
+    public class CacheAzureDevOps
+    {
+        public string Id { get; set; }
+        public string BuildDefinitions { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes (indeed reduce the chances it happens) https://github.com/gitextensions/gitextensions/pull/7452#issuecomment-559084273

## Proposed changes

- Put build definitions in cache:

Prevent doing every time calls to retrieve build definitions

by putting them in cache.

Build definitions don't change often
 and it's acceptable to restart GitExtensions when it's the case

Prevent 2 to 4 api calls at each revision grid refresh
keeping only the 2 calls to get the build results (finished and running).

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build b9f1245890c935f0bb6e964907c952b54a732e0a (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4042.0
- DPI 192dpi (200% scaling)

