### PR TITLE
Make DropDownWidth in BranchSelector adjust to longest item

### DIFF
--- a/GitUI/CommandsDialogs/FormCompareToBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.Designer.cs
@@ -66,6 +66,7 @@
             this.Controls.Add(this.btnCompare);
             this.Controls.Add(this.branchSelector);
             this.Name = "FormCompareToBranch";
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.Text = "Compare to branch";
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GitCommands;
 using GitCommands.Git;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
@@ -51,6 +52,8 @@ namespace GitUI.UserControls
                 : LocalBranch.Checked
                     ? GetLocalBranches()
                     : GetRemoteBranches());
+
+            Branches.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
             if (_containRevisions != null && Branches.Items.Count == 1)
             {


### PR DESCRIPTION
Fixes #

https://github.com/gitextensions/gitextensions/issues/7822

## Proposed changes
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/7032094/77673027-eddb5b00-6f89-11ea-9c0e-523ac57d2d8f.png)

### After

![grafik](https://user-images.githubusercontent.com/7032094/77672997-e320c600-6f89-11ea-986b-4e0699f178ba.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10 1909


:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
