### PR TITLE
removed TopMost attribute from the FormUpdates dialog

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -124,7 +124,6 @@
             this.Name = "FormUpdates";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Check for update";
-            this.TopMost = true;
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7713 

## Proposed changes

Removed the TopMost attribute from the FormUpdates dialog

## Test methodology 

Manual tests


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.1.7897
- Build 5a97671645532bcedc443bac7b727f40db47cb5c
- Git 2.22.0.windows.1 (recommended: 2.23.0 or later)
- Microsoft Windows NT 10.0.18363.0
- .NET Framework 4.8.4075.0
- DPI 96dpi (no scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
