### PR TITLE
SidePanel Submodules: Status for top module

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -108,6 +108,11 @@ namespace GitCommands.Submodules
                     _submoduleInfos[info.Path] = info;
                 }
 
+                if (!_submoduleInfos.ContainsKey(result.TopProject.Path))
+                {
+                    _submoduleInfos.Add(result.TopProject.Path, result.TopProject);
+                }
+
                 // Start update status for the submodules
                 if (updateStatus)
                 {
@@ -119,7 +124,7 @@ namespace GitCommands.Submodules
 
                     if (_gitStatusWhileUpdatingStructure != null)
                     {
-                        // Current module must be updated separetly (not in _submoduleInfos)
+                        // Current module must be updated separately (not in _submoduleInfos)
                         await UpdateSubmodulesStatusAsync(currentModule, _gitStatusWhileUpdatingStructure, cancelToken);
                     }
 
@@ -230,7 +235,7 @@ namespace GitCommands.Submodules
             {
                 var localPath = superprojectModule.WorkingDir.Substring(topProject.WorkingDir.Length);
                 name = Path.GetDirectoryName(localPath).ToPosixPath();
-             }
+            }
 
             string path = superprojectModule.WorkingDir;
             name += GetBranchNameSuffix(path, noBranchText);
@@ -312,6 +317,19 @@ namespace GitCommands.Submodules
             _previousSubmoduleUpdateTime = DateTime.Now;
             await TaskScheduler.Default;
 
+            // TopModule is dirty if there are any changes in any module
+            if (gitStatus != null
+                && gitStatus.Count > 0)
+            {
+                SetTopModuleAsDirty(module.GetTopModule().WorkingDir);
+            }
+            else if (module.GetTopModule() == module)
+            {
+                // status includes top module changes to files and 'dirty' can be cleared
+                // (keep 'dirty' if unknown)
+                _submoduleInfos[module.WorkingDir].Detailed = null;
+            }
+
             var changedSubmodules = gitStatus.Where(i => i.IsSubmodule);
             foreach (var submoduleName in module.GetSubmodulesLocalPaths(false).Where(s => !changedSubmodules.Any(i => i.Name == s)))
             {
@@ -323,6 +341,24 @@ namespace GitCommands.Submodules
                 cancelToken.ThrowIfCancellationRequested();
 
                 await GetSubmoduleDetailedStatusAsync(module, submoduleName.Name, cancelToken);
+            }
+        }
+
+        /// <summary>
+        /// Set the top module as dirty
+        /// If any module is changed
+        /// </summary>
+        /// <param name="topModuleWorkingDir">path to top module</param>
+        private void SetTopModuleAsDirty(string topModuleWorkingDir)
+        {
+            if (_submoduleInfos[topModuleWorkingDir].Detailed == null)
+            {
+                _submoduleInfos[topModuleWorkingDir].Detailed = new DetailedSubmoduleInfo()
+                {
+                    Status = SubmoduleStatus.Unknown,
+                    IsDirty = true,
+                    AddedAndRemovedText = ""
+                };
             }
         }
 
@@ -380,6 +416,11 @@ namespace GitCommands.Submodules
                     IsDirty = submoduleStatus.IsDirty,
                     AddedAndRemovedText = submoduleStatus.AddedAndRemovedString()
                 };
+
+            if (submoduleStatus != null)
+            {
+                SetTopModuleAsDirty(superModule.GetTopModule().WorkingDir);
+            }
 
             // Recursively update submodules
             var module = new GitModule(path);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -11,19 +11,12 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Submodules;
 using GitUI.Properties;
