### PR TITLE
Cleanup tests

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -188,7 +188,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 _form = form;
             }
 
-            public GitModule OpenGitRepository([NotNull] string path, ILocalRepositoryManager localRepositoryManager) => FormOpenDirectory.OpenGitRepository(path, localRepositoryManager);
+            public static GitModule OpenGitRepository([NotNull] string path, ILocalRepositoryManager localRepositoryManager)
+                => FormOpenDirectory.OpenGitRepository(path, localRepositoryManager);
         }
     }
 }

--- a/IntegrationTests/UITests/CommandsDialogs/FileStatusListTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FileStatusListTests.cs
@@ -29,10 +29,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TearDown]
         public void TearDown()
         {
-            _fileStatusList?.Dispose();
-            _fileStatusList = null;
-            _form?.Dispose();
-            _form = null;
+            _fileStatusList.Dispose();
+            _form.Dispose();
         }
 
         [Test]

--- a/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.Remotes.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.Remotes.cs
@@ -62,7 +62,6 @@ namespace GitExtensions.UITests.CommandsDialogs
         public void TearDown()
         {
             _referenceRepository.Dispose();
-            _commands = null;
         }
 
         [Test]

--- a/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.Remotes.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.Remotes.cs
@@ -67,29 +67,27 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void RepoObjectTree_should_load_active_remotes()
         {
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                remotesNode =>
                 {
                     // act
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    var remotesNode = GetRemoteNode(form);
-                    remotesNode.Nodes.Count.Should().Be(5);
+                    remotesNode.Nodes.Count.Should().Be(RemoteNames.Length);
                 });
         }
 
         [Test]
         public void RepoObjectTree_should_order_active_remotes_alphabetically()
         {
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                remotesNode =>
                 {
                     // act
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    var remotesNode = GetRemoteNode(form);
                     var names = remotesNode.Nodes.OfType<TreeNode>().Select(x => x.Text).ToList();
                     names.Should().BeEquivalentTo(RemoteNames);
                     names.Should().BeInAscendingOrder();
@@ -99,14 +97,13 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void RepoObjectTree_should_order_should_not_display_inactive_if_none()
         {
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                remotesNode =>
                 {
                     // act
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    var remotesNode = GetRemoteNode(form);
                     remotesNode.Nodes.OfType<TreeNode>().Any(n => n.Text == InactiveLabel).Should().BeFalse();
                 });
         }
@@ -117,14 +114,13 @@ namespace GitExtensions.UITests.CommandsDialogs
             // setup
             DeactivateTreeNode(RemoteNames[1]);
 
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                remotesNode =>
                 {
                     // act
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    var remotesNode = GetRemoteNode(form);
                     remotesNode.Nodes.OfType<TreeNode>().Count(n => n.Text == InactiveLabel).Should().Be(1);
                 });
         }
@@ -135,14 +131,13 @@ namespace GitExtensions.UITests.CommandsDialogs
             // setup
             DeactivateTreeNode(RemoteNames[1]);
 
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                remotesNode =>
                 {
                     // act
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    var remotesNode = GetRemoteNode(form);
                     remotesNode.Nodes.OfType<TreeNode>().Last().Text.Should().Be(InactiveLabel);
                 });
         }
@@ -155,14 +150,13 @@ namespace GitExtensions.UITests.CommandsDialogs
             DeactivateTreeNode(RemoteNames[0]);
             DeactivateTreeNode(RemoteNames[1]);
 
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                remotesNode =>
                 {
                     // act
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    var remotesNode = GetRemoteNode(form);
                     var inactiveNodes = remotesNode.Nodes.OfType<TreeNode>().Last().Nodes.OfType<TreeNode>().Select(n => n.Text).ToList();
                     inactiveNodes.Count.Should().Be(3);
                     inactiveNodes.Should().BeEquivalentTo(RemoteNames[3], RemoteNames[0], RemoteNames[1]);
@@ -183,12 +177,12 @@ namespace GitExtensions.UITests.CommandsDialogs
             return remotesNode;
         }
 
