### PR TITLE
Settings: Color title label missing

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -231,6 +231,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(tlpnlMain);
             this.Name = "ColorsSettingsPage";
+            this.Text = "Colors";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1020, 628);
             tlpnlMain.ResumeLayout(false);

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -679,6 +679,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
   </file>
   <file datatype="plaintext" original="ColorsSettingsPage" source-language="en">
     <body>
+      <trans-unit id="$this.Text">
+        <source>Colors</source>
+        <target />
+      </trans-unit>
       <trans-unit id="DefaultThemeName.Text">
         <source>default</source>
         <target />


### PR DESCRIPTION
Fixes #7917

## Proposed changes
Add the title label, probably lost at Designer changes when removing the Theme editor

We could add all title labels in the user code instead, but that should be changed for all pages if so

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/77886782-c1fdf500-7269-11ea-880e-1e2e7873aaf7.png)

### After

![image](https://user-images.githubusercontent.com/6248932/77886739-aeeb2500-7269-11ea-9411-251e78358296.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
