### PR TITLE
FileViewer context menu fixes

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1233,7 +1233,7 @@ namespace GitUI.CommandsDialogs
         private async Task SetSelectedDiffAsync(GitItemStatus item, bool staged)
         {
             Action openWithDiffTool = () => (staged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick();
-            if (!item.IsTracked || FileHelper.IsImage(item.Name))
+            if (FileHelper.IsImage(item.Name))
             {
                 var guid = staged ? ObjectId.IndexId : ObjectId.WorkTreeId;
                 await SelectedDiff.ViewGitItemRevisionAsync(item.Name, guid, openWithDiffTool);

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -113,7 +113,7 @@ namespace GitUI.CommandsDialogs
         {
             if (DiffFiles.SelectedItem == null)
             {
-                DiffText.ViewPatch(null);
+                DiffText.Clear();
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -64,7 +64,6 @@ namespace GitUI.CommandsDialogs
             {
                 fileViewer.ViewFileAsync(_fileName);
                 fileViewer.IsReadOnly = false;
-                fileViewer.SetVisibilityDiffContextMenu(false, false);
                 Text = _fileName;
 
                 // loading a new file from disk, the text hasn't been changed yet.

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
         {
             if (DiffFiles.SelectedItem == null)
             {
-                diffViewer.ViewPatch(null);
+                diffViewer.Clear();
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -191,7 +191,7 @@ namespace GitUI.CommandsDialogs
                     gitStash == _currentWorkingDirStashItem)
                 {
                     // current working directory
-                    View.ViewCurrentChanges(stashedItem);
+                    View.ViewCurrentChanges(stashedItem, isStaged: false, openWithDifftool: null);
                 }
                 else if (stashedItem != null)
                 {

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -213,29 +213,35 @@ namespace GitUI.CommandsDialogs
                     {
                         string extraDiffArguments = View.GetExtraDiffArguments();
                         Encoding encoding = View.Encoding;
-                        View.ViewPatchAsync(
+                        ThreadHelper.JoinableTaskFactory.Run(
                             () =>
                             {
-                                Patch patch = Module.GetSingleDiff(gitStash.Name + "^", gitStash.Name, stashedItem.Name, stashedItem.OldName, extraDiffArguments, encoding, true, stashedItem.IsTracked);
+                                Patch patch = Module.GetSingleDiff(gitStash.Name + "^",
+                                    gitStash.Name,
+                                    stashedItem.Name,
+                                    stashedItem.OldName,
+                                    extraDiffArguments,
+                                    encoding,
+                                    true,
+                                    stashedItem.IsTracked);
                                 if (patch == null)
                                 {
-                                    return (text: string.Empty, openWithDifftool: null /* not applicable */, filename: null);
+                                    return View.ViewPatchAsync(fileName: null, text: string.Empty, openWithDifftool: null /* not applicable */, isText: true);
                                 }
 
                                 if (stashedItem.IsSubmodule)
                                 {
-                                    return (text: LocalizationHelpers.ProcessSubmodulePatch(Module, stashedItem.Name, patch),
-                                            openWithDifftool: null /* not implemented */, filename: null);
+                                    return View.ViewPatchAsync(fileName: null, text: LocalizationHelpers.ProcessSubmodulePatch(Module, stashedItem.Name, patch),
+                                            openWithDifftool: null /* not implemented */, isText: stashedItem.IsSubmodule);
                                 }
 
-                                return (text: patch.Text, openWithDifftool: null /* not implemented */, filename: stashedItem.Name);
+                                return View.ViewPatchAsync(fileName: stashedItem.Name, text: patch.Text, openWithDifftool: null /* not implemented */, isText: stashedItem.IsSubmodule);
                             });
                     }
                 }
                 else
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(
-                        () => View.ViewTextAsync("", ""));
+                    View.Clear();
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ChangesList.ViewPatch(patch);
+            ChangesList.ViewPatch(patch.FileNameB, patch);
         }
 
         private void BrowsePatch_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -199,7 +199,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private void ResetAllAndShowLoadingPullRequests()
         {
             _discussionWB.DocumentText = "";
-            _diffViewer.ViewPatch(null);
+            _diffViewer.Clear();
             _fileStatusList.SetDiffs();
 
             _pullRequestsList.Items.Clear();
@@ -250,8 +250,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             {
                 _currentPullRequestInfo = null;
                 _discussionWB.DocumentText = "";
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    () => _diffViewer.ViewTextAsync("", ""));
+                _diffViewer.Clear();
                 return;
             }
 
@@ -269,7 +268,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _currentPullRequestInfo.HeadRepo.CloneProtocol = _cloneGitProtocol;
 
             _discussionWB.DocumentText = DiscussionHtmlCreator.CreateFor(_currentPullRequestInfo);
-            _diffViewer.ViewPatch(null);
+            _diffViewer.Clear();
             _fileStatusList.SetDiffs();
 
             LoadDiffPatch();
@@ -465,7 +464,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
 
             var data = _diffCache[gis.Name];
-            _diffViewer.ViewPatch(text: data, openWithDifftool: null /* not implemented */);
+            _diffViewer.ViewPatch(gis.Name, text: data, openWithDifftool: null, isText: gis.IsSubmodule);
         }
 
         private void _closePullRequestBtn_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -331,7 +331,7 @@ namespace GitUI.CommandsDialogs
         {
             if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null)
             {
-                DiffText.ViewPatch(null);
+                DiffText.Clear();
                 return;
             }
 
@@ -345,7 +345,11 @@ namespace GitUI.CommandsDialogs
                     diffOfConflict = Strings.UninterestingDiffOmitted;
                 }
 
-                DiffText.ViewPatch(text: diffOfConflict, openWithDifftool: null /* not implemented */);
+                DiffText.ViewPatch(DiffFiles.SelectedItem.Name,
+                    text: diffOfConflict,
+                    openWithDifftool: () => firstToSelectedToolStripMenuItem.PerformClick(),
+                    isText: DiffFiles.SelectedItem.IsSubmodule);
+
                 return;
             }
 
@@ -403,7 +407,7 @@ namespace GitUI.CommandsDialogs
         {
             if (DiffFiles.GitItemStatuses == null || !DiffFiles.GitItemStatuses.Any())
             {
-                DiffText.ViewPatch(null);
+                DiffText.Clear();
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -203,7 +203,7 @@ See the changes in the commit form.");
 
                 if (tvGitTree.SelectedNode == null)
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(() => FileText.ViewTextAsync("", ""));
+                    FileText.Clear();
                 }
             }
             finally

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -69,7 +69,6 @@ namespace GitUI.Editor
             this.copyPatchToolStripMenuItem,
             this.copyNewVersionToolStripMenuItem,
             this.copyOldVersionToolStripMenuItem,
-            this.findToolStripMenuItem,
             this.toolStripSeparator1,
             this.ignoreWhitespaceAtEolToolStripMenuItem,
             this.ignoreWhitespaceChangesToolStripMenuItem,
@@ -80,6 +79,7 @@ namespace GitUI.Editor
             this.toolStripSeparator2,
             this.treatAllFilesAsTextToolStripMenuItem,
             this.showNonprintableCharactersToolStripMenuItem,
+            this.findToolStripMenuItem,
             this.goToLineToolStripMenuItem});
             this.contextMenu.Name = "ContextMenu";
             this.contextMenu.Size = new System.Drawing.Size(244, 346);

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -116,28 +116,26 @@ namespace GitUI
                 return diffViewer.ViewGitItemRevisionAsync(file.Name, secondRevision, openWithDifftool);
             }
 
-            return diffViewer.ViewPatchAsync(() =>
+            string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
+            if (selectedPatch == null)
             {
-                string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);
-                if (selectedPatch == null)
-                {
-                    return (text: defaultText, openWithDifftool: null /* not applicable */, file.Name);
-                }
+                return diffViewer.ViewPatchAsync(file.Name, text: defaultText,
+                    openWithDifftool: null /* not applicable */, isText: true);
+            }
 
-                return (text: selectedPatch,
-                    openWithDifftool: openWithDifftool ?? OpenWithDifftool, file.Name);
+            return diffViewer.ViewPatchAsync(file.Name, text: selectedPatch,
+                openWithDifftool: openWithDifftool ?? OpenWithDifftool, isText: file.IsSubmodule);
 
-                void OpenWithDifftool()
-                {
-                    diffViewer.Module.OpenWithDifftool(
-                        file.Name,
-                        null,
-                        firstRevision.ToString(),
-                        firstRevision.ToString(),
-                        "",
-                        file.IsTracked);
-                }
-            });
+            void OpenWithDifftool()
+            {
+                diffViewer.Module.OpenWithDifftool(
+                    file.Name,
+                    null,
+                    firstRevision.ToString(),
+                    firstRevision.ToString(),
+                    "",
+                    file.IsTracked);
+            }
         }
 
         public static void RemoveIfExists(this TabControl tabControl, TabPage page)

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -95,7 +95,11 @@ namespace GitUI.UserControls
                     diffOfConflict = Strings.UninterestingDiffOmitted;
                 }
 
