### PR TITLE
Debug: add build branch to title

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -1,4 +1,5 @@
 using GitCommands.UserRepositoryHistory;
+using GitUIPluginInterfaces;
 
 namespace GitCommands
 {
@@ -21,6 +22,10 @@ namespace GitCommands
     /// </summary>
     public sealed class AppTitleGenerator : IAppTitleGenerator
     {
+#if DEBUG
+        private static string _extraInfo;
+#endif
+
         private readonly IRepositoryDescriptionProvider _description;
 
         public AppTitleGenerator(IRepositoryDescriptionProvider description)
@@ -46,9 +51,27 @@ namespace GitCommands
             var description = _description.Get(workingDir);
 
 #if DEBUG
-            return $"{description} ({branchName}) - Git Extensions [DEBUG]";
+            return $"{description} ({branchName}) - Git Extensions{_extraInfo}";
 #else
             return $"{description} ({branchName}) - Git Extensions";
+#endif
+        }
+
+        public static void Initialise(string sha, string buildBranch)
+        {
+#if DEBUG
+            if (ObjectId.TryParse(sha, out var objectId))
+            {
+                _extraInfo = $" @{objectId.ToShortString()}";
+                if (!string.IsNullOrWhiteSpace(buildBranch))
+                {
+                    _extraInfo += $" ({buildBranch})";
+                }
+            }
+            else
+            {
+                _extraInfo = " [DEBUG]";
+            }
 #endif
         }
     }

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -64,6 +64,7 @@ namespace GitExtensions
 
             // This is done here so these values can be used in the GitGui project but this project is the authority of the values.
             UserEnvironmentInformation.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty);
+            AppTitleGenerator.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.Branch);
 
             // NOTE we perform the rest of the application's startup in another method to defer
             // the JIT processing more types than required to configure NBug.


### PR DESCRIPTION
## Proposed changes

Add the branch the PR is built from to the window title.
The commit sha is visible in About, but especially if the branch is rebased there are several extra steps to find the branch (and the intended functionality included.

An alternative is to add the branch name in About for 'debug builds.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/6248932/71558834-a7906180-2a57-11ea-9f5e-68f12b8329e0.png)

### After

![image](https://user-images.githubusercontent.com/6248932/71558811-56806d80-2a57-11ea-963b-732acca93a31.png)


## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
