### PR TITLE
UX: Swap OK and Cancel button Recent Repo Settings UI

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.Designer.cs
@@ -76,8 +76,8 @@
             // 
             // flpnlControls
             // 
-            flpnlControls.Controls.Add(this.Ok);
             flpnlControls.Controls.Add(this.Abort);
+            flpnlControls.Controls.Add(this.Ok);
             flpnlControls.Dock = System.Windows.Forms.DockStyle.Bottom;
             flpnlControls.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             flpnlControls.Location = new System.Drawing.Point(0, 327);
@@ -91,9 +91,9 @@
             this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.Ok.AutoSize = true;
             this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.Ok.Location = new System.Drawing.Point(549, 3);
+            this.Ok.Location = new System.Drawing.Point(517, 3);
             this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(124, 25);
+            this.Ok.Size = new System.Drawing.Size(75, 25);
             this.Ok.TabIndex = 0;
             this.Ok.Text = "OK";
             this.Ok.UseCompatibleTextRendering = true;
@@ -105,7 +105,7 @@
             this.Abort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.Abort.AutoSize = true;
             this.Abort.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.Abort.Location = new System.Drawing.Point(468, 3);
+            this.Abort.Location = new System.Drawing.Point(598, 3);
             this.Abort.Name = "Abort";
             this.Abort.Size = new System.Drawing.Size(75, 25);
             this.Abort.TabIndex = 1;


### PR DESCRIPTION
Make OK button same width as Cancel button

## Proposed changes

- Swap order of OK and Cancel button in Recent Repo Settings Form to make it consistent (OK to the left of Cancel)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/7032094/77246374-c9e4e600-6c26-11ea-8f9c-2bfd176b2ca3.png)

### After

![grafik](https://user-images.githubusercontent.com/7032094/77246347-a883fa00-6c26-11ea-9896-aeb838e43050.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
