### PR TITLE
Fix slow plugins loading

### DIFF
--- a/Plugins/BuildServerIntegration/Directory.Build.props
+++ b/Plugins/BuildServerIntegration/Directory.Build.props
@@ -16,9 +16,16 @@
       Direct plugins artifacts to be placed under GitExtensions/Plugins folder
     -->
   <PropertyGroup>
-    <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(GitExtensionsOutputPath)$(TargetFramework)\Plugins\$(OutDirName)'))</BaseOutputPath>
+    <_BaseOutputPath>$([MSBuild]::NormalizePath('$(GitExtensionsOutputPath)', '$(TargetFramework)', 'Plugins'))</_BaseOutputPath>
+    <AssemblyName>GitExtensions.$(MSBuildProjectName)</AssemblyName>
+    <BaseOutputPath>$([MSBuild]::NormalizePath('$(_BaseOutputPath)', '$(OutDirName)'))</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
     <OutDir>$(BaseOutputPath)</OutDir>
+
+    <_IsTfsInterop>$(MSBuildProjectName.StartsWith('TfsInterop.'))</_IsTfsInterop>
+    <AssemblyName Condition="'$(_IsTfsInterop)' == true">$(MSBuildProjectName)</AssemblyName>
+    <OutDir Condition="'$(_IsTfsInterop)' == true">$([MSBuild]::NormalizePath('$(_BaseOutputPath)', 'TfsIntegration'))</OutDir>
+
   </PropertyGroup>
 
 </Project>

--- a/Plugins/Directory.Build.props
+++ b/Plugins/Directory.Build.props
@@ -10,6 +10,7 @@
       Direct plugins artifacts to be placed under GitExtensions/Plugins folder
     -->
   <PropertyGroup Condition=" '$(MSBuildProjectName)' != 'GitUIPluginInterfaces'">
+    <AssemblyName>GitExtensions.$(MSBuildProjectName)</AssemblyName>
     <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(GitExtensionsOutputPath)$(TargetFramework)\Plugins\$(OutDirName)'))</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
     <OutDir>$(BaseOutputPath)</OutDir>

--- a/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -54,7 +54,8 @@ namespace GitUIPluginInterfaces
             string defaultPluginsPath = Path.Combine(new FileInfo(Application.ExecutablePath).Directory.FullName, "Plugins");
             string userPluginsPath = UserPluginsPath;
 
-            var pluginFiles = PluginsPathScanner.GetFiles(defaultPluginsPath, userPluginsPath);
+            var pluginFiles = PluginsPathScanner.GetFiles(defaultPluginsPath, userPluginsPath)
+                .Where(f => f.Name.StartsWith("GitExtensions."));
 
             var cacheFile = Path.Combine(applicationDataFolder ?? "ignored", "Plugins", "composition.cache");
             IExportProviderFactory exportProviderFactory;

--- a/Plugins/Statistics/Directory.Build.props
+++ b/Plugins/Statistics/Directory.Build.props
@@ -15,6 +15,7 @@
       Direct plugins artifacts to be placed under GitExtensions/Plugins folder
     -->
   <PropertyGroup>
+    <AssemblyName>GitExtensions.$(MSBuildProjectName)</AssemblyName>
     <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(GitExtensionsOutputPath)$(TargetFramework)\Plugins\$(OutDirName)'))</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
     <OutDir>$(BaseOutputPath)</OutDir>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7842

## Proposed changes

- Try to load only plugin dlls following pattern `GitExtensions.*.dll`
- Rename all the plugin projects to follow this new convention

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 63496b38ed36086e42bb74966ea3e8554377d376
- Git 2.25.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 192dpi (200% scaling)
