### PR TITLE
fix: Plugins private binaries not resovled

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -48,6 +48,31 @@
     <Copy SourceFiles="@(Translations)" DestinationFolder="$(TargetDir)Translation" ContinueOnError="false" />
   </Target>
 
+  <Target Name="EnumeratePlugins" AfterTargets="AfterBuild">
+    <PropertyGroup>
+      <PluginsFolder>$(TargetDir)Plugins</PluginsFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Folders Include="$([System.IO.Directory]::GetDirectories(&quot;$(PluginsFolder)&quot;))" />
+      <OnlyDirs Include="@(Folders->Replace($(TargetDir), ''))"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <ProbingPrivatePath>Plugins;@(OnlyDirs)</ProbingPrivatePath>
+      <TargetAppConfig>@(AppConfigFileDestination)</TargetAppConfig>
+
+      <Namespace>
+        <Namespace Prefix="ns" Uri="urn:schemas-microsoft-com:asm.v1" />
+      </Namespace>
+    </PropertyGroup>
+
+    <XmlPoke XmlInputPath="$(TargetAppConfig.ToString())"
+            Namespaces="$(Namespace)"
+            Query="configuration/runtime/ns:assemblyBinding/ns:probing/@privatePath" 
+            Value="$(ProbingPrivatePath.ToString())" />
+  </Target>
+
   <Target Condition="Exists('$(VCTargetsPath)\Microsoft.Cpp.Default.props')" Name="BuildEasyHookDll" AfterTargets="AfterBuild">
     <MSBuild Projects="$(SolutionDir)\Externals\EasyHook\EasyHookDll\EasyHookDll.vcxproj" Properties="Configuration=Release;Platform=x64" />
     <MSBuild Projects="$(SolutionDir)\Externals\EasyHook\EasyHookDll\EasyHookDll.vcxproj" Properties="Configuration=Release;Platform=Win32" />

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/app.config
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/app.config
@@ -3,6 +3,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>


### PR DESCRIPTION

Resolves #7735

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

The recent change saw each plugin placed in own folder under the Plugins folder. This caused a number of plugins that had additional references (e.g. to Newtonsoft.Json) fail at runtime because these the app did not know where to probe for these assemblies.

Previously all plugins were placed in the same folder, Plugins, and the app was configured to probe in this folder (refer to app.config `configuration/runtime/ns:assemblyBinding/ns:probing`).

Now upon the start-up the app will ensure that all plugins under Plugin folder are added to the probing path. And if any of the plugins are missing, the probing path is updated and the app is restarted.


## Test methodology <!-- How did you ensure quality? -->

- TBD



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
