### PR TITLE
Stash: Form fail to load

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -715,7 +715,7 @@ namespace GitUI
             Revision = selectedRev;
             GitItemStatusesWithDescription = items == null
                 ? Array.Empty<(GitRevision, string, IReadOnlyList<GitItemStatus>)>()
-                : new[] { (parentRev, _diffWithParent.Text + GetDescriptionForRevision(parentRev.ObjectId), items) };
+                : new[] { (parentRev, _diffWithParent.Text + GetDescriptionForRevision(parentRev?.ObjectId), items) };
         }
 
         private string GetDescriptionForRevision(ObjectId objectId)
@@ -725,7 +725,7 @@ namespace GitUI
                 return DescribeRevision(objectId);
             }
 
-            return objectId.ToShortString();
+            return objectId?.ToShortString();
         }
 
         public void SetNoFilesText(string text)


### PR DESCRIPTION
Fixes a regression in #7720

## Proposed changes

Stash Form was not loaded due to the unused revision was set to null

## Test methodology 

Test already exists - failed in master

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
