### PR TITLE
Color scheme followup

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1651,7 +1651,10 @@ namespace GitCommands
         [CanBeNull]
         public static string GetGitExtensionsDirectory()
         {
-            return Path.GetDirectoryName(GetGitExtensionsFullPath());
+            var assembly = Assembly.GetEntryAssembly() ?? // common case, GitExtensions.exe
+                           Assembly.GetExecutingAssembly(); // unit test, GitCommands.dll
+            var path = new Uri(assembly.CodeBase).LocalPath;
+            return Path.GetDirectoryName(path);
         }
 
         private static RegistryKey _versionIndependentRegKey;

--- a/GitExtUtils/GitUI/Theming/AppColor.cs
+++ b/GitExtUtils/GitUI/Theming/AppColor.cs
@@ -1,5 +1,12 @@
 ﻿namespace GitExtUtils.GitUI.Theming
 {
+    /// <summary>
+    /// GitExtensions' application specific color names
+    /// </summary>
+    /// <remarks>
+    /// Values are stored in AppSettings class. Whenever new name is added here, add default value
+    /// to <see cref="AppColorDefaults"/> and \GitUI\Themes\win10default.colors
+    /// </remarks>
     public enum AppColor
     {
         OtherTag,

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -35,7 +35,8 @@ namespace GitExtUtils.GitUI.Theming
                     .Where(c => IsSystemColor(c) && !Duplicates.ContainsKey(c)));
 
         /// <summary>
-        /// Get GitExtensions app-specific color value as defined by this instance
+        /// Get GitExtensions app-specific color value as defined by this instance. If not defined,
+        /// returns <see cref="Color.Empty"/>
         /// </summary>
         public abstract Color GetColor(AppColor name);
 

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -47,7 +47,7 @@ namespace GitExtUtils.GitUI.Theming
         {
             if (!IsSystemColor(name))
             {
-                return Color.FromKnownColor(name);
+                throw new ArgumentException($"{name} is not system color");
             }
 
             var actualName = Duplicates.TryGetValue(name, out var duplicate)

--- a/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -16,8 +16,15 @@ namespace GitExtUtils.GitUI.Theming
         private static readonly ConditionalWeakTable<IWin32Window, IWin32Window> AlreadyFixedContextMenuOwners =
             new ConditionalWeakTable<IWin32Window, IWin32Window>();
 
+        public static bool UseSystemVisualStyle { private get; set; } = true;
+
         public static void FixVisualStyle(this Control container)
         {
+            if (UseSystemVisualStyle)
+            {
+                return;
+            }
+
             container.DescendantsToFix<GroupBox>()
                  .ForEach(SetupGroupBox);
             container.DescendantsToFix<TreeView>()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -581,16 +581,15 @@
             // lblRestartNeeded
             // 
             this.lblRestartNeeded.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.lblRestartNeeded.AutoSize = true;
             this.fpnlTheme.SetFlowBreak(this.lblRestartNeeded, true);
-            this.lblRestartNeeded.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblRestartNeeded.Image = global::GitUI.Properties.Images.Warning;
-            this.lblRestartNeeded.ImageAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.lblRestartNeeded.Location = new System.Drawing.Point(3, 3);
+            this.lblRestartNeeded.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblRestartNeeded.Location = new System.Drawing.Point(3, 5);
             this.lblRestartNeeded.Name = "lblRestartNeeded";
-            this.lblRestartNeeded.Size = new System.Drawing.Size(284, 21);
+            this.lblRestartNeeded.Size = new System.Drawing.Size(221, 16);
             this.lblRestartNeeded.TabIndex = 5;
-            this.lblRestartNeeded.Text = "     To apply changes restart is necessary";
+            this.lblRestartNeeded.Text = "To apply changes restart is necessary";
+            this.lblRestartNeeded.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // _NO_TRANSLATE_cbSelectTheme
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -588,7 +588,7 @@
             this.lblRestartNeeded.Name = "lblRestartNeeded";
             this.lblRestartNeeded.Size = new System.Drawing.Size(221, 16);
             this.lblRestartNeeded.TabIndex = 5;
-            this.lblRestartNeeded.Text = "To apply changes restart is necessary";
+            this.lblRestartNeeded.Text = "Restart required to apply changes";
             this.lblRestartNeeded.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // _NO_TRANSLATE_cbSelectTheme
@@ -634,6 +634,7 @@
             this.chkUseSystemVisualStyle.TabIndex = 4;
             this.chkUseSystemVisualStyle.Text = "Use system-defined visual style (looks bad with dark colors)";
             this.chkUseSystemVisualStyle.UseVisualStyleBackColor = true;
+            this.chkUseSystemVisualStyle.CheckedChanged += new System.EventHandler(this.ChkUseSystemVisualStyle_CheckedChanged);
             // 
             // ColorsSettingsPage
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Settings;
-using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
@@ -57,10 +56,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             result.AdjustForDpiScaling();
             result.EnableRemoveWordHotkey();
-            if (!AppSettings.UseSystemVisualStyle)
-            {
-                result.FixVisualStyle();
-            }
+            result.FixVisualStyle();
 
             result.Init(pageHost);
             return result;

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -277,7 +277,7 @@ namespace GitUI.Editor
         private void SetHighlightingStrategy(IHighlightingStrategy highlightingStrategy)
         {
             TextEditor.Document.HighlightingStrategy =
-                AppSettings.UseSystemVisualStyle
+                ThemeModule.Controller.UseSystemVisualStyle
                     ? highlightingStrategy
                     : new ThemeBasedHighlighting(highlightingStrategy);
             TextEditor.Refresh();

--- a/GitUI/Themes/win10default.colors
+++ b/GitUI/Themes/win10default.colors
@@ -30,6 +30,7 @@ MenuBar: f0f0f0
 MenuHighlight: 3399ff
 OtherTag: 808080
 AuthoredHighlight: ffffe0
+HighlightAllOccurences: ffffe0
 Tag: 00008b
 Graph: 8b0000
 Branch: 8b0000

--- a/GitUI/Theming/FormThemeEditor.cs
+++ b/GitUI/Theming/FormThemeEditor.cs
@@ -5,13 +5,18 @@ using System.Text;
 using System.Windows.Forms;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
+using ResourceManager;
 
 namespace GitUI.Theming
 {
     public class FormThemeEditor : GitExtensionsForm
     {
-        private const string Title = "Theme editor";
-        private const string HintOnResettingColor = "middle-click to reset";
+        private readonly TranslationString _title = new TranslationString("Theme editor");
+        private readonly TranslationString _hintOnResettingColor = new TranslationString("middle-click to reset");
+        private readonly TranslationString _resetAllColors = new TranslationString("Reset all colors");
+        private readonly TranslationString _save = new TranslationString("Save");
+        private readonly TranslationString _load = new TranslationString("Load");
+
         private readonly Size _cellSize;
         private readonly Padding _cellMargin;
         private readonly FlowLayoutPanel _layoutPanel;
@@ -32,7 +37,7 @@ namespace GitUI.Theming
 
             ShowIcon = false;
             StartPosition = FormStartPosition.CenterScreen;
-            Text = Title;
+            Text = _title.Text;
 
             FormClosing += (sender, args) =>
             {
@@ -163,7 +168,7 @@ namespace GitUI.Theming
                 if (getColor(_controller, colorName) != getDefaultColor(_controller, colorName))
                 {
                     result.AppendLine("*");
-                    result.Append(HintOnResettingColor);
+                    result.Append(_hintOnResettingColor);
                 }
 
                 control.Text = result.ToString();
@@ -178,19 +183,22 @@ namespace GitUI.Theming
                 switch (te.Button)
                 {
                     case MouseButtons.Left:
-                        var dialog = new ColorDialog();
-                        dialog.Color = ctrl.BackColor;
-                        var result = dialog.ShowDialog();
-                        if (result != DialogResult.OK)
+                        using (var dialog = new ColorDialog())
                         {
-                            break;
+                            dialog.Color = ctrl.BackColor;
+                            var result = dialog.ShowDialog();
+                            if (result != DialogResult.OK)
+                            {
+                                break;
+                            }
+
+                            var name = ctrl.GetTag<TName>();
+                            var value = dialog.Color;
+                            setColor(_controller, name, value);
+                            ctrl.BackColor = dialog.Color;
+                            ctrl.SetForeColorForBackColor();
                         }
 
-                        var name = ctrl.GetTag<TName>();
-                        var value = dialog.Color;
-                        setColor(_controller, name, value);
-                        ctrl.BackColor = dialog.Color;
-                        ctrl.SetForeColorForBackColor();
                         break;
 
                     case MouseButtons.Middle:
@@ -204,7 +212,7 @@ namespace GitUI.Theming
 
         private void AddButtons()
         {
-            CreateButton("Reset all colors", (s, e) =>
+            CreateButton(_resetAllColors.Text, (s, e) =>
             {
                 if (_resetting)
                 {
@@ -216,12 +224,12 @@ namespace GitUI.Theming
                 _resetting = false;
             });
 
-            CreateButton("Save", (s, e) =>
+            CreateButton(_save.Text, (s, e) =>
             {
                 _controller.SaveToFileDialog();
             });
 
-            CreateButton("Load", (s, e) =>
+            CreateButton(_load.Text, (s, e) =>
             {
                 _controller.ApplyThemeFromFileDialog();
             });

--- a/GitUI/Theming/FormThemeEditorController.cs
+++ b/GitUI/Theming/FormThemeEditorController.cs
@@ -71,8 +71,8 @@ namespace GitUI.Theming
             set => _manager.UseInitialTheme = value;
         }
 
-        public StaticTheme LoadInvariantTheme() =>
-            _persistence.LoadFile(GetOriginalThemePath(InvariantThemeName));
+        public StaticTheme LoadInvariantTheme(bool quiet = false) =>
+            _persistence.LoadFile(GetOriginalThemePath(InvariantThemeName), quiet);
 
         public bool IsCurrentThemeFile(string path) =>
             StringComparer.OrdinalIgnoreCase.Equals(path, GetThemePath(CurrentThemeName));

--- a/GitUI/Theming/FormThemeEditorController.cs
+++ b/GitUI/Theming/FormThemeEditorController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI.Theming;
+using ResourceManager;
 
 namespace GitUI.Theming
 {
@@ -14,9 +15,9 @@ namespace GitUI.Theming
         private const string Subdirectory = "Themes";
         public const string Extension = ".colors";
         private const string CurrentThemeName = "current";
-        private const string SaveDialogTitle = "Save theme";
-        private const string LoadDialogTitle = "Load theme";
-        private static readonly string Filter = $"GitExtensions theme (*{Extension})|*{Extension}";
+        private readonly TranslationString _saveDialogTitle = new TranslationString("Save theme");
+        private readonly TranslationString _loadDialogTitle = new TranslationString("Load theme");
+        private readonly TranslationString _filter = new TranslationString("GitExtensions theme (*{0})|*{0}");
 
         private readonly string _currentThemePath;
         private readonly string _invariantThemePath;
@@ -152,15 +153,18 @@ namespace GitUI.Theming
                     DefaultExt = Extension,
                     InitialDirectory = UserDirectory,
                     AddExtension = true,
-                    Filter = Filter,
-                    Title = SaveDialogTitle,
+                    Filter = string.Format(_filter.Text, Extension),
+                    Title = _saveDialogTitle.Text,
                     CheckPathExists = true
                 };
 
-                if (dlg.ShowDialog() == DialogResult.OK)
+                using (dlg)
                 {
-                    filename = dlg.FileName;
-                    return true;
+                    if (dlg.ShowDialog() == DialogResult.OK)
+                    {
+                        filename = dlg.FileName;
+                        return true;
+                    }
                 }
 
                 filename = null;
@@ -184,18 +188,21 @@ namespace GitUI.Theming
                     DefaultExt = Extension,
                     InitialDirectory = UserDirectory,
                     AddExtension = true,
-                    Filter = Filter,
-                    Title = LoadDialogTitle,
+                    Filter = string.Format(_filter.Text, Extension),
+                    Title = _loadDialogTitle.Text,
                     CheckFileExists = true
                 };
 
-                if (dlg.ShowDialog() != DialogResult.OK)
+                using (dlg)
                 {
-                    return false;
-                }
+                    if (dlg.ShowDialog() != DialogResult.OK)
+                    {
+                        return false;
+                    }
 
-                result = dlg.FileName;
-                return true;
+                    result = dlg.FileName;
+                    return true;
+                }
             }
         }
 

--- a/GitUI/Theming/StaticTheme.cs
+++ b/GitUI/Theming/StaticTheme.cs
@@ -9,24 +9,30 @@ namespace GitUI.Theming
     /// </summary>
     public class StaticTheme : Theme
     {
-        private readonly IReadOnlyDictionary<AppColor, Color> _appColors;
-        private readonly IReadOnlyDictionary<KnownColor, Color> _sysColors;
+        public IReadOnlyDictionary<AppColor, Color> AppColorValues { get; }
+        public IReadOnlyDictionary<KnownColor, Color> SysColorValues { get; }
+        public string Path { get; }
 
         public StaticTheme(
             IReadOnlyDictionary<AppColor, Color> appColors,
-            IReadOnlyDictionary<KnownColor, Color> sysColors)
+            IReadOnlyDictionary<KnownColor, Color> sysColors,
+            string path = null)
         {
-            _appColors = appColors;
-            _sysColors = sysColors;
+            Path = path;
+            AppColorValues = appColors;
+            SysColorValues = sysColors;
         }
 
+        public StaticTheme WithPath(string path) =>
+            new StaticTheme(AppColorValues, SysColorValues, path);
+
         public override Color GetColor(AppColor name) =>
-            _appColors.TryGetValue(name, out var result)
+            AppColorValues.TryGetValue(name, out var result)
                 ? result
                 : Color.Empty;
 
         protected override Color GetSysColor(KnownColor name) =>
-            _sysColors.TryGetValue(name, out var result)
+            SysColorValues.TryGetValue(name, out var result)
                 ? result
                 : Color.Empty;
     }

--- a/GitUI/Theming/ThemeManager.cs
+++ b/GitUI/Theming/ThemeManager.cs
@@ -197,7 +197,9 @@ namespace GitUI.Theming
             SysColors.Any(c => GetModifiedColor(c) != GetThemeColor(c));
 
         public bool IsCurrentThemeInitial() =>
-            CurrentTheme != null && CurrentTheme.Path == InitialTheme.Path;
+            ReferenceEquals(CurrentTheme, InitialTheme) || (
+                CurrentTheme?.Path != null &&
+                StringComparer.OrdinalIgnoreCase.Equals(CurrentTheme.Path, InitialTheme.Path));
 
         /// <summary>
         /// <inheritdoc cref="Theme"/>

--- a/GitUI/Theming/ThemeManager.cs
+++ b/GitUI/Theming/ThemeManager.cs
@@ -21,13 +21,38 @@ namespace GitUI.Theming
         private readonly PropertyInfo _threadDataProperty;
         private readonly object _systemBrushesKey;
         private readonly object _systemPensKey;
-        private readonly Dictionary<KnownColor, Color> _sysColors;
+
+        private readonly Dictionary<KnownColor, Color> _sysColorValues =
+            new Dictionary<KnownColor, Color>();
+        private readonly Dictionary<AppColor, Color> _appColorValues =
+            new Dictionary<AppColor, Color>();
+        private bool _useInitialTheme = true;
+
+        private StaticTheme InitialTheme { get; set; }
+        public StaticTheme CurrentTheme { get; private set; }
+
+        /// <summary>
+        /// if true: use colors from theme loaded at application startup, otherwise use colors
+        /// possibly changed in <see cref="FormThemeEditor"/>
+        /// </summary>
+        public bool UseInitialTheme
+        {
+            get => _useInitialTheme;
+            set
+            {
+                if (_useInitialTheme != value)
+                {
+                    _useInitialTheme = value;
+                    UpdateAppColors();
+                    ResetGdiCaches();
+                    ColorChanged?.Invoke();
+                }
+            }
+        }
 
         public ThemeManager(Theme defaultTheme)
         {
             _defaultTheme = defaultTheme;
-            _sysColors = new Dictionary<KnownColor, Color>();
-
             var systemDrawingAssembly = typeof(Color).Assembly;
 
             _colorTableField = systemDrawingAssembly.GetType("System.Drawing.KnownColorTable")
@@ -51,41 +76,49 @@ namespace GitUI.Theming
         private IDictionary ThreadData =>
             (IDictionary)_threadDataProperty.GetValue(null, null);
 
+        public void SetInitialTheme(StaticTheme theme)
+        {
+            InitialTheme = theme;
+            SetTheme(theme);
+        }
+
         /// <summary>
         /// Set current theme colors
         /// </summary>
-        /// <param name="appColors">GitExtensions app-specific colors</param>
-        /// <param name="systemColors">.Net system colors</param>
-        public void SetColors(
-            IReadOnlyDictionary<AppColor, Color> appColors,
-            IReadOnlyDictionary<KnownColor, Color> systemColors)
+        public void SetTheme(StaticTheme theme)
         {
-            _sysColors.Clear();
-            foreach (var (name, value) in systemColors)
+            _sysColorValues.Clear();
+            foreach (var (name, value) in theme.SysColorValues)
             {
-                _sysColors.Add(name, value);
+                _sysColorValues.Add(name, value);
             }
 
-            foreach (var (name, value) in appColors)
+            _appColorValues.Clear();
+            foreach (var (name, value) in theme.AppColorValues)
             {
-                AppSettings.SetColor(name, value);
+                _appColorValues.Add(name, value);
             }
 
+            CurrentTheme = theme;
+            UpdateAppColors();
             ResetGdiCaches();
             ColorChanged?.Invoke();
         }
 
+        public void ResetTheme()
+        {
+            CurrentTheme = null;
+            ResetAllColors();
+        }
+
         /// <summary>
         /// Get current theme colors
-        /// <param name="appColors">GitExtensions application-specific colors</param>
-        /// <param name="sysColors">.Net system colors</param>
         /// </summary>
-        public void GetColors(
-            out IReadOnlyDictionary<AppColor, Color> appColors,
-            out IReadOnlyDictionary<KnownColor, Color> sysColors)
+        public StaticTheme GetTheme()
         {
-            appColors = AppColors.ToDictionary(c => c, GetColor);
-            sysColors = SysColors.ToDictionary(c => c, GetSysColor);
+            return new StaticTheme(
+                AppColors.ToDictionary(c => c, GetModifiedColor),
+                SysColors.ToDictionary(c => c, GetModifiedColor));
         }
 
         /// <summary>
@@ -95,7 +128,7 @@ namespace GitUI.Theming
         /// </summary>
         public void ResetAllColors()
         {
-            SysColors.ForEach(ResetColor);
+            SysColors.ForEach(ResetInternal);
             AppColors.ForEach(ResetInternal);
 
             ResetGdiCaches();
@@ -107,8 +140,7 @@ namespace GitUI.Theming
         /// </summary>
         public void ResetColor(KnownColor name)
         {
-            _sysColors.Remove(name);
-
+            ResetInternal(name);
             ResetGdiCaches();
             ColorChanged?.Invoke();
         }
@@ -119,21 +151,29 @@ namespace GitUI.Theming
         public void ResetColor(AppColor name)
         {
             ResetInternal(name);
+            UpdateAppColors(name);
             ColorChanged?.Invoke();
         }
 
-        /// <summary>
-        /// <inheritdoc cref="Theme"/>
-        /// </summary>
-        public override Color GetColor(AppColor name) =>
-            AppSettings.GetColor(name);
+        public Color GetThemeColor(AppColor name) =>
+            (CurrentTheme ?? _defaultTheme).GetColor(name);
+
+        public Color GetThemeColor(KnownColor name) =>
+            (CurrentTheme ?? _defaultTheme).GetColor(name);
+
+        private Color GetInitialColor(AppColor name) =>
+            (InitialTheme ?? _defaultTheme).GetColor(name);
+
+        private Color GetInitialColor(KnownColor name) =>
+            (InitialTheme ?? _defaultTheme).GetColor(name);
 
         /// <summary>
         /// Define color value for GitExtensions app-specific color
         /// </summary>
-        public void SetColor(AppColor name, Color color)
+        public void SetColor(AppColor name, Color value)
         {
-            AppSettings.SetColor(name, color);
+            _appColorValues[name] = value;
+            UpdateAppColors(name);
             ColorChanged?.Invoke();
         }
 
@@ -147,18 +187,63 @@ namespace GitUI.Theming
                 throw new ArgumentException($"{name} is not system color");
             }
 
-            _sysColors[name] = value;
+            _sysColorValues[name] = value;
             ResetGdiCaches();
             ColorChanged?.Invoke();
         }
 
+        public bool IsCurrentThemeModified() =>
+            AppColors.Any(c => GetModifiedColor(c) != GetThemeColor(c)) ||
+            SysColors.Any(c => GetModifiedColor(c) != GetThemeColor(c));
+
+        public bool IsCurrentThemeInitial() =>
+            CurrentTheme != null && CurrentTheme.Path == InitialTheme.Path;
+
+        /// <summary>
+        /// <inheritdoc cref="Theme"/>
+        /// </summary>
+        public override Color GetColor(AppColor name) =>
+            UseInitialTheme
+                ? GetInitialColor(name)
+                : GetModifiedColor(name);
+
         protected override Color GetSysColor(KnownColor name) =>
-            _sysColors.TryGetValue(name, out var result)
+            UseInitialTheme
+                ? GetInitialColor(name)
+                : GetModifiedColor(name);
+
+        private Color GetModifiedColor(AppColor name) =>
+            _appColorValues.TryGetValue(name, out var result)
                 ? result
-                : _defaultTheme.GetColor(name);
+                : GetThemeColor(name);
+
+        private Color GetModifiedColor(KnownColor name) =>
+            _sysColorValues.TryGetValue(name, out var result)
+                ? result
+                : GetThemeColor(name);
+
+        private void ResetInternal(KnownColor name) =>
+            _sysColorValues.Remove(name);
 
         private void ResetInternal(AppColor name) =>
-            AppSettings.SetColor(name, _defaultTheme.GetColor(name));
+            _appColorValues.Remove(name);
+
+        private void UpdateAppColors(AppColor? nameToUpdate = null)
+        {
+            if (nameToUpdate.HasValue)
+            {
+                var color = GetColor(nameToUpdate.Value);
+                AppSettings.SetColor(nameToUpdate.Value, color);
+            }
+            else
+            {
+                foreach (var name in AppColors)
+                {
+                    var color = GetColor(name);
+                    AppSettings.SetColor(name, color);
+                }
+            }
+        }
 
         private void ResetGdiCaches()
         {

--- a/GitUI/Theming/Win32ThemeHooks.cs
+++ b/GitUI/Theming/Win32ThemeHooks.cs
@@ -3,7 +3,6 @@ using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using EasyHook;
-using GitCommands;
 using GitExtUtils.GitUI.Theming;
 using GitUI.UserControls;
 
@@ -34,8 +33,10 @@ namespace GitUI.Theming
 
         public static event Action<IntPtr> WindowCreated;
 
-        private static bool Bypass =>
-            AppSettings.UseSystemVisualStyle ||
+        private static bool BypassThemeRenderers =>
+            ThemeModule.Controller.UseSystemVisualStyle || BypassAnyHook;
+
+        private static bool BypassAnyHook =>
             _systemDialogDetector?.IsSystemDialogOpen == true;
 
         public static void InstallHooks(Theme theme, SystemDialogDetector systemDialogDetector)
@@ -158,7 +159,7 @@ namespace GitUI.Theming
 
         private static int GetSysColorHook(int nindex)
         {
-            if (!Bypass)
+            if (!BypassAnyHook)
             {
                 var name = Win32ColorTranslator.GetKnownColor(nindex);
                 var color = _theme.GetColor(name);
@@ -173,7 +174,7 @@ namespace GitUI.Theming
 
         private static IntPtr GetSysColorBrushHook(int nindex)
         {
-            if (!Bypass)
+            if (!BypassAnyHook)
             {
                 var name = Win32ColorTranslator.GetKnownColor(nindex);
                 var color = _theme.GetColor(name);
@@ -193,7 +194,7 @@ namespace GitUI.Theming
             int partid, int stateid,
             NativeMethods.RECT prect, NativeMethods.RECT pcliprect)
         {
-            if (!Bypass)
+            if (!BypassThemeRenderers)
             {
                 var renderer = _renderers.FirstOrDefault(_ => _.Supports(htheme));
                 if (renderer?.RenderBackground(hdc, partid, stateid, prect, pcliprect) == 0)
@@ -208,7 +209,7 @@ namespace GitUI.Theming
         private static int GetThemeColorHook(IntPtr htheme, int ipartid, int istateid, int ipropid,
             out int pcolor)
         {
-            if (!Bypass)
+            if (!BypassThemeRenderers)
             {
                 var renderer = _renderers.FirstOrDefault(_ => _.Supports(htheme));
                 if (renderer != null && renderer.GetThemeColor(ipartid, istateid, ipropid, out pcolor) == 0)
@@ -227,7 +228,7 @@ namespace GitUI.Theming
             string psztext, int cchtext,
             NativeMethods.DT dwtextflags, int dwtextflags2, IntPtr prect)
         {
-            if (!Bypass)
+            if (!BypassThemeRenderers)
             {
                 var renderer = _renderers.FirstOrDefault(_ => _.Supports(htheme));
                 if (renderer != null && renderer.ForceUseRenderTextEx)
@@ -259,7 +260,7 @@ namespace GitUI.Theming
             NativeMethods.DT dwtextflags,
             IntPtr prect, ref NativeMethods.DTTOPTS poptions)
         {
-            if (!Bypass)
+            if (!BypassThemeRenderers)
             {
                 var renderer = _renderers.FirstOrDefault(_ => _.Supports(htheme));
                 if (renderer != null && renderer.RenderTextEx(

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -768,7 +768,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="lblRestartNeeded.Text">
-        <source>     To apply changes restart is necessary</source>
+        <source>Restart required to apply changes</source>
         <target />
       </trans-unit>
     </body>

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -4,8 +4,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using GitCommands;
-using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using JetBrains.Annotations;
 
@@ -56,10 +54,7 @@ namespace ResourceManager
         protected void InitializeComplete()
         {
             _initialiser.InitializeComplete();
-            if (!AppSettings.UseSystemVisualStyle)
-            {
-                this.FixVisualStyle();
-            }
+            this.FixVisualStyle();
         }
 
         public virtual void AddTranslationItems(ITranslation translation)

--- a/UnitTests/GitUITests/GitUITests.csproj
+++ b/UnitTests/GitUITests/GitUITests.csproj
@@ -90,6 +90,8 @@
     <Compile Include="CommitInfo\CommitInfoTests.cs" />
     <Compile Include="CommitInfo\RefsFormatterTests.cs" />
     <Compile Include="ControlThreadingExtensionsTests.cs" />
+    <Compile Include="Theming\AppColorDefaultsTests.cs" />
+    <Compile Include="Theming\ThemeManagerTests.cs" />
     <Compile Include="UserEnvironmentInformationTests.cs" />
     <Compile Include="Editor\FileViewerInternal.CurrentViewPositionCacheTests.cs" />
     <Compile Include="Editor\FileViewerTests.cs" />
@@ -177,6 +179,5 @@
     <EmbeddedResource Include="Editor\MockData\UnixLines.bin" />
     <EmbeddedResource Include="Editor\MockData\WindowsLines.bin" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/UnitTests/GitUITests/Theming/AppColorDefaultsTests.cs
+++ b/UnitTests/GitUITests/Theming/AppColorDefaultsTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Drawing;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using NUnit.Framework;
+
+namespace GitUITests.Theming
+{
+    [TestFixture]
+    public class AppColorDefaultsTests
+    {
+        [Test]
+        public void Default_values_are_defined_in_AppColorDefaults()
+        {
+            foreach (AppColor name in Enum.GetValues(typeof(AppColor)))
+            {
+                Color value = AppColorDefaults.GetBy(name);
+                Assert.That(value, Is.Not.EqualTo(AppColorDefaults.FallbackColor));
+            }
+        }
+
+        [Test]
+        public void Default_values_are_specified_in_invariant_theme()
+        {
+            var controller = new FormThemeEditorController(null, new ThemePersistence());
+            var invariantTheme = controller.LoadInvariantTheme(quiet: true);
+            foreach (AppColor name in Enum.GetValues(typeof(AppColor)))
+            {
+                Color value = invariantTheme.GetColor(name);
+                Assert.That(value, Is.Not.EqualTo(Color.Empty));
+            }
+        }
+    }
+}

--- a/UnitTests/GitUITests/Theming/ThemeManagerTests.cs
+++ b/UnitTests/GitUITests/Theming/ThemeManagerTests.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using NUnit.Framework;
+
+namespace GitUITests.Theming
+{
+    [TestFixture]
+    public class ThemeManagerTests
+    {
+        private static readonly Color InitialColor = Color.Aqua;
+        private static readonly Color CurrentThemeColor = Color.Beige;
+        private static readonly Color ModifiedColor = Color.Crimson;
+
+        private const AppColor AppColor = GitExtUtils.GitUI.Theming.AppColor.Branch;
+        private const KnownColor SysColor = KnownColor.Control;
+
+        private static readonly DefaultTheme DefaultTheme = new DefaultTheme();
+
+        [Test]
+        public void Uses_initial_theme_by_default()
+        {
+            var themeManager = new ThemeManager(DefaultTheme);
+
+            Assert.That(themeManager.UseInitialTheme, Is.True);
+
+            themeManager.SetInitialTheme(CreateTheme(InitialColor));
+
+            Assert.That(themeManager.UseInitialTheme, Is.True);
+            Assert.That(themeManager.IsCurrentThemeInitial(), Is.True);
+        }
+
+        [TestCase(ThemeEditVariant.SelectAnotherTheme)]
+        [TestCase(ThemeEditVariant.ModifyCurrentTheme)]
+        public void When_using_initial_theme_returns_color_from_initial_theme(ThemeEditVariant editVariant)
+        {
+            var themeManager = new ThemeManager(DefaultTheme);
+            themeManager.SetInitialTheme(CreateTheme(InitialColor));
+
+            switch (editVariant)
+            {
+                case ThemeEditVariant.SelectAnotherTheme:
+                    themeManager.SetTheme(CreateTheme(ModifiedColor));
+                    Assert.That(themeManager.IsCurrentThemeInitial(), Is.False);
+                    Assert.That(themeManager.IsCurrentThemeModified(), Is.False);
+                    break;
+                case ThemeEditVariant.ModifyCurrentTheme:
+                    themeManager.SetColor(AppColor, ModifiedColor);
+                    themeManager.SetColor(SysColor, ModifiedColor);
+                    Assert.That(themeManager.IsCurrentThemeInitial(), Is.True);
+                    Assert.That(themeManager.IsCurrentThemeModified(), Is.True);
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            int repeats = 3;
+            for (int i = 0; i < repeats; i++)
+            {
+                themeManager.UseInitialTheme = true;
+                Assert.That(themeManager.GetColor(AppColor), Is.EqualTo(InitialColor));
+                Assert.That(themeManager.GetColor(SysColor), Is.EqualTo(InitialColor));
+
+                themeManager.UseInitialTheme = false;
+                Assert.That(themeManager.GetColor(AppColor), Is.EqualTo(ModifiedColor));
+                Assert.That(themeManager.GetColor(SysColor), Is.EqualTo(ModifiedColor));
+            }
+        }
+
+        [TestCase(ResetColorsVariant.ResetAllColors)]
+        [TestCase(ResetColorsVariant.ResetIndividualColor)]
+        public void ResetColor_reverts_to_current_theme(ResetColorsVariant resetVariant)
+        {
+            var themeManager = new ThemeManager(DefaultTheme);
+
+            themeManager.SetInitialTheme(CreateTheme(InitialColor));
+            themeManager.SetTheme(CreateTheme(CurrentThemeColor));
+            themeManager.SetColor(AppColor, ModifiedColor);
+            themeManager.SetColor(SysColor, ModifiedColor);
+            themeManager.UseInitialTheme = false;
+
+            Assert.That(themeManager.IsCurrentThemeInitial(), Is.False);
+            Assert.That(themeManager.IsCurrentThemeModified(), Is.True);
+
+            Assert.That(themeManager.GetColor(AppColor), Is.EqualTo(ModifiedColor));
+            Assert.That(themeManager.GetColor(SysColor), Is.EqualTo(ModifiedColor));
+
+            switch (resetVariant)
+            {
+                case ResetColorsVariant.ResetIndividualColor:
+                    themeManager.ResetColor(AppColor);
+                    themeManager.ResetColor(SysColor);
+                    break;
+                case ResetColorsVariant.ResetAllColors:
+                    themeManager.ResetAllColors();
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            Assert.That(themeManager.GetColor(AppColor), Is.EqualTo(CurrentThemeColor));
+            Assert.That(themeManager.GetColor(SysColor), Is.EqualTo(CurrentThemeColor));
+        }
+
+        [Test]
+        public void ResetTheme_resets_colors_to_default_theme()
+        {
+            var themeManager = new ThemeManager(DefaultTheme);
+
+            themeManager.SetInitialTheme(CreateTheme(InitialColor));
+            themeManager.SetTheme(CreateTheme(CurrentThemeColor));
+            themeManager.SetColor(AppColor, ModifiedColor);
+            themeManager.SetColor(SysColor, ModifiedColor);
+
+            themeManager.ResetTheme();
+
+            Assert.That(themeManager.CurrentTheme == null);
+
+            themeManager.UseInitialTheme = true;
+
+            Assert.That(themeManager.GetColor(AppColor), Is.EqualTo(InitialColor));
+            Assert.That(themeManager.GetColor(SysColor), Is.EqualTo(InitialColor));
+
+            themeManager.UseInitialTheme = false;
+
+            Assert.That(themeManager.GetColor(AppColor), Is.EqualTo(DefaultTheme.GetColor(AppColor)));
+            Assert.That(themeManager.GetColor(SysColor), Is.EqualTo(DefaultTheme.GetColor(SysColor)));
+        }
+
+        private static StaticTheme CreateTheme(Color color) =>
+            new StaticTheme(
+                new Dictionary<AppColor, Color> { [AppColor] = color },
+                new Dictionary<KnownColor, Color> { [SysColor] = color });
+
+        public enum ThemeEditVariant
+        {
+            SelectAnotherTheme,
+            ModifyCurrentTheme
+        }
+
+        public enum ResetColorsVariant
+        {
+            ResetIndividualColor,
+            ResetAllColors
+        }
+    }
+}

--- a/UnitTests/GitUITests/Theming/ThemeManagerTests.cs
+++ b/UnitTests/GitUITests/Theming/ThemeManagerTests.cs
@@ -56,6 +56,7 @@ namespace GitUITests.Theming
                     throw new NotSupportedException();
             }
 
+            // repeats to make sure UseInitialTheme property does not exhibit any sticky behavior
             int repeats = 3;
             for (int i = 0; i < repeats; i++)
             {

--- a/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
+++ b/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.2.0" />


### PR DESCRIPTION
## Proposed changes

- Use regular font in restart warning, used to be increased.
https://github.com/gitextensions/gitextensions/pull/7213#issuecomment-567018830

[screenshot before](https://user-images.githubusercontent.com/4403806/71087826-35b34f00-21f1-11ea-907b-baa405151b49.png)

[screenshot after](https://user-images.githubusercontent.com/12046452/71298738-96ca5680-239a-11ea-9d9d-499b684558f2.png)

- Fix previoulsy unnoticed review comments from https://github.com/gitextensions/gitextensions/pull/7213

- Do not apply color scheme changes until restart
[documented here](https://github.com/gitextensions/gitextensions/wiki/Dark-Theme-status#restart-required-to-change-theme)

- Show warning of restart needed only when theme has changed or another theme selected

## Tested

Manually, Windows 10

Added some Unit tests

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
