### PR TITLE
GE should not crash when no email applications are available and user…

### DIFF
--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
@@ -123,27 +124,29 @@ namespace GitUI.CommitInfo
         {
             var link = _linkFactory.ParseLink(e.LinkText);
 
-            try
+            if (Uri.TryCreate(link, UriKind.Absolute, out var uri))
             {
-                var result = new Uri(link);
-                if (result.Scheme == "gitext")
+                if (uri.Scheme == "gitext")
                 {
-                    CommandClicked?.Invoke(sender, new CommandEventArgs(result.Host, result.AbsolutePath.TrimStart('/')));
+                    CommandClicked?.Invoke(sender, new CommandEventArgs(uri.Host, uri.AbsolutePath.TrimStart('/')));
                 }
                 else
                 {
-                    using (var process = new Process
+                    using var process = new Process
                     {
                         EnableRaisingEvents = false,
-                        StartInfo = { FileName = result.AbsoluteUri }
-                    })
+                        StartInfo = { FileName = uri.AbsoluteUri }
+                    };
+
+                    try
                     {
                         process.Start();
                     }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(this, ex.Message, new TranslationString("Error").Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
                 }
-            }
-            catch (UriFormatException)
-            {
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -133,23 +133,21 @@ namespace GitUI.CommitInfo
             if (uri.Scheme == "gitext")
             {
                 CommandClicked?.Invoke(sender, new CommandEventArgs(uri.Host, uri.AbsolutePath.TrimStart('/')));
+                return;
             }
-            else
+
+            try
             {
                 using var process = new Process
                 {
                     EnableRaisingEvents = false,
                     StartInfo = { FileName = uri.AbsoluteUri }
                 };
-
-                try
-                {
-                    process.Start();
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(this, ex.Message, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                process.Start();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommitInfo
 {
     public partial class CommitInfoHeader : GitModuleControl
     {
+        private readonly TranslationString _error = new TranslationString("Error");
         private readonly IDateFormatter _dateFormatter = new DateFormatter();
         private readonly ILinkFactory _linkFactory = new LinkFactory();
         private readonly ICommitDataManager _commitDataManager;
@@ -124,28 +125,30 @@ namespace GitUI.CommitInfo
         {
             var link = _linkFactory.ParseLink(e.LinkText);
 
-            if (Uri.TryCreate(link, UriKind.Absolute, out var uri))
+            if (!Uri.TryCreate(link, UriKind.Absolute, out var uri))
             {
-                if (uri.Scheme == "gitext")
-                {
-                    CommandClicked?.Invoke(sender, new CommandEventArgs(uri.Host, uri.AbsolutePath.TrimStart('/')));
-                }
-                else
-                {
-                    using var process = new Process
-                    {
-                        EnableRaisingEvents = false,
-                        StartInfo = { FileName = uri.AbsoluteUri }
-                    };
+                return;
+            }
 
-                    try
-                    {
-                        process.Start();
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show(this, ex.Message, new TranslationString("Error").Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
+            if (uri.Scheme == "gitext")
+            {
+                CommandClicked?.Invoke(sender, new CommandEventArgs(uri.Host, uri.AbsolutePath.TrimStart('/')));
+            }
+            else
+            {
+                using var process = new Process
+                {
+                    EnableRaisingEvents = false,
+                    StartInfo = { FileName = uri.AbsoluteUri }
+                };
+
+                try
+                {
+                    process.Start();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, ex.Message, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }


### PR DESCRIPTION
… clicks on a "mailto:" link (issue #7436)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes issue #7436 + minor refactoring


## Proposed changes

- Added a try..catch to avoid crashing the application in case Process.Start fails (e.g. no registered applications found for the clicked link)
- Replaced try..new Uri(link)..catch with Uri.TryParse


## Test methodology 

Manual tests


## Test environment(s) 

- Git Extensions 3.3.1.7897
- Build 5a97671645532bcedc443bac7b727f40db47cb5c
- Git 2.22.0.windows.1 (recommended: 2.23.0 or later)
- Microsoft Windows NT 10.0.18363.0
- .NET Framework 4.8.4075.0
- DPI 96dpi (no scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
