### PR TITLE
Collect and publish plugins (portable)

### DIFF
--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -71,7 +71,7 @@
       <_PublishedPath>$([MSBuild]::NormalizeDirectory('$(PublishDir)', '..'))</_PublishedPath>
     </PropertyGroup>
 
-    <!-- Determine plugins assemblies and thier necessary references -->
+    <!-- Determine plugins assemblies and their required references -->
     <_GetPluginAssembliesCodeTask
           Solution="$(SolutionPath)"
           IsContinuousIntegrationBuild="$(ContinuousIntegrationBuild)">

--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -54,6 +54,8 @@
 
   <Target Name="CreatePortable" AfterTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_PublishExtraDependecies">
     <PropertyGroup>
+      <_AppPPluginsublishDir>$([MSBuild]::NormalizeDirectory('$(AppPublishDir)', 'Plugins'))</_AppPPluginsublishDir>
+
       <!-- Resolve app.config, so we can set/unset "portable" flag -->
       <_PublishAppConfig>$([System.IO.Path]::GetFileName('$(TargetAppConfig)'))</_PublishAppConfig>
       <_PublishAppConfigPath>$([System.IO.Path]::Combine('$(PublishDir)', '$(_PublishAppConfig)'))</_PublishAppConfigPath>
@@ -68,6 +70,19 @@
       <!-- We want to archive the whole publish folder, so get one level up -->
       <_PublishedPath>$([MSBuild]::NormalizeDirectory('$(PublishDir)', '..'))</_PublishedPath>
     </PropertyGroup>
+
+    <!-- Determine plugins assemblies and thier necessary references -->
+    <_GetPluginAssembliesCodeTask
+          Solution="$(SolutionPath)"
+          IsContinuousIntegrationBuild="$(ContinuousIntegrationBuild)">
+      <Output ItemName="PluginAssemblies" TaskParameter="Output"/>
+    </_GetPluginAssembliesCodeTask>
+
+    <!-- ...and copy them into Plugins folder -->
+    <Copy
+          SourceFiles="@(PluginAssemblies)"
+          DestinationFolder="$(_AppPPluginsublishDir)"
+        />
 
     <!-- Mark the package as "portable" -->
     <XmlPoke XmlInputPath="$(_PublishAppConfigPath)"

--- a/NetSpell.SpellChecker/SpellChecker.csproj
+++ b/NetSpell.SpellChecker/SpellChecker.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>NetSpell.SpellChecker</AssemblyName>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/Plugins/Bitbucket/Bitbucket.csproj
+++ b/Plugins/Bitbucket/Bitbucket.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="RestSharp" Version="$(RestSharpVersion)" />
   </ItemGroup>
@@ -13,6 +9,10 @@
     <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
     <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Bitbucket/Bitbucket.csproj
+++ b/Plugins/Bitbucket/Bitbucket.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
+  </ItemGroup>
+
 </Project>

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
+  </ItemGroup>
+
 </Project>

--- a/Plugins/BuildServerIntegration/Directory.Build.props
+++ b/Plugins/BuildServerIntegration/Directory.Build.props
@@ -16,16 +16,16 @@
       Direct plugins artifacts to be placed under GitExtensions/Plugins folder
     -->
   <PropertyGroup>
-    <_BaseOutputPath>$([MSBuild]::NormalizePath('$(GitExtensionsOutputPath)', '$(TargetFramework)', 'Plugins'))</_BaseOutputPath>
-    <AssemblyName>GitExtensions.$(MSBuildProjectName)</AssemblyName>
-    <BaseOutputPath>$([MSBuild]::NormalizePath('$(_BaseOutputPath)', '$(OutDirName)'))</BaseOutputPath>
-    <OutputPath>$(BaseOutputPath)</OutputPath>
-    <OutDir>$(BaseOutputPath)</OutDir>
-
     <_IsTfsInterop>$(MSBuildProjectName.StartsWith('TfsInterop.'))</_IsTfsInterop>
