### PR TITLE
Separate staged status from GetDiff

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -625,26 +625,34 @@ namespace GitCommands
         /// </summary>
         /// <param name="module">The Git module</param>
         /// <param name="statusString">output from the git command</param>
-        /// <param name="firstRevision">from revision string</param>
-        /// <param name="secondRevision">to revision</param>
-        /// <param name="parentToSecond">The parent for the second revision</param>
+        /// <param name="staged">required to determine if <see cref="StagedStatus"/> allows stage/unstage.</param>
         /// <returns>list with the parsed GitItemStatus</returns>
         /// <seealso href="https://git-scm.com/docs/git-diff"/>
-        /// <remarks>Git revisions are required to determine if the <see cref="GitItemStatus"/> are WorkTree or Index.</remarks>
-        public static IReadOnlyList<GitItemStatus> GetDiffChangedFilesFromString(IGitModule module, string statusString, [CanBeNull] string firstRevision, [CanBeNull] string secondRevision, [CanBeNull] string parentToSecond)
+        public static IReadOnlyList<GitItemStatus> GetDiffChangedFilesFromString(IGitModule module, string statusString, StagedStatus staged)
+        {
+            return GetAllChangedFilesFromString_v1(module, statusString, true, staged);
+        }
+
+        /// <summary>
+        /// If possible, find if files in a diff are index or worktree
+        /// </summary>
+        /// <param name="firstId">from revision string</param>
+        /// <param name="secondId">to revision</param>
+        /// <param name="parentToSecond">The parent for the second revision</param>
+        /// <remarks>Git revisions are required to determine if <see cref="StagedStatus"/> allows stage/unstage.</remarks>
+        public static StagedStatus GetStagedStatus([CanBeNull] ObjectId firstId, [CanBeNull] ObjectId secondId, [CanBeNull] ObjectId parentToSecond)
         {
             StagedStatus staged;
-            if (firstRevision == GitRevision.IndexGuid && secondRevision == GitRevision.WorkTreeGuid)
+            if (firstId == ObjectId.IndexId && secondId == ObjectId.WorkTreeId)
             {
                 staged = StagedStatus.WorkTree;
             }
-            else if (firstRevision == parentToSecond && secondRevision == GitRevision.IndexGuid)
+            else if (firstId == parentToSecond && secondId == ObjectId.IndexId)
             {
                 staged = StagedStatus.Index;
             }
-            else if ((firstRevision.IsNotNullOrWhitespace() && !firstRevision.IsArtificial()) ||
-                (secondRevision.IsNotNullOrWhitespace() && !secondRevision.IsArtificial()) ||
-                parentToSecond.IsNotNullOrWhitespace())
+            else if (firstId != null && !firstId.IsArtificial &&
+                     secondId != null && !secondId.IsArtificial)
             {
                 // This cannot be a worktree/index file
                 staged = StagedStatus.None;
@@ -654,7 +662,7 @@ namespace GitCommands
                 staged = StagedStatus.Unknown;
             }
 
-            return GetAllChangedFilesFromString_v1(module, statusString, true, staged);
+            return staged;
         }
 
         /// <summary>
@@ -672,7 +680,7 @@ namespace GitCommands
             }
             else
             {
-                return GetAllChangedFilesFromString_v1(module, statusString, false, StagedStatus.Index);
+                return GetAllChangedFilesFromString_v1(module, statusString, false, StagedStatus.Unset);
             }
         }
 
@@ -793,6 +801,11 @@ namespace GitCommands
         /// Parse git-status --porcelain=1 and git-diff --name-status
         /// Outputs are similar, except that git-status has status for both worktree and index
         /// </summary>
