### PR TITLE
Improve exception-safety of UITests.RunForm

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitUI;
+using NUnit.Framework;
 
 namespace GitExtensions.UITests
 {
@@ -27,32 +28,69 @@ namespace GitExtensions.UITests
         }
 
         public static void RunForm<T>(
-            Action showDialog,
-            Func<T, Task> runAsync)
+            Action showForm,
+            Func<T, Task> runTestAsync)
             where T : Form
         {
-            // Avoid using ThreadHelper.JoinableTaskFactory for the outermost operation because we don't want the task
-            // tracked by its collection. Otherwise, test code would not be able to wait for pending operations to
-            // complete.
-            var test = ThreadHelper.JoinableTaskContext.Factory.RunAsync(async () =>
+            // If form.Dipose was called by the async test task, closing the window would be done in a strange order.
+            T form = null;
+            try
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                await WaitForIdleAsync();
-                var dialog = Application.OpenForms.OfType<T>().Single();
-                try
-                {
-                    await runAsync(dialog);
-                }
-                finally
-                {
-                    dialog.Close();
-                }
-            });
+                // Start runTestAsync before calling showForm.
+                // The latter might block until the form is closed, especially if using Application.Run(form).
 
-            showDialog();
+                // Avoid using ThreadHelper.JoinableTaskFactory for the outermost operation because we don't want the task
+                // tracked by its collection. Otherwise, test code would not be able to wait for pending operations to
+                // complete.
+                var test = ThreadHelper.JoinableTaskContext.Factory.RunAsync(async () =>
+                {
+                    try
+                    {
+                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await WaitForIdleAsync();
+                        form = Application.OpenForms.OfType<T>().Single();
+                        await runTestAsync(form);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            form?.Close();
+                        }
+                        finally
+                        {
+                            // Try to close all open Forms in order to let return the blocking Application.Run(form)
+                            // which might have been called by showForm() below.
+                            for (int trial = 0; trial < 3 && Application.OpenForms.Count > 0; ++trial)
+                            {
+                                Application.DoEvents();
+                                Application.OpenForms.OfType<Form>().ForEach(f =>
+                                {
+                                    try
+                                    {
+                                        f.Close();
+                                    }
+                                    catch (Exception)
+                                    {
+                                        // ignore
+                                    }
+                                });
+                            }
+                        }
+                    }
+                });
 
-            // Join the asynchronous test operation so any exceptions are rethrown on this thread
-            test.Join();
+                showForm();
+
+                // Join the asynchronous test operation so any exceptions are rethrown on this thread.
+                test.Join();
+            }
+            finally
+            {
+                form?.Close();
+                form?.Dispose();
+                Assert.IsTrue(Application.OpenForms.Count == 0, $"{Application.OpenForms.Count} open form(s) after test");
+            }
         }
 
         private readonly struct VoidResult

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;

--- a/contributors.txt
+++ b/contributors.txt
@@ -119,4 +119,5 @@ YYYY/MM/DD, github id, Full name, email
 2020/02/10, ierof, Irina Erofeeva, babasya(at)gmail.com
 2020/02/10, Quppa, David Warner, david.p.warner(at)gmail.com
 2020/02/10, gpongelli, Gabriele Pongelli, gabriele.pongelli(at)gmail.com
+2020/02/10, EbenZhang, Eben Zhang, zhangyingneng(at)gmail.com
 2020/02/11, mwerle, Michael Werle, micha(at)michaelwerle.com


### PR DESCRIPTION
Related to #7382

## Proposed changes

- `Close` and `Dispose` `Form` in `UITest.RunForm`
- try to close all Forms on exception in async task of `UITest.RunForm`
  (happens for many `FormCommitTests`)

## Test methodology <!-- How did you ensure quality? -->

- run the NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).