### PR TITLE
Display text if an image cannot be displayed

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -33,6 +33,7 @@ namespace GitUI.Editor
 
         private readonly TranslationString _error = new TranslationString("Error");
         private readonly TranslationString _largeFileSizeWarning = new TranslationString("This file is {0:N1} MB. Showing large files can be slow. Click to show anyway.");
+        private readonly TranslationString _cannotViewImage = new TranslationString("Cannot view image {0}");
 
         public event EventHandler<SelectedLineEventArgs> SelectedLineChanged;
         public event EventHandler HScrollPositionChanged;
@@ -813,21 +814,25 @@ namespace GitUI.Editor
                 return _async.LoadAsync(getImage,
                             image =>
                             {
-                                ResetForImage(fileName);
-                                if (image != null)
+                                if (image == null)
                                 {
-                                    var size = DpiUtil.Scale(image.Size);
-                                    if (size.Height > PictureBox.Size.Height || size.Width > PictureBox.Size.Width)
-                                    {
-                                        PictureBox.SizeMode = PictureBoxSizeMode.Zoom;
-                                    }
-                                    else
-                                    {
-                                        PictureBox.SizeMode = PictureBoxSizeMode.CenterImage;
-                                    }
+                                    ResetForText(null);
+                                    internalFileViewer.SetText(string.Format(_cannotViewImage.Text, fileName), openWithDifftool);
+                                    return;
                                 }
 
-                                PictureBox.Image = image == null ? null : DpiUtil.Scale(image);
+                                ResetForImage(fileName);
+                                var size = DpiUtil.Scale(image.Size);
+                                if (size.Height > PictureBox.Size.Height || size.Width > PictureBox.Size.Width)
+                                {
+                                    PictureBox.SizeMode = PictureBoxSizeMode.Zoom;
+                                }
+                                else
+                                {
+                                    PictureBox.SizeMode = PictureBoxSizeMode.CenterImage;
+                                }
+
+                                PictureBox.Image = DpiUtil.Scale(image);
                                 internalFileViewer.SetText("", openWithDifftool);
                             });
             }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1306,6 +1306,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
   </file>
   <file datatype="plaintext" original="FileViewer" source-language="en">
     <body>
+      <trans-unit id="_cannotViewImage.Text">
+        <source>Cannot view image {0}</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_error.Text">
         <source>Error</source>
         <target />


### PR DESCRIPTION
See https://github.com/gitextensions/gitextensions/pull/7831#issuecomment-598459433

## Proposed changes

Display a text rather just an empty pane if the image has been removed or cannot be displayed for other reasons.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/76712015-1a36e200-6715-11ea-9880-8e9d09016785.png)

### After

![image](https://user-images.githubusercontent.com/6248932/76712026-30dd3900-6715-11ea-8994-11f1549820ad.png)

## Test methodology <!-- How did you ensure quality? -->
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
