### PR TITLE
Avoid NRE in CommitAutoCompleteProvider

### DIFF
--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -81,7 +81,7 @@ namespace GitUI.AutoCompletion
                 return File.ReadLines(path);
             }
 
-            Stream s = Assembly.GetEntryAssembly().GetManifestResourceStream("GitExtensions.AutoCompleteRegexes.txt");
+            Stream s = Assembly.GetEntryAssembly()?.GetManifestResourceStream("GitExtensions.AutoCompleteRegexes.txt");
             if (s == null)
             {
                 throw new NotImplementedException("Please add AutoCompleteRegexes.txt file into .csproj");


### PR DESCRIPTION
Fixes #7473

## Proposed changes

- Avoid NRE in CommitAutoCompleteProvider

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
