### PR TITLE
Fix commit info tests

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -77,6 +77,23 @@ namespace GitExtensions.UITests
             }
         }
 
+        public static void RunControl<T>(
+            Func<Form, T> createControl,
+            Func<T, Task> runTestAsync)
+            where T : Control
+        {
+            T control = null;
+            RunForm<Form>(
+                showForm: () =>
+                {
+                    var form = new Form { Text = $"Test {typeof(T).Name}" };
+                    control = createControl(form);
+                    Assert.True(form.Controls.Contains(control));
+                    Application.Run(form);
+                },
+                runTestAsync: form => runTestAsync(control));
+        }
+
         private readonly struct VoidResult
         {
         }

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -21,7 +21,6 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         // Created once for each test
         private MockExecutable _gitExecutable;
         private GitUICommands _commands;
-        private GitUI.CommitInfo.CommitInfo _commitInfo;
 
         [SetUp]
         public void SetUp()
@@ -44,23 +43,6 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
             var cmdRunner = new GitCommandRunner(_gitExecutable, () => GitModule.SystemEncoding);
             typeof(GitModule).GetField("_gitCommandRunner", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(_commands.Module, cmdRunner);
-
-            var uiCommandsSource = Substitute.For<IGitUICommandsSource>();
-            uiCommandsSource.UICommands.Returns(x => _commands);
-
-            // the following assignment of _commitInfo.UICommandsSource will already call this command
-            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/", "");
-
-            _commitInfo = new GitUI.CommitInfo.CommitInfo
-            {
-                UICommandsSource = uiCommandsSource
-            };
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            _commitInfo.Dispose();
         }
 
         [OneTimeTearDown]
@@ -72,90 +54,131 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         [Test]
         public void GetSortedTags_should_throw_on_git_warning()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
-                "refs/heads/master\nwarning: message");
+            RunCommitInfoTest(commitInfo =>
+            {
+                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                    "refs/heads/master\nwarning: message");
 
-            ((Action)(() => _commitInfo.GetTestAccessor().GetSortedTags())).Should().Throw<RefsWarningException>();
+                ((Action)(() => commitInfo.GetTestAccessor().GetSortedTags())).Should().Throw<RefsWarningException>();
+            });
         }
 
         [Test]
         public void GetSortedTags_should_split_output_if_no_warning()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
-                "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"); // does not contain "warning:"
-
-            var expected = new Dictionary<string, int>
+            RunCommitInfoTest(commitInfo =>
             {
-                ["refs/remotes/origin/master"] = 0,
-                ["refs/heads/master"] = 1,
-                ["refs/heads/warning"] = 2
-            };
+                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                    "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"); // does not contain "warning:"
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
+                var expected = new Dictionary<string, int>
+                {
+                    ["refs/remotes/origin/master"] = 0,
+                    ["refs/heads/master"] = 1,
+                    ["refs/heads/warning"] = 2
+                };
 
-            refs.Count.Should().Be(3);
-            refs.Should().BeEquivalentTo(expected);
+                var refs = commitInfo.GetTestAccessor().GetSortedTags();
+
+                refs.Count.Should().Be(3);
+                refs.Should().BeEquivalentTo(expected);
+            });
         }
 
         [Test]
         public void GetSortedTags_should_load_ref_different_in_case()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
-                "refs/remotes/origin/master\nrefs/heads/master\nrefs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375\nrefs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"); // case sensitive duplicates
-
-            var expected = new Dictionary<string, int>
+            RunCommitInfoTest(commitInfo =>
             {
-                ["refs/remotes/origin/master"] = 0,
-                ["refs/heads/master"] = 1,
-                ["refs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375"] = 2,
-                ["refs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"] = 3
-            };
+                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                    "refs/remotes/origin/master\nrefs/heads/master\nrefs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375\nrefs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"); // case sensitive duplicates
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
+                var expected = new Dictionary<string, int>
+                {
+                    ["refs/remotes/origin/master"] = 0,
+                    ["refs/heads/master"] = 1,
+                    ["refs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375"] = 2,
+                    ["refs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"] = 3
+                };
 
