### PR TITLE
Use ViewChangesAsync consistently for changes

### DIFF
--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -57,8 +57,9 @@ namespace GitCommands
 
         public static bool IsBinaryFileName(GitModule module, string fileName)
         {
-            return IsBinaryAccordingToGitAttributes(module, fileName)
-                ?? HasMatchingExtension(BinaryExtensions, fileName);
+            return fileName.IsNotNullOrWhitespace()
+                   && (IsBinaryAccordingToGitAttributes(module, fileName)
+                       ?? HasMatchingExtension(BinaryExtensions, fileName));
         }
 
         /// <returns>null if no info in .gitattributes (or ambiguous). True if marked as binary, false if marked as text</returns>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -4070,14 +4070,14 @@ namespace GitCommands
         }
 
         [CanBeNull]
-        public string GetCombinedDiffContent(GitRevision revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding)
+        public string GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding)
         {
             var args = new GitArgumentBuilder("diff-tree")
             {
                 { AppSettings.OmitUninterestingDiff, "--cc", "-c -p" },
                 "--no-commit-id",
                 extraArgs,
-                revisionOfMergeCommit.Guid,
+                revisionOfMergeCommit,
                 { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                 "--",
                 filePath.ToPosixPath().Quote()

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -112,15 +112,7 @@ namespace GitUI.CommandsDialogs
 
         private void ShowSelectedFileDiff()
         {
-            if (DiffFiles.SelectedItem == null)
-            {
-                DiffText.Clear();
-                return;
-            }
-
-            var baseCommit = (ckCompareToMergeBase.Checked ? _mergeBase : _baseRevision) ?? DiffFiles.SelectedItemParent;
-
-            DiffText.ViewChangesAsync(baseCommit?.ObjectId, _headRevision, DiffFiles.SelectedItem, string.Empty);
+            DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, _headRevision, DiffFiles.SelectedItem);
         }
 
         private void btnSwap_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -379,9 +379,9 @@ namespace GitUI.CommandsDialogs
                 };
                 var revisions = FileChanges.GetSelectedRevisions();
                 var selectedRev = revisions.FirstOrDefault();
-                var firstId = revisions.Skip(1).LastOrDefault()?.ObjectId;
+                var firstId = revisions.Skip(1).LastOrDefault()?.ObjectId ?? selectedRev?.FirstParentGuid;
                 Diff.ViewChangesAsync(firstId, selectedRev, file,
-                    "You need to select at least one revision to view diff.");
+                    defaultText: "You need to select at least one revision to view diff.");
             }
             else if (tabControl1.SelectedTab == CommitInfoTabPage)
             {

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -32,18 +32,12 @@ namespace GitUI.CommandsDialogs
 
         private void ViewSelectedFileDiff()
         {
-            if (DiffFiles.SelectedItem == null)
-            {
-                diffViewer.Clear();
-                return;
-            }
-
             using (WaitCursorScope.Enter())
             {
                 var revisions = RevisionGrid.GetSelectedRevisions();
                 var selectedRev = revisions.FirstOrDefault();
-                var firstId = revisions.Skip(1).LastOrDefault()?.ObjectId;
-                diffViewer.ViewChangesAsync(firstId, selectedRev, DiffFiles.SelectedItem, string.Empty);
+                var firstId = revisions.Skip(1).LastOrDefault()?.ObjectId ?? selectedRev?.FirstParentGuid;
+                diffViewer.ViewChangesAsync(firstId, selectedRev, DiffFiles.SelectedItem);
             }
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -463,7 +463,15 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
 
             var data = _diffCache[gis.Name];
-            _diffViewer.ViewPatch(gis.Name, text: data, openWithDifftool: null, isText: gis.IsSubmodule);
+
+            if (gis.IsSubmodule)
+            {
+                _diffViewer.ViewText(gis.Name, text: data);
+            }
+            else
+            {
+                _diffViewer.ViewPatch(gis.Name, text: data);
+            }
         }
 
         private void _closePullRequestBtn_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -325,32 +325,8 @@ namespace GitUI.CommandsDialogs
 
         private async Task ShowSelectedFileDiffAsync()
         {
-            if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null)
-            {
-                DiffText.Clear();
-                return;
-            }
-
-            if (DiffFiles.SelectedItemParent?.ObjectId == ObjectId.CombinedDiffId)
-            {
-                var diffOfConflict = Module.GetCombinedDiffContent(DiffFiles.Revision, DiffFiles.SelectedItem.Name,
-                    DiffText.GetExtraDiffArguments(), DiffText.Encoding);
-
-                if (string.IsNullOrWhiteSpace(diffOfConflict))
-                {
-                    diffOfConflict = Strings.UninterestingDiffOmitted;
-                }
-
-                await DiffText.ViewPatchAsync(DiffFiles.SelectedItem.Name,
-                    text: diffOfConflict,
-                    openWithDifftool: () => firstToSelectedToolStripMenuItem.PerformClick(),
-                    isText: DiffFiles.SelectedItem.IsSubmodule);
-
-                return;
-            }
-
-            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision, DiffFiles.SelectedItem, string.Empty,
-                openWithDifftool: () => firstToSelectedToolStripMenuItem.PerformClick());
+            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision, DiffFiles.SelectedItem,
+                openWithDiffTool: () => firstToSelectedToolStripMenuItem.PerformClick());
         }
 
         private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -560,7 +560,7 @@ namespace GitUI.Editor
                     {
                         var patch = await Module.GetCurrentChangesAsync(
                             item.Name, item.OldName, isStaged, GetExtraDiffArguments(), Encoding);
-                        await ViewPatchAsync(item.Name, patch?.Text ?? "", openWithDifftool, isText: false);
+                        await ViewPatchAsync(item.Name, patch?.Text ?? "", openWithDifftool);
                     }
 
                     SetVisibilityDiffContextMenuStaging();