-                DiffText.ViewPatch(text: diffOfConflict, openWithDifftool: null /* not implemented */);
+                DiffText.ViewPatch(DiffFiles.SelectedItem.Name,
+                    text: diffOfConflict,
+                    openWithDifftool: null,
+                    isText: DiffFiles.SelectedItem.IsSubmodule);
+
                 return;
             }
 

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
@@ -140,7 +140,7 @@ index 62a5c2f08..2bc482714 100644
                 testAccessor.ShowSyntaxHighlightingInDiff = true;
 
                 // act
-                _fileViewer.ViewPatch(sampleCsharpPatch, null, "FileViewerInternal.cs");
+                _fileViewer.ViewPatch("FileViewerInternal.cs", sampleCsharpPatch);
 
                 // assert
                 IHighlightingStrategy csharpHighlighting = HighlightingManager.Manager.FindHighlighterForFile("anycsharpfile.cs");
@@ -175,7 +175,7 @@ index 62a5c2f08..2bc482714 100644
                 testAccessor.ShowSyntaxHighlightingInDiff = false;
 
                 // act
-                _fileViewer.ViewPatch(sampleCsharpPatch, null, "FileViewerInternal.cs");
+                _fileViewer.ViewPatch("FileViewerInternal.cs", sampleCsharpPatch, null);
 
                 // assert
                 _fileViewer.GetTestAccessor().FileViewerInternal.GetTestAccessor().TextEditor.Document.HighlightingStrategy.Should().Be(HighlightingManager.Manager.DefaultHighlighting);
