### PR TITLE
Gerrit: add configuration for gerrit version

### DIFF
--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -209,6 +209,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".tx", ".tx", "{EFBCA0B9-9E0
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteUnusedBranchesTests", "UnitTests\Plugins\DeleteUnusedBranchesTests\DeleteUnusedBranchesTests.csproj", "{3FD5B353-17C0-4122-A693-27B707D06EFF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GerritTests", "UnitTests\Plugins\GerritTests\GerritTests.csproj", "{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -397,6 +399,10 @@ Global
 		{3FD5B353-17C0-4122-A693-27B707D06EFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3FD5B353-17C0-4122-A693-27B707D06EFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3FD5B353-17C0-4122-A693-27B707D06EFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -449,6 +455,7 @@ Global
 		{D017F26A-694F-4127-B917-9B1BD3F01E2F} = {472B72D9-9336-4C8B-A199-300F0CA7669E}
 		{EFBCA0B9-9E08-4464-BEAA-DAF2FF85C6AB} = {D017F26A-694F-4127-B917-9B1BD3F01E2F}
 		{3FD5B353-17C0-4122-A693-27B707D06EFF} = {C2276A26-13DF-485A-8B2C-414CF507798F}
+		{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3} = {C2276A26-13DF-485A-8B2C-414CF507798F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ECECB7EA-BCCF-44AD-B63E-C2FA45589FB0}

--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -563,28 +563,12 @@ Are you sure you want to continue?</source>
         <source>&amp;Publish</source>
         <target />
       </trans-unit>
-      <trans-unit id="PublishType.Text">
-        <source>For Review</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_publishCaption.Text">
         <source>Publish change</source>
         <target />
       </trans-unit>
       <trans-unit id="_publishGerritChangeCaption.Text">
         <source>Publish Gerrit Change</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_publishTypePrivate.Text">
-        <source>Private</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_publishTypeReview.Text">
-        <source>For Review</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_publishTypeWip.Text">
-        <source>Work-in-Progress</source>
         <target />
       </trans-unit>
       <trans-unit id="_selectBranch.Text">
@@ -823,6 +807,26 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="GerritCapabilities" source-language="en">
+    <body>
+      <trans-unit id="_publishTypeDraft.Text">
+        <source>Draft</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_publishTypePrivate.Text">
+        <source>Private</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_publishTypeReview.Text">
+        <source>For Review</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_publishTypeWip.Text">
+        <source>Work-in-Progress</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en">
     <body>
       <trans-unit id="Description.Text">
@@ -855,6 +859,10 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
       </trans-unit>
       <trans-unit id="_installCommitMsgHookShortText.Text">
         <source>Install commit-msg hook</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_predefinedGerritVersion.Caption">
+        <source>Treat Gerrit as having version</source>
         <target />
       </trans-unit>
       <trans-unit id="_publishGerritChange.Text">

--- a/Plugins/Gerrit/FormGerritBase.cs
+++ b/Plugins/Gerrit/FormGerritBase.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using GitUI;
 using GitUIPluginInterfaces;
-using RestSharp;
 
 namespace Gerrit
 {
     public class FormGerritBase : GitExtensionsForm
     {
         protected GerritSettings Settings { get; private set; }
-        protected Version Version { get; private set; }
-        protected readonly RestClient client = new RestClient();
         protected readonly IGitUICommands UICommands;
         protected IGitModule Module => UICommands.GitModule;
 
@@ -39,34 +36,7 @@ namespace Gerrit
                 return;
             }
 
-            SetRestClientUrl();
-            Version = GetGerritVersion();
-
             base.OnLoad(e);
-        }
-
-        private void SetRestClientUrl()
-        {
-            string host = Settings.Host;
-
-            if (!host.StartsWith("http://") || !host.StartsWith("https://"))
-            {
-                host = "https://" + host;
-            }
-
-            if (!host.EndsWith("/"))
-            {
-                host += "/";
-            }
-
-            client.BaseUrl = new Uri(host);
-        }
-
-        private Version GetGerritVersion()
-        {
-            RestRequest request = new RestRequest("/config/server/version");
-            IRestResponse response = client.Execute(request);
-            return Version.Parse(response.Content.Replace(")]}'", "").Replace("\n", "").Replace("\"", "").Split('-')[0]);
         }
     }
 }

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
+using Gerrit.Server;
 using GitCommands;
 using GitExtUtils;
 using GitUI.Properties;
@@ -13,8 +15,6 @@ namespace Gerrit
 {
     public partial class FormGerritPublish : FormGerritBase
     {
-        private string _currentBranchRemote;
-
         #region Translation
         private readonly TranslationString _publishGerritChangeCaption = new TranslationString("Publish Gerrit Change");
 
@@ -22,34 +22,28 @@ namespace Gerrit
 
         private readonly TranslationString _selectRemote = new TranslationString("Please select a remote repository");
         private readonly TranslationString _selectBranch = new TranslationString("Please enter a branch");
-
-        private readonly TranslationString _publishTypeReview = new TranslationString("For Review");
-        private readonly TranslationString _publishTypeWip = new TranslationString("Work-in-Progress");
-        private readonly TranslationString _publishTypePrivate = new TranslationString("Private");
         #endregion
 
-        public FormGerritPublish(IGitUICommands uiCommand)
+        private string _currentBranchRemote;
+        private GerritCapabilities _capabilities;
+
+        public FormGerritPublish(IGitUICommands uiCommand, GerritCapabilities capabilities)
             : base(uiCommand)
         {
+            _capabilities = capabilities;
             InitializeComponent();
             InitializeComplete();
 
             Publish.Image = Images.Push;
-            PublishType.Items.AddRange(new object[]
-            {
-                new KeyValuePair<string, string>(_publishTypeReview.Text, ""),
-                new KeyValuePair<string, string>(_publishTypeWip.Text, "wip")
-            });
-            PublishType.SelectedIndex = 0;
         }
 
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            if (Version >= Version.Parse("2.15"))
-            {
-                PublishType.Items.Add(new KeyValuePair<string, string>(_publishTypePrivate.Text, "private"));
-            }
+
+            _capabilities.PublishTypes.ForEach(
+                item => PublishType.Items.Add(item));
+            PublishType.SelectedIndex = 0;
         }
 
         private void PublishClick(object sender, EventArgs e)
@@ -88,59 +82,17 @@ namespace Gerrit
 
             GerritUtil.StartAgent(owner, Module, _NO_TRANSLATE_Remotes.Text);
 
-            List<string> additionalOptions = new List<string>();
-
-            string reviewers = _NO_TRANSLATE_Reviewers.Text.Trim();
-            if (!string.IsNullOrEmpty(reviewers))
-            {
-                additionalOptions.AddRange(reviewers.Split(new[] { ' ', ',', ';', '|' })
-                                                    .Where(r => !string.IsNullOrEmpty(r))
-                                                    .Select(r => "r=" + r));
-            }
-
-            string cc = _NO_TRANSLATE_Cc.Text.Trim();
-            if (!string.IsNullOrEmpty(cc))
-            {
-                additionalOptions.AddRange(cc.Split(new[] { ' ', ',', ';', '|' })
-                                             .Where(r => !string.IsNullOrEmpty(r))
-                                             .Select(r => "cc=" + r));
-            }
-
-            string topic = _NO_TRANSLATE_Topic.Text.Trim();
-            if (!string.IsNullOrEmpty(topic))
-            {
-                additionalOptions.Add("topic=" + topic);
-            }
-
-            string hashtag = _NO_TRANSLATE_Hashtag.Text.Trim();
-            if (!string.IsNullOrEmpty(hashtag))
-            {
-                additionalOptions.Add("hashtag=" + hashtag);
-            }
-
-            additionalOptions = additionalOptions.Where(r => !string.IsNullOrEmpty(r)).ToList();
-
-            string publishType = ((KeyValuePair<string, string>)PublishType.SelectedItem).Value;
-            string targetRef = "for";
-            if (Version >= Version.Parse("2.15"))
-            {
-                additionalOptions.Add(publishType);
-            }
-            else if (publishType == "wip")
-            {
-                targetRef = "drafts";
-            }
-
-            string targetBranch = $"refs/{targetRef}/{branch}";
-            if (additionalOptions.Count > 0)
-            {
-                targetBranch += "%" + string.Join(",", additionalOptions);
-            }
+            var builder = _capabilities.NewBuilder()
+                .WithReviewers(_NO_TRANSLATE_Reviewers.Text)
+                .WithCC(_NO_TRANSLATE_Cc.Text)
+                .WithTopic(_NO_TRANSLATE_Topic.Text)
+                .WithHashTag(_NO_TRANSLATE_Hashtag.Text)
+                .WithPublishType(((KeyValuePair<string, string>)PublishType.SelectedItem).Value);
 
             var pushCommand = UICommands.CreateRemoteCommand();
             pushCommand.CommandText = PushCmd(
                 _NO_TRANSLATE_Remotes.Text,
-                targetBranch);
+                builder.Build(branch));
 
             pushCommand.Remote = _NO_TRANSLATE_Remotes.Text;
             pushCommand.Title = _publishCaption.Text;
@@ -176,7 +128,7 @@ namespace Gerrit
                 }
             }
 
