### PR TITLE
Support merge.guitool

### DIFF
--- a/GitCommands/Config/SettingKeyString.cs
+++ b/GitCommands/Config/SettingKeyString.cs
@@ -45,5 +45,20 @@
         /// user.email
         /// </summary>
         public static string UserEmail = "user.email";
+
+        /// <summary>
+        /// diff.guitool
+        /// </summary>
+        public static string DiffToolKey = "diff.guitool";
+
+        /// <summary>
+        /// merge.guitool, requires Git 2.20.0
+        /// </summary>
+        public static string MergeToolKey = "merge.guitool";
+
+        /// <summary>
+        /// merge.tool
+        /// </summary>
+        public static string MergeToolNoGuiKey = "merge.tool";
     }
 }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -901,6 +901,7 @@ namespace GitCommands
         {
             var args = new GitArgumentBuilder("mergetool")
             {
+                { GitVersion.Current.SupportGuiMergeTool, "--gui" },
                 { fileName.IsNotNullOrWhitespace(), "--" },
                 fileName.ToPosixPath().QuoteNE()
             };

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -20,6 +20,7 @@ namespace GitCommands
         private static readonly GitVersion v2_15_0 = new GitVersion("2.15.0");
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
         private static readonly GitVersion v2_19_0 = new GitVersion("2.19.0");
+        private static readonly GitVersion v2_20_0 = new GitVersion("2.20.0");
 
         public static readonly GitVersion LastSupportedVersion = v2_11_0;
         public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.23.0");
@@ -126,6 +127,8 @@ namespace GitCommands
         public bool SupportNoOptionalLocks => this >= v2_15_2;
 
         public bool SupportRebaseMerges => this >= v2_19_0;
+
+        public bool SupportGuiMergeTool => this >= v2_20_0;
 
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.Utils;
 using GitExtUtils;
@@ -586,7 +587,17 @@ namespace GitUI.CommandsDialogs
 
         private bool InitMergetool()
         {
-            _mergetool = Module.GetEffectiveSetting("merge.tool");
+            if (GitVersion.Current.SupportGuiMergeTool)
+            {
+                _mergetool = Module.GetEffectiveSetting(SettingKeyString.MergeToolKey);
+            }
+
+            // Fallback and older Git
+            if (string.IsNullOrEmpty(_mergetool))
+            {
+                _mergetool = Module.GetEffectiveSetting(SettingKeyString.MergeToolNoGuiKey);
+            }
+
             if (string.IsNullOrEmpty(_mergetool))
             {
                 MessageBox.Show(this, _noMergeTool.Text, _errorCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
Fixes #5919

## Proposed changes
Use ```mergetool --gui```
GE already supports ```difftool --gui```.
This allows use of a separate mergetool from command line.

## Test methodology <!-- How did you ensure quality? -->
Added tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.25 - faked tests with older version (also testcases)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
