### PR TITLE
ls-tree: Use -- to escape files starting with "-"

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -707,9 +707,17 @@ namespace GitCommands
             filename = filename.ToPosixPath();
 
             var list = new List<ConflictData>();
+            var args = new GitArgumentBuilder("ls-files")
+            {
+                "-z",
+                "--unmerged",
+                { filename.IsNotNullOrWhitespace(), "--" },
+                filename.QuoteNE()
+            };
 
             var unmerged = (await _gitExecutable
-                .GetOutputAsync("ls-files -z --unmerged " + filename.QuoteNE()).ConfigureAwait(false))
+                .GetOutputAsync(args)
+                .ConfigureAwait(false))
                 .Split(new[] { '\0', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             var item = new ConflictedFileData[3];
@@ -804,6 +812,7 @@ namespace GitCommands
             var args = new GitArgumentBuilder("ls-tree")
             {
                 refName,
+                { filename.IsNotNullOrWhitespace(), "--" },
                 filename.QuoteNE()
             };
             var output = _gitExecutable.GetOutput(args);
@@ -3458,6 +3467,7 @@ namespace GitCommands
                 var args = new GitArgumentBuilder("ls-files")
                 {
                     "-s",
+                    { fileName.IsNotNullOrWhitespace(), "--" },
                     fileName.QuoteNE()
                 };
 
@@ -3475,6 +3485,7 @@ namespace GitCommands
                 {
                     "-r",
                     objectId,
+                    { fileName.IsNotNullOrWhitespace(), "--" },
                     fileName.QuoteNE()
                 };
                 var lines = _gitExecutable.GetOutput(args).Split(' ', '\t');

--- a/UnitTests/GitCommandsTests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommandsTests/Config/ConfigFileTest.cs
@@ -59,7 +59,7 @@ namespace GitCommandsTests.Config
             var args = new GitArgumentBuilder("config")
             {
                 "-f",
-                cfgFile.QuoteNE(),
+                cfgFile.Quote(),
                 "--add",
                 section,
                 value
@@ -72,7 +72,7 @@ namespace GitCommandsTests.Config
             var args = new GitArgumentBuilder("config")
             {
                 "-f",
-                cfgFile.QuoteNE(),
+                cfgFile.Quote(),
                 "--get",
                 key.Quote()
             };


### PR DESCRIPTION
Fixes #7650

## Proposed changes

Use -- to escape files starting with "-".
Quick review of other QuoteNE() usage. In addition to the issue, QuteNE was used without escaping paths in a couple of situations.
Incorrect use of QuoteNW in a testcase too.

Other commands could be affected too, this is quite hard to investigate.

## Test methodology <!-- How did you ensure quality? -->

Manual
Remove an image that starts with "-" and view the diff

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
