### PR TITLE
Change portable artifact name

### DIFF
--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -62,7 +62,7 @@
       <_PublishPortableVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishPortableVersionSuffix>
       <_PublishPortableCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishPortableCommitHashSuffix>
       <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableFileName>GitExtensions-portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
+      <_PublishPortableFileName>GitExtensions-Portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
       <_PublishPortablePath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)', '$(_PublishPortableFileName)'))</_PublishPortablePath>
 
       <!-- We want to archive the whole publish folder, so get one level up -->


### PR DESCRIPTION
#7785 changed the name of portable builds to `GitExtensions-portable-4.0.0.8648-65a1b55e7.zip`
This creates an issue with https://github.com/gitextensions/gitextensions.extensibility, because [this script](https://github.com/gitextensions/gitextensions.extensibility/blob/master/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1) expects the following naming convention: `*Portable*.zip` (with upper-case P).

## Proposed changes

- Change the artifact name to `GitExtensions-Portable-4.0.0.8648-65a1b55e7.zip`


## Test methodology <!-- How did you ensure quality? -->

- Manual. Checked on AppVeyor that my commit produces the desired artifact name: https://ci.appveyor.com/project/mast-eu/gitextensions/builds/31056636/artifacts


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
