### PR TITLE
kdiff3: add configuration for merge arguments

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -600,6 +600,20 @@ namespace GitUI.CommandsDialogs
                     return false;
                 }
 
+                // Temporary compatibility with GE <3.3
+                if (_mergetool == "kdiff3")
+                {
+                    if (string.IsNullOrEmpty(_mergetoolPath))
+                    {
+                        _mergetoolPath = "kdiff3";
+                    }
+
+                    if (string.IsNullOrEmpty(_mergetoolCmd))
+                    {
+                        _mergetoolCmd = "\"$BASE\" \"$LOCAL\" \"$REMOTE\" -o \"$MERGED\"";
+                    }
+                }
+
                 if (EnvUtils.RunningOnWindows())
                 {
                     // This only works when on Windows....

--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -320,6 +320,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$REMOTE\" \"$BASE\" \"$MERGED\"";
                 case "diffmerge":
                     return "\"" + exeFile + "\" -merge -result=\"$MERGED\" \"$LOCAL\" \"$BASE\" \"$REMOTE\"";
+                case "kdiff3":
+                    return "\"" + exeFile + "\" \"$BASE\" \"$LOCAL\" \"$REMOTE\" -o \"$MERGED\"";
                 case "meld":
                     return "\"" + exeFile + "\" \"$LOCAL\" \"$BASE\" \"$REMOTE\" --output \"$MERGED\"";
                 case "p4merge":


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7544
for 3.3, #7548 for master, since #7044 the implementation is completely different.

## Proposed changes

Correct the default arguments for kdiff3 merge tool
Also add compatibility mode to allow <3.3.1 where the options are not set. As the implementation is changed, this compatibility mode will automatically be removed

## Test methodology <!-- How did you ensure quality? -->

Manual testing conflict resolution

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
