### PR TITLE
Fixed missing auto suggested merge tool command line

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/MergeToolsHelper.cs
@@ -306,7 +306,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             string mergeTool = mergeToolText.ToLowerInvariant();
 
-            return AutoConfigMergeToolCmd(mergeToolText, exeFile);
+            return AutoConfigMergeToolCmd(mergeTool, exeFile);
         }
 
         public static string AutoConfigMergeToolCmd(string mergetoolText, string exeFile)

--- a/contributors.txt
+++ b/contributors.txt
@@ -108,3 +108,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/10/24, jvitkauskas, Julius Vitkauskas, zadintuvas(at)gmail.com
 2019/10/31, rickaas, Ricky Lindeman, saakcir(at)gmail.com
 2019/11/27, andrewcartwright1, Andrew Cartwright, kickme93(at)hotmail.co.uk
+2020/03/25, CodeBeast357, Martin Legault, brownavatar71(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

My mistake. ~Fixes #4864~

## Proposed changes

- The wrong variable was passed to the next method call.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/270547/77583957-54904400-6eb8-11ea-91f6-f976da8d7b44.png)

### After

![image](https://user-images.githubusercontent.com/270547/77584014-725da900-6eb8-11ea-8378-0276c7460937.png)



## Test methodology <!-- How did you ensure quality? -->

- In the Git configuration section, the 'Suggest" button didn't work for the merge tool.


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0.7719
- Build e52f5178e8d3c9899efbe6fae66026865afa3fe1
- Git 2.25.1.windows.1
- Microsoft Windows NT 10.0.18363.0
- .NET Framework 4.8.4150.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
