### PR TITLE
Bring into view already selected branch on ROT click

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -575,6 +575,13 @@ namespace GitUI
             {
                 if (_gridView.Rows[index].Selected)
                 {
+                    int countVisible = _gridView.DisplayedRowCount(includePartialRow: false);
+                    int firstVisible = _gridView.FirstDisplayedScrollingRowIndex;
+                    if (index < firstVisible || firstVisible + countVisible < index)
+                    {
+                        _gridView.FirstDisplayedScrollingRowIndex = index;
+                    }
+
                     return;
                 }
 


### PR DESCRIPTION
Fixes #5869


## Proposed changes

- use `DataGridView.FirstDisplayedScrollingRowIndex` to bring into view an already selected branch if clicked again in the RepoObjectsTree

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 9b925d2e09d8260a227030a790df3cb44809c208
- Git 2.24.1.windows.2
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
