### PR TITLE
FileViewer: Do not access the file system for git blobs

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3620,6 +3620,7 @@ namespace GitCommands
 
         public SubmoduleStatus CheckSubmoduleStatus([CanBeNull] ObjectId commit, [CanBeNull] ObjectId oldCommit, CommitData data, CommitData oldData, bool loadData = false)
         {
+            // TODO File access for Git revision access
             if (!IsValidGitWorkingDir() || oldCommit == null)
             {
                 return SubmoduleStatus.NewSubmodule;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1236,7 +1236,7 @@ namespace GitUI.CommandsDialogs
             if (FileHelper.IsImage(item.Name))
             {
                 var guid = staged ? ObjectId.IndexId : ObjectId.WorkTreeId;
-                await SelectedDiff.ViewGitItemRevisionAsync(item.Name, guid, openWithDiffTool);
+                await SelectedDiff.ViewGitItemRevisionAsync(item, guid, openWithDiffTool);
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -360,7 +360,13 @@ namespace GitUI.CommandsDialogs
             else if (tabControl1.SelectedTab == ViewTab)
             {
                 View.Encoding = Diff.Encoding;
-                View.ViewGitItemRevisionAsync(fileName, revision.ObjectId);
+                var file = new GitItemStatus
+                {
+                    IsTracked = true,
+                    Name = fileName,
+                    IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName))
+                };
+                View.ViewGitItemRevisionAsync(file, revision.ObjectId);
             }
             else if (tabControl1.SelectedTab == DiffTab)
             {

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -197,17 +197,7 @@ namespace GitUI.CommandsDialogs
                 {
                     if (stashedItem.IsNew)
                     {
-                        if (!stashedItem.IsSubmodule)
-                        {
-                            View.ViewGitItemAsync(stashedItem.Name, stashedItem.TreeGuid);
-                        }
-                        else
-                        {
-                            ThreadHelper.JoinableTaskFactory.RunAsync(
-                                () => View.ViewTextAsync(
-                                    stashedItem.Name,
-                                    LocalizationHelpers.GetSubmoduleText(Module, stashedItem.Name, stashedItem.TreeGuid?.ToString())));
-                        }
+                        View.ViewGitItemAsync(stashedItem);
                     }
                     else
                     {
@@ -231,7 +221,7 @@ namespace GitUI.CommandsDialogs
 
                                 if (stashedItem.IsSubmodule)
                                 {
-                                    return View.ViewPatchAsync(fileName: null, text: LocalizationHelpers.ProcessSubmodulePatch(Module, stashedItem.Name, patch),
+                                    return View.ViewPatchAsync(fileName: stashedItem.Name, text: LocalizationHelpers.ProcessSubmodulePatch(Module, stashedItem.Name, patch),
                                             openWithDifftool: null /* not implemented */, isText: stashedItem.IsSubmodule);
                                 }
 

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ChangesList.ViewPatch(patch.FileNameB, patch);
+            ChangesList.ViewPatch(patch.FileNameB, patch.Text ?? "");
         }
 
         private void BrowsePatch_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -366,13 +366,17 @@ See the changes in the commit form.");
                 switch (gitItem.ObjectType)
                 {
                     case GitObjectType.Blob:
-                    {
-                        return FileText.ViewGitItemAsync(gitItem.FileName, gitItem.ObjectId);
-                    }
-
                     case GitObjectType.Commit:
                     {
-                        return FileText.ViewTextAsync(gitItem.FileName, LocalizationHelpers.GetSubmoduleText(Module, gitItem.FileName, gitItem.Guid));
+                        var file = new GitItemStatus
+                        {
+                            IsTracked = true,
+                            Name = gitItem.Name,
+                            TreeGuid = gitItem.ObjectId,
+                            IsSubmodule = gitItem.ObjectType == GitObjectType.Commit
+                        };
+
+                        return FileText.ViewGitItemAsync(file);
                     }
 
                     default:

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -104,7 +104,7 @@ namespace GitUI
                 if (file.TreeGuid != null)
                 {
                     // blob guid exists
-                    return diffViewer.ViewGitItemAsync(file.Name, file.TreeGuid, openWithDifftool);
+                    return diffViewer.ViewGitItemAsync(file, openWithDifftool);
                 }
 
                 if (secondRevision == null)
@@ -113,7 +113,7 @@ namespace GitUI
                 }
 
                 // Get blob guid from revision
-                return diffViewer.ViewGitItemRevisionAsync(file.Name, secondRevision, openWithDifftool);
+                return diffViewer.ViewGitItemRevisionAsync(file, secondRevision, openWithDifftool);
             }
 
             string selectedPatch = diffViewer.GetSelectedPatch(firstRevision, secondRevision, file);

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -82,6 +82,8 @@ namespace ResourceManager
             sb.AppendLine("Submodule " + name);
             sb.AppendLine();
             GitModule module = superproject.GetSubmodule(name);
+
+            // TODO File access for Git revision access
             if (module.IsValidGitWorkingDir())
             {
                 // TEMP, will be moved in the follow up refactor
@@ -141,6 +143,8 @@ namespace ResourceManager
             sb.AppendLine();
             sb.AppendLine("From:\t" + (status.OldCommit?.ToString() ?? "null"));
             CommitData oldCommitData = null;
+
+            // TODO File access for Git revision access
             if (gitModule.IsValidGitWorkingDir())
             {
                 if (status.OldCommit != null)
@@ -168,6 +172,8 @@ namespace ResourceManager
             string dirty = !status.IsDirty ? "" : " (dirty)";
             sb.AppendLine("To:\t\t" + (status.Commit?.ToString() ?? "null") + dirty);
             CommitData commitData = null;
+
+            // TODO File access for Git revision access
             if (gitModule.IsValidGitWorkingDir())
             {
                 if (status.Commit != null)


### PR DESCRIPTION
Fixes #7660 
as well as some TODO in FileViewer seen in #7624 (while adding a few other)

## Proposed changes

Do not access the local file system for git items (blobs and commit=submodule) as it is irrelevant

Handle GitItemStatus objects in FileViewer to avoid guessing the file type
Cleanup a few call 

## Test methodology
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
