### PR TITLE
WIP: perf: Improve speed of directory change in the console

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3019,7 +3019,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
                 {
-                    ClearTerminalCommandLineWithCommentAndRunCommand("cd " + posixPath, "#");
+                    ClearTerminalCommandLineWithBackspacesAndRunCommand("cd " + posixPath, "#");
                 }
             }
             else
@@ -3035,16 +3035,15 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void ClearTerminalCommandLineWithCommentAndRunCommand(string command, string comment)
+        private void ClearTerminalCommandLineWithBackspacesAndRunCommand(string command, string comment)
         {
             if (_terminal?.RunningSession == null || string.IsNullOrWhiteSpace(command))
             {
                 return;
             }
 
-            _terminal.RunningSession.WriteInputTextAsync($"\x01 {comment} {Environment.NewLine}");
-
-            _terminal.RunningSession.WriteInputTextAsync(command + Environment.NewLine);
+            // Clear terminal line by sending 'backspace' characters
+            _terminal.RunningSession.WriteInputTextAsync(new string('\b', 500) + command + Environment.NewLine);
         }
 
         private void ClearTerminalCommandLineWithEscapeAndRunCommand(string command)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3019,31 +3019,27 @@ namespace GitUI.CommandsDialogs
             {
                 if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
                 {
-                    ClearTerminalCommandLineAndRunCommand("cd " + posixPath);
+                    ClearTerminalCommandLineWithCommentAndRunCommand("cd " + posixPath, "#");
                 }
             }
             else if (AppSettings.ConEmuTerminal.ValueOrDefault == "powershell")
             {
-                ClearTerminalCommandLineAndRunCommand("cd \"" + path + "\"");
+                ClearTerminalCommandLineWithCommentAndRunCommand("cd \"" + path + "\"", "#");
             }
             else
             {
-                ClearTerminalCommandLineAndRunCommand("cd /D \"" + path + "\"");
+                ClearTerminalCommandLineWithCommentAndRunCommand("cd /D \"" + path + "\"", "REM");
             }
         }
 
-        private void ClearTerminalCommandLineAndRunCommand(string command)
+        private void ClearTerminalCommandLineWithCommentAndRunCommand(string command, string comment)
         {
             if (_terminal?.RunningSession == null || string.IsNullOrWhiteSpace(command))
             {
                 return;
             }
 
-            // Clear terminal line by sending 'backspace' characters
-            for (int i = 0; i < 10000; i++)
-            {
-                _terminal.RunningSession.WriteInputTextAsync("\b");
-            }
+            _terminal.RunningSession.WriteInputTextAsync($"\x01 {comment} {Environment.NewLine}");
 
             _terminal.RunningSession.WriteInputTextAsync(command + Environment.NewLine);
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3022,13 +3022,16 @@ namespace GitUI.CommandsDialogs
                     ClearTerminalCommandLineWithCommentAndRunCommand("cd " + posixPath, "#");
                 }
             }
-            else if (AppSettings.ConEmuTerminal.ValueOrDefault == "powershell")
-            {
-                ClearTerminalCommandLineWithCommentAndRunCommand("cd \"" + path + "\"", "#");
-            }
             else
             {
-                ClearTerminalCommandLineWithCommentAndRunCommand("cd /D \"" + path + "\"", "REM");
+                if (AppSettings.ConEmuTerminal.ValueOrDefault == "cmd")
+                {
+                    ClearTerminalCommandLineWithEscapeAndRunCommand("cd /D \"" + path + "\"");
+                }
+                else
+                {
+                    ClearTerminalCommandLineWithEscapeAndRunCommand("cd \"" + path + "\"");
+                }
             }
         }
 
@@ -3042,6 +3045,16 @@ namespace GitUI.CommandsDialogs
             _terminal.RunningSession.WriteInputTextAsync($"\x01 {comment} {Environment.NewLine}");
 
             _terminal.RunningSession.WriteInputTextAsync(command + Environment.NewLine);
+        }
+
+        private void ClearTerminalCommandLineWithEscapeAndRunCommand(string command)
+        {
+            if (_terminal?.RunningSession == null || string.IsNullOrWhiteSpace(command))
+            {
+                return;
+            }
+
+            _terminal.RunningSession.WriteInputTextAsync("\x1B" + command + Environment.NewLine);
         }
 
         private void menuitemSparseWorkingCopy_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3019,7 +3019,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
                 {
-                    ClearTerminalCommandLineWithBackspacesAndRunCommand("cd " + posixPath, "#");
+                    CommentTerminalCommandAndRunCommand("cd " + posixPath, "#");
                 }
             }
             else
@@ -3035,15 +3035,15 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void ClearTerminalCommandLineWithBackspacesAndRunCommand(string command, string comment)
+        private void CommentTerminalCommandAndRunCommand(string command, string shellCommentString)
         {
             if (_terminal?.RunningSession == null || string.IsNullOrWhiteSpace(command))
             {
                 return;
             }
 
-            // Clear terminal line by sending 'backspace' characters
-            _terminal.RunningSession.WriteInputTextAsync(new string('\b', 500) + command + Environment.NewLine);
+            // Go to the begin of the line, type the command and comment the rest of the line
+            _terminal.RunningSession.WriteInputTextAsync($"\x01 {command} {shellCommentString} {Environment.NewLine}");
         }
 
         private void ClearTerminalCommandLineWithEscapeAndRunCommand(string command)


### PR DESCRIPTION
Fix #7595

## Proposed changes

Sending a lot of backspace in a console is slow
(especially with "cmd" but also with "bash" or "powershell").

Now, use a better strategy to send a char to go to the begin of the console line,
comment the line then evaluate it before launching the "cd" command.

Which is quicker...

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 2ae5475a5d956feeebf64c8d51d39c4c47aad3fa (Dirty)
- Git 2.23.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4075.0
- DPI 192dpi (200% scaling)
