### PR TITLE
Disable flaky test GetSuperprojectCurrentCheckout

### DIFF
--- a/UnitTests/GitCommandsTests/GitModuleTests.cs
+++ b/UnitTests/GitCommandsTests/GitModuleTests.cs
@@ -696,6 +696,7 @@ namespace GitCommandsTests
             }
         }
 
+        [Ignore("Flaky test - issue #7681")]
         [Test]
         public void GetSuperprojectCurrentCheckout()
         {


### PR DESCRIPTION
## Proposed changes

Disable the flaky test `GetSuperprojectCurrentCheckout` until #7681 is solved

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).