### PR TITLE
Open CommitInfo context menu not only in textboxes

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -236,6 +236,7 @@ namespace GitUI.CommitInfo
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.SystemColors.Window;
+            this.ContextMenuStrip = this.commitInfoContextMenuStrip;
             this.Controls.Add(this.tableLayout);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "CommitInfo";


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/issues/5741#issuecomment-564006028

## Proposed changes

- open CommitInfo context menu not only in textboxes but for the whole control

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 6739bd90eb258dc3732a1e91b879c9feb052a397
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4018.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
