### PR TITLE
Add A/B to RevisionDiff revision descriptions

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -28,8 +28,8 @@ namespace GitUI.CommandsDialogs
             new TranslationString("Are you sure you want to delete the selected file(s)?");
         private readonly TranslationString _deleteFailed = new TranslationString("Delete file failed");
         private readonly TranslationString _multipleDescription = new TranslationString("<multiple>");
-        private readonly TranslationString _selectedRevision = new TranslationString("Selected");
-        private readonly TranslationString _firstRevision = new TranslationString("First");
+        private readonly TranslationString _selectedRevision = new TranslationString("Selected: (B)");
+        private readonly TranslationString _firstRevision = new TranslationString("First: (A)");
 
         private RevisionGridControl _revisionGrid;
         private RevisionFileTreeControl _revisionFileTree;
@@ -686,7 +686,7 @@ namespace GitUI.CommandsDialogs
                 selectedDiffCaptionMenuItem.Visible = true;
                 MenuUtil.SetAsCaptionMenuItem(selectedDiffCaptionMenuItem, DiffContextMenu);
 
-                firstDiffCaptionMenuItem.Text = _firstRevision + ":";
+                firstDiffCaptionMenuItem.Text = _firstRevision.Text;
                 var parentDesc = DescribeSelectedParentRevision(DiffFiles.SelectedItemParents);
                 if (parentDesc.IsNotNullOrWhitespace())
                 {

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -210,18 +210,14 @@ namespace GitUI.CommandsDialogs
         /// Provide a description for the first selected or parent to the "primary" selected last
         /// </summary>
         /// <returns>A description of the selected parent</returns>
-        private string DescribeSelectedParentRevision()
+        private string DescribeSelectedParentRevision(IEnumerable<GitRevision> parents)
         {
-            var parents = DiffFiles.SelectedItemParents
-                .Distinct()
-                .Count();
-
-            if (parents == 1)
+            if (parents.Count() == 1)
             {
-                return DescribeRevision(DiffFiles.SelectedItemParent?.ObjectId, 50);
+                return DescribeRevision(parents.FirstOrDefault()?.ObjectId, 50);
             }
 
-            if (parents > 1)
+            if (parents.Count() > 1)
             {
                 return _multipleDescription.Text;
             }
@@ -686,12 +682,12 @@ namespace GitUI.CommandsDialogs
 
             if (DiffFiles.SelectedItemsWithParent.Any())
             {
-                selectedDiffCaptionMenuItem.Text = _selectedRevision + ": (" + _revisionGrid.DescribeRevision(DiffFiles.Revision, 50) + ")";
+                selectedDiffCaptionMenuItem.Text = _selectedRevision + " (" + DescribeRevision(DiffFiles.Revision?.ObjectId, 50) + ")";
                 selectedDiffCaptionMenuItem.Visible = true;
                 MenuUtil.SetAsCaptionMenuItem(selectedDiffCaptionMenuItem, DiffContextMenu);
 
                 firstDiffCaptionMenuItem.Text = _firstRevision + ":";
-                var parentDesc = DescribeSelectedParentRevision();
+                var parentDesc = DescribeSelectedParentRevision(DiffFiles.SelectedItemParents);
                 if (parentDesc.IsNotNullOrWhitespace())
                 {
                     firstDiffCaptionMenuItem.Text += " (" + parentDesc + ")";
@@ -749,10 +745,10 @@ namespace GitUI.CommandsDialogs
             {
                 resetFileToSelectedToolStripMenuItem.Visible = true;
                 resetFileToSelectedToolStripMenuItem.Text =
-                    _selectedRevision + " (" + _revisionGrid.DescribeRevision(DiffFiles.Revision, 50) + ")";
+                    _selectedRevision + " (" + DescribeRevision(DiffFiles.Revision?.ObjectId, 50) + ")";
             }
 
-            var parents = DiffFiles.SelectedItemParents.Distinct();
+            var parents = DiffFiles.SelectedItemParents;
             if (parents.Count() != 1 || !CanResetToRevision(parents.FirstOrDefault()))
             {
                 resetFileToParentToolStripMenuItem.Visible = false;
@@ -760,7 +756,8 @@ namespace GitUI.CommandsDialogs
             else
             {
                 resetFileToParentToolStripMenuItem.Visible = true;
-                resetFileToParentToolStripMenuItem.Text = _firstRevision + " (" + _revisionGrid.DescribeRevision(parents.FirstOrDefault(), 50) + ")";
+                resetFileToParentToolStripMenuItem.Text =
+                    _firstRevision + " (" + DescribeRevision(parents.FirstOrDefault()?.ObjectId, 50) + ")";
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -210,7 +210,7 @@ namespace GitUI.CommandsDialogs
         /// Provide a description for the first selected or parent to the "primary" selected last
         /// </summary>
         /// <returns>A description of the selected parent</returns>
-        private string DescribeSelectedParentRevision(IEnumerable<GitRevision> parents)
+        private string DescribeRevision(IEnumerable<GitRevision> parents)
         {
             if (parents.Count() == 1)
             {
@@ -687,7 +687,7 @@ namespace GitUI.CommandsDialogs
                 MenuUtil.SetAsCaptionMenuItem(selectedDiffCaptionMenuItem, DiffContextMenu);
 
                 firstDiffCaptionMenuItem.Text = _firstRevision.Text;
-                var parentDesc = DescribeSelectedParentRevision(DiffFiles.SelectedItemParents);
+                var parentDesc = DescribeRevision(DiffFiles.SelectedItemParents.ToList());
                 if (parentDesc.IsNotNullOrWhitespace())
                 {
                     firstDiffCaptionMenuItem.Text += " (" + parentDesc + ")";
@@ -748,7 +748,7 @@ namespace GitUI.CommandsDialogs
                     _selectedRevision + " (" + DescribeRevision(DiffFiles.Revision?.ObjectId, 50) + ")";
             }
 
-            var parents = DiffFiles.SelectedItemParents;
+            var parents = DiffFiles.SelectedItemParents.ToList();
             if (parents.Count() != 1 || !CanResetToRevision(parents.FirstOrDefault()))
             {
                 resetFileToParentToolStripMenuItem.Visible = false;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1317,7 +1317,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="_diffWithParent.Text">
-        <source>Diff with:</source>
+        <source>Diff with (A)</source>
         <target />
       </trans-unit>
       <trans-unit id="_openSubmoduleMenuItem.Text">
@@ -8113,7 +8113,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="_firstRevision.Text">
-        <source>First</source>
+        <source>First: (A)</source>
         <target />
       </trans-unit>
       <trans-unit id="_multipleDescription.Text">
@@ -8129,7 +8129,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="_selectedRevision.Text">
-        <source>Selected</source>
+        <source>Selected: (B)</source>
         <target />
       </trans-unit>
       <trans-unit id="blameToolStripMenuItem.Text">

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -29,7 +29,7 @@ namespace GitUI
     public sealed partial class FileStatusList : GitModuleControl
     {
         private static readonly TimeSpan SelectedIndexChangeThrottleDuration = TimeSpan.FromMilliseconds(50);
-        private readonly TranslationString _diffWithParent = new TranslationString("Diff with:");
+        private readonly TranslationString _diffWithParent = new TranslationString("Diff with (A)");
         public readonly TranslationString CombinedDiff = new TranslationString("Combined Diff");
         private readonly IGitRevisionTester _revisionTester;
         private readonly IFullPathResolver _fullPathResolver;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -632,20 +632,19 @@ namespace GitUI
 
         public string DescribeRevision(GitRevision revision, int maxLength = 0)
         {
+            var description = revision.IsArtificial
+                ? string.Empty
+                : revision.ObjectId.ToShortString() + ": ";
+
             var gitRefListsForRevision = new GitRefListsForRevision(revision);
 
             var descriptiveRef = gitRefListsForRevision.AllBranches
                 .Concat(gitRefListsForRevision.AllTags)
                 .FirstOrDefault();
 
-            var description = descriptiveRef != null
+            description += descriptiveRef != null
                 ? GetRefUnambiguousName(descriptiveRef)
                 : revision.Subject;
-
-            if (!revision.IsArtificial)
-            {
-                description += " @" + revision.ObjectId.ToShortString(4);
-            }
 
             if (maxLength > 0)
             {


### PR DESCRIPTION
Discussion in #4154

## Proposed changes
Add _(A)_ and _(B)_ to some revision descriptions in RevisionDiff

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6248932/72210720-1c37b700-34c0-11ea-84ce-c95b1db0ad25.png)

![image](https://user-images.githubusercontent.com/6248932/72210725-31144a80-34c0-11ea-8e55-67047c91fe42.png)

### After

![image](https://user-images.githubusercontent.com/6248932/72378349-7c716780-3711-11ea-854c-3bddab9a47db.png)

![image](https://user-images.githubusercontent.com/6248932/72378385-8abf8380-3711-11ea-88d3-cfb6862f92dc.png)

## Test methodology <!-- How did you ensure quality? -->
manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
