### PR TITLE
Adapt submodule button to context

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -358,11 +358,11 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripButtonLevelUp.AutoToolTip = false;
             this.toolStripButtonLevelUp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButtonLevelUp.Image = global::GitUI.Properties.Images.FolderSubmodule;
+            this.toolStripButtonLevelUp.Image = global::GitUI.Properties.Images.SubmodulesManage;
             this.toolStripButtonLevelUp.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonLevelUp.Name = "toolStripButtonLevelUp";
             this.toolStripButtonLevelUp.Size = new System.Drawing.Size(32, 22);
-            this.toolStripButtonLevelUp.Text = "Go to superproject";
+            this.toolStripButtonLevelUp.Text = "";
             this.toolStripButtonLevelUp.ToolTipText = "";
             this.toolStripButtonLevelUp.ButtonClick += new System.EventHandler(this.toolStripButtonLevelUp_ButtonClick);
             this.toolStripButtonLevelUp.DropDownOpening += new System.EventHandler(this.toolStripButtonLevelUp_DropDownOpening);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -358,6 +358,7 @@ namespace GitUI.CommandsDialogs
                     var brush = UpdateCommitButtonAndGetBrush(status, countToolbar);
 
                     RevisionGrid.UpdateArtificialCommitCount(countArtificial ? status : null);
+                    toolStripButtonLevelUp.Image = Module.SuperprojectModule != null ? Images.NavigateUp : Images.SubmodulesManage;
 
                     // The diff filelist is not updated, as the selected diff is unset
                     ////_revisionDiff.RefreshArtificial();


### PR DESCRIPTION
Replaces and closes #5717 

## Proposed changes
#5717 has other changes too, the discussion (over a year ago) for that PR was that the button should adapt to the context. 
(My personal opinion is to probably not changing this, but the arguments were convincing.)

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6248932/74376733-f5341400-4de2-11ea-9f94-cb9461b3b05c.png)

### After

top most project
![image](https://user-images.githubusercontent.com/6248932/74376868-2a406680-4de3-11ea-8ba1-2c3eb1d805f5.png)

submodule
![image](https://user-images.githubusercontent.com/6248932/74376920-43e1ae00-4de3-11ea-8524-72f79793d8a0.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
