### PR TITLE
Keep Syntax Highlight Rules Synced With Resources

### DIFF
--- a/UnitTests/GitUITests/UserControls/ICSharpTextEditorTest.cs
+++ b/UnitTests/GitUITests/UserControls/ICSharpTextEditorTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls
+{
+    public sealed class ICSharpTextEditorTest
+    {
+        [Test]
+        public void ResourceStreamNamesMatchSyntaxNodes()
+        {
+            Assembly assembly = typeof(ICSharpCode.TextEditor.Document.ResourceSyntaxModeProvider).Assembly;
+            var resources = assembly.GetManifestResourceNames();
+            var syntaxNodesResource = resources.First(r => r.Contains("SyntaxModes"));
+            var xmlModes = XElement.Load(assembly.GetManifestResourceStream(syntaxNodesResource)).Elements("Mode");
+            var resourcesToCheck = resources.Where(r => r.EndsWith("xshd"));
+
+            var matched = from xml in xmlModes
+                          join res in resourcesToCheck on xml.Attribute("file").Value equals
+                          res.Replace("ICSharpCode.TextEditor.Resources.", "")
+                          select new { ResourceName = res, XMLModeFile = xml.Attribute("file").Value };
+
+            var missingInXML = resourcesToCheck.Except(matched.Select(m => m.ResourceName));
+
+            var missingInResources = from nd in xmlModes
+                                     where !matched.Select(m => m.XMLModeFile).Contains(nd.Attribute("file").Value)
+                                     select nd.Attribute("file").Value;
+
+            Assert.That(!missingInXML.Any(), "The SyntaxNodes.xml file is out of sync with the actual resources. Check the following resource names that don't exist in xml file. {0}", string.Join(",", missingInXML));
+            Assert.That(!missingInResources.Any(), "The SyntaxNodes.xml file is out of sync with the actual resources. Check the following resource names that don't exist in embedded resources. {0}", string.Join(",", missingInResources));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7653


## Proposed changes

- Rename vb highlight rules file
- Add test to keep names and SyntaxNodes in sync
- ~~Switch ICSharp project to debug~~


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Renamed an xshd file and ran test
- Added a copy of one of the mode elements and altered the file attribute.



## Test environment(s) <!-- Remove any that don't apply -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
