### PR TITLE
WIP DiffTool for large files

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -423,7 +423,8 @@ namespace GitUI.Editor
                     getImage: GetImage,
                     getFileText: GetFileText,
                     getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), ""),
-                    openWithDifftool));
+                    openWithDifftool),
+                openWithDifftool);
 
             Image GetImage()
             {
@@ -470,9 +471,9 @@ namespace GitUI.Editor
             }
         }
 
-        private Task ShowOrDeferAsync(string fileName, Func<Task> showFunc)
+        private Task ShowOrDeferAsync(string fileName, Func<Task> showFunc, Action openWithDifftool)
         {
-            return ShowOrDeferAsync(GetFileLength(), showFunc);
+            return ShowOrDeferAsync(GetFileLength(), showFunc, openWithDifftool);
 
             long GetFileLength()
             {
@@ -496,13 +497,13 @@ namespace GitUI.Editor
             }
         }
 
-        private Task ShowOrDeferAsync(long contentLength, Func<Task> showFunc)
+        private Task ShowOrDeferAsync(long contentLength, Func<Task> showFunc, Action openWithDifftool)
         {
             const long maxLength = 5 * 1024 * 1024;
 
             if (contentLength > maxLength)
             {
-                Clear();
+                internalFileViewer.SetText("", openWithDifftool, isDiff: false);
                 Refresh();
                 _NO_TRANSLATE_lblShowPreview.Text = string.Format(_largeFileSizeWarning.Text, contentLength / (1024d * 1024));
                 _NO_TRANSLATE_lblShowPreview.Show();
@@ -605,7 +606,8 @@ namespace GitUI.Editor
 
                     TextLoaded?.Invoke(this, null);
                     return Task.CompletedTask;
-                });
+                },
+                openWithDifftool);
         }
 
         public async Task ViewTextAsync([NotNull] string fileName, [NotNull] string text,
@@ -650,7 +652,8 @@ namespace GitUI.Editor
 
                     TextLoaded?.Invoke(this, null);
                     return Task.CompletedTask;
-                });
+                },
+                openWithDifftool);
         }
 
         private FileInfo GetFileInfo(string fileName)


### PR DESCRIPTION
Fixes #7841 
See also alternative/complement #7891 that also resolves the original issue

## Proposed changes
A few forms uses the FileViewer OpenWithDifftool Action to start the difftool.
The result if the form internal handler or the FileViewer implementation is used
should be the same, starting difftool from GitModule

This is the case for the HotKey (F3) handling in FormCommit and both
HotKey and context menu for RevisionFileTreeControl

The difftool must be set also when displaying the "empty" message.

An alternative correction is maybe to remove the difftool handling completely in FileViewer, only support in the forms.
(I will not do that now, will conflict with other changes)

## Test methodology

Only tested in FormCommit, should be the same in RevisionFileTreeControl
It is difficult to get a 5MB diff (no such file in GE repo?),
I patched the limit to a lower value in FileViewer.cs:501

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
