### PR TITLE
git-status:  use config to set ignoreSubmodules

### DIFF
--- a/GitExtUtils/GitCommandConfiguration.cs
+++ b/GitExtUtils/GitCommandConfiguration.cs
@@ -24,6 +24,7 @@ namespace GitCommands
 
             Default.Add(new GitConfigItem("diff.submodule", "short"), "diff");
             Default.Add(new GitConfigItem("diff.noprefix", "false"), "diff");
+            Default.Add(new GitConfigItem("diff.ignoreSubmodules", "none"), "diff", "status");
         }
 
         /// <summary>

--- a/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
@@ -619,37 +619,37 @@ namespace GitCommandsTests.Git
         public void GetAllChangedFilesCmd()
         {
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules --ignored",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignored --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: false, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files=no --ignore-submodules",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files=no --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.No, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files=normal --ignore-submodules",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files=normal --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Normal, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files=all --ignore-submodules",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files=all --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.All, IgnoreSubmodulesMode.Default).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules=none",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.None).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules=none",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules=untracked",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=untracked",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Untracked).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules=dirty",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=dirty",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Dirty).Arguments);
             Assert.AreEqual(
-                "status --porcelain=2 -z --untracked-files --ignore-submodules=all",
+                "-c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules=all",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.All).Arguments);
             Assert.AreEqual(
-                "--no-optional-locks status --porcelain=2 -z --untracked-files --ignore-submodules",
+                "--no-optional-locks -c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files --ignore-submodules",
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default, noLocks: true).Arguments);
         }
 

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -744,9 +744,9 @@ namespace GitCommandsTests
             Assert.AreEqual(expected, _gitModule.GetStashesCmd(noLocks).ToString());
         }
 
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, [CanBeNull] string oldFileName, bool staged,
             string extraDiffArguments, bool noLocks)
         {


### PR DESCRIPTION
Fixes #7906

## Proposed changes

User configuration of git config diff.ignoreSubmodules need to be overridden,
to not rely on the user having proper configuration. This was done with a
git-status option --ignoreSubmodule=none
However, git-diff was not overridden, so the RevisionDiff tab could be inconsistent with the artificial status and FormCommit

Submodule config can be overridden per submodule, not just globally.
The PR #7906 argued that those configurations should be followed

Allow those overrides by using the config parameter
'-c diff.ignoreSubmodules=none'  instead of the command line option so
user specific overrides can have effect.

Similar for git-diff, if diff.ignoreSubmodules was configured, git-diff would
use the config


## Screenshots 

Showing behavior after, editing .gitmodules

![i7906-git-status](https://user-images.githubusercontent.com/6248932/77846539-1c8a4900-71b7-11ea-9737-81d73ecf9ef0.gif)


## Test methodology 

The existing meaningless tests are updated so similar testing as before.
There are no tests to test that the Git repos are parsed correctly. Such tests are quite difficult to setup and requires a lot of maintenance. 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
