### PR TITLE
Reduce clipping in FormSettings

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -156,6 +156,74 @@ namespace GitUI.CommandsDialogs
             }
 
             WindowState = FormWindowState.Normal;
+
+            if (HasClippedControl())
+            {
+                var appFont = AppSettings.Font;
+                var smallFont = new Font(appFont.FontFamily, emSize: 8);
+                ReplaceFont(Controls, appFont, smallFont);
+                foreach (var page in settingsTreeView.SettingsPages)
+                {
+                    ReplaceFont(page?.GuiControl?.Controls, appFont, smallFont);
+                }
+            }
+
+            return;
+
+            // TODO: C#8 static
+            void ReplaceFont(Control.ControlCollection controls, Font oldFont, Font newFont)
+            {
+                if (controls == null)
+                {
+                    return;
+                }
+
+                foreach (Control control in controls)
+                {
+                    if (control.Font.Equals(oldFont))
+                    {
+                        control.Font = newFont;
+                    }
+
+                    ReplaceFont(control.Controls, oldFont, newFont);
+                }
+            }
+
+            bool HasClippedControl()
+            {
+                foreach (var page in settingsTreeView.SettingsPages)
+                {
+                    if (ContainsClippedControl(page?.GuiControl?.Controls))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+
+                bool ContainsClippedControl(Control.ControlCollection controls)
+                {
+                    if (controls == null)
+                    {
+                        return false;
+                    }
+
+                    foreach (Control control in controls)
+                    {
+                        if (control.Bottom > panelCurrentSettingsPage.Bottom && control.Visible && control.GetType() != typeof(TableLayoutPanel))
+                        {
+                            return true;
+                        }
+
+                        if (ContainsClippedControl(control.Controls))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+            }
         }
 
         private void FormSettings_Shown(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -119,7 +119,7 @@
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.Size = new System.Drawing.Size(1337, 342);
             this.tlpnlConfirmations.TabIndex = 1;
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -134,13 +134,14 @@
             // toolStripManageCategories
             // 
             this.toolStripManageCategories.AllowMerge = false;
+            this.toolStripManageCategories.GripMargin = new System.Windows.Forms.Padding(0);
             this.toolStripManageCategories.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
             this.toolStripManageCategories.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.Add,
             this.toolStripSeparator1,
             this.Remove});
-            this.toolStripManageCategories.Location = new System.Drawing.Point(5, 0);
-            this.toolStripManageCategories.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.toolStripManageCategories.Location = new System.Drawing.Point(0, 1);
+            this.toolStripManageCategories.Margin = new System.Windows.Forms.Padding(0, 1, 0, 0);
             this.toolStripManageCategories.Name = "toolStripManageCategories";
             this.toolStripManageCategories.Size = new System.Drawing.Size(182, 25);
             this.toolStripManageCategories.TabIndex = 5;


### PR DESCRIPTION
Fixes #7514 
Fixes #7387

## Proposed changes

- switch to small font in case of clipped controls
  (should fit for screens with a height of 768 pixels)
- auto-size last row of Confirmations page
- remove horizontal padding for ToolStrip of Revision Links page
  There' still a glitch: The listbox is truncated at the bottom although `Dock = Fill`.

## Screenshots

### Before

![grafik](https://user-images.githubusercontent.com/36601201/70869008-b7ec0b00-1f86-11ea-947a-d502c7be276a.png)

### After

no change on higher resolution

low resolution (mocked up with huge application font):

![grafik](https://user-images.githubusercontent.com/36601201/70868994-912dd480-1f86-11ea-8dd1-ae66c5e3f6c6.png)

### Before

![grafik](https://user-images.githubusercontent.com/36601201/70869038-013c5a80-1f87-11ea-8806-a10c3d1f73b5.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/70869058-2df07200-1f87-11ea-9d36-10d9d5a2f93d.png)

### Before

![grafik](https://user-images.githubusercontent.com/36601201/70869092-81fb5680-1f87-11ea-987c-de626471290c.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/70869079-6a23d280-1f87-11ea-91c8-60d5ea5a0c0c.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 88f51039e4f2c1b281210f8152f8521b133c6d2a
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4075.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