-        private void RunFormTest(Action<FormBrowse> testDriver)
+        private void RunRepoObjectsTreeTest(Action<TreeNode> testDriver)
         {
             RunFormTest(
                 form =>
                 {
-                    testDriver(form);
+                    testDriver(GetRemoteNode(form));
                     return Task.CompletedTask;
                 });
         }

--- a/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.ReorderNodes.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.ReorderNodes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -8,6 +9,7 @@ using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using GitUI;
+using GitUI.BranchTreePanel;
 using GitUI.CommandsDialogs;
 using NUnit.Framework;
 
@@ -69,27 +71,28 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void RepoObjectTree_moving_first_up_and_last_down_does_nothing()
         {
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                repoObjectTree =>
                 {
+                    var testAccessor = repoObjectTree.GetTestAccessor();
+
                     // act
-                    var repoObjectTree = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor();
-                    var currNodes = repoObjectTree.TreeView.Nodes;
+                    var currNodes = testAccessor.TreeView.Nodes;
                     List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
 
                     // assert
-                    currNodes.Count.Should().Be(4);
+                    AssertListCount(currNodes, 4);
                     ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
 
                     int first = 0;
                     int last = currNodes.Count - 1;
 
                     // Trying to move first node up should do nothing
-                    repoObjectTree.ReorderTreeNode(currNodes[first], up: true);
+                    testAccessor.ReorderTreeNode(currNodes[first], up: true);
                     ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
 
                     // Similarly, moving last node down should do nothing
-                    repoObjectTree.ReorderTreeNode(currNodes[last], up: false);
+                    testAccessor.ReorderTreeNode(currNodes[last], up: false);
                     ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
                 });
         }
@@ -97,32 +100,33 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void RepoObjectTree_moving_node_legally_moves_it()
         {
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                repoObjectTree =>
                 {
+                    var testAccessor = repoObjectTree.GetTestAccessor();
+
                     // act
-                    var repoObjectTree = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor();
-                    var currNodes = repoObjectTree.TreeView.Nodes;
+                    var currNodes = testAccessor.TreeView.Nodes;
                     List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
 
                     // assert
-                    currNodes.Count.Should().Be(4);
+                    AssertListCount(currNodes, 4);
                     ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
 
                     // Move first down
-                    repoObjectTree.ReorderTreeNode(currNodes[0], up: false);
+                    testAccessor.ReorderTreeNode(currNodes[0], up: false);
                     ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3);
-                    repoObjectTree.ReorderTreeNode(currNodes[1], up: false);
+                    testAccessor.ReorderTreeNode(currNodes[1], up: false);
                     ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3);
-                    repoObjectTree.ReorderTreeNode(currNodes[2], up: false);
+                    testAccessor.ReorderTreeNode(currNodes[2], up: false);
                     ValidateOrder(initialNodes, currNodes, 1, 2, 3, 0);
 
                     // Then back up
-                    repoObjectTree.ReorderTreeNode(currNodes[3], up: true);
+                    testAccessor.ReorderTreeNode(currNodes[3], up: true);
                     ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3);
-                    repoObjectTree.ReorderTreeNode(currNodes[2], up: true);
+                    testAccessor.ReorderTreeNode(currNodes[2], up: true);
                     ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3);
-                    repoObjectTree.ReorderTreeNode(currNodes[1], up: true);
+                    testAccessor.ReorderTreeNode(currNodes[1], up: true);
                     ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
                 });
         }
