### PR TITLE
Temporarily build the Debug variant on AppVeyor

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build\Build.ps1""" -c Release -bl -ci  %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build\Build.ps1""" -c Debug -binaryLog -ci  %*"
 exit /b %ErrorLevel%


### PR DESCRIPTION
## Proposed changes

- temporarily build the Debug variant on AppVeyor because the Release does not respect `Attribute`s at least for tests

## Test methodology <!-- How did you ensure quality? -->

- AppVeyor

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
