### PR TITLE
Add setting to show branch name in recent repos drop down

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1409,7 +1409,7 @@ namespace GitCommands
             }
         }
 
-        public static bool DashboardShowCurrentBranch
+        public static bool ShowRepoCurrentBranch
         {
             get => GetBool("dashboardshowcurrentbranch", true);
             set => SetBool("dashboardshowcurrentbranch", value);

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -182,7 +182,7 @@ namespace GitCommands.Submodules
             {
                 var name = submodule;
                 string path = result.Module.GetSubmoduleFullPath(submodule);
-                if (AppSettings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(path))
+                if (AppSettings.ShowRepoCurrentBranch && !GitModule.IsBareRepository(path))
                 {
                     name = name + " " + GetModuleBranch(path, noBranchText);
                 }
@@ -290,7 +290,7 @@ namespace GitCommands.Submodules
 
         private string GetBranchNameSuffix(string repositoryPath, string noBranchText)
         {
-            if (AppSettings.DashboardShowCurrentBranch && !GitModule.IsBareRepository(repositoryPath))
+            if (AppSettings.ShowRepoCurrentBranch && !GitModule.IsBareRepository(repositoryPath))
             {
                 return " " + GetModuleBranch(repositoryPath, noBranchText);
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -23,7 +23,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private readonly TranslationString _issues = new TranslationString("Issues");
         private readonly TranslationString _openRepository = new TranslationString("Open repository");
         private readonly TranslationString _translate = new TranslationString("Translate");
-        private readonly TranslationString _showCurrentBranch = new TranslationString("Show current branch");
 
         private DashboardTheme _selectedTheme;
 
@@ -208,29 +207,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 return;
             }
 
-            //
-            // create Show current branch menu item and add to Dashboard menu
-            //
-            var showCurrentBranchMenuItem = new ToolStripMenuItem(_showCurrentBranch.Text);
-            showCurrentBranchMenuItem.Click += showCurrentBranchMenuItem_Click;
-            showCurrentBranchMenuItem.Checked = AppSettings.DashboardShowCurrentBranch;
-
-            if (Parent.FindForm() is FormBrowse form)
-            {
-                var menuStrip = form.FindDescendantOfType<MenuStrip>(p => p.Name == "menuStrip1");
-                var dashboardMenu = (ToolStripMenuItem)menuStrip.Items.Cast<ToolStripItem>().SingleOrDefault(p => p.Name == "dashboardToolStripMenuItem");
-                dashboardMenu?.DropDownItems.Add(showCurrentBranchMenuItem);
-            }
-
             Visible = true;
-        }
-
-        private void showCurrentBranchMenuItem_Click(object sender, EventArgs e)
-        {
-            bool newValue = !AppSettings.DashboardShowCurrentBranch;
-            AppSettings.DashboardShowCurrentBranch = newValue;
-            ((ToolStripMenuItem)sender).Checked = newValue;
-            RefreshContent();
         }
 
         private static void TranslateItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public string GetCurrentBranchName(string path)
         {
-            if (!AppSettings.DashboardShowCurrentBranch || GitModule.IsBareRepository(path))
+            if (!AppSettings.ShowRepoCurrentBranch || GitModule.IsBareRepository(path))
             {
                 return string.Empty;
             }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1802,6 +1802,16 @@ namespace GitUI.CommandsDialogs
 
             void AddRecentRepositories(Repository repo, string caption)
             {
+                if (AppSettings.ShowRepoCurrentBranch)
+                {
+                    var branchName = GitModule.GetSelectedBranchFast(repo.Path);
+
+                    if (!string.IsNullOrEmpty(branchName) && branchName != DetachedHeadParser.DetachedBranch)
+                    {
+                        caption = $"{caption} [{branchName}]";
+                    }
+                }
+
                 if (!string.IsNullOrEmpty(repo.Category))
                 {
                     caption = $"{caption} ({repo.Category})";

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -36,6 +36,7 @@
             this.truncatePathMethod = new System.Windows.Forms.ComboBox();
             this.truncateLongFilenames = new System.Windows.Forms.Label();
             this.chkEnableAutoScale = new System.Windows.Forms.CheckBox();
+            this.chkShowRepoCurrentBranch = new System.Windows.Forms.CheckBox();
             this.chkShowCurrentBranchInVisualStudio = new System.Windows.Forms.CheckBox();
             this.gbLanguages = new System.Windows.Forms.GroupBox();
             this.tlpnlLanguage = new System.Windows.Forms.TableLayoutPanel();
@@ -114,15 +115,17 @@
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpnlGeneral.Controls.Add(this.chkShowRelativeDate, 0, 0);
-            this.tlpnlGeneral.Controls.Add(this.chkShowCurrentBranchInVisualStudio, 0, 1);
-            this.tlpnlGeneral.Controls.Add(this.chkEnableAutoScale, 0, 2);
-            this.tlpnlGeneral.Controls.Add(this.chkSortByAuthorDate, 0, 3);
-            this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 4);
-            this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 4);
+            this.tlpnlGeneral.Controls.Add(this.chkShowRepoCurrentBranch, 0, 1);
+            this.tlpnlGeneral.Controls.Add(this.chkShowCurrentBranchInVisualStudio, 0, 2);
+            this.tlpnlGeneral.Controls.Add(this.chkEnableAutoScale, 0, 3);
+            this.tlpnlGeneral.Controls.Add(this.chkSortByAuthorDate, 0, 4);
+            this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 5);
+            this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 5);
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlGeneral.Location = new System.Drawing.Point(8, 21);
             this.tlpnlGeneral.Name = "tlpnlGeneral";
-            this.tlpnlGeneral.RowCount = 5;
+            this.tlpnlGeneral.RowCount = 6;
+            this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -142,6 +145,18 @@
             this.chkShowRelativeDate.TabIndex = 0;
             this.chkShowRelativeDate.Text = "Show relative date instead of full date";
             this.chkShowRelativeDate.UseVisualStyleBackColor = true;
+            // 
+            // chkShowRepoCurrentBranch
+            // 
+            this.chkShowRepoCurrentBranch.AutoSize = true;
+            this.tlpnlGeneral.SetColumnSpan(this.chkShowRepoCurrentBranch, 2);
+            this.chkShowRepoCurrentBranch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkShowRepoCurrentBranch.Location = new System.Drawing.Point(3, 26);
+            this.chkShowRepoCurrentBranch.Name = "chkShowRepoCurrentBranch";
+            this.chkShowRepoCurrentBranch.Size = new System.Drawing.Size(314, 17);
+            this.chkShowRepoCurrentBranch.TabIndex = 5;
+            this.chkShowRepoCurrentBranch.Text = "Show current branch names in the dashboard and the recent repositories dropdown menu";
+            this.chkShowRepoCurrentBranch.UseVisualStyleBackColor = true;
             // 
             // chkShowCurrentBranchInVisualStudio
             // 
@@ -527,6 +542,7 @@
         private System.Windows.Forms.LinkLabel helpTranslate;
         private System.Windows.Forms.GroupBox gbGeneral;
         private System.Windows.Forms.CheckBox chkShowRelativeDate;
+        private System.Windows.Forms.CheckBox chkShowRepoCurrentBranch;
         private System.Windows.Forms.CheckBox chkShowCurrentBranchInVisualStudio;
         private System.Windows.Forms.CheckBox chkEnableAutoScale;
         private System.Windows.Forms.Label truncateLongFilenames;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -67,6 +67,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             chkEnableAutoScale.Checked = AppSettings.EnableAutoScale;
 
+            chkShowRepoCurrentBranch.Checked = AppSettings.ShowRepoCurrentBranch;
             chkShowCurrentBranchInVisualStudio.Checked = AppSettings.ShowCurrentBranchInVisualStudio;
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
             ShowAuthorAvatarInCommitInfo.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
@@ -127,6 +128,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             AppSettings.EnableAutoScale = chkEnableAutoScale.Checked;
             AppSettings.TruncatePathMethod = GetTruncatePathMethodString(truncatePathMethod.SelectedIndex);
+            AppSettings.ShowRepoCurrentBranch = chkShowRepoCurrentBranch.Checked;
             AppSettings.ShowCurrentBranchInVisualStudio = chkShowCurrentBranchInVisualStudio.Checked;
             AppSettings.ShowAuthorAvatarColumn = ShowAuthorAvatarInCommitGraph.Checked;
             AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatarInCommitInfo.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -160,6 +160,10 @@ See http://en.gravatar.com/site/implement/images#default-image for more details.
         <source>Show relative date instead of full date</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkShowRepoCurrentBranch.Text">
+        <source>Show current branch names in the dashboard and the recent repositories dropdown menu</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkSortByAuthorDate.Text">
         <source>Sort by author date</source>
         <target />
@@ -1078,10 +1082,6 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
       </trans-unit>
       <trans-unit id="_openRepository.Text">
         <source>Open repository</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_showCurrentBranch.Text">
-        <source>Show current branch</source>
         <target />
       </trans-unit>
       <trans-unit id="_translate.Text">


### PR DESCRIPTION
Issue: https://github.com/gitextensions/gitextensions/issues/7882

## Proposed changes

-  Show branch name in recent repos drop down (optional)

## Screenshots 

### Before

![grafik](https://user-images.githubusercontent.com/7032094/77817221-9e9c4400-70c9-11ea-9441-25156d24c89c.png)

![grafik](https://user-images.githubusercontent.com/7032094/77817229-a825ac00-70c9-11ea-8a8a-53435db1d7be.png)

![grafik](https://user-images.githubusercontent.com/7032094/77817236-b5429b00-70c9-11ea-8a2f-19e0435b0dc0.png)

### After

![grafik](https://user-images.githubusercontent.com/7032094/77817321-4ca7ee00-70ca-11ea-8893-357779ec0cb3.png)

![grafik](https://user-images.githubusercontent.com/7032094/77817326-55002900-70ca-11ea-862d-faeb42061906.png)

![grafik](https://user-images.githubusercontent.com/7032094/77817333-634e4500-70ca-11ea-98c2-46b1833e600d.png)


## Test methodology <!-- How did you ensure quality? -->
- Manual

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
