### PR TITLE
RevDiff: follow selection only in first list group

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -154,11 +154,12 @@ namespace GitUI.CommandsDialogs
 
         private void SetDiffs(IReadOnlyList<GitRevision> revisions)
         {
-            GitItemStatus oldDiffItem = DiffFiles.SelectedItem;
+            var item = DiffFiles.SelectedItem;
+            var oldDiffItem = DiffFiles.FirstGroupItems.Contains(item) ? item : null;
             DiffFiles.SetDiffs(revisions, _revisionGrid.GetRevision);
 
             // Try to restore previous item
-            if (oldDiffItem != null && DiffFiles.GitItemStatuses.Any(i => i.Name.Equals(oldDiffItem.Name)))
+            if (oldDiffItem != null && DiffFiles.FirstGroupItems.Any(i => i.Name.Equals(oldDiffItem.Name)))
             {
                 DiffFiles.SelectedItem = oldDiffItem;
             }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -400,6 +400,24 @@ namespace GitUI
                 .Where(i => i.Group?.Tag is GitRevision)
                 .Select(i => new GitItemStatusWithParent(i.Group.Tag<GitRevision>(), i.Tag<GitItemStatus>()));
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Browsable(false)]
+        public IEnumerable<GitItemStatus> FirstGroupItems
+        {
+            get
+            {
+                if (FileStatusListView.Groups.Count == 0)
+                {
+                    yield break;
+                }
+
+                foreach (ListViewItem item in FileStatusListView.Groups[0].Items)
+                {
+                    yield return item.Tag<GitItemStatus>();
+                }
+            }
+        }
+
         [DefaultValue(true)]
         public bool SelectFirstItemOnSetItems { get; set; }
 


### PR DESCRIPTION
Fixes #7907

## Proposed changes

Do not try to retain the selected item, if selection was done in
other than the first group or if the item is only appearing in other than the first group

See the issue for a description and discussion. I personally prefer the current behavior, but @mstv has requested this change. (This also conflicts with several other open PRs.)
The retain/follow for RevDiff was introduced in #7798 

## Screenshots 

Showing the behavior after only

![i7907-retain-file](https://user-images.githubusercontent.com/6248932/77845840-29f10480-71b2-11ea-92e2-04cdfdb9e697.gif)

## Test methodology 

Code review, manual


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
