### PR TITLE
Move settings page titles from designer files

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -508,7 +508,6 @@
             this.Controls.Add(tlpnlMain);
             this.MinimumSize = new System.Drawing.Size(258, 255);
             this.Name = "AppearanceSettingsPage";
-            this.Text = "Appearance";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1558, 497);
             tlpnlMain.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -21,6 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public AppearanceSettingsPage()
         {
             InitializeComponent();
+            Text = "Appearance";
             InitializeComplete();
 
             FillComboBoxWithEnumValues<AvatarProvider>(AvatarProvider);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -231,7 +231,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(tlpnlMain);
             this.Name = "ColorsSettingsPage";
-            this.Text = "Colors";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1020, 628);
             tlpnlMain.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -24,6 +24,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public ColorsSettingsPage()
         {
             InitializeComponent();
+            Text = "Colors";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.Designer.cs
@@ -79,7 +79,6 @@
             this.Controls.Add(this.label1);
             this.Name = "FormChooseTranslation";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Choose language";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormChooseTranslation_FormClosing);
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -16,6 +16,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComponent();
             label1.Font = FontUtil.MainInstructionFont;
             label1.ForeColor = FontUtil.MainInstructionColor;
+            Text = "Choose language";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.Designer.cs
@@ -155,7 +155,6 @@
             this.Name = "FormFixHome";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Home";
             this.groupBox8.ResumeLayout(false);
             this.groupBox8.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -32,6 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public FormFixHome()
         {
             InitializeComponent();
+            Text = "Home";
             InitializeComplete();
         }
 


### PR DESCRIPTION
Fixes #7917
Follow up to #7919, more permanent solution

## Proposed changes
To avoid titles are lost when making changes in the designer, move title/text setting to the init code.
The Designer and code files for settings pages have been checked, only a few occurrences.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
