### PR TITLE
gitex: If no argument start browse in current workdir

### DIFF
--- a/Bin/gitex.cmd
+++ b/Bin/gitex.cmd
@@ -1,4 +1,7 @@
 @setlocal
 @for /F "delims=" %%I in ("%~dp0") do @set gitex_folder=%%~fI
 @set PATH=%gitex_folder%;%PATH%
-@start /B GitExtensions.exe %*
+@REM If no arguments, try open current working directory
+@set arg=%*
+@if "%arg%"=="" SET arg=browse .
+@start /B GitExtensions.exe %arg%


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7542

## Proposed changes
If gitex.cmd has no arguments, open browse with the current directory.
gitextensions.exe obeys the arguments since #7147 and defaults by opening the dashboard 

## Test methodology <!-- How did you ensure quality? -->
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
