### PR TITLE
use RECT class (not struct) in theming interop

### DIFF
--- a/GitUI/Interops/DTT_CALLBACK_PROC.cs
+++ b/GitUI/Interops/DTT_CALLBACK_PROC.cs
@@ -5,7 +5,7 @@ namespace System
     internal static partial class NativeMethods
     {
         public delegate int DTT_CALLBACK_PROC(IntPtr hdc,
-            [MarshalAs(UnmanagedType.LPWStr)] string text, int textLen, ref RECT rc, int flags,
+            [MarshalAs(UnmanagedType.LPWStr)] string text, int textLen, ref RECTCLS rc, int flags,
             IntPtr lParam);
     }
 }

--- a/GitUI/Interops/RECT.cs
+++ b/GitUI/Interops/RECT.cs
@@ -37,5 +37,22 @@ namespace System
             public Size Size
                 => new Size(right - left, bottom - top);
         }
+
+        /// <summary>
+        /// Theming interop requires RECT to be class
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public class RECTCLS
+        {
+#pragma warning disable 649
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+#pragma warning restore 649
+
+            public static implicit operator Rectangle(RECTCLS r)
+                => Rectangle.FromLTRB(r.Left, r.Top, r.Right, r.Bottom);
+        }
     }
 }

--- a/GitUI/Theming/Renderers/ButtonRenderer.cs
+++ b/GitUI/Theming/Renderers/ButtonRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Button";
 
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/ComboBoxRenderer.cs
+++ b/GitUI/Theming/Renderers/ComboBoxRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Combobox";
 
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/EditRenderer.cs
+++ b/GitUI/Theming/Renderers/EditRenderer.cs
@@ -8,7 +8,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Edit";
 
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/HeaderRenderer.cs
+++ b/GitUI/Theming/Renderers/HeaderRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Header";
 
         public override int RenderBackground(IntPtr hdc, int partId, int stateId, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/ListViewRenderer.cs
+++ b/GitUI/Theming/Renderers/ListViewRenderer.cs
@@ -38,7 +38,7 @@ namespace GitUI.Theming
         }
 
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/ScrollBarRenderer.cs
+++ b/GitUI/Theming/Renderers/ScrollBarRenderer.cs
@@ -10,7 +10,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Scrollbar";
 
         public override int RenderBackground(IntPtr hdc, int partId, int stateId, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/SpinRenderer.cs
+++ b/GitUI/Theming/Renderers/SpinRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Spin";
 
         public override int RenderBackground(IntPtr hdc, int partId, int stateId, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/ThemeRenderer.cs
+++ b/GitUI/Theming/Renderers/ThemeRenderer.cs
@@ -35,7 +35,7 @@ namespace GitUI.Theming
         public virtual bool ForceUseRenderTextEx => false;
 
         public virtual int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             return Unhandled;
         }
@@ -79,13 +79,13 @@ namespace GitUI.Theming
             }
         }
 
-        protected Context CreateRenderContext(IntPtr hdc, NativeMethods.RECT clip) =>
+        protected Context CreateRenderContext(IntPtr hdc, NativeMethods.RECTCLS clip) =>
             new Context(hdc, clip);
 
         protected class Context : IDisposable
         {
             private readonly IntPtr _hdc;
-            private readonly NativeMethods.RECT _clip;
+            private readonly NativeMethods.RECTCLS _clip;
             private readonly Lazy<Graphics> _graphicsLazy;
 
             private bool _clipChanged;
@@ -93,7 +93,7 @@ namespace GitUI.Theming
 
             public Graphics Graphics => _graphicsLazy.Value;
 
-            public Context(IntPtr hdc, NativeMethods.RECT clip)
+            public Context(IntPtr hdc, NativeMethods.RECTCLS clip)
             {
                 _hdc = hdc;
                 _clip = clip;
@@ -104,8 +104,11 @@ namespace GitUI.Theming
             {
                 var graphics = Graphics.FromHdcInternal(_hdc);
                 _originalClip = graphics.Clip;
-                graphics.SetClip((Rectangle)_clip);
-                _clipChanged = true;
+                if (_clip != null)
+                {
+                    graphics.SetClip((Rectangle)_clip);
+                    _clipChanged = true;
+                }
 
                 return graphics;
             }

--- a/GitUI/Theming/Renderers/TooltipRenderer.cs
+++ b/GitUI/Theming/Renderers/TooltipRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Tooltip";
 
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Renderers/TreeViewRenderer.cs
+++ b/GitUI/Theming/Renderers/TreeViewRenderer.cs
@@ -10,7 +10,7 @@ namespace GitUI.Theming
         protected override string Clsid { get; } = "Treeview";
 
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
-            NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS pcliprect)
         {
             using (var ctx = CreateRenderContext(hdc, pcliprect))
             {

--- a/GitUI/Theming/Win32ThemeDelegates.cs
+++ b/GitUI/Theming/Win32ThemeDelegates.cs
@@ -13,7 +13,7 @@ namespace GitUI.Theming
     internal delegate int DrawThemeBackgroundDelegate(
         IntPtr htheme, IntPtr hdc,
         int partId, int stateId,
-        ref NativeMethods.RECT prect, ref NativeMethods.RECT pcliprect);
+        NativeMethods.RECTCLS prect, NativeMethods.RECTCLS pcliprect);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     internal delegate int GetThemeColorDelegate(

--- a/GitUI/Theming/Win32ThemeHooks.cs
+++ b/GitUI/Theming/Win32ThemeHooks.cs
@@ -192,7 +192,7 @@ namespace GitUI.Theming
         private static int DrawThemeBackgroundHook(
             IntPtr htheme, IntPtr hdc,
             int partid, int stateid,
-            ref NativeMethods.RECT prect, ref NativeMethods.RECT pcliprect)
+            NativeMethods.RECTCLS prect, NativeMethods.RECTCLS pcliprect)
         {
             if (!BypassThemeRenderers)
             {
@@ -203,7 +203,7 @@ namespace GitUI.Theming
                 }
             }
 
-            return _drawThemeBackgroundBypass(htheme, hdc, partid, stateid, ref prect, ref pcliprect);
+            return _drawThemeBackgroundBypass(htheme, hdc, partid, stateid, prect, pcliprect);
         }
 
         private static int GetThemeColorHook(IntPtr htheme, int ipartid, int istateid, int ipropid,


### PR DESCRIPTION
fixes #7763

tested manually in win10