### PR TITLE
WaitForPendingOperations in FormCommitTests

### DIFF
--- a/IntegrationTests/UITests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UITests/CommandsDialogs/FormCommitTests.cs
@@ -47,6 +47,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         {
             RunFormTest(form =>
             {
+                AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
+
                 var commitAuthorStatus = form.GetTestAccessor().CommitAuthorStatusToolStripStatusLabel;
 
                 Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
@@ -58,6 +60,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         {
             RunFormTest(form =>
             {
+                AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
+
                 var commitAuthorStatus = form.GetTestAccessor().CommitAuthorStatusToolStripStatusLabel;
 
                 Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
@@ -142,12 +146,16 @@ namespace GitExtensions.UITests.CommandsDialogs
 
             RunFormTest(form =>
             {
+                AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
                 Assert.IsEmpty(form.GetTestAccessor().Message.Text);
                 form.GetTestAccessor().Message.Text = generatedCommitMessage;
             });
 
+            AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
+
             RunFormTest(form =>
             {
+                AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
                 Assert.AreEqual(generatedCommitMessage, form.GetTestAccessor().Message.Text);
             });
         }
@@ -161,14 +169,18 @@ namespace GitExtensions.UITests.CommandsDialogs
             RunFormTest(
                 form =>
                 {
+                    AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
                     string prefix = commitKind.ToString().ToLowerInvariant();
                     Assert.AreEqual($"{prefix}! A commit message", form.GetTestAccessor().Message.Text);
                     form.GetTestAccessor().Message.Text = generatedCommitMessage;
                 },
                 commitKind);
 
+            AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
+
             RunFormTest(form =>
             {
+                AsyncTestHelper.WaitForPendingOperations(AsyncTestHelper.UnexpectedTimeout);
                 Assert.IsEmpty(form.GetTestAccessor().Message.Text);
             });
         }

--- a/UnitTests/CommonTestUtils/AsyncTestHelper.cs
+++ b/UnitTests/CommonTestUtils/AsyncTestHelper.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using GitUI;
 
 namespace CommonTestUtils
@@ -34,10 +35,14 @@ namespace CommonTestUtils
 
         public static void WaitForPendingOperations(TimeSpan timeout)
         {
+            // Workaround for tests hanging in conjunction with canceled operations:
+            // Process the message loop before and after the wait.
+            Application.DoEvents();
             using (var cts = new CancellationTokenSource(timeout))
             {
                 WaitForPendingOperations(cts.Token);
             }
+            Application.DoEvents();
         }
 
         public static void WaitForPendingOperations(CancellationToken cancellationToken)


### PR DESCRIPTION
## Proposed changes

- add `WaitForPendingOperations` to testcases in `FormCommitTests` which deal with
  - `commitAuthorStatus.Text`
  - `Message.Text`

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
