### PR TITLE
do not crash on missing theme file

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using GitCommands;
 using GitExtUtils.GitUI.Theming;
@@ -34,10 +35,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             set
             {
-                int index = _NO_TRANSLATE_cbSelectTheme.Items.IndexOf(new FormattedThemeId(value));
+                var formattedThemeId = new FormattedThemeId(value);
+                int index = _NO_TRANSLATE_cbSelectTheme.Items.IndexOf(formattedThemeId);
                 if (index < 0)
                 {
-                    throw new InvalidOperationException("Themes were not added to ComboBox");
+                    // Handle case when selected theme is missing gracefully.
+                    // It may happen in a following scenario:
+                    // - user creates custom theme and selects it in this settings page
+                    // - user saves app settings
+                    // - user deletes the file with custom theme
+                    Trace.WriteLine("Theme not found: " + formattedThemeId);
+                    index = 0;
                 }
 
                 _NO_TRANSLATE_cbSelectTheme.SelectedIndex = index;
@@ -77,9 +85,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 .Select(id => new FormattedThemeId(id))
                 .Cast<object>()
                 .ToArray());
-
-            UseSystemVisualStyle = AppSettings.UseSystemVisualStyle;
             SelectedThemeId = AppSettings.ThemeId;
+            UseSystemVisualStyle = AppSettings.UseSystemVisualStyle;
             EndUpdateThemeSettings();
         }
 


### PR DESCRIPTION
Fixes #7811

## Proposed changes

Prevent crash when loading settings page if file for selected theme in AppSettings is missing.

Instead default theme is selected.

## Test methodology

- selected dark theme
- closed GitExtensions
- renamed `dark.css` to `dark2.css`
- started GitExtensions
- opened settings page

result:

- settings page opens
- default theme is selected

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
