### PR TITLE
fix no git url check in FormClone

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -183,7 +183,7 @@ namespace GitUI.CommandsDialogs
 
         private static bool CanBeGitURL(string url)
         {
-            if (url.IsNotNullOrWhitespace())
+            if (string.IsNullOrWhiteSpace(url))
             {
                 return false;
             }


### PR DESCRIPTION
## Proposed changes

- Fix empty/null git url check in FormClone

## Test methodology <!-- How did you ensure quality? -->

- manual, doesn't crash now

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
