### PR TITLE
Improve blame gutter display

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1690,6 +1690,12 @@ namespace GitCommands
             set => SetBool("Blame.ShowOriginalFilePath", value);
         }
 
+        public static bool BlameShowAuthorAvatar
+        {
+            get => GetBool("Blame.ShowAuthorAvatar", true);
+            set => SetBool("Blame.ShowAuthorAvatar", value);
+        }
+
         public static bool AutomaticContinuousScroll
         {
             get => GetBool("DiffViewer.AutomaticContinuousScroll", false);

--- a/GitUI/Avatars/AvatarService.cs
+++ b/GitUI/Avatars/AvatarService.cs
@@ -4,7 +4,7 @@ namespace GitUI.Avatars
 {
     public static class AvatarService
     {
-        private static InitialsAvatarGenerator AvatarGenerator = new InitialsAvatarGenerator();
+        private static readonly InitialsAvatarGenerator AvatarGenerator = new InitialsAvatarGenerator();
         public static IAvatarProvider Default { get; }
             = new BackupAvatarProvider(new AvatarMemoryCache(new AvatarPersistentCache(new AvatarDownloader(AvatarGenerator), AvatarGenerator)),
                 Images.User80);

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -67,6 +67,7 @@ namespace GitUI.CommandsDialogs
             this.showAuthorTimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showLineNumbersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showOriginalFilePathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAuthorAvatarToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -481,6 +482,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator5,
             this.displaySettingsToolStripMenuItem,
             this.displayAuthorFirstToolStripMenuItem,
+            this.showAuthorAvatarToolStripMenuItem,
             this.showAuthorToolStripMenuItem,
             this.showAuthorDateToolStripMenuItem,
             this.showAuthorTimeToolStripMenuItem,
@@ -575,6 +577,13 @@ namespace GitUI.CommandsDialogs
             this.showOriginalFilePathToolStripMenuItem.Text = "Show original file path";
             this.showOriginalFilePathToolStripMenuItem.Click += new System.EventHandler(this.showOriginalFilePathToolStripMenuItem_Click);
             // 
+            // showAuthorAvatarToolStripMenuItem
+            // 
+            this.showAuthorAvatarToolStripMenuItem.Name = "showAuthorAvatarToolStripMenuItem";
+            this.showAuthorAvatarToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.showAuthorAvatarToolStripMenuItem.Text = "Show author avatar";
+            this.showAuthorAvatarToolStripMenuItem.Click += new System.EventHandler(this.showAuthorAvatarToolStripMenuItem_Click);
+            // 
             // FormFileHistory
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -661,5 +670,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem displaySettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showAuthorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showOriginalFilePathToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAuthorAvatarToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -135,6 +135,7 @@ namespace GitUI.CommandsDialogs
                 detectMoveAndCopyInAllFilesToolStripMenuItem.Checked = AppSettings.DetectCopyInAllOnBlame;
                 detectMoveAndCopyInThisFileToolStripMenuItem.Checked = AppSettings.DetectCopyInFileOnBlame;
                 displayAuthorFirstToolStripMenuItem.Checked = AppSettings.BlameDisplayAuthorFirst;
+                showAuthorAvatarToolStripMenuItem.Checked = AppSettings.BlameShowAuthorAvatar;
                 showAuthorToolStripMenuItem.Checked = AppSettings.BlameShowAuthor;
                 showAuthorDateToolStripMenuItem.Checked = AppSettings.BlameShowAuthorDate;
                 showAuthorTimeToolStripMenuItem.Checked = AppSettings.BlameShowAuthorTime;
@@ -702,6 +703,13 @@ namespace GitUI.CommandsDialogs
         {
             AppSettings.BlameShowOriginalFilePath = !AppSettings.BlameShowOriginalFilePath;
             showOriginalFilePathToolStripMenuItem.Checked = AppSettings.BlameShowOriginalFilePath;
+            UpdateSelectedFileViewers(true);
+        }
+
+        private void showAuthorAvatarToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            AppSettings.BlameShowAuthorAvatar = !AppSettings.BlameShowAuthorAvatar;
+            showAuthorAvatarToolStripMenuItem.Checked = AppSettings.BlameShowAuthorAvatar;
             UpdateSelectedFileViewers(true);
         }
     }

--- a/GitUI/Editor/BlameAuthorMargin.cs
+++ b/GitUI/Editor/BlameAuthorMargin.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using GitExtUtils.GitUI;
+using ICSharpCode.TextEditor;
+
+namespace GitUI.Editor
+{
+    /// <summary>
+    /// This class display avatars in the gutter in a blame control.
+    /// </summary>
+    public class BlameAuthorMargin : AbstractMargin
+    {
+        private static readonly int AgeBucketMarkerWidth = Convert.ToInt32(4 * DpiUtil.ScaleX);
+        private List<Image> _avatars;
+        private readonly int _lineHeight;
+        private readonly Color _backgroundColor;
+        private List<GitBlameEntry> _blameLines;
+        private readonly Dictionary<int, SolidBrush> _brushs = new Dictionary<int, SolidBrush>();
+        private bool _isVisible = true;
+
+        public BlameAuthorMargin(TextArea textArea) : base(textArea)
+        {
+            _lineHeight = GetFontHeight(textArea.Font);
+            _backgroundColor = SystemColors.Window;
+            Width = _lineHeight + AgeBucketMarkerWidth + DpiUtil.Scale(2);
+        }
+
+        public override int Width { get; }
+        public override bool IsVisible => _isVisible;
+
+        private static int GetFontHeight(Font font)
+        {
+            var max = Math.Max(
+                TextRenderer.MeasureText("_", font).Height,
+                (int)Math.Ceiling(font.GetHeight()));
+
+            return max + 1;
+        }
+
+        public void Initialize(IEnumerable<GitBlameEntry> blameLines)
+        {
+            _blameLines = blameLines.ToList();
+            _avatars = _blameLines.Select(a => a.Avatar).ToList();
+
+            // Update the resolution otherwise the image is not drawn at the good size :(
+            foreach (var avatar in _avatars)
+            {
+                if (avatar is Bitmap bitmapAvatar)
+                {
+                    bitmapAvatar.SetResolution(DpiUtil.DpiX, DpiUtil.DpiY);
+                }
+            }
+
+            // Build brushes
+            foreach (var blameLine in _blameLines)
+            {
+                if (!_brushs.ContainsKey(blameLine.AgeBucketIndex))
+                {
+                    _brushs.Add(blameLine.AgeBucketIndex, new SolidBrush(blameLine.AgeBucketColor));
+                }
+            }
+        }
+
+        public void SetVisiblity(bool isVisible)
+        {
+            _isVisible = isVisible;
+        }
+
+        public override void Paint(Graphics g, Rectangle rect)
+        {
+            if (rect.Width <= 0 || rect.Height <= 0 || _blameLines == null || _blameLines.Count == 0)
+            {
+                return;
+            }
+
+            g.Clear(_backgroundColor);
+
+            if (_avatars == null || _avatars.Count == 0)
+            {
+                return;
+            }
+
+            var verticalOffset = textArea.VirtualTop.Y;
+            var lineStart = verticalOffset / _lineHeight;
+            var negativeOffset = (lineStart * _lineHeight) - verticalOffset;
+            var lineCount = (int)Math.Ceiling((double)(rect.Height - negativeOffset) / _lineHeight);
+
+            for (int i = 0; i < lineCount; i++)
+            {
+                if (lineStart + i >= _avatars.Count)
+                {
+                    break;
+                }
+
+                int y = negativeOffset + (i * _lineHeight);
+                g.FillRectangle(_brushs[_blameLines[lineStart + i].AgeBucketIndex], 0, y, AgeBucketMarkerWidth, _lineHeight);
+
+                if (_avatars[lineStart + i] != null)
+                {
+                    g.DrawImage(_avatars[lineStart + i], new Point(AgeBucketMarkerWidth, y));
+                }
+            }
+
+            base.Paint(g, rect);
+        }
+    }
+}

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
@@ -1666,6 +1667,16 @@ namespace GitUI.Editor
 
             public ToolStripButton IgnoreAllWhitespacesButton => _fileViewer.ignoreAllWhitespaces;
             public ToolStripMenuItem IgnoreAllWhitespacesMenuItem => _fileViewer.ignoreAllWhitespaceChangesToolStripMenuItem;
+        }
+
+        public void SetGitBlameGutter(IEnumerable<GitBlameEntry> gitBlameEntries)
+        {
+            internalFileViewer.ShowGutterAvatars = AppSettings.BlameShowAuthorAvatar;
+
+            if (AppSettings.BlameShowAuthorAvatar)
+            {
+                internalFileViewer.SetGitBlameGutter(gitBlameEntries);
+            }
         }
     }
 }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -37,6 +37,8 @@ namespace GitUI.Editor
         private bool _shouldScrollToBottom = false;
         private readonly int _bottomBlankHeight = DpiUtil.Scale(300);
         private ContinuousScrollEventManager _continuousScrollEventManager;
