### PR TITLE
Show new files as file, not diff 

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -867,11 +867,12 @@ namespace GitUI.CommandsDialogs
             }
 
             byte[] patch;
-            if (!_currentItemStaged && _currentItem.IsNew)
+            if (_currentItem.IsNew)
             {
+                var treeGuid = _currentItemStaged ? _currentItem.TreeGuid?.ToString() : null;
                 patch = PatchManager.GetSelectedLinesAsNewPatch(Module, _currentItem.Name,
                     SelectedDiff.GetText(), SelectedDiff.GetSelectionPosition(),
-                    SelectedDiff.GetSelectionLength(), SelectedDiff.Encoding, false, SelectedDiff.FilePreamble);
+                    SelectedDiff.GetSelectionLength(), SelectedDiff.Encoding, false, SelectedDiff.FilePreamble, treeGuid);
             }
             else
             {
@@ -937,18 +938,19 @@ namespace GitUI.CommandsDialogs
             }
 
             byte[] patch;
-            if (_currentItemStaged)
+            if (_currentItem.IsNew)
+            {
+                var treeGuid = _currentItemStaged ? _currentItem.TreeGuid?.ToString() : null;
+                patch = PatchManager.GetSelectedLinesAsNewPatch(Module, _currentItem.Name,
+                    SelectedDiff.GetText(), SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
+                    SelectedDiff.Encoding, !_currentItemStaged, SelectedDiff.FilePreamble, treeGuid);
+            }
+            else if (_currentItemStaged)
             {
                 patch = PatchManager.GetSelectedLinesAsPatch(
                     SelectedDiff.GetText(),
                     SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
                     _currentItemStaged, SelectedDiff.Encoding, _currentItem.IsNew);
-            }
-            else if (_currentItem.IsNew)
-            {
-                patch = PatchManager.GetSelectedLinesAsNewPatch(Module, _currentItem.Name,
-                    SelectedDiff.GetText(), SelectedDiff.GetSelectionPosition(), SelectedDiff.GetSelectionLength(),
-                    SelectedDiff.Encoding, true, SelectedDiff.FilePreamble);
             }
             else
             {


### PR DESCRIPTION
Fixes #5329 
Follow up to #7824

## Proposed changes

Always show new files as files, not as a patch

Note: A sideeffect for this is that it will not be possible to cherry-pick/revert lines for new files (except FormCommit, as is now).
This is planned for revDiff artificial commits in #7825 , not for other commits or forms right now.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/75617531-b206ce80-5b60-11ea-85df-cc21e1871e8e.png)

### After

![image](https://user-images.githubusercontent.com/6248932/75617504-52a8be80-5b60-11ea-905e-df636506a877.png)

![image](https://user-images.githubusercontent.com/6248932/75617513-6bb16f80-5b60-11ea-8537-6bb824d9d1c4.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
