### PR TITLE
Fix AppTitleGeneratorTests.Generate_should_include_debug_suffix

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -65,7 +65,7 @@ namespace GitCommands
                 _extraInfo = $" @{objectId.ToShortString()}";
                 if (!string.IsNullOrWhiteSpace(buildBranch))
                 {
-                    _extraInfo += $" ({buildBranch})";
+                    _extraInfo += $" [{buildBranch}]";
                 }
             }
             else

--- a/UnitTests/GitCommandsTests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommandsTests/AppTitleGeneratorTests.cs
@@ -56,11 +56,24 @@ namespace GitCommandsTests
 
 #if DEBUG
         [Test]
-        public void Generate_should_include_debug_suffix()
+        public void Generate_should_include_debug_suffix([Values(null, "invalid")] string buildSha)
         {
+            string buildBranch = "build_branch";
+            AppTitleGenerator.Initialise(buildSha, buildBranch);
             var title = _appTitleGenerator.Generate("a", true, null);
 
             title.Should().Be($"{ShortName} (no branch) - Git Extensions [DEBUG]");
+        }
+
+        [Test]
+        public void Generate_should_include_build_suffix()
+        {
+            string buildSha = "1234567812345678123456781234567812345678";
+            string buildBranch = "build_branch";
+            AppTitleGenerator.Initialise(buildSha, buildBranch);
+            var title = _appTitleGenerator.Generate("a", true, null);
+
+            title.Should().Be($"{ShortName} (no branch) - Git Extensions @{buildSha.Substring(0, 8)} [{buildBranch}]");
         }
 #endif
     }


### PR DESCRIPTION
## Proposed changes

- Fix AppTitleGeneratorTests.Generate_should_include_debug_suffix (addendum to #7569)
- Debug: put build branch in title into square brackets (as in the screenshot of #7569)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/73315699-0f8dbf80-4231-11ea-8380-9df1bf721ad5.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/73315794-54b1f180-4231-11ea-91f6-81ca86835949.png)

## Test methodology <!-- How did you ensure quality? -->

- NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 98dba0c69be55f80f8795a7501b69ce3066cecb4
- Git 2.24.1.windows.2
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4075.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
