### PR TITLE
Handle gracefully a NRE on body message

### DIFF
--- a/GitCommands/Git/GitRevisionSummaryBuilder.cs
+++ b/GitCommands/Git/GitRevisionSummaryBuilder.cs
@@ -21,6 +21,11 @@ namespace GitCommands
 
         public string BuildSummary(string body)
         {
+            if (body == null)
+            {
+                return null;
+            }
+
             var s = new StringBuilder(Math.Min(body.Length, CommitSummaryWorstCaseLength));
 
             int lineCount = 0;

--- a/GitCommands/Git/GitRevisionSummaryBuilder.cs
+++ b/GitCommands/Git/GitRevisionSummaryBuilder.cs
@@ -21,7 +21,7 @@ namespace GitCommands
 
         public string BuildSummary(string body)
         {
-            if (body == null)
+            if (string.IsNullOrWhiteSpace(body))
             {
                 return null;
             }

--- a/UnitTests/GitCommands.Tests/GitRevisionSummaryBuilderTests.cs
+++ b/UnitTests/GitCommands.Tests/GitRevisionSummaryBuilderTests.cs
@@ -10,6 +10,14 @@ namespace GitCommandsTests
 {
     public sealed class GitRevisionSummaryBuilderTests
     {
+        [Test]
+        public void Should_return_null_When_body_is_null()
+        {
+            Assert.AreEqual(null, new GitRevisionSummaryBuilder().BuildSummary(null));
+        }
+
+        [TestCase("")]
+        [TestCase("  ")]
         [TestCase("toto")]
         [TestCase("toto\ntata\ntiti")]
         public void Should_have_same_content_When_no_ellipsis(string bodyContent)

--- a/UnitTests/GitCommands.Tests/GitRevisionSummaryBuilderTests.cs
+++ b/UnitTests/GitCommands.Tests/GitRevisionSummaryBuilderTests.cs
@@ -10,14 +10,14 @@ namespace GitCommandsTests
 {
     public sealed class GitRevisionSummaryBuilderTests
     {
-        [Test]
-        public void Should_return_null_When_body_is_null()
-        {
-            Assert.AreEqual(null, new GitRevisionSummaryBuilder().BuildSummary(null));
-        }
-
+        [TestCase(null)]
         [TestCase("")]
         [TestCase("  ")]
+        public void Should_return_null_When_body_is_null_or_whitespace(string bodyContent)
+        {
+            Assert.AreEqual(null, new GitRevisionSummaryBuilder().BuildSummary(bodyContent));
+        }
+
         [TestCase("toto")]
         [TestCase("toto\ntata\ntiti")]
         public void Should_have_same_content_When_no_ellipsis(string bodyContent)


### PR DESCRIPTION
Fixes a not visible NRE (but boring when debugging)

## Proposed changes

- test if body is null

