### PR TITLE
Add feature to open repo in a new window

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1734,7 +1734,10 @@ namespace GitUI.CommandsDialogs
 
                     menuItemCategory.DropDownItems.Add(item);
 
-                    item.Click += delegate { ChangeWorkingDir(r.Repo.Path); };
+                    item.Click += (obj, args) =>
+                    {
+                        OpenRepo(r.Repo.Path);
+                    };
 
                     if (r.Repo.Path != r.Caption)
                     {
@@ -1798,13 +1801,37 @@ namespace GitUI.CommandsDialogs
 
                 container.DropDownItems.Add(item);
 
-                item.Click += (hs, he) => ChangeWorkingDir(repo.Path);
+                item.Click += (obj, args) =>
+                {
+                    OpenRepo(repo.Path);
+                };
 
                 if (repo.Path != caption)
                 {
                     item.ToolTipText = repo.Path;
                 }
             }
+        }
+
+        private void OpenRepo(string repoPath)
+        {
+            if (ModifierKeys != Keys.Control)
+            {
+                ChangeWorkingDir(repoPath);
+                return;
+            }
+
+            var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = AppSettings.GetGitExtensionsFullPath(),
+                    Arguments = "browse",
+                    WorkingDirectory = repoPath,
+                    UseShellExecute = false
+                }
+            };
+            process.Start();
         }
 
         public void SetWorkingDir(string path)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6866 


## Proposed changes

- Add a feature to open a GitExtensions repository in a new window when ctrl+clicking it, both in "Recent Repositories" menu and "Favorite Repositories" menu.


## Test methodology <!-- How did you ensure quality? -->

- User tests of all the different scenarios.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.24.1.windows.2
- Windows 10 Home 64bit

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