@@ -573,40 +573,37 @@ namespace GitUI.Editor
         /// <param name="fileName">The fileName to present</param>
         /// <param name="text">The patch text</param>
         /// <param name="openWithDifftool">The action to open the difftool</param>
-        /// <param name="isText">Handle as 'text' rather than diff/patch</param>
         public void ViewPatch([CanBeNull] string fileName,
             [NotNull] string text,
-            [CanBeNull] Action openWithDifftool = null,
-            bool isText = false)
+            [CanBeNull] Action openWithDifftool = null)
         {
             ThreadHelper.JoinableTaskFactory.Run(
-                () => ViewPatchAsync(fileName, text, openWithDifftool, isText));
+                () => ViewPatchAsync(fileName, text, openWithDifftool));
         }
 
-        public async Task ViewPatchAsync(string fileName, string text, Action openWithDifftool, bool isText)
+        public async Task ViewPatchAsync(string fileName, string text, Action openWithDifftool)
         {
             await ShowOrDeferAsync(
                 text.Length,
                 () =>
                 {
-                    if (isText)
-                    {
-                        // A submodule 'patch' is handled as text
-                        ResetForText(fileName);
-                        internalFileViewer.SetText(text, openWithDifftool, isDiff: false);
-                    }
-                    else
-                    {
-                        ResetForDiff(fileName);
-                        internalFileViewer.SetText(text, openWithDifftool, isDiff: true);
-                    }
+                    ResetForDiff(fileName);
+                    internalFileViewer.SetText(text, openWithDifftool, isDiff: true);
 
                     TextLoaded?.Invoke(this, null);
                     return Task.CompletedTask;
                 });
         }
 
