### PR TITLE
Remove obsolete 2-way merge tool names

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -385,11 +385,6 @@ namespace GitUI.CommandsDialogs
             {
                 case "kdiff3":
                 case "diffmerge":
-                case "beyondcompare3":
-                    arguments = arguments.Replace("\"$BASE\"", "");
-                    break;
-                case "araxis":
-                    arguments = arguments.Replace("-merge -3", "-merge");
                     arguments = arguments.Replace("\"$BASE\"", "");
                     break;
                 case "tortoisemerge":


### PR DESCRIPTION
Part of #7550 

## Proposed changes

If not 2-way merge is removed as a result of #7550, this is a minimal fix.
araxis was removed as a preconfigured tool in #7044 (see hints there to readd).
beyondcompare3 was renamed to bc3 and issues like #1844 indicates that manipulation is not helping

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
