### PR TITLE
Refactor: Compare with ObjectId rather than Guid

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1044,7 +1044,7 @@ namespace GitCommands
             if (loadRefs)
             {
                 revision.Refs = GetRefs()
-                    .Where(r => r.Guid == revision.Guid)
+                    .Where(r => r.ObjectId == revision.ObjectId)
                     .ToList();
             }
 
@@ -3009,7 +3009,7 @@ namespace GitCommands
             foreach (var gitRef in gitRefs)
             {
                 if (headByRemote.TryGetValue(gitRef.Remote, out var defaultHead) &&
-                    gitRef.Guid == defaultHead.Guid)
+                    gitRef.ObjectId == defaultHead.ObjectId)
                 {
                     headByRemote.Remove(gitRef.Remote);
                 }

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -37,7 +37,7 @@ namespace GitCommands
                 throw new ArgumentNullException(nameof(item));
             }
 
-            if (string.IsNullOrWhiteSpace(item.Guid))
+            if (item.ObjectId != null)
             {
                 throw new ArgumentException("Item must have a valid identifier", nameof(item.Guid));
             }

--- a/GitUI/CommandsDialogs/FileStatusListContextMenuController.cs
+++ b/GitUI/CommandsDialogs/FileStatusListContextMenuController.cs
@@ -74,7 +74,7 @@ namespace GitUI.CommandsDialogs
                 && !selectionInfo.AllAreDeleted
 
                 // Selected (B) is not local
-                && selectionInfo.SelectedRevision.Guid != GitRevision.WorkTreeGuid;
+                && selectionInfo.SelectedRevision.ObjectId != ObjectId.WorkTreeId;
         }
 
         public bool ShouldShowMenuFirstParentToLocal(ContextMenuDiffToolInfo selectionInfo)

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
         [ItemCanBeNull]
         public async Task<GpgInfo> LoadGpgInfoAsync(GitRevision revision)
         {
-            if (!AppSettings.ShowGpgInformation.ValueOrDefault || string.IsNullOrWhiteSpace(revision?.Guid))
+            if (!AppSettings.ShowGpgInformation.ValueOrDefault || revision?.ObjectId != null)
             {
                 return null;
             }

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -313,7 +313,7 @@ namespace GitUI.CommandsDialogs
                     if (localBranchRef != null && remoteBranchRef != null)
                     {
                         var mergeBaseGuid = Module.GetMergeBase(localBranchRef.ObjectId, remoteBranchRef.ObjectId);
-                        var isResetFastForward = localBranchRef.Guid == mergeBaseGuid?.ToString();
+                        var isResetFastForward = localBranchRef.ObjectId == mergeBaseGuid;
 
                         if (!isResetFastForward)
                         {

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -105,7 +105,7 @@ namespace GitUI.CommandsDialogs
             // I.e., git difftool --gui --no-prompt --dir-diff -R HEAD fails, but
             // git difftool --gui --no-prompt --dir-diff HEAD succeeds
             // Thus, we disable comparing "from" working directory.
-            var enableDifftoolDirDiff = _baseRevision?.Guid != GitRevision.WorkTreeGuid;
+            var enableDifftoolDirDiff = _baseRevision?.ObjectId != ObjectId.WorkTreeId;
             btnCompareDirectoriesWithDiffTool.Enabled = enableDifftoolDirDiff;
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -11,6 +11,7 @@ using GitCommands;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.Properties;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
 
@@ -141,7 +142,7 @@ namespace GitUI.CommandsDialogs
                 showOriginalFilePathToolStripMenuItem.Checked = AppSettings.BlameShowOriginalFilePath;
             }
 
-            if (filterByRevision && revision?.Guid != null)
+            if (filterByRevision && revision?.ObjectId != null)
             {
                 _filterBranchHelper.SetBranchFilter(revision.Guid, false);
             }
@@ -530,7 +531,7 @@ namespace GitUI.CommandsDialogs
             var selectedRevisions = FileChanges.GetSelectedRevisions();
 
             diffToolRemoteLocalStripMenuItem.Enabled =
-                selectedRevisions.Count == 1 && selectedRevisions[0].Guid != GitRevision.WorkTreeGuid &&
+                selectedRevisions.Count == 1 && selectedRevisions[0].ObjectId != ObjectId.WorkTreeId &&
                 File.Exists(_fullPathResolver.Resolve(FileName));
             openWithDifftoolToolStripMenuItem.Enabled =
                 selectedRevisions.Count >= 1 && selectedRevisions.Count <= 2;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -263,7 +263,7 @@ namespace GitUI.CommandsDialogs
             bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents, DiffFiles.Revision);
 
             // Combined diff is a display only diff, no manipulations
-            bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item.Guid == GitRevision.CombinedDiffGuid);
+            bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item.ObjectId == ObjectId.CombinedDiffId);
             bool isExactlyOneItemSelected = DiffFiles.SelectedItems.Count() == 1;
             bool isAnyItemSelected = DiffFiles.SelectedItems.Any();
 
