### PR TITLE
ObjectId ShortString: set default to 8 chars

### DIFF
--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -89,7 +89,7 @@ namespace GitCommands
 
         public string Name { get; set; }
 
-        public override string ToString() => $"{ObjectId.ToShortString(8)}:{Subject}";
+        public override string ToString() => $"{ObjectId.ToShortString()}:{Subject}";
 
         /// <summary>
         /// Indicates whether the commit is an artificial commit.

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1578,12 +1578,12 @@ namespace GitUI.CommandsDialogs
 
                 if (revisions[0].ObjectId == currentCheckout)
                 {
-                    from = revisions[1].ObjectId.ToShortString(8);
+                    from = revisions[1].ObjectId.ToShortString();
                     to = currentBranch;
                 }
                 else if (revisions[1].ObjectId == currentCheckout)
                 {
-                    from = revisions[0].ObjectId.ToShortString(8);
+                    from = revisions[0].ObjectId.ToShortString();
                     to = currentBranch;
                 }
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -308,7 +308,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision != null)
                 {
-                    txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString(8);
+                    txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString();
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -680,7 +680,7 @@ namespace GitUI.CommandsDialogs
                 return "@" + _deleted.Text;
             }
 
-            return '@' + item.ObjectId.ToShortString(8);
+            return '@' + item.ObjectId.ToShortString();
         }
 
         private void ConflictedFiles_SelectionChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -200,7 +200,7 @@ namespace GitUI.CommandsDialogs
 
             if (revision == null)
             {
-                return objectId.ToShortString(length: 8);
+                return objectId.ToShortString();
             }
 
             return _revisionGrid.DescribeRevision(revision, maxLength);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1037,7 +1037,7 @@ namespace GitUI
                     return DescribeRevision(objectId);
                 }
 
-                return objectId.ToShortString(length: 8);
+                return objectId.ToShortString();
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -644,7 +644,7 @@ namespace GitUI
 
             if (!revision.IsArtificial)
             {
-                description += " @" + revision.ObjectId.ToShortString(4);
+                description += " @" + revision.ObjectId.ToShortString();
             }
 
             if (maxLength > 0)

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -480,7 +480,7 @@ namespace GitUIPluginInterfaces
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is less than zero, or more than 40.</exception>
         [Pure]
         [NotNull]
-        public unsafe string ToShortString(int length = 10)
+        public unsafe string ToShortString(int length = 8)
         {
             if (length < 0)
             {

--- a/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManagerTests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -252,7 +252,7 @@ namespace ResourceManagerTests.CommitDataRenders
 
             var result = _renderer.Render(data, false);
 
-            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Parents:       3b6ce324e3 2a8788ff15 8e66fa8095");
+            result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Parents:       3b6ce324 2a8788ff 8e66fa80");
             _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
             _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
             _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());


### PR DESCRIPTION
Discussed here: https://github.com/gitextensions/gitextensions/pull/7626#issuecomment-574760763

## Proposed changes
The short version of commit hash was previously 10 characters but in 9 of 19 uses the size was modified (to 8 chars, except in revision diff where it was 4, changing to the default in #7666). 

The short format that is unique in a repo can be retrieved from Git. Many repos are OK with 7 bytes (this was the initial for the Linux repo), bigger repos need longer sha, Linux at least 12 bytes to _only_ use the short sha.

This short format is only used for display, in many places the link can be copied.
The short form should be used to present the sha in the GUI to correlate info in for instance CommitInfo to the revision grid. The short form should not be required to be unique.
However, the length should be consistent in the GUI.

In the UI 10 bytes is too long to be easily remembered. The first 2 bytes are normally enough to compare sha to the revision grid or similar, but also the 4 byte sha in revision diff has confused users (see #7626), so something longer is needed. I find 6 to be more than enough, however changing to 8 that is used in many situations already is a compromise.

## Screenshots <!-- Remove this section if PR does not change UI -->

One example only

### Before

![image](https://user-images.githubusercontent.com/6248932/72848646-5580db80-3ca5-11ea-84e6-c5cd155f5c3c.png)

### After

![image](https://user-images.githubusercontent.com/6248932/72848697-6fbab980-3ca5-11ea-9cb0-f4fa91a07a10.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