@@ -198,7 +198,7 @@ Binary files a/binaryfile.bin and b/binaryfile.bin differ";
                 _fileViewer.UICommandsSource = _uiCommandsSource;
 
                 // act
-                _fileViewer.ViewPatch(sampleBinaryPatch, null, "binaryfile.bin");
+                _fileViewer.ViewPatch("binaryfile.bin", sampleBinaryPatch, null);
 
                 // assert
                 _fileViewer.GetTestAccessor().FileViewerInternal.GetTestAccessor().TextEditor.Document.HighlightingStrategy.Should().Be(HighlightingManager.Manager.DefaultHighlighting);
@@ -207,7 +207,7 @@ Binary files a/binaryfile.bin and b/binaryfile.bin differ";
                 @"fldaksjflkdsjlfj";
 
                 // act
-                _fileViewer.ViewPatch(sampleRandomText, null, null);
+                _fileViewer.ViewPatch(null, sampleRandomText, null);
 
                 // assert
                 _fileViewer.GetTestAccessor().FileViewerInternal.GetTestAccessor().TextEditor.Document.HighlightingStrategy.Should().Be(HighlightingManager.Manager.DefaultHighlighting);


### PR DESCRIPTION
This started as an attempt to #7338, but some refactoring is needed first. (Maybe #7338 will not be finalized.)

## Proposed changes
Almost all changes seen in FileViewer for RevisionDiff

See screenshots for changes
Most changes to handle the submodule patch/"diff" as text, not as a diff in the FileViewer.
 
FileViewer internal ViewPatch call stack was cleaned up. Previously resetting internal properties like format highlighting was done several times.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

No syntax highlighting in FormViewPatch

![image](https://user-images.githubusercontent.com/6248932/72208664-ab83a100-34a5-11ea-82f5-84dec01ecfda.png)

Irrelevant context menu for submodules

![image](https://user-images.githubusercontent.com/6248932/72208711-67dd6700-34a6-11ea-8d9c-0c0e8b451f4a.png)

Cherry-pick/revert lines must not exist for files that do not exist (popup occurs) (fixing TODO in code)

![image](https://user-images.githubusercontent.com/6248932/72208754-e508dc00-34a6-11ea-979b-6c9c839abfd2.png)

![image](https://user-images.githubusercontent.com/6248932/72208779-4335bf00-34a7-11ea-832a-07dc156e867e.png)

Find grouped with patches, not go to line (see above)

### After

![image](https://user-images.githubusercontent.com/6248932/72208669-bcccad80-34a5-11ea-800d-09b489096b21.png)

![image](https://user-images.githubusercontent.com/6248932/72208720-7fb4eb00-34a6-11ea-8b52-80b5182d0e7d.png)

![image](https://user-images.githubusercontent.com/6248932/72208732-a541f480-34a6-11ea-8e3c-5c385c2ec144.png)

## Test methodology <!-- How did you ensure quality? -->
Tests adapted

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