@@ -331,7 +331,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (DiffFiles.SelectedItemParent?.Guid == GitRevision.CombinedDiffGuid)
+            if (DiffFiles.SelectedItemParent?.ObjectId == ObjectId.CombinedDiffId)
             {
                 var diffOfConflict = Module.GetCombinedDiffContent(DiffFiles.Revision, DiffFiles.SelectedItem.Name,
                     DiffText.GetExtraDiffArguments(), DiffText.Encoding);
@@ -587,7 +587,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var itemWithParent in DiffFiles.SelectedItemsWithParent)
             {
-                if (itemWithParent.ParentRevision.Guid == GitRevision.CombinedDiffGuid)
+                if (itemWithParent.ParentRevision.ObjectId == ObjectId.CombinedDiffId)
                 {
                     // CombinedDiff cannot be viewed in a difftool
                     // Disabled in menues but can be activated from shortcuts, just ignore

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -1,5 +1,6 @@
 ﻿using GitCommands;
 using GitCommands.Git;
+using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs
 {
@@ -111,7 +112,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowSubmoduleMenus(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsAnySubmodule && selectionInfo.SelectedRevision.Guid == GitRevision.WorkTreeGuid;
+            return selectionInfo.IsAnySubmodule && selectionInfo.SelectedRevision.ObjectId == ObjectId.WorkTreeId;
         }
 
         public bool ShouldShowMenuEditWorkingDirectoryFile(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -342,7 +342,7 @@ See the changes in the commit form.");
                     WorkingDirectory = _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator())
                 }
             };
-            if (item.Guid.IsNotNullOrWhitespace())
+            if (item.ObjectId != null)
             {
                 process.StartInfo.Arguments += " -commit=" + item.Guid;
             }

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -85,7 +85,7 @@ namespace GitUI.UserControls
                 return;
             }
 
-            if (DiffFiles.SelectedItemParent?.Guid == GitRevision.CombinedDiffGuid)
+            if (DiffFiles.SelectedItemParent?.ObjectId == ObjectId.CombinedDiffId)
             {
                 var diffOfConflict = Module.GetCombinedDiffContent(DiffFiles.Revision, DiffFiles.SelectedItem.Name,
                     DiffText.GetExtraDiffArguments(), DiffText.Encoding);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -879,7 +879,7 @@ namespace GitUI
                 if (revision != null)
                 {
                     string groupName;
-                    if (revision.Guid == GitRevision.CombinedDiffGuid)
+                    if (revision.ObjectId == ObjectId.CombinedDiffId)
                     {
                         groupName = CombinedDiff.Text;
                     }

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -15,7 +15,7 @@ namespace GitUIPluginInterfaces
     /// </remarks>
     public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     {
-        private static readonly ThreadLocal<byte[]> _buffer = new ThreadLocal<byte[]>(() => new byte[20], trackAllValues: false);
+        private static readonly ThreadLocal<byte[]> _buffer = new ThreadLocal<byte[]>(() => new byte[Sha1ByteCount], trackAllValues: false);
         private static readonly Random _random = new Random();
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace GitUIPluginInterfaces
         {
             var buffer = _buffer.Value;
 
-            stream.ReadBytes(buffer, offset: 0, count: 20);
+            stream.ReadBytes(buffer, offset: 0, count: Sha1ByteCount);
 
             return Parse(buffer, index: 0);
         }


### PR DESCRIPTION
Originated as a part #4154, but broken out

## Proposed changes

Comparisions should not use GitRevision.Guid but GitRevision.ObjectId, as Guid => ObjectId.ToString()

Probably not making any noticeable difference, but sets the example and is a step to remove Guid

I would like to change e.g.  GitRevision.WorkTreeGuid -> ObjectId.WorkTreeId.ToString() when comparing to raw strings, but this will be slightly less efficient.
(The Guid version is used to compare strings, but this makes it more difficult to find the Artificial commits. There are tests that the two definitions are identical.)
 
## Test methodology <!-- How did you ensure quality? -->

Tests updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
