### PR TITLE
WIP: handle keyboard shortcuts in FormCommit on KeyDown, not on KeyUp

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1110,7 +1110,6 @@ namespace GitUI.CommandsDialogs
             this.Message.SelectionChanged += new System.EventHandler(this.Message_SelectionChanged);
             this.Message.Enter += new System.EventHandler(this.Message_Enter);
             this.Message.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Message_KeyDown);
-            this.Message.KeyUp += new System.Windows.Forms.KeyEventHandler(this.Message_KeyUp);
             //
             // flowCommitButtons
             //

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2732,16 +2732,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void Message_KeyUp(object sender, KeyEventArgs e)
-        {
-            // Ctrl + Enter = Commit
-            if (e.Control && e.KeyCode == Keys.Enter)
-            {
-                ExecuteCommitCommand();
-                e.Handled = true;
-            }
-        }
-
         private void ExecuteCommitCommand()
         {
             CheckForStagedAndCommit(Amend.Checked, push: false);
@@ -2749,10 +2739,13 @@ namespace GitUI.CommandsDialogs
 
         private void Message_KeyDown(object sender, KeyEventArgs e)
         {
-            // Prevent adding a line break when all we want is to commit
             if (e.Control && e.KeyCode == Keys.Enter)
             {
+                // Prevent adding a line break when all we want is to commit
                 e.Handled = true;
+
+                // Ctrl + Enter = Commit
+                ExecuteCommitCommand();
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7791


## Proposed changes

- Respond to keyboard shortcuts, like `CTRL+ENTER`, in the commit window on KeyDown, as opposed to KeyUp.


## Test methodology <!-- How did you ensure quality? -->

- Manual tests, including but not limited to the examples given in #7791:
  - Press Enter, Ctrl, and release Enter -> It doesn't commit anymore.
  - Press Ctrl, press Enter -> It now commits as soon as you key-down.
  - Release Ctrl then Enter -> Now obsolete
  - Checked that this PR doesn't introduce extra line breaks in multi-line messages


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 274762857c751d3a82c59dba60cc70e7d1dc9cda (Dirty)
- Git 2.25.1.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 120dpi (125% scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
