### PR TITLE
Break the build if there are any errors in publish tasks

### DIFF
--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -56,7 +56,10 @@
     Creates a portable archive.
     ============================================================
     -->
-  <Target Name="CreatePortable" AfterTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_PublishExtraDependecies">
+  <!-- Any errors in targets that executed as 'AfterTargets' don't break the build: https://github.com/microsoft/msbuild/issues/3345
+       A fix is going out in VS16.6p3, but it is way too long for us to wait.
+    -->
+  <Target Name="CreatePortable" BeforeTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_PublishExtraDependecies">
     <PropertyGroup>
       <_AppPluginsPublishDir>$([MSBuild]::NormalizeDirectory('$(AppPublishDir)', 'Plugins'))</_AppPluginsPublishDir>
 
@@ -99,29 +102,37 @@
 
     <!-- Copy the plugins to the Plugins folder -->
     <Copy
-          SourceFiles="@(PluginAssemblies)"
-          DestinationFolder="$(_AppPluginsPublishDir)"
-        />
+            SourceFiles="@(PluginAssemblies)"
+            DestinationFolder="$(_AppPluginsPublishDir)"
+            ContinueOnError="ErrorAndStop"
+          />
     <!-- Copy the plugins' resources to the Plugins folder -->
     <Copy
-          SourceFiles="@(PluginResourcesAssemblies)"
-          DestinationFiles="@(PluginResourcesAssemblies->'%(DestinationFiles)')"
-        />
+            SourceFiles="@(PluginResourcesAssemblies)"
+            DestinationFiles="@(PluginResourcesAssemblies->'%(DestinationFiles)')"
+            ContinueOnError="ErrorAndStop"
+          />
 
     <!-- Mark the package as "portable" -->
     <XmlPoke XmlInputPath="$(_PublishAppConfigPath)"
             Query="configuration/applicationSettings/GitCommands.Properties.Settings/setting[@name='IsPortable']/value" 
-            Value="True" />
+            Value="True"
+            ContinueOnError="ErrorAndStop"
+          />
 
     <ZipDirectory
             SourceDirectory="$(_PublishedPath)"
             DestinationFile="$(_PublishPortablePath)"
-            Overwrite="true" />
+            Overwrite="true"
+            ContinueOnError="ErrorAndStop"
+          />
 
     <!-- Reset the "portable" flag -->
     <XmlPoke XmlInputPath="$(_PublishAppConfigPath)"
             Query="configuration/applicationSettings/GitCommands.Properties.Settings/setting[@name='IsPortable']/value" 
-            Value="False" />
+            Value="False"
+            ContinueOnError="ErrorAndStop"
+          />
   </Target>
 
 </Project>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes


Fixes broken builds like https://ci.appveyor.com/project/gitextensions/gitextensions/builds/31840877

MSBuild had a bug that caused builds not break if errors occurred in targets executed via `AfterTargets` (https://github.com/microsoft/msbuild/issues/3345). A workaround is to use `BeforeTargets` execution chain.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/78090145-10032c00-7415-11ea-9723-373c629bed2b.png)

### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/78090174-1ee9de80-7415-11ea-865c-b02e17a1d120.png)


## Test methodology <!-- How did you ensure quality? -->

- Locally and on the CI: https://ci.appveyor.com/project/RussKie/gitextensions/builds/31864931



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
