### PR TITLE
fix: Unable to update due to network configurations

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -19,12 +19,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
     public partial class FormUpdates : GitExtensionsForm
     {
         #region Translation
-        private readonly TranslationString _newVersionAvailable =
-            new TranslationString("There is a new version {0} of Git Extensions available");
-        private readonly TranslationString _noUpdatesFound =
-            new TranslationString("No updates found");
-        private readonly TranslationString _downloadingUpdate =
-            new TranslationString("Downloading update...");
+        private readonly TranslationString _newVersionAvailable = new TranslationString("There is a new version {0} of Git Extensions available");
+        private readonly TranslationString _noUpdatesFound = new TranslationString("No updates found");
+        private readonly TranslationString _downloadingUpdate = new TranslationString("Downloading update...");
+        private readonly TranslationString _errorHeading = new TranslationString("Download Failed");
+        private readonly TranslationString _errorMessage = new TranslationString("Failed to download an update.");
         #endregion
 
         public IWin32Window OwnerWindow;
@@ -175,19 +174,27 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private async void btnUpdateNow_Click(object sender, EventArgs e)
         {
+            linkChangeLog.Visible = false;
+            progressBar1.Visible = true;
+            btnUpdateNow.Enabled = false;
+            UpdateLabel.Text = _downloadingUpdate.Text;
+            string fileName = Path.GetFileName(UpdateUrl);
+
             try
             {
-                linkChangeLog.Visible = false;
-                progressBar1.Visible = true;
-                btnUpdateNow.Enabled = false;
-                UpdateLabel.Text = _downloadingUpdate.Text;
-                string fileName = Path.GetFileName(UpdateUrl);
-
                 using (WebClient webClient = new WebClient())
                 {
                     await webClient.DownloadFileTaskAsync(new Uri(UpdateUrl), Environment.GetEnvironmentVariable("TEMP") + "\\" + fileName);
                 }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, _errorMessage.Text + Environment.NewLine + ex.Message, _errorHeading.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
 
+            try
+            {
                 Process process = new Process();
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.FileName = "msiexec.exe";

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6932,6 +6932,14 @@ Do you want to register the host's fingerprint and restart the process?</source>
         <source>Downloading update...</source>
         <target />
       </trans-unit>
+      <trans-unit id="_errorHeading.Text">
+        <source>Download Failed</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_errorMessage.Text">
+        <source>Failed to download an update.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_newVersionAvailable.Text">
         <source>There is a new version {0} of Git Extensions available</source>
         <target />


### PR DESCRIPTION


Closes #7565
Closes #7563



## Proposed changes

Handle errors while downloading updates separate from errors during launches of those updates.

This way we can report an error with network configuration etc without crashing the app.


## Screenshots <!-- Remove this section if PR does not change UI -->


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/71582484-89f9ef80-2b5e-11ea-84aa-4e1b6aedda02.png)


## Test methodology <!-- How did you ensure quality? -->

- manual



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
