### PR TITLE
ObjectId test corrections

### DIFF
--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -37,7 +37,7 @@ namespace GitCommands
                 throw new ArgumentNullException(nameof(item));
             }
 
-            if (item.ObjectId != null)
+            if (item.ObjectId == null)
             {
                 throw new ArgumentException("Item must have a valid identifier", nameof(item.Guid));
             }

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
         [ItemCanBeNull]
         public async Task<GpgInfo> LoadGpgInfoAsync(GitRevision revision)
         {
-            if (!AppSettings.ShowGpgInformation.ValueOrDefault || revision?.ObjectId != null)
+            if (!AppSettings.ShowGpgInformation.ValueOrDefault || revision?.ObjectId == null)
             {
                 return null;
             }

--- a/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
@@ -28,13 +29,16 @@ namespace GitCommandsTests
             ((Action)(() => _provider.LoadChildren(null))).Should().Throw<ArgumentNullException>();
         }
 
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public void LoadChildren_should_throw_if_guid_not_supplied(string guid)
+        [Test]
+        public void LoadChildren_should_throw_if_ObjectId_is_null()
         {
             var item = Substitute.For<IGitItem>();
-            item.Guid.Returns(guid);
+
+            // ObjectId checks input, use Try to get an illegal value
+            ObjectId objectId;
+            var sourceBytes = Encoding.ASCII.GetBytes("");
+            ObjectId.TryParseAsciiHexBytes(sourceBytes, 0, out objectId);
+            item.ObjectId.Returns(objectId);
 
             ((Action)(() => _provider.LoadChildren(item))).Should().Throw<ArgumentException>();
         }


### PR DESCRIPTION
Follow up from #7719

## Proposed changes
Changed irrelevant test for Guid
Guid => ObjectId.toString() and can only be null or valid

Flipped check for ObjectId in GitRevisionInfoProvider.cs 

## Test methodology <!-- How did you ensure quality? -->
Updated tests

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