+        /// <param name="module">The GitModule</param>
+        /// <param name="statusString">Output from Git command</param>
+        /// <param name="fromDiff">Parse git-diff</param>
+        /// <param name="staged">The staged status <see cref="GitItemStatus"/>, only relevant for git-diff (parsed for git-status)</param>
+        /// <returns>list with the git items</returns>
         private static IReadOnlyList<GitItemStatus> GetAllChangedFilesFromString_v1(IGitModule module, string statusString, bool fromDiff, StagedStatus staged)
         {
             var diffFiles = new List<GitItemStatus>();

--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -8,12 +8,17 @@ using Microsoft.VisualStudio.Threading;
 
 namespace GitCommands
 {
+    /// <summary>
+    /// Status if the file can be staged (worktree->index), unstaged or None (normal commits)
+    /// The status may not be available or unset for some commands
+    /// </summary>
     public enum StagedStatus
     {
-        Unknown = 0,
+        Unset = 0,
         None,
         WorkTree,
-        Index
+        Index,
+        Unknown
     }
 
     public sealed class GitItemStatus : IComparable<GitItemStatus>
@@ -45,19 +50,7 @@ namespace GitCommands
         public ObjectId TreeGuid { get; set; }
         public string RenameCopyPercentage { get; set; }
 
-        // Staged is three state and has no default status
-        private StagedStatus _staged = StagedStatus.Unknown;
-        public StagedStatus Staged
-        {
-            get
-            {
-                // Catch usage of unset accesses
-                Debug.Assert(_staged != StagedStatus.Unknown, "Staged is used without being set. Continue should generally be OK.");
-
-                return _staged;
-            }
-            set { _staged = value; }
-        }
+        public StagedStatus Staged { get; set; }
 
         #region Flags
 

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -160,7 +160,7 @@ namespace GitUI.CommandsDialogs
             else if (checkboxRevisionFilter.Checked)
             {
                 // 1. get all changed (and not deleted files) from selected to current revision
-                var files = UICommands.Module.GetDiffFiles(DiffSelectedRevision.Guid, SelectedRevision.Guid, SelectedRevision.ParentIds.FirstOrDefault()?.ToString()).Where(f => !f.IsDeleted);
+                var files = UICommands.Module.GetDiffFiles(DiffSelectedRevision?.Guid, SelectedRevision?.Guid, StagedStatus.None).Where(f => !f.IsDeleted);
 
                 // 2. wrap file names with ""
                 // 3. join together with space as separator

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -23,15 +23,15 @@ namespace GitUI
         private static Patch GetItemPatch(
             [NotNull] GitModule module,
             [NotNull] GitItemStatus file,
-            [CanBeNull] ObjectId firstRevision,
-            [CanBeNull] ObjectId secondRevision,
+            [CanBeNull] ObjectId firstId,
+            [CanBeNull] ObjectId secondId,
             [NotNull] string diffArgs,
             [NotNull] Encoding encoding)
         {
             // Files with tree guid should be presented with normal diff
-            var isTracked = file.IsTracked || (file.TreeGuid != null && secondRevision != null);
+            var isTracked = file.IsTracked || (file.TreeGuid != null && secondId != null);
 
-            return module.GetSingleDiff(firstRevision?.ToString(), secondRevision?.ToString(), file.Name, file.OldName, diffArgs, encoding, true, isTracked);
+            return module.GetSingleDiff(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
         }
 
         /// <summary>


### PR DESCRIPTION
This was done as a part of #7902 but separated

## Proposed changes

Separate the evaluation of getting "staged status" to a separate function and add tests.
The Git documentation mostly uses stage/unstage as the action to move between the indexes, this text uses staged/unstaged to some extent too.

git-status reports if a file is changed in the worktree or index. This is used in FormCommit.
RevisionDiff allows comparing any commit to worktree/index and uses git-diff.
RevDiff allows the user to stage/unstage files if conditions allow.

The problem here is that git-diff reports the differences for the file but not if a file is changed in any of worktree, index or a intermediate commit. Therefore the staged status is calculated separately from commit. So if a file is changed from index to worktree, it must be changed in the index and it can be staged. If a commit other than index is compared to worktree, the staged status is Unknown. If two normal commits are compared, the status is None.

The 'Staged' calculation was bundled with the parsing of git-diff, it was a little confusing why "parent to second" had to be provided in the API, staged status is therefore evaluated explicitly (or provided manually.)

This PR also changes GetSingleDiff() from using string to ObjectId to be able to use ObjectId in the broken out method.
This requires that FormStash will have to do git-rev-parse. So while slightly more efficient in most forms, 40*2 milliseconds extra to open FormStash for me.  

The refactoring also corrected that status was set to None in some situations it should have been set to Unknown, and that the default should be Unset so that was added. The problem does not make a difference as only explicit WorkTree and Index is used, but the assert in GitItemStatus had to be removed.

It could be possible to set staged status only when parsing git-status, and let git-diff dynamically calculate the staged status from the compared commits. This requires a GitItemStatusWithParents as added in #7899 
(I do not propose that this is changed).

If you have read all the way here: This is not an important change, but some of the lengthy explanation will not be needed after the change.

## Test methodology 
Tests added

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
