### PR TITLE
Run the test assemblies one after the other

### DIFF
--- a/Build/Run-Tests.ps1
+++ b/Build/Run-Tests.ps1
@@ -12,7 +12,7 @@ $opencover_console = "packages\OpenCover.$opencover_version\tools\OpenCover.Cons
     -excludebyfile:*\*Designer.cs `
     -output:"OpenCover.GitExtensions.xml" `
     -target:"nunit3-console.exe" `
-    -targetargs:"$testAssemblies --workers=1 --timeout=90000"
+    -targetargs:"$testAssemblies --agents=1 --workers=1 --timeout=90000"
 $testExitCode = $LastExitCode
 Push-AppveyorArtifact "TestResult.xml"
 if ($testExitCode -ne 0) { $host.SetShouldExit($testExitCode) }


### PR DESCRIPTION
in order to avoid conflicts with singletons e.g.
- AppSettings
- clipboard
- ConfigureJoinableTaskFactoryAttribute

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
