### PR TITLE
improve file status list presentation

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -78,7 +78,7 @@ namespace GitUI.CommandsDialogs
 
                 if (revisions.Count > 0 && revisions[0].IsArtificial)
                 {
-                    DiffFiles.SetDiffs(revisions);
+                    DiffFiles.SetDiffs(revisions, _revisionGrid.GetRevision);
                 }
             }
         }
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs
         public void DisplayDiffTab()
         {
             var revisions = _revisionGrid.GetSelectedRevisions();
-            DiffFiles.SetDiffs(revisions);
+            DiffFiles.SetDiffs(revisions, _revisionGrid.GetRevision);
             if (_oldDiffItem != null && DiffFiles.Revision?.Guid == _oldRevision)
             {
                 DiffFiles.SelectedItem = _oldDiffItem;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -1,14 +1,25 @@
 ﻿using GitCommands;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class DiffViewerSettingsPage : SettingsPageWithHeader
     {
+        private readonly TranslationString _showDiffForAllParents = new TranslationString(
+            @"Show all differences between the selected commits, not limiting to only one difference.
+
+- For a single selected commit, show the difference with its parent commit.
+- For a single selected merge commit, show the difference with all parents.
+- For two selected commits, show the difference between the commits as well as the difference between a common ancestor (BASE) to the last selected commit.
+- For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
+- For more than four selected commits, show the difference as if the first and the last selected commit were selected.");
+
         public DiffViewerSettingsPage()
         {
             InitializeComponent();
             Text = "Diff Viewer";
             InitializeComplete();
+            tooltip.SetToolTip(chkShowDiffForAllParents, _showDiffForAllParents.Text);
         }
 
         protected override void SettingsToPage()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1313,7 +1313,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="_diffWithParent.Text">
-        <source>Diff with: a/</source>
+        <source>Diff with a/</source>
         <target />
       </trans-unit>
       <trans-unit id="_openSubmoduleMenuItem.Text">

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -609,7 +609,7 @@ namespace GitUI
             _nextIndexToSelect = -1;
         }
 
-        public void SetDiffs(IReadOnlyList<GitRevision> revisions)
+        public void SetDiffs(IReadOnlyList<GitRevision> revisions, Func<ObjectId, GitRevision> getRevision = null)
         {
             Revision = revisions.FirstOrDefault();
 
@@ -630,10 +630,13 @@ namespace GitUI
                     if (AppSettings.ShowDiffForAllParents)
                     {
                         // Get base commit, add as parent if unique
-                        Lazy<ObjectId> head = new Lazy<ObjectId>(() => Module.RevParse("HEAD"));
+                        Lazy<ObjectId> head = getRevision != null
+                            ? new Lazy<ObjectId>(() => getRevision(ObjectId.IndexId).FirstParentGuid)
+                            : new Lazy<ObjectId>(() => Module.RevParse("HEAD"));
                         var revA = parentRevs[0].ObjectId;
                         var revB = Revision.ObjectId;
-                        ObjectId baseRevGuid = Module.GetMergeBase(GetRevisionOrHead(revA, head), GetRevisionOrHead(revB, head));
+                        ObjectId baseRevGuid = Module.GetMergeBase(GetRevisionOrHead(revA, head),
+                            GetRevisionOrHead(revB, head));
                         if (baseRevGuid != null
                             && baseRevGuid != revA
                             && baseRevGuid != revB)


### PR DESCRIPTION
Part of #4154 

## Proposed changes

A few related changes, preferably reviewed commit by commit
- Avoid a call to git-rev-parse to get common ancestor (BASE) when comparing
- Show the diff for common ancestor (BASE) in the status list
- ToolTip for multiple parents setting

English.xlf is not updated, UpdateLocalEnglishTranslations.ps1 require changes

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

### After

![image](https://user-images.githubusercontent.com/6248932/73617690-b56e6f00-4621-11ea-9625-702d49b0d477.png)

(removed colon after with:)
![image](https://user-images.githubusercontent.com/6248932/73617707-e5b60d80-4621-11ea-9f42-9a4b45dd1b3e.png)


## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
