### PR TITLE
AzureDevOps CI: Fix and improvements

### DIFF
--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -110,7 +110,7 @@ namespace AzureDevOpsIntegration
             return build.Definition.Name;
         }
 
-        public async Task<IEnumerable<Build>> QueryFinishedBuildsAsync(string buildDefinitionsToQuery, DateTime? sinceDate)
+        public async Task<IList<Build>> QueryFinishedBuildsAsync(string buildDefinitionsToQuery, DateTime? sinceDate)
         {
             string queryUrl = QueryForBuildStatus(buildDefinitionsToQuery, "completed");
             queryUrl += sinceDate.HasValue
@@ -121,11 +121,12 @@ namespace AzureDevOpsIntegration
             return finishedBuilds;
         }
 
-        public async Task<IEnumerable<Build>> QueryRunningBuildsAsync(string buildDefinitionsToQuery)
+        public async Task<IList<Build>> QueryRunningBuildsAsync(string buildDefinitionsToQuery)
         {
             string queryUrl = QueryForBuildStatus(buildDefinitionsToQuery, "cancelling,inProgress,none,notStarted,postponed") + "&api-version=2.0";
 
             var runningBuilds = (await HttpGetAsync<ListWrapper<Build>>(queryUrl)).Value;
+
             return runningBuilds;
         }
 

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -179,7 +179,7 @@ namespace AzureDevOpsIntegration
             var buildInfo = new BuildInfo
             {
                 Id = buildDetail.BuildNumber,
-                StartDate = buildDetail.StartTime ?? DateTime.Now.AddHours(1),
+                StartDate = buildDetail.StartTime ?? DateTime.MinValue,
                 Status = buildDetail.IsInProgress ? BuildInfo.BuildStatus.InProgress : MapResult(buildDetail.Result),
                 Description = duration + " " + buildDetail.BuildNumber,
                 Tooltip = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(buildDetail.IsInProgress ? buildDetail.Status : buildDetail.Result) + Environment.NewLine + duration + Environment.NewLine + buildDetail.BuildNumber,

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Properties/AssemblyInfo.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
-[assembly: AssemblyDescription("GitExtensions plugin for integration with VSTS server")]
+[assembly: AssemblyDescription("GitExtensions plugin for integration with Azure DevOps service/server")]
+[assembly: InternalsVisibleTo("AzureDevOpsIntegration.Tests")]

--- a/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegration.Tests/AzureDevOpsAdapterTests.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegration.Tests/AzureDevOpsAdapterTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using AzureDevOpsIntegration;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace AzureDevOpsIntegrationTests
+{
+    [TestFixture]
+    public class AzureDevOpsAdapterTests
+    {
+        private AzureDevOpsAdapter.TestAccessor _sut;
+
+        [SetUp]
+        public void Initialize()
+        {
+            var adapter = new AzureDevOpsAdapter();
+            _sut = adapter.GetTestAccessor();
+        }
+
+        [Test]
+        public void Should_not_filter_running_builds_When_only_one_returned()
+        {
+            var myBuild = new Build { SourceVersion = "ACommitHash" };
+            IList<Build> runningBuilds = new List<Build> { myBuild };
+
+            var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
+
+            filteredRunningBuilds.Should().ContainSingle().And.Contain(myBuild);
+        }
+
+        [Test]
+        public void Should_not_filter_running_builds_When_builds_are_on_different_commits()
+        {
+            var buildOnOneCommit = new Build { SourceVersion = "a_commit_Hash" };
+            var buildOnAnotherCommit = new Build { SourceVersion = "another_commit_Hash" };
+            IList<Build> runningBuilds = new List<Build> { buildOnOneCommit, buildOnAnotherCommit };
+
+            var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
+
+            filteredRunningBuilds.Should().ContainInOrder(buildOnOneCommit, buildOnAnotherCommit);
+        }
+
+        [Test]
+        public void Should_take_only_the_first_started_running_builds_When_multiple_builds_on_same_commit()
+        {
+            var firstBuildStartedOnACommit = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 1) };
+            var buildAlsoStartedOnSameCommitButAfter = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 2) };
+            var buildAlsoStartedOnSameCommitButAfterAlso = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 3) };
+            IList<Build> runningBuilds = new List<Build> { firstBuildStartedOnACommit, buildAlsoStartedOnSameCommitButAfter, buildAlsoStartedOnSameCommitButAfterAlso };
+
+            var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
+
+            filteredRunningBuilds.Should().HaveCount(1).And.ContainInOrder(firstBuildStartedOnACommit);
+        }
+
+        [Test]
+        public void Should_take_whatever_build_When_multiple_not_yet_started_builds_on_same_commit()
+        {
+            var firstBuildStartedOnACommit = new Build { SourceVersion = "a_commit_Hash" };
+            var buildAlsoStartedOnSameCommitButAfter = new Build { SourceVersion = "a_commit_Hash" };
+            var buildAlsoStartedOnSameCommitButAfterAlso = new Build { SourceVersion = "a_commit_Hash" };
+            IList<Build> runningBuilds = new List<Build> { firstBuildStartedOnACommit, buildAlsoStartedOnSameCommitButAfter, buildAlsoStartedOnSameCommitButAfterAlso };
+
+            var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
+
+            filteredRunningBuilds.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void Should_take_only_a_started_running_builds_When_multiple_builds_on_same_commit()
+        {
+            var notStartedBuildOnACommit = new Build { SourceVersion = "a_commit_Hash" };
+            var startedBuild = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 2) };
+            var anotherNotStartedBuildOnACommit = new Build { SourceVersion = "a_commit_Hash" };
+            IList<Build> runningBuilds = new List<Build> { notStartedBuildOnACommit, startedBuild, anotherNotStartedBuildOnACommit };
+
+            var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
+
+            filteredRunningBuilds.Should().HaveCount(1).And.ContainInOrder(startedBuild);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

One commit for each (that could be reviewed separatly)
1. Make lighter and quicker api calls
    * by providing filters values in the query parameters (less build are returned instead of filtering them after)
    * by specifying the `properties` requested (less data returned for each build)
2.  Fix "in progress" display sometimes not refreshed for the case 
where the first display was done when the build was not yet started
i.e. `StartDate` was filled with a bad default value
that prevent later refresh once the build is really started
3. Better choose the running build to display when there is more than one build to display for a specific commit.

    * Before: Multiple build was returned and due to the condition in `BuildServerWatcher.cs`/`OnBuildInfoUpdate()`, the last started build is displayed.

    * Now: Return only one build by commit by better selecting the one displayed. The first started build is now return and displayed

## Screenshots <!-- Remove this section if PR does not change UI -->

Nothing really changed...

## Test methodology <!-- How did you ensure quality? -->

- Manual & debugger


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build ddf5a30bd261aff2e1675ddbfe76fe2e1d61a5f4
- Git 2.20.1.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.3815.0
- DPI 96dpi (no scaling)