-using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
-using ResourceManager;
 
 namespace GitUI.BranchTreePanel
 {
     partial class RepoObjectsTree
     {
-        // If true, display submodules as a tree of folders and nodes; otherwise, display a single node per module
-        // as in the Submodules menu.
-        // TODO: Possibly expose this as a user option, or just get rid of it.
-        private static bool UseFolderTree = true;
-
         // Top-level nodes used to group SubmoduleNodes
         private class SubmoduleFolderNode : Node
         {
@@ -88,11 +81,6 @@ namespace GitUI.BranchTreePanel
 
             protected override string DisplayText()
             {
-                if (!UseFolderTree)
-                {
-                    return Info.Text;
-                }
-
                 return SubmoduleName + BranchText + Info.Detailed?.AddedAndRemovedText;
             }
 
@@ -132,15 +120,7 @@ namespace GitUI.BranchTreePanel
                     TreeViewNode.NodeFont = new Font(AppSettings.Font, FontStyle.Bold);
                 }
 
-                if (Info.Detailed == null)
-                {
-                    TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.FolderSubmodule);
-                }
-                else
-                {
-                    TreeViewNode.ImageKey = GetSubmoduleItemImage(Info.Detailed);
-                }
-
+                TreeViewNode.ImageKey = GetSubmoduleItemImage(Info.Detailed);
                 TreeViewNode.SelectedImageKey = TreeViewNode.ImageKey;
 
                 return;
@@ -148,7 +128,7 @@ namespace GitUI.BranchTreePanel
                 // NOTE: Copied and adapated from FormBrowse.GetSubmoduleItemImage
                 string GetSubmoduleItemImage(DetailedSubmoduleInfo details)
                 {
-                    if (details.Status == null)
+                    if (details?.Status == null)
                     {
                         return nameof(Images.FolderSubmodule);
                     }
@@ -173,6 +153,7 @@ namespace GitUI.BranchTreePanel
                         return details.IsDirty ? nameof(Images.SubmoduleRevisionSemiDownDirty) : nameof(Images.SubmoduleRevisionSemiDown);
                     }
 
+                    // Unknown
                     return details.IsDirty ? nameof(Images.SubmoduleDirty) : nameof(Images.FileStatusModified);
                 }
             }
@@ -345,12 +326,6 @@ namespace GitUI.BranchTreePanel
                 GitModule threadModule,
                 SubmoduleInfo topProject)
             {
-                if (!UseFolderTree)
-                {
-                    nodes.AddNodes(submoduleNodes);
-                    return;
-                }
-
                 // Create tree of SubmoduleFolderNode for each path directory and add input SubmoduleNodes as leaves.
 
                 // Example of (SuperPath + LocalPath).ToPosixPath() for all nodes:


### PR DESCRIPTION
## Proposed changes 

Show status for top module in the side panel.
If there are changes in any submodules (commit or dirty) or changes in the topmodule itself, this status should be seen in the top most icon.
(The top module cannot be ahead/behind only dirty but will be so for any changes)

Minor refactorings and removal of unused code too, to be squashed.

### Limitations
There are some limitations to the implementation, due to performance issues (git-status can require some resources).

git-status reuses the call for the commit button and artificial commits in the grid, so it is executed for the current module only. If there are changes, the side panel status is currently refreshed only for the current submodule (and below).
At the initial opening, the status is calculated for all modules though, except files in the current top module.
There is also a limiter to not refresh the status too often (ignore updates within 15s).

If the top module is current, the git-status updates are sufficient to set the status for the top module sufficient. (When rewriting this section about the limitations, I updated the implementation too.)

If another submodule is current, git-status cannot be used to refresh all status. (Previously no update at all was done.) If a submodule has changes, also the top module is dirty. However, it is not possible to determine if the status for the top module (and all modules in between) can be cleared as the modules and files in the top module is not calculated. The status is therefore is therefore additive, i.e. 'dirty' is set but not cleared.

Summary limitations if top module is not current:
 * If only files in top module is changed, top is not set as dirty (not even initially)
 * Status for top module is changed to dirty, not cleared if there are changes
 * Changes in modules outside the tree is not monitored.
 * If the current submodule is level 3 or lower, the upper modules are not changed to dirty if current module is changed (this could be changed though).

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6248932/74597612-97adfa80-5062-11ea-9fa0-403b3ecbd91f.png)

### After

![image](https://user-images.githubusercontent.com/6248932/74597620-a98f9d80-5062-11ea-86c4-a825d2c8feac.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