-        public async Task ViewTextAsync([NotNull] string fileName, [NotNull] string text,
+        public void ViewText([CanBeNull] string fileName,
+            [NotNull] string text,
+            [CanBeNull] Action openWithDifftool = null)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(
+                () => ViewTextAsync(fileName, text, openWithDifftool));
+        }
+
+        public async Task ViewTextAsync([CanBeNull] string fileName, [NotNull] string text,
             [CanBeNull] Action openWithDifftool = null, bool checkGitAttributes = false)
         {
             await ShowOrDeferAsync(

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -34,82 +34,92 @@ namespace GitUI
             return module.GetSingleDiff(firstRevision?.ToString(), secondRevision?.ToString(), file.Name, file.OldName, diffArgs, encoding, true, isTracked);
         }
 
-        [CanBeNull]
-        private static string GetSelectedPatch(
-            [NotNull] this FileViewer diffViewer,
-            [CanBeNull] ObjectId firstRevision,
-            [CanBeNull] ObjectId secondRevision,
-            [NotNull] GitItemStatus file)
-        {
-            if (!file.IsTracked)
-            {
-                var fullPath = Path.Combine(diffViewer.Module.WorkingDir, file.Name);
-                if (Directory.Exists(fullPath) && GitModule.IsValidGitWorkingDir(fullPath))
-                {
-                    // git-status does not detect details for untracked and git-diff --no-index will not give info
-                    return LocalizationHelpers.GetSubmoduleText(diffViewer.Module, file.Name.TrimEnd('/'), "");
-                }
-            }
-
-            if (file.IsSubmodule && file.GetSubmoduleStatusAsync() != null)
-            {
-                return LocalizationHelpers.ProcessSubmoduleStatus(diffViewer.Module, ThreadHelper.JoinableTaskFactory.Run(() => file.GetSubmoduleStatusAsync()));
-            }
-
-            Patch patch = GetItemPatch(diffViewer.Module, file, firstRevision, secondRevision,
-                diffViewer.GetExtraDiffArguments(), diffViewer.Encoding);
-
-            if (patch == null)
-            {
-                return string.Empty;
-            }
-
-            if (file.IsSubmodule)
-            {
-                return LocalizationHelpers.ProcessSubmodulePatch(diffViewer.Module, file.Name, patch);
-            }
-
-            return patch.Text;
-        }
-
-        public static Task ViewChangesAsync(this FileViewer diffViewer,
+        /// <summary>
+        /// View the changes between the revisions, if possible as a diff
+        /// </summary>
+        /// <param name="fileViewer">Current FileViewer</param>
+        /// <param name="firstId">The first (A) commit</param>
+        /// <param name="selectedRev">The selected (B) commit</param>
+        /// <param name="file">The git item to view</param>
+        /// <param name="defaultText">default text if no diff is possible</param>
+        /// <param name="openWithDiffTool">The difftool command to open with</param>
+        /// <returns>Task to view</returns>
+        public static Task ViewChangesAsync(this FileViewer fileViewer,
             [CanBeNull] ObjectId firstId,
-            [CanBeNull] GitRevision selectedRevision,
-            [NotNull] GitItemStatus file,
-            [NotNull] string defaultText,
-            [CanBeNull] Action openWithDifftool = null)
+            [CanBeNull] GitRevision selectedRev,
+            [CanBeNull] GitItemStatus file,
+            [NotNull] string defaultText = "",
+            [CanBeNull] Action openWithDiffTool = null)
         {
-            if (firstId == null && selectedRevision != null)
+            if (file == null || selectedRev?.ObjectId == null)
             {
-                firstId = selectedRevision.FirstParentGuid;
+                if (defaultText.IsNotNullOrWhitespace())
+                {
+                    return fileViewer.ViewTextAsync(file?.Name, defaultText, openWithDiffTool);
+                }
+
+                fileViewer.Clear();
+                return Task.CompletedTask;
             }
 
-            openWithDifftool ??= OpenWithDifftool;
+            firstId ??= selectedRev.FirstParentGuid;
+
+            openWithDiffTool ??= OpenWithDiffTool;
+
             if (file.IsNew || firstId == null || FileHelper.IsImage(file.Name))
             {
-                // The previous commit does not exist, nothing to compare with
-                if (selectedRevision == null)
-                {
-                    throw new ArgumentNullException(nameof(selectedRevision));
-                }
-
                 // View blob guid from revision, or file for worktree
-                return diffViewer.ViewGitItemRevisionAsync(file, selectedRevision.ObjectId, openWithDifftool);
+                return fileViewer.ViewGitItemRevisionAsync(file, selectedRev.ObjectId, openWithDiffTool);
             }
 
-            string selectedPatch = diffViewer.GetSelectedPatch(firstId, selectedRevision.ObjectId, file);
-            return diffViewer.ViewPatchAsync(file.Name, text: selectedPatch ?? defaultText,
-                openWithDifftool: openWithDifftool, isText: file.IsSubmodule || selectedPatch == null);
+            string selectedPatch = GetSelectedPatch(fileViewer, firstId, selectedRev.ObjectId, file);
 
-            void OpenWithDifftool()
+            return file.IsSubmodule || selectedPatch == null
+                ? fileViewer.ViewTextAsync(file.Name, text: selectedPatch ?? defaultText, openWithDifftool: openWithDiffTool)
+                : fileViewer.ViewPatchAsync(file.Name, text: selectedPatch, openWithDifftool: openWithDiffTool);
+
+            void OpenWithDiffTool()
             {
-                diffViewer.Module.OpenWithDifftool(
+                fileViewer.Module.OpenWithDifftool(
                     file.Name,
                     file.OldName,
                     firstId?.ToString(),
-                    selectedRevision?.ToString(),
+                    selectedRev?.ToString(),
                     "",
                     file.IsTracked);
+            }
+
+            static string GetSelectedPatch(
+                FileViewer fileViewer,
+                ObjectId firstId,
+                ObjectId selectedId,
+                GitItemStatus file)
+            {
+                if (firstId == ObjectId.CombinedDiffId)
+                {
+                    var diffOfConflict = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
+                        fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
+
+                    return string.IsNullOrWhiteSpace(diffOfConflict)
+                        ? Strings.UninterestingDiffOmitted
+                        : diffOfConflict;
+                }
+
+                if (file.IsSubmodule && file.GetSubmoduleStatusAsync() != null)
+                {
+                    // Patch already evaluated
+                    var status = ThreadHelper.JoinableTaskFactory.Run(file.GetSubmoduleStatusAsync);
+                    return status != null
+                        ? LocalizationHelpers.ProcessSubmoduleStatus(fileViewer.Module, status)
+                        : $"Failed to get status for submodule \"{file.Name}\"";
+                }
+
+                var patch = GetItemPatch(fileViewer.Module, file, firstId, selectedId,
+                    fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
+
+                return file.IsSubmodule
+                    ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, patch)
+                    : patch?.Text;
             }
         }
 

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -71,34 +71,9 @@ namespace GitUI.UserControls
             }).FileAndForget();
         }
 
