### PR TITLE
Improve speed of directory change in console tab

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3015,27 +3015,27 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (AppSettings.ConEmuTerminal.ValueOrDefault == "bash")
+            switch (AppSettings.ConEmuTerminal.ValueOrDefault)
             {
-                if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
-                {
-                    ClearTerminalCommandLineWithMacroAndRunCommand("cd " + posixPath, "#");
-                }
-            }
-            else
-            {
-                if (AppSettings.ConEmuTerminal.ValueOrDefault == "cmd")
-                {
-                    ClearTerminalCommandLineWithEscapeAndRunCommand("cd /D \"" + path + "\"");
-                }
-                else
-                {
-                    ClearTerminalCommandLineWithEscapeAndRunCommand("cd \"" + path + "\"");
-                }
+                case "bash":
+                    if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
+                    {
+                        ClearTerminalCommandLineWithMacroAndRunCommand($"cd {posixPath}");
+                    }
+
+                    break;
+                case "cmd":
+                    ClearTerminalCommandLineWithEscapeAndRunCommand($"cd /D \"{path}\"");
+                    break;
+                case "powershell":
+                    ClearTerminalCommandLineWithEscapeAndRunCommand($"cd \"{path}\"");
+                    break;
+                default:
+                    break;
             }
         }
 
-        private void ClearTerminalCommandLineWithMacroAndRunCommand(string command, string shellCommentString)
+        private void ClearTerminalCommandLineWithMacroAndRunCommand(string command)
         {
             if (_terminal?.RunningSession == null || string.IsNullOrWhiteSpace(command))
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3019,7 +3019,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
                 {
-                    CommentTerminalCommandAndRunCommand("cd " + posixPath, "#");
+                    ClearTerminalCommandLineWithMacroAndRunCommand("cd " + posixPath, "#");
                 }
             }
             else
@@ -3035,15 +3035,16 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void CommentTerminalCommandAndRunCommand(string command, string shellCommentString)
+        private void ClearTerminalCommandLineWithMacroAndRunCommand(string command, string shellCommentString)
         {
             if (_terminal?.RunningSession == null || string.IsNullOrWhiteSpace(command))
             {
                 return;
             }
 
-            // Go to the begin of the line, type the command and comment the rest of the line
-            _terminal.RunningSession.WriteInputTextAsync($"\x01 {command} {shellCommentString} {Environment.NewLine}");
+            // Use a ConEmu macro to send the sequence for clearing the bash command line
+            _terminal.RunningSession.BeginGuiMacro("Keys").WithParam("^A").WithParam("^K").ExecuteSync();
+            _terminal.RunningSession.WriteInputTextAsync(command + Environment.NewLine);
         }
 
         private void ClearTerminalCommandLineWithEscapeAndRunCommand(string command)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3020,15 +3020,15 @@ namespace GitUI.CommandsDialogs
                 case "bash":
                     if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
                     {
-                        ClearTerminalCommandLineWithMacroAndRunCommand($"cd \"{posixPath}\"");
+                        ClearTerminalCommandLineWithMacroAndRunCommand($"cd {posixPath.QuoteNE()}");
                     }
 
                     break;
                 case "cmd":
-                    ClearTerminalCommandLineWithEscapeAndRunCommand($"cd /D \"{path}\"");
+                    ClearTerminalCommandLineWithEscapeAndRunCommand($"cd /D {path.QuoteNE()}");
                     break;
                 case "powershell":
-                    ClearTerminalCommandLineWithEscapeAndRunCommand($"cd \"{path}\"");
+                    ClearTerminalCommandLineWithEscapeAndRunCommand($"cd {path.QuoteNE()}");
                     break;
                 default:
                     break;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3020,7 +3020,7 @@ namespace GitUI.CommandsDialogs
                 case "bash":
                     if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
                     {
-                        ClearTerminalCommandLineWithMacroAndRunCommand($"cd {posixPath}");
+                        ClearTerminalCommandLineWithMacroAndRunCommand($"cd \"{posixPath}\"");
                     }
 
                     break;

--- a/contributors.txt
+++ b/contributors.txt
@@ -112,3 +112,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/12/25, dfev77, Florin Daneliuc, florin.daneliuc@gmail.com
 2020/01/02, c3er, Christian Dreier, flipper.x3r(at)googlemail.com
 2020/01/04, MarkJ74, Mark Jackson, markj74(at)outlook.com
+2020/01/07, asherber, Aaron Sherber, aaron(at)sherber.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7595 
Alternative to #7600


## Proposed changes

Existing code sends 10K backspaces to clear the current console line, which is slow. For `cmd` and `powershell`, we can send `Esc` to clear the line; for `bash` we can use a ConEmu macro sequence to send Ctrl+A, Ctrl+K.
## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.24.1.windows.2
- Windows 10 v 1903 (OS Build 18362.535)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
