### PR TITLE
fix: installer defaults to PuTTY

### DIFF
--- a/Setup/EnableUpgrades.wxi
+++ b/Setup/EnableUpgrades.wxi
@@ -9,4 +9,21 @@
     DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit."
     AllowSameVersionUpgrades="yes"/>
 
+
+  <SetProperty After="FindRelatedProducts" Id="FirstInstall" Value="true">
+      NOT Installed AND NOT WIX_UPGRADE_DETECTED AND NOT WIX_DOWNGRADE_DETECTED
+  </SetProperty>
+  <SetProperty After="SetFirstInstall" Id="Upgrading" Value="true">
+      WIX_UPGRADE_DETECTED AND NOT (REMOVE="ALL")
+  </SetProperty>
+  <SetProperty After="RemoveExistingProducts" Id="RemovingForUpgrade" Sequence="execute" Value="true">
+      (REMOVE="ALL") AND UPGRADINGPRODUCTCODE
+  </SetProperty>
+  <SetProperty After="SetUpgrading" Id="Uninstalling" Value="true">
+      Installed AND (REMOVE="ALL") AND NOT (WIX_UPGRADE_DETECTED OR UPGRADINGPRODUCTCODE)
+  </SetProperty>
+  <SetProperty After="SetUninstalling" Id="Maintenance" Value="true">
+      Installed AND NOT Upgrading AND NOT Uninstalling AND NOT UPGRADINGPRODUCTCODE
+  </SetProperty>
+
 </Include>

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -9,12 +9,30 @@
     <Condition Message=".NET Framework 4.6.1 must be installed prior to installation of Git Extensions.">
       Installed OR WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED
     </Condition>
+
+    <!-- 
+      Read the currently configured value.
+     -->
+    <Property Id="CURRENT_SSHCLIENT" Secure="yes">
+      <RegistrySearch Id="CurrentSshClient"
+          Root="HKCU"
+          Key="$(var.AppRegKey)"
+          Name="gitssh"
+          Type="raw" />
+    </Property>
+
+    <!--
+      Use OpenSSH by default. If we read a value from the registry - assume PuTTY.
+      These values are used only if the app is installed for the first time
+     -->
+    <Property Id="SSHCLIENT" Value="OpenSSH" Secure="yes" />
+    <SetProperty Action="SetSSHCLIENT0" Id="SSHCLIENT" After="CostInitialize" Value="PuTTY"><![CDATA[CURRENT_SSHCLIENT<>""]]></SetProperty>
+
     <Icon Id="gitextensions.ico" SourceFile="..\Logo\git-extensions-logo.ico" />
     <?include AddRemove.wxi?>
     <?include EnableUpgrades.wxi?>
     <UIRef Id="WixUI_GitExtensions" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
-    <Property Id="SSHCLIENT" Value="PuTTY" Secure="yes" />
     <Property Id="LAUNCH" Value="0" />
     <Property Id="TELEMETRY_ENABLED" Value="1" Secure="yes" />
     <WixVariable Id="WixUIDialogBmp" Value="dialog.bmp" />
@@ -808,12 +826,16 @@
         <File Source="..\Bin\puttygen.exe" />
       </Component>
       <Component Id="gitssh_openssh.reg" Guid="5f730698-ac38-4e63-ad5d-505b21d1fa22">
-        <Condition>SSHCLIENT="OpenSSH"</Condition>
+        <Condition><![CDATA[NOT Upgrading AND SSHCLIENT="OpenSSH"]]></Condition>
         <RegistryValue Name="gitssh" Value="" Root="HKCU" Key="$(var.AppRegKey)" Type="string" />
       </Component>
       <Component Id="gitssh_putty.reg" Guid="2cb64776-8035-413e-9266-4ad9e5ecbad3">
-        <Condition>SSHCLIENT="PuTTY"</Condition>
+        <Condition><![CDATA[NOT Upgrading AND SSHCLIENT="PuTTY"]]></Condition>
         <RegistryValue Name="gitssh" Value="[INSTALLDIR]PuTTY\plink.exe" Root="HKCU" Key="$(var.AppRegKey)" Type="string" />