-        // Partly the same as RevisionDiffControl.cs ShowSelectedFileDiffAsync()
         private async Task ViewSelectedDiffAsync()
         {
-            if (DiffFiles.SelectedItem == null || DiffFiles.Revision == null)
-            {
-                DiffText.Clear();
-                return;
-            }
-
-            if (DiffFiles.SelectedItemParent?.ObjectId == ObjectId.CombinedDiffId)
-            {
-                var diffOfConflict = Module.GetCombinedDiffContent(DiffFiles.Revision, DiffFiles.SelectedItem.Name,
-                    DiffText.GetExtraDiffArguments(), DiffText.Encoding);
-
-                if (string.IsNullOrWhiteSpace(diffOfConflict))
-                {
-                    diffOfConflict = Strings.UninterestingDiffOmitted;
-                }
-
-                await DiffText.ViewPatchAsync(DiffFiles.SelectedItem.Name,
-                    text: diffOfConflict,
-                    openWithDifftool: null,
-                    isText: DiffFiles.SelectedItem.IsSubmodule);
-
-                return;
-            }
-
-            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision, DiffFiles.SelectedItem, string.Empty);
+            await DiffText.ViewChangesAsync(DiffFiles.SelectedItemParent?.ObjectId, DiffFiles.Revision, DiffFiles.SelectedItem);
         }
     }
 }


### PR DESCRIPTION
Part of #7338 
Related to #7825 
Fixes #7866 

## Proposed changes

There are many codepaths that "presents changes" to files (binary, images) and submodules. The presentation differs if the file is new, tracked etc.
The logic for that is split between the separate forms and GitUIExtensions.cs, ViewChangesAsync(). Some of that has been cleaned up in previous PRs.
(FormCommit.cs also needs to have some logic in FileViewer.cs ViewCurrentChanges(), that requires #7825 first.)
The presentation therefore differs from form to form.

This change unifies the handling to be consistent, all using ViewChangesAsync()

This PR shares (conflicts) a change in #7914, rev-parse is required to get guid, see the explanation there.

This only changes how FormStash presents changes, the only actual change of this PR is that images that are changed should now be displayed.
(and FormCommit should not see any changes when this is applied in or after #78825, depending what goes in first).

## Test methodology
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
