### PR TITLE
RevisionDiff: Limit parents

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -620,11 +620,17 @@ namespace GitUI
                 GitRevision[] parentRevs;
                 if (revisions.Count == 1)
                 {
-                    // Note: RevisionGrid could in some forms be used to get the parent guids
+                    // Get the parents for the selected revision
                     parentRevs = Revision.ParentIds?.Select(item => new GitRevision(item)).ToArray();
+                }
+                else if (revisions.Count > 4)
+                {
+                    // Assume only first to selected is interesting
+                    parentRevs = new GitRevision[1] { revisions.Last() };
                 }
                 else
                 {
+                    // Limited selections: Show multi selection
                     parentRevs = revisions.Skip(1).ToArray();
                 }
 
@@ -646,6 +652,7 @@ namespace GitUI
                     }
 
                     // Show combined (merge conflicts) only when all first (A) are parents to selected (B)
+                    // (a single merge commit is selected with parents explicit or implicit selected)
                     var isMergeCommit = AppSettings.ShowDiffForAllParents &&
                                         Revision.ParentIds != null && Revision.ParentIds.Count > 1 &&
                                         _revisionTester.AllFirstAreParentsToSelected(parentRevs, Revision);


### PR DESCRIPTION
Fixes #7469

## Proposed changes

If more than three parents are selected in the revision grid, only show the diff to the first.
This will avoid that the GUI freezes if Ctrl-A is selected or many are selected with shift-click.
It still allows multi selection in reasonable cases.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6248932/71447741-bfec3d80-2732-11ea-9b87-b70e430ee90b.png)

### After

![image](https://user-images.githubusercontent.com/6248932/71447745-d4303a80-2732-11ea-84e2-99622476a42b.png)


## Test methodology <!-- How did you ensure quality? -->
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
