### PR TITLE
Disable maximising/minimising of update form

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -119,6 +119,8 @@
             this.Controls.Add(this.UpdateLabel);
             this.Controls.Add(this.progressBar1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "FormUpdates";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Check for update";

--- a/contributors.txt
+++ b/contributors.txt
@@ -111,3 +111,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/12/02, nick-bulleid, Nick Bulleid, nickedb(at)gmail.com
 2019/12/25, dfev77, Florin Daneliuc, florin.daneliuc@gmail.com
 2020/01/02, c3er, Christian Dreier, flipper.x3r(at)googlemail.com
+2020/01/04, MarkJ74, Mark Jackson, markj74(at)outlook.com


### PR DESCRIPTION
Fixes #7580 

## Proposed changes

Disabled the minimize and maximize boxes on update form in the designer.

## Test methodology <!-- How did you ensure quality? -->

Ran GitExt and checked you can no longer maximize or minimize the update form.

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10 - 1909

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
