### PR TITLE
Fix 3 not reproduced exceptions

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1120,9 +1120,14 @@ namespace GitUI
         {
             if (DoubleClick == null)
             {
+                if (SelectedItem == null)
+                {
+                    return;
+                }
+
                 if (AppSettings.OpenSubmoduleDiffInSeparateWindow && SelectedItem.IsSubmodule)
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(() => OpenSubmoduleAsync());
+                    ThreadHelper.JoinableTaskFactory.RunAsync(OpenSubmoduleAsync);
                 }
                 else
                 {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1398,7 +1398,9 @@ namespace GitUI
             var pt = _gridView.PointToClient(Cursor.Position);
             var hti = _gridView.HitTest(pt.X, pt.Y);
 
-            if (_latestSelectedRowIndex == hti.RowIndex && _gridView.Rows[_latestSelectedRowIndex].Selected)
+            if (_latestSelectedRowIndex == hti.RowIndex
+                && _latestSelectedRowIndex < _gridView.Rows.Count
+                && _gridView.Rows[_latestSelectedRowIndex].Selected)
             {
                 return;
             }

--- a/GitUI/WebBrowserEmulationMode.cs
+++ b/GitUI/WebBrowserEmulationMode.cs
@@ -24,7 +24,14 @@ namespace GitUI
 
             if (TryGetBrowserEmulationMode(out var emulationMode))
             {
-                Registry.SetValue(featureControlRegKey + "FEATURE_BROWSER_EMULATION", appName, emulationMode, RegistryValueKind.DWord);
+                try
+                {
+                    Registry.SetValue(featureControlRegKey + "FEATURE_BROWSER_EMULATION", appName, emulationMode, RegistryValueKind.DWord);
+                }
+                catch (System.UnauthorizedAccessException)
+                {
+                    // Don't fail when user have no rights to update the registry...
+                }
             }
         }
 


### PR DESCRIPTION
Fixes 3 exceptions not easily to reproduce but where stacktrace helps us understand what is happening...


## Proposed changes

- RevisionGridControl: fix Index was out of range exception. Fix #7374
- Don't fail when user have no rights to update the registry. Fix #7918
- Add protection againt NRE when SelectedItem is null. Probably fix #7857

## Test methodology <!-- How did you ensure quality? -->

- None because not reproducible. Read and write code ;)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 5b00c7b4c0bddae9d93b4d01b449d57794963292
- Git 2.25.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4150.0
- DPI 192dpi (200% scaling)