-    <AssemblyName Condition="'$(_IsTfsInterop)' == true">$(MSBuildProjectName)</AssemblyName>
-    <OutDir Condition="'$(_IsTfsInterop)' == true">$([MSBuild]::NormalizePath('$(_BaseOutputPath)', 'TfsIntegration'))</OutDir>
+    <_AssemblyRename>$(ContinuousIntegrationBuild) != true and !$(MSBuildProjectName.StartsWith('GitExtensions.')) and '$(_IsTfsInterop)' != true</_AssemblyRename>
+    <_PluginsBaseOutputPath>$([MSBuild]::NormalizeDirectory('$(GitExtensionsOutputPath)', '$(TargetFramework)', 'Plugins'))</_PluginsBaseOutputPath>
+    <_BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(_PluginsBaseOutputPath)', '$(OutDirName)'))</_BaseOutputPath>
+    <_BaseOutputPath Condition="'$(_IsTfsInterop)' == true">$([MSBuild]::NormalizeDirectory('$(_PluginsBaseOutputPath)', 'TfsIntegration'))</_BaseOutputPath>
 
+    <AssemblyName Condition="$(_AssemblyRename) == true">GitExtensions.$(MSBuildProjectName)</AssemblyName>
+    <BaseOutputPath>$(_BaseOutputPath)</BaseOutputPath>
+    <OutputPath>$(_BaseOutputPath)</OutputPath>
+    <OutDir>$(_BaseOutputPath)</OutDir>
   </PropertyGroup>
 
 </Project>

--- a/Plugins/BuildServerIntegration/Directory.Build.targets
+++ b/Plugins/BuildServerIntegration/Directory.Build.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="..\..\Directory.Build.targets" />
+
+  <!--
+      List of plugin files to be included into the installer
+    -->
+  <ItemGroup>
+    <PluginAssembly Include="$(TargetPath)" />
+  </ItemGroup>
+
+</Project>

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
+  </ItemGroup>
+
 </Project>

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsIntegration.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.TeamFoundation.Build2.WebApi.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.TeamFoundation.Common.dll'))" />
     <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.TeamFoundation.Core.WebApi.dll'))" />
     <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.VisualStudio.Services.Common.dll'))" />
     <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.VisualStudio.Services.WebApi.dll'))" />

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsIntegration.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <ItemGroup>
     <PackageReference Include="System.Reactive.Linq" Version="$(SystemReactiveVersion)" />
   </ItemGroup>
@@ -8,6 +7,14 @@
     <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
     <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.TeamFoundation.Build2.WebApi.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.TeamFoundation.Core.WebApi.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.VisualStudio.Services.Common.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Microsoft.VisualStudio.Services.WebApi.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'System.Net.Http.Formatting.dll'))" />
   </ItemGroup>
 
 </Project>

--- a/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
+++ b/Plugins/BuildServerIntegration/TfsInterop.Vs2015/TfsInterop.Vs2015.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\TfsIntegration\TfsIntegration.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Newtonsoft.Json.dll'))" />
+  </ItemGroup>
+
 </Project>

--- a/Plugins/Directory.Build.props
+++ b/Plugins/Directory.Build.props
@@ -6,20 +6,22 @@
     <CodeAnalysisRuleSet>..\..\GitExtensions.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <!--
-      Direct plugins artifacts to be placed under GitExtensions/Plugins folder
-    -->
-  <PropertyGroup Condition=" '$(MSBuildProjectName)' != 'GitUIPluginInterfaces'">
-    <AssemblyName>GitExtensions.$(MSBuildProjectName)</AssemblyName>
-    <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(GitExtensionsOutputPath)$(TargetFramework)\Plugins\$(OutDirName)'))</BaseOutputPath>
-    <OutputPath>$(BaseOutputPath)</OutputPath>
-    <OutDir>$(BaseOutputPath)</OutDir>
-  </PropertyGroup>
-  
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
   </ItemGroup>
