### PR TITLE
Improve closing of FormCommit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -418,19 +418,23 @@ namespace GitUI.CommandsDialogs
             base.OnActivated(e);
         }
 
-        protected override void OnFormClosing(FormClosingEventArgs e)
+        protected override void OnFormClosed(FormClosedEventArgs e)
         {
-            // Do not remember commit message of fixup or squash commits, since they have
-            // a special meaning, and can be dangerous if used inappropriately.
-            if (CommitKind == CommitKind.Normal)
+            // Do not attempt to store again if the form has already been closed. Unfortunately, OnFormClosed is always called by Close.
+            if (Visible)
             {
-                _commitMessageManager.MergeOrCommitMessage = Message.Text;
-                _commitMessageManager.AmendState = Amend.Checked;
+                // Do not remember commit message of fixup or squash commits, since they have
+                // a special meaning, and can be dangerous if used inappropriately.
+                if (CommitKind == CommitKind.Normal)
+                {
+                    _commitMessageManager.MergeOrCommitMessage = Message.Text;
+                    _commitMessageManager.AmendState = Amend.Checked;
+                }
+
+                _splitterManager.SaveSplitters();
             }
 
-            _splitterManager.SaveSplitters();
-
-            base.OnFormClosing(e);
+            base.OnFormClosed(e);
         }
 
         protected override void OnLoad(EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -420,8 +420,6 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            Message.CancelAutoComplete();
-
             // Do not remember commit message of fixup or squash commits, since they have
             // a special meaning, and can be dangerous if used inappropriately.
             if (CommitKind == CommitKind.Normal)


### PR DESCRIPTION
## Proposed changes

- Remove duplicate `CancelAutoComplete` in FormCommit
  It is done by `EditNetSpell.Dispose`.
- Store only on first close of FormCommit
  - use correct event `FormClosed`, not `FormClosing
  - check `Visible` because this method can still be called multiple times

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
