### PR TITLE
Prevent crash where _btnPreview is null when event triggered

### DIFF
--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -102,18 +102,15 @@ namespace JiraCommitHintPlugin
                 Multiline = true,
                 ScrollBars = ScrollBars.Horizontal
             };
-            txtTemplate.SizeChanged += (s, e) =>
-            {
-                _btnPreview.Left = txtTemplate.Width - _btnPreview.Width - DpiUtil.Scale(8);
-            };
             _btnPreview = new Button
             {
                 Text = PreviewButtonText.Text,
                 Top = DpiUtil.Scale(45),
-                Anchor = AnchorStyles.Right
+                Anchor = AnchorStyles.Right | AnchorStyles.Bottom
             };
             _btnPreview.Size = DpiUtil.Scale(_btnPreview.Size);
             _btnPreview.Click += btnPreviewClick;
+            _btnPreview.Left = txtTemplate.Width - _btnPreview.Width - DpiUtil.Scale(8);
             txtTemplate.Controls.Add(_btnPreview);
             _stringTemplateSetting.CustomControl = txtTemplate;
             yield return _stringTemplateSetting;


### PR DESCRIPTION
by removing the use of the event
and relying on control placement configuration
to keep the same behavior.

Fixes #7522
Same fix than #7536 but on `master`.

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 63aaf21d9ea76f72cf80640421d869f6fb444463 (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4067.0
- DPI 192dpi (200% scaling)

