### PR TITLE
Run FormCommitTests & FormInitTests with an explicit message loop

### DIFF
--- a/IntegrationTests/UITests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormCommitTests.cs
@@ -321,21 +321,21 @@ namespace GitExtensions.UITests.CommandsDialogs
 
         private void RunFormTest(Func<FormCommit, Task> testDriverAsync, CommitKind commitKind = CommitKind.Normal)
         {
-            UITest.RunForm(
-                () =>
+            UITest.RunDialog(
+                (mainForm) =>
                 {
                     switch (commitKind)
                     {
                         case CommitKind.Normal:
-                            Assert.True(_commands.StartCommitDialog(owner: null));
+                            Assert.True(_commands.StartCommitDialog(owner: mainForm));
                             break;
 
                         case CommitKind.Squash:
-                            Assert.True(_commands.StartSquashCommitDialog(owner: null, _referenceRepository.Module.GetRevision()));
+                            Assert.True(_commands.StartSquashCommitDialog(owner: mainForm, _referenceRepository.Module.GetRevision()));
                             break;
 
                         case CommitKind.Fixup:
-                            Assert.True(_commands.StartFixupCommitDialog(owner: null, _referenceRepository.Module.GetRevision()));
+                            Assert.True(_commands.StartFixupCommitDialog(owner: mainForm, _referenceRepository.Module.GetRevision()));
                             break;
 
                         default:

--- a/IntegrationTests/UITests/CommandsDialogs/FormInitTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormInitTests.cs
@@ -112,10 +112,10 @@ namespace GitExtensions.UITests.CommandsDialogs
 
         private void RunFormTest(Func<FormInit, Task> testDriverAsync, string path)
         {
-            UITest.RunForm(
-                () =>
+            UITest.RunDialog(
+                (mainForm) =>
                 {
-                    Assert.True(_commands.StartInitializeDialog(owner: null, path));
+                    Assert.True(_commands.StartInitializeDialog(owner: mainForm, path));
                 },
                 testDriverAsync);
         }


### PR DESCRIPTION
## Proposed changes

- Run `FormCommitTests` & `FormInitTests` with an explicit message loop
- Let `UITest.RunForm` dispose the tested form
- Let `UITest.RunForm` assert the tested form is visible

Merge undisputed changes of #7623 with this PR in order to see whether further changes are necessary or not.

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).