### PR TITLE
BitBucket plugin update of RestSharp

### DIFF
--- a/Plugins/Bitbucket/ApprovePullRequest.cs
+++ b/Plugins/Bitbucket/ApprovePullRequest.cs
@@ -13,7 +13,7 @@ namespace Bitbucket
             _info = info;
         }
 
-        protected override object RequestBody => "";
+        protected override object RequestBody => null;
 
         protected override Method RequestMethod => Method.POST;
 

--- a/Plugins/Bitbucket/Bitbucket.csproj
+++ b/Plugins/Bitbucket/Bitbucket.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="RestSharp" Version="106.2.1" />
+    <PackageReference Include="RestSharp" Version="$(RestSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Bitbucket/BitbucketRequestBase.cs
+++ b/Plugins/Bitbucket/BitbucketRequestBase.cs
@@ -42,14 +42,7 @@ namespace Bitbucket
             var request = new RestRequest(ApiUrl, RequestMethod);
             if (RequestBody != null)
             {
-                if (RequestBody is string)
-                {
-                    request.AddParameter("application/json", RequestBody, ParameterType.RequestBody);
-                }
-                else
-                {
-                    request.AddBody(RequestBody);
-                }
+                request.AddJsonBody(RequestBody);
             }
 
             // XSRF check fails when approving/creating

--- a/Plugins/Bitbucket/MergePullRequest.cs
+++ b/Plugins/Bitbucket/MergePullRequest.cs
@@ -21,7 +21,7 @@ namespace Bitbucket
             _info = info;
         }
 
-        protected override object RequestBody => "";
+        protected override object RequestBody => null;
 
         protected override Method RequestMethod => Method.POST;
 


### PR DESCRIPTION
See https://github.com/gitextensions/gitextensions/pull/7878#issuecomment-601216437
Fixes #7855

## Proposed changes

Update plugin for newer RestSharp. Add .json body with supported methods.

## Test methodology <!-- How did you ensure quality? -->
Test to a private BitBucket Server (not working with BitBucket Cloud).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
