### PR TITLE
Add TempAppSettingsAttribute for all tests

### DIFF
--- a/IntegrationTests/UITests/Properties/AssemblyInfo.cs
+++ b/IntegrationTests/UITests/Properties/AssemblyInfo.cs
@@ -37,4 +37,5 @@ using CommonTestUtils;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ConfigureJoinableTaskFactory]
+[assembly: TestAppSettings]
 [assembly: UseReporter(typeof(NUnitReporter), typeof(AppVeyorReporter), typeof(DiffReporter))]

--- a/UnitTests/CommonTestUtils/Properties/AssemblyInfo.cs
+++ b/UnitTests/CommonTestUtils/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/CommonTestUtils/TestAppSettingsAttribute.cs
+++ b/UnitTests/CommonTestUtils/TestAppSettingsAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using GitCommands;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace CommonTestUtils
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class TestAppSettingsAttribute : Attribute, ITestAction
+    {
+        public ActionTargets Targets => ActionTargets.Suite;
+
+        public void BeforeTest(ITest test)
+        {
+            AppSettings.CheckForUpdates = false;
+        }
+
+        public void AfterTest(ITest test)
+        {
+        }
+    }
+}

--- a/UnitTests/GitCommandsTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/GitCommandsTests/Properties/AssemblyInfo.cs
@@ -39,4 +39,5 @@ using CommonTestUtils;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ConfigureJoinableTaskFactory]
+[assembly: TestAppSettings]
 [assembly: UseReporter(typeof(NUnitReporter), typeof(AppVeyorReporter), typeof(DiffReporter))]

--- a/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
+++ b/UnitTests/GitExtUtils/GitExtUtilsTests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Externals\ICSharpCode.TextEditor\Project\ICSharpCode.TextEditor.csproj" />
     <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
+    <ProjectReference Include="..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UnitTests/GitExtUtils/Properties/AssemblyInfo.cs
+++ b/UnitTests/GitExtUtils/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/GitUITests/Properties/AssemblyInfo.cs
+++ b/UnitTests/GitUITests/Properties/AssemblyInfo.cs
@@ -39,4 +39,5 @@ using CommonTestUtils;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: ConfigureJoinableTaskFactory]
+[assembly: TestAppSettings]
 [assembly: UseReporter(typeof(NUnitReporter), typeof(AppVeyorReporter), typeof(DiffReporter))]

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegrationTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegrationTests/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using ApprovalTests.Namers;
 using ApprovalTests.Reporters;
 using ApprovalTests.Reporters.ContinuousIntegration;
 using ApprovalTests.Reporters.TestFrameworks;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -38,5 +39,6 @@ using ApprovalTests.Reporters.TestFrameworks;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
+[assembly: TestAppSettings]
 [assembly: UseReporter(typeof(NUnitReporter), typeof(AppVeyorReporter), typeof(DiffReporter))]
 [assembly: UseApprovalSubdirectory("ApprovedFiles")]

--- a/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegrationTests/AzureDevOpsIntegrationTests.csproj
+++ b/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegrationTests/AzureDevOpsIntegrationTests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Plugins\BuildServerIntegration\AzureDevOpsIntegration\AzureDevOpsIntegration.csproj" />
+    <ProjectReference Include="..\..\..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegrationTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegrationTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/Plugins/DeleteUnusedBranchesTests/DeleteUnusedBranchesTests.csproj
+++ b/UnitTests/Plugins/DeleteUnusedBranchesTests/DeleteUnusedBranchesTests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Plugins\DeleteUnusedBranches\DeleteUnusedBranches.csproj" />
+    <ProjectReference Include="..\..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UnitTests/Plugins/DeleteUnusedBranchesTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/DeleteUnusedBranchesTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/Plugins/GerritTests/GerritTests.csproj
+++ b/UnitTests/Plugins/GerritTests/GerritTests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Plugins\Gerrit\Gerrit.csproj" />
     <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
+    <ProjectReference Include="..\..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UnitTests/Plugins/GerritTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/GerritTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/Plugins/GitUIPluginInterfacesTests/GitUIPluginInterfacesTests.csproj
+++ b/UnitTests/Plugins/GitUIPluginInterfacesTests/GitUIPluginInterfacesTests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins/GitUIPluginInterfacesTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/GitUIPluginInterfacesTests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 [assembly: AssemblyTitle("GitUIPluginInterfacesTests")]
 [assembly: AssemblyDescription("")]
@@ -18,3 +19,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
+++ b/UnitTests/Plugins/ReleaseNotesGeneratorTests/ReleaseNotesGeneratorTests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Plugins\ReleaseNotesGenerator\ReleaseNotesGenerator.csproj" />
+    <ProjectReference Include="..\..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UnitTests/ResourceManagerTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/ResourceManagerTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using CommonTestUtils;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: TestAppSettings]

--- a/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
+++ b/UnitTests/ResourceManagerTests/ResourceManagerTests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
     <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
+    <ProjectReference Include="..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Proposed changes

- Add `TempAppSettingsAttribute` for all tests
  in order to set `AppSettings.CheckForUpdates = false`

There is no need to tinker the `AppSettings.SettingsFilePath` because the user's GE settings file is not used but one which is specific for the test runner, e.g. 
`SettingsFilePath: C:\Users\appveyor\AppData\Roaming\NUnit Software\NUnit Engine\GitExtensions.settings`

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).