### PR TITLE
Fix incomplete reset in ReferenceRepository

### DIFF
--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GitCommands;
+using GitCommands.Config;
 using LibGit2Sharp;
 using Remote = LibGit2Sharp.Remote;
 
@@ -80,6 +81,9 @@ namespace CommonTestUtils
                 var options = new LibGit2Sharp.CheckoutOptions();
                 repository.Reset(LibGit2Sharp.ResetMode.Hard, (LibGit2Sharp.Commit)repository.Lookup(CommitHash, LibGit2Sharp.ObjectType.Commit), options);
                 repository.RemoveUntrackedFiles();
+
+                repository.Config.Set(SettingKeyString.UserName, "author");
+                repository.Config.Set(SettingKeyString.UserEmail, "author@mail.com");
             }
 
             new CommitMessageManager(Module.WorkingDirGitDir, Module.CommitEncoding).ResetCommitMessage();

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using GitCommands;
 using GitCommands.Config;
 using LibGit2Sharp;
@@ -81,6 +82,12 @@ namespace CommonTestUtils
                 var options = new LibGit2Sharp.CheckoutOptions();
                 repository.Reset(LibGit2Sharp.ResetMode.Hard, (LibGit2Sharp.Commit)repository.Lookup(CommitHash, LibGit2Sharp.ObjectType.Commit), options);
                 repository.RemoveUntrackedFiles();
+
+                var remoteNames = repository.Network.Remotes.Select(remote => remote.Name).ToArray();
+                foreach (var remoteName in remoteNames)
+                {
+                    repository.Network.Remotes.Remove(remoteName);
+                }
 
                 repository.Config.Set(SettingKeyString.UserName, "author");
                 repository.Config.Set(SettingKeyString.UserEmail, "author@mail.com");


### PR DESCRIPTION
`ReferenceRepository.Reset` is supposed to efficiently reset the repository to a fresh state. This pull request fixes two cases where state was not reset.