### PR TITLE
Add pwsh as a choice of shell in Console tab

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -180,12 +180,15 @@
             this.cboTerminal.Items.AddRange(new object[] {
             "bash",
             "cmd",
-            "powershell"});
+            "powershell",
+            "pwsh"});
             this.cboTerminal.Location = new System.Drawing.Point(118, 59);
             this.cboTerminal.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cboTerminal.Name = "cboTerminal";
             this.cboTerminal.Size = new System.Drawing.Size(262, 21);
             this.cboTerminal.TabIndex = 4;
+            this.cboTerminal.SelectionChangeCommitted += new System.EventHandler(this.cboTerminal_SelectionChangeCommitted);
+            this.cboTerminal.Enter += new System.EventHandler(this.cboTerminal_Enter);
             // 
             // _NO_TRANSLATE_cboStyle
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -4,6 +4,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class FormBrowseRepoSettingsPage : SettingsPageWithHeader
     {
+        private int _cboTerminalPreviousIndex = -1;
+
         public FormBrowseRepoSettingsPage()
         {
             InitializeComponent();
@@ -31,6 +33,22 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public static SettingsPageReference GetPageReference()
         {
             return new SettingsPageReferenceByType(typeof(FormBrowseRepoSettingsPage));
+        }
+
+        private void cboTerminal_SelectionChangeCommitted(object sender, System.EventArgs e)
+        {
+            if (ShellHelper.ShellIsOnPath((string)cboTerminal.SelectedItem))
+            {
+                return;
+            }
+
+            MessageBoxes.ShellNotFound(this);
+            cboTerminal.SelectedIndex = _cboTerminalPreviousIndex;
+        }
+
+        private void cboTerminal_Enter(object sender, System.EventArgs e)
+        {
+            _cboTerminalPreviousIndex = cboTerminal.SelectedIndex;
         }
     }
 }

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -30,6 +30,9 @@ namespace GitUI
         private readonly TranslationString _rememberChoice = new TranslationString("Remember choice");
         private readonly TranslationString _confirmDeleteRemoteBranch = new TranslationString("Do you want to delete the branch {0} from {1}?");
 
+        private readonly TranslationString _shellNotFoundCaption = new TranslationString("Shell not found");
+        private readonly TranslationString _shellNotFound = new TranslationString("The selected shell is not installed, or is not on your path.");
+
         // internal for FormTranslate
         internal MessageBoxes()
         {
@@ -99,6 +102,11 @@ namespace GitUI
         {
             return MessageBox.Show(owner, string.Format(Instance._confirmDeleteRemoteBranch.Text, branchName, remote),
                 "", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
+        }
+
+        public static void ShellNotFound([CanBeNull] IWin32Window owner)
+        {
+            MessageBox.Show(owner, Instance._shellNotFound.Text, Instance._shellNotFoundCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 }

--- a/GitUI/ShellHelper.cs
+++ b/GitUI/ShellHelper.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ConEmu.WinForms;
+using GitCommands;
+
+namespace GitUI
+{
+    public static class ShellHelper
+    {
+        internal static string GetCommandLineForCurrentShell()
+        {
+            string shell = AppSettings.ConEmuTerminal.ValueOrDefault.ToLower();
+            string result = GetShellPath(shell);
+
+            if (result == null)
+            {
+                return ConEmuConstants.DefaultConsoleCommandLine;
+            }
+
+            result = result.Quote();
+            if (shell == "bash")
+            {
+                result = $"{result} --login -i";
+            }
+
+            return result;
+        }
+
+        private static string GetShellPath(string shell)
+        {
+            string[] exeList;
+            switch (shell?.ToLower())
+            {
+                case "cmd":
+                case "powershell":
+                case "pwsh":
+                    exeList = new[] { $"{shell.ToLower()}.exe" };
+                    break;
+                case "bash":
+                    const string justBash = "bash.exe"; // Generic bash, should generally be in the git dir
+                    const string justSh = "sh.exe"; // Fallback to SH
+                    exeList = new[] { justBash, justSh };
+                    break;
+                default:
+                    exeList = null;
+                    break;
+            }
+
+            return exeList?.Select(exe => PathUtil.TryFindShellPath(exe, out var exePath) ? exePath : null)
+                  .FirstOrDefault(exePath => exePath != null);
+        }
+
+        internal static bool ShellIsOnPath(string shell) => GetShellPath(shell) != null;
+
+        internal static void ChangeFolder(this ConEmuControl terminal, string path)
+        {
+            if (terminal?.RunningSession == null || string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            switch (AppSettings.ConEmuTerminal.ValueOrDefault.ToLower())
+            {
+                case "bash":
+                    if (PathUtil.TryConvertWindowsPathToPosix(path, out var posixPath))
+                    {
+                        terminal.ClearCurrentLineWithMacroAndRunCommand($"cd {posixPath.QuoteNE()}");
+                    }
+
+                    break;
+                case "cmd":
+                    terminal.ClearCurrentLineWithEscapeAndRunCommand($"cd /D {path.QuoteNE()}");
+                    break;
+                case "powershell":
+                case "pwsh":
+                    terminal.ClearCurrentLineWithEscapeAndRunCommand($"cd {path.QuoteNE()}");
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private static void ClearCurrentLineWithMacroAndRunCommand(this ConEmuControl terminal, string command)
+        {
+            // Use a ConEmu macro to send the sequence for clearing the bash command line
+            terminal.RunningSession.BeginGuiMacro("Keys").WithParam("^A").WithParam("^K").ExecuteSync();
+            terminal.RunningSession.WriteInputTextAsync(command + Environment.NewLine);
+        }
+
+        private static void ClearCurrentLineWithEscapeAndRunCommand(this ConEmuControl terminal, string command)
+        {
+            terminal.RunningSession.WriteInputTextAsync("\x1B" + command + Environment.NewLine);
+        }
+    }
+}

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2625,6 +2625,10 @@ Do you want to continue?</source>
         <source>powershell</source>
         <target />
       </trans-unit>
+      <trans-unit id="cboTerminal.Item3">
+        <source>pwsh</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkChowConsoleTab.Text">
         <source>Show the Console tab (restart required)</source>
         <target />
@@ -7691,6 +7695,14 @@ help</source>
         <source>The server's host key is not cached in the registry.
 
 Do you want to trust this host key and then try again?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_shellNotFound.Text">
+        <source>The selected shell is not installed, or is not on your path.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_shellNotFoundCaption.Text">
+        <source>Shell not found</source>
         <target />
       </trans-unit>
       <trans-unit id="_theRepositorySubmodules.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Addresses part of #7523 


## Proposed changes

- Add `pwsh` in the settings dialog as an additional option for the shell to run in the Console tab

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/5248041/73000052-4f3a4e80-3dce-11ea-90b3-8c70da66d67a.png)


### Before

Dialog offers choice of bash, cmd, and powershell

### After

Dialog offers pwsh as an additional choice


## Test methodology <!-- How did you ensure quality? -->
-  Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.25.0.windows.1
- Windows Win10 1903 (build 18362.592)
<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