@@ -130,42 +134,54 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void RepoObjectTree_moving_node_across_hidden_trees_skips_them()
         {
-            RunFormTest(
-                form =>
+            RunRepoObjectsTreeTest(
+                repoObjectTree =>
                 {
-                    // act
-                    var repoObjectTree = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor();
+                    var testAccessor = repoObjectTree.GetTestAccessor();
 
-                    List<TreeNode> initialNodes = repoObjectTree.TreeView.Nodes.OfType<TreeNode>().ToList();
+                    // act
+                    var currNodes = testAccessor.TreeView.Nodes;
+                    List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
+                    AssertListCount(initialNodes, 4);
 
                     // Hide nodes between first and last
-                    repoObjectTree.SetTreeVisibleByIndex(1, false);
-                    repoObjectTree.SetTreeVisibleByIndex(2, false);
+                    testAccessor.SetTreeVisibleByIndex(1, false);
+                    testAccessor.SetTreeVisibleByIndex(2, false);
 
                     // assert
-                    var currNodes = repoObjectTree.TreeView.Nodes;
-                    currNodes.Count.Should().Be(2);
+                    AssertListCount(currNodes, 2);
 
                     // Move node 0 down, which should move it to index 3
-                    repoObjectTree.ReorderTreeNode(currNodes[0], up: false);
+                    testAccessor.ReorderTreeNode(currNodes[0], up: false);
 
                     // Unhide nodes between first and last
-                    repoObjectTree.SetTreeVisibleByIndex(1, true);
-                    repoObjectTree.SetTreeVisibleByIndex(2, true);
+                    testAccessor.SetTreeVisibleByIndex(1, true);
+                    testAccessor.SetTreeVisibleByIndex(2, true);
 
                     // Reset currNodes, should be back to 4
-                    currNodes = repoObjectTree.TreeView.Nodes;
-                    currNodes.Count.Should().Be(4);
+                    AssertListCount(currNodes, 4);
 
                     // Only first and last nodes should have swapped
                     ValidateOrder(initialNodes, currNodes, 3, 1, 2, 0);
                 });
         }
 
+        private static void AssertListCount(ICollection collection, int expectedCount)
+        {
+            int actualCount = collection.Count;
+            if (actualCount == expectedCount)
+            {
+                return;
+            }
+
+            string items = collection.OfType<object>().Select(n => n.ToString()).Join(", ");
+            Assert.Fail($"Actual count {actualCount} differs from expected {expectedCount}.{Environment.NewLine}Actual items: {items}");
+        }
+
         private void ValidateOrder(List<TreeNode> initialNodes, TreeNodeCollection currNodes, params int[] expectedOrder)
         {
-            initialNodes.Count.Should().Be(currNodes.Count);
-            initialNodes.Count.Should().Be(expectedOrder.Count());
+            AssertListCount(currNodes, expectedOrder.Length);
+            AssertListCount(initialNodes, expectedOrder.Length);
 
             for (int i = 0; i < initialNodes.Count; ++i)
             {
@@ -173,12 +189,12 @@ namespace GitExtensions.UITests.CommandsDialogs
             }
         }
 
-        private void RunFormTest(Action<FormBrowse> testDriver)
+        private void RunRepoObjectsTreeTest(Action<RepoObjectsTree> testDriver)
         {
             RunFormTest(
                 form =>
                 {
-                    testDriver(form);
+                    testDriver(form.GetTestAccessor().RepoObjectsTree);
                     return Task.CompletedTask;
                 });
         }

--- a/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.ReorderNodes.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.ReorderNodes.cs
@@ -63,7 +63,6 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TearDown]
         public void TearDown()
         {
-            _commands = null;
             _repo1.Dispose();
         }
 

--- a/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
@@ -72,8 +72,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TearDown]
         public void TearDown()
         {
-            _commands = null;
-
+            //// _provider is a singleton and must not be disposed
             _repo1.Dispose();
             _repo2.Dispose();
             _repo3.Dispose();

--- a/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormBrowseTests.cs
@@ -55,12 +55,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_referenceRepository.Module);
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            _commands = null;
-        }
-
         [Test]
         public void PopulateFavouriteRepositoriesMenu_should_order_favourites_alphabetically()
         {

--- a/IntegrationTests/UITests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormCommitTests.cs
@@ -36,12 +36,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_referenceRepository.Module);
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            _commands = null;
-        }
-
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {

--- a/IntegrationTests/UITests/CommandsDialogs/FormEditorTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormEditorTests.cs
@@ -36,12 +36,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_referenceRepository.Module);
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            _commands = null;
-        }
-
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {

--- a/IntegrationTests/UITests/CommandsDialogs/FormInitTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormInitTests.cs
@@ -32,12 +32,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_referenceRepository.Module);
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            _commands = null;
-        }
-
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {

--- a/IntegrationTests/UITests/CommandsDialogs/FormPullTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormPullTests.cs
@@ -47,7 +47,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             AppSettings.DefaultPullAction = _originalDefaultPullAction;
             AppSettings.FormPullAction = _originalFormPullAction;
             AppSettings.AutoStash = _originalAutoStash;
-            _commands = null;
         }
 
         [OneTimeTearDown]

