### PR TITLE
JoinPendingOperationsAsync right after closing the tested Form

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.LeftPanel.Remotes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.LeftPanel.Remotes.cs
@@ -59,11 +59,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [TearDown]
-        public async Task TearDownAsync()
+        public void TearDown()
         {
-            // Wait for pending operations so the repository is not deleted while operations run in the background
-            await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
-
             _referenceRepository.Dispose();
         }
 
@@ -209,10 +206,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
         {
             UITest.RunForm(
-                () =>
-                {
-                    Assert.True(_commands.StartBrowseDialog(owner: null));
-                },
+                showForm: () => _commands.StartBrowseDialog(owner: null).Should().BeTrue(),
                 testDriverAsync);
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.LeftPanel.ReorderNodes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.LeftPanel.ReorderNodes.cs
@@ -63,11 +63,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [TearDown]
-        public async Task TearDownAsync()
+        public void TearDown()
         {
-            // Wait for pending operations so the repository is not deleted while operations run in the background
-            await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
-
             _repo1.Dispose();
         }
 
@@ -205,10 +202,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
         {
             UITest.RunForm(
-                () =>
-                {
-                    Assert.True(_commands.StartBrowseDialog(owner: null));
-                },
+                showForm: () => _commands.StartBrowseDialog(owner: null).Should().BeTrue(),
                 testDriverAsync);
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.LeftPanel.Submodules.cs
@@ -70,11 +70,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [TearDown]
-        public async Task TearDownAsync()
+        public void TearDown()
         {
-            // Wait for pending operations so the repository is not deleted while operations run in the background
-            await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
-
             //// _provider is a singleton and must not be disposed
             _repo1.Dispose();
             _repo2.Dispose();
@@ -120,10 +117,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
         {
             UITest.RunForm(
-                () =>
-                {
-                    Assert.True(_commands.StartBrowseDialog(owner: null));
-                },
+                showForm: () => _commands.StartBrowseDialog(owner: null).Should().BeTrue(),
                 testDriverAsync);
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -91,10 +91,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
         {
             UITest.RunForm(
-                () =>
-                {
-                    Assert.True(_commands.StartBrowseDialog(owner: null));
-                },
+                showForm: () => _commands.StartBrowseDialog(owner: null).Should().BeTrue(),
                 testDriverAsync);
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -369,7 +369,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private void RunFormTest(Func<FormCommit, Task> testDriverAsync, CommitKind commitKind = CommitKind.Normal)
         {
             UITest.RunForm(
-                () =>
+                showForm: () =>
                 {
                     switch (commitKind)
                     {

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -204,7 +204,9 @@ namespace GitExtensions.UITests.Script
 
         private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
         {
-            UITest.RunForm(() => _uiCommands.StartBrowseDialog().Should().BeTrue(), testDriverAsync);
+            UITest.RunForm(
+                showForm: () => _uiCommands.StartBrowseDialog(owner: null).Should().BeTrue(),
+                testDriverAsync);
         }
     }
 }

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using CommonTestUtils;
 using GitUI;
 using NUnit.Framework;
 
@@ -57,6 +58,10 @@ namespace GitExtensions.UITests
                         // Close the form after the test completes. This will unblock the 'showForm()' call if it's
                         // waiting for the form to close.
                         form.Close();
+
+                        // This should be changed to assert no pending operations once background operations are tied
+                        // to the life of the owning dialog - issue #7792.
+                        await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
                     }
                 });
 


### PR DESCRIPTION
Related to #7382
Based on #7765

## Proposed changes

- `await JoinPendingOperationsAsync` right after closing the tested `Form`
  in the async task of `UITest.RunForm`, i.e. inside the message loop
  because with #7753 tests hang in `Application.Run(form)` called by `showForm`
- revert `await` in `TearDownAsync` of ROT tests
- standardize opening of FormBrowse and FormCommit in tests

## Test methodology <!-- How did you ensure quality? -->

- run the NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).