### PR TITLE
Make message textbox bounds clear

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -135,7 +135,9 @@ namespace GitUI.CommandsDialogs
             TagOperation tagOperation = GetSelectedOperation(annotate.SelectedIndex);
             textBoxGpgKey.Enabled = tagOperation == TagOperation.SignWithSpecificKey;
             keyIdLbl.Enabled = tagOperation == TagOperation.SignWithSpecificKey;
-            tagMessage.Enabled = tagOperation.CanProvideMessage();
+            bool providesMessage = tagOperation.CanProvideMessage();
+            tagMessage.Enabled = providesMessage;
+            tagMessage.BorderStyle = providesMessage ? BorderStyle.FixedSingle : BorderStyle.None;
         }
 
         private static TagOperation GetSelectedOperation(int dropdownSelection)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7581 


## Proposed changes

- Show border on textbox when user can edit message


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
As seen in the issue, the textbox does not show a border


<!-- TODO -->

### After
![image](https://user-images.githubusercontent.com/3629489/71623699-76757580-2bac-11ea-87d8-b4bf12b24350.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Showed  Create Tag dialog
- Selected different tag types



## Test environment(s) <!-- Remove any that don't apply -->

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
