### PR TITLE
Do not deregister from Application.ThreadException between tests

### DIFF
--- a/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
+++ b/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
@@ -21,11 +21,14 @@ namespace CommonTestUtils
 
         public ActionTargets Targets => ActionTargets.Test;
 
+        public ConfigureJoinableTaskFactoryAttribute()
+        {
+            Application.ThreadException += HandleApplicationThreadException;
+        }
+
         public void BeforeTest(ITest test)
         {
             Assert.IsNull(ThreadHelper.JoinableTaskContext, "Tests with joinable tasks must not be run in parallel!");
-
-            Application.ThreadException += HandleApplicationThreadException;
 
             IList apartmentState = null;
             for (var scope = test; scope != null; scope = scope.Parent)
@@ -81,8 +84,6 @@ namespace CommonTestUtils
             }
             finally
             {
-                Application.ThreadException -= HandleApplicationThreadException;
-
                 // Reset _threadException to null, and throw if it was set during the current test.
                 Interlocked.Exchange(ref _threadException, null)?.Throw();
             }


### PR DESCRIPTION
Fixes #7684

## Proposed changes

Do not deregister from `Application.ThreadException` _between_ tests in order to catch all exceptions while running tests

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).