--- a/IntegrationTests/UITests/NBugReports/BugReportFormTests.cs
+++ b/IntegrationTests/UITests/NBugReports/BugReportFormTests.cs
@@ -17,6 +17,12 @@ namespace GitExtensions.UITests.NBugReports
             _form = new BugReportForm();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _form.Dispose();
+        }
+
         [TestCase("", false)]
         [TestCase("\t\r\n\t\t   \r   \n   \r", false)]
         [TestCase("\t\r\n\t\t  a \r   \n   \r", true)]

--- a/IntegrationTests/UITests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UITests/Script/ScriptRunnerTests.cs
@@ -52,12 +52,6 @@ namespace GitExtensions.UITests.Script
             _exampleScript.RunInBackground = true; // avoid any dialogs popping up
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            _uiCommands = null;
-        }
-
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {

--- a/IntegrationTests/UITests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
+++ b/IntegrationTests/UITests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
@@ -36,6 +36,12 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             _copyContextMenuItem.Owner = new ToolStrip();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _copyContextMenuItem.Owner.Dispose();
+        }
+
         [Test]
         public void Should_should_contain_single_item_if_no_revision_supplied()
         {

--- a/UnitTests/GitCommandsTests/ExternalLinks/ConfiguredLinkDefinitionsProviderTests.cs
+++ b/UnitTests/GitCommandsTests/ExternalLinks/ConfiguredLinkDefinitionsProviderTests.cs
@@ -53,7 +53,6 @@ namespace GitCommandsTests.ExternalLinks
             _repoLocal.SettingsCache.Dispose();
 
             _testHelper.Dispose();
-            _testHelper = null;
         }
 
         [Test]

--- a/UnitTests/GitCommandsTests/ExternalLinks/ExternalLinksManagerIntegrationTests.cs
+++ b/UnitTests/GitCommandsTests/ExternalLinks/ExternalLinksManagerIntegrationTests.cs
@@ -48,7 +48,6 @@ namespace GitCommandsTests.ExternalLinks
             _repoLocal.SettingsCache.Dispose();
 
             _testHelper.Dispose();
-            _testHelper = null;
         }
 
         [Test]

--- a/UnitTests/GitUITests/Avatars/AvatarTestBase.cs
+++ b/UnitTests/GitUITests/Avatars/AvatarTestBase.cs
@@ -50,6 +50,7 @@ namespace GitUITests.Avatars
             _img2.Dispose();
             _img3.Dispose();
             _img4.Dispose();
+            _imgGenerated.Dispose();
         }
 
         [SetUp]

--- a/UnitTests/GitUITests/BranchTreePanel/GitRefMenuItemsTest.cs
+++ b/UnitTests/GitUITests/BranchTreePanel/GitRefMenuItemsTest.cs
@@ -22,6 +22,7 @@ namespace GitUITests.BranchTreePanel
         private Queue<ToolStripMenuItem> _factoryQueue = new Queue<ToolStripMenuItem>();
         private IMenuItemFactory _factory = null;
         private TestBranchNode _testNode = new TestBranchNode();
