### PR TITLE
RevisionDiff: Try retain the file selection when switching commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -630,7 +630,7 @@ namespace GitUI.CommandsDialogs
 
             if (_dashboard == null || !_dashboard.Visible)
             {
-                revisionDiff.ForceRefreshRevisions();
+                revisionDiff.RefreshArtificial();
                 RevisionGrid.ForceRefreshRevisions();
                 InternalInitialize(true);
             }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -105,6 +105,7 @@ namespace GitUI.CommandsDialogs
             this.DiffFiles.Location = new System.Drawing.Point(0, 0);
             this.DiffFiles.Margin = new System.Windows.Forms.Padding(0);
             this.DiffFiles.Name = "DiffFiles";
+            this.DiffFiles.SelectFirstItemOnSetItems = false;
             this.DiffFiles.Size = new System.Drawing.Size(300, 360);
             this.DiffFiles.TabIndex = 1;
             this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFiles_SelectedIndexChanged);


### PR DESCRIPTION
Part of #7338 

## Proposed changes

RevisionDiff had some functionality to retain the selected file that did not really work.

This change try to retain the file selected, also when changing the selected commit. This makes it easier to follow a file from commit to commit. A more important use case is for handling artificial commits. If refreshing after staging lines, the same file should be kept (not select the first file).

A second change is to retain the index when staging/unstaging files (or staging all lines) for Artificial commits, rather than the first is selected again.

In some situations, no file was selected in RevisionDiff. This should make sure that a file is always selected. Not reproduced though.

## Test methodology

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
