### PR TITLE
Prepopulate branch name in FormCreateBranch

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -40,10 +40,17 @@ namespace GitUI.CommandsDialogs
                 objectId = null;
             }
 
-            objectId = objectId ?? Module.GetCurrentCheckout();
+            objectId ??= Module.GetCurrentCheckout();
             if (objectId != null)
             {
                 commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
+
+                if (newBranchNamePrefix.IsNullOrWhiteSpace())
+                {
+                    var refs = Module.GetRevision(objectId, shortFormat: true, loadRefs: true).Refs;
+                    IGitRef firstRef = refs.FirstOrDefault(r => !r.IsTag) ?? refs.FirstOrDefault(r => r.IsTag);
+                    newBranchNamePrefix = firstRef?.LocalName;
+                }
             }
 
             if (newBranchNamePrefix.IsNotNullOrWhitespace())


### PR DESCRIPTION
## Proposed changes

- prepopulate the branch name in `FormCreateBranch` with the first branch or tag at the current revision
  It can be replaced easily because the whole string is selected.

My use case:
I often create temporary copies of branches before rebasing, squashing or fetching force-pushed branches. I don't want to search the ref log.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/77862363-3c535880-721b-11ea-922a-4dcbdfcf7e44.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/77862385-58ef9080-721b-11ea-99af-ffa683562205.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build d6096c423875b5d63cf4e12469a7ae29915b7e8d
- Git 2.24.1.windows.2
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
