### PR TITLE
Improve restoring of the commit dialog geometry (Fixes #7588)

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -3339,6 +3339,8 @@ namespace GitUI.CommandsDialogs
 
             internal CommandStatus ExecuteCommand(Command command) => _formCommit.ExecuteCommand((int)command);
 
+            internal Rectangle Bounds => _formCommit.Bounds;
+
             internal static string FormatCommitMessageFromTextBox(
                 string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
                     => FormCommit.FormatCommitMessageFromTextBox(commitMessageText, usingCommitTemplate, ensureCommitMessageSecondLineEmpty);

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -68,15 +68,20 @@ namespace GitUI
 
                 if (prevSize > 0 && prevDistance > 0)
                 {
+                    var fixedPanel = Splitter.FixedPanel;
+                    var splitterWidth = Splitter.SplitterWidth;
                     if (SplitterSize == prevSize && Dpi == prevDpi)
                     {
-                        SetSplitterDistance(prevDistance);
+                        SetSplitterDistance(fixedPanel == FixedPanel.Panel2 ? prevDistance + splitterWidth : prevDistance);
                     }
                     else
                     {
-                        switch (Splitter.FixedPanel)
+                        switch (fixedPanel)
                         {
                             case FixedPanel.None:
+                                // At this point, the property "SplitterSize" has its original value from design time,
+                                // i.e. the actual size after opening the window is unknown yet. The calculation below
+                                // determines the resulting splitter distance by the ratio of both sides of the splitter.
                                 SetSplitterDistance((float)SplitterSize * prevDistance / prevSize);
                                 break;
                             case FixedPanel.Panel1:
@@ -84,7 +89,7 @@ namespace GitUI
                                 break;
                             case FixedPanel.Panel2:
                                 int panel2PrevSize = DpiUtil.Scale(prevSize, prevDpi) - DpiUtil.Scale(prevDistance, prevDpi);
-                                SetSplitterDistance(SplitterSize - panel2PrevSize);
+                                SetSplitterDistance(SplitterSize - panel2PrevSize + splitterWidth);
                                 break;
                         }
                     }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -269,6 +270,49 @@ namespace GitExtensions.UITests.CommandsDialogs
             });
         }
 
+        [Test]
+        public void Dialog_remembers_window_geometry()
+        {
+            RunGeometryMemoryTest(
+                form => form.GetTestAccessor().Bounds,
+                (bounds1, bounds2) => bounds2.Should().Be(bounds1));
+        }
+
+        [Test]
+        public void MessageEdit_remembers_geometry()
+        {
+            RunGeometryMemoryTest(
+                form => form.GetTestAccessor().Message.Bounds,
+                (bounds1, bounds2) => bounds2.Should().Be(bounds1));
+        }
+
+        [Test]
+        public void UnstagedList_remembers_geometry()
+        {
+            RunGeometryMemoryTest(
+                form => form.GetTestAccessor().UnstagedList.Bounds,
+                (bounds1, bounds2) =>
+                {
+                    bounds2.Width.Should().Be(bounds1.Width);
+
+                    // The method to determine the height is prone to rounding errors.
+                    // This seems not to affect the user experience, because
+                    // - the rounding error is only +- 1 pixel
+                    // - if the user does not change the geometry, the height will oscillate to a constant value
+                    var height1 = bounds1.Height;
+                    var height2 = bounds2.Height;
+                    Assert.IsTrue(height1 >= height2 - 1 && height1 <= height2 + 1);
+                });
+        }
+
+        [Test]
+        public void SelectedDiff_remembers_geometry()
+        {
+            RunGeometryMemoryTest(
+                form => form.GetTestAccessor().SelectedDiff.Bounds,
+                (bounds1, bounds2) => bounds2.Should().Be(bounds1));
+        }
+
         private void TestAddSelectionToCommitMessage(
             bool focusSelectedDiff,
             string selectedText,
@@ -300,6 +344,15 @@ namespace GitExtensions.UITests.CommandsDialogs
                 ta.Message.SelectionStart.Should().Be(expectedSelectionStart);
                 ta.Message.SelectionLength.Should().Be(expectedResult ? 0 : selectionLength);
             });
+        }
+
+        private void RunGeometryMemoryTest(Func<FormCommit, Rectangle> boundsAccessor, Action<Rectangle, Rectangle> testDriver)
+        {
+            var bounds1 = Rectangle.Empty;
+            var bounds2 = Rectangle.Empty;
+            RunFormTest(form => bounds1 = boundsAccessor(form));
+            RunFormTest(form => bounds2 = boundsAccessor(form));
+            testDriver(bounds1, bounds2);
         }
 
         private void RunFormTest(Action<FormCommit> testDriver, CommitKind commitKind = CommitKind.Normal)

--- a/UnitTests/GitUI.Tests/SplitterManagerTest.cs
+++ b/UnitTests/GitUI.Tests/SplitterManagerTest.cs
@@ -107,7 +107,9 @@ namespace GitUITests
                 splitManager.RestoreSplitters();
 
                 // assert splitter moved by the width delta
-                splitter.SplitterDistance.Should().Be(splitterDistance + deltaWidth);
+                // Note: if the width of the splitter control itself is not regarded,
+                // this splitter control would move to the left every time the splitter container is restored.
+                splitter.SplitterDistance.Should().Be(splitterDistance + deltaWidth + splitter.SplitterWidth);
             }
         }
 
@@ -133,7 +135,8 @@ namespace GitUITests
                 var splitManager = new SplitterManager(_settings);
                 SplitContainer splitter = CreateVerticalSplitContainer();
                 splitManager.AddSplitter(splitter, splitterName);
-                const int splitterNewWidth = 180;
+                const int deltaWidth = -20;
+                const int splitterNewWidth = splitterWidth + deltaWidth;
                 splitter.Width = splitterNewWidth;
                 splitter.SplitterDistance = splitterDistance;
                 splitter.FixedPanel = FixedPanel.Panel2;
@@ -151,7 +154,9 @@ namespace GitUITests
                 }
                 else
                 {
-                    splitter.SplitterDistance.Should().Be(100);
+                    // Note: if the width of the splitter control itself is not regarded,
+                    // this splitter control would move to the left every time the splitter container is restored.
+                    splitter.SplitterDistance.Should().Be(splitterDistance + deltaWidth + splitter.SplitterWidth);
                 }
             }
         }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7588

This fixes GitExtensions issue #7588


## Proposed changes

- Inside the application code not much more as to regard the property `SplitterWidth` of the `SplitContainer` control
- Some additional comments
- Some additional tests and updates to some SplitterManager tests


### Before

See section "Current behaviour" in issue #7588

### After

See section "Expected behaviour" in issue #7588


## Test methodology <!-- How did you ensure quality? -->

- Manual testing both of the main (browse) window and the commit dialog
- Adding of UI tests to ensure that the geometry of the commit dialog is restored properly after reopening the dialog


## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.24.1.windows.2
- Windows 10 1909


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
