### PR TITLE
Restore test Submodule_status_changes_for_top_module

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCommands.Git;
@@ -32,7 +33,8 @@ namespace GitCommands.Submodules
         /// </summary>
         /// <param name="workingDirectory">Current module working directory</param>
         /// <param name="gitStatus">The Git status for the changes (also other than submodules)</param>
-        void UpdateSubmodulesStatus(string workingDirectory, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus);
+        /// <param name="forceUpdate">Suppress the usual delay of 15 seconds between consecutive updates</param>
+        void UpdateSubmodulesStatus(string workingDirectory, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus, bool forceUpdate = false);
     }
 
     public sealed class SubmoduleStatusProvider : ISubmoduleStatusProvider
@@ -129,7 +131,7 @@ namespace GitCommands.Submodules
         }
 
         /// <inheritdoc />
-        public void UpdateSubmodulesStatus(string workingDirectory, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus)
+        public void UpdateSubmodulesStatus(string workingDirectory, [CanBeNull] IReadOnlyList<GitItemStatus> gitStatus, bool forceUpdate)
         {
             if (_submoduleInfoResult == null)
             {
@@ -139,8 +141,9 @@ namespace GitCommands.Submodules
 
             // Throttle updates triggered from status updates
             TimeSpan elapsed = DateTime.Now - _previousSubmoduleUpdateTime;
-            if (gitStatus == null || elapsed.TotalSeconds <= 15)
+            if (gitStatus == null || (!forceUpdate && elapsed.TotalSeconds <= 15))
             {
+                Console.WriteLine($"{MethodBase.GetCurrentMethod().Name} called too early again - aborting");
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -101,7 +101,7 @@ namespace GitUI.CommandsDialogs
         private readonly IAppTitleGenerator _appTitleGenerator;
         [CanBeNull] private readonly IAheadBehindDataProvider _aheadBehindDataProvider;
         private readonly WindowsJumpListManager _windowsJumpListManager;
-        private readonly SubmoduleStatusProvider _submoduleStatusProvider;
+        private readonly ISubmoduleStatusProvider _submoduleStatusProvider;
         private readonly FormBrowseDiagnosticsReporter _formBrowseDiagnosticsReporter;
         [CanBeNull] private BuildReportTabPageExtension _buildReportTabPageExtension;
         private ConEmuControl _terminal;

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -9,20 +9,24 @@ namespace CommonTestUtils
         public static SubmoduleInfoResult UpdateSubmoduleStructureAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
         {
             SubmoduleInfoResult result = null;
-            provider.StatusUpdated += Provider_StatusUpdated;
+            provider.StatusUpdated += ProviderStatusUpdated;
+            try
+            {
+                provider.UpdateSubmodulesStructure(
+                    workingDirectory: module.WorkingDir,
+                    noBranchText: string.Empty,
+                    updateStatus: updateStatus);
 
-            provider.UpdateSubmodulesStructure(
-                workingDirectory: module.WorkingDir,
-                noBranchText: string.Empty,
-                updateStatus: updateStatus);
-
-            AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
-
-            provider.StatusUpdated -= Provider_StatusUpdated;
+                AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
+            }
+            finally
+            {
+                provider.StatusUpdated -= ProviderStatusUpdated;
+            }
 
             return result;
 
-            void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
+            void ProviderStatusUpdated(object sender, SubmoduleStatusEventArgs e)
             {
                 result = e.Info;
             }
@@ -30,22 +34,9 @@ namespace CommonTestUtils
 
         public static void UpdateSubmoduleStatusAndWaitForResult(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
         {
-            List<DetailedSubmoduleInfo> result = new List<DetailedSubmoduleInfo>();
-            provider.StatusUpdated += Provider_StatusUpdated;
-
-            provider.UpdateSubmodulesStatus(
-                workingDirectory: module.WorkingDir,
-                gitStatus: gitStatus);
+            provider.UpdateSubmodulesStatus(workingDirectory: module.WorkingDir, gitStatus: gitStatus, forceUpdate: true);
 
             AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
-
-            provider.StatusUpdated -= Provider_StatusUpdated;
-
-            return;
-
-            void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
-            {
-            }
         }
     }
 }

--- a/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommandsTests/Submodules/SubmoduleStatusProviderTests.cs
@@ -118,8 +118,7 @@ namespace GitCommandsTests.Submodules
                 changedFiles.Should().HaveCount(1);
                 SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResult(_provider, currentModule, changedFiles);
 
-                // Disabled test as the test case does not await async retrieval of submodule status
-                ////result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+                result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
                 result.OurSubmodules[1].Detailed.Should().BeNull();
 
                 // Revert the change


### PR DESCRIPTION
## Proposed changes

Restore test Submodule_status_changes_for_top_module
- add ISubmoduleStatusProvider.UpdateSubmodulesStatus argument forceUpdate
- remove unused locals from UpdateSubmoduleStatusAndWaitForResult

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).