### PR TITLE
revdiff: Show new file in worktree as file, not diff

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -118,16 +118,9 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var baseCommit = ckCompareToMergeBase.Checked ? _mergeBase : _baseRevision;
+            var baseCommit = (ckCompareToMergeBase.Checked ? _mergeBase : _baseRevision) ?? DiffFiles.SelectedItemParent;
 
-            var items = new List<GitRevision> { _headRevision, baseCommit };
-            if (baseCommit == null)
-            {
-                // This should not happen
-                items = new List<GitRevision> { _headRevision, DiffFiles.SelectedItemParent };
-            }
-
-            DiffText.ViewChangesAsync(items, DiffFiles.SelectedItem, string.Empty);
+            DiffText.ViewChangesAsync(baseCommit?.ObjectId, _headRevision, DiffFiles.SelectedItem, string.Empty);
         }
 
         private void btnSwap_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -377,7 +377,11 @@ namespace GitUI.CommandsDialogs
                     Name = fileName,
                     IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName))
                 };
-                Diff.ViewChangesAsync(FileChanges.GetSelectedRevisions(), file, "You need to select at least one revision to view diff.");
+                var revisions = FileChanges.GetSelectedRevisions();
+                var selectedRev = revisions.FirstOrDefault();
+                var firstId = revisions.Skip(1).LastOrDefault()?.ObjectId;
+                Diff.ViewChangesAsync(firstId, selectedRev, file,
+                    "You need to select at least one revision to view diff.");
             }
             else if (tabControl1.SelectedTab == CommitInfoTabPage)
             {

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace GitUI.CommandsDialogs
 {
@@ -39,7 +40,10 @@ namespace GitUI.CommandsDialogs
 
             using (WaitCursorScope.Enter())
             {
-                diffViewer.ViewChangesAsync(RevisionGrid.GetSelectedRevisions(), DiffFiles.SelectedItem, string.Empty);
+                var revisions = RevisionGrid.GetSelectedRevisions();
+                var selectedRev = revisions.FirstOrDefault();
+                var firstId = revisions.Skip(1).LastOrDefault()?.ObjectId;
+                diffViewer.ViewChangesAsync(firstId, selectedRev, DiffFiles.SelectedItem, string.Empty);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -348,7 +348,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision?.ObjectId, DiffFiles.SelectedItem, string.Empty,
+            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision, DiffFiles.SelectedItem, string.Empty,
                 openWithDifftool: () => firstToSelectedToolStripMenuItem.PerformClick());
         }
 

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GitCommands;
@@ -97,8 +98,7 @@ namespace GitUI.UserControls
                 return;
             }
 
-            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision?.ObjectId, DiffFiles.SelectedItem, string.Empty,
-                openWithDifftool: null /* use default */);
+            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision, DiffFiles.SelectedItem, string.Empty);
         }
     }
 }


### PR DESCRIPTION
Part of #7338
(likely the last before the feature itself)

## Proposed changes

Present new files in WorkTree as plain files instead of a diff.
This aligns RevDiff with FormCommit again.
This was changed in  2.49 or so by myself when implementing diff to artificial commits, I did not find a good solution at time.

However, the actual reason I change this is to simplify #7338 to stage changes in new files. (FilePreamble is not set for diffs, which should be fixable too.)

Alternatives:
 * Change FormCommit (and more?) as well as FilePreamble
 * Show all New (and removed) as files

This also makes a minor refactoring for ViewChangesAsync, tobe squashed

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/6248932/75586468-c7063380-5a74-11ea-9182-97187d2a13d0.png)

### After

![image](https://user-images.githubusercontent.com/6248932/75586404-a3db8400-5a74-11ea-8a3a-27f2c10dabf5.png)


## Test methodology

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