+
+  <!--
+      Direct plugins artifacts to be placed under GitExtensions/Plugins folder
+    -->
+  <PropertyGroup Condition=" '$(MSBuildProjectName)' != 'GitUIPluginInterfaces'">
+    <_AssemblyRename>$(ContinuousIntegrationBuild) != true and !$(MSBuildProjectName.StartsWith('GitExtensions.'))</_AssemblyRename>
+
+    <AssemblyName Condition="$(_AssemblyRename) == true">GitExtensions.$(MSBuildProjectName)</AssemblyName>
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(GitExtensionsOutputPath)', '$(TargetFramework)', 'Plugins', '$(OutDirName)'))</BaseOutputPath>
+    <OutputPath>$(BaseOutputPath)</OutputPath>
+    <OutDir>$(BaseOutputPath)</OutDir>
+  </PropertyGroup>
 
 </Project>

--- a/Plugins/Directory.Build.targets
+++ b/Plugins/Directory.Build.targets
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="..\Directory.Build.targets" />
+
+  <!--
+      List of plugin files to be included into the installer
+    -->
+  <ItemGroup Condition=" '$(MSBuildProjectName)' != 'GitUIPluginInterfaces'">
+    <PluginAssembly Include="$(TargetPath)" />
+  </ItemGroup>
+</Project>

--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="$(ContinuousIntegrationBuild) == true">CI_BUILD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -54,8 +54,10 @@ namespace GitUIPluginInterfaces
             string defaultPluginsPath = Path.Combine(new FileInfo(Application.ExecutablePath).Directory.FullName, "Plugins");
             string userPluginsPath = UserPluginsPath;
 
-            var pluginFiles = PluginsPathScanner.GetFiles(defaultPluginsPath, userPluginsPath)
-                .Where(f => f.Name.StartsWith("GitExtensions."));
+            var pluginFiles = PluginsPathScanner.GetFiles(defaultPluginsPath, userPluginsPath);
+#if !CI_BUILD
+            pluginFiles = pluginFiles.Where(f => f.Name.StartsWith("GitExtensions."));
+#endif
 
             var cacheFile = Path.Combine(applicationDataFolder ?? "ignored", "Plugins", "composition.cache");
             IExportProviderFactory exportProviderFactory;

--- a/Plugins/Gource/Gource.csproj
+++ b/Plugins/Gource/Gource.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'ICSharpCode.SharpZipLib.dll'))" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Resources -->
     <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
   </ItemGroup>

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.csproj
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Atlassian.Jira.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'NString.dll'))" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Atlassian.SDK" Version="10.0.2" />

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.csproj
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Atlassian.Jira.dll'))" />
-    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'NString.dll'))" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Atlassian.SDK" Version="10.0.2" />
     <PackageReference Include="NString" Version="1.2.0" />
   </ItemGroup>
@@ -21,6 +16,11 @@
 
   <ItemGroup>
     <None Include="Resources\IconJira.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'Atlassian.Jira.dll'))" />
+    <PluginAssembly Include="$([System.IO.Path]::Combine('$(TargetDir)', 'NString.dll'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Statistics/Directory.Build.props
+++ b/Plugins/Statistics/Directory.Build.props
@@ -15,8 +15,10 @@
       Direct plugins artifacts to be placed under GitExtensions/Plugins folder
     -->
   <PropertyGroup>
-    <AssemblyName>GitExtensions.$(MSBuildProjectName)</AssemblyName>
-    <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(GitExtensionsOutputPath)$(TargetFramework)\Plugins\$(OutDirName)'))</BaseOutputPath>
+    <_AssemblyRename>$(ContinuousIntegrationBuild) != true and !$(MSBuildProjectName.StartsWith('GitExtensions.'))</_AssemblyRename>
+
+    <AssemblyName Condition="$(_AssemblyRename) == true">GitExtensions.$(MSBuildProjectName)</AssemblyName>
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(GitExtensionsOutputPath)', '$(TargetFramework)', 'Plugins', '$(OutDirName)'))</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
     <OutDir>$(BaseOutputPath)</OutDir>
   </PropertyGroup>

