### PR TITLE
fix InteractiveGitActionControl buttons text in dark theme

### DIFF
--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -100,7 +100,7 @@ namespace GitUI.UserControls
 
             IconBox.Image = _hasConflicts ? Properties.Images.SolveMerge : Properties.Resources.information;
             BackColor = (_hasConflicts ? System.Drawing.Color.Orange : System.Drawing.Color.LightSkyBlue).AdaptBackColor();
-            this.SetForeColorForBackColor();
+            TextLabel.SetForeColorForBackColor();
 
             string actionStr = "";
 


### PR DESCRIPTION
## Screenshots

### Before

![image](https://user-images.githubusercontent.com/12046452/74579409-47c02c80-4fab-11ea-9d57-e74d4042be88.png)

### After

![image](https://user-images.githubusercontent.com/12046452/74579412-4c84e080-4fab-11ea-8f98-bed8d44e1319.png)

## Test methodology 

Tested manually

## Test environment(s) <!-- Remove any that don't apply -->

Win10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
