### PR TITLE
FormCommit: F3 to diff large files

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -796,7 +796,7 @@ namespace GitUI.CommandsDialogs
                 case Command.ShowHistory: return StartFileHistoryDialog();
                 case Command.ToggleSelectionFilter: return ToggleSelectionFilter();
                 case Command.StageAll: return StageAllFiles();
-                case Command.OpenWithDifftool: SelectedDiff.OpenWithDifftool?.Invoke(); return true;
+                case Command.OpenWithDifftool: OpenWithDiffTool(); return true;
                 case Command.OpenFile: openToolStripMenuItem.PerformClick(); return true;
                 case Command.OpenFileWith: openWithToolStripMenuItem.PerformClick(); return true;
                 case Command.EditFile: editFileToolStripMenuItem.PerformClick(); return true;
@@ -1234,15 +1234,14 @@ namespace GitUI.CommandsDialogs
 
         private async Task SetSelectedDiffAsync(GitItemStatus item, bool staged)
         {
-            Action openWithDiffTool = () => (staged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick();
             if (FileHelper.IsImage(item.Name))
             {
                 var guid = staged ? ObjectId.IndexId : ObjectId.WorkTreeId;
-                await SelectedDiff.ViewGitItemRevisionAsync(item, guid, openWithDiffTool);
+                await SelectedDiff.ViewGitItemRevisionAsync(item, guid, () => OpenWithDiffTool());
             }
             else
             {
-                SelectedDiff.ViewCurrentChanges(item, staged, openWithDiffTool);
+                SelectedDiff.ViewCurrentChanges(item, staged, () => OpenWithDiffTool());
             }
         }
 
@@ -2602,6 +2601,11 @@ namespace GitUI.CommandsDialogs
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
             OpenFilesWithDiffTool(Unstaged.SelectedItems, GitRevision.IndexGuid, GitRevision.WorkTreeGuid);
+        }
+
+        private void OpenWithDiffTool()
+        {
+            (_currentItemStaged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick();
         }
 
         private void ResetPartOfFileToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -583,7 +583,7 @@ See the changes in the commit form.");
             openWithToolStripMenuItem.Visible = isFile;
             openWithToolStripMenuItem.Enabled = isExistingFileOrDirectory;
             openWithDifftoolToolStripMenuItem.Visible = isFile;
-            openWithDifftoolToolStripMenuItem.Enabled = FileText.OpenWithDifftool != null;
+            openWithDifftoolToolStripMenuItem.Enabled = isExistingFileOrDirectory;
             openFileToolStripMenuItem.Visible = isFile;
             openFileWithToolStripMenuItem.Visible = isFile;
 
@@ -650,7 +650,10 @@ See the changes in the commit form.");
 
         private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            FileText.OpenWithDifftool?.Invoke();
+            if (tvGitTree.SelectedNode?.Tag is GitItem gitItem)
+            {
+                Module.OpenWithDifftool(gitItem.Name, null, _revision?.ObjectId?.ToString());
+            }
         }
 
         private void resetToThisRevisionToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #7841 
Alternative or complement to #7887

## Proposed changes

Use 'internal' difftool command instead of FileViewer to view hot key diffs

RevisionFileTree tried to use FileViewer difftool, but the action was
never enabled (so the menu option was always disabled). Instead invoke Module.DiffTool,
compare displayed item to worktree, something I have occasionally missed.
(Note that if there is no diff, difftool will not open, not changed, so to test this select an older commit).

#7887 fixes the problem in FileViewer for FormDiff. 
That PR need to set difftool in ViewGitItemAsync() (by default, use explicit or use ViewChangesAsync() to set a difftool in FileViewer)

With this change #7887 is maybe not needed and FileViewer.DiffTool could possibly be removed.
There is still some use of difftool with F3, to investigate later.

## Test methodology <!-- How did you ensure quality? -->

See #7887 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
