### PR TITLE
WIP Resolve race condition in UITest.RunForm

### DIFF
--- a/IntegrationTests/UITests/UITest.cs
+++ b/IntegrationTests/UITests/UITest.cs
@@ -1,58 +1,177 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using CommonTestUtils;
 using GitUI;
+using NUnit.Framework;
 
 namespace GitExtensions.UITests
 {
     public static class UITest
     {
-        public static async Task WaitForIdleAsync()
-        {
-            var idleCompletionSource = new TaskCompletionSource<VoidResult>();
-            Application.Idle += HandleApplicationIdle;
-
-            // Queue an event to make sure we don't stall if the application was already idle
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            await Task.Yield();
-
-            await idleCompletionSource.Task;
-            Application.Idle -= HandleApplicationIdle;
-
-            void HandleApplicationIdle(object sender, EventArgs e)
-            {
-                idleCompletionSource.TrySetResult(default);
-            }
-        }
-
         public static void RunForm<T>(
-            Action showDialog,
-            Func<T, Task> runAsync)
+            Action showForm,
+            Func<T, Task> runTestAsync)
             where T : Form
         {
+            LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} entry");
+            var idleCompletionSource = new TaskCompletionSource<VoidResult>();
+
+            // Start runAsync before calling showForm.
+            // The latter might block until the form is closed, especially if using Application.Run(form).
+
             // Avoid using ThreadHelper.JoinableTaskFactory for the outermost operation because we don't want the task
             // tracked by its collection. Otherwise, test code would not be able to wait for pending operations to
             // complete.
             var test = ThreadHelper.JoinableTaskContext.Factory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                await WaitForIdleAsync();
-                var dialog = Application.OpenForms.OfType<T>().Single();
+                LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}.test entry");
+
+                // Wait for the form to be opened by the test thread.
+                await idleCompletionSource.Task;
+                LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}.test idle");
+                var form = Application.OpenForms.OfType<T>().Single();
+                if (!form.Visible)
+                {
+                    var errorMessage = $"{form.GetType().FullName} {form.Name} should be visible";
+                    form.Dispose();
+                    Assert.Fail(errorMessage);
+                }
+
                 try
                 {
-                    await runAsync(dialog);
+                    // Wait for potential pending asynchronous tasks triggered by the form.
+                    WaitForPendingOperations();
+                    LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}.test form loaded");
+
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}.test on main thread");
+
+                    try
+                    {
+                        await runTestAsync(form);
+                        LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}.test passed");
+                    }
+                    catch (Exception ex)
+                    {
+                        LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}.test failed", ex);
+                        throw;
+                    }
                 }
                 finally
                 {
-                    dialog.Close();
+                    CloseOrDispose(form, $"{MethodBase.GetCurrentMethod().Name}.test");
                 }
             });
 
-            showDialog();
+            // The following call to showForm will trigger messages.
+            // So we can be sure we don't stall waiting for idle if the application was already idle.
+            Application.Idle += HandleApplicationIdle;
+            LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} subscribed");
+            try
+            {
+                try
+                {
+                    showForm();
+                    LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} form shown");
+                }
+                catch (Exception outer)
+                {
+                    try
+                    {
+                        // Wake up and join the asynchronous test operation.
+                        LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} exception",  outer);
+                        idleCompletionSource.TrySetResult(default);
+                        test.Join();
+                        LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} test joined");
+                    }
+                    catch (Exception inner)
+                    {
+                        // ignore
+                        LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} exception", inner);
+                    }
 
-            // Join the asynchronous test operation so any exceptions are rethrown on this thread
-            test.Join();
+                    throw;
+                }
+
+                // Join the asynchronous test operation so any exceptions are rethrown on this thread.
+                test.Join();
+                LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} test joined");
+            }
+            finally
+            {
+                Application.Idle -= HandleApplicationIdle;
+                LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} unsubscribed");
+
+                // Safety net for the case the task "test" threw very early and didn't close the form.
+                var form = Application.OpenForms.OfType<T>().SingleOrDefault();
+                if (form != null)
+                {
+                    string formState = form.Visible ? "open" : "exists";
+                    LoggingService.Log($"{MethodBase.GetCurrentMethod().Name} {typeof(T).FullName} still {formState}");
+
+                    CloseOrDispose(form, $"{MethodBase.GetCurrentMethod().Name} {typeof(T).FullName}");
+                }
+
+                Assert.IsTrue(Application.OpenForms.Count == 0, $"{Application.OpenForms.Count} open form(s)");
+            }
+
+            return;
+
+            void HandleApplicationIdle(object sender, EventArgs e)
+            {
+                LoggingService.Log($"{MethodBase.GetCurrentMethod().Name}");
+                idleCompletionSource.TrySetResult(default);
+            }
+        }
+
+        private static void CloseOrDispose(Form form, string description)
+        {
+            try
+            {
+                if (form == null)
+                {
+                    LoggingService.Log($"{description} form is null");
+                    return;
+                }
+
+                var actionDescription = description + " form ";
+                try
+                {
+                    if (form.Visible)
+                    {
+                        actionDescription += "close";
+                        form.Close(); // also calls form.Dispose()
+                    }
+                    else
+                    {
+                        actionDescription += "dispose";
+                        form.Dispose();
+                    }
+
+                    LoggingService.Log($"{actionDescription}d");
+                }
+                catch (Exception ex)
+                {
+                    LoggingService.Log($"{actionDescription} threw {ex.Demystify()}");
+                    form.Dispose();
+                    LoggingService.Log($"{description} form disposed");
+                }
+            }
+            finally
+            {
+                // Wait for potential pending asynchronous tasks triggered by the form.
+                WaitForPendingOperations();
+                LoggingService.Log($"{description} form operations done");
+            }
+        }
+
+        private static void WaitForPendingOperations()
+        {
+            AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
         }
 
         private readonly struct VoidResult

--- a/IntegrationTests/UITests/UITest.cs
+++ b/IntegrationTests/UITests/UITest.cs
@@ -171,7 +171,11 @@ namespace GitExtensions.UITests
 
         private static void WaitForPendingOperations()
         {
+            // Workaround for tests hanging in conjunction with canceled operations:
+            // Process the message loop before and after the wait.
+            Application.DoEvents();
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
+            Application.DoEvents();
         }
 
         private readonly struct VoidResult

--- a/UnitTests/CommonTestUtils/LoggingService.cs
+++ b/UnitTests/CommonTestUtils/LoggingService.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace CommonTestUtils
+{
+    public static class LoggingService
+    {
+        public static void Log(string message, bool debugOnly = true)
+        {
+#if !DEBUG
+            if (debugOnly)
+            {
+                return;
+            }
+#endif
+
+            Console.WriteLine(message);
+        }
+
+        public static void Log(string message, Exception ex)
+        {
+            Log($"{message}: {ex.Demystify()}", debugOnly: false);
+        }
+    }
+}


### PR DESCRIPTION
Solves parts of #7382

## Proposed changes

- resolve the following race condition in `UITest.RunForm`:
  WaitForIdleAsync could have finished before attempting to open the form.
- wait for potential pending asynchronous tasks triggered by the form
  before running the test and after closing the form
- check for open forms, close/dispose form on failed tests
- output exceptions; verbose output in debug build

- workaround for tests hanging in conjunction with canceled operations:
  Process the message loop before and after the wait.

## Test environment(s)

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