+
         [SetUp]
         public void Setup()
         {

--- a/UnitTests/GitUITests/CommandsDialogs/FormOpenDirectoryTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormOpenDirectoryTests.cs
@@ -34,6 +34,12 @@ namespace GitUITests.CommandsDialogs
             _form = new FormOpenDirectory(null);
         }
 
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
         [Test]
         public void OpenGitRepository_should_return_null_if_directory_not_exist()
         {

--- a/UnitTests/GitUITests/CommandsDialogs/FormOpenDirectoryTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/FormOpenDirectoryTests.cs
@@ -16,8 +16,6 @@ namespace GitUITests.CommandsDialogs
         private ReferenceRepository _referenceRepository;
         private ILocalRepositoryManager _localRepositoryManager;
 
-        private FormOpenDirectory _form;
-
         [SetUp]
         public void Setup()
         {
@@ -31,7 +29,6 @@ namespace GitUITests.CommandsDialogs
             }
 
             _localRepositoryManager = Substitute.For<ILocalRepositoryManager>();
-            _form = new FormOpenDirectory(null);
         }
 
         [OneTimeTearDown]
@@ -45,7 +42,7 @@ namespace GitUITests.CommandsDialogs
         {
             string path = @"C:\some\directory\that\does\not\exist\at\all";
 
-            _form.GetTestAccessor().OpenGitRepository(path, _localRepositoryManager).Should().BeNull();
+            FormOpenDirectory.TestAccessor.OpenGitRepository(path, _localRepositoryManager).Should().BeNull();
             _localRepositoryManager.DidNotReceive().AddAsMostRecentAsync(Arg.Any<string>());
         }
 
@@ -56,7 +53,7 @@ namespace GitUITests.CommandsDialogs
             string path = Path.GetTempPath();
             path[path.Length - 1].Should().Be(Path.DirectorySeparatorChar);
 
-            _form.GetTestAccessor().OpenGitRepository(path, _localRepositoryManager).Should().BeNull();
+            FormOpenDirectory.TestAccessor.OpenGitRepository(path, _localRepositoryManager).Should().BeNull();
             _localRepositoryManager.DidNotReceive().AddAsMostRecentAsync(Arg.Any<string>());
         }
 
@@ -69,7 +66,7 @@ namespace GitUITests.CommandsDialogs
 
             // ensure absence of the trailing slash isn't a problem
             path = path.Substring(0, path.Length - 1);
-            Assert.DoesNotThrow(() => _form.GetTestAccessor().OpenGitRepository(path, _localRepositoryManager));
+            Assert.DoesNotThrow(() => FormOpenDirectory.TestAccessor.OpenGitRepository(path, _localRepositoryManager));
         }
 
         [Test]
@@ -79,7 +76,7 @@ namespace GitUITests.CommandsDialogs
             string path = Path.GetTempPath();
             path[path.Length - 1].Should().Be(Path.DirectorySeparatorChar);
 
-            var module = _form.GetTestAccessor().OpenGitRepository(_referenceRepository.Module.WorkingDir, _localRepositoryManager);
+            var module = FormOpenDirectory.TestAccessor.OpenGitRepository(_referenceRepository.Module.WorkingDir, _localRepositoryManager);
 
             module.Should().NotBeNull();
             module.WorkingDir.Should().Be(_referenceRepository.Module.WorkingDir);

--- a/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUITests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -37,8 +37,7 @@ namespace GitUITests.CommandsDialogs
         [TearDown]
         public void TearDown()
         {
-            _imageList?.Dispose();
-            _imageList = null;
+            _imageList.Dispose();
         }
 
         [Test]

--- a/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
+++ b/UnitTests/GitUITests/CommitInfo/CommitInfoTests.cs
@@ -65,7 +65,7 @@ namespace GitUITests.CommitInfo
         [TearDown]
         public void TearDown()
         {
-            _commands = null;
+            _commitInfo.Dispose();
         }
 
         [OneTimeTearDown]

--- a/UnitTests/GitUITests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -22,6 +22,12 @@ namespace GitUITests.Editor
             _viewPositionCache = new FileViewerInternal.CurrentViewPositionCache(_fileViewerInternal);
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _fileViewerInternal.Dispose();
+        }
+
         [TestCase(null)]
         [TestCase("a")]
         public void Capture_should_not_change_capture_if_less_then_two_lines(string text)