--- a/Plugins/Statistics/Directory.Build.targets
+++ b/Plugins/Statistics/Directory.Build.targets
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="..\..\Directory.Build.targets" />
+
+  <!--
+      List of plugin files to be included into the installer
+    -->
+  <ItemGroup>
+    <PluginAssembly Include="$(TargetPath)" />
+  </ItemGroup>
+
+
+</Project>

--- a/scripts/tools/Imports.targets
+++ b/scripts/tools/Imports.targets
@@ -4,5 +4,6 @@
 
   <Import Project="ProjectDefaults.targets"/>
   <Import Project="Tests.targets" Condition="'$(DisableArcadeTestFramework)' != 'true'" />
+  <Import Project="Publish.targets"/>
 
 </Project>

--- a/scripts/tools/NUnit/NUnit.targets
+++ b/scripts/tools/NUnit/NUnit.targets
@@ -23,8 +23,8 @@
     <PropertyGroup>
       <_UseOpenCover>true</_UseOpenCover>
       <_NUnitConsoleExe>nunit3-console.exe</_NUnitConsoleExe>
-      <_NUnitRunnerCommand Condition="$(ContinuousIntegrationBuild) != 'true'">$(PkgNUnit_ConsoleRunner)\tools\$(_NUnitConsoleExe)</_NUnitRunnerCommand>
-      <_NUnitRunnerCommand Condition="$(ContinuousIntegrationBuild) == 'true'">$(_NUnitConsoleExe)</_NUnitRunnerCommand>
+      <_NUnitRunnerCommand Condition="$(ContinuousIntegrationBuild) != true">$(PkgNUnit_ConsoleRunner)\tools\$(_NUnitConsoleExe)</_NUnitRunnerCommand>
+      <_NUnitRunnerCommand Condition="$(ContinuousIntegrationBuild) == true">$(_NUnitConsoleExe)</_NUnitRunnerCommand>
       <_NUnitRunnerCommandArgs>"@(TestToRun)"</_NUnitRunnerCommandArgs>
 
       <_TestArchitecture>%(_TestArchitectureItems.Identity)</_TestArchitecture>

--- a/scripts/tools/Publish.targets
+++ b/scripts/tools/Publish.targets
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+
+  <UsingTask TaskName="_GetPluginAssembliesCodeTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <Solution ParameterType="System.String" Required="true"/>
+      <IsContinuousIntegrationBuild ParameterType="System.String" Required="true"/>
+      <Output ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true"/>
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Xml"/>
+      <Reference Include="Microsoft.Build"/>
+      <Using Namespace="Microsoft.Build.Construction"/>
+      <Using Namespace="Microsoft.Build.Evaluation"/>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        var _solutionFile = SolutionFile.Parse(Solution); 
+        Output = _solutionFile.ProjectsInOrder
+            .Where(proj => proj.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat)
+            .SelectMany(proj => 
+                        {
+                            var project = new Project(proj.AbsolutePath);
+                            project.SetGlobalProperty("ContinuousIntegrationBuild", IsContinuousIntegrationBuild);
+                            project.ReevaluateIfNecessary();
+
+                            return project.Items
+                                .Where(item => item.ItemType == "PluginAssembly")
+                                .Select(item => item.EvaluatedInclude);
+                        })
+            .Distinct()
+            .OrderBy(pluginAssemblyPath => pluginAssemblyPath)
+            .Select(pluginAssemblyPath => new TaskItem(pluginAssemblyPath))
+            .ToArray();
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+</Project>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Addendum to #7649, solves parts of #7702.

## Proposed changes

* Partially alter #7850 to not rename any plugins for CI builds
* Enumerate all plugin satellite files
* Publish plugins in the portable artifact


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
