### PR TITLE
Adapt colors for warning header with dark theme

### DIFF
--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using ResourceManager;
@@ -98,7 +99,8 @@ namespace GitUI.UserControls
             }
 
             IconBox.Image = _hasConflicts ? Properties.Images.SolveMerge : Properties.Resources.information;
-            BackColor = _hasConflicts ? System.Drawing.Color.Orange : System.Drawing.Color.LightSkyBlue;
+            BackColor = (_hasConflicts ? System.Drawing.Color.Orange : System.Drawing.Color.LightSkyBlue).AdaptBackColor();
+            this.SetForeColorForBackColor();
 
             string actionStr = "";
 


### PR DESCRIPTION
Fixes #7457 in dark theme

## Proposed changes

Adapt the colors for the warning header in the dark theme

#7457 was submitted before dark theme was merged so @NikolayXHD could not fix this too.

## Screenshots <!-- Remove this section if PR does not change UI -->
Light theme unchanged what I see and expect

### Before

![image](https://user-images.githubusercontent.com/6248932/73981642-eeb12280-4932-11ea-9f8b-de8f71e57834.png)

![image](https://user-images.githubusercontent.com/6248932/73981761-40f24380-4933-11ea-87a4-3394dbb1b9fc.png)

### After

![conflict_upd2](https://user-images.githubusercontent.com/6248932/73981787-50718c80-4933-11ea-95fd-e76452d059a4.JPG)

![conflict_upd](https://user-images.githubusercontent.com/6248932/73981789-50718c80-4933-11ea-8ce4-916ab7466b94.JPG)

## Test methodology <!-- How did you ensure quality? -->
Manual - insert code to get headers

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