+      </Component>
+      <Component Id="gitssh_current.reg" Guid="44F8A1D4-B107-457B-A599-58AB346986E1">
+        <Condition><![CDATA[Upgrading]]></Condition>
+        <RegistryValue Name="gitssh" Value="[CURRENT_SSHCLIENT]" Root="HKCU" Key="$(var.AppRegKey)" Type="string" />
       </Component>
       <Component Id="plink.reg" Guid="*">
         <RegistryValue Name="plink" Value="[INSTALLDIR]PuTTY\plink.exe" Root="HKCU" Key="$(var.AppRegKey)" Type="string" />
@@ -1481,6 +1503,7 @@
       <ComponentRef Id="InstallDir.reg" />
       <ComponentRef Id="gitssh_openssh.reg" />
       <ComponentRef Id="gitssh_putty.reg" />
+      <ComponentRef Id="gitssh_current.reg" />
       <ComponentRef Id="plink.exe" />
       <ComponentRef Id="plink.reg" />
       <ComponentRef Id="pageant.exe" />

--- a/Setup/UI/WixUI.wxs
+++ b/Setup/UI/WixUI.wxs
@@ -50,23 +50,21 @@
       <Publish Dialog="GitEx_InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
       <Publish Dialog="GitEx_InstallDirDlg" Control="Next" Event="NewDialog" Value="GitEx_CustomizeDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
 
-      <Publish Dialog="GitEx_CustomizeDlg" Control="Back" Event="NewDialog" Value="GitEx_MaintenanceTypeDlg" Order="1">Installed</Publish>
-      <Publish Dialog="GitEx_CustomizeDlg" Control="Back" Event="NewDialog" Value="GitEx_InstallDirDlg" Order="2">NOT Installed</Publish>
-      <Publish Dialog="GitEx_CustomizeDlg" Control="Next" Event="NewDialog" Value="GitEx_VerifyReadyDlg" Order="1">Installed</Publish>
-      <Publish Dialog="GitEx_CustomizeDlg" Control="Next" Event="NewDialog" Value="GitEx_SSHClientDlg" Order="2">NOT Installed</Publish>
+      <!-- update: skip SSH selection and telemetry screens -->
+      <Publish Dialog="GitEx_CustomizeDlg" Control="Back" Event="NewDialog" Value="GitEx_InstallDirDlg" Order="1"><![CDATA[Upgrading]]></Publish>
+      <Publish Dialog="GitEx_CustomizeDlg" Control="Next" Event="NewDialog" Value="GitEx_VerifyReadyDlg" Order="1"><![CDATA[Upgrading]]></Publish>
 
-      <Publish Dialog="GitEx_SSHClientDlg" Control="Back" Event="NewDialog" Value="GitEx_CustomizeDlg">1</Publish>
-      <Publish Dialog="GitEx_SSHClientDlg" Control="Next" Event="NewDialog" Value="GitEx_TelemetryDlg">1</Publish>
+      <!-- not installed: show SSH selection and telemetry screens -->
+      <Publish Dialog="GitEx_CustomizeDlg" Control="Back" Event="NewDialog" Value="GitEx_InstallDirDlg" Order="2"><![CDATA[NOT Upgrading]]></Publish>
+      <Publish Dialog="GitEx_CustomizeDlg" Control="Next" Event="NewDialog" Value="GitEx_SSHClientDlg" Order="2"><![CDATA[NOT Upgrading]]></Publish>
+      <Publish Dialog="GitEx_SSHClientDlg" Control="Back" Event="NewDialog" Value="GitEx_CustomizeDlg" Order="2"><![CDATA[NOT Upgrading]]></Publish>
+      <Publish Dialog="GitEx_SSHClientDlg" Control="Next" Event="NewDialog" Value="GitEx_TelemetryDlg" Order="2"><![CDATA[NOT Upgrading]]></Publish>
+      <Publish Dialog="GitEx_TelemetryDlg" Control="Back" Event="NewDialog" Value="GitEx_SSHClientDlg" Order="2"><![CDATA[NOT Upgrading]]></Publish>
+      <Publish Dialog="GitEx_TelemetryDlg" Control="Next" Event="NewDialog" Value="GitEx_VerifyReadyDlg" Order="2"><![CDATA[NOT Upgrading]]></Publish>
 