-            refs.Count.Should().Be(4);
-            refs.Should().BeEquivalentTo(expected);
+                var refs = commitInfo.GetTestAccessor().GetSortedTags();
+
+                refs.Count.Should().Be(4);
+                refs.Should().BeEquivalentTo(expected);
+            });
         }
 
         [Test]
         public void GetSortedTags_should_load_ref_with_extra_spaces()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
-                "refs/remotes/origin/master\nrefs/heads/master\nrefs/tags/v3.1\nrefs/tags/v3.1 \n refs/tags/v3.1"); // have leading and trailing spaces
-
-            var expected = new Dictionary<string, int>
+            RunCommitInfoTest(commitInfo =>
             {
-                ["refs/remotes/origin/master"] = 0,
-                ["refs/heads/master"] = 1,
-                ["refs/tags/v3.1"] = 2,
-                ["refs/tags/v3.1 "] = 3,
-                [" refs/tags/v3.1"] = 4
-            };
+                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                    "refs/remotes/origin/master\nrefs/heads/master\nrefs/tags/v3.1\nrefs/tags/v3.1 \n refs/tags/v3.1"); // have leading and trailing spaces
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
+                var expected = new Dictionary<string, int>
+                {
+                    ["refs/remotes/origin/master"] = 0,
+                    ["refs/heads/master"] = 1,
+                    ["refs/tags/v3.1"] = 2,
+                    ["refs/tags/v3.1 "] = 3,
+                    [" refs/tags/v3.1"] = 4
+                };
 
-            refs.Count.Should().Be(5);
-            refs.Should().BeEquivalentTo(expected);
+                var refs = commitInfo.GetTestAccessor().GetSortedTags();
+
+                refs.Count.Should().Be(5);
+                refs.Should().BeEquivalentTo(expected);
+            });
         }
 
         [Test]
         public void GetSortedTags_should_remove_duplicate_refs()
         {
-            _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
-                "refs/remotes/origin/master\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/bar\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/last"); // exact duplicates
-
-            var expected = new Dictionary<string, int>
+            RunCommitInfoTest(commitInfo =>
             {
-                ["refs/remotes/origin/master"] = 0,
-                ["refs/remotes/foo/duplicate"] = 1,
-                ["refs/remotes/foo/bar"] = 2,
-                ["refs/remotes/foo/last"] = 3,
-            };
+                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                    "refs/remotes/origin/master\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/bar\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/last"); // exact duplicates
 
-            var refs = _commitInfo.GetTestAccessor().GetSortedTags();
+                var expected = new Dictionary<string, int>
+                {
+                    ["refs/remotes/origin/master"] = 0,
+                    ["refs/remotes/foo/duplicate"] = 1,
+                    ["refs/remotes/foo/bar"] = 2,
+                    ["refs/remotes/foo/last"] = 3,
+                };
 
-            refs.Count.Should().Be(4);
-            refs.Should().BeEquivalentTo(expected);
+                var refs = commitInfo.GetTestAccessor().GetSortedTags();
+
+                refs.Count.Should().Be(4);
+                refs.Should().BeEquivalentTo(expected);
+            });
+        }
+
+        private void RunCommitInfoTest(Action<GitUI.CommitInfo.CommitInfo> runTest)
+        {
+            UITest.RunControl(
+                createControl: form =>
+                {
+                    var uiCommandsSource = Substitute.For<IGitUICommandsSource>();
+                    uiCommandsSource.UICommands.Returns(x => _commands);
+
+                    // the following assignment of CommitInfo.UICommandsSource will already call this command
+                    _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/", "");
+
+                    return new GitUI.CommitInfo.CommitInfo
+                    {
+                        Parent = form,
+                        UICommandsSource = uiCommandsSource
+                    };
+                },
+                runTestAsync: async commitInfo =>
+                {
+                    // Wait for pending operations so the Control is loaded completely before testing it
+                    await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                    runTest(commitInfo);
+                });
         }
     }
 }


### PR DESCRIPTION
Fixes #7745
Fixes #7382 (hopefully the last jigsaw piece)

## Proposed changes

`CommitInfoTests` failed because the ctor `CommitInfo` triggers async tasks using `FileAndForget`.
The tests must wait until these finish before they can modify the mock-up for the next git command.
A plain `await AsyncTestHelper.JoinPendingOperationsAsync` hangs.
Running the tests with a dummy main form resolves these hangs.

## Test methodology <!-- How did you ensure quality? -->

- run the NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).