### PR TITLE
Convert and quote file names for BatchUnstageFiles

### DIFF
--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -379,5 +379,8 @@ namespace GitCommands
 
             return batches;
         }
+
+        public static List<BatchArgumentItem> BuildBatchArgumentsForFiles(this ArgumentBuilder builder, IEnumerable<string> files)
+            => builder.BuildBatchArguments(files.Select(f => f.ToPosixPath().QuoteNE()));
     }
 }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1368,7 +1368,7 @@ namespace GitCommands
                     "--force",
                     "--"
                 }
-                .BuildBatchArguments(files.Select(item => item.ToPosixPath().Quote())));
+                .BuildBatchArgumentsForFiles(files));
         }
 
         /// <summary>
@@ -1418,7 +1418,7 @@ namespace GitCommands
                     revision,
                     "--"
                 }
-                .BuildBatchArguments(files.Select(f => f.ToPosixPath().Quote())));
+                .BuildBatchArgumentsForFiles(files));
         }
 
         public string RemoveFiles(IReadOnlyList<string> files, bool force)
@@ -1866,7 +1866,7 @@ namespace GitCommands
             {
                 var args = GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, "HEAD");
                 _gitExecutable.RunBatchCommand(new ArgumentBuilder() { args }
-                    .BuildBatchArguments(filesToRemove),
+                    .BuildBatchArgumentsForFiles(filesToRemove),
                     action);
             }
 

--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -848,7 +848,7 @@ namespace GitCommandsTests
             },
             new string[]
             {
-                "reset \"HEAD\" -- abc2 abc3 def",
+                "reset \"HEAD\" -- \"abc2\" \"abc3\" \"def\"",
                 "update-index --info-only --index-info",
                 "update-index --force-remove --stdin"
             },
@@ -860,7 +860,7 @@ namespace GitCommandsTests
             },
             new string[]
             {
-                "reset \"HEAD\" -- abc2 abc3",
+                "reset \"HEAD\" -- \"abc2\" \"abc3\"",
             },
             true)
         };


### PR DESCRIPTION
Fixes #7607

## Proposed changes

- Convert and quote file names for `GitModule.BatchUnstageFiles`

## Test methodology <!-- How did you ensure quality? -->

- manual
- adapted NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 38d5f9135c7cb0099e42c58cbe32f6c5b96a78e8
- Git 2.24.1.windows.2
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4075.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
