### PR TITLE
CI: Improve Azure Devops builds

### DIFF
--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -118,10 +118,15 @@ namespace AzureDevOpsIntegration
 
             var builds = (await HttpGetAsync<ListWrapper<Build>>($"build/builds?api-version=2.0&definitions={buildDefinitionsToQuery}")).Value;
 
+            if (!running.HasValue || running.Value)
+            {
+                return builds
+                    .Where(b => !running.HasValue || running.Value == b.IsInProgress)
+                    .Where(b => !sinceDate.HasValue || b.StartTime >= sinceDate.Value.ToUniversalTime());
+            }
+
             return builds
-                .Where(b => !running.HasValue || running.Value == b.IsInProgress)
-                .Where(b => !sinceDate.HasValue || b.StartTime >= sinceDate.Value)
-                .ToList();
+                .Where(b => !sinceDate.HasValue || (b.FinishTime != null && b.FinishTime >= sinceDate.Value.ToUniversalTime()));
         }
 
         public void Dispose()

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -31,6 +31,7 @@ namespace AzureDevOpsIntegration
     {
         public const string PluginName = "Azure DevOps and Team Foundation Server (since TFS2015)";
 
+        private bool _firstCallForFinishedBuildsWasIgnored = false;
         private IBuildServerWatcher _buildServerWatcher;
         private IntegrationSettings _settings;
         private ApiClient _apiClient;
@@ -86,6 +87,12 @@ namespace AzureDevOpsIntegration
 
         public IObservable<BuildInfo> GetFinishedBuildsSince(IScheduler scheduler, DateTime? sinceDate = null)
         {
+            if (!_firstCallForFinishedBuildsWasIgnored)
+            {
+                _firstCallForFinishedBuildsWasIgnored = true;
+                return Observable.Empty<BuildInfo>();
+            }
+
             return GetBuilds(scheduler, sinceDate, false);
         }
 


### PR DESCRIPTION
## Proposed changes

- Solve case where a running build stay displayed as running forever even if it is finished since a long time (condition on how to filter on finished build was not good)
by filtering on the FinishTime instead of the StartTime
& solve time management as AzureDevOps use UTC time format

- AzureDevOps: Ignore first api call for finished builds
because as it is implemented now, the 2 first calls (to retrieve today finished builds and all finished builds) are doing the same api call. So we could skip the first call to only keep the one retrieving all the finished builds and so prevent a useless api call (and be more server friendly)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 63aaf21d9ea76f72cf80640421d869f6fb444463 (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4067.0
- DPI 192dpi (200% scaling)

