### PR TITLE
Surround access to plugin collection with a `lock()`

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -707,24 +707,32 @@ namespace GitUI.CommandsDialogs
         private void RegisterPlugins()
         {
             var existingPluginMenus = pluginsToolStripMenuItem.DropDownItems.OfType<ToolStripMenuItem>().ToLookup(c => c.Tag);
-            var pluginEntries = PluginRegistry.Plugins
-                .OrderBy(entry => entry.Name, StringComparer.CurrentCultureIgnoreCase);
 
-            foreach (var plugin in pluginEntries)
+            lock (PluginRegistry.Plugins)
             {
-                // Add the plugin to the Plugins menu, if not already added
-                if (!existingPluginMenus.Contains(plugin))
-                {
-                    var item = new ToolStripMenuItem { Text = plugin.Description, Image = plugin.Icon, Tag = plugin };
-                    item.Click += delegate
-                    {
-                        if (plugin.Execute(new GitUIEventArgs(this, UICommands)))
-                        {
-                            RefreshRevisions();
-                        }
-                    };
+                var pluginEntries = PluginRegistry.Plugins
+                    .OrderBy(entry => entry.Name, StringComparer.CurrentCultureIgnoreCase);
 
-                    pluginsToolStripMenuItem.DropDownItems.Insert(pluginsToolStripMenuItem.DropDownItems.Count - 2, item);
+                foreach (var plugin in pluginEntries)
+                {
+                    // Add the plugin to the Plugins menu, if not already added
+                    if (!existingPluginMenus.Contains(plugin))
+                    {
+                        var item = new ToolStripMenuItem
+                        {
+                            Text = plugin.Description, Image = plugin.Icon, Tag = plugin
+                        };
+                        item.Click += delegate
+                        {
+                            if (plugin.Execute(new GitUIEventArgs(this, UICommands)))
+                            {
+                                RefreshRevisions();
+                            }
+                        };
+
+                        pluginsToolStripMenuItem.DropDownItems.Insert(pluginsToolStripMenuItem.DropDownItems.Count - 2,
+                            item);
+                    }
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -112,14 +112,17 @@ namespace GitUI.CommandsDialogs
             SettingsPageReference pluginsPageRef = PluginsSettingsGroup.GetPageReference();
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<PluginRootIntroductionPage>(this), pluginsPageRef, icon: null, asRoot: true);
 
-            var pluginEntries = PluginRegistry.Plugins
-                .Where(p => p.HasSettings)
-                .Select(plugin => (Plugin: plugin, Page: PluginSettingsPage.CreateSettingsPageFromPlugin(this, plugin)))
-                .OrderBy(entry => entry.Page.GetTitle(), StringComparer.CurrentCultureIgnoreCase);
-
-            foreach (var entry in pluginEntries)
+            lock (PluginRegistry.Plugins)
             {
-                settingsTreeView.AddSettingsPage(entry.Page, pluginsPageRef, entry.Plugin.Icon as Bitmap);
+                var pluginEntries = PluginRegistry.Plugins
+                    .Where(p => p.HasSettings)
+                    .Select(plugin => (Plugin: plugin, Page: PluginSettingsPage.CreateSettingsPageFromPlugin(this, plugin)))
+                    .OrderBy(entry => entry.Page.GetTitle(), StringComparer.CurrentCultureIgnoreCase);
+
+                foreach (var entry in pluginEntries)
+                {
+                    settingsTreeView.AddSettingsPage(entry.Page, pluginsPageRef, entry.Plugin.Icon as Bitmap);
+                }
             }
 
             if (initialPage == null && _lastSelectedSettingsPageType != null)

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -68,8 +68,12 @@ namespace GitUI
                 return;
             }
 
-            Plugins.ForEach(p => p.Register(gitUiCommands));
             PluginsRegistered = true;
+
+            lock (Plugins)
+            {
+                Plugins.ForEach(p => p.Register(gitUiCommands));
+            }
         }
 
         public static void Unregister(IGitUICommands gitUiCommands)
@@ -79,7 +83,11 @@ namespace GitUI
                 return;
             }
 
-            Plugins.ForEach(p => p.Unregister(gitUiCommands));
+            lock (Plugins)
+            {
+                Plugins.ForEach(p => p.Unregister(gitUiCommands));
+            }
+
             PluginsRegistered = false;
         }
     }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -103,12 +103,16 @@ namespace GitUI.Script
             if (command.StartsWith(PluginPrefix))
             {
                 command = command.Replace(PluginPrefix, "");
-                foreach (var plugin in PluginRegistry.Plugins)
+
+                lock (PluginRegistry.Plugins)
                 {
-                    if (plugin.Description.ToLower().Equals(command, StringComparison.CurrentCultureIgnoreCase))
+                    foreach (var plugin in PluginRegistry.Plugins)
                     {
-                        var eventArgs = new GitUIEventArgs(owner, uiCommands);
-                        return new CommandStatus(executed: true, needsGridRefresh: plugin.Execute(eventArgs));
+                        if (plugin.Description.ToLower().Equals(command, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            var eventArgs = new GitUIEventArgs(owner, uiCommands);
+                            return new CommandStatus(executed: true, needsGridRefresh: plugin.Execute(eventArgs));
+                        }
                     }
                 }
 


### PR DESCRIPTION
as we already did it in `PluginRegistry.Initialize()` to populate the collection

Should fix #6924, #7813, ...

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 398d29d61eb3260555fd0c187dccef1b881b3c13 (Dirty)
- Git 2.25.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 192dpi (200% scaling)

