### PR TITLE
Merge branch dialog: Make form border style fixed and align checkboxes

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -191,8 +191,7 @@
             // 
             this.allowUnrelatedHistories.AutoSize = true;
             this.advancedPanel.SetColumnSpan(this.allowUnrelatedHistories, 2);
-            this.allowUnrelatedHistories.Location = new System.Drawing.Point(2, 52);
-            this.allowUnrelatedHistories.Margin = new System.Windows.Forms.Padding(2);
+            this.allowUnrelatedHistories.Location = new System.Drawing.Point(3, 52);
             this.allowUnrelatedHistories.Name = "allowUnrelatedHistories";
             this.allowUnrelatedHistories.Size = new System.Drawing.Size(143, 17);
             this.allowUnrelatedHistories.TabIndex = 3;
@@ -429,6 +428,7 @@
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.ClientSize = new System.Drawing.Size(772, 460);
             this.Controls.Add(this.tableLayoutPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(478, 380);


### PR DESCRIPTION
Fixes #7602

## Proposed changes

On merge branch form:
1. Changed form border style from sizable to fixed.
2. Changed position of 'Allow unrelated histories' checkbox so it's aligned better with the other checkboxes.

## Screenshots

Before:

![MergeBranchFormBefore](https://user-images.githubusercontent.com/26597823/71883663-c87b4580-312e-11ea-9932-b327aeccbaba.png)

After:

![MergeBranchFormAfter](https://user-images.githubusercontent.com/26597823/71883676-d0d38080-312e-11ea-88c9-a1926f778f61.png)

## Test methodology

Manually checked.

## Test environment(s)

- Windows 10 1909.