### PR TITLE
Workaround for #7521 on 3.3 branch

### DIFF
--- a/Plugins/Gerrit/FormGerritBase.cs
+++ b/Plugins/Gerrit/FormGerritBase.cs
@@ -7,6 +7,7 @@ namespace Gerrit
 {
     public class FormGerritBase : GitExtensionsForm
     {
+        protected static readonly Version GerritVersionWithPrivateWorkflow = Version.Parse("2.15");
         protected GerritSettings Settings { get; private set; }
         protected Version Version { get; private set; }
         protected readonly RestClient client = new RestClient();
@@ -66,7 +67,9 @@ namespace Gerrit
         {
             RestRequest request = new RestRequest("/config/server/version");
             IRestResponse response = client.Execute(request);
-            return Version.Parse(response.Content.Replace(")]}'", "").Replace("\n", "").Replace("\"", "").Split('-')[0]);
+
+            string versionString = response.Content.Replace(")]}'", "").Replace("\n", "").Replace("\"", "").Split('-')[0];
+            return Version.TryParse(versionString, out Version finalVersion) ? finalVersion : GerritVersionWithPrivateWorkflow;
         }
     }
 }

--- a/Plugins/Gerrit/FormGerritPublish.cs
+++ b/Plugins/Gerrit/FormGerritPublish.cs
@@ -46,7 +46,7 @@ namespace Gerrit
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
-            if (Version >= Version.Parse("2.15"))
+            if (Version >= GerritVersionWithPrivateWorkflow)
             {
                 PublishType.Items.Add(new KeyValuePair<string, string>(_publishTypePrivate.Text, "private"));
             }
@@ -122,7 +122,7 @@ namespace Gerrit
 
             string publishType = ((KeyValuePair<string, string>)PublishType.SelectedItem).Value;
             string targetRef = "for";
-            if (Version >= Version.Parse("2.15"))
+            if (Version >= GerritVersionWithPrivateWorkflow)
             {
                 additionalOptions.Add(publishType);
             }


### PR DESCRIPTION
Do not error when we have no gerrit version (server might be on
another port) and instead use 2.15 as Gerrit version. That version
comes with the WIP workflow.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7521


## Proposed changes

- Do not error if Gerrit version cannot be parsed
- Use default version of 2.15 (with WIP workflow)