+        private BlameAuthorMargin _authorsAvatarMargin;
+        private bool _showGutterAvatars;
 
         public FileViewerInternal()
         {
@@ -535,6 +537,39 @@ namespace GitUI.Editor
         }
 
         #endregion
+
+        public void SetGitBlameGutter(IEnumerable<GitBlameEntry> gitBlameEntries)
+        {
+            if (_showGutterAvatars)
+            {
+                _authorsAvatarMargin.Initialize(gitBlameEntries);
+            }
+        }
+
+        public bool ShowGutterAvatars
+        {
+            get => _showGutterAvatars;
+            set
+            {
+                _showGutterAvatars = value;
+                if (!_showGutterAvatars)
+                {
+                    _authorsAvatarMargin?.SetVisiblity(false);
+
+                    return;
+                }
+
+                if (_authorsAvatarMargin == null)
+                {
+                    _authorsAvatarMargin = new BlameAuthorMargin(TextEditor.ActiveTextAreaControl.TextArea);
+                    TextEditor.ActiveTextAreaControl.TextArea.InsertLeftMargin(0, _authorsAvatarMargin);
+                }
+                else
+                {
+                    _authorsAvatarMargin.SetVisiblity(true);
+                }
+            }
+        }
 
         internal sealed class CurrentViewPositionCache
         {

--- a/GitUI/Editor/GitBlameEntry.cs
+++ b/GitUI/Editor/GitBlameEntry.cs
@@ -1,0 +1,11 @@
+﻿using System.Drawing;
+
+namespace GitUI.Editor
+{
+    public class GitBlameEntry
+    {
+        public Image Avatar { get; set; }
+        public int AgeBucketIndex { get; set; }
+        public Color AgeBucketColor { get; set; }
+    }
+}

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4268,6 +4268,10 @@ If you are not sure just close this window.</source>
         <source>Save as</source>
         <target />
       </trans-unit>
+      <trans-unit id="showAuthorAvatarToolStripMenuItem.Text">
+        <source>Show author avatar</source>
+        <target />
+      </trans-unit>
       <trans-unit id="showAuthorDateToolStripMenuItem.Text">
         <source>Show author date</source>
         <target />


### PR DESCRIPTION
Please, give your point of view and probable improvements...

## Proposed changes

- Display avatars in the gutter with a thin vertical marker for recency

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/78081967-29bf5780-73b2-11ea-932a-6b437e7b2c81.png)


### After

Note: the same information could be displayed in the gutter, that's just that it is configured differently

With avatars (notice the thin color line next to avatars that highlight recency of changes):
![image](https://user-images.githubusercontent.com/460196/78282110-09131100-751c-11ea-986b-c44cf8838856.png)

last update on heatmap colors:

* for light theme:

![image](https://user-images.githubusercontent.com/460196/78377835-708a9880-75d0-11ea-887c-0181db1e548f.png)


* for dark theme:
![image](https://user-images.githubusercontent.com/460196/78377581-112c8880-75d0-11ea-90cd-3eab5b411ca1.png)




## Test methodology <!-- How did you ensure quality? -->

- Manual (for more than 6 months now...)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build ad8be3dafc0537dafa2a96e1cb5daf0f09b302ef
- Git 2.25.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4150.0
- DPI 192dpi (200% scaling)

