### PR TITLE
kdiff3: Incorrect merge cmd

### DIFF
--- a/GitCommands/DiffMergeTools/Kdiff3.cs
+++ b/GitCommands/DiffMergeTools/Kdiff3.cs
@@ -8,6 +8,9 @@ namespace GitCommands.DiffMergeTools
         public override string ExeFileName => "kdiff3.exe";
 
         /// <inheritdoc />
+        public override string MergeCommand => "\"$BASE\" \"$LOCAL\" \"$REMOTE\" -o \"$MERGED\"";
+
+        /// <inheritdoc />
         public override string Name => "kdiff3";
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #7544

## Proposed changes

Correct the default arguments for kdiff3 merge tool
http://kdiff3.sourceforge.net/doc/documentation.html

kdiff3 merge commands were not set in settings.
When pressing mergetool, the Git defaults were used 
When pressing "open kdiff3", the arguments were hardcoded in FormResolveConflicts (that happened to be the same as for Git)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
