### PR TITLE
Bugfix/i7898 nre no parent

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2420,10 +2420,10 @@ namespace GitCommands
                 cache: noCache ? null : GitCommandCache);
         }
 
-        public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(string firstRevision, string secondRevision, string parentToSecond)
+        public IReadOnlyList<GitItemStatus> GetDiffFilesWithSubmodulesStatus(ObjectId firstId, ObjectId secondId, ObjectId parentToSecond)
         {
-            var status = GetDiffFiles(firstRevision, secondRevision, parentToSecond);
-            GetSubmoduleStatus(status, firstRevision, secondRevision);
+            var status = GetDiffFiles(firstId?.ToString(), secondId?.ToString(), parentToSecond?.ToString());
+            GetSubmoduleStatus(status, firstId?.ToString(), secondId?.ToString());
             return status;
         }
 

--- a/GitCommands/Git/GitRevisionTester.cs
+++ b/GitCommands/Git/GitRevisionTester.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
+using GitUIPluginInterfaces;
 
 namespace GitCommands.Git
 {
@@ -15,7 +16,7 @@ namespace GitCommands.Git
         /// <returns>
         /// True if one of the first selected is parent
         /// </returns>
-        bool AllFirstAreParentsToSelected(IEnumerable<GitRevision> firstSelected, GitRevision selectedRevision);
+        bool AllFirstAreParentsToSelected(IEnumerable<ObjectId> firstSelected, GitRevision selectedRevision);
 
         /// <summary>
         /// Finds if any of the git items exists as a file.
@@ -41,14 +42,14 @@ namespace GitCommands.Git
         }
 
         /// <inheritdoc />
-        public bool AllFirstAreParentsToSelected(IEnumerable<GitRevision> firstSelected, GitRevision selectedRevision)
+        public bool AllFirstAreParentsToSelected(IEnumerable<ObjectId> firstSelected, GitRevision selectedRevision)
         {
             if (selectedRevision?.ParentIds == null || firstSelected == null)
             {
                 return false;
             }
 
-            foreach (var item in firstSelected.Select(r => r.ObjectId))
+            foreach (var item in firstSelected)
             {
                 if (!selectedRevision.ParentIds.Contains(item))
                 {

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -274,7 +274,7 @@ namespace GitUI.CommandsDialogs
 
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
-            bool firstIsParent = _revisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents, DiffFiles.Revision);
+            bool firstIsParent = _revisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents.Select(item => item.ObjectId), DiffFiles.Revision);
             bool localExists = _revisionTester.AnyLocalFileExists(DiffFiles.SelectedItemsWithParent.Select(i => i.Item));
 
             var selectedItemParentRevs = DiffFiles.SelectedItemParents.Select(i => i.ObjectId).ToList();

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -259,7 +259,7 @@ namespace GitUI.CommandsDialogs
         private ContextMenuSelectionInfo GetSelectionInfo()
         {
             // First (A) is parent if one revision selected or if parent, then selected
-            bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents, DiffFiles.Revision);
+            bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents.Select(item => item.ObjectId), DiffFiles.Revision);
 
             // Combined diff is a display only diff, no manipulations
             bool isAnyCombinedDiff = DiffFiles.SelectedItemParents.Any(item => item.ObjectId == ObjectId.CombinedDiffId);
@@ -656,7 +656,7 @@ namespace GitUI.CommandsDialogs
 
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
-            bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents, DiffFiles.Revision);
+            bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(DiffFiles.SelectedItemParents.Select(item => item.ObjectId), DiffFiles.Revision);
             bool localExists = _gitRevisionTester.AnyLocalFileExists(DiffFiles.SelectedItemsWithParent.Select(i => i.Item));
 
             var selectedItemParentRevs = DiffFiles.SelectedItemParents.Select(i => i.ObjectId).ToList();

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -633,11 +633,14 @@ namespace GitUI
                     // Get the parents for the selected revision
                     parentRevs = Revision.ParentIds?.Select(item => new GitRevision(item)).ToArray();
                 }
-                else if (revisions.Count == 2 || revisions.Count > 4)
+                else
                 {
-                    // only first -> selected is interesting
-                    parentRevs = new[] { revisions.Last() };
-                    if (AppSettings.ShowDiffForAllParents)
+                    // With more than 4, only first -> selected is interesting
+                    // Limited selections: Show multi selection if more than two selected
+                    var i = revisions.Count <= 4 ? revisions.Count : 2;
+                    parentRevs = revisions.Skip(1).Take(i - 1).ToArray();
+
+                    if (AppSettings.ShowDiffForAllParents && revisions.Count == 2)
                     {
                         // Get base commit, add as parent if unique
                         Lazy<ObjectId> head = getRevision != null
@@ -655,11 +658,6 @@ namespace GitUI
                             parentRevs[1] = new GitRevision(baseRevGuid);
                         }
                     }
-                }
-                else
-                {
-                    // Limited selections: Show multi selection
-                    parentRevs = revisions.Skip(1).ToArray();
                 }
 
                 if (parentRevs == null || parentRevs.Length == 0)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -678,7 +678,7 @@ namespace GitUI
                     {
                         var desc = (rev.ObjectId != baseRevGuid ? _diffWithParent.Text : _diffWithBase.Text)
                                    + GetDescriptionForRevision(rev.ObjectId);
-                        var status = Module.GetDiffFilesWithSubmodulesStatus(rev.Guid, Revision.Guid, Revision.ParentIds?.FirstOrDefault()?.ToString());
+                        var status = Module.GetDiffFilesWithSubmodulesStatus(rev.ObjectId, Revision.ObjectId, Revision.FirstParentGuid);
                         tuples.Add((rev, desc, status));
                     }
 
@@ -686,7 +686,7 @@ namespace GitUI
                     // (a single merge commit is selected with parents explicit or implicit selected)
                     var isMergeCommit = AppSettings.ShowDiffForAllParents &&
                                         Revision.ParentIds != null && Revision.ParentIds.Count > 1 &&
-                                        _revisionTester.AllFirstAreParentsToSelected(parentRevs, Revision);
+                                        _revisionTester.AllFirstAreParentsToSelected(parentRevs.Select(item => item.ObjectId), Revision);
                     if (isMergeCommit)
                     {
                         var conflicts = Module.GetCombinedDiffFileList(Revision.Guid);

--- a/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.cs
@@ -37,7 +37,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void AllFirstAreParentsToSelected_should_return_false_if_no_parents_contains_any_of_selected_items()
         {
-            var firstSelected = new[] { new GitRevision(ObjectId.IndexId), new GitRevision(ObjectId.Random()) };
+            var firstSelected = new[] { ObjectId.IndexId, ObjectId.Random() };
 
             var selectedRevision = new GitRevision(ObjectId.WorkTreeId)
             {
@@ -55,8 +55,8 @@ namespace GitCommandsTests.Git
 
             var firstSelected2 = new[]
             {
-                new GitRevision(parent1),
-                new GitRevision(parent2)
+                parent1,
+                parent2
             };
 
             var selectedRevision2 = new GitRevision(ObjectId.Random())


### PR DESCRIPTION
Fixes #7898

## Proposed changes

 * Uses a refactoring part of #7899
 * check for null of parents to currently selected. This is used to get the IsStaged status, used for artificial commits (to compare if Index is compared to HEAD).
 * avoids trying a common BASE if more than two are selected (does not seem to be an issue here but probably what is expected)

first,second commit to be squashed

## Test methodology 

Manual
Tests are updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
