### PR TITLE
Improve ConfigureJoinableTaskFactoryAttribute

### DIFF
--- a/UnitTests/CommonTestUtils/AsyncTestHelper.cs
+++ b/UnitTests/CommonTestUtils/AsyncTestHelper.cs
@@ -46,7 +46,19 @@ namespace CommonTestUtils
         {
             using (var cts = new CancellationTokenSource(timeout))
             {
-                WaitForPendingOperations(cts.Token);
+                try
+                {
+                    WaitForPendingOperations(cts.Token);
+                }
+                catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                {
+                    if (int.TryParse(Environment.GetEnvironmentVariable("GE_TEST_SLEEP_SECONDS_ON_HANG"), out var sleepSeconds) && sleepSeconds > 0)
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(sleepSeconds));
+                    }
+
+                    throw;
+                }
             }
         }
 

--- a/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
+++ b/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
@@ -21,6 +21,8 @@ namespace CommonTestUtils
 
         public void BeforeTest(ITest test)
         {
+            Assert.IsNull(ThreadHelper.JoinableTaskContext, "Tests with joinable tasks must not be run in parallel!");
+
             Application.ThreadException += HandleApplicationThreadException;
 
             IList apartmentState = null;
@@ -56,10 +58,8 @@ namespace CommonTestUtils
             {
                 try
                 {
-                    using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
-                    {
-                        ThreadHelper.JoinableTaskContext?.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(cts.Token));
-                    }
+                    // Wait for eventual pending operations triggered by the test.
+                    AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
                 }
                 finally
                 {

--- a/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
+++ b/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
@@ -79,7 +79,9 @@ namespace CommonTestUtils
             finally
             {
                 Application.ThreadException -= HandleApplicationThreadException;
-                _threadException?.Throw();
+
+                // Reset _threadException to null, and throw if it was set during the current test.
+                Interlocked.Exchange(ref _threadException, null)?.Throw();
             }
         }
 

--- a/UnitTests/GitUITests/ThreadHelperTests.cs
+++ b/UnitTests/GitUITests/ThreadHelperTests.cs
@@ -232,21 +232,10 @@ namespace GitUITests
         [Test]
         [Apartment(ApartmentState.MTA)]
         public async Task AllowAwaitForAsynchronousMTATest()
-        {
-            await Task.Yield();
-        }
+            => await Task.Yield();
 
         private static void JoinPendingOperations()
-        {
-            // Since we are testing a FileAndForget method, we need to join all pending operations before continuing.
-            // Note that ThreadHelper.JoinableTaskContext.Factory must be used to bypass the default behavior of
-            // ThreadHelper.JoinableTaskFactory since the latter adds new tasks to the collection and would therefore
-            // never complete.
-            using (var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout))
-            {
-                ThreadHelper.JoinableTaskContext?.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(cts.Token));
-            }
-        }
+            => AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
 
         private sealed class ThreadExceptionHelper : IDisposable
         {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
   - IdeVersion: VS2019
   SKIP_PAUSE: TRUE
   ARCHIVE_WITH_PDB: TRUE
+  GE_TEST_SLEEP_SECONDS_ON_HANG: 0
+  GE_TEST_LAUNCH_DEBUGGER_ON_HANG: 0
 
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
Solves parts of #7382

## Proposed changes

- The singleton JTF instance must not be null.
  - Throw InvalidOperationException if `ThreadHelper.JoinableTaskFactory/JoinableTaskContext == null`.
  - Assert in `BeforeTest` that there is no dangling singleton instance,
    which should have been destroyed by `AfterTest`.
- Aggregate follow-up exceptions.
- Reset _threadException to null in `AfterTest`.
- Report detected hangs.
  - Launch debugger if `GE_TEST_LAUNCH_DEBUGGER_ON_HANG` is `1`.
  - Delay execution by `GE_TEST_SLEEP_SECONDS_ON_HANG` on `WaitForPendingOperations` timeout.

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
