### PR TITLE
formstash improvements

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -199,7 +199,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             _discussionWB.DocumentText = "";
             _diffViewer.Clear();
-            _fileStatusList.SetDiffs();
+            _fileStatusList.ClearDiffs();
 
             _pullRequestsList.Items.Clear();
             _pullRequestsList.Items.Add(new ListViewItem("") { SubItems = { _strLoading.Text } });
@@ -268,7 +268,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             _discussionWB.DocumentText = DiscussionHtmlCreator.CreateFor(_currentPullRequestInfo);
             _diffViewer.Clear();
-            _fileStatusList.SetDiffs();
+            _fileStatusList.ClearDiffs();
 
             LoadDiffPatch();
             LoadDiscussion();
@@ -367,7 +367,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 _diffCache.Add(gis.Name, match.Groups[3].Value);
             }
 
-            _fileStatusList.SetDiffs(items: giss);
+            // Commits in PR may not exist in the repo so GitRevision in FileStatusList is not used,
+            // patches directly from the cache
+            _fileStatusList.SetDiffs(selectedRev: null, parentRev: null, items: giss);
         }
 
         private void _fetchBtn_Click(object sender, EventArgs e)

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -24,7 +24,7 @@ namespace GitUI.UserControls
             DiffText.EscapePressed += () => EscapePressed?.Invoke();
             DiffText.ExtraDiffArgumentsChanged += DiffText_ExtraDiffArgumentsChanged;
             DiffFiles.Focus();
-            DiffFiles.SetDiffs();
+            DiffFiles.ClearDiffs();
 
             splitContainer1.SplitterDistance = DpiUtil.Scale(200);
             splitContainer2.SplitterDistance = DpiUtil.Scale(260);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -741,12 +741,55 @@ namespace GitUI
             }
         }
 
-        public void SetDiffs(GitRevision selectedRev = null, GitRevision parentRev = null, IReadOnlyList<GitItemStatus> items = null)
+        /// <summary>
+        /// FormStash init for WorkTree and Index
+        /// Special handling, Revision and ParentRev is not used as for e.g. RevisionDiffControl
+        /// </summary>
+        /// <param name="worktreeRev">The GitRevision for WorkTree</param>
+        /// <param name="worktreeDesc">The description for WorkTree</param>
+        /// <param name="worktreeItems">The GitItems for WorkTree</param>
+        /// <param name="indexRev">The GitRevision for Index</param>
+        /// <param name="indexDesc">The description for Index</param>
+        /// <param name="indexItems">The GitItems for Index</param>
+        public void SetStashDiffs(GitRevision worktreeRev, string worktreeDesc, [NotNull] IReadOnlyList<GitItemStatus> worktreeItems,
+            GitRevision indexRev, string indexDesc, [NotNull] IReadOnlyList<GitItemStatus> indexItems)
         {
+            GroupByRevision = true;
+            Revision = worktreeRev;
+            GitItemStatusesWithDescription = new[]
+            {
+                (worktreeRev, worktreeDesc, worktreeItems),
+                (indexRev, indexDesc, indexItems)
+            };
+        }
+
+        /// <summary>
+        /// FormStash init for stashed commits
+        /// Special handling, Revision and ParentRev is not used as for e.g. RevisionDiffControl
+        /// </summary>
+        /// <param name="selectedRev">The GitRevision for the stash</param>
+        /// <param name="selectedItems">The GitItems for the stash</param>
+        public void SetStashDiffs(GitRevision selectedRev, [NotNull] IReadOnlyList<GitItemStatus> selectedItems)
+        {
+            GroupByRevision = false;
             Revision = selectedRev;
-            GitItemStatusesWithDescription = items == null
-                ? Array.Empty<(GitRevision, string, IReadOnlyList<GitItemStatus>)>()
-                : new[] { (parentRev, _diffWithParent.Text + GetDescriptionForRevision(parentRev?.ObjectId), items) };
+            GitItemStatusesWithDescription = new[]
+            {
+                (selectedRev, "", selectedItems)
+            };
+        }
+
+        public void SetDiffs([CanBeNull] GitRevision selectedRev, [CanBeNull] GitRevision parentRev, [NotNull] IReadOnlyList<GitItemStatus> items)
+        {
+            GroupByRevision = false;
+            Revision = selectedRev;
+            GitItemStatusesWithDescription = new[] { (parentRev, _diffWithParent.Text + GetDescriptionForRevision(parentRev?.ObjectId), items) };
+        }
+
+        public void ClearDiffs()
+        {
+            Revision = null;
+            GitItemStatusesWithDescription = Array.Empty<(GitRevision, string, IReadOnlyList<GitItemStatus>)>();
         }
 
         private string GetDescriptionForRevision(ObjectId objectId)

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
@@ -48,7 +48,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             var itemAt0 = item1;
             var itemAt1 = item2;
             var itemAt2 = item0;
-            _fileStatusList.SetDiffs(items: items);
+            _fileStatusList.SetDiffs(selectedRev: null, parentRev: null, items: items);
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
             _fileStatusList.SelectedIndex.Should().Be(0);


### PR DESCRIPTION
Separated from #7926 
See https://github.com/gitextensions/gitextensions/pull/7926#pullrequestreview-385057653


## Proposed changes
Stash currently presents worktree and index files as one list.
The diff for index files is incorrect, always show the worktree changes.

FileStatusList will have better support for this after #7899, but the FileStatusList can be tweaked to present this as two groups

WIP as it builds on #7926, the first two commits are from the #7926 review too and all will be squashed.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Both diffs are identical

![stash-before](https://user-images.githubusercontent.com/6248932/78301685-be07f680-7539-11ea-8eb1-40da516d3b0a.JPG)

### After

![stash-worktree](https://user-images.githubusercontent.com/6248932/78301768-dbd55b80-7539-11ea-9823-b8709297f696.JPG)

![stash-index](https://user-images.githubusercontent.com/6248932/78301776-e09a0f80-7539-11ea-8bc0-bcf76480fbe1.JPG)

## Test methodology
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