-            return true;
+            return !pushCommand.ErrorOccurred;
         }
 
         [CanBeNull]

--- a/Plugins/Gerrit/Gerrit.csproj
+++ b/Plugins/Gerrit/Gerrit.csproj
@@ -95,6 +95,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Server\CommandBuilder.cs" />
+    <Compile Include="Server\CommandBuilderWithDraftSupport.cs" />
+    <Compile Include="Server\CommandBuilderWithPrivateSupport.cs" />
+    <Compile Include="Server\GerritCapabilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
@@ -156,5 +160,6 @@
     <Content Include="Resources\GerritInstallHook.png" />
     <None Include="Resources\IconGerrit.png" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Plugins/Gerrit/Properties/AssemblyInfo.cs
+++ b/Plugins/Gerrit/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyDescription("GitExtensions plugin for integration with Gerrit")]
+[assembly: InternalsVisibleTo("GerritTests")]

--- a/Plugins/Gerrit/Server/CommandBuilder.cs
+++ b/Plugins/Gerrit/Server/CommandBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gerrit.Server
+{
+    public abstract class CommandBuilder
+    {
+        protected string TargetRef = "for";
+        protected List<string> CommandArguments { get; } = new List<string>();
+
+        private static IEnumerable<string> SplitAndComposeArguments(string argumentName, string values)
+        {
+            values = values?.Trim();
+            if (string.IsNullOrEmpty(values))
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return ComposeArguments(argumentName, values.Split(new[] { ' ', ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        private static IEnumerable<string> ComposeArguments(string argumentName, string[] values)
+        {
+            return values.Where(text => !string.IsNullOrEmpty(text))
+                .Select(text => $"{argumentName}={text}");
+        }
+
+        private static IEnumerable<string> ComposeArgument(string argumentName, string value)
+        {
+            return ComposeArguments(argumentName, new[] { value?.Trim() });
+        }
+
+        public CommandBuilder WithReviewers(string text)
+        {
+            CommandArguments.AddRange(SplitAndComposeArguments("r", text));
+            return this;
+        }
+
+        public CommandBuilder WithCC(string text)
+        {
+            CommandArguments.AddRange(SplitAndComposeArguments("cc", text));
+            return this;
+        }
+
+        public CommandBuilder WithTopic(string topic)
+        {
+            CommandArguments.AddRange(ComposeArgument(@"topic", topic));
+            return this;
+        }
+
+        public CommandBuilder WithHashTag(string hashTag)
+        {
+            CommandArguments.AddRange(ComposeArgument(@"hashtag", hashTag));
+            return this;
+        }
+
+        public abstract CommandBuilder WithPublishType(string publishType);
+
+        public virtual string Build(string branch)
+        {
+            string targetBranch = $"refs/{TargetRef}/{branch}";
+            if (CommandArguments.Count > 0)
+            {
+                targetBranch += "%" + string.Join(",", CommandArguments);
+            }
+
+            return targetBranch;
+        }
+    }
+}

--- a/Plugins/Gerrit/Server/CommandBuilderWithDraftSupport.cs
+++ b/Plugins/Gerrit/Server/CommandBuilderWithDraftSupport.cs
@@ -1,0 +1,17 @@
+﻿namespace Gerrit.Server
+{
+    public class CommandBuilderWithDraftSupport : CommandBuilder
+    {
+        public const string DraftsPublishType = @"drafts";
+
+        public override CommandBuilder WithPublishType(string publishType)
+        {
+            if (publishType == DraftsPublishType)
+            {
+                TargetRef = DraftsPublishType;
+            }
+
+            return this;
+        }
+    }
+}

--- a/Plugins/Gerrit/Server/CommandBuilderWithPrivateSupport.cs
+++ b/Plugins/Gerrit/Server/CommandBuilderWithPrivateSupport.cs
@@ -1,0 +1,24 @@
+﻿namespace Gerrit.Server
+{
+    public class CommandBuilderWithPrivateSupport : CommandBuilder
+    {
+        private string _publishType;
+
+        public override CommandBuilder WithPublishType(string publishType)
+        {
+            _publishType = publishType?.Trim();
+
+            return this;
+        }
+
+        public override string Build(string branch)
+        {
+            if (!string.IsNullOrEmpty(_publishType))
+            {
+                CommandArguments.Add(_publishType);
+            }
+
+            return base.Build(branch);
+        }
+    }
+}

--- a/Plugins/Gerrit/Server/GerritCapabilities.cs
+++ b/Plugins/Gerrit/Server/GerritCapabilities.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using ResourceManager;
+
+namespace Gerrit.Server
+{
+    public class GerritCapabilities : Translate
+    {
+        #region Translation
+        private static readonly TranslationString _publishTypeReview = new TranslationString("For Review");
+        private static readonly TranslationString _publishTypeWip = new TranslationString("Work-in-Progress");
+        private static readonly TranslationString _publishTypePrivate = new TranslationString("Private");
+        private static readonly TranslationString _publishTypeDraft = new TranslationString("Draft");
+        #endregion
+
+        private readonly Func<CommandBuilder> _builderFactory;
+
+        private GerritCapabilities(KeyValuePair<string, string>[] publishTypes,
+            Func<CommandBuilder> builderFactory)
+        {
+            PublishTypes = publishTypes;
+            _builderFactory = builderFactory;
+        }
+
+        public IReadOnlyList<KeyValuePair<string, string>> PublishTypes { get; }
+
+        public CommandBuilder NewBuilder()
+            => _builderFactory();
+
+        public static GerritCapabilities Version2_15 { get; }
+            = new GerritCapabilities(
+                new[]
+                {
+                    new KeyValuePair<string, string>(_publishTypeReview.Text, ""),
+                    new KeyValuePair<string, string>(_publishTypeWip.Text, "wip"),
+                    new KeyValuePair<string, string>(_publishTypePrivate.Text, "private"),
+                },
+                () => new CommandBuilderWithPrivateSupport());
+
+        public static GerritCapabilities OldestVersion { get; }
+            = new GerritCapabilities(
+                new[]
+                {
+                    new KeyValuePair<string, string>(_publishTypeReview.Text, ""),
+                    new KeyValuePair<string, string>(_publishTypeDraft.Text, CommandBuilderWithDraftSupport.DraftsPublishType),
+                },
+                () => new CommandBuilderWithDraftSupport());
+    }
+}

--- a/UnitTests/Plugins/GerritTests/GerritTests.csproj
+++ b/UnitTests/Plugins/GerritTests/GerritTests.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{02A5CF27-302A-48FA-9FFD-E9A2C341FAE3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GerritTests</RootNamespace>
+    <AssemblyName>GerritTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\GitExtensionsTest.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Debug\GerritTests.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\..\..\GitExtensionsTest.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Release\GerritTests.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Server\CommandBuilderWithPrivateSupportTests.cs" />
+    <Compile Include="Server\CommandBuilderWithDraftSupportTests.cs" />
+    <Compile Include="Server\GerritCapabilityTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions">
+      <Version>5.2.0</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit">
+      <Version>3.10.1</Version>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.10.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Plugins\Gerrit\Gerrit.csproj">
+      <Project>{ec6988f6-0e8e-42d2-8e41-e562c5fb65bc}</Project>
+      <Name>Gerrit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <Project>{D3440FD7-AFC5-4351-8741-6CDBF15CE944}</Project>
+      <Name>ResourceManager</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/UnitTests/Plugins/GerritTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/GerritTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GerritTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GerritTests")]
+[assembly: AssemblyCopyright("Copyright © 2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2f8f55f7-c82f-44fc-ab52-9d0c692996fc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests/Plugins/GerritTests/Server/CommandBuilderWithDraftSupportTests.cs
+++ b/UnitTests/Plugins/GerritTests/Server/CommandBuilderWithDraftSupportTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Gerrit.Server;
+using NUnit.Framework;
+
+namespace GerritTests.Server
+{
+    public static class CommandBuilderWithDraftSupportTests
+    {
+        [TestCase("a, b, c", "fix-7521", ExpectedResult = "refs/for/fix-7521%r=a,r=b,r=c")]
+        [TestCase("a|b|c", "fix-7521", ExpectedResult = "refs/for/fix-7521%r=a,r=b,r=c")]
+        [TestCase("a b c", "fix-7521", ExpectedResult = "refs/for/fix-7521%r=a,r=b,r=c")]
+        [TestCase("a; b;c", "fix-7521", ExpectedResult = "refs/for/fix-7521%r=a,r=b,r=c")]
+        [TestCase("q", "fix-7521", ExpectedResult = "refs/for/fix-7521%r=q")]
+        [TestCase("", "fix-7521", ExpectedResult = "refs/for/fix-7521")]
+        [TestCase(null, "fix-7521", ExpectedResult = "refs/for/fix-7521")]
+        public static string Build_WithReviewers_splits_reviewrs_and_builds_expected_command(string reviewer, string branch)
+        {
+            var sut = new CommandBuilderWithDraftSupport();
+            return sut.WithReviewers(reviewer).Build(branch);
+        }
+
+        [Test(ExpectedResult = "refs/drafts/master%r=a")]
+        public static string Build_when_publishtype_is_drafts_builds_expected_command()
+        {
+            var sut = new CommandBuilderWithDraftSupport();
+            return sut.WithReviewers("a").WithPublishType("drafts").Build("master");
+        }
+
+        [Test(ExpectedResult = "refs/for/fix-7521")]
+        public static string Build_with_all_values_on_default_builds_expected_command()
+        {
+            var sut = new CommandBuilderWithDraftSupport();
+            return sut.WithReviewers(string.Empty)
+                .WithCC(string.Empty)
+                .WithTopic(string.Empty)
+                .WithPublishType(string.Empty)
+                .WithHashTag(string.Empty)
+                .Build("fix-7521");
+        }
+
+        [Test(ExpectedResult = "refs/for/fix-7521%r=mygroup,cc=team2,topic=ABC-123,hashtag=what")]
+        public static string Build_with_values_for_all_options_builds_expected_command()
+        {
+            var sut = new CommandBuilderWithDraftSupport();
+            return sut.WithReviewers("mygroup")
+                .WithCC("team2")
+                .WithTopic("ABC-123")
+                .WithPublishType(string.Empty)
+                .WithHashTag("what")
+                .Build("fix-7521");
+        }
+    }
+}

--- a/UnitTests/Plugins/GerritTests/Server/CommandBuilderWithPrivateSupportTests.cs
+++ b/UnitTests/Plugins/GerritTests/Server/CommandBuilderWithPrivateSupportTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Gerrit.Server;
+using NUnit.Framework;
+
+namespace GerritTests.Server
+{
+    public static class CommandBuilderWithPrivateSupportTests
+    {
+        [TestCase("", ExpectedResult = "refs/for/mybranch")]
+        [TestCase("wip", ExpectedResult = "refs/for/mybranch%wip")]
+        [TestCase("private", ExpectedResult = "refs/for/mybranch%private")]
+        public static string Build_given_a_publishType_builds_expected_command(string publishType)
+        {
+            var sut = new CommandBuilderWithPrivateSupport();
+
+            return sut.WithPublishType(publishType).Build("mybranch");
+        }
+
+        [Test]
+        public static void Build_given_a_set_of_values_builds_expected_command()
+        {
+            var sut = new CommandBuilderWithPrivateSupport();
+
+            Assert.AreEqual("refs/for/master%r=myteam",
+                sut.WithReviewers("myteam").WithPublishType(string.Empty).Build("master"));
+        }
+    }
+}

--- a/UnitTests/Plugins/GerritTests/Server/GerritCapabilityTests.cs
+++ b/UnitTests/Plugins/GerritTests/Server/GerritCapabilityTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using Gerrit.Server;
+using NUnit.Framework;
+
+namespace GerritTests.Server
+{
+    public static class GerritCapabilityTests
+    {
+        [Test]
+        public static void PublishTypes_for_Version2_15_has_expected_list_of_values()
+        {
+            RunTest(GerritCapabilities.Version2_15, new[] { "", "wip", "private" });
+        }
+
+        [Test]
+        public static void PublishTypes_for_OlderVersion_has_expected_list_of_values()
+        {
+            RunTest(GerritCapabilities.OldestVersion, new[] { "", "drafts" });
+        }
+
+        private static void RunTest(GerritCapabilities capability, string[] expectedValues)
+        {
+            var publishTypes = capability.PublishTypes
+                .Select(x => x.Value)
+                .ToArray();
+
+            Assert.That(publishTypes, Is.EqualTo(expectedValues));
+        }
+    }
+}

--- a/contributors.txt
+++ b/contributors.txt
@@ -108,3 +108,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/10/24, jvitkauskas, Julius Vitkauskas, zadintuvas(at)gmail.com
 2019/10/31, rickaas, Ricky Lindeman, saakcir(at)gmail.com
 2019/11/27, andrewcartwright1, Andrew Cartwright, kickme93(at)hotmail.co.uk
+2019/12/25, dfev77, Florin Daneliuc, florin.daneliuc@gmail.com


### PR DESCRIPTION
Connecting to gerrit and retrieving configuration requires too many
configurations to work properly due to possible configuration
combinations (api port, http/https, etc.).
Instead just allow the user to configure the desired Gerrit version.

Extract code that is dependent on Gerrit version into separate
classes (list of publish types and logic for composing command) in
order to be able to test it.

(cherry picked from commit 475786d3ab93ed6f8400ae630ceeb23fa4b16998)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7521