--- a/UnitTests/GitUITests/Editor/FileViewerTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerTests.cs
@@ -17,6 +17,12 @@ namespace GitUITests.Editor
             _fileViewer = new FileViewer();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _fileViewer.Dispose();
+        }
+
         [Test]
         [TestCase(IgnoreWhitespaceKind.None, IgnoreWhitespaceKind.Eol, true, false, false)]
         [TestCase(IgnoreWhitespaceKind.None, IgnoreWhitespaceKind.Change, true, true, false)]

--- a/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUITests/Editor/FileViewerTextTests.cs
@@ -30,6 +30,12 @@ namespace GitUITests.Editor
             _fileViewer = new FileViewer();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            _fileViewer.Dispose();
+        }
+
         [Test]
         [TestCase(AutoCRLFType.@true, "UnixLines")]
         [TestCase(AutoCRLFType.@true, "MacLines")]

--- a/UnitTests/GitUITests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUITests/GitExtensionsFormTests.cs
@@ -25,7 +25,7 @@ namespace GitUITests
         [Test]
         public void RestorePosition_should_not_restore_position_if_not_required()
         {
-            var form = new MockForm(false)
+            using var form = new MockForm(false)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(500, 500)
@@ -43,7 +43,7 @@ namespace GitUITests
         [Test]
         public void RestorePosition_should_not_restore_position_if_minimised()
         {
-            var form = new MockForm(false)
+            using var form = new MockForm(false)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(500, 500),
@@ -63,7 +63,7 @@ namespace GitUITests
         [Test]
         public void RestorePosition_should_not_restore_position_if_not_persisted()
         {
-            var form = new MockForm(true)
+            using var form = new MockForm(true)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(500, 500)
@@ -88,13 +88,12 @@ namespace GitUITests
         [TestCase(FormBorderStyle.None)]
         public void RestorePosition_should_not_scale_fixed_window_if_different_dpi(FormBorderStyle borderStyle)
         {
-            var form = new MockForm(true)
+            using var form = new MockForm(true)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(300, 300),
                 FormBorderStyle = borderStyle
             };
-
             var screens = new[]
             {
                 new Rectangle(-1920, 0, 1920, 1080),
@@ -106,7 +105,8 @@ namespace GitUITests
             test.GetScreensWorkingArea = () => screens;
             test.WindowPositionManager = _windowPositionManager;
 
-            _windowPositionManager.LoadPosition(form).Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), 96, FormWindowState.Normal, "bla"));
+            _windowPositionManager.LoadPosition(form)
+                .Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), 96, FormWindowState.Normal, "bla"));
 
             form.InvokeRestorePosition();
 
@@ -124,12 +124,11 @@ namespace GitUITests
                 Assert.Inconclusive("The test must be run at 96dpi");
             }
 
-            var form = new MockForm(true)
+            using var form = new MockForm(true)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(300, 300),
             };
-
             var screens = new[]
             {
                 new Rectangle(-1920, 0, 1920, 1080),
@@ -141,7 +140,8 @@ namespace GitUITests
             test.GetScreensWorkingArea = () => screens;
             test.WindowPositionManager = _windowPositionManager;
 
-            _windowPositionManager.LoadPosition(form).Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), savedDpi, FormWindowState.Normal, "bla"));
+            _windowPositionManager.LoadPosition(form)
+                .Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), savedDpi, FormWindowState.Normal, "bla"));
 
             form.InvokeRestorePosition();
 
@@ -158,12 +158,12 @@ namespace GitUITests
                 Assert.Inconclusive("The test must be run at 96dpi");
             }
 
-            var owner = new Form
+            using var owner = new Form
             {
                 Location = new Point(ownerFormTop, ownerFormLeft),
                 Size = new Size(800, 600)
             };