-      <Publish Dialog="GitEx_TelemetryDlg" Control="Back" Event="NewDialog" Value="GitEx_SSHClientDlg">1</Publish>
-      <Publish Dialog="GitEx_TelemetryDlg" Control="Next" Event="NewDialog" Value="GitEx_VerifyReadyDlg">1</Publish>
 
-      <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_TelemetryDlg" Order="1">
-        NOT Installed
-      </Publish>
-      <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_MaintenanceTypeDlg" Order="3">
-        Installed
-      </Publish>
+      <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_TelemetryDlg" Order="1"><![CDATA[NOT Upgrading]]></Publish>
+      <Publish Dialog="GitEx_VerifyReadyDlg" Control="Back" Event="NewDialog" Value="GitEx_CustomizeDlg" Order="3"><![CDATA[Upgrading]]></Publish>
 
       <Publish Dialog="GitEx_MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="GitEx_MaintenanceTypeDlg">1</Publish>
 


### PR DESCRIPTION
The installer would always default to PuTTY as the SSH client. Whilst in an interactive mode a user is able to choose the SSH client, a silent installer (e.g. the auto-update) will reset the setting to PuTTY despite users using OpenSSH previously.
This has caused issues like #7543 and numerous questions on SO.

The installer is updated to do the following:
* Read the currently configured value from the registry.
    * If the app is being installed for the first time, there are only two choices - if the value is absent or unset - use `OpenSSH`, else presume PuTTY.
	* If the app is being upgraded, SSH config and telemetry dialog screens are skipped, the existing configurations are retained

Fixes #6286

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Test methodology <!-- How did you ensure quality? -->

- Configure in the app: OpenSSH
- Run the installer and observe "OpenSSH" option selected
- Cancel the installation process
- Verify the configuration in the logs:
   ```
    ...
    AppSearch: Property: CURRENT_SSHCLIENT, Signature: CurrentSshClient
    MSI (c) (18:C8) [21:05:22:599]: Note: 1: 2262 2: Signature 3: -2147287038 
    ...
    MSI (c) (18:C8) [21:05:22:701]: Skipping action: SetSSHCLIENT0 (condition is false)
    ...
    Property(C): SSHCLIENT = OpenSSH
    ...
   ```
- Configure in the app: PuTTY
- Run the installer and observe "PuTTY" option selected
- Cancel the installation process
- Verify the configuration in the logs:
	```
    ...
    AppSearch: Property: CURRENT_SSHCLIENT, Signature: CurrentSshClient
    MSI (c) (08:A4) [21:06:08:908]: Note: 1: 2262 2: Signature 3: -2147287038 
    MSI (c) (08:A4) [21:06:08:908]: PROPERTY CHANGE: Adding CURRENT_SSHCLIENT property. Its value is 'C:\Development\gitextensions\Build\transifex\tx.exe'.
    ...
    Action 21:06:08: SetSSHCLIENT0. 
    Action start 21:06:08: SetSSHCLIENT0.
    MSI (c) (08:A4) [21:06:08:988]: PROPERTY CHANGE: Modifying SSHCLIENT property. Its current value is 'OpenSSH'. Its new value: 'PuTTY'.
    Action ended 21:06:08: SetSSHCLIENT0. Return value 1.
	...
	Property(C): SSHCLIENT = PuTTY
	...
	```
- Set a custom SSH tool
- Install a new version of the app using the new installer and observe 
	- the custom configuration remains unchanged
	- both SSH configuration and Telemetry dialogs skipped
	- "Back" navigation works correctly



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
