### PR TITLE
Prevent NRE in designers that use EditNetSpell

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -369,7 +369,7 @@ namespace GitUI.SpellChecker
 
         private void ToggleAutoCompletion()
         {
-            if (!AppSettings.ProvideAutocompletion)
+            if (!AppSettings.ProvideAutocompletion || (Site != null && Site.DesignMode))
             {
                 CloseAutoComplete();
                 CancelAutoComplete();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7583 


## Proposed changes

- Add design check to ToggleAutoCompletion.




<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Built Project.
- Opened FormCreateTag Designer
- Did not get NRE in designer


## Test environment(s) <!-- Remove any that don't apply -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