-            var form = new MockForm(true)
+            using var form = new MockForm(true)
             {
                 Owner = owner,
                 StartPosition = FormStartPosition.CenterParent
@@ -178,7 +178,8 @@ namespace GitUITests
             var test = form.GetGitExtensionsFormTestAccessor();
             test.GetScreensWorkingArea = () => screens;
             test.WindowPositionManager = _windowPositionManager;
-            _windowPositionManager.LoadPosition(form).Returns(x => new WindowPosition(new Rectangle(100, 100, 300, 200), 96, FormWindowState.Normal, "bla"));
+            _windowPositionManager.LoadPosition(form)
+                .Returns(x => new WindowPosition(new Rectangle(100, 100, 300, 200), 96, FormWindowState.Normal, "bla"));
 
             form.InvokeRestorePosition();
 

--- a/UnitTests/GitUITests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUITests/UserControls/BlameControlTests.cs
@@ -17,7 +17,7 @@ namespace GitUITests.UserControls
     [Apartment(ApartmentState.STA)]
     public class BlameControlTests
     {
-        private BlameControl.TestAccessor _sut;
+        private BlameControl _blameControl;
         private GitBlameLine _gitBlameLine;
 
         [SetUp]
@@ -51,14 +51,20 @@ namespace GitUITests.UserControls
 
             _gitBlameLine = new GitBlameLine(blameCommit1, 1, 1, "line1");
 
-            _sut = new BlameControl().GetTestAccessor();
-            _sut.Blame = new GitBlame(new GitBlameLine[]
+            _blameControl = new BlameControl();
+            _blameControl.GetTestAccessor().Blame = new GitBlame(new GitBlameLine[]
             {
                 _gitBlameLine,
                 new GitBlameLine(blameCommit1, 2, 2, "line2"),
                 new GitBlameLine(blameCommit2, 3, 3, "line3"),
                 new GitBlameLine(blameCommit2, 4, 4, "line4"),
             });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _blameControl.Dispose();
         }
 
         [TestCase(true, true, true, true, "author1 - 3/22/2010 - fileName.txt")]
@@ -70,7 +76,8 @@ namespace GitUITests.UserControls
         {
             var line = new StringBuilder();
 
-            _sut.BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, "fileName_different.txt", showAuthor, showAuthorDate, showFilePath, displayAuthorFirst);
+            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+                "fileName_different.txt", showAuthor, showAuthorDate, showFilePath, displayAuthorFirst);
 
             line.ToString().Should().StartWith(expectedResult);
         }
@@ -80,7 +87,8 @@ namespace GitUITests.UserControls
         {
             var line = new StringBuilder();
 
-            _sut.BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, "fileName.txt", true, true, true, false);
+            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+                "fileName.txt", true, true, true, false);
 
             line.ToString().Should().StartWith("3/22/2010 - author1");
         }
@@ -94,7 +102,7 @@ namespace GitUITests.UserControls
             {
                 AppSettings.BlameShowAuthorTime = true;
 
-                var (gutter, content) = _sut.BuildBlameContents("fileName.txt");
+                var (gutter, content) = _blameControl.GetTestAccessor().BuildBlameContents("fileName.txt");
 
                 content.Should().Be($"line1{Environment.NewLine}line2{Environment.NewLine}line3{Environment.NewLine}line4{Environment.NewLine}");
                 var gutterLines = gutter.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
@@ -123,7 +131,7 @@ namespace GitUITests.UserControls
                 AppSettings.BlameShowAuthorTime = false;
 
                 // When
-                var (gutter, content) = _sut.BuildBlameContents("fileName.txt");
+                var (gutter, content) = _blameControl.GetTestAccessor().BuildBlameContents("fileName.txt");
 
                 // Then
                 content.Should().Be($"line1{Environment.NewLine}line2{Environment.NewLine}line3{Environment.NewLine}line4{Environment.NewLine}");


### PR DESCRIPTION
## Proposed changes

- More complete `TearDown`; remove `null` assignments
- No unused `Form` instance in `FormOpenDirectoryTests`
- Dispose `Form` instances in `GitExtensionsFormTests`
- Refactor `FormBrowseTests.LeftPanel.*`

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).